### PR TITLE
try generics and traits instead of enums for events

### DIFF
--- a/engine/src/sc_observer/staking.rs
+++ b/engine/src/sc_observer/staking.rs
@@ -77,49 +77,49 @@ pub struct ClaimSignatureIssuedEvent<S: Staking> {
     pub _phantom: PhantomData<S>,
 }
 
-/// Wrapper for all Staking event types
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum StakingEvent<S: Staking> {
-    ClaimSigRequestedEvent(ClaimSigRequestedEvent<S>),
+// /// Wrapper for all Staking event types
+// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+// pub enum StakingEvent<S: Staking> {
+//     ClaimSigRequestedEvent(ClaimSigRequestedEvent<S>),
 
-    ClaimSignatureIssuedEvent(ClaimSignatureIssuedEvent<S>),
+//     ClaimSignatureIssuedEvent(ClaimSignatureIssuedEvent<S>),
 
-    StakedEvent(StakedEvent<S>),
+//     StakedEvent(StakedEvent<S>),
 
-    StakeRefundEvent(StakeRefundEvent<S>),
+//     StakeRefundEvent(StakeRefundEvent<S>),
 
-    ClaimedEvent(ClaimedEvent<S>),
-}
+//     ClaimedEvent(ClaimedEvent<S>),
+// }
 
-impl From<ClaimSigRequestedEvent<StateChainRuntime>> for SCEvent {
-    fn from(claim_sig_requested: ClaimSigRequestedEvent<StateChainRuntime>) -> Self {
-        SCEvent::StakingEvent(StakingEvent::ClaimSigRequestedEvent(claim_sig_requested))
-    }
-}
+// impl From<ClaimSigRequestedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(claim_sig_requested: ClaimSigRequestedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::StakingEvent(StakingEvent::ClaimSigRequestedEvent(claim_sig_requested))
+//     }
+// }
 
-impl From<ClaimSignatureIssuedEvent<StateChainRuntime>> for SCEvent {
-    fn from(claim_sig_issued: ClaimSignatureIssuedEvent<StateChainRuntime>) -> Self {
-        SCEvent::StakingEvent(StakingEvent::ClaimSignatureIssuedEvent(claim_sig_issued))
-    }
-}
+// impl From<ClaimSignatureIssuedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(claim_sig_issued: ClaimSignatureIssuedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::StakingEvent(StakingEvent::ClaimSignatureIssuedEvent(claim_sig_issued))
+//     }
+// }
 
-impl From<ClaimedEvent<StateChainRuntime>> for SCEvent {
-    fn from(claimed: ClaimedEvent<StateChainRuntime>) -> Self {
-        SCEvent::StakingEvent(StakingEvent::ClaimedEvent(claimed))
-    }
-}
+// impl From<ClaimedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(claimed: ClaimedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::StakingEvent(StakingEvent::ClaimedEvent(claimed))
+//     }
+// }
 
-impl From<StakedEvent<StateChainRuntime>> for SCEvent {
-    fn from(staked: StakedEvent<StateChainRuntime>) -> Self {
-        SCEvent::StakingEvent(StakingEvent::StakedEvent(staked))
-    }
-}
+// impl From<StakedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(staked: StakedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::StakingEvent(StakingEvent::StakedEvent(staked))
+//     }
+// }
 
