### PR TITLE
Test/circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,7 @@ orbs:
 workflows:
   chainflip-backend-checks:
     jobs:
-      - lint:
-          context:
-            - ghcr-credentials
-          <<: *ignore_main_branches
       - build-rust-base:
-          requires:
-            - lint
           context:
             - ghcr-credentials
           <<: *ignore_main_branches
@@ -45,13 +39,6 @@ workflows:
           <<: *ignore_main_branches
 
 jobs:
-  lint:
-    docker:
-      - image: circleci/circleci-cli
-    steps:
-      - checkout
-      - run: circleci config validate
-
   build-rust-base:
     executor: docker/docker
     steps:


### PR DESCRIPTION
This PR literally ports the main and most important job we have (PR checks) to CircleCI. 

Having spent some time using it, I really think this is a far more production ready system. 

Notable differences:

1. Easily configure machine size depending on the job
2. Beautitful easy to use UI
3. Comprehensive UI structure allowing for massive flexibility when configuring workflows
4. Organisation wide secret management
5. Contexts allow you to specify the right secrets/resources for the right job
6. Similar implementation as drone with plugins only better
7. Faster build times (3m40 for a check)
8. Potential for test visualisation and tracking
9. Ability to run Runners in k8s as well for our Testnet 
10. Granular job status' allowing us to block merging on only certain conditions
11. Save money on wasted resources within K8s
12. Make my life easier 😄
13. Requires no change from developer side

I also set up a redis instance in Digital Ocean with a massive RAM to work as our cache. This also allows developers to use this cache for their machine builds.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/472"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

