### PR TITLE
Better Eth logging

### DIFF
--- a/engine/src/eth/eth_event_streamer.rs
+++ b/engine/src/eth/eth_event_streamer.rs
@@ -129,12 +129,8 @@ pub async fn new_eth_event_stream<
                 let result_event =
                     result_unparsed_log.and_then(|log| Event::decode(&decode_log, log));
 
-                if result_event.is_ok() {
-                    slog::debug!(
-                        logger,
-                        "Received ETH log {}",
-                        result_event.as_ref().expect("is ok")
-                    );
+                if let Ok(ok_result) = &result_event {
+                    slog::debug!(logger, "Received ETH log {}", ok_result);
                 }
 
                 result_event


### PR DESCRIPTION
This ETH log will now display with it's hex tx hash like: `0x0a7a5858a4c1f6bf6ef4be8310c5deae30018425377c85f6543d2e2fdd7f77a8`

Rather than `[2, 252, 251, 92, 0...]` which is a silly form to log.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/723"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

