### PR TITLE
Fix trailing comma in types.json

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -54,5 +54,5 @@
   "TokenAmount": "u128",
   "ValidatorId": "AccountId",
   "ValidatorSize": "u32",
-  "VoteCount": "u32",
+  "VoteCount": "u32"
 }


### PR DESCRIPTION
JSON spec doesn't allow it.  Not sure if its a problem though 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/277"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

