### PR TITLE
Ci/testnet reset

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -212,7 +212,7 @@ steps:
     depends_on:
       - test-chainflip-backend
     settings:
-      username: s/Testnet/Testnet
+      username: Testnet Bot
       webhook_id:
         from_secret: discord_webhook_id
       webhook_token:
@@ -259,7 +259,7 @@ steps:
     depends_on:
       - create
     settings:
-      username: s/Testnet/Testnet
+      username: Testnet Bot
       webhook_id:
         from_secret: discord_webhook_id
       webhook_token:
@@ -277,7 +277,7 @@ steps:
       status:
         - failure
     settings:
-      username: s/Testnet/Testnet
+      username: Testnet Bot
       webhook_id:
         from_secret: discord_webhook_id
       webhook_token:


### PR DESCRIPTION
On every merge to `release/*` we we build new images, tear down the testnet, reset it with the new images. All devs will be notified on this before and after.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/183"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

