### PR TITLE
feature/no-claiming-during-auction

### DIFF
--- a/engine/src/sc_observer/staking.rs
+++ b/engine/src/sc_observer/staking.rs
@@ -1,6 +1,7 @@
 // Implements support for the staking module
 
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use codec::{Decode, Encode};
 use substrate_subxt::{module, sp_core::crypto::AccountId32, system::System, Event};
@@ -71,6 +72,8 @@ pub struct ClaimSignatureIssuedEvent<S: Staking> {
     pub nonce: u64,
 
     pub eth_address: [u8; 20],
+    
+    pub expiry: Duration,
 
     pub signature: Signature,
 
@@ -259,6 +262,7 @@ mod tests {
         let sig: [u8; 65] = [0; 65];
 
         let sig = Signature(sig);
+        let expiry = Duration::from_secs(1);
 
         let event: <SCRuntime as Config>::Event =
             pallet_cf_staking::Event::<SCRuntime>::ClaimSignatureIssued(
@@ -266,6 +270,7 @@ mod tests {
                 150u128,
                 1u64,
                 eth_address,
+                expiry,
                 sig.clone(),
             )
             .into();
@@ -286,6 +291,7 @@ mod tests {
             nonce: 1u64,
             eth_address,
             signature: sig,
+            expiry: expiry,
             _phantom: PhantomData,
         };
 

--- a/state-chain/pallets/cf-staking/src/mock/epoch_info.rs
+++ b/state-chain/pallets/cf-staking/src/mock/epoch_info.rs
@@ -6,6 +6,7 @@ pub struct Mock;
 thread_local! {
 	pub static CURRENT_VALIDATORS: RefCell<Vec<AccountId>> = RefCell::new(vec![]);
 	pub static BOND: RefCell<u128> = RefCell::new(0);
+	pub static IS_AUCTION: RefCell<bool> = RefCell::new(false);
 }
 
 impl Mock {
@@ -23,6 +24,10 @@ impl Mock {
 
 	pub fn set_bond(bond: u128) {
 		BOND.with(|cell| *(cell.borrow_mut()) = bond);
+	}
+
+	pub fn set_is_auction_phase(is_auction: bool) {
+		IS_AUCTION.with(|cell| *(cell.borrow_mut()) = is_auction);
 	}
 }
 
@@ -50,5 +55,9 @@ impl cf_traits::EpochInfo for Mock {
 
 	fn epoch_index() -> Self::EpochIndex {
 		unimplemented!()
+	}
+
+	fn is_auction_phase() -> bool {
+		IS_AUCTION.with(|cell| *cell.borrow())
 	}
 }

--- a/state-chain/pallets/cf-staking/src/tests.rs
+++ b/state-chain/pallets/cf-staking/src/tests.rs
@@ -430,3 +430,28 @@ fn claim_expiry() {
 		assert!(!PendingClaims::<Test>::contains_key(CHARLIE));
 	});
 }
+
+#[test]
+fn no_claims_during_auction() {
+	new_test_ext().execute_with(|| {
+		let stake = 45u128;
+		epoch_info::Mock::set_is_auction_phase(true);
+
+		// Staking during an auction is OK.
+		assert_ok!(StakeManager::staked(
+			Origin::root(),
+			ALICE,
+			stake,
+			ETH_DUMMY_ADDR
+		));
+
+		// Claiming during an auction isn't OK.
+		assert_noop!(StakeManager::claim(
+				Origin::signed(ALICE),
+				stake,
+				ETH_DUMMY_ADDR
+			),
+			<Error<Test>>::NoClaimsDuringAuctionPhase
+		);
+	});
+}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -369,6 +369,10 @@ impl<T: Config> EpochInfo for Pallet<T> {
 	fn is_validator(account: &Self::ValidatorId) -> bool {
 		ValidatorLookup::<T>::contains_key(account)
 	}
+
+	fn is_auction_phase() -> bool {
+		Self::is_auction_phase()
+	}
 }
 
 impl<T: Config> pallet_session::SessionHandler<T::ValidatorId> for Pallet<T> {

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -5,6 +5,7 @@ use sp_std::prelude::*;
 use frame_support::traits::ValidatorRegistration;
 use codec::{Encode, Decode};
 use sp_runtime::RuntimeDebug;
+
 /// A trait abstracting the functionality of the witnesser
 pub trait Witnesser {
 	/// The type of accounts that can witness.
@@ -42,6 +43,9 @@ pub trait EpochInfo {
 
 	/// The current epoch we are in
 	fn epoch_index() -> Self::EpochIndex;
+
+	/// Whether or not we are currently in the auction resolution phase of the current Epoch.
+	fn is_auction_phase() -> bool;
 }
 
 /// Something that can provide us a list of candidates with their corresponding stakes


### PR DESCRIPTION
This addresses the possibility of an attack whereby someone might participate in a validator auction and, before the vault rotation concludes, withdraw their stake in order get a 'free' validator slot.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/99"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

