### PR TITLE
More readable CLI logs from slog

### DIFF
--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -9,7 +9,7 @@ pub mod test_utils {
     use slog::{o, Drain, Fuse, Level, OwnedKVList, Record};
     use std::result;
 
-    pub struct PrintlnDrain;
+    struct PrintlnDrain;
 
     impl Drain for PrintlnDrain {
         type Ok = ();


### PR DESCRIPTION
The new JSON logs are not great to read on a CLI when running tests. So I looked at the [PrintlnDrain ](https://github.com/slog-rs/slog/blob/master/examples/common/mod.rs) example from Slog GH made a simple version of it to get logs like we used to have. It works well and even has color for the event level.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/369"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

