### PR TITLE
Add unsigned validation check to integ tests.

### DIFF
--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -283,7 +283,7 @@ mod tests {
 											public_key,
 											ethereum_block_number,
 											tx_hash,
-										).expect("should be able to witness vault key rotation for node");
+										).expect("should be able to witness ethereum vault key rotation");
 									},
 									_ => {}
 								}


### PR DESCRIPTION
Adds the runtime's unsigned validation to the integration tests.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/897"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

