### PR TITLE
Refactor: add a proxy for multisig requests

### DIFF
--- a/engine/src/multisig/keygen_verification.rs
+++ b/engine/src/multisig/keygen_verification.rs
@@ -1,0 +1,128 @@
+use std::{collections::BTreeSet, iter::FromIterator, sync::Arc};
+
+use slog::o;
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
+
+use crate::{
+    logging::{CEREMONY_ID_KEY, COMPONENT_KEY},
+    state_chain::client::{StateChainClient, StateChainRpcApi},
+};
+
+use super::{KeygenOutcome, MultisigInstruction, MultisigOutcome, SigningOutcome};
+
+async fn process_multisig_outcome<RpcClient>(
+    state_chain_client: Arc<StateChainClient<RpcClient>>,
+    multisig_outcome: MultisigOutcome,
+    logger: &slog::Logger,
+) where
+    RpcClient: StateChainRpcApi,
+{
+    match multisig_outcome {
+        MultisigOutcome::Signing(SigningOutcome { id, result }) => match result {
+            Ok(sig) => {
+                let _result = state_chain_client
+                    .submit_unsigned_extrinsic(
+                        pallet_cf_threshold_signature::Call::signature_success(id, sig.into()),
+                        logger,
+                    )
+                    .await;
+            }
+            Err((err, bad_account_ids)) => {
+                slog::error!(
+                    logger,
+                    "Signing ceremony failed with error: {:?}",
+                    err;
+                    CEREMONY_ID_KEY => id,
+                );
+
+                let _result = state_chain_client
+                    .submit_signed_extrinsic(
+                        pallet_cf_threshold_signature::Call::report_signature_failed_unbounded(
+                            id,
+                            bad_account_ids.into_iter().collect(),
+                        ),
+                        logger,
+                    )
+                    .await;
+            }
+        },
+        MultisigOutcome::Keygen(KeygenOutcome { id, result }) => match result {
+            Ok(pubkey) => {
+                let _result = state_chain_client
+                    .submit_signed_extrinsic(
+                        pallet_cf_vaults::Call::report_keygen_outcome(
+                            id,
+                            pallet_cf_vaults::KeygenOutcome::Success(
+                                cf_chains::eth::AggKey::from_pubkey_compressed(pubkey.serialize()),
+                            ),
+                        ),
+                        logger,
+                    )
+                    .await;
+            }
+            Err((err, bad_account_ids)) => {
+                slog::error!(
+                    logger,
+                    "Keygen ceremony failed with error: {:?}",
+                    err;
+                    CEREMONY_ID_KEY => id,
+                );
+                let _result = state_chain_client
+                    .submit_signed_extrinsic(
+                        pallet_cf_vaults::Call::report_keygen_outcome(
+                            id,
+                            pallet_cf_vaults::KeygenOutcome::Failure(BTreeSet::from_iter(
+                                bad_account_ids,
+                            )),
+                        ),
+                        logger,
+                    )
+                    .await;
+            }
+        },
+    };
+}
+
+pub async fn start<RpcClient>(
+    multisig_instruction_sender: UnboundedSender<MultisigInstruction>,
+    mut multisig_instruction_receiver: UnboundedReceiver<MultisigInstruction>,
+    mut multisig_outcome_receiver: UnboundedReceiver<MultisigOutcome>,
+    state_chain_client: Arc<StateChainClient<RpcClient>>,
+    mut shutdown: oneshot::Receiver<()>,
+    logger: &slog::Logger,
+) where
+    RpcClient: StateChainRpcApi,
+{
+    let logger = logger.new(o!(COMPONENT_KEY => "KeygenVerification"));
+
+    loop {
+        tokio::select! {
+
+          Some(instruction) = multisig_instruction_receiver.recv() => {
+
+            multisig_instruction_sender.send(instruction).expect("receiver should exist");
+
+          }
+          option_multisig_outcome = multisig_outcome_receiver.recv() => {
+
+              match option_multisig_outcome {
+                  Some(outcome) => {
+                    process_multisig_outcome(state_chain_client.clone(), outcome, &logger).await;
+                  },
+                  None => {
+                      slog::error!(logger, "Exiting as multisig_outcome channel ended");
+                      break;
+                  }
+              }
+          }
+          Ok(()) = &mut shutdown => {
+              slog::info!(logger, "Received shutdown signal, exiting...");
+              break;
+          }
+
+        }
+    }
+}

