### PR TITLE
Confirm state and last epoch index in account state

### DIFF
--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -641,7 +641,10 @@ mod tests {
 
 	mod epoch {
 		use super::*;
-		use cf_traits::{AuctionPhase, AuctionResult, EpochInfo};
+		use cf_traits::{
+			AuctionPhase, AuctionResult, ChainflipAccount, ChainflipAccountState,
+			ChainflipAccountStore, EpochInfo,
+		};
 		use state_chain_runtime::{Auction, HeartbeatBlockInterval, Validator};
 
 		#[test]
@@ -731,6 +734,8 @@ mod tests {
 		// - All nodes stake above the MAB
 		// - A new auction index has been generated
 		// - We have two nodes that haven't registered their session keys
+		// - New validators have the state of Validator with the last active epoch stored
+		// - Nodes without keys state remains passive with `None` as their last active epoch
 		fn epoch_rotates() {
 			const EPOCH_BLOCKS: BlockNumber = 100;
 			super::genesis::default()
@@ -810,6 +815,33 @@ mod tests {
 						nodes,
 						"the new validators should be those genesis validators and the new nodes created in test"
 					);
+
+					for account in keyless_nodes.iter() {
+						assert_eq!(
+							None,
+							ChainflipAccountStore::<Runtime>::get(account).last_active_epoch,
+							"this node should have never been active"
+						);
+						assert_eq!(
+							ChainflipAccountState::Passive,
+							ChainflipAccountStore::<Runtime>::get(account).state,
+							"should be a passive node"
+						);
+					}
+
+					let current_epoch = Validator::epoch_index();
+					for account in new_validators.iter() {
+						assert_eq!(
+							Some(current_epoch),
+							ChainflipAccountStore::<Runtime>::get(account).last_active_epoch,
+							"validator should have been active in current epoch"
+						);
+						assert_eq!(
+							ChainflipAccountState::Validator,
+							ChainflipAccountStore::<Runtime>::get(account).state,
+							"should be validator"
+						);
+					}
 				});
 		}
 	}


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Tests confirm state transitions for account state and last active epoch