### PR TITLE
Chore/chainspec aggkey env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "state-chain-runtime",
  "structopt",
  "tokio 1.13.0",
+ "utilities",
 ]
 
 [[package]]
@@ -8571,6 +8572,7 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "utilities",
 ]
 
 [[package]]
@@ -9551,6 +9553,9 @@ dependencies = [
 [[package]]
 name = "utilities"
 version = "0.1.0"
+dependencies = [
+ "hex",
+]
 
 [[package]]
 name = "value-bag"

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -14,6 +14,7 @@ serde = {version = "1.0", features = ["derive", "rc"]}
 slog = {version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"]}
 structopt = "0.3.23"
 tokio = {version = "1.5.0", features = ["full"]}
+utilities = {path = "../../utilities"}
 
 # State chain
 pallet-cf-rewards = {path = "../../state-chain/pallets/cf-rewards"}

--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use chainflip_engine::state_chain::client::connect_to_state_chain;
 use futures::StreamExt;
 use settings::{CLICommandLineOptions, CLISettings};
@@ -7,6 +5,7 @@ use structopt::StructOpt;
 
 use crate::settings::CFCommand::*;
 use anyhow::Result;
+use utilities::clean_eth_address;
 
 mod settings;
 
@@ -38,26 +37,13 @@ async fn run_cli() -> Result<()> {
             eth_address,
         } => Ok(send_claim(
             amount,
-            clean_eth_address(eth_address)
+            clean_eth_address(&eth_address)
                 .map_err(|_| anyhow::Error::msg("You supplied an invalid ETH address"))?,
             &cli_settings,
             &logger,
         )
         .await?),
     }
-}
-
-fn clean_eth_address(dirty_eth_address: String) -> Result<[u8; 20]> {
-    let eth_address_hex_str = match dirty_eth_address.strip_prefix("0x") {
-        Some(eth_address_stripped) => eth_address_stripped,
-        None => &dirty_eth_address,
-    };
-
-    let eth_address: [u8; 20] = hex::decode(eth_address_hex_str)?
-        .try_into()
-        .map_err(|_| anyhow::Error::msg("Could not create a [u8; 20]"))?;
-
-    Ok(eth_address)
 }
 
 async fn send_claim(
@@ -165,29 +151,5 @@ fn confirm_submit() -> bool {
                 continue;
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cleans_eth_address() {
-        // fail too short
-        let input = "0x323232".to_string();
-        assert!(clean_eth_address(input).is_err());
-
-        // fail invalid chars
-        let input = "0xZ29aB9EbDb421CE48b70flippya6e9a3DBD609C5".to_string();
-        assert!(clean_eth_address(input).is_err());
-
-        // success with 0x
-        let input = "0xB29aB9EbDb421CE48b70699758a6e9a3DBD609C5".to_string();
-        assert!(clean_eth_address(input).is_ok());
-
-        // success without 0x
-        let input = "B29aB9EbDb421CE48b70699758a6e9a3DBD609C5".to_string();
-        assert!(clean_eth_address(input).is_ok());
     }
 }

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
+build = 'build.rs'
 description = 'The Chainflip State Chain node, based on substrate-node-template'
 edition = '2018'
 homepage = 'https://chainflip.io'
 license = '<TODO>'
-publish = false
 name = 'state-chain-node'
+publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
 version = '0.1.0'
-build = 'build.rs'
 
 [[bin]]
 name = 'state-chain-node'
@@ -26,12 +26,13 @@ path = '../runtime'
 
 [dependencies]
 # Chainflip-specific dependencies  
-cf-p2p = { path = '../client/cf-p2p' }
-futures = { version = '0.3.4' }
-hex-literal = '0.3.1'
+cf-p2p = {path = '../client/cf-p2p'}
+futures = {version = '0.3.4'}
 hex = '0.4'
+hex-literal = '0.3.1'
 jsonrpc-core-client = '18.0.0'
 jsonrpc-derive = '18.0.0'
+utilities = {path = '../../utilities'}
 
 # Substrate dependencies
 jsonrpc-core = '18.0.0'
@@ -150,11 +151,10 @@ default = []
 runtime-benchmarks = ['state-chain-runtime/runtime-benchmarks']
 
 [package.metadata.deb]
-name = "state-chain-node"
-maintainer = "Chainflip UG <dev@chainflip.io>"
+depends = "$auto"
 extended-description = """\
 Chainflip Validator Node Package"""
-depends = "$auto"
-section = "rust"
+maintainer = "Chainflip UG <dev@chainflip.io>"
+name = "state-chain-node"
 priority = "required"
-
+section = "rust"

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -10,6 +10,7 @@ use state_chain_runtime::{
 	ValidatorConfig, VaultsConfig, WASM_BINARY,
 };
 use std::{convert::TryInto, env};
+use utilities::clean_eth_address;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
@@ -48,21 +49,16 @@ pub struct StateChainEnvironment {
 	ethereum_chain_id: u64,
 	eth_init_agg_key: [u8; 33],
 }
-
-/// Get the values for the state-chain environment.
+/// Get the values from the State Chain's environment variables. Else set them via the defaults
 pub fn get_environment() -> StateChainEnvironment {
-	let stake_manager_address: [u8; 20] = hex::decode(
-		env::var("STAKE_MANAGER_ADDRESS").unwrap_or(String::from(STAKE_MANAGER_ADDRESS_DEFAULT)),
+	let stake_manager_address: [u8; 20] = clean_eth_address(
+		&env::var("STAKE_MANAGER_ADDRESS").unwrap_or(String::from(STAKE_MANAGER_ADDRESS_DEFAULT)),
 	)
-	.unwrap()
-	.try_into()
-	.expect("address cast failed");
-	let key_manager_address: [u8; 20] = hex::decode(
-		env::var("KEY_MANAGER_ADDRESS").unwrap_or(String::from(KEY_MANAGER_ADDRESS_DEFAULT)),
+	.unwrap();
+	let key_manager_address: [u8; 20] = clean_eth_address(
+		&env::var("KEY_MANAGER_ADDRESS").unwrap_or(String::from(KEY_MANAGER_ADDRESS_DEFAULT)),
 	)
-	.unwrap()
-	.try_into()
-	.expect("address cast failed");
+	.unwrap();
 	let ethereum_chain_id = env::var("ETHEREUM_CHAIN_ID")
 		.unwrap_or(ETHEREUM_CHAIN_ID_DEFAULT.to_string())
 		.parse::<u64>()

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -9,3 +9,10 @@ repository = 'https://github.com/chainflip-io/chainflip-backend'
 version = '0.1.0'
 
 [dependencies]
+hex = {version = "0.4.3", default-features = false}
+
+[features]
+default = ['std']
+std = [
+  'hex/std',
+]

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -5,11 +5,11 @@
 /// i.e. at least `t+1` parties are required.
 /// This follows the notation in the multisig library that
 /// we are using and in the corresponding literature.
+
 pub fn threshold_from_share_count(share_count: u32) -> u32 {
     ((share_count * 2) - 1) / 3
 }
 
-#[cfg(test)]
 #[test]
 fn check_threshold_calculation() {
     assert_eq!(threshold_from_share_count(150), 99);
@@ -17,4 +17,39 @@ fn check_threshold_calculation() {
     assert_eq!(threshold_from_share_count(90), 59);
     assert_eq!(threshold_from_share_count(3), 1);
     assert_eq!(threshold_from_share_count(4), 2);
+}
+
+use core::convert::TryInto;
+
+pub fn clean_eth_address(dirty_eth_address: &str) -> Result<[u8; 20], &str> {
+    let eth_address_hex_str = match dirty_eth_address.strip_prefix("0x") {
+        Some(eth_address_stripped) => eth_address_stripped,
+        None => &dirty_eth_address,
+    };
+
+    let eth_address: [u8; 20] = hex::decode(eth_address_hex_str)
+        .map_err(|_| "Invalid hex")?
+        .try_into()
+        .map_err(|_| "Could not create a [u8; 20]")?;
+
+    Ok(eth_address)
+}
+
+#[test]
+fn cleans_eth_address() {
+    // fail too short
+    let input = "0x323232";
+    assert!(clean_eth_address(input).is_err());
+
+    // fail invalid chars
+    let input = "0xZ29aB9EbDb421CE48b70flippya6e9a3DBD609C5";
+    assert!(clean_eth_address(input).is_err());
+
+    // success with 0x
+    let input = "0xB29aB9EbDb421CE48b70699758a6e9a3DBD609C5";
+    assert!(clean_eth_address(input).is_ok());
+
+    // success without 0x
+    let input = "B29aB9EbDb421CE48b70699758a6e9a3DBD609C5";
+    assert!(clean_eth_address(input).is_ok());
 }


### PR DESCRIPTION
Small improvements:
- Factors out ETH address parsing done in the chain spec and the CLI
- Can now read in the initial Ethereum aggregate key

## State Chain

- [x] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [x] Were any changes to the genesis config of any pallets? If yes:
   - [x] Has the Chainspec been updated accordingly?
   - [x] Has the chainspec version been incremented?
- [x] Is `types.json` up to date? Test this against polka js.
- [x] Have any new dependencies been added? If yes:
   - [x] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/844"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

