### PR TITLE
throw error instead of ok on stop of eth broadcaster

### DIFF
--- a/engine/src/eth/eth_broadcaster.rs
+++ b/engine/src/eth/eth_broadcaster.rs
@@ -64,8 +64,9 @@ impl<M: IMQClient + Send + Sync> EthBroadcaster<M> {
             }
         }
 
-        log::info!("ETH broadcaster has stopped");
-        Ok(())
+        let err_msg = "ETH broadcaster has stopped!";
+        log::error!("{}", err_msg);
+        Err(anyhow::Error::msg(err_msg))
     }
 }
 


### PR DESCRIPTION
For: https://github.com/chainflip-io/chainflip-backend/issues/142

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/151"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

