### PR TITLE
Sort validator ids in genesis test

### DIFF
--- a/engine/src/signing/client/client_inner/tests/helpers.rs
+++ b/engine/src/signing/client/client_inner/tests/helpers.rs
@@ -406,7 +406,9 @@ impl KeygenContext {
         KeygenContext::inner_new(account_ids)
     }
 
-    pub fn new_with_account_ids(account_ids: Vec<AccountId>) -> Self {
+    pub fn new_with_account_ids(mut account_ids: Vec<AccountId>) -> Self {
+        // The test expects the array to be sorted
+        account_ids.sort();
         KeygenContext::inner_new(account_ids)
     }
 


### PR DESCRIPTION
The original 3 account ids happened to be in the lexicographical order, so the "test" was passing, but could break if the account id list is modified.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/719"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

