### PR TITLE
set nonce 0 instead of error when account info not found

### DIFF
--- a/engine/src/state_chain/client.rs
+++ b/engine/src/state_chain/client.rs
@@ -586,7 +586,7 @@ pub async fn connect_to_state_chain(
             .key(&our_account_id);
 
         let nonce = AtomicU32::new({
-            let nonce = if let Some(data) = &mut &state_chain_rpc_client
+            if let Some(data) = &mut &state_chain_rpc_client
                 .state_rpc_client
                 .storage(account_storage_key.clone(), Some(latest_block_hash))
                 .await
@@ -602,8 +602,7 @@ pub async fn connect_to_state_chain(
             } else {
                 // if we can't find the account, then the nonce is 0
                 0
-            };
-            nonce
+            }
         });
 
         Ok((


### PR DESCRIPTION
TODO: 
- Look into account creation on SC - when is the account actually created?
- Does submitting an extrinsic successfully with a node initialise the Account