### PR TITLE
Use node endpoint instead of hostname port for eth node connection

### DIFF
--- a/engine/config/Default.toml
+++ b/engine/config/Default.toml
@@ -13,8 +13,7 @@ signing_key_file = ""
 ws_port = "9944"
 
 [eth]
-hostname = "localhost"
-port = "8545"
+node_endpoint = "wss://network.my_eth_node:80/<secret_key>"
 # Ethereum private key file path. Default is the docker secrets path. This file should contain a hex-encoded private key.
 private_key_file = "/run/secrets/eth_private_key"
 # Address used on the Ganache/Brownie tests

--- a/engine/config/Testing.toml
+++ b/engine/config/Testing.toml
@@ -13,8 +13,7 @@ signing_key_file = "./tests/test_keystore/alice_key"
 ws_port = "9944"
 
 [eth]
-hostname = "localhost"
-port = "8545"
+node_endpoint = "wss://network.my_eth_node:80/<secret_key>"
 # Ethereum private key file path. Default is the docker secrets path. This file should contain a hex-encoded private key.
 private_key_file = "/run/secrets/eth_private_key"
 # Address used on the Ganache/Brownie tests

--- a/engine/src/eth/eth_broadcaster.rs
+++ b/engine/src/eth/eth_broadcaster.rs
@@ -36,26 +36,24 @@ fn secret_key_from_file(filename: &Path) -> Result<SecretKey> {
 
 /// Adapter struct to build the ethereum web3 client from settings.
 struct EthClientBuilder {
-    hostname: String,
-    port: u16,
+    node_endpoint: String,
 }
 
 impl EthClientBuilder {
-    pub fn new(hostname: String, port: u16) -> Self {
-        Self { hostname, port }
+    pub fn new(node_endpoint: String) -> Self {
+        Self { node_endpoint }
     }
 
     /// Builds a web3 ethereum client with websocket transport.
     pub async fn ws_client(&self) -> Result<Web3<WebSocket>> {
-        let url = format!("ws://{}:{}", self.hostname, self.port);
-        let transport = web3::transports::WebSocket::new(url.as_str()).await?;
+        let transport = web3::transports::WebSocket::new(self.node_endpoint.as_str()).await?;
         Ok(Web3::new(transport))
     }
 }
 
 impl From<&settings::Settings> for EthClientBuilder {
     fn from(settings: &settings::Settings) -> Self {
-        EthClientBuilder::new(settings.eth.hostname.clone(), settings.eth.port)
+        EthClientBuilder::new(settings.eth.node_endpoint.clone())
     }
 }
 

--- a/engine/src/eth/stake_manager/mod.rs
+++ b/engine/src/eth/stake_manager/mod.rs
@@ -25,8 +25,8 @@ pub async fn start_stake_manager_witness(settings: settings::Settings) -> Result
     let mq_client = *factory.create().await?;
 
     let sm_sink = StakeManagerSink::<NatsMQClient>::new(mq_client).await?;
-    let eth_node_ws_url = format!("ws://{}:{}", settings.eth.hostname, settings.eth.port);
-    let sm_event_stream = EthEventStreamBuilder::new(eth_node_ws_url.as_str(), stake_manager);
+    let sm_event_stream =
+        EthEventStreamBuilder::new(settings.eth.node_endpoint.as_str(), stake_manager);
     let sm_event_stream = sm_event_stream.with_sink(sm_sink).build().await?;
     sm_event_stream
         .run(Some(0))

--- a/engine/src/settings.rs
+++ b/engine/src/settings.rs
@@ -21,8 +21,7 @@ pub struct StateChain {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Eth {
-    pub hostname: String,
-    pub port: u16,
+    pub node_endpoint: String,
 
     // TODO: Into an Ethereum Address type?
     pub stake_manager_eth_address: String,


### PR DESCRIPTION
Infura endpoints are specified like:
`wss://<network>.infura.io/<key_path/`

Previously this code would append the port after the path. Now it's simplified so you just include the whole endpoint, including protocol (which offers more flexibility on whether we use `ws` or `wss` too).

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/269"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