--- a/engine/src/multisig/mod.rs
+++ b/engine/src/multisig/mod.rs
@@ -7,6 +7,9 @@ mod crypto;
 /// Storage for the keys
 pub mod db;
 
+/// Layer between the State Chain and Multisig module that handles keygen verification
+pub mod keygen_verification;
+
 #[cfg(test)]
 mod tests;
 

--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -6,92 +6,16 @@ use pallet_cf_vaults::BlockHeightWindow;
 use slog::o;
 use sp_core::H256;
 use state_chain_runtime::AccountId;
-use std::{collections::BTreeSet, iter::FromIterator, sync::Arc};
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     eth::{EthBroadcaster, EthRpcApi},
-    logging::{CEREMONY_ID_KEY, COMPONENT_KEY, LOG_ACCOUNT_STATE},
-    multisig::{
-        KeyId, KeygenInfo, KeygenOutcome, MessageHash, MultisigInstruction, MultisigOutcome,
-        SigningInfo, SigningOutcome,
-    },
+    logging::{COMPONENT_KEY, LOG_ACCOUNT_STATE},
+    multisig::{KeyId, KeygenInfo, MessageHash, MultisigInstruction, SigningInfo},
     multisig_p2p::AccountPeerMappingChange,
     state_chain::client::{StateChainClient, StateChainRpcApi},
 };
-
-async fn process_multisig_outcome<RpcClient>(
-    state_chain_client: Arc<StateChainClient<RpcClient>>,
-    multisig_outcome: MultisigOutcome,
-    logger: &slog::Logger,
-) where
-    RpcClient: StateChainRpcApi,
-{
-    match multisig_outcome {
-        MultisigOutcome::Signing(SigningOutcome { id, result }) => match result {
-            Ok(sig) => {
-                let _result = state_chain_client
-                    .submit_unsigned_extrinsic(
-                        pallet_cf_threshold_signature::Call::signature_success(id, sig.into()),
-                        logger,
-                    )
-                    .await;
-            }
-            Err((err, bad_account_ids)) => {
-                slog::error!(
-                    logger,
-                    "Signing ceremony failed with error: {:?}",
-                    err;
-                    CEREMONY_ID_KEY => id,
-                );
-
-                let _result = state_chain_client
-                    .submit_signed_extrinsic(
-                        pallet_cf_threshold_signature::Call::report_signature_failed_unbounded(
-                            id,
-                            bad_account_ids.into_iter().collect(),
-                        ),
-                        logger,
-                    )
-                    .await;
-            }
-        },
-        MultisigOutcome::Keygen(KeygenOutcome { id, result }) => match result {
-            Ok(pubkey) => {
-                let _result = state_chain_client
-                    .submit_signed_extrinsic(
-                        pallet_cf_vaults::Call::report_keygen_outcome(
-                            id,
-                            pallet_cf_vaults::KeygenOutcome::Success(
-                                cf_chains::eth::AggKey::from_pubkey_compressed(pubkey.serialize()),
-                            ),
-                        ),
-                        logger,
-                    )
-                    .await;
-            }
-            Err((err, bad_account_ids)) => {
-                slog::error!(
-                    logger,
-                    "Keygen ceremony failed with error: {:?}",
-                    err;
-                    CEREMONY_ID_KEY => id,
-                );
-                let _result = state_chain_client
-                    .submit_signed_extrinsic(
-                        pallet_cf_vaults::Call::report_keygen_outcome(
-                            id,
-                            pallet_cf_vaults::KeygenOutcome::Failure(BTreeSet::from_iter(
-                                bad_account_ids,
-                            )),
-                        ),
-                        logger,
-                    )
-                    .await;
-            }
-        },
-    };
-}
 
 pub async fn start<BlockStream, RpcClient, EthRpc>(
     state_chain_client: Arc<StateChainClient<RpcClient>>,
@@ -103,7 +27,6 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
         sp_core::ed25519::Public,
         AccountPeerMappingChange,
     )>,
