### PR TITLE
Chore/sc 3199 storage migration for runtime v112

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod benchmarking;
 mod chainflip;
 pub mod constants;
+mod migrations;
 #[cfg(test)]
 mod tests;
 use cf_chains::Ethereum;
@@ -18,6 +19,7 @@ pub use frame_support::{
 	StorageValue,
 };
 use frame_system::offchain::SendTransactionTypes;
+use migrations::DeleteRewardsPallet;
 pub use pallet_cf_environment::cfe::CfeSettings;
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
@@ -537,7 +539,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
-	(),
+	migrations::VersionedMigration<DeleteRewardsPallet, 112>,
 >;
 
 impl_runtime_apis! {

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -3,6 +3,9 @@ use crate::System;
 use frame_support::traits::OnRuntimeUpgrade;
 use sp_std::marker::PhantomData;
 
+mod delete_rewards;
+pub use delete_rewards::DeleteRewardsPallet;
+
 /// A runtime storage migration that will only be applied if the `SPEC_VERSION` matches the
 /// post-upgrade runtime's spec version.
 pub struct VersionedMigration<U, const SPEC_VERSION: u32>(PhantomData<U>);

--- a/state-chain/runtime/src/migrations/delete_rewards.rs
+++ b/state-chain/runtime/src/migrations/delete_rewards.rs
@@ -1,0 +1,56 @@
+use cf_traits::Issuance;
+use frame_support::{
+	generate_storage_alias, migration,
+	traits::{Imbalance, OnRuntimeUpgrade},
+	weights::RuntimeDbWeight,
+	Twox64Concat,
+};
+use pallet_cf_flip::{FlipIssuance, ReserveId};
+
+use crate::{Flip, FlipBalance, Runtime};
+
+pub struct DeleteRewardsPallet;
+
+const VALIDATOR_REWARDS: ReserveId = *b"VALR";
+
+generate_storage_alias!(
+	Rewards, RewardsEntitlement => Map<(ReserveId, Twox64Concat), FlipBalance>
+);
+
+impl OnRuntimeUpgrade for DeleteRewardsPallet {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		// 1. Burn the reserves.
+		// 2. Delete the reserve.
+		// 3. Delete the storage items from the pallet.
+		if let Some(amount) = RewardsEntitlement::take(VALIDATOR_REWARDS) {
+			if let Ok(reserve) = Flip::try_withdraw_reserves(VALIDATOR_REWARDS, amount) {
+				let _ = FlipIssuance::burn(amount).offset(reserve);
+			}
+			if Flip::reserve(VALIDATOR_REWARDS) > 0 {
+				log::error!("runtime upgrade: rewards reserve was not burned");
+			}
+			pallet_cf_flip::Reserve::<Runtime>::remove(VALIDATOR_REWARDS);
+		}
+		migration::remove_storage_prefix(b"Rewards", b"RewardsEntitlement", &[]);
+		migration::remove_storage_prefix(b"Rewards", b"ApportionedRewards", &[]);
+		migration::remove_storage_prefix(b"Rewards", b"Beneficiaries", &[]);
+
+		RuntimeDbWeight::default().reads_writes(3, 5)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		use frame_support::ensure;
+
+		ensure!(
+			RewardsEntitlement::contains_key(VALIDATOR_REWARDS),
+			"Expected a validator rewards reserve."
+		);
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		Ok(())
+	}
+}


### PR DESCRIPTION
We deleted the rewards pallet so this introduces a runtime upgrade hook in the runtime itself (rather than in a pallet). 

I added as a new `VersionedMigration` that ensures that the migration will only run when we've just upgraded to the specified version. We can re-use this for future migrations where pallet-level migrations are too cumbersome. 


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1378"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

