### PR TITLE
type keys for decode for cf_validator::set_keys

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -112,7 +112,10 @@
     "BlameVotes": "BTreeMap<ValidatorId, u32>"
   },
   "KeyId": "Vec<u8>",
-  "Keys": "u32",
+  "Keys": {
+    "aura": "[u8; 32]",
+    "grandpa": "[u8; 32]"
+  },
   "Liveness": {
     "last_heartbeat": "BlockNumber",
     "banned_until": "BlockNumber"


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
   - [ ] Has the chainspec version been incremented?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Types update for:

```
getBlock(hash?: BlockHash): SignedBlock:: createType(SignedBlock):: Struct: failed on block: {"header":"Header","extrinsics":"Vec<Extrinsic>"}:: Struct: failed on extrinsics: Vec<Extrinsic>:: createType(ExtrinsicV4):: createType(Call):: Call: failed decoding validator.setKeys:: Struct: failed on args: {"keys":"Keys","proof":"Bytes"}:: decodeU8a: failed at 0x1e2a12d6088bbe1e8e1b4932357dd072… on keys: (AccountId,AccountId,AccountId,AccountId):: decodeU8a: failed at 0x0400…: AccountId:: Invalid AccountId provided, expected 32 bytes, found 2
```


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

