### PR TITLE
Partially Revert "ValidatorId -> AccountId" on state chain

### DIFF
--- a/state-chain/pallets/cf-auction/src/lib.rs
+++ b/state-chain/pallets/cf-auction/src/lib.rs
@@ -72,21 +72,18 @@ pub mod pallet {
 		/// An amount for a bid
 		type Amount: Member + Parameter + Default + Eq + Ord + Copy + AtLeast32BitUnsigned;
 		/// An identity for a validator
-		type AccountId: Member + Parameter;
+		type ValidatorId: Member + Parameter;
 		/// Providing bidders
-		type BidderProvider: BidderProvider<
-			AccountId = <Self as pallet::Config>::AccountId,
-			Amount = Self::Amount,
-		>;
+		type BidderProvider: BidderProvider<ValidatorId = Self::ValidatorId, Amount = Self::Amount>;
 		/// To confirm we have a session key registered for a validator
-		type Registrar: ValidatorRegistration<<Self as pallet::Config>::AccountId>;
+		type Registrar: ValidatorRegistration<Self::ValidatorId>;
 		/// An index for the current auction
 		type AuctionIndex: Member + Parameter + Default + Add + One + Copy;
 		/// Minimum amount of bidders
 		#[pallet::constant]
 		type MinAuctionSize: Get<u32>;
 		/// The lifecycle of our auction
-		type Handler: VaultRotation<AccountId = <Self as pallet::Config>::AccountId>;
+		type Handler: VaultRotation<ValidatorId = Self::ValidatorId>;
 	}
 
 	/// Pallet implements [`Hooks`] trait
@@ -97,7 +94,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn current_phase)]
 	pub(super) type CurrentPhase<T: Config> =
-		StorageValue<_, AuctionPhase<<T as pallet::Config>::AccountId, T::Amount>, ValueQuery>;
+		StorageValue<_, AuctionPhase<T::ValidatorId, T::Amount>, ValueQuery>;
 
 	/// Size range for number of bidders in auction (min, max)
 	#[pallet::storage]
