### PR TITLE
Autogenerate markdown docs for State Chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,7 +599,7 @@ jobs:
       - store_artifacts:
           path: target/release
       - store_artifacts:
-          path: generated/
+          path: ./chainflip-docgen/generated/
 
   create-testnet:
     parameters:


### PR DESCRIPTION
We can work out how to host these at some versioned location in the future. For now you can see them on the artifacts tab on the CircleCI job.

https://app.circleci.com/pipelines/github/chainflip-io/chainflip-backend/4368/workflows/092af06c-e97d-4303-a87d-b30d713bb816/jobs/20896/artifacts

It uses the slightly shoddy script that I wrote at https://github.com/chainflip-io/chainflip-docgen.

Hopefully this makes your lives a bit easier @cdrn @zoheb391 @YassineFlip 🥳 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1486"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

