### PR TITLE
type defintions for BalanceSettled event

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -35,6 +35,7 @@
     "minimum_active_bid": "Amount"
   },
   "BasisPoints": "u32",
+  "Balance": "FlipBalance",
   "Bid": "(ValidatorId, Amount)",
   "BlockHeightWindow": {
     "from": "u64",
@@ -82,12 +83,18 @@
   },
   "FlipBalance": "u128",
   "H256": "[u8; 32]",
+  "InternalSource": {
+    "_enum": {
+      "Account": "(ValidatorId)",
+      "Reserve": "(ReserveId)"
+    }
+  },
   "ImbalanceSource": {
-    "_enum": [
-      "External",
-      "Account(AccountId)",
-      "Emissions"
-    ]
+    "_enum": {
+      "External": "",
+      "Internal": "(InternalSource)",
+      "Emissions": ""
+    }
   },
   "KeyId": "Vec<u8>",
   "LookupSource": "MultiAddress",
@@ -104,10 +111,10 @@
     "_enum": [
       "BroadcastOutputFailed",
       "ParticipateSigningFailed",
-      "NotEnoughPerformanceCredits",
-      "ContradictingSelfDuringSigningCeremony"
+      "NotEnoughPerformanceCredits"
     ]
   },
+  "OnlineCredits": "BlockNumber",
   "OnlineCreditsFor": "BlockNumber",
   "PayloadFor": "[u8; 32]",
   "PercentageRange": {
@@ -128,7 +135,11 @@
     "points": "ReputationPoints",
     "blocks": "BlockNumber"
   },
-  "ReputationOf": "BlockNumber",
+  "Reputation": {
+    "online_credits": "OnlineCredits",
+    "reputation_points": "ReputationPoints"
+  },
+  "ReputationOf": "Reputation",
   "ReputationPoints": "i32",
   "ReserveId": "[u8;4]",
   "Retired": "bool",
@@ -159,7 +170,16 @@
     ]
   },
   "Uint": "[u8; 32]",
-  "UnsignedTransactionFor": "Vec<u8>",
+  "UnsignedTransaction": {
+    "chain_id": "u64",
+    "max_priority_fee_per_gas": "Option<U256>",
+    "max_fee_per_gas": "Option<U256>",
+    "gas_limit": "Option<U256>",
+    "contract": "EthereumAddress",
+    "value": "U256",
+    "data": "Vec<u8>"
+  },
+  "UnsignedTransactionFor": "UnsignedTransaction",
   "ValidatorId": "AccountId",
   "Vault": {
     "public_key": "PublicKey",


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Revised types and caught that the `BalanceSettled` event wasn't being caught which is emitted on slashing, which in this case was being triggered due to reputation of nodes. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/868"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

