### PR TITLE
Store keys in a separate data structure

### DIFF
--- a/engine/src/signing/client/client_inner/common.rs
+++ b/engine/src/signing/client/client_inner/common.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use crate::{
+    p2p::ValidatorId,
+    signing::crypto::{Keys, Parameters, SharedKeys, VerifiableSS, GE},
+};
+
+use super::utils::ValidatorMaps;
+
+#[derive(Clone)]
+pub struct KeygenResult {
+    pub keys: Keys,
+    pub shared_keys: SharedKeys,
+    pub aggregate_pubkey: GE,
+    pub vss: Vec<VerifiableSS<GE>>,
+}
+
+// TODO: combine the two Arcs?
+#[derive(Clone)]
+pub struct KeygenResultInfo {
+    pub key: Arc<KeygenResult>,
+    pub validator_map: Arc<ValidatorMaps>,
+    pub params: Parameters,
+}
+
+impl KeygenResultInfo {
+    pub fn get_idx(&self, id: &ValidatorId) -> Option<usize> {
+        self.validator_map.get_idx(id)
+    }
+
+    pub fn get_id(&self, idx: usize) -> ValidatorId {
+        // providing an invalid idx is considered a programmer error here
+        self.validator_map
+            .get_id(idx)
+            .expect("invalid index")
+            .clone()
+    }
+}

--- a/engine/src/signing/client/client_inner/key_store.rs
+++ b/engine/src/signing/client/client_inner/key_store.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use crate::signing::KeyId;
+
+use super::common::KeygenResultInfo;
+
+// Successfully generated multisig keys live here
+#[derive(Clone)]
+pub struct KeyStore {
+    keys: HashMap<KeyId, KeygenResultInfo>,
+}
+
+impl KeyStore {
+    pub fn new() -> Self {
+        KeyStore {
+            keys: HashMap::new(),
+        }
+    }
+
+    pub fn get_key(&self, key_id: KeyId) -> Option<&KeygenResultInfo> {
+        self.keys.get(&key_id)
+    }
+
+    // Save `key` under key `key_id` overwriting if exists
+    pub fn set_key(&mut self, key_id: KeyId, key: KeygenResultInfo) {
+        self.keys.insert(key_id, key);
+    }
+}

