### PR TITLE
chore: set a runtime CALL_ENUM_MAX_SIZE

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -777,3 +777,35 @@ impl_runtime_apis! {
 		}
 	}
 }
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	const CALL_ENUM_MAX_SIZE: usize = 320;
+
+	// Introduced from polkdadot
+	#[test]
+	fn call_size() {
+		assert!(
+			core::mem::size_of::<Call>() <= CALL_ENUM_MAX_SIZE,
+			r"
+			Polkadot suggests a 230 byte limit for the size of the Call type. We use {} but this runtime's call size
+			is {}. If this test fails then you have just added a call variant that exceed the limit.
+
+			Congratulations!
+
+			Maybe consider boxing some calls to reduce their size. Otherwise, increasing the CALL_ENUM_MAX_SIZE is
+			acceptable (within reason). The issue is that the enum always uses max(enum_size) of memory, even if your
+			are using a smaller variant. Note this is irrelevant from a SCALE-encoding POV, it only affects the size of
+			the enum on the stack.
+			Context:
+			  - https://github.com/paritytech/substrate/pull/9418
+			  - https://rust-lang.github.io/rust-clippy/master/#large_enum_variant
+			  - https://fasterthanli.me/articles/peeking-inside-a-rust-enum
+			",
+			CALL_ENUM_MAX_SIZE,
+			core::mem::size_of::<Call>(),
+		);
+	}
+}


### PR DESCRIPTION
Based on something I noticed in Polkadot, apparently recommended by their auditors.

Context:
			  - https://github.com/paritytech/substrate/pull/9418
			  - https://rust-lang.github.io/rust-clippy/master/#large_enum_variant
			  - https://fasterthanli.me/articles/peeking-inside-a-rust-enum

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1707"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

