### PR TITLE
fix/missing-std-section

### DIFF
--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -113,4 +113,5 @@ std = [
   'pallet-cf-emissions/std',
   'pallet-cf-rewards/std',
   'pallet-cf-witnesser-api/std',
+  'pallet-cf-reputation/std',
 ]


### PR DESCRIPTION
Added pallet-cf-reputation/std to runtime Cargo.toml

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

