### PR TITLE
add lost types from merge and some new ones missed

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -43,7 +43,7 @@
     }
   },
   "ClaimDetailsFor": {
-    "msg_hash": "Option<U256>",
+    "msg_hash": "Option<AggKeySignature>",
     "amount": "FlipBalance",
     "nonce": "Nonce",
     "address": "EthereumAddress",


### PR DESCRIPTION
Some types got lost in a merge and I have added some that were missing

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/540"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

