### PR TITLE
cargo fmt sometimes will leave formatting alone (Must manually format code)

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -391,14 +391,14 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
                                 match result {
                                     Ok(sig) => {
                                         let _result = state_chain_client
-                                        .submit_unsigned_extrinsic(
-                                            pallet_cf_threshold_signature::Call::signature_success(
-                                                id,
-                                                sig.into()
-                                            ),
-                                            &logger,
-                                        )
-                                        .await;
+                                            .submit_unsigned_extrinsic(
+                                                pallet_cf_threshold_signature::Call::signature_success(
+                                                    id,
+                                                    sig.into()
+                                                ),
+                                                &logger,
+                                            )
+                                            .await;
                                     }
                                     Err((err, bad_account_ids)) => {
                                         slog::error!(
@@ -409,14 +409,14 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
                                         );
 
                                         let _result = state_chain_client
-                                        .submit_signed_extrinsic(
-                                            pallet_cf_threshold_signature::Call::report_signature_failed_unbounded(
-                                                id,
-                                                bad_account_ids.into_iter().collect()
-                                            ),
-                                            &logger,
-                                        )
-                                        .await;
+                                            .submit_signed_extrinsic(
+                                                pallet_cf_threshold_signature::Call::report_signature_failed_unbounded(
+                                                    id,
+                                                    bad_account_ids.into_iter().collect()
+                                                ),
+                                                &logger,
+                                            )
+                                            .await;
                                     }
                                 }
                             }
@@ -427,13 +427,13 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
                                 match result {
                                     Ok(pubkey) => {
                                         let _result = state_chain_client
-                                        .submit_signed_extrinsic(pallet_cf_vaults::Call::report_keygen_outcome(
-                                            id,
-                                            pallet_cf_vaults::KeygenOutcome::Success(
-                                                cf_chains::eth::AggKey::from_pubkey_compressed(pubkey.serialize()),
-                                            ),
-                                        ), &logger)
-                                        .await;
+                                            .submit_signed_extrinsic(pallet_cf_vaults::Call::report_keygen_outcome(
+                                                id,
+                                                pallet_cf_vaults::KeygenOutcome::Success(
+                                                    cf_chains::eth::AggKey::from_pubkey_compressed(pubkey.serialize()),
+                                                ),
+                                            ), &logger)
+                                            .await;
                                     }
                                     Err((err, bad_account_ids)) => {
                                         slog::error!(
@@ -443,13 +443,13 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
                                             CEREMONY_ID_KEY => id,
                                         );
                                         let _result = state_chain_client
-                                        .submit_signed_extrinsic(pallet_cf_vaults::Call::report_keygen_outcome(
-                                            id,
-                                            pallet_cf_vaults::KeygenOutcome::Failure(
-                                                BTreeSet::from_iter(bad_account_ids),
-                                            ),
-                                        ), &logger)
-                                        .await;
+                                            .submit_signed_extrinsic(pallet_cf_vaults::Call::report_keygen_outcome(
+                                                id,
+                                                pallet_cf_vaults::KeygenOutcome::Failure(
+                                                    BTreeSet::from_iter(bad_account_ids),
+                                                ),
+                                            ), &logger)
+                                            .await;
                                     }
                                 }
                             }


### PR DESCRIPTION
I've only noticed this before inside of macros calls. Note this code is inside the tokio::select macro