### PR TITLE
chore: improve multisig logs

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -465,7 +465,7 @@ impl<C: CryptoScheme> CeremonyManager<C> {
             }
         };
 
-        if let Some(result) = state.process_message(sender_id, data) {
+        if let Some(result) = state.process_or_delay_message(sender_id, data) {
             self.process_signing_ceremony_outcome(ceremony_id, result);
         }
     }
@@ -490,6 +490,8 @@ impl<C: CryptoScheme> CeremonyManager<C> {
             );
             return;
         }
+
+        slog::debug!(self.logger, "Received keygen data {}", &data; CEREMONY_ID_KEY => ceremony_id);
 
         // Only stage 1 messages can create unauthorised ceremonies
         let state = if matches!(data, KeygenData::HashComm1(_)) {
@@ -523,7 +525,7 @@ impl<C: CryptoScheme> CeremonyManager<C> {
             }
         };
 
-        if let Some(result) = state.process_message(sender_id, data) {
+        if let Some(result) = state.process_or_delay_message(sender_id, data) {
             self.process_keygen_ceremony_outcome(ceremony_id, result);
         }
     }

--- a/engine/src/multisig/client/state_runner.rs
+++ b/engine/src/multisig/client/state_runner.rs
@@ -158,18 +158,11 @@ where
 
     /// Process message from a peer, returning ceremony outcome if
     /// the ceremony stage machine cannot progress any further
-    pub fn process_message(
+    pub fn process_or_delay_message(
         &mut self,
         sender_id: AccountId,
         data: CeremonyData,
     ) -> OptionalCeremonyReturn<CeremonyResult, FailureReason> {
-        slog::trace!(
-            self.logger,
-            "Received message {} from party [{}] ",
-            data,
-            sender_id
-        );
-
         match &mut self.inner {
             None => {
                 self.add_delayed(sender_id, data);
@@ -219,7 +212,7 @@ where
                 id,
             );
 
-            if let Some(result) = self.process_message(id, m) {
+            if let Some(result) = self.process_or_delay_message(id, m) {
                 return Some(result);
             }
         }


### PR DESCRIPTION
I notices that "Received message" gets printed even when the message was received a long time ago and we are simply processing it as delayed, which is misleading. I removed the log from `process_or_delay_message` and instead made sure that we log before the function is called, so we can provide more context.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1672"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

