### PR TITLE
chore: removing old validators from on_new_epoch()

### DIFF
--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -386,10 +386,7 @@ impl<T: Config> EmissionsTrigger for Pallet<T> {
 impl<T: Config> EpochTransitionHandler for Pallet<T> {
 	type ValidatorId = <T as frame_system::Config>::AccountId;
 
-	fn on_new_epoch(
-		_previous_epoch_validators: &[Self::ValidatorId],
-		_epoch_validators: &[Self::ValidatorId],
-	) {
+	fn on_new_epoch(_epoch_validators: &[Self::ValidatorId]) {
 		// Calculate block emissions on every epoch
 		Self::calculate_block_emissions();
 		// Process any outstanding emissions.

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -359,10 +359,7 @@ impl<T: Config> Heartbeat for Pallet<T> {
 impl<T: Config> EpochTransitionHandler for Pallet<T> {
 	type ValidatorId = T::ValidatorId;
 
-	fn on_new_epoch(
-		_previous_epoch_validators: &[Self::ValidatorId],
-		_epoch_validators: &[Self::ValidatorId],
-	) {
+	fn on_new_epoch(_epoch_validators: &[Self::ValidatorId]) {
 		KeygenExclusionSet::<T>::kill();
 	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -757,7 +757,6 @@ impl<T: Config> Pallet<T> {
 			(*epoch - 1, *epoch)
 		});
 
-		let old_validators = Validators::<T>::get();
 		// Update state of current validators
 		Validators::<T>::set(epoch_validators.to_vec());
 
@@ -799,7 +798,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		// Handler for a new epoch
-		T::EpochTransitionHandler::on_new_epoch(&old_validators, epoch_validators);
+		T::EpochTransitionHandler::on_new_epoch(epoch_validators);
 
 		// Emit that a new epoch will be starting
 		Self::deposit_event(Event::NewEpoch(new_epoch));

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -168,10 +168,7 @@ pub struct TestEpochTransitionHandler;
 impl EpochTransitionHandler for TestEpochTransitionHandler {
 	type ValidatorId = ValidatorId;
 
-	fn on_new_epoch(
-		_previous_epoch_validators: &[Self::ValidatorId],
-		epoch_validators: &[Self::ValidatorId],
-	) {
+	fn on_new_epoch(epoch_validators: &[Self::ValidatorId]) {
 		for validator in epoch_validators {
 			MockChainflipAccount::update_validator_account_data(
 				validator,

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -752,10 +752,7 @@ impl<T: Config<I>, I: 'static> KeyProvider<T::Chain> for Pallet<T, I> {
 impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
 	type ValidatorId = <T as Chainflip>::ValidatorId;
 
-	fn on_new_epoch(
-		_previous_epoch_validators: &[Self::ValidatorId],
-		_epoch_validators: &[Self::ValidatorId],
-	) {
+	fn on_new_epoch(_epoch_validators: &[Self::ValidatorId]) {
 		PendingVaultRotation::<T, I>::kill();
 	}
 }

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -7,21 +7,9 @@ pub struct ChainflipEpochTransitions;
 impl EpochTransitionHandler for ChainflipEpochTransitions {
 	type ValidatorId = AccountId;
 
-	fn on_new_epoch(
-		previous_epoch_validators: &[Self::ValidatorId],
-		epoch_validators: &[Self::ValidatorId],
-	) {
-		<Emissions as EpochTransitionHandler>::on_new_epoch(
-			previous_epoch_validators,
-			epoch_validators,
-		);
-		<Reputation as EpochTransitionHandler>::on_new_epoch(
-			previous_epoch_validators,
-			epoch_validators,
-		);
-		<EthereumVault as EpochTransitionHandler>::on_new_epoch(
-			previous_epoch_validators,
-			epoch_validators,
-		);
+	fn on_new_epoch(epoch_validators: &[Self::ValidatorId]) {
+		<Emissions as EpochTransitionHandler>::on_new_epoch(epoch_validators);
+		<Reputation as EpochTransitionHandler>::on_new_epoch(epoch_validators);
+		<EthereumVault as EpochTransitionHandler>::on_new_epoch(epoch_validators);
 	}
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -226,10 +226,7 @@ pub trait EpochTransitionHandler {
 	///
 	/// The `previous_epoch_validators` now let `epoch_validators` take control
 	/// There can be an overlap between these two sets of validators
-	fn on_new_epoch(
-		previous_epoch_validators: &[Self::ValidatorId],
-		epoch_validators: &[Self::ValidatorId],
-	);
+	fn on_new_epoch(epoch_validators: &[Self::ValidatorId]);
 }
 
 /// Providing bidders for an auction


### PR DESCRIPTION
## State Chain

closes #1506 

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- [ ] Were any changes to the genesis config of any pallets? If yes:
   - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- [ ] Have any new dependencies been added? If yes:
   - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- [ ] Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
   - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- [ ] Do the changes require a runtime upgrade? If yes:
- [ ] Have any storage items or stored data types been modified? If yes:
   - [ ] Has the pallet's storage version been bumped and a storage migration been defined? 

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?
- [ ] Has the pallet been added to formatting checks in CI?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1520"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

