### PR TITLE
refactor: remove unused ceremony id parameter from on_ceremony_request()

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -271,12 +271,7 @@ impl CeremonyManager {
             Box::new(BroadcastStage::new(processor, common))
         };
 
-        match state.on_ceremony_request(
-            ceremony_id,
-            initial_stage,
-            validator_map,
-            self.outcome_sender.clone(),
-        ) {
+        match state.on_ceremony_request(initial_stage, validator_map, self.outcome_sender.clone()) {
             Ok(Some(result)) => {
                 self.process_keygen_ceremony_outcome(ceremony_id, result);
             }
@@ -363,7 +358,6 @@ impl CeremonyManager {
         };
 
         match state.on_ceremony_request(
-            ceremony_id,
             initial_stage,
             key_info.validator_map,
             self.outcome_sender.clone(),


### PR DESCRIPTION
The assert is confusing, is unneeded, and requires us to pass around an otherwise unused parameter, so we removed it.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

