### PR TITLE
Remove default implementation of take_stream() on the p2p conductor

### DIFF
--- a/engine/src/p2p/conductor.rs
+++ b/engine/src/p2p/conductor.rs
@@ -33,7 +33,7 @@ where
         let stream = mq
             .subscribe::<P2PMessageCommand>(Subject::P2POutgoing)
             .await
-            .unwrap();
+            .expect("Should be able to subscribe to Subject::P2POutgoing");
 
         P2PConductor {
             mq,
@@ -50,7 +50,12 @@ where
 
         let mq_stream = mq_stream.map(Msg::Left);
 
-        let p2p_stream = self.p2p.take_stream().await.unwrap().map(Msg::Right);
+        let p2p_stream = self
+            .p2p
+            .take_stream()
+            .await
+            .expect("Should have p2p stream")
+            .map(Msg::Right);
 
         let mut stream = futures::stream::select(mq_stream, p2p_stream);
 

--- a/engine/src/p2p/mod.rs
+++ b/engine/src/p2p/mod.rs
@@ -32,9 +32,7 @@ pub trait P2PNetworkClient<B: Base58, S: Stream<Item = P2PMessage>> {
     /// Send to a specific `validator` only
     async fn send(&self, to: &B, data: &[u8]) -> Result<StatusCode, P2PNetworkClientError>;
 
-    async fn take_stream(&mut self) -> Result<S, P2PNetworkClientError> {
-        Err(P2PNetworkClientError::Rpc)
-    }
+    async fn take_stream(&mut self) -> Result<S, P2PNetworkClientError>;
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/296"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

