### PR TITLE
fix: update endpoints to infrua (#1432)

### DIFF
--- a/Default.enc.toml
+++ b/Default.enc.toml
@@ -1,5 +1,5 @@
 {
-	"data": "ENC[AES256_GCM,data:9PfDHi5pGl8XDN0jFisP67RmkFsZskeRlgbM98HsCv++6IidZgA3nekhfBG5uA1RHW48nifiVjEuzaYa8mhBeUwxQqrRdl5dGQMbf0Ig6kcKtlE0iYsgGRXucrcs5jnaBSfdhZxks7bn7HZXUqd09/J7sEfFBgvKQAYlXbz5yi2y6IeDEoj80Kupu12JssHe4k95YK3aGzdYDXx3SCfgZyt2IDaDKD06RCrPiI075D7K/8LhrKHoCU7bZaP2JpOSO+xv9zn2XlXQ7lL/D2Yrn6fCq2kPwF/YNgqMiCo59XUHuRE158JzD6vx9PZDIRk6/8n7/U7FlbovmUbIK800GnvjABIC6HNeZi+J67emvDkjInPZHEy09OVQXaa1M/nl+or2ks2dUTyi557gjyw/r5s6lKVbWHK6ti4n9CjgRR7VnfaCwsXQlvcF04w9litSDsURXDtONI9dXdphsRqGCQ3U+UaHy43/EbObphrdssdYDsDPbjOIRHCiDSyk+PSelD0pK+6oq9yD34RgHjzdwST6U4CVQXC6IJ3484Y54jc5PoakzBpG/U0KrSg2Hhpx,iv:W0Hmb0npBR3wb9CYaIj1Ao9mvmhgYgHp+Ggb7qTgPHA=,tag:aIyrG6df6EyJO/UXJCh2IQ==,type:str]",
+	"data": "ENC[AES256_GCM,data:uWXr8DpmeUwUJtrLPh97aE0J6+V8iGbHigpjz9/YExu7nJt5zavAIIzTqW1cN51WX/y1LmtDZf2t6kalVq6j60twvswoagTZA6t/iQGUdzGNVvTjfdfdaPrb2MNO4ZWJKiGpTZT91UC3JnBODoHC5FAo6ot6fuK3bL7E1H1YHjjh337CiyR3gGXBjbj8WX6Jx18tABW0dspVtBV1MeBx1doGmoN1EV46oNyRsR7j+8ZjUZauUay0NF5cEV8jWteov/5DdaYR+ApjpFt5oNf/bXlMdMhaVmFdVxiFtz8uBaDi0RobAz/WS1catpdPNzrSn/Ow9gX7ftulUY/8DXEeRaLxHhMe5EIn0VW2bRuJoC/Rjfg/BjSy3xlzNw26ryz+z/eZs7bfoMoP6Bey5fJiR5CqkvNtxsyrR7++H0+SEFGnQrnRcyrlUU+WdYqQsylPNOcMuYks7UQCVnfroRlot4v3gtI37IWG5/ymVI2H0d1tMzfEgthxihXk8LCOsYD0ygmfj6h+aAbVm66btGVcliMIT9CmTqGf2hOYysIEVq80IGpAB/LW/n47PW4=,iv:13CDcpWJuh3GnSfffcKw/bNdO5ZECYrfBcvBRwYC9Zk=,tag:Y8kRSEE+stQMkvMo8/PmXw==,type:str]",
 	"sops": {
 		"kms": [
 			{
@@ -13,8 +13,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2022-02-21T16:38:40Z",
-		"mac": "ENC[AES256_GCM,data:eZ3cHNwpdiuxPdl8mxKUc7WPqVc0JDRYkpf0ytl/wVjg+lBwejlogjWu59UYENBDVSxjrCZnuc7XP7YN9ks6LVsFqVkJaPXQjgc9GDE0/DoXiWV1grmuC3y+CJpcgSOgIVDvazZeY+oJJFJ9fwQfk0WiafgSfma6yRNy/nF/sTE=,iv:/GZW1kdq2VOLDyj/SF5BwxPj0GF8aE8roFC6KtFd4sE=,tag:Ruuk4PHEYC7Crh20+jraFg==,type:str]",
+		"lastmodified": "2022-03-16T10:59:16Z",
+		"mac": "ENC[AES256_GCM,data:YS9722yPktynKA4+WOQFUa1/jzhUozJ73V7oL+W0dop+IcCwqxKxOclc0LmtJ7dR3Qsvia/2gA69RFPtYALfkdyigyYkwA7sbvxMEGPjZM/nXzSuqV7kIN0DChqV6UdHQZETzAJgR+Xwp/pBEkOMmtSQOx1UYOaeZZgGgHjqjhU=,iv:E/ZbLCBsR0StQuagBQp7eR+oHbJN89OQecelriqfp58=,tag:X74nDTunT6HpUsXDy+yQ3g==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.1"


### PR DESCRIPTION
## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- [ ] Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
   - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- [ ] Do the changes require a runtime upgrade? If yes:
- [ ] Have any storage items or stored data types been modified? If yes:
   - [ ] Has the pallet's storage version been bumped and a storage migration been defined? 

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1435"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

