### PR TITLE
Do not ignore result when processing delayed messages

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -274,14 +274,20 @@ impl CeremonyManager {
             Box::new(BroadcastStage::new(processor, common))
         };
 
-        if let Err(reason) = state.on_ceremony_request(
+        match state.on_ceremony_request(
             ceremony_id,
             initial_stage,
             validator_map,
             self.outcome_sender.clone(),
         ) {
-            slog::warn!(self.logger, #KEYGEN_REQUEST_IGNORED, "Keygen request ignored: {}", reason);
-        }
+            Ok(Some(result)) => {
+                self.process_keygen_ceremony_outcome(ceremony_id, result);
+            }
+            Err(reason) => {
+                slog::warn!(self.logger, #KEYGEN_REQUEST_IGNORED, "Keygen request ignored: {}", reason);
+            }
+            _ => { /* nothing to do */ }
+        };
     }
 
     /// Process a request to sign
@@ -364,14 +370,20 @@ impl CeremonyManager {
             Box::new(BroadcastStage::new(processor, common))
         };
 
-        if let Err(reason) = state.on_ceremony_request(
+        match state.on_ceremony_request(
             ceremony_id,
             initial_stage,
             key_info.validator_map,
             self.outcome_sender.clone(),
         ) {
-            slog::warn!(logger, #REQUEST_TO_SIGN_IGNORED, "Request to sign ignored: {}", reason);
-        }
+            Ok(Some(result)) => {
+                self.process_signing_ceremony_outcome(ceremony_id, result);
+            }
+            Err(reason) => {
+                slog::warn!(logger, #REQUEST_TO_SIGN_IGNORED, "Request to sign ignored: {}", reason);
+            }
+            _ => { /* nothing to do */ }
+        };
     }
 
     /// Process data for a signing ceremony arriving from a peer


### PR DESCRIPTION
From the logs linked in #1279 looks like the bug that @AlastairHolmes discovered where we ignore a ceremony result if it was generated by processing a delayed message happens more often than originally thought.

Basically it can only be triggered when the messages for the next stage from all other parties have been received (and delayed) before we transitioned to the next stage ourselves. I think this is happening now due to some p2p messages being dropped + recovery mechanisms: if a party sends a message to everyone but us, all other nodes will be able to proceed to the next stage, sending us new messages that we will have to delay. Once we reach the time out, we are sometimes able to recover and transition to the next stage for which we already have all messages (but delayed). If processing the last delayed message happened to generate a ceremony result (either a failure or a success), it won't be correctly processed.

I realise that this is being addressed in #1233, but this is a simple change and I want to fix this asap.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

