### PR TITLE
Remove P2PConductor

### DIFF
--- a/engine/src/p2p/conductor.rs
+++ b/engine/src/p2p/conductor.rs
@@ -10,69 +10,45 @@ use crate::{
 
 use super::{P2PMessageCommand, P2PNetworkClient};
 use crate::p2p::ValidatorId;
-use std::{marker::PhantomData, pin::Pin};
 
 /// Intermediates P2P events between MQ and P2P interface
-pub struct P2PConductor<MQ, P2P, S>
-where
-    MQ: IMQClient + Send,
-    S: Stream<Item = P2PMessage>,
-    P2P: P2PNetworkClient<ValidatorId, S>,
-{
+pub fn start<S, P2P, MQ>(
+    mut p2p: P2P,
     mq: MQ,
-    p2p: P2P,
-    stream: Pin<Box<dyn Stream<Item = Result<P2PMessageCommand, anyhow::Error>>>>,
-    marker: PhantomData<S>,
-    logger: slog::Logger,
-}
-
-impl<MQ, P2P, S> P2PConductor<MQ, P2P, S>
+    mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    logger: &slog::Logger,
+) -> impl futures::Future
 where
     MQ: IMQClient + Send,
     S: Stream<Item = P2PMessage> + Unpin,
     P2P: P2PNetworkClient<ValidatorId, S> + Send,
 {
-    pub async fn new(mq: MQ, p2p: P2P, logger: &slog::Logger) -> Self {
-        let stream = mq
+    let logger = logger.new(o!(COMPONENT_KEY => "P2PConductor"));
+
+    async move {
+        slog::info!(logger, "Starting");
+
+        let mut p2p_command_stream = mq
             .subscribe::<P2PMessageCommand>(Subject::P2POutgoing)
             .await
             .expect("Should be able to subscribe to Subject::P2POutgoing");
 
-        P2PConductor {
-            mq,
-            p2p,
-            stream,
-            marker: PhantomData,
-            logger: logger.new(o!(COMPONENT_KEY => "P2PConductor")),
-        }
-    }
-
-    pub async fn start(mut self, mut shutdown_rx: tokio::sync::oneshot::Receiver<()>) {
-        slog::info!(self.logger, "Starting");
-
-        let mut p2p_command_stream = self.stream;
-
-        let mut p2p_stream = self
-            .p2p
-            .take_stream()
-            .await
-            .expect("Should have p2p stream");
+        let mut p2p_stream = p2p.take_stream().await.expect("Should have p2p stream");
 
         loop {
             tokio::select! {
                 Some(outgoing) = p2p_command_stream.next() => {
                     if let Ok(P2PMessageCommand { destination, data }) = outgoing {
-                        self.p2p.send(&destination, &data).await.expect("Could not send outgoing P2PMessageCommand");
+                        p2p.send(&destination, &data).await.expect("Could not send outgoing P2PMessageCommand");
                     }
                 }
                 Some(incoming) = p2p_stream.next() => {
-                    self.mq
-                    .publish::<P2PMessage>(Subject::P2PIncoming, &incoming)
-                    .await
-                    .expect("Could not publish incoming message to Subject::P2PIncoming");
+                    mq.publish::<P2PMessage>(Subject::P2PIncoming, &incoming)
+                        .await
+                        .expect("Could not publish incoming message to Subject::P2PIncoming");
                 }
                 Ok(()) = &mut shutdown_rx =>{
-                    slog::info!(self.logger, "Shutting down");
+                    slog::info!(logger, "Shutting down");
                     break;
                 }
             }
@@ -115,7 +91,6 @@ mod tests {
         let mc1 = mq.get_client();
         let mc1_copy = mq.get_client();
         let p2p_client_1 = network.new_client(id_1);
-        let conductor_1 = P2PConductor::new(mc1, p2p_client_1, &logger).await;
 
         // Validator 2 setup
         let id_2: ValidatorId = ValidatorId::new(2);
@@ -124,18 +99,17 @@ mod tests {
         let mc2 = mq.get_client();
         let mc2_copy = mq.get_client();
         let p2p_client_2 = network.new_client(id_2.clone());
-        let conductor_2 = P2PConductor::new(mc2, p2p_client_2, &logger).await;
 
         let (_, shutdown_conductor1_rx) = tokio::sync::oneshot::channel::<()>();
         let (_, shutdown_conductor2_rx) = tokio::sync::oneshot::channel::<()>();
 
         let conductor_fut_1 = timeout(
             Duration::from_millis(100),
-            conductor_1.start(shutdown_conductor1_rx),
+            start(p2p_client_1, mc1, shutdown_conductor1_rx, &logger),
         );
         let conductor_fut_2 = timeout(
             Duration::from_millis(100),
-            conductor_2.start(shutdown_conductor2_rx),
+            start(p2p_client_2, mc2, shutdown_conductor2_rx, &logger),
         );
 
         let msg = String::from("hello");

--- a/engine/src/p2p/mod.rs
+++ b/engine/src/p2p/mod.rs
@@ -2,12 +2,11 @@
 #[cfg(test)]
 pub mod mock;
 
-mod conductor;
+pub mod conductor;
 mod rpc;
 
 use std::convert::TryInto;
 
-pub use conductor::P2PConductor;
 pub use rpc::RpcP2PClient;
 
 use serde::{Deserialize, Serialize};

--- a/engine/src/signing/tests/distributed_signing.rs
+++ b/engine/src/signing/tests/distributed_signing.rs
@@ -10,7 +10,7 @@ use tokio::time::Duration;
 use crate::{
     logging,
     mq::{mq_mock::MQMock, IMQClient, Subject},
-    p2p::{mock::NetworkMock, P2PConductor, ValidatorId},
+    p2p::{self, mock::NetworkMock, ValidatorId},
     signing::db::KeyDBMock,
 };
 
@@ -203,12 +203,15 @@ async fn distributed_signing() {
 
                 let mq_client = mq.get_client();
 
-                let conductor = P2PConductor::new(mq_client.clone(), p2p_client, &logger).await;
-
                 let (shutdown_conductor_tx, shutdown_conductor_rx) =
                     tokio::sync::oneshot::channel::<()>();
 
-                let conductor_fut = conductor.start(shutdown_conductor_rx);
+                let conductor_fut = p2p::conductor::start(
+                    p2p_client,
+                    mq_client.clone(),
+                    shutdown_conductor_rx,
+                    &logger,
+                );
 
                 let db = KeyDBMock::new();
 


### PR DESCRIPTION
Replaces the P2PConductor with a start function, like the rest of the CFE futures.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/371"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

