### PR TITLE
fix: broken merged tomls

### DIFF
--- a/state-chain/pallets/cf-environment/Cargo.toml
+++ b/state-chain/pallets/cf-environment/Cargo.toml
@@ -47,24 +47,24 @@ tag = 'chainflip-monthly-2021-09+1'
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'merge-config-option'
+tag = 'chainflip-monthly-2021-09+1'
 
 [dependencies.frame-benchmarking]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
 optional = true
-tag = 'merge-config-option'
+tag = 'chainflip-monthly-2021-09+1'
 
 # Dev dependencies
 [dev-dependencies.sp-io]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'merge-config-option'
+tag = 'chainflip-monthly-2021-09+1'
 
 [dev-dependencies.sp-core]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'merge-config-option'
+tag = 'chainflip-monthly-2021-09+1'
 
 [features]
 default = ['std']

--- a/state-chain/test-utilities/Cargo.toml
+++ b/state-chain/test-utilities/Cargo.toml
@@ -7,7 +7,7 @@ description = "Chainflip test utilities used in multiple crates"
 
 [dependencies.frame-system]
 git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'merge-config-option'
+tag = 'chainflip-monthly-2021-09+1'
 
 [features]
 default = ['std']


### PR DESCRIPTION
I broke dev's toml files. This fixes it.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1609"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

