### PR TITLE
fix: add ChainBlockNumber

### DIFF
--- a/state-chain/types.json
+++ b/state-chain/types.json
@@ -54,6 +54,7 @@
   },
   "CallHash": "[u8;32]",
   "CeremonyId": "u64",
+  "ChainBlockNumber": "u64",
   "ChainflipAccountData": {
     "state": "ChainflipAccountState",
     "last_active_epoch": "Option<EpochIndex>"


### PR DESCRIPTION
Noticed this one when viewing a testnet the other day.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1595"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

