### PR TITLE
ValidatorId is equivalent to AccountId

### DIFF
--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -30,8 +30,7 @@ benchmarks! {
 		};
 	}: _(RawOrigin::Signed(caller.clone()), version.clone())
 	verify {
-		let validator_id = <T as pallet_session::Config>::ValidatorIdOf::convert(caller)
-								.expect("validator is account");
+		let validator_id: T::ValidatorId = caller.into();
 		assert_eq!(Pallet::<T>::validator_cfe_version(validator_id), version)
 	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -57,7 +57,10 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
-	pub trait Config: frame_system::Config + pallet_session::Config {
+	pub trait Config:
+		frame_system::Config
+		+ pallet_session::Config<ValidatorId = <Self as frame_system::Config>::AccountId>
+	{
 		/// The overarching event type.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
@@ -210,10 +213,7 @@ pub mod pallet {
 		#[pallet::weight(T::ValidatorWeightInfo::cfe_version())]
 		pub fn cfe_version(origin: OriginFor<T>, version: Version) -> DispatchResultWithPostInfo {
 			let account_id = ensure_signed(origin)?;
-
-			let validator_id = T::ValidatorIdOf::convert(account_id)
-				.ok_or(pallet_session::Error::<T>::NoAssociatedValidatorId)?;
-
+			let validator_id: T::ValidatorId = account_id.into();
 			ValidatorCFEVersion::<T>::try_mutate(validator_id.clone(), |current_version| {
 				if *current_version < version {
 					Self::deposit_event(Event::CFEVersionUpdated(


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Associated types `AccountId` and `ValidatorId`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/925"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

