### PR TITLE
Log new account states in SC Observer more consistently

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -355,8 +355,8 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
 
 
 
-                                // If we are Backup, Validator or outgoing, we need to send a heartbeat
-                                // we send it in the middle of the online interval (so any node sync issues don't
+                                // All nodes must send a heartbeat regardless of their validator status (at least for now).
+                                // We send it in the middle of the online interval (so any node sync issues don't
                                 // cause issues (if we tried to send on one of the interval boundaries)
                                 if (current_block_header.number + (state_chain_client.heartbeat_block_interval / 2))
                                     % blocks_per_heartbeat


### PR DESCRIPTION
So I wanted to look into `should have a vault` panics that were observed on testnet. I noticed there are a few places in SC Observer where some extra logs would be helpful. For example, we print all of the events that we *ignore*, but almost none of the events that we do process. Also, when we get our new validatorship status, the status does not always get printed (e.g. when we panic immediately after).

In this small PR I added/updated these logs, but also slightly changed the code around validatorship status to avoid some code duplication (and I think it got a bit clearer as well). I changed the comments accordingly, @kylezs let me know if you are happy with that.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

