### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.rs]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Simple `.editorconfig` to set the tab width to 4 for better viewing in github.