### PR TITLE
[ch1766] Vault Witness

### DIFF
--- a/engine/config/Default.toml
+++ b/engine/config/Default.toml
@@ -17,6 +17,7 @@ private_key_file = "/run/secrets/eth_private_key"
 # Address used on the Ganache/Brownie tests
 key_manager_eth_address = "0xdBa9b6065Deb6Cc057BC779fF6736709ecBa3409"
 stake_manager_eth_address = "0xEAd5De9C41543E4bAbB09f9fE4f79153c036044f"
+vault_contract_eth_address = "0x70bC6D873D110Da59a9c49E7485a27B0F605E5db"
 
 [health_check]
 hostname = "0.0.0.0"

--- a/engine/config/Testing.toml
+++ b/engine/config/Testing.toml
@@ -17,6 +17,7 @@ private_key_file = "/run/secrets/eth_private_key"
 # Address used on the Ganache/Brownie tests
 key_manager_eth_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
 stake_manager_eth_address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+vault_contract_eth_address = "0x70bC6D873D110Da59a9c49E7485a27B0F605E5db"
 
 [health_check]
 hostname = "127.0.0.1"
@@ -25,5 +26,5 @@ port = 5555
 [signing]
 db_file = "data.db"
 genesis_validator_ids = [
-    [212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125], # alice
+  [212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125], # alice
 ]

--- a/engine/src/eth/abis/Vault.json
+++ b/engine/src/eth/abis/Vault.json
@@ -1,0 +1,398 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "contract IKeyManager",
+                "name": "keyManager",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "lowLevelData",
+                "type": "bytes"
+            }
+        ],
+        "name": "TransferFailed",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "fetchSwapIDs",
+                "type": "bytes32[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "fetchTokenAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "tranTokenAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address payable[]",
+                "name": "tranRecipients",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "tranAmounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "allBatch",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "swapID",
+                "type": "bytes32"
+            }
+        ],
+        "name": "fetchDepositEth",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "swapIDs",
+                "type": "bytes32[]"
+            }
+        ],
+        "name": "fetchDepositEthBatch",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "swapID",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "tokenAddr",
+                "type": "address"
+            }
+        ],
+        "name": "fetchDepositToken",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "bytes32[]",
+                "name": "swapIDs",
+                "type": "bytes32[]"
+            },
+            {
+                "internalType": "address[]",
+                "name": "tokenAddrs",
+                "type": "address[]"
+            }
+        ],
+        "name": "fetchDepositTokenBatch",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getKeyManager",
+        "outputs": [
+            {
+                "internalType": "contract IKeyManager",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            }
+        ],
+        "name": "sendEth",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "address",
+                "name": "tokenAddr",
+                "type": "address"
+            },
+            {
+                "internalType": "address payable",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "msgHash",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "sig",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "nonce",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "kTimesGAddr",
+                        "type": "address"
+                    }
+                ],
+                "internalType": "struct IShared.SigData",
+                "name": "sigData",
+                "type": "tuple"
+            },
+            {
+                "internalType": "address[]",
+                "name": "tokenAddrs",
+                "type": "address[]"
+            },
+            {
+                "internalType": "address payable[]",
+                "name": "recipients",
+                "type": "address[]"
+            },
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "transferBatch",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -1,5 +1,6 @@
 pub mod key_manager;
 pub mod stake_manager;
+pub mod vault_witness;
 
 pub mod eth_event_streamer;
 

