### PR TITLE
Remove unused return value

### DIFF
--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
 			eth_block_safety_margin: u32,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
-			Self::do_cfe_config_update(&|settings: &mut cfe::CfeSettings| {
+			Self::do_cfe_config_update(|settings: &mut cfe::CfeSettings| {
 				settings.eth_block_safety_margin = eth_block_safety_margin;
 			});
 			Ok(().into())
@@ -110,7 +110,7 @@ pub mod pallet {
 			max_extrinsic_retry_attempts: u32,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
-			Self::do_cfe_config_update(&|settings: &mut cfe::CfeSettings| {
+			Self::do_cfe_config_update(|settings: &mut cfe::CfeSettings| {
 				settings.max_extrinsic_retry_attempts = max_extrinsic_retry_attempts;
 			});
 			Ok(().into())
@@ -126,7 +126,7 @@ pub mod pallet {
 			max_ceremony_stage_duration: u32,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
-			Self::do_cfe_config_update(&|settings: &mut cfe::CfeSettings| {
+			Self::do_cfe_config_update(|settings: &mut cfe::CfeSettings| {
 				settings.max_ceremony_stage_duration = max_ceremony_stage_duration;
 			});
 			Ok(().into())
@@ -142,7 +142,7 @@ pub mod pallet {
 			pending_sign_duration: u32,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
-			Self::do_cfe_config_update(&|settings: &mut cfe::CfeSettings| {
+			Self::do_cfe_config_update(|settings: &mut cfe::CfeSettings| {
 				settings.pending_sign_duration = pending_sign_duration;
 			});
 			Ok(().into())


### PR DESCRIPTION
The return value in the update_settings closure is unused and can be removed. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

