### PR TITLE
Don't use pretty printing for peer mapping logs

### DIFF
--- a/engine/src/multisig_p2p.rs
+++ b/engine/src/multisig_p2p.rs
@@ -191,17 +191,8 @@ pub async fn start<RPCClient: 'static + StateChainRpcApi + Sync + Send>(
         )
         .await
         .map_err(rpc_error_into_anyhow_error)
-        .with_context(|| {
-            format!(
-                "Failed to add peers to reserved set: {:?}",
-                account_to_peer
-            )
-        })?;
-    slog::info!(
-        logger,
-        "Added peers to reserved set: {:?}",
-        account_to_peer
-    );
+        .with_context(|| format!("Failed to add peers to reserved set: {:?}", account_to_peer))?;
+    slog::info!(logger, "Added peers to reserved set: {:?}", account_to_peer);
 
     let mut incoming_p2p_message_stream = client
         .subscribe_messages()


### PR DESCRIPTION
Currently the peer mappings are printed like this:

2022-01-05 09:51:12	
{"msg":"Loaded account peer mapping from chain: {\n    AccountId(4girA2UR7MmWNzRb2fQJn8NY4tbHhg7RsrP2ZJ9SzGAt): (\n        PeerId(\n            \"12D3KooWMhShLQVZM6n8NBLGryFpWbAW7dBVqqYGzbGGwJvKRwiF\",\n        ),\n        30333,\n        ::ffff:10.244.19.17,\n    ),\n    AccountId(ACDHPX1nFRuZt6uQKL42pKDS6LQuiZrRvXhRjyokh2d9): (\n        PeerId(\n            \"12D3KooWMYz1WmSdcsJqDymjuRn3kWqUxZM2keNRTGNpftwSxZrp\",\n        ),\n        30333,\n        ::ffff:10.244.19.117,\n    ),\n}","level":"INFO","ts":"2022-01-05T08:51:12.489198336+00:00","tag":"","component":"P2PClient"}

Which isn't very helpful as grafana just prints the newlines as "\n" instead of wrapping line, so this PR changes the logging of the peer mappings so they will not have newlines.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

