### PR TITLE
rename chain-type to chain

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -303,7 +303,7 @@ impl<T: Config> VaultRotator for Pallet<T> {
 		ensure!(!candidates.is_empty(), RotationError::EmptyValidatorSet);
 		// Create a KeyGenRequest for Ethereum
 		let keygen_request = KeygenRequest {
-			chain_type: ChainType::Ethereum,
+			chain: Chain::Ethereum,
 			validator_candidates: candidates.clone(),
 		};
 
@@ -458,8 +458,8 @@ impl<T: Config>
 			VaultRotationResponse::Success { tx_hash } => {
 				if let Some(vault_rotation) = VaultRotations::<T>::take(ceremony_id) {
 					// At the moment we just have Ethereum to notify
-					match vault_rotation.keygen_request.chain_type {
-						ChainType::Ethereum => EthereumChain::<T>::vault_rotated(
+					match vault_rotation.keygen_request.chain {
+						Chain::Ethereum => EthereumChain::<T>::vault_rotated(
 							vault_rotation.new_public_key,
 							tx_hash,
 						),

--- a/state-chain/pallets/cf-vaults/src/rotation.rs
+++ b/state-chain/pallets/cf-vaults/src/rotation.rs
@@ -62,7 +62,7 @@ pub trait ChainHandler {
 
 /// Chain types supported
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
-pub enum ChainType {
+pub enum Chain {
 	/// Ethereum type blockchain
 	Ethereum,
 }
@@ -92,7 +92,7 @@ pub struct VaultRotation<ValidatorId, PublicKey> {
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
 pub struct KeygenRequest<ValidatorId> {
 	/// A Chain's type
-	pub(crate) chain_type: ChainType,
+	pub(crate) chain: Chain,
 	/// The set of validators from which we would like to generate the key
 	pub validator_candidates: Vec<ValidatorId>,
 }

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -35,7 +35,7 @@ mod test {
 				mock::Event::pallet_cf_vaults(crate::Event::KeygenRequest(
 					VaultsPallet::current_request(),
 					KeygenRequest {
-						chain_type: ChainType::Ethereum,
+						chain: Chain::Ethereum,
 						validator_candidates: vec![ALICE, BOB, CHARLIE],
 					}
 				))

--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -31,7 +31,7 @@
     }
   },
   "CeremonyId": "u64",
-  "ChainType": {
+  "Chain": {
     "_enum": [
       "Ethereum"
     ]
@@ -66,7 +66,7 @@
     ]
   },
   "KeygenRequest": {
-    "chain": "ChainParams",
+    "chain": "Chain",
     "validator_candidates": "Vec<ValidatorId>"
   },
   "KeygenResponse": {


### PR DESCRIPTION
A conflict in the types found so renaming `ChainType`  to `Chain`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/562"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

