### PR TITLE
remove some of the more obvious `expect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log 0.4.14",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -236,8 +236,9 @@ impl<T: Config> Pallet<T> {
 			.ok_or(Error::<T>::UnauthorisedWitness)? as usize;
 
 		// The number of validators for the epoch
-		let num_validators = EpochValidatorCount::<T>::get(epoch_index)
-			.expect("This value is updated alongside ValidatorIndex, so if we have a validator, we have a validator count.");
+		// This value is updated alongside ValidatorIndex, so if we have a validator, we have a
+		// validator count.
+		let num_validators = EpochValidatorCount::<T>::get(epoch_index).unwrap_or_default();
 
 		// Register the vote
 		let call_hash = Hashable::blake2_256(&call);

--- a/state-chain/traits/Cargo.toml
+++ b/state-chain/traits/Cargo.toml
@@ -10,6 +10,8 @@ description = "Common traits used in the Chainflip runtime"
 cf-chains = { path ='../chains', default-features = false }
 cf-utilities = { package = 'utilities', path = '../../utilities', default-features = false }
 
+log = { version = '0.4.14', default-features = false }
+
 # Parity deps
 [dependencies.codec]
 default-features = false

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -438,14 +438,14 @@ impl<T: frame_system::Config<AccountData = ChainflipAccountData>> ChainflipAccou
 		frame_system::Pallet::<T>::mutate(account_id, |account_data| {
 			(*account_data).state = state;
 		})
-		.expect("mutating account state")
+		.unwrap_or_else(|e| log::error!("Mutating account state failed {:?}", e));
 	}
 
 	fn update_last_active_epoch(account_id: &Self::AccountId, index: EpochIndex) {
 		frame_system::Pallet::<T>::mutate(account_id, |account_data| {
 			(*account_data).last_active_epoch = Some(index);
 		})
-		.expect("mutating account state")
+		.unwrap_or_else(|e| log::error!("Mutating account state failed {:?}", e));
 	}
 }
 


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- [ ] Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
   - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- [ ] Do the changes require a runtime upgrade? If yes:
- [ ] Have any storage items or stored data types been modified? If yes:
   - [ ] Has the pallet's storage version been bumped and a storage migration been defined? 

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?

Remove some of the `expect` calls we have in the state-chain.  In most cases we would want to log the error condition or use a default as opposed to `panic`.  

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1327"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

