### PR TITLE
Add Extra P2P Logging

### DIFF
--- a/state-chain/client/cf-p2p/src/lib.rs
+++ b/state-chain/client/cf-p2p/src/lib.rs
@@ -216,7 +216,7 @@ pub fn new_p2p_validator_network_node<
 					}
 
 					log::info!(
-						"Set reserved peers (Total Reserved: {})",
+						"Set {} reserved peers (Total Reserved: {})",
 						CHAINFLIP_P2P_PROTOCOL_NAME,
 						state.reserved_peers.len()
 					);


### PR DESCRIPTION
Logs the number of connected and reserved (The number we want to be connected to) peers.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/963"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

