### PR TITLE
Fix signer selection test and add new test

### DIFF
--- a/state-chain/runtime/src/chainflip/signer_nomination.rs
+++ b/state-chain/runtime/src/chainflip/signer_nomination.rs
@@ -133,7 +133,9 @@ mod tests {
 			// collision should be quite low.
 			assert_ne!(
 				BTreeSet::from_iter(try_select_random_subset(seed, 100, set.clone()).unwrap()),
-				BTreeSet::from_iter(try_select_random_subset(seed + 100, 100, set.clone()).unwrap()),
+				BTreeSet::from_iter(
+					try_select_random_subset(seed + 100, 100, set.clone()).unwrap()
+				),
 			);
 		}
 	}


### PR DESCRIPTION
Changed the other test because it was selecting sets of two different sizes, naturally these would not be equal, with or without the seed.

Added a new test to verify that the same seed produces the same set.

Closes #1180.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1188"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

