### PR TITLE
chore: use try_into_result_sender instead of pub inner

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -174,9 +174,8 @@ impl CeremonyManager {
             .keygen_states
             .remove(&ceremony_id)
             .unwrap()
-            .inner
-            .unwrap()
-            .result_sender;
+            .try_into_result_sender()
+            .unwrap();
         self.ceremony_id_tracker.consume_keygen_id(&ceremony_id);
         if let Err((blamed_parties, reason)) = &result {
             slog::warn!(

--- a/engine/src/multisig/client/state_runner.rs
+++ b/engine/src/multisig/client/state_runner.rs
@@ -22,7 +22,7 @@ pub struct StateAuthorised<CeremonyData, CeremonyResult> {
 }
 
 pub struct StateRunner<CeremonyData, CeremonyResult> {
-    pub inner: Option<StateAuthorised<CeremonyData, CeremonyResult>>,
+    inner: Option<StateAuthorised<CeremonyData, CeremonyResult>>,
     // Note that we use a map here to limit the number of messages
     // that can be delayed from any one party to one per stage.
     delayed_messages: BTreeMap<AccountId, CeremonyData>,


### PR DESCRIPTION
Sorry, I didn't notice I missed this.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1519"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

