### PR TITLE
feature/CH-737/enforce-address-staking-pallet

### DIFF
--- a/state-chain/pallets/cf-staking/src/lib.rs
+++ b/state-chain/pallets/cf-staking/src/lib.rs
@@ -563,11 +563,12 @@ impl<T: Config> Pallet<T> {
 			match (withdrawal_address, existing_withdrawal_address) {
 				// User account exists and both addresses hold a value - the value of both addresses is different
 				(Some(provided), Some(existing)) if provided != existing => {
-					Self::log_failed_stake_attempt(account_id, provided, amount)?;
+					Self::log_failed_stake_attempt(account_id, provided, amount)?
 				}
-				// Only the provided address exists
+				// Only the provided address exists:
+				// We only want to add a new withdrawal address if this is the first staking attempt, ie. the account doesn't exist.
 				(Some(provided), None) => {
-					Self::log_failed_stake_attempt(account_id, provided, amount)?;
+					Self::log_failed_stake_attempt(account_id, provided, amount)?
 				}
 				_ => (),
 			}


### PR DESCRIPTION
* added ReturnAddress
* added FailedStakeAttempts storage
* implemented basic logic of using a return address provided by the stake manager
* updated tests

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/309"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

