### PR TITLE
fix: avoid creating a temporary copy for a secret

### DIFF
--- a/engine/src/multisig/crypto.rs
+++ b/engine/src/multisig/crypto.rs
@@ -128,10 +128,9 @@ impl Scalar {
     pub fn random(mut rng: &mut Rng) -> Self {
         use curv::elliptic::curves::secp256_k1::SK;
 
-        let scalar = secp256k1::SecretKey::new(&mut rng);
-
-        let scalar = Secp256k1Scalar::from_underlying(Some(SK(scalar)));
-        Scalar(scalar)
+        Scalar(Secp256k1Scalar::from_underlying(Some(SK(
+            secp256k1::SecretKey::new(&mut rng),
+        ))))
     }
 
     pub fn zero() -> Self {


### PR DESCRIPTION
Addresses finding 3.3 from Kudelski report.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1437"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

