### PR TITLE
Update types.json

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -4,7 +4,7 @@
   "VoteCount": "u32",
   "TokenAmount": "u128",
   "Nonce": "u64",
-  "Duration": "u64",
+  "Duration": "(u64,u32)",
   "AccountInfo": "AccountInfoWithDualRefCount",
   "Address": "MultiAddress",
   "LookupSource": "MultiAddress",


### PR DESCRIPTION
Updates the `Duration` type from `u64` to `(u64,u32)`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