-impl From<StakeRefundEvent<StateChainRuntime>> for SCEvent {
-    fn from(stake_refund: StakeRefundEvent<StateChainRuntime>) -> Self {
-        SCEvent::StakingEvent(StakingEvent::StakeRefundEvent(stake_refund))
-    }
-}
+// impl From<StakeRefundEvent<StateChainRuntime>> for SCEvent {
+//     fn from(stake_refund: StakeRefundEvent<StateChainRuntime>) -> Self {
+//         SCEvent::StakingEvent(StakingEvent::StakeRefundEvent(stake_refund))
+//     }
+// }
 
 #[cfg(test)]
 mod tests {

--- a/engine/src/sc_observer/validator.rs
+++ b/engine/src/sc_observer/validator.rs
@@ -46,55 +46,55 @@ pub struct ForceRotationRequestedEvent<V: Validator> {
     pub _phantom: PhantomData<V>,
 }
 
-/// Wrapper for all Validator events
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum ValidatorEvent<V: Validator> {
-    MaximumValidatorsChangedEvent(MaximumValidatorsChangedEvent<V>),
+// / Wrapper for all Validator events
+// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+// pub enum ValidatorEvent<V: Validator> {
+//     MaximumValidatorsChangedEvent(MaximumValidatorsChangedEvent<V>),
 
-    EpochDurationChangedEvent(EpochDurationChangedEvent<V>),
+//     EpochDurationChangedEvent(EpochDurationChangedEvent<V>),
 
-    AuctionStartedEvent(AuctionStartedEvent<V>),
+//     AuctionStartedEvent(AuctionStartedEvent<V>),
 
-    AuctionEndedEvent(AuctionEndedEvent<V>),
+//     AuctionEndedEvent(AuctionEndedEvent<V>),
 
-    ForceRotationRequestedEvent(ForceRotationRequestedEvent<V>),
-}
+//     ForceRotationRequestedEvent(ForceRotationRequestedEvent<V>),
+// }
 
-impl From<MaximumValidatorsChangedEvent<StateChainRuntime>> for SCEvent {
-    fn from(max_validators_changed: MaximumValidatorsChangedEvent<StateChainRuntime>) -> Self {
-        SCEvent::ValidatorEvent(ValidatorEvent::MaximumValidatorsChangedEvent(
-            max_validators_changed,
-        ))
-    }
-}
+// impl From<MaximumValidatorsChangedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(max_validators_changed: MaximumValidatorsChangedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::ValidatorEvent(ValidatorEvent::MaximumValidatorsChangedEvent(
+//             max_validators_changed,
+//         ))
+//     }
+// }
 
-impl From<EpochDurationChangedEvent<StateChainRuntime>> for SCEvent {
-    fn from(epoch_duration_changed: EpochDurationChangedEvent<StateChainRuntime>) -> Self {
-        SCEvent::ValidatorEvent(ValidatorEvent::EpochDurationChangedEvent(
-            epoch_duration_changed,
-        ))
-    }
-}
+// impl From<EpochDurationChangedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(epoch_duration_changed: EpochDurationChangedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::ValidatorEvent(ValidatorEvent::EpochDurationChangedEvent(
+//             epoch_duration_changed,
+//         ))
+//     }
+// }
 
-impl From<AuctionStartedEvent<StateChainRuntime>> for SCEvent {
-    fn from(auction_started: AuctionStartedEvent<StateChainRuntime>) -> Self {
-        SCEvent::ValidatorEvent(ValidatorEvent::AuctionStartedEvent(auction_started))
-    }
-}
+// impl From<AuctionStartedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(auction_started: AuctionStartedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::ValidatorEvent(ValidatorEvent::AuctionStartedEvent(auction_started))
+//     }
+// }
 
-impl From<AuctionEndedEvent<StateChainRuntime>> for SCEvent {
-    fn from(auction_ended: AuctionEndedEvent<StateChainRuntime>) -> Self {
-        SCEvent::ValidatorEvent(ValidatorEvent::AuctionEndedEvent(auction_ended))
-    }
-}
+// impl From<AuctionEndedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(auction_ended: AuctionEndedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::ValidatorEvent(ValidatorEvent::AuctionEndedEvent(auction_ended))
+//     }
+// }
 
-impl From<ForceRotationRequestedEvent<StateChainRuntime>> for SCEvent {
-    fn from(force_rotation_requested: ForceRotationRequestedEvent<StateChainRuntime>) -> Self {
-        SCEvent::ValidatorEvent(ValidatorEvent::ForceRotationRequestedEvent(
-            force_rotation_requested,
-        ))
-    }
-}
+// impl From<ForceRotationRequestedEvent<StateChainRuntime>> for SCEvent {
+//     fn from(force_rotation_requested: ForceRotationRequestedEvent<StateChainRuntime>) -> Self {
+//         SCEvent::ValidatorEvent(ValidatorEvent::ForceRotationRequestedEvent(
+//             force_rotation_requested,
+//         ))
+//     }
+// }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
From here:
https://github.com/chainflip-io/chainflip-backend/pull/35#discussion_r626529818

> Yeah not sure we in fact save the extra decoding since we need to decode the message to see what it is and hence what subject to publish it under. We might save the re-encode step if we keep the original encoded binary sitting around, but I think freeing the downstream components from depending on SCALE outweighs that marginal performance gain.
> 
> Regarding the SCEvent definition (and more generally the use of enums to wrap different types of message), we could use a different approach using generics and traits that might save a lot of boilerplate, and leverages the type checker to be less susceptible to typos (not that there were any!).
> 
> The general idea would be to replace the enums with something like this:
> 
> #[derive(Serialize, Deseralize)] // and whatever other derives are useful
> pub struct ChainflipEvent<E: Serialize + Deserialize> {
>     event: E;
>     // can add other metadata if needed, eg. source (state chain / btc witnesser / etc.), timestamp etc.
> }
> 
> impl<E: Serialize + Deserialize> ChainflipEvent<E> {
>     pub fn new(event: E) -> Self {
>         Self { event }
>     }
> }
> 
> // Define a trait to tag all `StakingEvent`s
> pub trait StakingEvent;
> 
> // Tag the events
> impl StakingEvent for ChainflipEvent<ClaimSigRequestedEvent> {};
> impl StakingEvent for ChainflipEvent<ClaimSignatureIssuedEvent> {};
> // etc.
> This way you save having to define From for all of the variants, you can just call ChainflipEvent::new(event) to wrap the event.

In the code I commented a bunch of stuff out. `sc_event.rs` is the file of interest.

So, I started to try this but a few things became apparent:
- To achieve the same hierarchical structure, you need to use super types (this is fine, and it works)
- You then need to impl *both* traits on the general event struct (in this PR `SCEvent`), this doesn't make it much less boilerplate than the alternative
- We now need to return `Box<dyn ISCEvent>` (also fine, but a little messier than without `Box`)
- How do we get the concrete objects back, after wrapping them in this way? We'd have a trait object and we'd only be able to use methods defined on `ISCEvent` ?
- We have to implement things like `Debug` on `dyn ISCEvent` if we want to print them in log statements, what do we print here? if `self` has access to no methods?
   - I tried implementing this, but then compiler starts complaining about Send, Sync and Serialize not implement for `dyn ISCEvent`, since they're being published. 
   
tl;dr; I can't see how this way is better, unless there's some standard pattern of doing things this way?

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/59"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