--- a/engine/src/signing/client/client_inner/keygen_manager.rs
+++ b/engine/src/signing/client/client_inner/keygen_manager.rs
@@ -13,8 +13,8 @@ use crate::{
 
 use super::{
     client_inner::{Broadcast1, KeyGenMessageWrapped, KeygenData},
+    common::KeygenResultInfo,
     keygen_state::KeygenState,
-    signing_state::KeygenResultInfo,
     utils::get_our_idx,
     InnerEvent, KeygenOutcome,
 };
@@ -59,14 +59,6 @@ impl KeygenManager {
             our_id,
             phase_timeout,
         }
-    }
-
-    // Get the key that was generated as the result of
-    // a keygen ceremony between the winners of auction `id`
-    pub(super) fn get_key_info_by_id(&self, id: KeyId) -> Option<&KeygenResultInfo> {
-        let entry = self.keygen_states.get(&id)?;
-
-        entry.key_info.as_ref()
     }
 
     pub(super) fn process_keygen_message(

--- a/engine/src/signing/client/client_inner/keygen_state.rs
+++ b/engine/src/signing/client/client_inner/keygen_state.rs
@@ -22,8 +22,8 @@ use crate::{
 
 use super::{
     client_inner::{KeygenData, MultisigMessage},
+    common::KeygenResultInfo,
     shared_secret::SharedSecretState,
-    signing_state::KeygenResultInfo,
     utils::ValidatorMaps,
     InnerEvent,
 };
@@ -52,7 +52,6 @@ pub struct KeygenState {
     /// Multisig parameters are only stored here so we can put
     /// them inside `KeygenResultInfo` when we create the key
     params: Parameters,
-    pub(super) key_info: Option<KeygenResultInfo>,
     /// Last time we were able to make progress
     pub(super) last_message_timestamp: Instant,
 }
@@ -81,7 +80,6 @@ impl KeygenState {
             all_signer_idxs,
             delayed_next_stage_data: Vec::new(),
             key_id,
-            key_info: None,
             params,
             maps_for_validator_id_and_idx: Arc::new(idx_map),
             last_message_timestamp: Instant::now(),
@@ -266,8 +264,6 @@ impl KeygenState {
                     validator_map: Arc::clone(&self.maps_for_validator_id_and_idx),
                     params: self.params,
                 };
-
-                self.key_info = Some(key_info.clone());
 
                 return Some(key_info);
             }

--- a/engine/src/signing/client/client_inner/mod.rs
+++ b/engine/src/signing/client/client_inner/mod.rs
@@ -1,4 +1,6 @@
 mod client_inner;
+mod common;
+mod key_store;
 mod keygen_manager;
 mod keygen_state;
 mod shared_secret;

--- a/engine/src/signing/client/client_inner/shared_secret.rs
+++ b/engine/src/signing/client/client_inner/shared_secret.rs
@@ -8,7 +8,7 @@ use crate::signing::{
 
 use super::{
     client_inner::{Broadcast1, Secret2},
-    signing_state::KeygenResult,
+    common::KeygenResult,
 };
 
 use log::*;

--- a/engine/src/signing/client/client_inner/signing_state.rs
+++ b/engine/src/signing/client/client_inner/signing_state.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::time::Instant;
 
 use itertools::Itertools;
 use log::*;
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 
 use super::{
     client_inner::{InnerEvent, MultisigMessage, SigningDataWrapped},
-    utils::ValidatorMaps,
+    common::{KeygenResult, KeygenResultInfo},
 };
 
 use crate::{
@@ -20,42 +20,12 @@ use crate::{
             },
             SigningInfo,
         },
-        crypto::{Keys, LocalSig, Parameters, SharedKeys, Signature, VerifiableSS, GE},
+        crypto::{LocalSig, Parameters, Signature},
         MessageInfo,
     },
 };
 
 use super::{client_inner::SigningData, shared_secret::SharedSecretState};
-
-#[derive(Clone)]
-pub(super) struct KeygenResult {
-    pub(super) keys: Keys,
-    pub(super) shared_keys: SharedKeys,
-    pub(super) aggregate_pubkey: GE,
-    pub(super) vss: Vec<VerifiableSS<GE>>,
-}
-
-// TODO: combine the two Arcs?
-#[derive(Clone)]
-pub(super) struct KeygenResultInfo {
-    pub key: Arc<KeygenResult>,
-    pub validator_map: Arc<ValidatorMaps>,
-    pub params: Parameters,
-}
-
-impl KeygenResultInfo {
-    pub(super) fn get_idx(&self, id: &ValidatorId) -> Option<usize> {
-        self.validator_map.get_idx(id)
-    }
-
-    pub(super) fn get_id(&self, idx: usize) -> ValidatorId {
-        // providing an invalid idx is considered a programmer error here
-        self.validator_map
-            .get_id(idx)
-            .expect("invalid index")
-            .clone()
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(super) enum SigningStage {

--- a/engine/src/signing/client/client_inner/signing_state_manager.rs
+++ b/engine/src/signing/client/client_inner/signing_state_manager.rs
@@ -10,14 +10,14 @@ use crate::{
     p2p::ValidatorId,
     signing::{
         client::{client_inner::client_inner::SigningData, SigningInfo},
-        crypto::Parameters,
         MessageHash, MessageInfo,
     },
 };
 
 use super::{
     client_inner::{Broadcast1, InnerEvent, SigningDataWrapped},
-    signing_state::{KeygenResultInfo, SigningState},
+    common::KeygenResultInfo,
+    signing_state::SigningState,
 };
 
 /// Manages multiple signing states for multiple signing processes

--- a/engine/src/signing/client/client_inner/tests/signing_unit_tests.rs
+++ b/engine/src/signing/client/client_inner/tests/signing_unit_tests.rs
@@ -8,11 +8,7 @@ async fn should_await_bc1_after_rts() {
 
     let mut c1 = states.key_ready.clients[0].clone();
 
-    let key = c1
-        .get_keygen()
-        .get_key_info_by_id(KEY_ID)
-        .expect("no key")
-        .to_owned();
+    let key = c1.get_key(KEY_ID).expect("no key").to_owned();
 
     c1.signing_manager
         .on_request_to_sign(MESSAGE_HASH.clone(), key, SIGN_INFO.clone());
@@ -43,11 +39,7 @@ async fn should_process_delayed_bc1_after_rts() {
 
     assert_eq!(signing_delayed_count(&c1, &MESSAGE_INFO), 1);
 
-    let key = c1
-        .get_keygen()
-        .get_key_info_by_id(KEY_ID)
-        .expect("no key")
-        .to_owned();
+    let key = c1.get_key(KEY_ID).expect("no key").to_owned();
 
     c1.signing_manager
         .on_request_to_sign(MESSAGE_HASH.clone(), key, SIGN_INFO.clone());

--- a/engine/src/signing/client/client_inner/utils.rs
+++ b/engine/src/signing/client/client_inner/utils.rs
@@ -35,7 +35,7 @@ fn reorg_vector_works() {
 
 /// Mappings from signer_idx to Validator Id and back
 #[derive(Clone, Debug)]
-pub(super) struct ValidatorMaps {
+pub struct ValidatorMaps {
     id_to_idx: HashMap<ValidatorId, usize>,
     // TODO: create SortedVec and use it here:
     // Sorted Validator Ids
@@ -43,11 +43,11 @@ pub(super) struct ValidatorMaps {
 }
 
 impl ValidatorMaps {
-    pub(super) fn get_idx(&self, id: &ValidatorId) -> Option<usize> {
+    pub fn get_idx(&self, id: &ValidatorId) -> Option<usize> {
         self.id_to_idx.get(id).copied()
     }
 
-    pub(super) fn get_id(&self, idx: usize) -> Option<&ValidatorId> {
+    pub fn get_id(&self, idx: usize) -> Option<&ValidatorId> {
         let idx = idx.checked_sub(1)?;
         self.validator_ids.get(idx)
     }


### PR DESCRIPTION
Keys are now stored in `KeyStore` to decouple key generation from key storage.

This is in preparation for #229

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/250"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

