### PR TITLE
fix: don't output PeerIdRegistered event if the same mapping already exists

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -277,7 +277,9 @@ pub mod pallet {
 				Error::<T>::InvalidAccountPeerMappingSignature
 			);
 
-			if let Some((_, existing_peer_id, _, _)) = AccountPeerMapping::<T>::get(&account_id) {
+			if let Some((_, existing_peer_id, existing_port, existing_ip_address)) =
+				AccountPeerMapping::<T>::get(&account_id)
+			{
 				if existing_peer_id != peer_id {
 					ensure!(
 						!MappedPeers::<T>::contains_key(&peer_id),
@@ -285,6 +287,11 @@ pub mod pallet {
 					);
 					MappedPeers::<T>::remove(&existing_peer_id);
 					MappedPeers::<T>::insert(&peer_id, ());
+				} else {
+					ensure!(
+						existing_port != port || existing_ip_address != ip_address,
+						Error::<T>::AccountPeerMappingOverlap
+					);
 				}
 			} else {
 				ensure!(


### PR DESCRIPTION
While outputting the event repeatedly don't cause any failure/crashes, it does cause the peers to repeatedly connect and disconnect (Each cycle taking 20 seconds), which if the event repeats many times, can last a while.

This is an example of this happening, and repeated connecting and disconnecting lasts several hours:
https://grafana.chainflip.xyz/explore?orgId=1&left=%5B%221646290930000%22,%221646298130000%22,%22Loki%20(euc1-monitoring)%22,%7B%22refId%22:%22A%22,%22expr%22:%22%7Bname%3D%5C%22soundcheck-fra1-pet-lizard-1%5C%22%7D%20%7C~%20%5C%2212D3KooWCAgHgrQt3AhweRvu2gGCDRj4UPSntxzMFPAkXPXtu4Gm%5C%22%22%7D%5D

If you want we can use a different new error for the "ensure", happy to do so. Also I wouldn't mind also added similar don't repeatedly connect logic in the CFE/mutisig_p2p_transport code. But it is not actually needed.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1393"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

