### PR TITLE
Disable reporting of unauthorised ceremonies

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -70,11 +70,16 @@ impl CeremonyManager {
         self.signing_states.retain(|ceremony_id, state| {
             if let Some(bad_nodes) = state.try_expiring() {
                 slog::warn!(logger, #REQUEST_TO_SIGN_EXPIRED, "Signing state expired and will be abandoned");
-                let outcome = SigningOutcome::timeout(*ceremony_id, bad_nodes);
-                events_to_send.push(MultisigOutcome::Signing(outcome));
 
                 // Only consume the ceremony id if it has been authorized
                 if state.is_authorized(){
+
+                    // NOTE: we only respond if we have received a ceremony request from
+                    // SC (i.e. the ceremony is "authorised")
+                    // TODO: report nodes via a different extrinsic instead
+                    let outcome = SigningOutcome::timeout(*ceremony_id, bad_nodes);
+                    events_to_send.push(MultisigOutcome::Signing(outcome));
+
                     signing_ceremony_ids_to_consume.push(*ceremony_id);
                 }
 
@@ -87,11 +92,16 @@ impl CeremonyManager {
         self.keygen_states.retain(|ceremony_id, state| {
             if let Some(bad_nodes) = state.try_expiring() {
                 slog::warn!(logger, #KEYGEN_REQUEST_EXPIRED, "Keygen state expired and will be abandoned");
-                let outcome = KeygenOutcome::timeout(*ceremony_id, bad_nodes);
-                events_to_send.push(MultisigOutcome::Keygen(outcome));
 
                 // Only consume the ceremony id if it has been authorized
                 if state.is_authorized(){
+
+                    // NOTE: we only respond if we have received a ceremony request from
+                    // SC (i.e. the ceremony is "authorised")
+                    // TODO: report nodes via a different extrinsic instead
+                    let outcome = KeygenOutcome::timeout(*ceremony_id, bad_nodes);
+                    events_to_send.push(MultisigOutcome::Keygen(outcome));
+
                     keygen_ceremony_ids_to_consume.push(*ceremony_id);
                 }
 

--- a/engine/src/multisig/client/tests/frost_unit_tests.rs
+++ b/engine/src/multisig/client/tests/frost_unit_tests.rs
@@ -145,6 +145,7 @@ async fn should_handle_inconsistent_broadcast_sig3() {
 }
 
 #[tokio::test]
+#[ignore = "functionality disabled as SC does not expect this response"]
 async fn should_report_on_timeout_before_request_to_sign() {
     let mut ctx = helpers::KeygenContext::new();
     let keygen_states = ctx.generate().await;

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -32,6 +32,7 @@ async fn happy_path_results_in_valid_key() {
 /// If keygen state expires before a formal request to keygen
 /// (from our SC), we should report initiators of that ceremony
 #[tokio::test]
+#[ignore = "functionality disabled as SC does not expect this response"]
 async fn should_report_on_timeout_before_keygen_request() {
     let mut ctx = helpers::KeygenContext::new();
     let keygen_states = ctx.generate().await;


### PR DESCRIPTION
As discussed in #1131, we need to disable this as this functionality is not (at least at the moment) supported by the SC, and is causing issues in the current SC Observer as it can get a response to a request that it didn't issue. I do think we need to support this in the future, but perhaps the signer could submit a different extrinsic to SC instead for this.

Edit: created new issue: #1135

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
