### PR TITLE
Use enum for ceremony id tracking

### DIFF
--- a/engine/src/multisig/client/ceremony_id_tracker.rs
+++ b/engine/src/multisig/client/ceremony_id_tracker.rs
@@ -3,14 +3,21 @@ use std::collections::HashSet;
 use pallet_cf_vaults::CeremonyId;
 
 // Ids that are more then this amount behind the latest id are removed
-const USED_CEREMONY_IDS_AGE_LIMIT: u64 = 1_000;
+const TRACKED_CEREMONY_AGE_LIMIT: u64 = 1_000;
+
+/// Enum used internally to track signing and keygen ceremony ids.
+/// They are tracked separately so they can have overlapping CeremonyId's.
+#[derive(Clone, PartialEq, Eq, Hash)]
+enum TrackedCeremony {
+    Keygen(CeremonyId),
+    Signing(CeremonyId),
+}
 
 /// Used to track every ceremony id that has been used in the past,
 /// so we can make sure they are not reused.
 #[derive(Clone)]
 pub struct CeremonyIdTracker {
-    used_signing_ids: UsedCeremonyIds,
-    used_keygen_ids: UsedCeremonyIds,
+    used_ceremonies: HashSet<TrackedCeremony>,
     logger: slog::Logger,
 }
 
