### PR TITLE
Remove SCCACHE_REDIS environment variable.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -25,7 +25,6 @@ USER gitpod
 
 # Set sccache as the default compiler cache
 ENV RUSTC_WRAPPER=sccache
-ENV SCCACHE_REDIS=redis://sccache.chainflip.xyz
 
 # Download and set nightly as the default Rust compiler
 RUN rustup default nightly-2021-03-24 \


### PR DESCRIPTION
The Redis instance of sccache is currently inaccessible.

@tomjohnburton feel free to nuke this if it doesn't make sense. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/527"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

