### PR TITLE
Dump logs and destroy testnet on failure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -373,6 +373,9 @@ steps:
     pull: always
     image: ghcr.io/chainflip-io/infrastructure/chainflip-master:latest
     failure: ignore
+    when:
+      status:
+        - failure
     depends_on:
       - create
     commands:


### PR DESCRIPTION

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/257"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

We shouldn't keep the testnet going unnecessarily while the code does not work. This will tear it down if there is a failure in the pipeline