### PR TITLE
Keygen ceremony aborts if pubkey is incompatible with the contract

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -66,6 +66,7 @@ async fn main() {
             p2p_message_receiver,
             p2p_message_command_sender,
             shutdown_client_rx,
+            multisig::KeygenOptions::default(),
             &root_logger,
         ),
         p2p::conductor::start(

--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -20,6 +20,8 @@ use crate::multisig::{InnerEvent, KeygenInfo, KeygenOutcome, MessageHash, Signin
 
 use crate::p2p::AccountId;
 
+use super::keygen::KeygenOptions;
+
 type SigningStateRunner = StateRunner<SigningData, SchnorrSignature>;
 
 /// Responsible for mapping ceremonies to the corresponding states and
@@ -109,7 +111,7 @@ impl CeremonyManager {
     }
 
     /// Process a keygen request
-    pub fn on_keygen_request(&mut self, keygen_info: KeygenInfo) {
+    pub fn on_keygen_request(&mut self, keygen_info: KeygenInfo, keygen_options: KeygenOptions) {
         let KeygenInfo {
             ceremony_id,
             mut signers,
@@ -142,6 +144,7 @@ impl CeremonyManager {
             validator_map,
             our_idx,
             signer_idxs,
+            keygen_options,
         );
     }
 

--- a/engine/src/multisig/client/keygen.rs
+++ b/engine/src/multisig/client/keygen.rs
@@ -30,6 +30,34 @@ pub struct KeygenInfo {
     pub signers: Vec<AccountId>,
 }
 
+#[derive(Clone, Copy)]
+pub struct KeygenOptions {
+    /// This is intentionally private to ensure that the only
+    /// way to unset this flag with via test-only constructor
+    low_pubkey_only: bool,
+}
+
+impl Default for KeygenOptions {
+    fn default() -> Self {
+        Self {
+            low_pubkey_only: true,
+        }
+    }
+}
+
+impl KeygenOptions {
+    /// This should not be used in production as it could
+    /// result in pubkeys incompatible with the KeyManager
+    /// contract, but it is useful in tests that need to be
+    /// deterministic and don't interact with the contract
+    #[cfg(test)]
+    pub fn allowing_high_pubkey() -> Self {
+        Self {
+            low_pubkey_only: false,
+        }
+    }
+}
+
 impl KeygenInfo {
     pub fn new(ceremony_id: CeremonyId, signers: Vec<AccountId>) -> Self {
         KeygenInfo {

--- a/engine/src/multisig/client/keygen_state_runner.rs
+++ b/engine/src/multisig/client/keygen_state_runner.rs
@@ -6,7 +6,7 @@ use crate::{multisig::client::ThresholdParameters, p2p::AccountId};
 
 use super::{
     common::{broadcast::BroadcastStage, CeremonyCommon, KeygenResult},
-    keygen::{AwaitCommitments1, KeygenData, KeygenP2PSender},
+    keygen::{AwaitCommitments1, KeygenData, KeygenOptions, KeygenP2PSender},
     state_runner::StateRunner,
     utils::PartyIdxMapping,
     EventSender, KeygenResultInfo,
@@ -35,6 +35,7 @@ impl KeygenStateRunner {
         idx_mapping: Arc<PartyIdxMapping>,
         own_idx: usize,
         all_idxs: Vec<usize>,
+        keygen_options: KeygenOptions,
     ) {
         self.idx_mapping = Some(idx_mapping.clone());
 
@@ -50,7 +51,7 @@ impl KeygenStateRunner {
             logger: self.logger.clone(),
         };
 
-        let processor = AwaitCommitments1::new(ceremony_id, common.clone());
+        let processor = AwaitCommitments1::new(ceremony_id, common.clone(), keygen_options);
 
         let stage = Box::new(BroadcastStage::new(processor, common));
 

--- a/engine/src/multisig/client/mod.rs
+++ b/engine/src/multisig/client/mod.rs
@@ -39,6 +39,8 @@ pub use common::KeygenResultInfo;
 
 use self::{ceremony_manager::CeremonyManager, signing::PendingSigningInfo};
 
+pub use keygen::KeygenOptions;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SchnorrSignature {
     /// Scalar component
@@ -177,6 +179,7 @@ where
     inner_event_sender: EventSender,
     /// Requests awaiting a key
     pending_requests_to_sign: HashMap<KeyId, Vec<PendingSigningInfo>>,
+    keygen_options: KeygenOptions,
     logger: slog::Logger,
 }
 
@@ -188,6 +191,7 @@ where
         my_account_id: AccountId,
         db: S,
         inner_event_sender: EventSender,
+        keygen_options: KeygenOptions,
         logger: &slog::Logger,
     ) -> Self {
         MultisigClient {
@@ -200,6 +204,7 @@ where
             ),
             inner_event_sender,
             pending_requests_to_sign: Default::default(),
+            keygen_options,
             logger: logger.clone(),
         }
     }
@@ -241,7 +246,8 @@ where
                     CEREMONY_ID_KEY => keygen_info.ceremony_id
                 );
 
-                self.ceremony_manager.on_keygen_request(keygen_info);
+                self.ceremony_manager
+                    .on_keygen_request(keygen_info, self.keygen_options);
             }
             MultisigInstruction::Sign(sign_info) => {
                 let key_id = &sign_info.key_id;

--- a/engine/src/multisig/client/signing/frost.rs
+++ b/engine/src/multisig/client/signing/frost.rs
@@ -409,7 +409,7 @@ fn build_challenge(
 
     let eth_addr = crate::eth::utils::pubkey_to_eth_addr(nonce_commitment);
 
-    let agg_key = AggKey::from(pubkey);
+    let agg_key = AggKey::from(&pubkey);
 
     // Assemble the challenge in correct order according to this contract:
     // https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/abstract/SchnorrSECP256K1.sol

--- a/engine/src/multisig/client/tests/db_tests.rs
+++ b/engine/src/multisig/client/tests/db_tests.rs
@@ -1,7 +1,10 @@
 use futures::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use crate::{logging, multisig::client::MultisigClient};
+use crate::{
+    logging,
+    multisig::client::{keygen::KeygenOptions, MultisigClient},
+};
 
 use super::helpers;
 
@@ -25,7 +28,8 @@ async fn check_signing_db() {
     let id = client1.get_my_account_id();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let logger = logging::test_utils::new_test_logger();
-    let restarted_client = MultisigClient::new(id, db, tx, &logger);
+    let restarted_client =
+        MultisigClient::new(id, db, tx, KeygenOptions::allowing_high_pubkey(), &logger);
 
     // 4. Replace the client
     ctx.substitute_client_at(

--- a/engine/src/multisig/client/tests/helpers.rs
+++ b/engine/src/multisig/client/tests/helpers.rs
@@ -6,7 +6,10 @@ use pallet_cf_vaults::CeremonyId;
 
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use crate::multisig::{client::signing, KeyId, MultisigInstruction};
+use crate::multisig::{
+    client::{keygen::KeygenOptions, signing},
+    KeyId, MultisigInstruction,
+};
 
 use signing::frost::{
     self, LocalSig3, SigningCommitment, SigningData, SigningDataWrapped, VerifyComm2,
@@ -418,7 +421,13 @@ impl KeygenContext {
             .iter()
             .map(|id| {
                 let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-                let c = MultisigClient::new(id.clone(), KeyDBMock::new(), tx, &logger);
+                let c = MultisigClient::new(
+                    id.clone(),
+                    KeyDBMock::new(),
+                    tx,
+                    KeygenOptions::allowing_high_pubkey(),
+                    &logger,
+                );
                 (c, Box::pin(UnboundedReceiverStream::new(rx).peekable()))
             })
             .unzip();

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -85,7 +85,7 @@ async fn should_delay_comm1_before_keygen_request() {
 
     assert_stage1(&c1);
 
-    // Recieve the remaining stage1 messages. Provided that the first
+    // Receive the remaining stage1 messages. Provided that the first
     // message was properly delayed, this should advance us to the next stage
     receive_comm1!(c1, 2, keygen_states);
     receive_comm1!(c1, 3, keygen_states);

--- a/engine/src/multisig/mod.rs
+++ b/engine/src/multisig/mod.rs
@@ -27,7 +27,7 @@ use crate::p2p::P2PMessage;
 
 use client::InnerEvent;
 
-pub use client::{KeygenOutcome, MultisigClient, SchnorrSignature, SigningOutcome};
+pub use client::{KeygenOptions, KeygenOutcome, MultisigClient, SchnorrSignature, SigningOutcome};
 
 pub use db::{KeyDB, PersistentKeyDB};
 
@@ -76,6 +76,7 @@ pub fn start_client<S>(
     mut p2p_message_receiver: UnboundedReceiver<P2PMessage>,
     p2p_message_command_sender: UnboundedSender<P2PMessageCommand>,
     mut shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+    keygen_options: KeygenOptions,
     logger: &slog::Logger,
 ) -> impl futures::Future
 where
@@ -86,7 +87,13 @@ where
     slog::info!(logger, "Starting");
 
     let (inner_event_sender, mut inner_event_receiver) = mpsc::unbounded_channel();
-    let mut client = MultisigClient::new(my_account_id, db, inner_event_sender, &logger);
+    let mut client = MultisigClient::new(
+        my_account_id,
+        db,
+        inner_event_sender,
+        keygen_options,
+        &logger,
+    );
 
     async move {
         // Stream outputs () approximately every ten seconds

--- a/engine/src/multisig/tests/distributed_signing.rs
+++ b/engine/src/multisig/tests/distributed_signing.rs
@@ -9,7 +9,12 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use crate::{
     logging,
     multisig::{
-        client::{self, keygen::KeygenInfo, signing::SigningInfo, SigningOutcome},
+        client::{
+            self,
+            keygen::{KeygenInfo, KeygenOptions},
+            signing::SigningInfo,
+            SigningOutcome,
+        },
         KeyDBMock, KeyId, MessageHash, MultisigEvent, MultisigInstruction,
     },
     p2p::{
@@ -194,6 +199,7 @@ async fn distributed_signing() {
             mock_channel_event_handler_receiver,
             p2p_message_command_tx,
             shutdown_client_rx,
+            KeygenOptions::allowing_high_pubkey(),
             &logger,
         );
 

--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -104,7 +104,7 @@ impl Tokenizable for SigData {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Copy, Clone, RuntimeDebug, Default, PartialEq, Eq)]
 pub struct AggKey {
-	/// The public key as a 32-byte array.
+	/// X coordinate of the public key as a 32-byte array.
 	pub pub_key_x: [u8; 32],
 	/// The parity bit can be `1u8` (odd) or `0u8` (even).
 	pub pub_key_y_parity: u8,
@@ -157,8 +157,8 @@ impl TryFrom<&[u8]> for AggKey {
 }
 
 #[cfg(feature = "std")]
-impl From<secp256k1::PublicKey> for AggKey {
-	fn from(key: secp256k1::PublicKey) -> Self {
+impl From<&secp256k1::PublicKey> for AggKey {
+	fn from(key: &secp256k1::PublicKey) -> Self {
 		AggKey::from_pubkey_compressed(key.serialize())
 	}
 }
@@ -192,7 +192,7 @@ pub struct SchnorrVerificationComponents {
 	pub k_times_g_addr: [u8; 20],
 }
 
-/// Required information to construct and sign an ethereum transaction. Equivalet to
+/// Required information to construct and sign an ethereum transaction. Equivalent to
 /// [ethereum::EIP1559TransactionMessage] with the following fields omitted: nonce,
 ///
 /// The signer will need to add its account nonce and then sign and rlp-encode the transaction.


### PR DESCRIPTION
At an early stage of keygen we check if x of the pubkey that would be generated is too high and aborts if so with no validators reported. The check could be disabled in tests only with `KeygenOptions` when deterministic (and successful) outcome is required.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/811"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

