### PR TITLE
Log the unshortened eth tx_hashs

### DIFF
--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -84,7 +84,7 @@ async fn send_claim(
         .expect("Failed to submit claim extrinsic");
 
     println!(
-        "Your claim has transaction hash: `{:?}`. Waiting for your request to be confirmed...",
+        "Your claim has transaction hash: `{:#x}`. Waiting for your request to be confirmed...",
         tx_hash
     );
 

--- a/engine/src/state_chain/client.rs
+++ b/engine/src/state_chain/client.rs
@@ -250,7 +250,7 @@ impl<RpcClient: StateChainRpcApi> StateChainClient<RpcClient> {
                 Ok(tx_hash) => {
                     slog::trace!(
                         logger,
-                        "{:?} submitted successfully with tx_hash: {}",
+                        "{:?} submitted successfully with tx_hash: {:#x}",
                         extrinsic,
                         tx_hash
                     );
@@ -307,7 +307,7 @@ impl<RpcClient: StateChainRpcApi> StateChainClient<RpcClient> {
             Ok(tx_hash) => {
                 slog::trace!(
                     logger,
-                    "{:?} submitted successfully with tx_hash: {}",
+                    "{:?} submitted successfully with tx_hash: {:#x}",
                     extrinsic,
                     tx_hash
                 );

--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -374,7 +374,7 @@ pub async fn start<BlockStream, RpcClient>(
                                         Ok(tx_hash) => {
                                             slog::debug!(
                                                 logger,
-                                                "Successful broadcast attempt {}, tx_hash: {}",
+                                                "Successful broadcast attempt {}, tx_hash: {:#x}",
                                                 attempt_id,
                                                 tx_hash
                                             );


### PR DESCRIPTION
Before we logged only the shortened tx_hash "0x4f8a...3e9a0"

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/926"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

