### PR TITLE
Better RpcError Info

### DIFF
--- a/engine/src/common.rs
+++ b/engine/src/common.rs
@@ -102,7 +102,7 @@ mod tests {
 
 // Needed due to the jsonrpc maintainer's not definitely unquestionable decision to impl their error types without the Sync trait
 pub fn rpc_error_into_anyhow_error(error: RpcError) -> anyhow::Error {
-    anyhow::Error::msg(format!("{:?}", error))
+    anyhow::Error::msg(format!("{}", error))
 }
 
 pub fn read_clean_and_decode_hex_str_file<V, T: FnOnce(&str) -> Result<V, anyhow::Error>>(


### PR DESCRIPTION
For the "oneshot cancelled" variant (An internal jsonrpc error, RpcError Debug impl is empty making its error message confusing, so we can move to use the Display impl which is more informative.

Note this is not related at all to my oneshot changes. Jsonrpc happens to internally uses something similar.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1145"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

