### PR TITLE
fix: emergency rotations should not revert keygen.

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -958,7 +958,9 @@ impl<T: Config> EmergencyRotation for Pallet<T> {
 		if !EmergencyRotationRequested::<T>::get() {
 			EmergencyRotationRequested::<T>::set(true);
 			Pallet::<T>::deposit_event(Event::EmergencyRotationRequested());
-			Self::set_rotation_status(RotationStatus::RunAuction);
+			if RotationPhase::<T>::get() == RotationStatusOf::<T>::Idle {
+				Self::set_rotation_status(RotationStatus::RunAuction);
+			}
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -73,6 +73,20 @@ fn should_request_emergency_rotation() {
 			!ValidatorPallet::emergency_rotation_in_progress(),
 			"we should not be in an emergency rotation"
 		);
+
+		// Once we've passed the Idle phase, requesting an emergency rotation should have no
+		// effect on the rotation status.
+		for status in [
+			RotationStatusOf::<Test>::RunAuction,
+			RotationStatusOf::<Test>::AwaitingVaults(Default::default()),
+			RotationStatusOf::<Test>::VaultsRotated(Default::default()),
+			RotationStatusOf::<Test>::SessionRotating(Default::default()),
+		] {
+			RotationPhase::<Test>::put(&status);
+			ValidatorPallet::request_emergency_rotation();
+			assert_eq!(RotationPhase::<Test>::get(), status,);
+			ValidatorPallet::emergency_rotation_completed();
+		}
 	});
 }
 


### PR DESCRIPTION
Closes #1568 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1569"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

