### PR TITLE
use to_str for the path

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -65,10 +65,7 @@ async fn main() {
     };
 
     // TODO: Investigate whether we want to encrypt it on disk
-    let db = PersistentKeyDB::new(
-        &settings.signing.db_file.to_str().expect("Invalid path"),
-        &root_logger,
-    );
+    let db = PersistentKeyDB::new(&settings.signing.db_file.as_path(), &root_logger);
 
     let (_, p2p_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let (_, shutdown_client_rx) = tokio::sync::oneshot::channel::<()>();

--- a/engine/src/signing/db/persistent.rs
+++ b/engine/src/signing/db/persistent.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, convert::TryInto, path::Path};
 
 use super::KeyDB;
 use kvdb_rocksdb::{Database, DatabaseConfig};
@@ -17,10 +17,11 @@ pub struct PersistentKeyDB {
 }
 
 impl PersistentKeyDB {
-    // TODO: Update to kvdb 14 and then can pass in &Path
-    pub fn new(path: &str, logger: &slog::Logger) -> Self {
+    pub fn new(path: &Path, logger: &slog::Logger) -> Self {
         let config = DatabaseConfig::default();
-        let db = Database::open(&config, path).expect("could not open database");
+        // TODO: Update to kvdb 14 and then can pass in &Path
+        let db = Database::open(&config, path.to_str().expect("Invalid path"))
+            .expect("could not open database");
 
         PersistentKeyDB {
             db,


### PR DESCRIPTION
This is to get develop branch building again. I'll look at upgrading the kvdb version, such that we don't have to `unwrap`/`expect` here. The latest version of kvdb takes an `AsRef<Path>`, so it will be neater once / if we can upgrade.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/431"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

