### PR TITLE
Fix: check signer indexes in broadcast verification messages

### DIFF
--- a/engine/src/multisig/client/keygen/keygen_stages.rs
+++ b/engine/src/multisig/client/keygen/keygen_stages.rs
@@ -135,7 +135,7 @@ impl BroadcastStageProcessor<KeygenData, KeygenResultInfo> for VerifyCommitments
         self,
         messages: std::collections::HashMap<usize, Option<Self::Message>>,
     ) -> StageResult<KeygenData, KeygenResultInfo> {
-        let commitments = match verify_broadcasts(messages) {
+        let commitments = match verify_broadcasts(messages, &self.common.logger) {
             Ok(comms) => comms,
             Err(blamed_parties) => {
                 return StageResult::Error(
@@ -345,7 +345,7 @@ impl BroadcastStageProcessor<KeygenData, KeygenResultInfo> for VerifyComplaintsB
         self,
         messages: HashMap<usize, Option<Self::Message>>,
     ) -> StageResult<KeygenData, KeygenResultInfo> {
-        let verified_complaints = match verify_broadcasts(messages) {
+        let verified_complaints = match verify_broadcasts(messages, &self.common.logger) {
             Ok(comms) => comms,
             Err(blamed_parties) => {
                 return StageResult::Error(
@@ -565,7 +565,7 @@ impl BroadcastStageProcessor<KeygenData, KeygenResultInfo> for VerifyBlameRespon
             "Processing verifications for blame responses"
         );
 
-        let verified_responses = match verify_broadcasts(messages) {
+        let verified_responses = match verify_broadcasts(messages, &self.common.logger) {
             Ok(comms) => comms,
             Err(blamed_parties) => {
                 return StageResult::Error(

--- a/engine/src/multisig/client/signing/frost_stages.rs
+++ b/engine/src/multisig/client/signing/frost_stages.rs
@@ -104,7 +104,7 @@ impl BroadcastStageProcessor<SigningData, SchnorrSignature> for VerifyCommitment
 
     /// Verify that all values have been broadcast correctly during stage 1
     fn process(self, messages: HashMap<usize, Option<Self::Message>>) -> SigningStageResult {
-        let verified_commitments = match verify_broadcasts(messages) {
+        let verified_commitments = match verify_broadcasts(messages, &self.common.logger) {
             Ok(comms) => comms,
             Err(blamed_parties) => {
                 return StageResult::Error(
@@ -216,7 +216,7 @@ impl BroadcastStageProcessor<SigningData, SchnorrSignature> for VerifyLocalSigsB
     /// Verify that signature shares have been broadcast correctly, and if so,
     /// combine them into the (final) aggregate signature
     fn process(self, messages: HashMap<usize, Option<Self::Message>>) -> SigningStageResult {
-        let local_sigs = match verify_broadcasts(messages) {
+        let local_sigs = match verify_broadcasts(messages, &self.common.logger) {
             Ok(sigs) => sigs,
             Err(blamed_parties) => {
                 return StageResult::Error(


### PR DESCRIPTION
While we know that "outer" indexes in `messages` received in `BroadcastStageProcessor::process` are always correct as they are constructed locally, @AlastairHolmes found that we don't ensure that the indexes inside `BroadcastVerificationMessage` are set correctly by the sender, potentially resulting in a panic due to an assertion.

I modified `verify_broadcasts` to exclude any verification messages with indexes not exactly matching what we expect (at the same time removing the assert). Added unit tests for:
- missing indexes
- extra indexes
- correct number of indexes, but some of them are unexpected

I also realised that `participating_idxs` could be incorrectly computed in presence of malicious parties (as it was assumed that the inner indexes could be relied upon). This PR fixes this as well.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1365"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

