### PR TITLE
Test ceremony request with unsorted account ids

### DIFF
--- a/engine/src/multisig/client/tests/frost_unit_tests.rs
+++ b/engine/src/multisig/client/tests/frost_unit_tests.rs
@@ -11,7 +11,7 @@ use crate::logging::{
 macro_rules! receive_comm1 {
     ($c1:expr, $sender: expr, $sign_states:expr) => {
         let comm1 = $sign_states.sign_phase1.comm1_vec[$sender].clone();
-        let m = helpers::sig_data_to_p2p(comm1, &VALIDATOR_IDS[$sender]);
+        let m = helpers::sig_data_to_p2p(comm1, &ACCOUNT_IDS[$sender]);
         $c1.process_p2p_message(m);
     };
 }
@@ -19,7 +19,7 @@ macro_rules! receive_comm1 {
 macro_rules! receive_ver2 {
     ($c1:expr, $sender: expr, $sign_states:expr) => {
         let ver2 = $sign_states.sign_phase2.ver2_vec[$sender].clone();
-        let m = helpers::sig_data_to_p2p(ver2, &VALIDATOR_IDS[$sender]);
+        let m = helpers::sig_data_to_p2p(ver2, &ACCOUNT_IDS[$sender]);
         $c1.process_p2p_message(m);
     };
 }
@@ -28,7 +28,7 @@ macro_rules! receive_sig3 {
     ($c1:expr, $sender: expr, $sign_states:expr) => {
         let sign_phase3 = $sign_states.sign_phase3.as_ref().expect("phase 3");
         let sig3 = sign_phase3.local_sigs[$sender].clone();
-        let m = helpers::sig_data_to_p2p(sig3, &VALIDATOR_IDS[$sender]);
+        let m = helpers::sig_data_to_p2p(sig3, &ACCOUNT_IDS[$sender]);
         $c1.process_p2p_message(m);
     };
 }
@@ -37,7 +37,7 @@ macro_rules! receive_ver4 {
     ($c1:expr, $sender: expr, $sign_states:expr) => {
         let sign_phase4 = $sign_states.sign_phase4.as_ref().expect("phase 4");
         let ver4 = sign_phase4.ver4_vec[$sender].clone();
-        let m = helpers::sig_data_to_p2p(ver4, &VALIDATOR_IDS[$sender]);
+        let m = helpers::sig_data_to_p2p(ver4, &ACCOUNT_IDS[$sender]);
         $c1.process_p2p_message(m);
     };
 }
@@ -425,7 +425,7 @@ async fn should_ignore_signing_non_participant() {
 
     // Make sure that the non_participant_id is not a signer
     let non_participant_idx = 3;
-    let non_participant_id = VALIDATOR_IDS[non_participant_idx].clone();
+    let non_participant_id = ACCOUNT_IDS[non_participant_idx].clone();
     assert!(!SIGNER_IDS.contains(&non_participant_id));
 
     // Send some ver2 data from the non-participant to the client
@@ -447,7 +447,7 @@ async fn should_ignore_rts_with_unknown_signer_id() {
 
     // Get an id that was not in the keygen and substitute it in the signer list
     let unknown_signer_id = AccountId([0; 32]);
-    assert!(!VALIDATOR_IDS.contains(&unknown_signer_id));
+    assert!(!ACCOUNT_IDS.contains(&unknown_signer_id));
     let mut signer_ids = SIGNER_IDS.clone();
     signer_ids[1] = unknown_signer_id;
 
@@ -500,7 +500,7 @@ async fn should_ignore_rts_with_incorrect_amount_of_signers() {
 
     // Send the request to sign with too many signers
     let mut signer_ids = SIGNER_IDS.clone();
-    signer_ids.push(VALIDATOR_IDS[3].clone());
+    signer_ids.push(ACCOUNT_IDS[3].clone());
     c1.send_request_to_sign_default(ctx.key_id(), signer_ids);
 
     // The rts should not have started a ceremony and we should see an error tag

--- a/engine/src/multisig/client/tests/helpers.rs
+++ b/engine/src/multisig/client/tests/helpers.rs
@@ -37,7 +37,7 @@ use crate::{
 pub type MultisigClientNoDB = MultisigClient<KeyDBMock>;
 
 use super::{
-    KEYGEN_CEREMONY_ID, MESSAGE_HASH, SIGNER_IDS, SIGNER_IDXS, SIGN_CEREMONY_ID, VALIDATOR_IDS,
+    ACCOUNT_IDS, KEYGEN_CEREMONY_ID, MESSAGE_HASH, SIGNER_IDS, SIGNER_IDXS, SIGN_CEREMONY_ID,
 };
 
 macro_rules! recv_data_keygen {
@@ -329,8 +329,8 @@ fn gen_invalid_keygen_comm1() -> DKGUnverifiedCommitment {
         &HashContext([0; 32]),
         0,
         ThresholdParameters {
-            share_count: VALIDATOR_IDS.len(),
-            threshold: VALIDATOR_IDS.len(),
+            share_count: ACCOUNT_IDS.len(),
+            threshold: ACCOUNT_IDS.len(),
         },
     );
     fake_comm1
@@ -442,7 +442,7 @@ async fn broadcast_all_signing_comm1(
                     .remove(&(*sender_idx, *receiver_idx))
                     .unwrap_or(valid_comm1.clone());
 
-                let id = &super::VALIDATOR_IDS[*sender_idx];
+                let id = &super::ACCOUNT_IDS[*sender_idx];
 
                 let m = sig_data_to_p2p(comm1, id);
 
@@ -483,7 +483,7 @@ async fn broadcast_all_ver2(clients: &mut Vec<MultisigClientNoDB>, ver2_vec: &Ve
             if sender_idx != receiver_idx {
                 let ver2 = ver2_vec[*sender_idx].clone();
 
-                let id = &super::VALIDATOR_IDS[*sender_idx];
+                let id = &super::ACCOUNT_IDS[*sender_idx];
 
                 let m = sig_data_to_p2p(ver2, id);
 
@@ -505,7 +505,7 @@ async fn broadcast_all_local_sigs(
                 .remove(&(*sender_idx, *receiver_idx))
                 .unwrap_or(valid_sig);
 
-            let id = &super::VALIDATOR_IDS[*sender_idx];
+            let id = &super::ACCOUNT_IDS[*sender_idx];
 
             let m = sig_data_to_p2p(sig3, id);
 
@@ -525,7 +525,7 @@ async fn broadcast_all_ver4(
             if sender_idx != receiver_idx {
                 let ver4 = ver4_vec[*sender_idx].clone();
 
-                let id = &super::VALIDATOR_IDS[*sender_idx];
+                let id = &super::ACCOUNT_IDS[*sender_idx];
 
                 let m = sig_data_to_p2p(ver4, id);
 
@@ -539,7 +539,7 @@ impl KeygenContext {
     /// Generate context without starting the keygen ceremony.
     /// `allowing_high_pubkey` is enabled so tests will not fail.
     pub fn new() -> Self {
-        let account_ids = super::VALIDATOR_IDS.clone();
+        let account_ids = super::ACCOUNT_IDS.clone();
         KeygenContext::inner_new(account_ids, KeygenOptions::allowing_high_pubkey())
     }
 
@@ -549,7 +549,7 @@ impl KeygenContext {
 
     /// Generate context with the KeygenOptions as default, (No `allowing_high_pubkey`)
     pub fn new_disallow_high_pubkey() -> Self {
-        let account_ids = super::VALIDATOR_IDS.clone();
+        let account_ids = super::ACCOUNT_IDS.clone();
         KeygenContext::inner_new(account_ids, KeygenOptions::default())
     }
 
@@ -1398,7 +1398,7 @@ impl MultisigClientNoDB {
         }
     }
 
-    /// Sends the correct keygen data from the `VALIDATOR_IDS[sender_idx]` to the client via `process_p2p_message`
+    /// Sends the correct keygen data from the `ACCOUNT_IDS[sender_idx]` to the client via `process_p2p_message`
     pub fn receive_keygen_stage_data(
         &mut self,
         stage: usize,
@@ -1409,7 +1409,7 @@ impl MultisigClientNoDB {
             stage,
             keygen_states,
             sender_idx,
-            &VALIDATOR_IDS[sender_idx],
+            &ACCOUNT_IDS[sender_idx],
         );
         self.process_p2p_message(message);
     }

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -229,8 +229,8 @@ async fn should_ignore_keygen_request_if_not_participating() {
 
     // Get an id that is not `c1`s id
     let unknown_id = AccountId([0; 32]);
-    assert!(!VALIDATOR_IDS.contains(&unknown_id));
-    let mut keygen_ids = VALIDATOR_IDS.clone();
+    assert!(!ACCOUNT_IDS.contains(&unknown_id));
+    let mut keygen_ids = ACCOUNT_IDS.clone();
     keygen_ids[0] = unknown_id;
 
     // Send the keygen request
@@ -253,8 +253,8 @@ async fn should_ignore_duplicate_keygen_request() {
 
     // Create a list of accounts that is different from the default Keygen
     let unknown_id = AccountId([0; 32]);
-    assert!(!VALIDATOR_IDS.contains(&unknown_id));
-    let mut keygen_ids = VALIDATOR_IDS.clone();
+    assert!(!ACCOUNT_IDS.contains(&unknown_id));
+    let mut keygen_ids = ACCOUNT_IDS.clone();
     keygen_ids[1] = unknown_id;
 
     // Send another keygen request with the same ceremony_id but different signers
@@ -280,7 +280,7 @@ async fn should_ignore_unexpected_message_for_stage() {
 
     // Get an id that is not in the keygen ceremony
     let unknown_id = AccountId([0; 32]);
-    assert!(!VALIDATOR_IDS.contains(&unknown_id));
+    assert!(!ACCOUNT_IDS.contains(&unknown_id));
 
     // Test for all keygen stages
     for current_stage in 1..=7 {
@@ -442,7 +442,7 @@ async fn should_ignore_keygen_request_with_duplicate_signer() {
     let mut c1 = keygen_states.get_client_at_stage(0);
 
     // Create a duplicate in the list of signers
-    let mut keygen_ids = VALIDATOR_IDS.clone();
+    let mut keygen_ids = ACCOUNT_IDS.clone();
     keygen_ids[1] = keygen_ids[2].clone();
 
     // Send the keygen request with the modified signers list

--- a/engine/src/multisig/client/tests/mod.rs
+++ b/engine/src/multisig/client/tests/mod.rs
@@ -24,12 +24,12 @@ pub const SIGN_CEREMONY_ID: CeremonyId = 0;
 
 lazy_static! {
 
-    static ref VALIDATOR_IDS: Vec<AccountId> =
+    static ref ACCOUNT_IDS: Vec<AccountId> =
         [1, 2, 3, 4].iter().map(|i| AccountId([*i; 32])).collect();
     static ref SIGNER_IDXS: Vec<usize> = vec![0, 1, 2];
     static ref SIGNER_IDS: Vec<AccountId> = SIGNER_IDXS
         .iter()
-        .map(|idx| VALIDATOR_IDS[*idx].clone())
+        .map(|idx| ACCOUNT_IDS[*idx].clone())
         .collect();
     static ref UNEXPECTED_VALIDATOR_ID: AccountId = AccountId(
         "unexpected|unexpected|unexpected"
@@ -49,6 +49,6 @@ lazy_static! {
         .unwrap();
     static ref KEYGEN_INFO: KeygenInfo = KeygenInfo {
         ceremony_id: KEYGEN_CEREMONY_ID,
-        signers: VALIDATOR_IDS.clone()
+        signers: ACCOUNT_IDS.clone()
     };
 }


### PR DESCRIPTION
- modify distributed signing to use an unsorted list of signers (to test that we don't rely on the order)
- renamed `VALIDATOR_IDS` -> `ACCOUNT_IDS`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/872"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