@@ -112,8 +109,7 @@ pub mod pallet {
 	/// The set of bad validators
 	#[pallet::storage]
 	#[pallet::getter(fn bad_validators)]
-	pub(super) type BadValidators<T: Config> =
-		StorageValue<_, Vec<<T as pallet::Config>::AccountId>, ValueQuery>;
+	pub(super) type BadValidators<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
@@ -121,7 +117,7 @@ pub mod pallet {
 		/// An auction phase has started \[auction_index\]
 		AuctionStarted(T::AuctionIndex),
 		/// An auction has a set of winners \[auction_index, winners\]
-		AuctionCompleted(T::AuctionIndex, Vec<<T as pallet::Config>::AccountId>),
+		AuctionCompleted(T::AuctionIndex, Vec<T::ValidatorId>),
 		/// The auction has been confirmed off-chain \[auction_index\]
 		AuctionConfirmed(T::AuctionIndex),
 		/// Awaiting bidders for the auction
@@ -193,7 +189,7 @@ pub mod pallet {
 }
 
 impl<T: Config> Auction for Pallet<T> {
-	type AccountId = <T as pallet::Config>::AccountId;
+	type ValidatorId = T::ValidatorId;
 	type Amount = T::Amount;
 	type BidderProvider = T::BidderProvider;
 
@@ -222,7 +218,7 @@ impl<T: Config> Auction for Pallet<T> {
 		Ok(old)
 	}
 
-	fn phase() -> AuctionPhase<Self::AccountId, Self::Amount> {
+	fn phase() -> AuctionPhase<Self::ValidatorId, Self::Amount> {
 		<CurrentPhase<T>>::get()
 	}
 
@@ -234,7 +230,7 @@ impl<T: Config> Auction for Pallet<T> {
 	///
 	/// At each phase we assess the bidders based on a fixed set of criteria which results
 	/// in us arriving at a winning list and a bond set for this auction
-	fn process() -> Result<AuctionPhase<Self::AccountId, Self::Amount>, AuctionError> {
+	fn process() -> Result<AuctionPhase<Self::ValidatorId, Self::Amount>, AuctionError> {
 		return match <CurrentPhase<T>>::get() {
 			// Run some basic rules on what we consider as valid bidders
 			// At the moment this includes checking that their bid is more than 0, which
@@ -277,7 +273,7 @@ impl<T: Config> Auction for Pallet<T> {
 					let bidders = bidders.get(0..max_size as usize);
 					if let Some(bidders) = bidders {
 						if let Some((_, min_bid)) = bidders.last() {
-							let winners: Vec<Self::AccountId> =
+							let winners: Vec<T::ValidatorId> =
 								bidders.iter().map(|i| i.0.clone()).collect();
 							let phase = AuctionPhase::WinnersSelected(winners.clone(), *min_bid);
 							<CurrentPhase<T>>::put(phase.clone());
@@ -325,14 +321,14 @@ impl<T: Config> Auction for Pallet<T> {
 }
 
 impl<T: Config> VaultRotationHandler for Pallet<T> {
-	type AccountId = <T as pallet::Config>::AccountId;
+	type ValidatorId = T::ValidatorId;
 
 	fn abort() {
 		<CurrentPhase<T>>::put(AuctionPhase::default());
 		Self::deposit_event(Event::AuctionAborted(<CurrentAuctionIndex<T>>::get()));
 	}
 
-	fn penalise(bad_validators: Vec<Self::AccountId>) {
+	fn penalise(bad_validators: Vec<Self::ValidatorId>) {
 		BadValidators::<T>::set(bad_validators);
 	}
 }

--- a/state-chain/pallets/cf-auction/src/mock.rs
+++ b/state-chain/pallets/cf-auction/src/mock.rs
@@ -15,19 +15,19 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 type Amount = u64;
-type AccountId = u64;
+type ValidatorId = u64;
 
-pub const LOW_BID: (AccountId, Amount) = (2, 2);
-pub const JOE_BID: (AccountId, Amount) = (3, 100);
-pub const MAX_BID: (AccountId, Amount) = (4, 101);
-pub const INVALID_BID: (AccountId, Amount) = (1, 0);
+pub const LOW_BID: (ValidatorId, Amount) = (2, 2);
+pub const JOE_BID: (ValidatorId, Amount) = (3, 100);
+pub const MAX_BID: (ValidatorId, Amount) = (4, 101);
+pub const INVALID_BID: (ValidatorId, Amount) = (1, 0);
 
 pub const MIN_AUCTION_SIZE: u32 = 2;
 pub const MAX_AUCTION_SIZE: u32 = 150;
 
 thread_local! {
 	// A set of bidders, we initialise this with the proposed genesis bidders
-	pub static BIDDER_SET: RefCell<Vec<(AccountId, Amount)>> = RefCell::new(vec![
+	pub static BIDDER_SET: RefCell<Vec<(ValidatorId, Amount)>> = RefCell::new(vec![
 		INVALID_BID, LOW_BID, JOE_BID, MAX_BID
 	]);
 }
@@ -79,7 +79,7 @@ parameter_types! {
 impl Config for Test {
 	type Event = Event;
 	type Amount = Amount;
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 	type BidderProvider = TestBidderProvider;
 	type Registrar = Test;
 	type AuctionIndex = u32;
@@ -87,8 +87,8 @@ impl Config for Test {
 	type Handler = MockAuctionHandler;
 }
 
-impl ValidatorRegistration<AccountId> for Test {
-	fn is_registered(_id: &AccountId) -> bool {
+impl ValidatorRegistration<ValidatorId> for Test {
+	fn is_registered(_id: &ValidatorId) -> bool {
 		true
 	}
 }
@@ -96,10 +96,10 @@ impl ValidatorRegistration<AccountId> for Test {
 pub struct TestBidderProvider;
 
 impl BidderProvider for TestBidderProvider {
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 	type Amount = Amount;
 
-	fn get_bidders() -> Vec<(Self::AccountId, Self::Amount)> {
+	fn get_bidders() -> Vec<(Self::ValidatorId, Self::Amount)> {
 		BIDDER_SET.with(|l| l.borrow().to_vec())
 	}
 }

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -54,6 +54,16 @@ use pallet_cf_validator::EpochTransitionHandler;
 use sp_runtime::traits::Zero;
 use sp_std::vec::Vec;
 
+/// Slashing a validator
+pub trait Slashing {
+	/// An identifier for our validator
+	type ValidatorId;
+	/// Block number
+	type BlockNumber;
+	/// Slash this validator based on the number of blocks offline
+	fn slash(validator_id: &Self::ValidatorId, blocks_offline: &Self::BlockNumber) -> Weight;
+}
+
 /// Conditions as judged as offline
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
 pub enum OfflineCondition {
@@ -76,13 +86,13 @@ pub enum ReportError {
 
 /// Offline conditions are reported on
 pub trait OfflineConditions {
-	type AccountId;
+	type ValidatorId;
 	/// Report the condition for validator
 	/// Returns `Ok(Weight)` else an error if the validator isn't valid
 	fn report(
 		condition: OfflineCondition,
 		penalty: ReputationPoints,
-		validator_id: &Self::AccountId,
+		validator_id: &Self::ValidatorId,
 	) -> Result<Weight, ReportError>;
 }
 
@@ -123,7 +133,7 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
 		/// A stable ID for a validator.
-		type AccountId: Member + Parameter + From<<Self as frame_system::Config>::AccountId>;
+		type ValidatorId: Member + Parameter + From<<Self as frame_system::Config>::AccountId>;
 
 		// An amount of a bid
 		type Amount: Copy;
@@ -142,15 +152,12 @@ pub mod pallet {
 
 		/// When we have to, we slash
 		type Slasher: Slashing<
-			AccountId = <Self as pallet::Config>::AccountId,
+			AccountId = Self::ValidatorId,
 			BlockNumber = <Self as frame_system::Config>::BlockNumber,
 		>;
 
 		// Information about the current epoch.
-		type EpochInfo: EpochInfo<
-			AccountId = <Self as pallet::Config>::AccountId,
-			Amount = Self::Amount,
-		>;
+		type EpochInfo: EpochInfo<ValidatorId = Self::ValidatorId, Amount = Self::Amount>;
 	}
 
 	/// Pallet implements [`Hooks`] trait
@@ -178,7 +185,7 @@ pub mod pallet {
 	///
 	#[pallet::storage]
 	pub(super) type AwaitingHeartbeats<T: Config> =
-		StorageMap<_, Blake2_128Concat, <T as pallet::Config>::AccountId, bool, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::ValidatorId, bool, OptionQuery>;
 
 	/// A map tracking our validators.  We record the number of blocks they have been alive
 	/// according to the heartbeats submitted.  We are assuming that during a `HeartbeatInterval`
@@ -187,23 +194,14 @@ pub mod pallet {
 	///
 	#[pallet::storage]
 	#[pallet::getter(fn reputation)]
-	pub type Reputations<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		<T as pallet::Config>::AccountId,
-		ReputationOf<T>,
-		ValueQuery,
-	>;
+	pub type Reputations<T: Config> =
+		StorageMap<_, Blake2_128Concat, T::ValidatorId, ReputationOf<T>, ValueQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// An offline condition has been met
-		OfflineConditionPenalty(
-			<T as pallet::Config>::AccountId,
-			OfflineCondition,
-			ReputationPoints,
-		),
+		OfflineConditionPenalty(T::ValidatorId, OfflineCondition, ReputationPoints),
 		/// The accrual rate for our reputation poins has been updated \[points, online credits\]
 		AccrualRateUpdated(ReputationPoints, OnlineCreditsFor<T>),
 	}
@@ -229,7 +227,7 @@ pub mod pallet {
 		#[pallet::weight(10_000)]
 		pub(super) fn heartbeat(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			// for the validator
-			let validator_id: <T as pallet::Config>::AccountId = ensure_signed(origin)?.into();
+			let validator_id: T::ValidatorId = ensure_signed(origin)?.into();
 			// Ensure we haven't had a heartbeat for this interval yet for this validator
 			ensure!(
 				AwaitingHeartbeats::<T>::get(&validator_id).unwrap_or(false),
@@ -343,10 +341,10 @@ pub mod pallet {
 	/// expected list of validators.
 	///
 	impl<T: Config> EpochTransitionHandler for Pallet<T> {
-		type AccountId = <T as pallet::Config>::AccountId;
+		type ValidatorId = T::ValidatorId;
 		type Amount = T::Amount;
 
-		fn on_new_epoch(new_validators: &Vec<Self::AccountId>, _new_bond: Self::Amount) {
+		fn on_new_epoch(new_validators: &Vec<Self::ValidatorId>, _new_bond: Self::Amount) {
 			// Clear our expectations
 			AwaitingHeartbeats::<T>::remove_all();
 			// Set the new list of validators we expect a heartbeat from
@@ -359,12 +357,12 @@ pub mod pallet {
 	/// Implementation of `OfflineConditions` reporting on `OfflineCondition` with specified number
 	/// of reputation points
 	impl<T: Config> OfflineConditions for Pallet<T> {
-		type AccountId = <T as pallet::Config>::AccountId;
+		type ValidatorId = T::ValidatorId;
 
 		fn report(
 			condition: OfflineCondition,
 			penalty: ReputationPoints,
-			validator_id: &Self::AccountId,
+			validator_id: &Self::ValidatorId,
 		) -> Result<Weight, ReportError> {
 			// Confirm validator is present
 			ensure!(
@@ -392,10 +390,7 @@ pub mod pallet {
 
 		/// Update reputation for validator.  Points are clamped to `ReputationPointFloorAndCeiling`
 		///
-		fn update_reputation(
-			validator_id: &<T as pallet::Config>::AccountId,
-			points: ReputationPoints,
-		) -> Weight {
+		fn update_reputation(validator_id: &T::ValidatorId, points: ReputationPoints) -> Weight {
 			Reputations::<T>::mutate(
 				validator_id,
 				|Reputation {
@@ -470,5 +465,16 @@ pub mod pallet {
 
 			weight
 		}
+	}
+}
+
+pub struct ZeroSlasher<T: Config>(PhantomData<T>);
+/// An implementation of `Slashing` which kindly doesn't slash
+impl<T: Config> Slashing for ZeroSlasher<T> {
+	type ValidatorId = T::ValidatorId;
+	type BlockNumber = T::BlockNumber;
+
+	fn slash(_validator_id: &Self::ValidatorId, _blocks_offline: &Self::BlockNumber) -> Weight {
+		0
 	}
 }

--- a/state-chain/pallets/cf-reputation/src/mock.rs
+++ b/state-chain/pallets/cf-reputation/src/mock.rs
@@ -84,7 +84,7 @@ impl Slashing for MockSlasher {
 	type AccountId = u64;
 	type BlockNumber = u64;
 
-	fn slash(_account_id: &Self::AccountId, _blocks_offline: Self::BlockNumber) -> Weight {
+	fn slash(_validator_id: &Self::AccountId, _blocks_offline: Self::BlockNumber) -> Weight {
 		// Count those slashes
 		SLASH_COUNT.with(|count| {
 			let mut c = count.borrow_mut();
@@ -99,7 +99,7 @@ pub const BOB: <Test as frame_system::Config>::AccountId = 456u64;
 
 impl Config for Test {
 	type Event = Event;
-	type AccountId = u64;
+	type ValidatorId = u64;
 	type Amount = u128;
 	type HeartbeatBlockInterval = HeartbeatBlockInterval;
 	type ReputationPointPenalty = ReputationPointPenalty;

--- a/state-chain/pallets/cf-staking/src/lib.rs
+++ b/state-chain/pallets/cf-staking/src/lib.rs
@@ -132,7 +132,7 @@ pub mod pallet {
 
 		/// Information about the current epoch.
 		type EpochInfo: EpochInfo<
-			AccountId = <Self as frame_system::Config>::AccountId,
+			ValidatorId = <Self as frame_system::Config>::AccountId,
 			Amount = FlipBalance<Self>,
 		>;
 
@@ -790,10 +790,10 @@ impl<T: Config> Pallet<T> {
 /// This implementation of [pallet_cf_validator::CandidateProvider] simply returns a list of `(account_id, stake)` for
 /// all non-retired accounts.
 impl<T: Config> BidderProvider for Pallet<T> {
-	type AccountId = T::AccountId;
+	type ValidatorId = T::AccountId;
 	type Amount = T::Balance;
 
-	fn get_bidders() -> Vec<(Self::AccountId, Self::Amount)> {
+	fn get_bidders() -> Vec<(Self::ValidatorId, Self::Amount)> {
 		AccountRetired::<T>::iter()
 			.filter_map(|(acct, retired)| {
 				if retired {

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -70,16 +70,16 @@ type SessionIndex = u32;
 /// Handler for Epoch life cycle events.
 pub trait EpochTransitionHandler {
 	/// The id type used for the validators.
-	type AccountId;
+	type ValidatorId;
 	type Amount: Copy;
 	/// A new epoch has started
 	///
 	/// The new set of validator `new_validators` are now validating
-	fn on_new_epoch(_new_validators: &Vec<Self::AccountId>, _new_bond: Self::Amount) {}
+	fn on_new_epoch(_new_validators: &Vec<Self::ValidatorId>, _new_bond: Self::Amount) {}
 }
 
 impl<T: Config> EpochTransitionHandler for PhantomData<T> {
-	type AccountId = T::AccountId;
+	type ValidatorId = T::ValidatorId;
 	type Amount = T::Amount;
 }
 
@@ -100,7 +100,7 @@ pub mod pallet {
 
 		/// A handler for epoch lifecycle events
 		type EpochTransitionHandler: EpochTransitionHandler<
-			AccountId = Self::AccountId,
+			ValidatorId = Self::ValidatorId,
 			Amount = Self::Amount,
 		>;
 
@@ -118,7 +118,7 @@ pub mod pallet {
 		type Amount: Parameter + Default + Eq + Ord + Copy + AtLeast32BitUnsigned;
 
 		/// An auction type
-		type Auction: Auction<AccountId = Self::AccountId, Amount = Self::Amount>;
+		type Auction: Auction<ValidatorId = Self::ValidatorId, Amount = Self::Amount>;
 	}
 
 	#[pallet::event]
@@ -218,7 +218,7 @@ pub mod pallet {
 	/// Validator lookup
 	#[pallet::storage]
 	pub(super) type ValidatorLookup<T: Config> =
-		StorageMap<_, Blake2_128Concat, <T as pallet_session::Config>::ValidatorId, ()>;
+		StorageMap<_, Blake2_128Concat, T::ValidatorId, ()>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
@@ -248,19 +248,19 @@ pub mod pallet {
 }
 
 impl<T: Config> EpochInfo for Pallet<T> {
-	type AccountId = <T as pallet_session::Config>::ValidatorId;
+	type ValidatorId = T::ValidatorId;
 	type Amount = T::Amount;
 	type EpochIndex = T::EpochIndex;
 
-	fn current_validators() -> Vec<Self::AccountId> {
+	fn current_validators() -> Vec<Self::ValidatorId> {
 		<pallet_session::Module<T>>::validators()
 	}
 
-	fn is_validator(account: &Self::AccountId) -> bool {
+	fn is_validator(account: &Self::ValidatorId) -> bool {
 		ValidatorLookup::<T>::contains_key(account)
 	}
 
-	fn next_validators() -> Vec<Self::AccountId> {
+	fn next_validators() -> Vec<Self::ValidatorId> {
 		<pallet_session::Module<T>>::queued_keys()
 			.into_iter()
 			.map(|(k, _)| k)
@@ -283,14 +283,14 @@ impl<T: Config> EpochInfo for Pallet<T> {
 	}
 }
 
-impl<T: Config> pallet_session::SessionHandler<T::AccountId> for Pallet<T> {
+impl<T: Config> pallet_session::SessionHandler<T::ValidatorId> for Pallet<T> {
 	/// TODO look at the key management
 	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[];
-	fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(T::AccountId, Ks)]) {}
+	fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(T::ValidatorId, Ks)]) {}
 	fn on_new_session<Ks: OpaqueKeys>(
 		_changed: bool,
-		_validators: &[(T::AccountId, Ks)],
-		_queued_validators: &[(T::AccountId, Ks)],
+		_validators: &[(T::ValidatorId, Ks)],
+		_queued_validators: &[(T::ValidatorId, Ks)],
 	) {
 	}
 	fn on_before_session_ending() {}
@@ -352,9 +352,9 @@ impl<T: Config> Pallet<T> {
 }
 
 /// Provides the new set of validators to the session module when session is being rotated.
-impl<T: Config> pallet_session::SessionManager<T::AccountId> for Pallet<T> {
+impl<T: Config> pallet_session::SessionManager<T::ValidatorId> for Pallet<T> {
 	/// Prepare candidates for a new session
-	fn new_session(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+	fn new_session(_new_index: SessionIndex) -> Option<Vec<T::ValidatorId>> {
 		return match T::Auction::phase() {
 			// Successfully completed the process, these are the next set of validators to be used
 			AuctionPhase::WinnersSelected(winners, _) => Some(winners),

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -21,7 +21,7 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 pub type Amount = u64;
-pub type AccountId = u64;
+pub type ValidatorId = u64;
 
 impl WeightInfo for () {
 	fn set_blocks_for_epoch() -> u64 {
@@ -41,7 +41,7 @@ thread_local! {
 	pub static CANDIDATE_IDX: RefCell<u64> = RefCell::new(0);
 	pub static CURRENT_VALIDATORS: RefCell<Vec<u64>> = RefCell::new(vec![]);
 	pub static MIN_BID: RefCell<u64> = RefCell::new(0);
-	pub static PHASE: RefCell<AuctionPhase<AccountId, Amount>> =  RefCell::new(AuctionPhase::default());
+	pub static PHASE: RefCell<AuctionPhase<ValidatorId, Amount>> =  RefCell::new(AuctionPhase::default());
 	pub static BIDDERS: RefCell<Vec<(u64, u64)>> = RefCell::new(vec![]);
 	pub static WINNERS: RefCell<Vec<u64>> = RefCell::new(vec![]);
 	pub static CONFIRM: RefCell<bool> = RefCell::new(false);
@@ -102,7 +102,7 @@ impl pallet_session::Config for Test {
 	type ShouldEndSession = ValidatorPallet;
 	type SessionManager = ValidatorPallet;
 	type SessionHandler = ValidatorPallet;
-	type ValidatorId = AccountId;
+	type ValidatorId = ValidatorId;
 	type ValidatorIdOf = ConvertInto;
 	type Keys = MockSessionKeys;
 	type Event = Event;
@@ -118,16 +118,16 @@ parameter_types! {
 impl pallet_cf_auction::Config for Test {
 	type Event = Event;
 	type Amount = Amount;
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 	type BidderProvider = TestBidderProvider;
 	type Registrar = Test;
 	type AuctionIndex = u32;
 	type MinAuctionSize = MinAuctionSize;
-	type Handler = MockHandler<AccountId = AccountId, Amount = Amount>;
+	type Handler = MockHandler<ValidatorId = ValidatorId, Amount = Amount>;
 }
 
-impl ValidatorRegistration<AccountId> for Test {
-	fn is_registered(_id: &AccountId) -> bool {
+impl ValidatorRegistration<ValidatorId> for Test {
+	fn is_registered(_id: &ValidatorId) -> bool {
 		true
 	}
 }
@@ -135,10 +135,10 @@ impl ValidatorRegistration<AccountId> for Test {
 pub struct TestBidderProvider;
 
 impl BidderProvider for TestBidderProvider {
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 	type Amount = Amount;
 
-	fn get_bidders() -> Vec<(Self::AccountId, Self::Amount)> {
+	fn get_bidders() -> Vec<(Self::ValidatorId, Self::Amount)> {
 		let idx = CANDIDATE_IDX.with(|idx| {
 			let new_idx = *idx.borrow_mut() + 1;
 			*idx.borrow_mut() = new_idx;
@@ -152,9 +152,9 @@ impl BidderProvider for TestBidderProvider {
 pub struct TestEpochTransitionHandler;
 
 impl EpochTransitionHandler for TestEpochTransitionHandler {
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 	type Amount = Amount;
-	fn on_new_epoch(new_validators: &Vec<Self::AccountId>, min_bid: Self::Amount) {
+	fn on_new_epoch(new_validators: &Vec<Self::ValidatorId>, min_bid: Self::Amount) {
 		CURRENT_VALIDATORS.with(|l| *l.borrow_mut() = new_validators.clone());
 		MIN_BID.with(|l| *l.borrow_mut() = min_bid);
 	}

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -14,7 +14,7 @@ mod test {
 			.event
 	}
 
-	fn assert_winners() -> Vec<AccountId> {
+	fn assert_winners() -> Vec<ValidatorId> {
 		assert_matches!(AuctionPallet::phase(), AuctionPhase::WinnersSelected(winners, _) => {
 			winners
 		})

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -46,8 +46,7 @@ use frame_support::pallet_prelude::*;
 use sp_std::prelude::*;
 
 use cf_traits::{
-	Chainflip, Nonce, NonceIdentifier, NonceProvider, RotationError, VaultRotation,
-	VaultRotationHandler,
+	Nonce, NonceIdentifier, NonceProvider, RotationError, VaultRotation, VaultRotationHandler,
 };
 pub use pallet::*;
 use sp_core::H160;
@@ -67,19 +66,19 @@ mod tests;
 
 /// A signing request
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub struct EthSigningTxRequest<AccountId> {
+pub struct EthSigningTxRequest<ValidatorId> {
 	// Payload to be signed by the existing aggregate key
 	pub(crate) payload: Vec<u8>,
-	pub(crate) validators: Vec<AccountId>,
+	pub(crate) validators: Vec<ValidatorId>,
 }
 
 /// A response back with our signature else a list of bad validators
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum EthSigningTxResponse<AccountId> {
+pub enum EthSigningTxResponse<ValidatorId> {
 	// Signature
 	Success(Vec<u8>),
 	// Bad validators
-	Error(Vec<AccountId>),
+	Error(Vec<ValidatorId>),
 }
 
 #[frame_support::pallet]
@@ -93,7 +92,7 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: Chainflip + frame_system::Config {
+	pub trait Config: frame_system::Config + Chainflip {
 		/// The event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Provides an origin check for witness transactions.
@@ -103,7 +102,7 @@ pub mod pallet {
 		/// A transaction
 		type Transaction: Member + Parameter + Into<Vec<u8>> + Default;
 		/// Rotation handler
-		type RotationHandler: VaultRotationHandler<AccountId = <Self as Chainflip>::AccountId>;
+		type RotationHandler: VaultRotationHandler<ValidatorId = Self::ValidatorId>;
 		/// A nonce provider
 		type NonceProvider: NonceProvider;
 	}
@@ -127,7 +126,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn vault_rotations)]
 	pub(super) type VaultRotations<T: Config> =
-		StorageMap<_, Blake2_128Concat, RequestIndex, KeygenRequest<<T as Chainflip>::AccountId>>;
+		StorageMap<_, Blake2_128Concat, RequestIndex, KeygenRequest<T::ValidatorId>>;
 
 	/// A map of Nonces for chains supported
 	#[pallet::storage]
@@ -139,7 +138,7 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub (super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Request a key generation \[request_index, request\]
-		KeygenRequest(RequestIndex, KeygenRequest<<T as Chainflip>::AccountId>),
+		KeygenRequest(RequestIndex, KeygenRequest<T::ValidatorId>),
 		/// Request a rotation of the vault for this chain \[request_index, request\]
 		VaultRotationRequest(RequestIndex, VaultRotationRequest),
 		/// The vault for the request has rotated \[request_index\]
@@ -149,10 +148,7 @@ pub mod pallet {
 		/// A complete set of vaults have been rotated
 		VaultsRotated,
 		/// Request this payload to be signed by the existing aggregate key
-		EthSignTxRequest(
-			RequestIndex,
-			EthSigningTxRequest<<T as Chainflip>::AccountId>,
-		),
+		EthSignTxRequest(RequestIndex, EthSigningTxRequest<T::ValidatorId>),
 	}
 
 	#[pallet::error]
@@ -189,7 +185,7 @@ pub mod pallet {
 		pub fn keygen_response(
 			origin: OriginFor<T>,
 			request_id: RequestIndex,
-			response: KeygenResponse<<T as Chainflip>::AccountId, T::PublicKey>,
+			response: KeygenResponse<T::ValidatorId, T::PublicKey>,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureWitnessed::ensure_origin(origin)?;
 			match KeygenRequestResponse::<T>::handle_response(request_id, response) {
@@ -219,7 +215,7 @@ pub mod pallet {
 		pub fn eth_signing_tx_response(
 			origin: OriginFor<T>,
 			request_id: RequestIndex,
-			response: EthSigningTxResponse<<T as Chainflip>::AccountId>,
+			response: EthSigningTxResponse<T::ValidatorId>,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureWitnessed::ensure_origin(origin)?;
 			match EthereumChain::<T>::handle_response(request_id, response) {
@@ -246,8 +242,8 @@ pub mod pallet {
 	}
 }
 
-impl<T: Config> From<RotationError<<T as Chainflip>::AccountId>> for Error<T> {
-	fn from(err: RotationError<<T as Chainflip>::AccountId>) -> Self {
+impl<T: Config> From<RotationError<T::ValidatorId>> for Error<T> {
+	fn from(err: RotationError<T::ValidatorId>) -> Self {
 		match err {
 			RotationError::EmptyValidatorSet => Error::<T>::EmptyValidatorSet,
 			RotationError::BadValidators(_) => Error::<T>::BadValidators,
@@ -297,10 +293,10 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> VaultRotation for Pallet<T> {
-	type AccountId = <T as Chainflip>::AccountId;
+	type ValidatorId = T::ValidatorId;
 	fn start_vault_rotation(
-		candidates: Vec<Self::AccountId>,
-	) -> Result<(), RotationError<Self::AccountId>> {
+		candidates: Vec<Self::ValidatorId>,
+	) -> Result<(), RotationError<Self::ValidatorId>> {
 		// Main entry point for the pallet
 		ensure!(!candidates.is_empty(), RotationError::EmptyValidatorSet);
 		// Create a KeyGenRequest for Ethereum
@@ -313,7 +309,7 @@ impl<T: Config> VaultRotation for Pallet<T> {
 			.map_err(|_| RotationError::FailedToMakeKeygenRequest)
 	}
 
-	fn finalize_rotation() -> Result<(), RotationError<Self::AccountId>> {
+	fn finalize_rotation() -> Result<(), RotationError<Self::ValidatorId>> {
 		// The 'exit' point for the pallet, no rotations left to process
 		if Pallet::<T>::rotations_complete() {
 			// We can now confirm the auction and rotate
@@ -333,17 +329,17 @@ struct KeygenRequestResponse<T: Config>(PhantomData<T>);
 impl<T: Config>
 	RequestResponse<
 		RequestIndex,
-		KeygenRequest<<T as Chainflip>::AccountId>,
-		KeygenResponse<<T as Chainflip>::AccountId, T::PublicKey>,
-		RotationError<<T as Chainflip>::AccountId>,
+		KeygenRequest<T::ValidatorId>,
+		KeygenResponse<T::ValidatorId, T::PublicKey>,
+		RotationError<T::ValidatorId>,
 	> for KeygenRequestResponse<T>
 {
 	/// Emit as an event the key generation request, this is the first step after receiving a proposed
 	/// validator set from the `AuctionHandler::on_auction_completed()`
 	fn make_request(
 		index: RequestIndex,
-		request: KeygenRequest<<T as Chainflip>::AccountId>,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+		request: KeygenRequest<T::ValidatorId>,
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		VaultRotations::<T>::insert(index, request.clone());
 		Pallet::<T>::deposit_event(Event::KeygenRequest(index, request));
 		Ok(())
@@ -354,8 +350,8 @@ impl<T: Config>
 	/// and the vault rotation aborted.
 	fn handle_response(
 		index: RequestIndex,
-		response: KeygenResponse<<T as Chainflip>::AccountId, T::PublicKey>,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+		response: KeygenResponse<T::ValidatorId, T::PublicKey>,
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		ensure_index!(index);
 		match response {
 			KeygenResponse::Success(new_public_key) => {
@@ -384,15 +380,15 @@ impl<T: Config>
 // We have now had feedback from the vault/chain that we can proceed with the final request for the
 // vault rotation
 impl<T: Config> ChainHandler for Pallet<T> {
-	type AccountId = <T as Chainflip>::AccountId;
-	type Error = RotationError<<T as Chainflip>::AccountId>;
+	type ValidatorId = T::ValidatorId;
+	type Error = RotationError<T::ValidatorId>;
 
 	/// Try to complete the final vault rotation with feedback from the chain implementation over
 	/// the `ChainHandler` trait.  This is forwarded as a request and hence an event is emitted.
 	/// Failure is handled and potential bad validators are penalised and the rotation is now aborted.
 	fn request_vault_rotation(
 		index: RequestIndex,
-		result: Result<VaultRotationRequest, RotationError<Self::AccountId>>,
+		result: Result<VaultRotationRequest, RotationError<Self::ValidatorId>>,
 	) -> Result<(), Self::Error> {
 		ensure_index!(index);
 		match result {
@@ -417,14 +413,14 @@ impl<T: Config>
 		RequestIndex,
 		VaultRotationRequest,
 		VaultRotationResponse<T::PublicKey, T::Transaction>,
-		RotationError<<T as Chainflip>::AccountId>,
+		RotationError<T::ValidatorId>,
 	> for VaultRotationRequestResponse<T>
 {
 	/// Emit our event for the start of a vault rotation generation request.
 	fn make_request(
 		index: RequestIndex,
 		request: VaultRotationRequest,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		ensure_index!(index);
 		Pallet::<T>::deposit_event(Event::VaultRotationRequest(index, request));
 		Ok(())
@@ -436,7 +432,7 @@ impl<T: Config>
 	fn handle_response(
 		index: RequestIndex,
 		response: VaultRotationResponse<T::PublicKey, T::Transaction>,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		ensure_index!(index);
 		// Feedback to vaults
 		// We have assumed here that once we have one confirmation of a vault rotation we wouldn't
@@ -476,8 +472,8 @@ pub struct EthereumChain<T: Config>(PhantomData<T>);
 impl<T: Config> ChainVault for EthereumChain<T> {
 	type PublicKey = T::PublicKey;
 	type Transaction = T::Transaction;
-	type AccountId = <T as Chainflip>::AccountId;
-	type Error = RotationError<<T as Chainflip>::AccountId>;
+	type ValidatorId = T::ValidatorId;
+	type Error = RotationError<T::ValidatorId>;
 
 	/// Parameters required when creating key generation requests
 	fn chain_params() -> ChainParams {
@@ -492,7 +488,7 @@ impl<T: Config> ChainVault for EthereumChain<T> {
 	fn start_vault_rotation(
 		index: RequestIndex,
 		new_public_key: Self::PublicKey,
-		validators: Vec<Self::AccountId>,
+		validators: Vec<Self::ValidatorId>,
 	) -> Result<(), Self::Error> {
 		// Create payload for signature here
 		// function setAggKeyWithAggKey(SigData calldata sigData, Key calldata newKey)
@@ -523,16 +519,16 @@ impl<T: Config> ChainVault for EthereumChain<T> {
 impl<T: Config>
 	RequestResponse<
 		RequestIndex,
-		EthSigningTxRequest<<T as Chainflip>::AccountId>,
-		EthSigningTxResponse<<T as Chainflip>::AccountId>,
-		RotationError<<T as Chainflip>::AccountId>,
+		EthSigningTxRequest<T::ValidatorId>,
+		EthSigningTxResponse<T::ValidatorId>,
+		RotationError<T::ValidatorId>,
 	> for EthereumChain<T>
 {
 	/// Make the request to sign by emitting an event
 	fn make_request(
 		index: RequestIndex,
-		request: EthSigningTxRequest<<T as Chainflip>::AccountId>,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+		request: EthSigningTxRequest<T::ValidatorId>,
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		Pallet::<T>::deposit_event(Event::EthSignTxRequest(index, request));
 		Ok(().into())
 	}
@@ -540,8 +536,8 @@ impl<T: Config>
 	/// Try to handle the response and pass this onto `Vaults` to complete the vault rotation
 	fn handle_response(
 		index: RequestIndex,
-		response: EthSigningTxResponse<<T as Chainflip>::AccountId>,
-	) -> Result<(), RotationError<<T as Chainflip>::AccountId>> {
+		response: EthSigningTxResponse<T::ValidatorId>,
+	) -> Result<(), RotationError<T::ValidatorId>> {
 		match response {
 			EthSigningTxResponse::Success(signature) => {
 				VaultRotationRequestResponse::<T>::make_request(index, Ethereum(signature).into())

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -18,11 +18,11 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<MockRunt
 type Block = frame_system::mocking::MockBlock<MockRuntime>;
 
 type Amount = u64;
-type AccountId = u64;
+type ValidatorId = u64;
 
 thread_local! {
 	pub static OTHER_CHAIN_RESULT: RefCell<RequestIndex> = RefCell::new(0);
-	pub static BAD_VALIDATORS: RefCell<Vec<AccountId>> = RefCell::new(vec![]);
+	pub static BAD_VALIDATORS: RefCell<Vec<ValidatorId>> = RefCell::new(vec![]);
 }
 
 construct_runtime!(
@@ -91,14 +91,14 @@ impl cf_traits::Witnesser for MockWitnesser {
 
 impl Chainflip for MockRuntime {
 	type Amount = Amount;
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 }
 
 impl VaultRotationHandler for MockRuntime {
-	type AccountId = u64;
+	type ValidatorId = u64;
 	fn abort() {}
 
-	fn penalise(bad_validators: Vec<Self::AccountId>) {
+	fn penalise(bad_validators: Vec<Self::ValidatorId>) {
 		BAD_VALIDATORS.with(|l| *l.borrow_mut() = bad_validators);
 	}
 }
@@ -118,7 +118,7 @@ impl pallet_cf_vaults::Config for MockRuntime {
 	type NonceProvider = Self;
 }
 
-pub fn bad_validators() -> Vec<AccountId> {
+pub fn bad_validators() -> Vec<ValidatorId> {
 	BAD_VALIDATORS.with(|l| l.borrow().to_vec())
 }
 

--- a/state-chain/pallets/cf-vaults/src/rotation.rs
+++ b/state-chain/pallets/cf-vaults/src/rotation.rs
@@ -22,7 +22,7 @@ pub trait ChainVault {
 	/// A transaction
 	type Transaction: Into<Vec<u8>>;
 	/// An identifier for a validator involved in the rotation of the vault
-	type AccountId;
+	type ValidatorId;
 	/// An error on rotating the vault
 	type Error;
 	/// A set of params for the chain for this vault
@@ -34,7 +34,7 @@ pub trait ChainVault {
 	fn start_vault_rotation(
 		index: RequestIndex,
 		new_public_key: Self::PublicKey,
-		validators: Vec<Self::AccountId>,
+		validators: Vec<Self::ValidatorId>,
 	) -> Result<(), Self::Error>;
 	/// We have confirmation of the rotation back from `Vaults`
 	fn vault_rotated(response: Vault<Self::PublicKey, Self::Transaction>);
@@ -43,13 +43,13 @@ pub trait ChainVault {
 /// Events coming in from our chain.  This is used to callback from the request to complete the vault
 /// rotation phase.  See `ChainVault::try_start_vault_rotation()` for more details.
 pub trait ChainHandler {
-	type AccountId;
+	type ValidatorId;
 	type Error;
 	/// Request initial vault rotation phase complete with a result describing the outcome of this phase
 	/// Feedback is provided back on this step
 	fn request_vault_rotation(
 		index: RequestIndex,
-		result: Result<VaultRotationRequest, RotationError<Self::AccountId>>,
+		result: Result<VaultRotationRequest, RotationError<Self::ValidatorId>>,
 	) -> Result<(), Self::Error>;
 }
 
@@ -68,20 +68,20 @@ pub enum ChainParams {
 /// A representation of a key generation request
 /// This would be used for each supporting chain
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub struct KeygenRequest<AccountId> {
+pub struct KeygenRequest<ValidatorId> {
 	/// A Chain's parameters
 	pub(crate) chain: ChainParams,
 	/// The set of validators from which we would like to generate the key
-	pub(crate) validator_candidates: Vec<AccountId>,
+	pub(crate) validator_candidates: Vec<ValidatorId>,
 }
 
 /// A response for our KeygenRequest
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum KeygenResponse<AccountId, PublicKey: Into<Vec<u8>>> {
+pub enum KeygenResponse<ValidatorId, PublicKey: Into<Vec<u8>>> {
 	/// The key generation ceremony has completed successfully with a new proposed public key
 	Success(PublicKey),
 	/// Something went wrong and it failed.
-	Failure(Vec<AccountId>),
+	Failure(Vec<ValidatorId>),
 }
 
 /// The vault rotation request

--- a/state-chain/pallets/cf-witnesser-api/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser-api/src/lib.rs
@@ -14,7 +14,7 @@ mod tests;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use cf_traits::{Chainflip, Witnesser};
+	use cf_traits::Witnesser;
 	use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
 	use pallet_cf_staking::{
@@ -102,7 +102,7 @@ pub mod pallet {
 		pub fn witness_keygen_response(
 			origin: OriginFor<T>,
 			request_id: RequestIndex,
-			response: KeygenResponse<<T as Chainflip>::AccountId, T::PublicKey>,
+			response: KeygenResponse<T::ValidatorId, T::PublicKey>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			let call = VaultsCall::keygen_response(request_id, response);
@@ -127,7 +127,7 @@ pub mod pallet {
 		pub fn witness_eth_signing_tx_response(
 			origin: OriginFor<T>,
 			request_id: RequestIndex,
-			response: EthSigningTxResponse<<T as Chainflip>::AccountId>,
+			response: EthSigningTxResponse<T::ValidatorId>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			let call = VaultsCall::eth_signing_tx_response(request_id, response);

--- a/state-chain/pallets/cf-witnesser-api/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser-api/src/mock.rs
@@ -82,18 +82,18 @@ impl pallet_cf_staking::Config for Test {
 }
 
 type Amount = u64;
-type AccountId = u64;
+type ValidatorId = u64;
 
 impl Chainflip for Test {
 	type Amount = Amount;
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 }
 
 impl VaultRotationHandler for Test {
-	type AccountId = AccountId;
+	type ValidatorId = ValidatorId;
 
 	fn abort() {}
-	fn penalise(_bad_validators: Vec<Self::AccountId>) {}
+	fn penalise(_bad_validators: Vec<Self::ValidatorId>) {}
 }
 
 impl NonceProvider for Test {

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -74,15 +74,12 @@ pub mod pallet {
 
 		type Epoch: Member + FullCodec + Copy + AtLeast32BitUnsigned + Default;
 
-		type AccountId: Member
+		type ValidatorId: Member
 			+ FullCodec
 			+ From<<Self as frame_system::Config>::AccountId>
 			+ Into<<Self as frame_system::Config>::AccountId>;
 
-		type EpochInfo: EpochInfo<
-			AccountId = <Self as pallet::Config>::AccountId,
-			EpochIndex = Self::Epoch,
-		>;
+		type EpochInfo: EpochInfo<ValidatorId = Self::ValidatorId, EpochIndex = Self::Epoch>;
 
 		type Amount: Parameter + Default + Eq + Ord + Copy + AtLeast32BitUnsigned;
 	}
@@ -137,7 +134,7 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Some external event has been witnessed [call_sig, who, num_votes]
-		WitnessReceived(CallHash, <T as Config>::AccountId, VoteCount),
+		WitnessReceived(CallHash, <T as Config>::ValidatorId, VoteCount),
 
 		/// The witness threshold has been reached [call_sig, num_votes]
 		ThresholdReached(CallHash, VoteCount),
@@ -278,7 +275,7 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: pallet::Config> cf_traits::Witnesser for Pallet<T> {
-	type AccountId = <T as pallet::Config>::AccountId;
+	type AccountId = T::ValidatorId;
 	type Call = <T as pallet::Config>::Call;
 
 	fn witness(who: Self::AccountId, call: Self::Call) -> DispatchResultWithPostInfo {
@@ -319,10 +316,10 @@ where
 }
 
 impl<T: Config> pallet_cf_validator::EpochTransitionHandler for Pallet<T> {
-	type AccountId = <T as pallet::Config>::AccountId;
+	type ValidatorId = T::ValidatorId;
 	type Amount = T::Amount;
 
-	fn on_new_epoch(new_validators: &Vec<Self::AccountId>, _new_bond: Self::Amount) {
+	fn on_new_epoch(new_validators: &Vec<Self::ValidatorId>, _new_bond: Self::Amount) {
 		let epoch = T::EpochInfo::epoch_index();
 
 		let mut total = 0;
@@ -332,7 +329,6 @@ impl<T: Config> pallet_cf_validator::EpochTransitionHandler for Pallet<T> {
 		}
 		NumValidators::<T>::set(total);
 
-		// TODO: This code is in about 3 places across the code base
 		let calc_threshold = |total: u32| -> u32 {
 			let doubled = total * 2;
 			if doubled % 3 == 0 {

--- a/state-chain/pallets/cf-witnesser/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock.rs
@@ -62,7 +62,7 @@ impl pallet_cf_witness::Config for Test {
 	type Origin = Origin;
 	type Call = Call;
 	type Epoch = <mocks::epoch_info::Mock as EpochInfo>::EpochIndex;
-	type AccountId = AccountId;
+	type ValidatorId = AccountId;
 	type EpochInfo = mocks::epoch_info::Mock;
 	type Amount = u64;
 }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -9,10 +9,10 @@ pub struct ChainflipEpochTransitions;
 
 /// Trigger emissions on epoch transitions.
 impl EpochTransitionHandler for ChainflipEpochTransitions {
-	type AccountId = AccountId;
+	type ValidatorId = AccountId;
 	type Amount = FlipBalance;
 
-	fn on_new_epoch(new_validators: &Vec<Self::AccountId>, new_bond: Self::Amount) {
+	fn on_new_epoch(new_validators: &Vec<Self::ValidatorId>, new_bond: Self::Amount) {
 		// Process any outstanding emissions.
 		<Emissions as EmissionsTrigger>::trigger_emissions();
 		// Rollover the rewards.

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -144,7 +144,7 @@ impl pallet_cf_auction::Config for Runtime {
 	type BidderProvider = pallet_cf_staking::Pallet<Self>;
 	type AuctionIndex = u64;
 	type Registrar = Session;
-	type AccountId = AccountId;
+	type ValidatorId = AccountId;
 	type MinAuctionSize = MinAuctionSize;
 	type Handler = Vaults;
 }
@@ -344,7 +344,7 @@ impl pallet_cf_witnesser::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Epoch = EpochIndex;
-	type AccountId = <Self as frame_system::Config>::AccountId;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
 	type EpochInfo = pallet_cf_validator::Pallet<Self>;
 	type Amount = FlipBalance;
 }
@@ -415,7 +415,7 @@ impl pallet_cf_witnesser_api::Config for Runtime {
 
 impl Chainflip for Runtime {
 	type Amount = FlipBalance;
-	type AccountId = <Self as frame_system::Config>::AccountId;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
 }
 
 parameter_types! {
@@ -426,7 +426,7 @@ parameter_types! {
 
 impl pallet_cf_reputation::Config for Runtime {
 	type Event = Event;
-	type AccountId = <Self as frame_system::Config>::AccountId;
+	type ValidatorId = <Self as frame_system::Config>::AccountId;
 	type Amount = FlipBalance;
 	type HeartbeatBlockInterval = HeartbeatBlockInterval;
 	type ReputationPointPenalty = ReputationPointPenalty;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -19,7 +19,7 @@ pub trait Chainflip {
 	/// An amount for a bid
 	type Amount: Member + Parameter + Default + Eq + Ord + Copy + AtLeast32BitUnsigned;
 	/// An identity for a validator
-	type AccountId: Member + Parameter;
+	type ValidatorId: Member + Parameter;
 }
 
 /// A trait abstracting the functionality of the witnesser
@@ -41,21 +41,21 @@ pub trait Witnesser {
 
 pub trait EpochInfo {
 	/// The id type used for the validators.
-	type AccountId;
+	type ValidatorId;
 	/// An amount
 	type Amount;
 	/// The index of an epoch
 	type EpochIndex;
 
 	/// The current set of validators
-	fn current_validators() -> Vec<Self::AccountId>;
+	fn current_validators() -> Vec<Self::ValidatorId>;
 
 	/// Checks if the account is currently a validator.
-	fn is_validator(account: &Self::AccountId) -> bool;
+	fn is_validator(account: &Self::ValidatorId) -> bool;
 
 	/// If we are in auction phase then the proposed set to validate once the auction is
 	/// confirmed else an empty vector
-	fn next_validators() -> Vec<Self::AccountId>;
+	fn next_validators() -> Vec<Self::ValidatorId>;
 
 	/// The amount to be used as bond, this is the minimum stake needed to get into the
 	/// candidate validator set
@@ -71,24 +71,24 @@ pub trait EpochInfo {
 /// The phase of an Auction. At the start we are waiting on bidders, we then run an auction and
 /// finally it is completed
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum AuctionPhase<AccountId, Amount> {
+pub enum AuctionPhase<ValidatorId, Amount> {
 	// Waiting for bids, we store the last set of winners and min bid required
-	WaitingForBids(Vec<AccountId>, Amount),
+	WaitingForBids(Vec<ValidatorId>, Amount),
 	// Bids are now taken and validated
-	BidsTaken(Vec<Bid<AccountId, Amount>>),
+	BidsTaken(Vec<Bid<ValidatorId, Amount>>),
 	// We have ran the auction and have a set of winners with min bid.  This waits on confirmation
 	// via the trait `AuctionConfirmation`
-	WinnersSelected(Vec<AccountId>, Amount),
+	WinnersSelected(Vec<ValidatorId>, Amount),
 }
 
-impl<AccountId, Amount: Default> Default for AuctionPhase<AccountId, Amount> {
+impl<ValidatorId, Amount: Default> Default for AuctionPhase<ValidatorId, Amount> {
 	fn default() -> Self {
 		AuctionPhase::WaitingForBids(Vec::new(), Amount::default())
 	}
 }
 
 /// A bid represented by a validator and the amount they wish to bid
-pub type Bid<AccountId, Amount> = (AccountId, Amount);
+pub type Bid<ValidatorId, Amount> = (ValidatorId, Amount);
 /// A range of min, max for our winning set
 pub type AuctionRange = (u32, u32);
 
@@ -101,7 +101,7 @@ pub type AuctionRange = (u32, u32);
 /// on.  An confirmation is looked to before completing the auction with the `AuctionConfirmation`
 /// trait.
 pub trait Auction {
-	type AccountId;
+	type ValidatorId;
 	type Amount;
 	type BidderProvider;
 
@@ -110,30 +110,30 @@ pub trait Auction {
 	/// Set the auction range
 	fn set_auction_range(range: AuctionRange) -> Result<AuctionRange, AuctionError>;
 	/// The current phase we find ourselves in
-	fn phase() -> AuctionPhase<Self::AccountId, Self::Amount>;
+	fn phase() -> AuctionPhase<Self::ValidatorId, Self::Amount>;
 	/// Are we in an auction?
 	fn waiting_on_bids() -> bool;
 	/// Move the process forward by one step, returns the phase completed or error
-	fn process() -> Result<AuctionPhase<Self::AccountId, Self::Amount>, AuctionError>;
+	fn process() -> Result<AuctionPhase<Self::ValidatorId, Self::Amount>, AuctionError>;
 }
 
 pub trait VaultRotationHandler {
-	type AccountId;
+	type ValidatorId;
 	/// Abort requested after failed vault rotation
 	fn abort();
 	// Penalise validators during a vault rotation
-	fn penalise(bad_validators: Vec<Self::AccountId>);
+	fn penalise(bad_validators: Vec<Self::ValidatorId>);
 }
 
 /// Errors occurring during a rotation
 #[derive(RuntimeDebug, Encode, Decode, PartialEq, Clone)]
-pub enum RotationError<AccountId> {
+pub enum RotationError<ValidatorId> {
 	/// An invalid request index
 	InvalidRequestIndex,
 	/// Empty validator set provided
 	EmptyValidatorSet,
 	/// A set of badly acting validators
-	BadValidators(Vec<AccountId>),
+	BadValidators(Vec<ValidatorId>),
 	/// The key generation response failed
 	KeyResponseFailed,
 	/// Failed to construct a valid chain specific payload for rotation
@@ -148,15 +148,15 @@ pub enum RotationError<AccountId> {
 
 /// Rotating vaults
 pub trait VaultRotation {
-	type AccountId;
+	type ValidatorId;
 	/// Start a vault rotation with the following `candidates`
 	fn start_vault_rotation(
-		candidates: Vec<Self::AccountId>,
-	) -> Result<(), RotationError<Self::AccountId>>;
+		candidates: Vec<Self::ValidatorId>,
+	) -> Result<(), RotationError<Self::ValidatorId>>;
 
 	/// In order for the validators to be rotated we are waiting on a confirmation that the vaults
 	/// have been rotated.
-	fn finalize_rotation() -> Result<(), RotationError<Self::AccountId>>;
+	fn finalize_rotation() -> Result<(), RotationError<Self::ValidatorId>>;
 }
 
 /// An error has occurred during an auction
@@ -171,9 +171,9 @@ pub enum AuctionError {
 
 /// Providing bidders for our auction
 pub trait BidderProvider {
-	type AccountId;
+	type ValidatorId;
 	type Amount;
-	fn get_bidders() -> Vec<(Self::AccountId, Self::Amount)>;
+	fn get_bidders() -> Vec<(Self::ValidatorId, Self::Amount)>;
 }
 
 pub trait StakeTransfer {

--- a/state-chain/traits/src/mocks/epoch_info.rs
+++ b/state-chain/traits/src/mocks/epoch_info.rs
@@ -55,15 +55,15 @@ impl Mock {
 }
 
 impl EpochInfo for Mock {
-	type AccountId = AccountId;
+	type ValidatorId = AccountId;
 	type Amount = u128;
 	type EpochIndex = u32;
 
-	fn current_validators() -> Vec<Self::AccountId> {
+	fn current_validators() -> Vec<Self::ValidatorId> {
 		CURRENT_VALIDATORS.with(|cell| cell.borrow().clone())
 	}
 
-	fn is_validator(account: &Self::AccountId) -> bool {
+	fn is_validator(account: &Self::ValidatorId) -> bool {
 		Self::current_validators().as_slice().contains(account)
 	}
 
@@ -71,7 +71,7 @@ impl EpochInfo for Mock {
 		BOND.with(|cell| *cell.borrow())
 	}
 
-	fn next_validators() -> Vec<Self::AccountId> {
+	fn next_validators() -> Vec<Self::ValidatorId> {
 		NEXT_VALIDATORS.with(|cell| cell.borrow().clone())
 	}
 

--- a/state-chain/traits/src/mocks/vault_rotation.rs
+++ b/state-chain/traits/src/mocks/vault_rotation.rs
@@ -13,16 +13,16 @@ pub fn clear_confirmation() {
 }
 
 impl VaultRotation for Mock {
-	type AccountId = u64;
+	type ValidatorId = u64;
 
 	fn start_vault_rotation(
-		_candidates: Vec<Self::AccountId>,
-	) -> Result<(), RotationError<Self::AccountId>> {
+		_candidates: Vec<Self::ValidatorId>,
+	) -> Result<(), RotationError<Self::ValidatorId>> {
 		TO_CONFIRM.with(|l| *l.borrow_mut() = Err(RotationError::NotConfirmed));
 		Ok(())
 	}
 
-	fn finalize_rotation() -> Result<(), RotationError<Self::AccountId>> {
+	fn finalize_rotation() -> Result<(), RotationError<Self::ValidatorId>> {
 		TO_CONFIRM.with(|l| (*l.borrow()).clone())
 	}
 }

--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -17,9 +17,9 @@
   "AuctionIndex": "u64",
   "AuctionPhase": {
     "_enum": {
-      "WaitingForBids": "(Vec<AccountId>, Amount)",
-      "BidsTaken": "(Vec<(AccountId, Amount)>)",
-      "WinnersSelected": "(Vec<AccountId>, Amount)"
+      "WaitingForBids": "(Vec<ValidatorId>, Amount)",
+      "BidsTaken": "(Vec<(ValidatorId, Amount)>)",
+      "WinnersSelected": "(Vec<ValidatorId>, Amount)"
     }
   },
   "AuctionRange": "(u32,u32)",
@@ -42,7 +42,7 @@
   "EthSigningTxResponse": {
     "_enum": {
       "Success": "(Vec<u8>)",
-      "Error": "(Vec<AccountId>)"
+      "Error": "(Vec<ValidatorId>)"
     }
   },
   "EthereumAddress": "[u8;20]",
@@ -61,12 +61,12 @@
   },
   "KeygenRequest": {
     "chain": "ChainParams",
-    "validator_candidates": "Vec<AccountId>"
+    "validator_candidates": "Vec<ValidatorId>"
   },
   "KeygenResponse": {
     "_enum": {
       "Success": "(PublicKey)",
-      "Failure": "(Vec<AccountId>)"
+      "Failure": "(Vec<ValidatorId>)"
     }
   },
   "LookupSource": "MultiAddress",
@@ -90,7 +90,7 @@
   "Retired": "bool",
   "Signature": "H256",
   "TokenAmount": "u128",
-  "AccountId": "AccountId",
+  "ValidatorId": "AccountId",
   "Transaction": "Vec<u8>",
   "Vault": {
     "old_key": "PublicKey",


### PR DESCRIPTION
This partially reverts commit 98490987ae32d1a605a2f2cb9cc4909302c32337 , specifically, reverting the renaming of `ValidatorId`s for state chain pallets and runtime definitions. 

I kept the changes in the p2p rpc server to maintain compatibility with the CFE. 

I'm not against reviewing the naming of validator_id, but we should not do so indiscriminately. In particular, the change as implemented didn't actually merge the type, it mostly just renames the *associated* types to `AccountId` meaning we had lots of things all named `AccountId` that were in fact different as far as the compiler was concerned and then had to be differentiated using `<<T as frame_system>::Config>::AccountId` syntax etc. which doesn't improve readability at all. 

## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
  - [ ] Type sizes on subxt (you can run the ignored test in `sc_observer.rs` with a running state chain and Nats and it will tell  you what types are missing from the runtime (`engine/src/state_chain/runtime.rs`)
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordinglt?

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/522"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

