### PR TITLE
More verbose CLI logging for CFE

### DIFF
--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -79,8 +79,8 @@ pub mod utils {
     /// Prints an easy to read log and the list of key/values. eg:
     /// ```sh
     /// [level] <module::module> - <msg>
-    ///     <Key> - <value>
-    ///     <Key> - <value>
+    ///     <Key> = <value>
+    ///     <Key> = <value>
     /// ```
     pub fn create_cli_logger_verbose() -> slog::Logger {
         slog::Logger::root(Fuse(PrintlnDrainVerbose), o!())


### PR DESCRIPTION
After a discussion with @msgmaxim, I made a more verbose variant of the CLI logger that also prints a list of key/values that the logger has.
Might come in handy in testing.
I set it as the default for `create_test_logger`.

Usage:
```rust
logger.new(o!(key => value, "my name" => "Jamie"))
```

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

