### PR TITLE
[Chore] Remove unneded CeremonyOutcome::Ignore; uninline process_multisig_outcome

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -236,8 +236,6 @@ impl CeremonyManager {
             Ok(res) => res,
             Err(reason) => {
                 slog::warn!(logger, #KEYGEN_REQUEST_IGNORED, "Keygen request ignored: {}", reason);
-                // TODO: Look at better way of releasing the lock on the sc_observer
-                self.outcome_sender.send(MultisigOutcome::Ignore).unwrap();
                 return;
             }
         };
@@ -247,7 +245,6 @@ impl CeremonyManager {
             .is_keygen_ceremony_id_used(&ceremony_id)
         {
             slog::warn!(logger, #KEYGEN_REQUEST_IGNORED, "Keygen request ignored: ceremony id {} has already been used", ceremony_id);
-            self.outcome_sender.send(MultisigOutcome::Ignore).unwrap();
             return;
         }
 
@@ -312,8 +309,6 @@ impl CeremonyManager {
                 "Request to sign ignored: not enough signers {}/{}",
                 signers.len(), minimum_signers_needed
             );
-            // TODO: Look at better way of releasing the lock on the sc_observer
-            self.outcome_sender.send(MultisigOutcome::Ignore).unwrap();
             return;
         }
 
@@ -323,8 +318,6 @@ impl CeremonyManager {
             Ok(res) => res,
             Err(reason) => {
                 slog::warn!(logger, #REQUEST_TO_SIGN_IGNORED, "Request to sign ignored: {}", reason);
-                // TODO: Look at better way of releasing the lock on the sc_observer
-                self.outcome_sender.send(MultisigOutcome::Ignore).unwrap();
                 return;
             }
         };
@@ -334,7 +327,6 @@ impl CeremonyManager {
             .is_signing_ceremony_id_used(&ceremony_id)
         {
             slog::warn!(logger, #REQUEST_TO_SIGN_IGNORED, "Request to sign ignored: ceremony id {} has already been used", ceremony_id);
-            self.outcome_sender.send(MultisigOutcome::Ignore).unwrap();
             return;
         }
 

--- a/engine/src/multisig/client/mod.rs
+++ b/engine/src/multisig/client/mod.rs
@@ -168,7 +168,6 @@ pub type MultisigOutcomeSender = tokio::sync::mpsc::UnboundedSender<MultisigOutc
 pub enum MultisigOutcome {
     Signing(SigningOutcome),
     Keygen(KeygenOutcome),
-    Ignore,
 }
 
 derive_try_from_variant!(SigningOutcome, MultisigOutcome::Signing, MultisigOutcome);
@@ -272,11 +271,6 @@ where
                 self.logger,
                 "Keygen request ignored: we are not among participants"
             );
-
-            // TODO: remove this once parallel ceremonies PR is merged
-            self.multisig_outcome_sender
-                .send(MultisigOutcome::Ignore)
-                .unwrap();
             return;
         }
 
@@ -335,11 +329,6 @@ where
                 self.logger,
                 "Signing request ignored: we are not among participants"
             );
-
-            // TODO: remove this once parallel ceremonies PR is merged
-            self.multisig_outcome_sender
-                .send(MultisigOutcome::Ignore)
-                .unwrap();
             return;
         }
 

--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -33,7 +33,7 @@ async fn process_multisig_outcome<RpcClient>(
                 let _result = state_chain_client
                     .submit_unsigned_extrinsic(
                         pallet_cf_threshold_signature::Call::signature_success(id, sig.into()),
-                        &logger,
+                        logger,
                     )
                     .await;
             }
@@ -51,12 +51,11 @@ async fn process_multisig_outcome<RpcClient>(
                             id,
                             bad_account_ids.into_iter().collect(),
                         ),
-                        &logger,
+                        logger,
                     )
                     .await;
             }
         },
-        MultisigOutcome::Ignore => { /* ignore */ }
         MultisigOutcome::Keygen(KeygenOutcome { id, result }) => match result {
             Ok(pubkey) => {
                 let _result = state_chain_client
@@ -67,7 +66,7 @@ async fn process_multisig_outcome<RpcClient>(
                                 cf_chains::eth::AggKey::from_pubkey_compressed(pubkey.serialize()),
                             ),
                         ),
-                        &logger,
+                        logger,
                     )
                     .await;
             }
@@ -86,7 +85,7 @@ async fn process_multisig_outcome<RpcClient>(
                                 bad_account_ids,
                             )),
                         ),
-                        &logger,
+                        logger,
                     )
                     .await;
             }


### PR DESCRIPTION
Just making a few trivial changes so I don't clutter the upcoming keygen verification PR with them.

1. Uninlined part of SC Observer that handles multisig outcomes. Currently any code that's directly insude the select! macro can't be formatted by rustfmt, but extracting the code into a separate function makes it happy again. Also this is in accordance with #1127. Nothing controversial hopefully. If there are existing branches making changes to this code, it should be tirival to resolve the conflicts as I simply cut and pasted the code.
2. `MultisigOutcome::Ignore` is no longer needed since we can process more than one ceremony in parallel, so I removed it. (Didn't feel like creating a separete PR for this especially as this one would have to depend on the other somewhat. Let me know if I'm wrong and should have made two separate PRs.)

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

