### PR TITLE
Fix for eth event streamer missing events

### DIFF
--- a/engine/src/eth/key_manager/key_manager.rs
+++ b/engine/src/eth/key_manager/key_manager.rs
@@ -125,10 +125,20 @@ impl Display for KeyManagerEvent {
 impl EventSource for KeyManager {
     type Event = KeyManagerEvent;
 
-    fn filter_builder(&self, block: BlockNumber) -> FilterBuilder {
-        FilterBuilder::default()
-            .from_block(block)
-            .address(vec![self.deployed_address])
+    fn filter_builder(
+        &self,
+        from_block: BlockNumber,
+        to_block: Option<BlockNumber>,
+    ) -> FilterBuilder {
+        match to_block {
+            Some(to_block) => FilterBuilder::default()
+                .from_block(from_block)
+                .to_block(to_block)
+                .address(vec![self.deployed_address]),
+            None => FilterBuilder::default()
+                .from_block(from_block)
+                .address(vec![self.deployed_address]),
+        }
     }
 
     fn parse_event(&self, log: web3::types::Log) -> Result<Self::Event> {

--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -30,9 +30,13 @@ pub trait EventSource {
     /// The Event type expected from this contract. Likely to be an enum of all possible events.
     type Event: Clone + Send + Sync + std::fmt::Debug;
 
-    /// Returns an eth filter for the events from the contract, starting at the given
-    /// block number.
-    fn filter_builder(&self, block: BlockNumber) -> FilterBuilder;
+    /// Returns an eth filter for the events from the contract
+    /// spanning from 'from_block' to 'to_block' or no end if 'to_block' is None.
+    fn filter_builder(
+        &self,
+        from_block: BlockNumber,
+        to_block: Option<BlockNumber>,
+    ) -> FilterBuilder;
 
     /// Attempt to parse an event from an ethereum Log item.
     fn parse_event(&self, log: web3::types::Log) -> Result<Self::Event>;

--- a/engine/src/eth/stake_manager/stake_manager.rs
+++ b/engine/src/eth/stake_manager/stake_manager.rs
@@ -212,10 +212,20 @@ fn node_id_from_log(log: &Log) -> Result<AccountId32> {
 impl EventSource for StakeManager {
     type Event = StakeManagerEvent;
 
-    fn filter_builder(&self, block: BlockNumber) -> FilterBuilder {
-        FilterBuilder::default()
-            .from_block(block)
-            .address(vec![self.deployed_address])
+    fn filter_builder(
+        &self,
+        from_block: BlockNumber,
+        to_block: Option<BlockNumber>,
+    ) -> FilterBuilder {
+        match to_block {
+            Some(to_block) => FilterBuilder::default()
+                .from_block(from_block)
+                .to_block(to_block)
+                .address(vec![self.deployed_address]),
+            None => FilterBuilder::default()
+                .from_block(from_block)
+                .address(vec![self.deployed_address]),
+        }
     }
 
     fn parse_event(&self, log: web3::types::Log) -> Result<Self::Event> {


### PR DESCRIPTION
Addresses Issue #375.
I think this solves it, but i'm not 100% because its hard to test the exact condition.
So by making the past_logs and future_logs decide the blocks that they will get up to before hand removes the use of BlockNumber::Pending and shouldn't allow any blocks to be missed... unless that comment about from_block being unreliable is true. In that case, i'm not sure what to do to fix it.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/382"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

