### PR TITLE
fix: don't log ceremony_id twice

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -223,10 +223,11 @@ impl CeremonyManager {
             return;
         }
 
+        let logger = &self.logger;
         let state = self
             .keygen_states
             .entry(ceremony_id)
-            .or_insert_with(|| KeygenStateRunner::new_unauthorised(ceremony_id, &logger));
+            .or_insert_with(|| KeygenStateRunner::new_unauthorised(ceremony_id, logger));
 
         let initial_stage = {
             let context = generate_keygen_context(ceremony_id, participants);


### PR DESCRIPTION
We were seeing this `"ceremony_id":5,"ceremony_id":5`:

```
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5ENvxmZXZNsqaPBe5Gdh6R5aAzafuPHzLFNiJ291RDBA97Mf] ","level":"trace","ts":"2022-04-08T09:35:37.547136364+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5CUTL28V8xDSaBtwcpgt92fWTBv4xBt7PmUTxnovLzU1vvAj] ","level":"trace","ts":"2022-04-08T09:35:37.547140880+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5HVjtscZ4wk7FGdLyD8pgAMR2HtZUkGDt3gQFeURTFgU4FKH] ","level":"trace","ts":"2022-04-08T09:35:37.547145273+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5CwSYw7SM3Lh68V6pn5RvAsmvQ9FpQeUhrxgfGHvfzBwKunM] ","level":"trace","ts":"2022-04-08T09:35:37.547149895+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5DfHaREECeoHGbpzCkYHooADCojopaQWrGQJJeFyi7t4eK5y] ","level":"trace","ts":"2022-04-08T09:35:37.547154408+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5Ctxa1J9T2m1Krr3tQ4xzWHSre3jNJxbuXoQ7fAvPWvdsrvi] ","level":"trace","ts":"2022-04-08T09:35:37.547158931+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5Ea1aPHZTqfGuwe5QBtKPXUSg7NGFNPwhiJVGqPr5rNqtwUb] ","level":"trace","ts":"2022-04-08T09:35:37.547163458+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
Apr 08 09:35:37 yeet-net-validator-122 chainflip-engine[4663]: {"tag":"","msg":"Received message KeygenData(HashComm1) from party [5FP4TDAavrG1XJdfifcdYXzufbzH54XD9iAfvWxAs6tuKUDH] ","level":"trace","ts":"2022-04-08T09:35:37.547169624+00:00","ceremony_id":5,"ceremony_id":5,"component":"MultisigClient"}
```

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1515"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

