### PR TITLE
Use current block hash instead of latest

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -438,7 +438,7 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
                     {
                         send_windows_to_witness_processes(
                             state_chain_client.clone(),
-                            latest_block_hash,
+                            block_hash,
                             account_data,
                             &sm_window_sender,
                             &km_window_sender,


### PR DESCRIPTION
I started looking at SC Observer trying to understand it better and ran into this. Not 100% sure that this is correct, but `latest_block_hash` is never updated so the original code is most definitely wrong, and `block_hash` makes the most sense to me.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1173"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

