### PR TITLE
P2P Prep 3 - SC Block Subscription always starts from latest_block_hash

### DIFF
--- a/engine/src/state_chain/client.rs
+++ b/engine/src/state_chain/client.rs
@@ -172,8 +172,6 @@ pub trait StateChainRpcApi {
 
     async fn get_block(&self, block_hash: state_chain_runtime::Hash)
         -> Result<Option<SignedBlock>>;
-
-    async fn latest_block_hash(&self) -> Result<state_chain_runtime::Hash>;
 }
 
 #[async_trait]
@@ -223,16 +221,6 @@ impl StateChainRpcApi for StateChainRpcClient {
             .await
             .map_err(into_anyhow_error)
     }
-
-    async fn latest_block_hash(&self) -> Result<state_chain_runtime::Hash> {
-        try_unwrap_value(
-            self.chain_rpc_client
-                .block_hash(None)
-                .await
-                .map_err(into_anyhow_error)?,
-            anyhow::Error::msg("Failed to get latest block hash"),
-        )
-    }
 }
 
 pub struct StateChainClient<RpcClient: StateChainRpcApi> {
@@ -247,11 +235,6 @@ pub struct StateChainClient<RpcClient: StateChainRpcApi> {
 }
 
 impl<RpcClient: StateChainRpcApi> StateChainClient<RpcClient> {
-    /// Get the latest block hash at the time of the call
-    pub async fn get_latest_block_hash(&self) -> Result<state_chain_runtime::Hash> {
-        self.state_chain_rpc_client.latest_block_hash().await
-    }
-
     /// Submit an extrinsic and retry if it fails on an invalid nonce
     pub async fn submit_extrinsic<Extrinsic>(
         &self,


### PR DESCRIPTION
The idea here is that the latest block we use (When the cfe starts) and subscription that the sc_observer uses start at the same point in time. Particularly so that if I get all whole account-peer mapping at the start of the CFE (At the latest block), and then listen for events (Register and Unregister) it can be kept upto date, without possibly missing changes, and in a way that is synchronous to multisig instructions being sent to the multisig client (So the mapping is guaranteed to contain a mapping for any validators in a signing or keygen request).

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/862"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

