### PR TITLE
confirm the slashing rate is not zero

### DIFF
--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -484,7 +484,7 @@ where
 		let slashing_rate: T::Balance = SlashingRate::<T>::get();
 		// Check that the slashing rate is not zero, no need to slash if this is set to zero, right
 		if slashing_rate == Zero::zero() {
-			return T::DbWeight::get().reads(1);
+			return T::DbWeight::get().reads(1)
 		}
 		// Get the MBA aka the bond
 		let bond = Account::<T>::get(account_id).validator_bond;


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

As the slashing rate in cf-flip is configurable we should check at the time of slashing whether this is zero or not to save needless slashing operations.  It's currently set to zero in genesis.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/873"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

