### PR TITLE
Add WitnessCheck SignedExtension

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -317,6 +317,10 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
+parameter_types! {
+	pub const WitnessRegistrationPriority: TransactionPriority = 100;
+}
+
 impl pallet_cf_witness::Config for Runtime {
 	type Event = Event;
 	type Origin = Origin;
@@ -324,6 +328,7 @@ impl pallet_cf_witness::Config for Runtime {
 	type Epoch = pallet_cf_validator::EpochIndex;
 	type ValidatorId = <Self as frame_system::Config>::AccountId;
 	type EpochInfo = Validator;
+	type WitnessRegistrationPriority = WitnessRegistrationPriority;
 }
 
 impl pallet_cf_staking::Config for Runtime {
@@ -382,6 +387,7 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
+	pallet_cf_witness::WitnessCheck<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
This is a first attempt at adding validation to the witnesser. Would appreciate some feedback since I think there are still some potential issues. 

We need to:
- Restrict witness registrations such that only validators can submit them. 
- De-duplicate the registrations prior to inclusion in a block to avoid rejecting them on-chain. 

This approach uses *signed* transactions via the `SignedExtensions` trait. I initially intended to use *unsigned* txs via `ValidateUnsigned` but ran into some issues: 
- Unsigned txs don't allow you attach any metadata (like a signature) so the extra data has to be passed as part of the call. 
- Unsigned txs require us to figure out a lookup mechanism to get the authority keys for the validator in order to verify the provided signature. `pallet_im_online` does this by hooking into the session management to store the keys on session rotations. This seems a bit heavyweight, means we need an extra db lookup for each transaction validation, of which there are potentially quite a lot (this happens before inclusion in the block and is potential DOS vector so the recommendation is to keep these validations as cheap as possible). 

I've pushed an incomplete version of the unsigned implementation to the branch [`feature/witnesser-tx-validation-unsigned`](https://github.com/chainflip-io/chainflip-backend/tree/feature/witnesser-tx-validation-unsigned) for comparison, but I think the signed version will be better going forward. 

Using signed txs has the advantage that we can trust that the account_id provided is genuine and substrate internals take care of all the lookup stuff mentioned above.  It also allows us to add a requires tag to the `witness` txs and so make sure that witness txs wait for the registration before being included in a block.

A couple of things to note:
- I set `propagate` to `false` meaning that validators need to submit their own registration, they can't rely on receiving this from other nodes. Not sure if this is useful but I figured it would eliminate unnecessary network gossip.
- I'm not sure how this will interact with nonces since all validators might send txs but only one will actually be included in the block. This means that the other 149 validators' subsequent txs might get stuck in the mempool... So for these types of txs we might want to somehow remove the nonce... (replay attacks should not be possible / profitable anyhow for these).

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/87"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

