### PR TITLE
Fix/eth logging freq

### DIFF
--- a/engine/src/constants.rs
+++ b/engine/src/constants.rs
@@ -29,5 +29,8 @@ pub const SYNC_POLL_INTERVAL: Duration = Duration::from_secs(4);
 /// Number of blocks one of the protocols needs to fall behind before we sound the alarms
 pub const ETH_FALLING_BEHIND_MARGIN_BLOCKS: u64 = 10;
 
+/// Duration between intervals before we emit a log that one the ETH streams is behind
+pub const ETH_STILL_BEHIND_LOG_INTERVAL: Duration = Duration::from_secs(180);
+
 /// Number of blocks before logging that a stream is behind again
 pub const ETH_LOG_BEHIND_REPORT_BLOCK_INTERVAL: u64 = 10;

--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -15,10 +15,10 @@ use cf_traits::EpochIndex;
 use regex::Regex;
 
 use crate::{
-    common::read_clean_and_decode_hex_str_file,
+    common::{make_periodic_tick, read_clean_and_decode_hex_str_file},
     constants::{
         ETH_BLOCK_SAFETY_MARGIN, ETH_FALLING_BEHIND_MARGIN_BLOCKS,
-        ETH_LOG_BEHIND_REPORT_BLOCK_INTERVAL,
+        ETH_LOG_BEHIND_REPORT_BLOCK_INTERVAL, ETH_STILL_BEHIND_LOG_INTERVAL,
     },
     eth::{
         http_safe_stream::{safe_polling_http_head_stream, HTTP_POLL_INTERVAL},
@@ -30,7 +30,7 @@ use crate::{
     state_chain::client::{StateChainClient, StateChainRpcApi},
 };
 use ethbloom::{Bloom, Input};
-use futures::{stream, StreamExt};
+use futures::{stream, FutureExt, StreamExt};
 use slog::o;
 use sp_core::{H160, U256};
 use std::{
@@ -556,6 +556,7 @@ pub trait EthObserver {
         #[derive(Debug)]
         struct ProtocolState {
             last_block_pulled: u64,
+            log_ticker: tokio::time::Interval,
             protocol: TransportProtocol,
         }
         #[derive(Debug)]
@@ -575,11 +576,13 @@ pub trait EthObserver {
         let init_state = StreamState::<BlockEventsStreamWs, BlockEventsStreamHttp> {
             ws_state: ProtocolState {
                 last_block_pulled: 0,
+                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL),
                 protocol: TransportProtocol::Ws,
             },
             ws_stream: safe_ws_block_events_stream,
             http_state: ProtocolState {
                 last_block_pulled: 0,
+                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL),
                 protocol: TransportProtocol::Http,
             },
             http_stream: safe_http_block_events_stream,
@@ -667,8 +670,14 @@ pub trait EthObserver {
             let opt_block_events = if merged_has_yielded {
                 if block_events.block_number == next_block_to_yield {
                     Some(block_events)
+                    // if we're only one block "behind" we're not really "behind", we were just the second stream polled
+                } else if block_events.block_number + 1 < next_block_to_yield {
+                    None
                 } else if block_events.block_number < next_block_to_yield {
-                    slog::trace!(merged_stream_state.logger, "ETH {} stream pulled block {}. But this is behind the next block to yield of {}. Continuing...", protocol_state.protocol, block_events.block_number, next_block_to_yield);
+                    // we're behind, but we only want to log once every interval
+                    if protocol_state.log_ticker.tick().now_or_never().is_some() {
+                        slog::trace!(merged_stream_state.logger, "ETH {} stream pulled block {}. But this is behind the next block to yield of {}. Continuing...", protocol_state.protocol, block_events.block_number, next_block_to_yield);
+                    }
                     None
                 } else {
                     panic!("Input streams to merged stream started at different block numbers. This should not occur.");


### PR DESCRIPTION
Changes to the logging:
- If one of the streams is only one block "behind" we don't log. This is because if we have two streams that are polled, one of them must be polled first. So it's not really "behind". 
- When a stream is *actually* behind, then we log immediately the first time, then in an interval of 3 minutes. 