### PR TITLE
log error when subxt submission fails, increment nonce on success

### DIFF
--- a/engine/src/eth/key_manager.rs
+++ b/engine/src/eth/key_manager.rs
@@ -35,7 +35,7 @@ pub async fn start_key_manager_witness(
     let logger = logger.new(o!(COMPONENT_KEY => "KeyManagerWitness"));
     slog::info!(logger, "Starting KeyManager witness");
 
-    slog::info!(logger, "Load KeyManager Contract ABI");
+    slog::info!(logger, "Load Contract ABI");
     let key_manager = KeyManager::new(&settings)?;
 
     let mut event_stream = key_manager

--- a/engine/src/eth/stake_manager.rs
+++ b/engine/src/eth/stake_manager.rs
@@ -38,7 +38,7 @@ pub async fn start_stake_manager_witness(
     let logger = logger.new(o!(COMPONENT_KEY => "StakeManagerWitness"));
     slog::info!(logger, "Starting StakeManager witness");
 
-    slog::info!(logger, "Load StakeManager Contract ABI");
+    slog::info!(logger, "Load Contract ABI");
     let stake_manager = StakeManager::new(&settings)?;
 
     let mut event_stream = stake_manager


### PR DESCRIPTION
This PR will log instead throw up a result, I don't think it's a crashable error if we can't submit a witness.

Also remove the `todo!()` in the KeyManager witness, so we don't crash while we run a (more) persistent testnet. Will raise an issue to implement the witnessing of KeyManager events, and how it interacts with the vaults.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/581"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

