### PR TITLE
Set state to *Validator* at genesis

### DIFF
--- a/state-chain/pallets/cf-auction/src/lib.rs
+++ b/state-chain/pallets/cf-auction/src/lib.rs
@@ -218,6 +218,14 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			Pallet::<T>::set_active_range(self.validator_size_range).expect("valid range");
+
+			for validator_id in &self.winners {
+				T::ChainflipAccount::update_state(
+					&(validator_id.clone().into()),
+					ChainflipAccountState::Validator,
+				);
+			}
+
 			LastAuctionResult::<T>::put(AuctionResult {
 				winners: self.winners.clone(),
 				minimum_active_bid: self.minimum_active_bid,

--- a/state-chain/pallets/cf-auction/src/tests.rs
+++ b/state-chain/pallets/cf-auction/src/tests.rs
@@ -8,6 +8,14 @@ mod tests {
 	fn we_have_a_set_of_winners_at_genesis() {
 		new_test_ext().execute_with(|| {
 			let (winners, minimum_active_bid) = expected_validating_set();
+
+			for winner in &winners {
+				assert_eq!(
+					MockChainflipAccount::get(winner).state,
+					ChainflipAccountState::Validator
+				);
+			}
+
 			assert_eq!(
 				AuctionPallet::auction_result(),
 				Some(AuctionResult {


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordinglt?

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

The validators at genesis had no state.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

