### PR TITLE
Run fmt always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ only_main_branches: &only_main_branches
         - develop
         - /epic\/.*/
         - /release\/.*/
-        - fix/release-ci
+#        - update/epic-ci-1
 ignore_main_branches: &ignore_main_branches
   filters:
     branches:
@@ -16,7 +16,7 @@ ignore_main_branches: &ignore_main_branches
         - develop
         - /epic\/.*/
         - /release\/.*/
-        - fix/release-ci
+#        - update/epic-ci-1
 
 auth: &dockerconfig
   username: $DOCKER_USERNAME


### PR DESCRIPTION
Right now the CI doesn't run on merge because the workflow depends on `fmt` running but `fmt` is set to only run on `PRs`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/706"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

