### PR TITLE
[SC-2395] Witness vote extrinsic should not return result

### DIFF
--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -249,18 +249,16 @@ impl<T: Config> Pallet<T> {
 		));
 
 		// Check if threshold is reached and, if so, apply the voted-on Call.
-		let threshold = ConsensusThreshold::<T>::get() as usize;
-		if num_votes == threshold {
+		if num_votes == ConsensusThreshold::<T>::get() as usize {
 			Self::deposit_event(Event::<T>::ThresholdReached(call_hash, num_votes as VoteCount));
 			let result = call.dispatch_bypass_filter((RawOrigin::WitnessThreshold).into());
 			Self::deposit_event(Event::<T>::WitnessExecuted(
 				call_hash,
 				result.map(|_| ()).map_err(|e| e.error),
 			));
-			result
-		} else {
-			Ok(().into())
 		}
+
+		Ok(().into())
 	}
 }
 


### PR DESCRIPTION
Resolves #741

## State Chain

- [x] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR

@kylezs / @AlastairHolmes does the CFE do anything with the result of witness extrinsics?

This change means that witness_* extrinsics no longer the return the result of the witnessed call, ie. the return value of Ok/Err indicates the success of the witness vote but doesn't give any information about the result when we reach threshold. Previously, if we reached the threshold vote, the Ok/Err of the delegated call (for example stake attempt) would be returned. FWIW this is emitted in an event already. 

The intention is to make the behaviour of witness extrinsics more consistent. I don't think this will break anything but would prefer if an Echidna would confirm this. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1215"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

