### PR TITLE
update chainspec to take genesis stake amount as an env var

### DIFF
--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -21,7 +21,7 @@ const ETHEREUM_CHAIN_ID_DEFAULT: u64 = 4;
 const ETH_INIT_AGG_KEY_DEFAULT: &str =
 	"02e61afd677cdfbec838c6f309deff0b2c6056f8a27f2c783b68bba6b30f667be6";
 // 50k FLIP in Fliperinos
-const GENESIS_STAKE_AMOUNT_DEFAULT: u128 = 50_000_000_000_000_000_000_000;
+const GENESIS_STAKE_AMOUNT_DEFAULT: FlipBalance = 50_000_000_000_000_000_000_000;
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {


### PR DESCRIPTION
This is step one of closing the linked issue, being able to read in a genesis stake value at genesis.

Next step is to use this value in the CI, when launching testnets - this PR can be merged safely without breaking current CI though.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

