### PR TITLE
[SC-3269] More CFE keygen & signing unit tests Part3

### DIFF
--- a/engine/src/multisig/client/tests/frost_unit_tests.rs
+++ b/engine/src/multisig/client/tests/frost_unit_tests.rs
@@ -105,7 +105,7 @@ async fn should_delay_comm1_before_rts() {
 }
 
 #[tokio::test]
-async fn should_handle_invalid_local_sig() {
+async fn should_report_on_invalid_local_sig3() {
     let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
     let (messages, result_receivers) = signing_ceremony.request().await;
@@ -137,7 +137,7 @@ async fn should_handle_invalid_local_sig() {
 }
 
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_com1() {
+async fn should_report_on_inconsistent_broadcast_comm1() {
     let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
     let (mut messages, result_receivers) = signing_ceremony.request().await;
@@ -162,7 +162,7 @@ async fn should_handle_inconsistent_broadcast_com1() {
 }
 
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_sig3() {
+async fn should_report_on_inconsistent_broadcast_local_sig3() {
     let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
     let (messages, result_receivers) = signing_ceremony.request().await;
@@ -749,7 +749,7 @@ mod timeout {
         // agree on a party timing out in the following broadcast verification stage, the party gets reported
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage1() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage1() {
             let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             let (mut messages, result_receivers) = signing_ceremony.request().await;
@@ -785,7 +785,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage3() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage3() {
             let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             let (messages, result_receivers) = signing_ceremony.request().await;
@@ -834,7 +834,7 @@ mod timeout {
         // If timeout during a broadcast verification stage, and we have enough data, we can recover
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage2() {
+        async fn should_recover_if_agree_on_values_stage2() {
             let (mut ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             let [bad_node_id] = &ceremony.select_account_ids();
@@ -856,7 +856,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage4() {
+        async fn should_recover_if_agree_on_values_stage4() {
             let (mut ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             let [bad_node_id] = &ceremony.select_account_ids();
@@ -887,7 +887,7 @@ mod timeout {
         // because that would need another round of "voting" which can also timeout.
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_2() {
+        async fn should_report_if_insufficient_messages_stage2() {
             let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             // bad party 1 will timeout during a broadcast stage. It should be reported
@@ -914,7 +914,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_4() {
+        async fn should_report_if_insufficient_messages_stage4() {
             let (mut signing_ceremony, _) = new_signing_ceremony_with_keygen().await;
 
             // bad party 1 will timeout during a broadcast stage. It should be reported

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -239,7 +239,7 @@ async fn should_enter_blaming_stage_on_timeout_secret_shares() {
 /// time and during the blaming stage, the ceremony is aborted with these
 /// parties reported
 #[tokio::test]
-async fn should_handle_invalid_blame_response6() {
+async fn should_report_on_invalid_blame_response6() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
     let party_idx_mapping = PartyIdxMapping::from_unsorted_signers(
         &ceremony.nodes.keys().cloned().collect::<Vec<_>>()[..],
@@ -513,7 +513,7 @@ async fn should_ignore_unexpected_message_for_stage() {
 // the ceremony should be aborted and all faulty parties should be reported.
 // Fail on `verify_broadcasts` during `VerifyCommitmentsBroadcast2`
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_comm1() {
+async fn should_report_on_inconsistent_broadcast_comm1() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (messages, result_receivers) = ceremony.request().await;
@@ -543,7 +543,7 @@ async fn should_handle_inconsistent_broadcast_comm1() {
 }
 
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_hash_comm() {
+async fn should_report_on_inconsistent_broadcast_hash_comm1a() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (mut messages, result_receivers) = ceremony.request().await;
@@ -574,7 +574,7 @@ async fn should_handle_inconsistent_broadcast_hash_comm() {
 // to the hash commitments sent earlier, the ceremony should be aborted with
 // those parties reported.
 #[tokio::test]
-async fn should_report_on_invalid_hash_commitment() {
+async fn should_report_on_invalid_hash_comm1a() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (messages, result_receivers) = ceremony.request().await;
@@ -612,7 +612,7 @@ async fn should_report_on_invalid_hash_commitment() {
 }
 
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_complaints4() {
+async fn should_report_on_inconsistent_broadcast_complaints4() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (messages, result_receivers) = ceremony.request().await;
@@ -652,7 +652,7 @@ async fn should_handle_inconsistent_broadcast_complaints4() {
 }
 
 #[tokio::test]
-async fn should_handle_inconsistent_broadcast_blame_responses6() {
+async fn should_report_on_inconsistent_broadcast_blame_responses6() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let party_idx_mapping = PartyIdxMapping::from_unsorted_signers(
@@ -720,7 +720,7 @@ async fn should_handle_inconsistent_broadcast_blame_responses6() {
 // If one or more parties send invalid commitments, the ceremony should be aborted.
 // Fail on `validate_commitments` during `VerifyCommitmentsBroadcast2`.
 #[tokio::test]
-async fn should_handle_invalid_comm1() {
+async fn should_report_on_invalid_comm1() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (messages, result_receivers) = ceremony.request().await;
@@ -758,7 +758,7 @@ async fn should_handle_invalid_comm1() {
 }
 
 #[tokio::test]
-async fn should_handle_invalid_complaints4() {
+async fn should_report_on_invalid_complaints4() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
     let (messages, result_receivers) = ceremony.request().await;
@@ -938,7 +938,7 @@ mod timeout {
         use super::*;
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage1a() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage1a() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (mut messages, result_receivers) = ceremony.request().await;
@@ -975,7 +975,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage1() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage1() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1012,7 +1012,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage4() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage4() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1050,7 +1050,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_party_appears_offline_to_minority_stage6() {
+        async fn should_recover_if_party_appears_offline_to_minority_stage6() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1108,7 +1108,7 @@ mod timeout {
         use super::*;
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage2a() {
+        async fn should_recover_if_agree_on_values_stage2a() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1134,7 +1134,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage2() {
+        async fn should_recover_if_agree_on_values_stage2() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1153,7 +1153,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage5() {
+        async fn should_recover_if_agree_on_values_stage5() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1176,7 +1176,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn recover_if_agree_on_values_stage7() {
+        async fn should_recover_if_agree_on_values_stage7() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1214,7 +1214,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_2a() {
+        async fn should_report_if_insufficient_messages_stage2a() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1238,7 +1238,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_2() {
+        async fn should_report_if_insufficient_messages_stage2() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1261,7 +1261,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_5() {
+        async fn should_report_if_insufficient_messages_stage5() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;
@@ -1295,7 +1295,7 @@ mod timeout {
         }
 
         #[tokio::test]
-        async fn report_if_insufficient_messages_stage_7() {
+        async fn should_report_if_insufficient_messages_stage7() {
             let mut ceremony = KeygenCeremonyRunner::new_with_default();
 
             let (messages, result_receivers) = ceremony.request().await;


### PR DESCRIPTION
Closes #1458
I think this is the last of my changes to multisig unit tests for now.
- Added one more unit test for keygen
- Renamed the unit tests so they are all standardized

The updated documentation is [here](https://github.com/chainflip-io/design-documentation/pull/95) 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1533"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

