### PR TITLE
Remove step as it doesn't work as expected

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -316,21 +316,6 @@ steps:
       - cd cluster/applications/staging/chainflip-validator
       - ./build.sh --branch=$DRONE_COMMIT_BRANCH --destroy --rpc
 
-# Destroy the testnet in the source branch
-  - name: destroy-source-testnet
-    pull: always
-    image: ghcr.io/chainflip-io/infrastructure/chainflip-master:latest
-    failure: ignore
-    when:
-      branch:
-        - develop
-    depends_on:
-      - clone-cluster
-      - test-chainflip-backend
-    commands:
-      - cd cluster/applications/staging/chainflip-validator
-      - ./build.sh --branch=$DRONE_SOURCE_BRANCH --destroy --rpc
-
 # Create new testnet
   - name: create
     pull: always


### PR DESCRIPTION
This actually just deletes develop again, DRONE_SOURCE_BRANCH is not the branch where the request came from 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