@@ -18,58 +25,49 @@ impl CeremonyIdTracker {
     // Create a new `CeremonyIdTracker` with empty `UsedCeremonyIds`
     pub fn new(logger: slog::Logger) -> Self {
         CeremonyIdTracker {
-            used_signing_ids: UsedCeremonyIds {
-                ids: HashSet::new(),
-            },
-            used_keygen_ids: UsedCeremonyIds {
-                ids: HashSet::new(),
-            },
+            used_ceremonies: HashSet::new(),
             logger,
         }
     }
 
-    /// Mark this ceremony id as used
+    /// Mark this signing ceremony id as used
     pub fn consume_signing_id(&mut self, ceremony_id: &CeremonyId) {
-        self.used_signing_ids.add(ceremony_id);
+        self.consume_ceremony(&TrackedCeremony::Signing(*ceremony_id));
     }
 
-    /// Mark this ceremony id as used
+    /// Mark this keygen ceremony id as used
     pub fn consume_keygen_id(&mut self, ceremony_id: &CeremonyId) {
-        self.used_keygen_ids.add(ceremony_id);
+        self.consume_ceremony(&TrackedCeremony::Keygen(*ceremony_id));
     }
 
-    /// Check if the ceremony id has already been used
-    pub fn is_signing_ceremony_id_used(&self, ceremony_id: &CeremonyId) -> bool {
-        self.used_signing_ids.is_used(ceremony_id)
-    }
-
-    /// Check if the ceremony id has already been used
-    pub fn is_keygen_ceremony_id_used(&self, ceremony_id: &CeremonyId) -> bool {
-        self.used_keygen_ids.is_used(ceremony_id)
-    }
-}
-
-/// Wrapper around the used ceremony id data
-#[derive(Clone)]
-struct UsedCeremonyIds {
-    // All used ids
-    ids: HashSet<CeremonyId>,
-}
-
-impl UsedCeremonyIds {
-    /// Mark this ceremony id as used
-    pub fn add(&mut self, ceremony_id: &CeremonyId) {
-        // Cleanup ceremonies that are more then `USED_CEREMONY_IDS_AGE_LIMIT` old.
-        self.ids
-            .retain(|id| *id > ceremony_id.saturating_sub(USED_CEREMONY_IDS_AGE_LIMIT));
+    fn consume_ceremony(&mut self, ceremony_to_consume: &TrackedCeremony) {
+        // Cleanup ceremonies that are more then `TRACKED_CEREMONY_AGE_LIMIT` old.
+        let ceremony_id = match ceremony_to_consume {
+            TrackedCeremony::Signing(id) => id,
+            TrackedCeremony::Keygen(id) => id,
+        };
+        self.used_ceremonies.retain(|used_id_number| {
+            let used_id = match used_id_number {
+                TrackedCeremony::Signing(id) => id,
+                TrackedCeremony::Keygen(id) => id,
+            };
+            *used_id > ceremony_id.saturating_sub(TRACKED_CEREMONY_AGE_LIMIT)
+        });
 
         // Mark the ceremony id as used by adding it to the hashset
-        self.ids.insert(*ceremony_id);
+        self.used_ceremonies.insert(ceremony_to_consume.clone());
     }
 
-    /// Check if the ceremony id has already been used (false = never seen before, safe to continue)
-    pub fn is_used(&self, ceremony_id: &CeremonyId) -> bool {
-        self.ids.contains(ceremony_id)
+    /// Check if the ceremony id has already been used for singing
+    pub fn is_signing_ceremony_id_used(&self, ceremony_id: &CeremonyId) -> bool {
+        self.used_ceremonies
+            .contains(&TrackedCeremony::Signing(*ceremony_id))
+    }
+
+    /// Check if the ceremony id has already been used for keygen
+    pub fn is_keygen_ceremony_id_used(&self, ceremony_id: &CeremonyId) -> bool {
+        self.used_ceremonies
+            .contains(&TrackedCeremony::Keygen(*ceremony_id))
     }
 }
 
@@ -97,19 +95,28 @@ fn test_ceremony_id_consumption() {
 // Test that the age limit is enforced
 #[test]
 fn test_ceremony_id_age_limit() {
-    let mut used_ids = UsedCeremonyIds {
-        ids: HashSet::new(),
-    };
+    let mut tracker = CeremonyIdTracker::new(crate::logging::test_utils::new_test_logger());
+    let signing_test_id = 1;
+    let keygen_test_id = 2;
+    assert_ne!(signing_test_id, keygen_test_id);
 
     // Consume an id and the id +1
-    let test_id = 100;
-    used_ids.add(&test_id);
-    used_ids.add(&(test_id + 1));
-    assert!(used_ids.is_used(&(test_id + 1)));
-    assert!(used_ids.is_used(&test_id));
+    tracker.consume_signing_id(&signing_test_id);
+    tracker.consume_signing_id(&(signing_test_id + 1));
+    assert!(tracker.is_signing_ceremony_id_used(&signing_test_id));
+    assert!(tracker.is_signing_ceremony_id_used(&(signing_test_id + 1)));
+
+    tracker.consume_keygen_id(&keygen_test_id);
+    tracker.consume_keygen_id(&(keygen_test_id + 1));
+    assert!(tracker.is_keygen_ceremony_id_used(&keygen_test_id));
+    assert!(tracker.is_keygen_ceremony_id_used(&(keygen_test_id + 1)));
 
     // Now consume an id that is past the age limit for the id, but not the id+1
-    used_ids.add(&(test_id + USED_CEREMONY_IDS_AGE_LIMIT));
-    assert!(!used_ids.is_used(&test_id));
-    assert!(used_ids.is_used(&(test_id + 1)));
+    tracker.consume_signing_id(&(signing_test_id + TRACKED_CEREMONY_AGE_LIMIT));
+    assert!(!tracker.is_signing_ceremony_id_used(&signing_test_id));
+    assert!(tracker.is_signing_ceremony_id_used(&(signing_test_id + 1)));
+
+    tracker.consume_keygen_id(&(keygen_test_id + TRACKED_CEREMONY_AGE_LIMIT));
+    assert!(!tracker.is_keygen_ceremony_id_used(&keygen_test_id));
+    assert!(tracker.is_keygen_ceremony_id_used(&(keygen_test_id + 1)));
 }


### PR DESCRIPTION
Closes #1248
- Refactored the ceremony id tracking to use a single hashset (instead of 2).
- No functionality change. (No changes needed in CFE for #1242)

I believe this refactor represents how the SC works a bit better, but still allows the CFE to use the same keygen id for signing.
Seems a bit cleaner too, but I am open for suggestions on how it could be done better, or weather it should be kept the way it was before.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1390"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

