### PR TITLE
Short-term fix for issue #722

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -104,7 +104,7 @@
     "s": "[u8; 32]",
     "k_times_g_addr": "[u8; 20]"
   },
-  "Signature": "H256",
+  "Signature": "SchnorrVerificationComponents",
   "SignedTransactionFor": "Vec<u8>",
   "StakeAttempt": "(EthereumAddress, Amount)",
   "Timestamp": "u64",


### PR DESCRIPTION
The definition of `Signature` was broken. This fixes the definition so that it can be decoded correctly. 
In the long run this might be fixed by `scale-info` (tbc.)
Otherwise we need to figure out how to deal with associated types in the types.json.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/775"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

