### PR TITLE
update StakeManager abi

### DIFF
--- a/engine/src/eth/abis/StakeManager.json
+++ b/engine/src/eth/abis/StakeManager.json
@@ -1,4 +1,4 @@
-[
+  [
     {
       "inputs": [
         {
@@ -332,6 +332,11 @@
               "internalType": "uint256",
               "name": "nonce",
               "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "kTimesGAddr",
+              "type": "address"
             }
           ],
           "internalType": "struct IShared.SigData",
@@ -382,6 +387,11 @@
               "internalType": "uint256",
               "name": "nonce",
               "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "kTimesGAddr",
+              "type": "address"
             }
           ],
           "internalType": "struct IShared.SigData",
@@ -417,6 +427,11 @@
               "internalType": "uint256",
               "name": "nonce",
               "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "kTimesGAddr",
+              "type": "address"
             }
           ],
           "internalType": "struct IShared.SigData",


### PR DESCRIPTION
Updates the StakeManager ABI to include the changes to the `Key` and `SigData` structs on the contract - only `SigData` is relevant to this contract.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/256"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

