### PR TITLE
Reset forced rotation flag

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -347,7 +347,6 @@ impl<T: Config> Pallet<T> {
 	/// block number
 	fn should_rotate(now: T::BlockNumber) -> bool {
 		if Force::<T>::get() {
-			Force::<T>::set(false);
 			return true
 		}
 
@@ -390,6 +389,10 @@ impl<T: Config> pallet_session::SessionManager<T::ValidatorId> for Pallet<T> {
 			AuctionPhase::ConfirmedValidators(winners, minimum_active_bid) => {
 				// If we have a set of winners
 				if !winners.is_empty() {
+					// Reset forced rotation flag
+					if Force::<T>::get() {
+						Force::<T>::set(false);
+					}
 					// If we were in an emergency, mark as completed
 					Self::emergency_rotation_completed();
 					// Calculate our new epoch index


### PR DESCRIPTION

## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Closes #894 

An error within a forced auction wasn't being cycled as if it were an auction triggered on epoch. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/900"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

