### PR TITLE
Rustfmt settings for CFE

### DIFF
--- a/engine/.rustfmt.toml
+++ b/engine/.rustfmt.toml
@@ -1,0 +1,2 @@
+# Consistency
+newline_style = "Unix"


### PR DESCRIPTION
We already have a rustfmt settings file for the state chain to ensure we follow parity's formatting conventions for substrate. We don't have a rustfmt file for the CFE though - this means that formatting might be inconsistent depending on local settings - @ramizhasan111 experienced this when he ran `cargo fmt` and it added windows line endings to all his files... 

I've added a basic rustfmt.toml to fix the line ending issue but we might want to add some other settings at a later point. 

Here is the list of settings that currently apply to the state chain: 

```toml
# Basic
max_width = 100
use_small_heuristics = "Max"

# Imports
imports_granularity = "Crate"
reorder_imports = true

# Format comments
comment_width = 100
wrap_comments = true

# Misc
chain_width = 80
spaces_around_ranges = false
binop_separator = "Back"
reorder_impl_items = false
match_arm_leading_pipes = "Preserve"
match_arm_blocks = false
match_block_trailing_comma = true
trailing_comma = "Vertical"
trailing_semicolon = false
use_field_init_shorthand = true
```

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1332"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

