### PR TITLE
ci(.circleci/config.yml): update master image name 👾

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ version: 2.1
 executors:
   chainflip-master:
     docker:
-      - image: docker pull ghcr.io/chainflip-io/chainflip-platform-monorepo/chainflip-master:latest
+      - image: ghcr.io/chainflip-io/chainflip-platform-monorepo/chainflip-master:latest
         auth: *dockerconfig
   rust-base:
     docker:


### PR DESCRIPTION
the master image was migrated to a new package name. The old one will
still be valid and working but will stop receiving updates as of `06.05.2022` 🤓

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

