### PR TITLE
Unwrap on error in TryRuntime::on_runtime_upgrade

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -670,7 +670,8 @@ impl_runtime_apis! {
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
 		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
-			let weight = Executive::try_runtime_upgrade()?;
+			// Use unwrap here otherwise the error is swallowed silently.
+			let weight = Executive::try_runtime_upgrade().unwrap();
 			Ok((weight, BlockWeights::get().max_block))
 		}
 	}


### PR DESCRIPTION
Same as [here](https://github.com/paritytech/substrate/commit/04bb4e02137f7aba9c20be071bcf9ba6bceaf8da#diff-82192a4e8c402abbb09970152bf6f7097fbbf8b853b12137474b434815ba591d)

This ensures that errors in the pre/post upgrade hooks in try-runtime actually cause an error. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1194"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

