### PR TITLE
fix potential no heartbeat bug

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -44,7 +44,7 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
 {
     let logger = logger.new(o!(COMPONENT_KEY => "SCObserver"));
 
-    let blocks_per_heartbeat = state_chain_client.heartbeat_block_interval / 2;
+    let blocks_per_heartbeat = std::cmp::max(1, state_chain_client.heartbeat_block_interval / 2);
 
     slog::info!(
         logger,


### PR DESCRIPTION
Integer arithmetic means 1/2 = 0, which means if the heartbeat interval was ever set to 1, we wouldn't submit them at all.

(I know we'll probs remove them, but yeah, easy bug to remove for the time being).

Edit, actually it's worse, it'd panic, division by 0...

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

