### PR TITLE
Add Events / Errors doc to Witnesser Api Pallet

### DIFF
--- a/state-chain/pallets/cf-witnesser-api/README.md
+++ b/state-chain/pallets/cf-witnesser-api/README.md
@@ -1,8 +1,8 @@
-# Chainflip Witness Api Pallet
+# Chainflip Witnesser Api Pallet
 
 This pallet exposes dedicated extrinsics for witnessing Chainflip events.
 
-## Purpose
+## Overview
 
 Provide dedicated extrinsics to abstract away the use of the Witnesser pallet.
 
@@ -39,7 +39,7 @@ Provide dedicated extrinsics to abstract away the use of the Witnesser pallet.
 
     ```rust
     use pallet_cf_staking::{EthTransactionHash, FlipBalance};
-    
+
     // ...
 
     pub fn witness_staked(
@@ -70,11 +70,3 @@ This pallet has explicit dependencies on the following Chainflip pallets:
 ### Genesis Configuration
 
 N/A
-
-## Reference Docs
-
-You can view the reference docs for this pallet by running:
-
-```sh
-cargo doc --open --document-private-items
-```

--- a/state-chain/pallets/cf-witnesser-api/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser-api/src/lib.rs
@@ -63,6 +63,14 @@ pub mod pallet {
 		/// Witness the success of a threshold signing ceremony.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_eth_signature_success(
 			origin: OriginFor<T>,
@@ -78,6 +86,14 @@ pub mod pallet {
 		/// Witness the failure of a threshold signing ceremony.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_eth_signature_failed(
 			origin: OriginFor<T>,
@@ -95,6 +111,14 @@ pub mod pallet {
 		/// Witness the successful completion of an outgoing broadcast.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_eth_transmission_success(
 			origin: OriginFor<T>,
@@ -110,6 +134,14 @@ pub mod pallet {
 		/// Witness the failure of an outgoing broadcast.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_eth_transmission_failure(
 			origin: OriginFor<T>,
@@ -128,6 +160,14 @@ pub mod pallet {
 		/// Witness that a `Staked` event was emitted by the `StakeManager` smart contract.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_staked(
 			origin: OriginFor<T>,
@@ -144,6 +184,14 @@ pub mod pallet {
 		/// Witness that a `Claimed` event was emitted by the `StakeManager` smart contract.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_claimed(
 			origin: OriginFor<T>,
@@ -161,6 +209,14 @@ pub mod pallet {
 		/// Witness a successful key generation.
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_keygen_success(
 			origin: OriginFor<T>,
@@ -174,6 +230,14 @@ pub mod pallet {
 		}
 
 		/// Witness a keygen failure
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_keygen_failure(
 			origin: OriginFor<T>,
@@ -189,6 +253,14 @@ pub mod pallet {
 		/// Witness an on-chain vault key rotation
 		///
 		/// This is a convenience extrinsic that simply delegates to the configured witnesser.
+		///
+		/// ## Events
+		///
+		/// - None
+		///
+		/// ## Errors
+		///
+		/// - None
 		#[pallet::weight(10_000)]
 		pub fn witness_vault_key_rotated(
 			origin: OriginFor<T>,


### PR DESCRIPTION
You could argue this is pointless, but I'm a stickler for completeness.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/730"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

