### PR TITLE
Fix out of bounds signature bug

### DIFF
--- a/engine/src/signing/client/client_inner/client_inner.rs
+++ b/engine/src/signing/client/client_inner/client_inner.rs
@@ -49,7 +49,7 @@ impl From<SchnorrSignature> for pallet_cf_vaults::SchnorrSigTruncPubkey {
         // Take the Keccak-256 hash of the public key. You should now have a string that is 64 characters / 32 bytes. (note: SHA3-256 eventually became the standard, but Ethereum uses Keccak)
         let hash = Keccak256::hash(&cfe_sig.r.serialize_uncompressed()).0;
         // Take the last 40 characters / 20 bytes of this public key (Keccak-256). Or, in other words, drop the first 24 characters / 12 bytes. These 40 characters / 20 bytes are the address. When prefixed with 0x it becomes 42 characters long.
-        let eth_pub_key: [u8; 20] = hash[12..=32].try_into().expect("Is valid pubkey");
+        let eth_pub_key: [u8; 20] = hash[12..].try_into().expect("Is valid pubkey");
         Self {
             s: cfe_sig.s,
             eth_pub_key,


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
  - [ ] Type sizes on subxt (you can run the ignored test in `sc_observer.rs` with a running state chain and Nats and it will tell  you what types are missing from the runtime (`engine/src/state_chain/runtime.rs`)
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordinglt?

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/580"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