-    mut multisig_outcome_receiver: UnboundedReceiver<MultisigOutcome>,
 
     // TODO: we should be able to factor this out into a single ETH window sender
     sm_window_sender: UnboundedSender<BlockHeightWindow>,
@@ -196,276 +119,264 @@ pub async fn start<BlockStream, RpcClient, EthRpc>(
     }
 
     let mut sc_block_stream = Box::pin(sc_block_stream);
-    loop {
-        tokio::select! {
-            option_result_block_header = sc_block_stream.next() => {
-                match option_result_block_header {
-                    Some(result_block_header) => {
-                        match result_block_header {
-                            Ok(current_block_header) => {
-                                let current_block_hash = current_block_header.hash();
-                                slog::debug!(
-                                    logger,
-                                    "Processing SC block {} with block hash: {:#x}",
-                                    current_block_header.number,
-                                    current_block_hash
-                                );
 
-                                let mut received_new_epoch = false;
+    while let Some(result_block_header) = sc_block_stream.next().await {
+        match result_block_header {
+            Ok(current_block_header) => {
+                let current_block_hash = current_block_header.hash();
+                slog::debug!(
+                    logger,
+                    "Processing SC block {} with block hash: {:#x}",
+                    current_block_header.number,
+                    current_block_hash
+                );
 
-                                // Process this block's events
-                                match state_chain_client.get_events(current_block_hash).await {
-                                    Ok(events) => {
-                                        for (_phase, event, _topics) in events {
+                let mut received_new_epoch = false;
 
-                                            slog::debug!(logger, "Received event at block {}: {:?}", current_block_header.number, &event);
+                // Process this block's events
+                match state_chain_client.get_events(current_block_hash).await {
+                    Ok(events) => {
+                        for (_phase, event, _topics) in events {
+                            slog::debug!(
+                                logger,
+                                "Received event at block {}: {:?}",
+                                current_block_header.number,
+                                &event
+                            );
 
-                                            match event {
-                                                state_chain_runtime::Event::Validator(
-                                                    pallet_cf_validator::Event::NewEpoch(_),
-                                                ) => {
-                                                    received_new_epoch = true;
-                                                }
-                                                state_chain_runtime::Event::Validator(
-                                                    pallet_cf_validator::Event::PeerIdRegistered(
-                                                        account_id,
-                                                        peer_id,
-                                                        port,
-                                                        ip_address,
-                                                    ),
-                                                ) => {
-                                                    account_peer_mapping_change_sender
-                                                        .send((
-                                                            account_id,
-                                                            peer_id,
-                                                            AccountPeerMappingChange::Registered(
-                                                                port,
-                                                                ip_address.into(),
-                                                            ),
-                                                        ))
-                                                        .unwrap();
-                                                }
-                                                state_chain_runtime::Event::Validator(
-                                                    pallet_cf_validator::Event::PeerIdUnregistered(
-                                                        account_id,
-                                                        peer_id,
-                                                    ),
-                                                ) => {
-                                                    account_peer_mapping_change_sender
-                                                        .send((
-                                                            account_id,
-                                                            peer_id,
-                                                            AccountPeerMappingChange::Unregistered,
-                                                        ))
-                                                        .unwrap();
-                                                }
-                                                state_chain_runtime::Event::EthereumVault(
-                                                    pallet_cf_vaults::Event::KeygenRequest(
-                                                        ceremony_id,
-                                                        validator_candidates,
-                                                    ),
-                                                ) => {
-                                                    let gen_new_key_event = MultisigInstruction::Keygen(
-                                                        KeygenInfo::new(ceremony_id, validator_candidates),
-                                                    );
+                            match event {
+                                state_chain_runtime::Event::Validator(
+                                    pallet_cf_validator::Event::NewEpoch(_),
+                                ) => {
+                                    received_new_epoch = true;
+                                }
+                                state_chain_runtime::Event::Validator(
+                                    pallet_cf_validator::Event::PeerIdRegistered(
+                                        account_id,
+                                        peer_id,
+                                        port,
+                                        ip_address,
+                                    ),
+                                ) => {
+                                    account_peer_mapping_change_sender
+                                        .send((
+                                            account_id,
+                                            peer_id,
+                                            AccountPeerMappingChange::Registered(
+                                                port,
+                                                ip_address.into(),
+                                            ),
+                                        ))
+                                        .unwrap();
+                                }
+                                state_chain_runtime::Event::Validator(
+                                    pallet_cf_validator::Event::PeerIdUnregistered(
+                                        account_id,
+                                        peer_id,
+                                    ),
+                                ) => {
+                                    account_peer_mapping_change_sender
+                                        .send((
+                                            account_id,
+                                            peer_id,
+                                            AccountPeerMappingChange::Unregistered,
+                                        ))
+                                        .unwrap();
+                                }
+                                state_chain_runtime::Event::EthereumVault(
+                                    pallet_cf_vaults::Event::KeygenRequest(
+                                        ceremony_id,
+                                        validator_candidates,
+                                    ),
+                                ) => {
+                                    let gen_new_key_event = MultisigInstruction::Keygen(
+                                        KeygenInfo::new(ceremony_id, validator_candidates),
+                                    );
 
-                                                    multisig_instruction_sender
-                                                        .send(gen_new_key_event)
-                                                        .map_err(|_| "Receiver should exist")
-                                                        .unwrap();
-                                                }
-                                                state_chain_runtime::Event::EthereumThresholdSigner(
-                                                    pallet_cf_threshold_signature::Event::ThresholdSignatureRequest(
-                                                        ceremony_id,
-                                                        key_id,
-                                                        validators,
-                                                        payload,
-                                                    ),
-                                                ) if validators.contains(&state_chain_client.our_account_id) => {
-                                                    let sign_tx = MultisigInstruction::Sign(SigningInfo::new(
-                                                        ceremony_id,
-                                                        KeyId(key_id),
-                                                        MessageHash(payload.to_fixed_bytes()),
-                                                        validators,
-                                                    ));
+                                    multisig_instruction_sender
+                                        .send(gen_new_key_event)
+                                        .map_err(|_| "Receiver should exist")
+                                        .unwrap();
+                                }
+                                state_chain_runtime::Event::EthereumThresholdSigner(
+                                    pallet_cf_threshold_signature::Event::ThresholdSignatureRequest(
+                                        ceremony_id,
+                                        key_id,
+                                        validators,
+                                        payload,
+                                    ),
+                                ) if validators.contains(&state_chain_client.our_account_id) => {
+                                    let sign_req = MultisigInstruction::Sign(SigningInfo::new(
+                                        ceremony_id,
+                                        KeyId(key_id),
+                                        MessageHash(payload.to_fixed_bytes()),
+                                        validators,
+                                    ));
 
-                                                    // The below will be replaced with one shot channels
-                                                    multisig_instruction_sender
-                                                        .send(sign_tx)
-                                                        .map_err(|_| "Receiver should exist")
-                                                        .unwrap();
-                                                }
-                                                state_chain_runtime::Event::EthereumBroadcaster(
-                                                    pallet_cf_broadcast::Event::TransactionSigningRequest(
-                                                        attempt_id,
-                                                        validator_id,
-                                                        unsigned_tx,
-                                                    ),
-                                                ) if validator_id == state_chain_client.our_account_id => {
-                                                    slog::debug!(
-                                                        logger,
-                                                        "Received signing request with attempt_id {} for transaction: {:?}",
-                                                        attempt_id,
-                                                        unsigned_tx,
-                                                    );
-                                                    match eth_broadcaster.encode_and_sign_tx(unsigned_tx).await {
-                                                        Ok(raw_signed_tx) => {
-                                                            let _result = state_chain_client.submit_signed_extrinsic(
-                                                                state_chain_runtime::Call::EthereumBroadcaster(
-                                                                    pallet_cf_broadcast::Call::transaction_ready_for_transmission(
-                                                                        attempt_id,
-                                                                        raw_signed_tx.0,
-                                                                        eth_broadcaster.address,
-                                                                    ),
+                                    // The below will be replaced with one shot channels
+                                    multisig_instruction_sender
+                                        .send(sign_req)
+                                        .map_err(|_| "Receiver should exist")
+                                        .unwrap();
+                                }
+                                state_chain_runtime::Event::EthereumBroadcaster(
+                                    pallet_cf_broadcast::Event::TransactionSigningRequest(
+                                        attempt_id,
+                                        validator_id,
+                                        unsigned_tx,
+                                    ),
+                                ) if validator_id == state_chain_client.our_account_id => {
+                                    slog::debug!(
+                                                    logger,
+                                                    "Received signing request with attempt_id {} for transaction: {:?}",
+                                                    attempt_id,
+                                                    unsigned_tx,
+                                                );
+                                    match eth_broadcaster.encode_and_sign_tx(unsigned_tx).await {
+                                        Ok(raw_signed_tx) => {
+                                            let _result = state_chain_client.submit_signed_extrinsic(
+                                                            state_chain_runtime::Call::EthereumBroadcaster(
+                                                                pallet_cf_broadcast::Call::transaction_ready_for_transmission(
+                                                                    attempt_id,
+                                                                    raw_signed_tx.0,
+                                                                    eth_broadcaster.address,
                                                                 ),
-                                                                &logger,
-                                                            ).await;
-                                                        }
-                                                        Err(e) => {
-                                                            // Note: this error case should only occur if there is a problem with the
-                                                            // local ethereum node, which would mean the web3 lib is unable to fill in
-                                                            // the tranaction params, mainly the gas limit.
-                                                            // In the long run all transaction parameters will be provided by the state
-                                                            // chain and the above eth_broadcaster.sign_tx method can be made
-                                                            // infallible.
-                                                            slog::error!(
-                                                                logger,
-                                                                "TransactionSigningRequest attempt_id {} failed: {:?}",
-                                                                attempt_id,
-                                                                e
-                                                            );
-                                                        }
-                                                    }
-                                                }
-                                                state_chain_runtime::Event::EthereumBroadcaster(
-                                                    pallet_cf_broadcast::Event::TransmissionRequest(
-                                                        attempt_id,
-                                                        signed_tx,
-                                                    ),
-                                                ) => {
-                                                    let response_extrinsic = match eth_broadcaster
-                                                        .send(signed_tx)
-                                                        .await
-                                                    {
-                                                        Ok(tx_hash) => {
-                                                            slog::debug!(
-                                                                logger,
-                                                                "Successful TransmissionRequest attempt_id {}, tx_hash: {:#x}",
-                                                                attempt_id,
-                                                                tx_hash
-                                                            );
-                                                            pallet_cf_witnesser_api::Call::witness_eth_transmission_success(
-                                                                attempt_id, tx_hash.into()
-                                                            )
-                                                        }
-                                                        Err(e) => {
-                                                            slog::error!(
-                                                                logger,
-                                                                "TransmissionRequest attempt_id {} failed: {:?}",
-                                                                attempt_id,
-                                                                e
-                                                            );
-                                                            // TODO: Fill in the transaction hash with the real one
-                                                            pallet_cf_witnesser_api::Call::witness_eth_transmission_failure(
-                                                                attempt_id, TransmissionFailure::TransactionRejected, Default::default()
-                                                            )
-                                                        }
-                                                    };
-                                                    let _result = state_chain_client
-                                                        .submit_signed_extrinsic(response_extrinsic, &logger)
-                                                        .await;
-                                                }
-                                                ignored_event => {
-                                                    // ignore events we don't care about
-                                                    slog::trace!(
-                                                        logger,
-                                                        "Ignoring event at block {}: {:?}",
-                                                        current_block_header.number,
-                                                        ignored_event
-                                                    );
-                                                }
-                                            }
+                                                            ),
+                                                            &logger,
+                                                        ).await;
+                                        }
+                                        Err(e) => {
+                                            // Note: this error case should only occur if there is a problem with the
+                                            // local ethereum node, which would mean the web3 lib is unable to fill in
+                                            // the transaction params, mainly the gas limit.
+                                            // In the long run all transaction parameters will be provided by the state
+                                            // chain and the above eth_broadcaster.sign_tx method can be made
+                                            // infallible.
+                                            slog::error!(
+                                                            logger,
+                                                            "TransactionSigningRequest attempt_id {} failed: {:?}",
+                                                            attempt_id,
+                                                            e
+                                                        );
                                         }
                                     }
-                                    Err(error) => {
-                                        slog::error!(
-                                            logger,
-                                            "Failed to decode events at block {}. {}",
-                                            current_block_header.number,
-                                            error,
-                                        );
-                                    }
                                 }
-
-                                // Backup and passive nodes need to update their state on every block (since it's possible to move
-                                // between Backup and Passive on every block), while Active nodes only need to update every new epoch.
-                                if received_new_epoch || matches!(
-                                    account_data.state,
-                                    ChainflipAccountState::Backup | ChainflipAccountState::Passive
-                                ) {
-                                    let (new_account_data, new_is_outgoing) =
-                                        get_current_account_state(state_chain_client.clone(), current_block_hash, &logger).await;
-                                    account_data = new_account_data;
-                                    is_outgoing = new_is_outgoing;
-
-                                }
-
-                                // New windows should be sent to outgoing validators (so they know when to finish) or to
-                                // new/existing validators (so they know when to start)
-                                // Note: nodes that were outgoing in the last epoch (active 2 epochs ago) have already
-                                // received their end window, so we don't need to send anything to them
-                                if received_new_epoch && (matches!(account_data.state, ChainflipAccountState::Validator) || is_outgoing) {
-                                    send_windows_to_witness_processes(
-                                        state_chain_client.clone(),
-                                        current_block_hash,
-                                        account_data,
-                                        &sm_window_sender,
-                                        &km_window_sender,
-                                    )
-                                    .await
-                                    .expect("Failed to send windows to the witness processes");
-                                }
-
-
-
-                                // All nodes must send a heartbeat regardless of their validator status (at least for now).
-                                // We send it in the middle of the online interval (so any node sync issues don't
-                                // cause issues (if we tried to send on one of the interval boundaries)
-                                if (current_block_header.number + (state_chain_client.heartbeat_block_interval / 2))
-                                    % blocks_per_heartbeat
-                                    == 0
-                                {
-                                    slog::info!(
-                                        logger,
-                                        "Sending heartbeat at block: {}",
-                                        current_block_header.number
-                                    );
+                                state_chain_runtime::Event::EthereumBroadcaster(
+                                    pallet_cf_broadcast::Event::TransmissionRequest(
+                                        attempt_id,
+                                        signed_tx,
+                                    ),
+                                ) => {
+                                    let response_extrinsic = match eth_broadcaster
+                                        .send(signed_tx)
+                                        .await
+                                    {
+                                        Ok(tx_hash) => {
+                                            slog::debug!(
+                                                            logger,
+                                                            "Successful TransmissionRequest attempt_id {}, tx_hash: {:#x}",
+                                                            attempt_id,
+                                                            tx_hash
+                                                        );
+                                            pallet_cf_witnesser_api::Call::witness_eth_transmission_success(
+                                                            attempt_id, tx_hash.into()
+                                                        )
+                                        }
+                                        Err(e) => {
+                                            slog::error!(
+                                                logger,
+                                                "TransmissionRequest attempt_id {} failed: {:?}",
+                                                attempt_id,
+                                                e
+                                            );
+                                            // TODO: Fill in the transaction hash with the real one
+                                            pallet_cf_witnesser_api::Call::witness_eth_transmission_failure(
+                                                            attempt_id, TransmissionFailure::TransactionRejected, Default::default()
+                                                        )
+                                        }
+                                    };
                                     let _result = state_chain_client
-                                        .submit_signed_extrinsic(pallet_cf_online::Call::heartbeat(), &logger)
+                                        .submit_signed_extrinsic(response_extrinsic, &logger)
                                         .await;
                                 }
-                            }
-                            Err(error) => {
-                                slog::error!(logger, "Failed to decode block header: {}", error,);
+                                ignored_event => {
+                                    // ignore events we don't care about
+                                    slog::trace!(
+                                        logger,
+                                        "Ignoring event at block {}: {:?}",
+                                        current_block_header.number,
+                                        ignored_event
+                                    );
+                                }
                             }
                         }
-                    },
-                    None => {
-                        slog::error!(logger, "Exiting as State Chain block stream ended");
-                        break
+                    }
+                    Err(error) => {
+                        slog::error!(
+                            logger,
+                            "Failed to decode events at block {}. {}",
+                            current_block_header.number,
+                            error,
+                        );
                     }
                 }
-            },
-            option_multisig_outcome = multisig_outcome_receiver.recv() => {
-                match option_multisig_outcome {
-                    Some(multisig_outcome) => {
-                        process_multisig_outcome(state_chain_client.clone(), multisig_outcome, &logger).await;
-                    },
-                    None => {
-                        slog::error!(logger, "Exiting as multisig_outcome channel ended");
-                        break
-                    }
+
+                // Backup and passive nodes need to update their state on every block (since it's possible to move
+                // between Backup and Passive on every block), while Active nodes only need to update every new epoch.
+                if received_new_epoch
+                    || matches!(
+                        account_data.state,
+                        ChainflipAccountState::Backup | ChainflipAccountState::Passive
+                    )
+                {
+                    let (new_account_data, new_is_outgoing) = get_current_account_state(
+                        state_chain_client.clone(),
+                        current_block_hash,
+                        &logger,
+                    )
+                    .await;
+                    account_data = new_account_data;
+                    is_outgoing = new_is_outgoing;
                 }
+
+                // New windows should be sent to outgoing validators (so they know when to finish) or to
+                // new/existing validators (so they know when to start)
+                // Note: nodes that were outgoing in the last epoch (active 2 epochs ago) have already
+                // received their end window, so we don't need to send anything to them
+                if received_new_epoch
+                    && (matches!(account_data.state, ChainflipAccountState::Validator)
+                        || is_outgoing)
+                {
+                    send_windows_to_witness_processes(
+                        state_chain_client.clone(),
+                        current_block_hash,
+                        account_data,
+                        &sm_window_sender,
+                        &km_window_sender,
+                    )
+                    .await
+                    .expect("Failed to send windows to the witness processes");
+                }
+
+                // All nodes must send a heartbeat regardless of their validator status (at least for now).
+                // We send it in the middle of the online interval (so any node sync issues don't
+                // cause issues (if we tried to send on one of the interval boundaries)
+                if (current_block_header.number + (state_chain_client.heartbeat_block_interval / 2))
+                    % blocks_per_heartbeat
+                    == 0
+                {
+                    slog::info!(
+                        logger,
+                        "Sending heartbeat at block: {}",
+                        current_block_header.number
+                    );
+                    let _result = state_chain_client
+                        .submit_signed_extrinsic(pallet_cf_online::Call::heartbeat(), &logger)
+                        .await;
+                }
+            }
+            Err(error) => {
+                slog::error!(logger, "Failed to decode block header: {}", error,);
             }
         }
     }

--- a/engine/src/state_chain/tests/sc_observer_tests.rs
+++ b/engine/src/state_chain/tests/sc_observer_tests.rs
@@ -17,7 +17,7 @@ use web3::types::{Bytes, SignedTransaction};
 use crate::{
     eth::{EthBroadcaster, EthWsRpcClient, MockEthRpcApi},
     logging::{self, test_utils::new_test_logger},
-    multisig::{MultisigInstruction, MultisigOutcome},
+    multisig::MultisigInstruction,
     settings::test_utils::new_test_settings,
     state_chain::{
         client::{
@@ -142,8 +142,6 @@ async fn sends_initial_extrinsics_and_starts_witnessing_when_active_on_startup()
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -155,7 +153,6 @@ async fn sends_initial_extrinsics_and_starts_witnessing_when_active_on_startup()
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -249,8 +246,6 @@ async fn sends_initial_extrinsics_and_starts_witnessing_when_outgoing_on_startup
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -263,7 +258,6 @@ async fn sends_initial_extrinsics_and_starts_witnessing_when_outgoing_on_startup
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -339,8 +333,6 @@ async fn sends_initial_extrinsics_when_backup_but_not_outgoing_on_startup() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -353,7 +345,6 @@ async fn sends_initial_extrinsics_when_backup_but_not_outgoing_on_startup() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -378,8 +369,6 @@ async fn backup_checks_account_data_every_block() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -442,7 +431,6 @@ async fn backup_checks_account_data_every_block() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -478,8 +466,6 @@ async fn validator_to_validator_on_new_epoch_event() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -612,7 +598,6 @@ async fn validator_to_validator_on_new_epoch_event() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -667,8 +652,6 @@ async fn backup_to_validator_on_new_epoch() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -793,7 +776,6 @@ async fn backup_to_validator_on_new_epoch() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -978,8 +960,6 @@ async fn validator_to_outgoing_passive_on_new_epoch_event() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -992,7 +972,6 @@ async fn validator_to_outgoing_passive_on_new_epoch_event() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -1157,8 +1136,6 @@ async fn only_encodes_and_signs_when_active_and_specified() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let (sm_window_sender, mut sm_window_receiver) =
         tokio::sync::mpsc::unbounded_channel::<BlockHeightWindow>();
@@ -1171,7 +1148,6 @@ async fn only_encodes_and_signs_when_active_and_specified() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,
@@ -1208,8 +1184,6 @@ async fn run_the_sc_observer() {
         tokio::sync::mpsc::unbounded_channel::<MultisigInstruction>();
     let (account_peer_mapping_change_sender, _account_peer_mapping_change_receiver) =
         tokio::sync::mpsc::unbounded_channel();
-    let (_multisig_outcome_sender, multisig_outcome_receiver) =
-        tokio::sync::mpsc::unbounded_channel::<MultisigOutcome>();
 
     let eth_ws_rpc_client = EthWsRpcClient::new(&settings.eth, &logger).await.unwrap();
     let eth_broadcaster =
@@ -1226,7 +1200,6 @@ async fn run_the_sc_observer() {
         eth_broadcaster,
         multisig_instruction_sender,
         account_peer_mapping_change_sender,
-        multisig_outcome_receiver,
         sm_window_sender,
         km_window_sender,
         initial_block_hash,


### PR DESCRIPTION
This is one of those PRs where most of the changes are due to indentation...

In short, this PR is in preparation for Keygen Verification (#1227), which needs to be able to intercept multisig instructions/responses. I added a keygen verification module that currently proxies all SC Observer requests to the multisig module. It also now handles the responses directly as there is no real reason they should be handled by SC Observer (e.g. we have many other modules that communicate with the SC Client directly, it makes sense that SC Observer is only used for observing).

Note that while I could put the logic for keygen verification directly in SC Observer, I don't think this would be ideal as it would make testing more cumbersome and SC Observer already has more responsibilities than it should.

Note that `process_multisig_outcome` is moved verbatim, and the only change in SC Observer is removing the `multisig_outcome_receiver` so it now listens on a single stream (w/o `select!`).

I will have a PR for #1227 shorty that will be based on this PR and add processing to the keygen verification module.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1382"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

