### PR TITLE
Create workflow action for building rust-base

### DIFF
--- a/.github/workflows/.docker-build.yaml
+++ b/.github/workflows/.docker-build.yaml
@@ -1,0 +1,56 @@
+on:
+  workflow_dispatch:
+    inputs:
+      nightly_version:
+        type: string
+        default: nightly-2021-11-16
+        description: Toolchain version you want to build
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "${{ github.repository }}/rust-base"
+  TAG: ${{ github.event.inputs.nightly_version }}
+
+jobs:
+  build:
+    name: Build Docker Image
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.TAG }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: rust-base.Dockerfile
+          build-args: |
+            NIGHTLY=${{ env.TAG }}

--- a/rust-base.Dockerfile
+++ b/rust-base.Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSLo /tmp/sccache.tgz \
  && mv /tmp/sccache /usr/bin && chmod +x /usr/bin/sccache \
  && rm -rf /tmp/*
 
-ARG NIGHTLY=nightly-2021-11-16
+ARG NIGHTLY
 # Download and set nightly as the default Rust compiler
 RUN rustup default ${NIGHTLY} \
     && rustup target add wasm32-unknown-unknown --toolchain ${NIGHTLY} \


### PR DESCRIPTION
First job to move from CircleCI to GitHub. This will allow anyone to generate a `rust-base` Dockerfile, with the desired nightly version.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1585"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

closes https://github.com/chainflip-io/chainflip-platform-monorepo/issues/345
fixes https://github.com/chainflip-io/chainflip-platform-monorepo/issues/344
