### PR TITLE
fix: avoid potentially clipping a 64 byte value

### DIFF
--- a/engine/src/multisig/crypto.rs
+++ b/engine/src/multisig/crypto.rs
@@ -139,7 +139,7 @@ impl Scalar {
     }
 
     pub fn from_usize(a: usize) -> Self {
-        Scalar(ECScalar::from_bigint(&BigInt::from(a as u32)))
+        Scalar(ECScalar::from_bigint(&BigInt::from(a as u64)))
     }
 
     pub fn from_bytes(x: &[u8; 32]) -> Self {


### PR DESCRIPTION
Addresses finding 3.7 from Kudelski report.

This isn't a problem currently as we only use this funciton for signer indexes which won't exceed the maximum number of authorities holding a key (`n <= 150` in our case), but it doesn't hurt to use the appropriate type here.

(In the future we could probably switch to `u32` everywhere though)

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1438"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

