### PR TITLE
fix/env-pallet-is-not-shown

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -465,7 +465,7 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Environment: pallet_cf_environment::{Pallet, Call, Event<T>, Config},
+		Environment: pallet_cf_environment::{Pallet, Storage, Event<T>, Config},
 		Flip: pallet_cf_flip::{Pallet, Event<T>, Storage, Config<T>},
 		Emissions: pallet_cf_emissions::{Pallet, Event<T>, Storage, Config},
 		Rewards: pallet_cf_rewards::{Pallet, Call, Event<T>},


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/827"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

