### PR TITLE
Remove cirlce ci range usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,8 @@ auth: &dockerconfig
   password: $DOCKER_PASSWORD
 
 cargo-base-job: &cargo-base-job
-  circleci_ip_ranges: true
   executor: rust-base
   environment: &sccache_environment
-    SCCACHE_REDIS: redis://sccache.chainflip.xyz
     SCCACHE_CACHE_SIZE: 14G
   resource_class: 2xlarge+
 ######################## /Anchors ########################
@@ -309,7 +307,6 @@ jobs:
 
   run-integration-tests:
     resource_class: xlarge
-    circleci_ip_ranges: true
     docker:
       - image: ghcr.io/chainflip-io/chainflip-backend/rust-poetry:latest
         auth: *dockerconfig


### PR DESCRIPTION
Redis url is now specified in a circle ci environment var. It is also password protected and on a different port as can be seen with this PR. https://github.com/chainflip-io/chainflip-cluster/pull/27