### PR TITLE
fix: upgrade dependencies (cargo audit recommendations - kudelski)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "log 0.4.14",
- "mockall 0.11.0",
+ "mockall",
  "multisig-p2p-transport",
  "num",
  "pallet-cf-auction",
@@ -1695,12 +1695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,12 +1780,6 @@ dependencies = [
  "byteorder",
  "quick-error 1.2.3",
 ]
-
-[[package]]
-name = "downcast"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "downcast"
@@ -2207,15 +2195,6 @@ dependencies = [
  "libc",
  "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
-dependencies = [
- "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -4545,44 +4524,17 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
-dependencies = [
- "cfg-if 1.0.0",
- "downcast 0.10.0",
- "fragile",
- "lazy_static",
- "mockall_derive 0.10.2",
- "predicates 1.0.8",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
 dependencies = [
  "cfg-if 1.0.0",
- "downcast 0.11.0",
+ "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive 0.11.0",
- "predicates 2.1.1",
+ "mockall_derive",
+ "predicates",
  "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
-dependencies = [
- "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4696,8 +4648,8 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log 0.4.14",
- "mockall 0.10.2",
- "predicates 2.1.1",
+ "mockall",
+ "predicates",
  "sc-network",
  "sc-rpc",
  "sc-service",
@@ -5933,25 +5885,12 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
-dependencies = [
- "difference",
- "float-cmp 0.8.0",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
- "float-cmp 0.9.0",
+ "float-cmp",
  "itertools",
  "normalize-line-endings",
  "predicates-core",
@@ -9274,11 +9213,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
- "autocfg 1.0.1",
  "bytes 1.1.0",
  "libc",
  "memchr",
@@ -9326,9 +9264,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -58,7 +58,7 @@ slog = {version = "2.7.0", features = ["max_level_trace", "release_max_level_tra
 slog-async = {version = "2.6.0"}
 slog-json = {version = "2.3.0"}
 thiserror = "1.0.26"
-tokio = {version = "1.5.0", features = ["full"]}
+tokio = {version = "1.13.1", features = ["full"]}
 tokio-stream = "0.1.5"
 url = "1.7.2"
 web3 = {git = 'https://github.com/tomusdrw/rust-web3.git', rev = 'a425fa7'}

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -13,7 +13,7 @@ hex = "0.4.3"
 serde = {version = "1.0", features = ["derive", "rc"]}
 slog = {version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"]}
 structopt = "0.3.23"
-tokio = {version = "1.5.0", features = ["full"]}
+tokio = {version = "1.13.1", features = ["full"]}
 utilities = {path = "../../utilities"}
 web3 = {git = 'https://github.com/tomusdrw/rust-web3.git', rev = 'a425fa7'}
 

--- a/state-chain/multisig-p2p-transport/Cargo.toml
+++ b/state-chain/multisig-p2p-transport/Cargo.toml
@@ -16,7 +16,7 @@ jsonrpc-pubsub = '18.0.0'
 serde_json = '1.0.68'
 bs58 = '0.4.0'
 futures = { version = '0.3.4', features = ['compat'] }
-tokio = {version = '1.5.0', features = ['full']}
+tokio = {version = '1.13.1', features = ['full']}
 async-trait = "0.1.49"
 predicates = "2.1.1"
 
@@ -43,5 +43,5 @@ git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'merge-config-option'
 
 [dev-dependencies]
-mockall = "0.10.2"
+mockall = "0.11.0"
 tokio-stream = '0.1.5'


### PR DESCRIPTION
The rest of the cargo audit recommendations we cannot do anything about without upgrading substrate versions or further modifying substrate (Of course thats not worth doing yet).

The version of tokio (1.13.0) we were using had a bug in its oneshot impl that may have been causing problems (Although I don't think so).

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1544"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

