### PR TITLE
Assert that response is for the expected ceremony id

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -196,12 +196,15 @@ pub async fn start<BlockStream, RpcClient>(
                                         .await
                                         .expect("Channel closed!")
                                     {
-                                        MultisigOutcome::Keygen(KeygenOutcome {
-                                            id: _,
-                                            result,
-                                        }) => match result {
-                                            Ok(pubkey) => {
-                                                let _ = state_chain_client
+                                        MultisigOutcome::Keygen(KeygenOutcome { id, result }) => {
+                                            assert_eq!(
+                                                id, ceremony_id,
+                                                "unexpected keygen ceremony id"
+                                            );
+
+                                            match result {
+                                                Ok(pubkey) => {
+                                                    let _ = state_chain_client
                                                     .submit_signed_extrinsic(&logger, pallet_cf_vaults::Call::report_keygen_outcome(
                                                         ceremony_id,
                                                         chain_id,
@@ -210,14 +213,14 @@ pub async fn start<BlockStream, RpcClient>(
                                                         ),
                                                     ))
                                                     .await;
-                                            }
-                                            Err((err, bad_account_ids)) => {
-                                                slog::error!(
-                                                    logger,
-                                                    "Keygen failed with error: {:?}",
-                                                    err
-                                                );
-                                                let _ = state_chain_client
+                                                }
+                                                Err((err, bad_account_ids)) => {
+                                                    slog::error!(
+                                                        logger,
+                                                        "Keygen failed with error: {:?}",
+                                                        err
+                                                    );
+                                                    let _ = state_chain_client
                                                     .submit_signed_extrinsic(&logger, pallet_cf_vaults::Call::report_keygen_outcome(
                                                         ceremony_id,
                                                         chain_id,
@@ -226,8 +229,9 @@ pub async fn start<BlockStream, RpcClient>(
                                                         ),
                                                     ))
                                                     .await;
+                                                }
                                             }
-                                        },
+                                        }
                                         MultisigOutcome::Ignore => {
                                             // ignore
                                         }
@@ -265,12 +269,15 @@ pub async fn start<BlockStream, RpcClient>(
                                         .await
                                         .expect("Channel closed!")
                                     {
-                                        MultisigOutcome::Signing(SigningOutcome {
-                                            id: _,
-                                            result,
-                                        }) => match result {
-                                            Ok(sig) => {
-                                                let _ = state_chain_client
+                                        MultisigOutcome::Signing(SigningOutcome { id, result }) => {
+                                            assert_eq!(
+                                                id, ceremony_id,
+                                                "unexpected signing ceremony id"
+                                            );
+
+                                            match result {
+                                                Ok(sig) => {
+                                                    let _ = state_chain_client
                                                     .submit_unsigned_extrinsic(
                                                         &logger,
                                                         pallet_cf_threshold_signature::Call::signature_success(
@@ -279,9 +286,9 @@ pub async fn start<BlockStream, RpcClient>(
                                                         )
                                                     )
                                                     .await;
-                                            }
-                                            Err((_, bad_account_ids)) => {
-                                                let _ = state_chain_client
+                                                }
+                                                Err((_, bad_account_ids)) => {
+                                                    let _ = state_chain_client
                                                     .submit_signed_extrinsic(
                                                         &logger,
                                                         pallet_cf_threshold_signature::Call::report_signature_failed_unbounded(
@@ -290,8 +297,9 @@ pub async fn start<BlockStream, RpcClient>(
                                                         )
                                                     )
                                                     .await;
+                                                }
                                             }
-                                        },
+                                        }
                                         MultisigOutcome::Ignore => {
                                             // ignore
                                         }


### PR DESCRIPTION
I noticed that the ceremony id returned in the response is ignored and instead we used the id that we expect to see. While I don't see why the expected value it would be any different, I thought it might be a good idea to add assertions to rule that possibility out.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