--- a/engine/src/eth/vault_witness.rs
+++ b/engine/src/eth/vault_witness.rs
@@ -1,0 +1,185 @@
+//! Contains the information required to use the Vault contract as a source for
+//! the EthEventStreamer
+
+use std::sync::{Arc, Mutex};
+
+use crate::{
+    eth::{eth_event_streamer, utils, EventParseError, SignatureAndEvent},
+    logging::COMPONENT_KEY,
+    settings,
+    state_chain::runtime::StateChainRuntime,
+};
+
+use substrate_subxt::{Client, PairSigner};
+
+use web3::{
+    ethabi::{self, RawLog},
+    transports::WebSocket,
+    types::{H160, H256},
+    Web3,
+};
+
+use anyhow::Result;
+use futures::{Future, Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use slog::o;
+
+/// Set up the eth event streamer for the vault contract, and start it
+pub async fn start_vault_witness(
+    web3: &Web3<WebSocket>,
+    settings: &settings::Settings,
+    _signer: Arc<Mutex<PairSigner<StateChainRuntime, sp_core::sr25519::Pair>>>,
+    _subxt_client: Client<StateChainRuntime>,
+    logger: &slog::Logger,
+) -> Result<impl Future> {
+    let logger = logger.new(o!(COMPONENT_KEY => "VaultWitness"));
+    slog::info!(logger, "Starting Vault witness");
+
+    slog::info!(logger, "Load Contract ABI");
+    let vault_witness = VaultWitness::new(&settings)?;
+
+    slog::info!(logger, "Creating Event Stream");
+    let mut event_stream = vault_witness
+        .event_stream(web3, settings.eth.from_block, &logger)
+        .await?;
+
+    Ok(async move {
+        while let Some(result_event) = event_stream.next().await {
+            match result_event.unwrap() {
+                // TODO: Handle unwraps
+                VaultEvent::TransferFailed { .. } => {
+                    todo!();
+                }
+            }
+        }
+    })
+}
+#[derive(Clone)]
+/// A wrapper for the Vault Ethereum contract.
+pub struct VaultWitness {
+    pub deployed_address: H160,
+    contract: ethabi::Contract,
+}
+
+/// Represents the events that are expected from the Vault contract.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VaultEvent {
+    /// The `Staked(nodeId, amount)` event.
+    TransferFailed {
+        /// The address of the recipient of the transfer
+        recipient: ethabi::Address,
+        /// The amount to transfer, in wei (uint)
+        amount: u128,
+        /// The data returned by the error
+        low_level_data: ethabi::Bytes,
+        /// Transaction hash that created the event
+        tx_hash: [u8; 32],
+    },
+}
+
+impl VaultWitness {
+    /// Loads the contract abi to get event definitions
+    pub fn new(settings: &settings::Settings) -> Result<Self> {
+        let contract = ethabi::Contract::load(std::include_bytes!("abis/Vault.json").as_ref())?;
+        Ok(Self {
+            deployed_address: settings.eth.vault_contract_eth_address,
+            contract,
+        })
+    }
+
+    // TODO: Maybe try to factor this out (See StakeManager)
+    pub async fn event_stream(
+        &self,
+        web3: &Web3<WebSocket>,
+        from_block: u64,
+        logger: &slog::Logger,
+    ) -> Result<impl Stream<Item = Result<VaultEvent>>> {
+        eth_event_streamer::new_eth_event_stream(
+            web3,
+            self.deployed_address,
+            self.decode_log_closure()?,
+            from_block,
+            logger,
+        )
+        .await
+    }
+
+    pub fn decode_log_closure(&self) -> Result<impl Fn(H256, H256, RawLog) -> Result<VaultEvent>> {
+        let transfer_failed = SignatureAndEvent::new(&self.contract, "TransferFailed")?;
+
+        Ok(
+            move |signature: H256, tx_hash: H256, raw_log: RawLog| -> Result<VaultEvent> {
+                let tx_hash = tx_hash.to_fixed_bytes();
+                if signature == transfer_failed.signature {
+                    let log = transfer_failed.event.parse_log(raw_log)?;
+                    let event = VaultEvent::TransferFailed {
+                        recipient: utils::decode_log_param(&log, "recipient")?,
+                        amount: utils::decode_log_param::<ethabi::Uint>(&log, "amount")?.as_u128(),
+                        low_level_data: utils::decode_log_param(&log, "lowLevelData")?,
+                        tx_hash,
+                    };
+                    Ok(event)
+                } else {
+                    Err(anyhow::Error::from(EventParseError::UnexpectedEvent(
+                        signature,
+                    )))
+                }
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use web3::types::H256;
+
+    use super::*;
+
+    #[test]
+    fn test_key_change_parsing() {
+        let settings = settings::test_utils::new_test_settings().unwrap();
+        let vault_witness = VaultWitness::new(&settings).unwrap();
+
+        let decode_log = vault_witness.decode_log_closure().unwrap();
+
+        let transfer_failed_event_signature =
+            H256::from_str("0x6a67a47f2d3e3318710790c8238d45019beef95e77203aa85cf756eec2dc539e")
+                .unwrap();
+
+        let transaction_hash =
+            H256::from_str("0x7e0ea5c0fa52294b74c12d8da0299476cffeaa82fff71a8d366dd2aa383a94a1")
+                .unwrap();
+
+        match decode_log(
+            transfer_failed_event_signature,
+            transaction_hash,
+            RawLog {
+                topics : vec![transfer_failed_event_signature],
+                data : hex::decode("0000000000000000000000009e4c14403d7d9a8a782044e86a93cae09d7b2ac9000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000").unwrap()
+            }
+        ).expect("Failed parsing AGG_SET_AGG_LOG event") {
+            VaultEvent::TransferFailed {
+                recipient,
+                amount,
+                low_level_data,
+                tx_hash,
+            } => {
+                assert_eq!(
+                    recipient,
+                    H160::from_str("0x9e4c14403d7d9a8a782044e86a93cae09d7b2ac9").unwrap()
+                );
+                assert_eq!(amount, 100000000000000000);
+                assert!(low_level_data.is_empty());
+                assert_eq!(
+                    tx_hash,
+                    H256::from_str(
+                        "0x7e0ea5c0fa52294b74c12d8da0299476cffeaa82fff71a8d366dd2aa383a94a1",
+                    )
+                    .unwrap()
+                    .to_fixed_bytes()
+                );
+            }
+        }
+    }
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use chainflip_engine::{
-    eth::{self, eth_broadcaster, eth_tx_encoding, key_manager, stake_manager},
+    eth::{eth_broadcaster, eth_tx_encoding, key_manager, stake_manager, vault_witness},
     health::HealthMonitor,
     heartbeat,
     mq::nats_client::NatsMQClient,
@@ -129,6 +129,15 @@ async fn main() {
         .await
         .unwrap(),
         key_manager::start_key_manager_witness(
+            &web3,
+            &settings,
+            pair_signer,
+            subxt_client,
+            &root_logger
+        )
+        .await
+        .unwrap(),
+        vault_witness::start_vault_witness(
             &web3,
             &settings,
             pair_signer,

--- a/engine/src/settings.rs
+++ b/engine/src/settings.rs
@@ -31,6 +31,7 @@ pub struct Eth {
     pub node_endpoint: String,
     pub stake_manager_eth_address: H160,
     pub key_manager_eth_address: H160,
+    pub vault_contract_eth_address: H160,
     #[serde(deserialize_with = "deser_path")]
     pub private_key_file: PathBuf,
 }


### PR DESCRIPTION
Addresses [ch1766](https://app.clubhouse.io/chainflip/story/1766/vault-witness)
I didn't realise that this wasn't needed for Sandstorm. The vault contract was the only one that didn't have a witness for its event, so i added it. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/474"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

