### PR TITLE
feature/SC-3161/ensure-validator-status-is-updated

### DIFF
--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -109,6 +109,7 @@ pub struct MockAuctioneer;
 
 thread_local! {
 	pub static AUCTION_RUN_BEHAVIOUR: RefCell<Result<AuctionResult<ValidatorId, Amount>, AuctionError>> = RefCell::new(Ok(Default::default()));
+	pub static AUCTION_WINNERS: RefCell<Option<Vec<ValidatorId>>> = RefCell::new(None);
 }
 
 impl MockAuctioneer {
@@ -127,7 +128,11 @@ impl Auctioneer for MockAuctioneer {
 		AUCTION_RUN_BEHAVIOUR.with(|cell| (*cell.borrow()).clone())
 	}
 
-	fn update_validator_status(_winners: &[Self::ValidatorId]) {}
+	fn update_validator_status(winners: &[Self::ValidatorId]) {
+		AUCTION_WINNERS.with(|cell| {
+			*cell.borrow_mut() = Some(winners.to_vec());
+		});
+	}
 }
 
 pub struct MockIsOutgoing;

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -220,6 +220,13 @@ fn should_rotate_at_epoch() {
 			"the new validators are now validating"
 		);
 		assert_eq!(min_bid(), bond, "bond should be updated");
+
+		let auction_winners = AUCTION_WINNERS
+			.with(|cell| (*cell.borrow()).clone())
+			.expect("no value for auction winners is provided!");
+
+		// Expect new_validators to be auction winners as well
+		assert_eq!(new_validators, auction_winners);
 	});
 }
 


### PR DESCRIPTION
ensure validator status is updated when an auction completes

#1338

## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- [ ] Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
   - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- [ ] Do the changes require a runtime upgrade? If yes:
- [ ] Have any storage items or stored data types been modified? If yes:
   - [ ] Has the pallet's storage version been bumped and a storage migration been defined? 

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1371"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

