### PR TITLE
chore: remove the old_validators argument from on_new_epoch() in EpochTransitionHandler trait

### DIFF
--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -386,7 +386,7 @@ impl<T: Config> EmissionsTrigger for Pallet<T> {
 impl<T: Config> EpochTransitionHandler for Pallet<T> {
 	type ValidatorId = <T as frame_system::Config>::AccountId;
 
-	fn on_new_epoch(_old_validators: &[Self::ValidatorId], _new_validators: &[Self::ValidatorId]) {
+	fn on_new_epoch(_new_validators: &[Self::ValidatorId]) {
 		// Calculate block emissions on every epoch
 		Self::calculate_block_emissions();
 		// Process any outstanding emissions.

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -359,7 +359,7 @@ impl<T: Config> Heartbeat for Pallet<T> {
 impl<T: Config> EpochTransitionHandler for Pallet<T> {
 	type ValidatorId = T::ValidatorId;
 
-	fn on_new_epoch(_old_validators: &[Self::ValidatorId], _new_validators: &[Self::ValidatorId]) {
+	fn on_new_epoch(_new_validators: &[Self::ValidatorId]) {
 		KeygenExclusionSet::<T>::kill();
 	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -729,7 +729,6 @@ impl<T: Config> Pallet<T> {
 	/// Starting a new epoch we update the storage, emit the event and call
 	/// `EpochTransitionHandler::on_new_epoch`
 	fn start_new_epoch(new_validators: &[ValidatorIdOf<T>], new_bond: T::Amount) {
-		let old_validators = Validators::<T>::get();
 		// Update state of current validators
 		Validators::<T>::set(new_validators.to_vec());
 		ValidatorLookup::<T>::remove_all(None);
@@ -777,7 +776,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		// Handler for a new epoch
-		T::EpochTransitionHandler::on_new_epoch(&old_validators, new_validators);
+		T::EpochTransitionHandler::on_new_epoch(new_validators);
 	}
 
 	fn expire_epoch(epoch: EpochIndex) {

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -162,7 +162,7 @@ pub struct TestEpochTransitionHandler;
 impl EpochTransitionHandler for TestEpochTransitionHandler {
 	type ValidatorId = ValidatorId;
 
-	fn on_new_epoch(_old_validators: &[Self::ValidatorId], new_validators: &[Self::ValidatorId]) {
+	fn on_new_epoch(new_validators: &[Self::ValidatorId]) {
 		for validator in new_validators {
 			MockChainflipAccount::update_last_active_epoch(
 				validator,

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -752,7 +752,7 @@ impl<T: Config<I>, I: 'static> KeyProvider<T::Chain> for Pallet<T, I> {
 impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
 	type ValidatorId = <T as Chainflip>::ValidatorId;
 
-	fn on_new_epoch(_old_validators: &[Self::ValidatorId], _new_validators: &[Self::ValidatorId]) {
+	fn on_new_epoch(_new_validators: &[Self::ValidatorId]) {
 		PendingVaultRotation::<T, I>::kill();
 	}
 }

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -365,7 +365,7 @@ where
 impl<T: Config> EpochTransitionHandler for Pallet<T> {
 	type ValidatorId = T::ValidatorId;
 
-	fn on_new_epoch(_old_validators: &[Self::ValidatorId], new_validators: &[Self::ValidatorId]) {
+	fn on_new_epoch(new_validators: &[Self::ValidatorId]) {
 		// Update the list of validators in the witnesser.
 		let epoch = T::EpochInfo::epoch_index();
 

--- a/state-chain/pallets/cf-witnesser/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock.rs
@@ -95,7 +95,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		// This is required to log events.
 		System::set_block_number(1);
 		MockEpochInfo::incr_epoch();
-		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[], &VALIDATORS);
+		<Witnesser as EpochTransitionHandler>::on_new_epoch(&VALIDATORS);
 	});
 
 	ext

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -128,11 +128,11 @@ fn can_continue_to_witness_for_old_epochs() {
 		let call = Box::new(Call::Dummy(pallet_dummy::Call::<Test>::try_get_value()));
 		// Run through a few epochs; 1, 2 and 3
 		MockEpochInfo::incr_epoch(); // 1 - Alice
-		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[], &[ALISSA]);
+		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[ALISSA]);
 		MockEpochInfo::incr_epoch(); // 2 - Alice
-		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[], &[ALISSA]);
+		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[ALISSA]);
 		MockEpochInfo::incr_epoch(); // 3 - Bob
-		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[], &[BOBSON]);
+		<Witnesser as EpochTransitionHandler>::on_new_epoch(&[BOBSON]);
 
 		let current_epoch = MockEpochInfo::epoch_index();
 

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -7,10 +7,10 @@ pub struct ChainflipEpochTransitions;
 impl EpochTransitionHandler for ChainflipEpochTransitions {
 	type ValidatorId = AccountId;
 
-	fn on_new_epoch(old_validators: &[Self::ValidatorId], new_validators: &[Self::ValidatorId]) {
-		<Emissions as EpochTransitionHandler>::on_new_epoch(old_validators, new_validators);
-		<Witnesser as EpochTransitionHandler>::on_new_epoch(old_validators, new_validators);
-		<Reputation as EpochTransitionHandler>::on_new_epoch(old_validators, new_validators);
-		<EthereumVault as EpochTransitionHandler>::on_new_epoch(old_validators, new_validators);
+	fn on_new_epoch(new_validators: &[Self::ValidatorId]) {
+		<Emissions as EpochTransitionHandler>::on_new_epoch(new_validators);
+		<Witnesser as EpochTransitionHandler>::on_new_epoch(new_validators);
+		<Reputation as EpochTransitionHandler>::on_new_epoch(new_validators);
+		<EthereumVault as EpochTransitionHandler>::on_new_epoch(new_validators);
 	}
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -218,7 +218,7 @@ pub trait EpochTransitionHandler {
 	///
 	/// The `old_validators` have moved on to leave the `new_validators` securing the network with
 	/// a `new_bond`
-	fn on_new_epoch(old_validators: &[Self::ValidatorId], new_validators: &[Self::ValidatorId]);
+	fn on_new_epoch(new_validators: &[Self::ValidatorId]);
 }
 
 /// Providing bidders for an auction


### PR DESCRIPTION
## State Chain

closes #1506

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- [ ] Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
   - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- [ ] Do the changes require a runtime upgrade? If yes:
- [ ] Have any storage items or stored data types been modified? If yes:
   - [ ] Has the pallet's storage version been bumped and a storage migration been defined? 

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1516"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

