### PR TITLE
chore: changed format on CLI logger for CFE

### DIFF
--- a/engine/src/logging.rs
+++ b/engine/src/logging.rs
@@ -44,21 +44,18 @@ pub mod utils {
             Level::Trace => "[0;35m",
         };
 
-        //Only show the tag if its not empty
-        let tag_string = if record.tag().is_empty() {
-            "".to_string()
-        } else {
-            format!("[{}], ", record.tag())
-        };
-
         // Print the readable log
         println!(
-            "\x1b{}[{}]\x1b[0m {} ({}{})",
+            "\x1b{}[{}]\x1b[0m {} {}",
             level_color,
             record.level(),
             record.msg(),
-            tag_string,
-            record.module(),
+            // Only show the tag if its not empty
+            if !record.tag().is_empty() {
+                format!("([{}], {})", record.tag(), record.module())
+            } else {
+                format!("({})", record.module())
+            }
         );
 
         // Print the location of the log call if its a Warning or above


### PR DESCRIPTION
Closes #1400

- Changed the order of the components in the log message to `[level] msg ([tag, path)`
- Hiding the tag if its empty (which it is 95% of the time)

Here is what it looks like now:
```sh
[DEBG] Removed a finished signing ceremony (chainflip_engine::multisig::client::ceremony_manager)
    | ceremony_id = 1
[WARN] Signing ceremony failed: Inconsistent broadcast of local signatures ([E2], chainflip_engine::multisig::client::ceremony_manager)
    --> engine/src/multisig/client/ceremony_manager.rs:163
    | ceremony_id = 1
    | reported parties = 5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT
```

I left out the "tag: " and "module: " words to keep things clean. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

