### PR TITLE
fix: remove unused index from SigningCommitment

### DIFF
--- a/engine/src/multisig/client/signing/frost.rs
+++ b/engine/src/multisig/client/signing/frost.rs
@@ -54,7 +54,6 @@ impl SecretNoncePair {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 
 pub struct SigningCommitment {
-    pub index: usize,
     pub d: Point,
     pub e: Point,
 }
@@ -183,12 +182,9 @@ fn generate_bindings(
     commitments: &HashMap<usize, SigningCommitment>,
     all_idxs: &BTreeSet<usize>,
 ) -> HashMap<usize, Scalar> {
-    commitments
+    all_idxs
         .iter()
-        .map(|(idx, c)| {
-            assert_eq!(c.index, *idx);
-            (*idx, gen_rho_i(*idx, msg, commitments, all_idxs))
-        })
+        .map(|idx| (*idx, gen_rho_i(*idx, msg, commitments, all_idxs)))
         .collect()
 }
 

--- a/engine/src/multisig/client/signing/frost_stages.rs
+++ b/engine/src/multisig/client/signing/frost_stages.rs
@@ -52,7 +52,6 @@ impl BroadcastStageProcessor<SigningData, SchnorrSignature> for AwaitCommitments
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         DataToSend::Broadcast(Comm1 {
-            index: self.common.own_idx,
             d: self.nonces.d_pub,
             e: self.nonces.e_pub,
         })

--- a/engine/src/multisig/client/tests/helpers.rs
+++ b/engine/src/multisig/client/tests/helpers.rs
@@ -861,7 +861,6 @@ pub fn gen_invalid_keygen_comm1(mut rng: &mut Rng) -> DKGUnverifiedCommitment {
 
 pub fn gen_invalid_signing_comm1(mut rng: &mut Rng) -> SigningCommitment {
     SigningCommitment {
-        index: 0,
         d: Point::random(&mut rng),
         e: Point::random(&mut rng),
     }


### PR DESCRIPTION
Even though `index` was unused, we did assert that it matches the signer index of the party sending it, which would give a malicious node an opportunity to crash all other nodes (as the broadcast of these values must have been consistent due to broadcast verification) at the final stage of the ceremony. Simply removing it solves this problem.

BREAKING CHANGE: this changes how SigningCommitment is serialized, so not backwards compatible and will result in signing ceremonies failing if not all nodes are up to date. Are we still able to update all signers at once, or do we need to write some kind of compatibility layer? Alternatively, we could keep the unused field and simply remove the assert statement.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1359"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

