### PR TITLE
Sc broadcaster nonce

### DIFF
--- a/engine/src/state_chain/sc_broadcaster.rs
+++ b/engine/src/state_chain/sc_broadcaster.rs
@@ -53,7 +53,7 @@ where
     ) -> Self {
         let sc_client = create_subxt_client(settings.state_chain.clone())
             .await
-            .unwrap();
+            .expect("Could not create subxt client");
 
         let account_id = signer.account_id();
         let nonce = sc_client


### PR DESCRIPTION
Previously the SC broadcaster would use the same nonce for each transaction it submitted causing an error.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/274"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

