### PR TITLE
feat/revamped-flip-pallet-tests-now-using-quickcheck

### DIFF
--- a/state-chain/pallets/cf-flip/src/mock.rs
+++ b/state-chain/pallets/cf-flip/src/mock.rs
@@ -144,10 +144,29 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	ext
 }
+
+pub type SlashingRateType = u128;
+pub type Bond = u128;
+pub type BlocksOffline = u64;
+pub type Mint = u128;
+
 #[derive(Clone, Debug)]
 pub enum FlipOperation {
-	Stake(AccountId, FlipBalance),
+	MintExternal(FlipBalance, FlipBalance),
+	BurnExternal(FlipBalance, FlipBalance),
+	BurnReverts(FlipBalance),
+	MintReverts(FlipBalance),
+	CreditReverts(FlipBalance),
+	DebitReverts(FlipBalance),
+	BridgeInReverts(FlipBalance),
+	BridgeOutReverts(FlipBalance),
+	MintToReserve(FlipBalance),
+	BurnFromReserve(FlipBalance),
 	BurnFromAccount(AccountId, FlipBalance),
 	MintToAccount(AccountId, FlipBalance),
-	Claim(AccountId, FlipBalance),
+	ExternalTransferOut(AccountId, FlipBalance),
+	ExternalTransferIn(AccountId, FlipBalance),
+	UpdateStakeAndBond(AccountId, FlipBalance, FlipBalance),
+	SlashAccount(AccountId, SlashingRateType, Bond, BlocksOffline, Mint),
+	AccountToAccount(AccountId, AccountId, FlipBalance, FlipBalance),
 }

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -1,82 +1,415 @@
 use std::mem;
 
 use crate::{
-	mock::*, Account as FlipAccount, Bonder, Config, Error, FlipIssuance, OffchainFunds,
-	TotalIssuance,
+	mock::*, Account as FlipAccount, Bonder, Config, Error, FlipIssuance, FlipSlasher,
+	OffchainFunds, Reserve, SlashingRate, TotalIssuance,
 };
-use cf_traits::{Bonding, Issuance, StakeTransfer};
+use cf_traits::{Bonding, Issuance, Slashing, StakeTransfer};
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_noop,
 	traits::{HandleLifetime, Imbalance},
 };
 use quickcheck::{Arbitrary, Gen, TestResult};
 use quickcheck_macros::quickcheck;
 
 impl FlipOperation {
-	pub fn execute(&self) {
+	pub fn execute(&self) -> bool {
 		match self {
-			FlipOperation::Stake(account_id, amount) => {
-				<Flip as StakeTransfer>::credit_stake(account_id, *amount);
+			// Mint to external
+			FlipOperation::MintExternal(amount_1, amount_2) => {
+				let previous_issuance = TotalIssuance::<Test>::get();
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				mem::drop(Flip::mint(*amount_1).offset(Flip::bridge_out(*amount_1)));
+				let intermediate_issuance = TotalIssuance::<Test>::get();
+				let intermediate_offchain_funds = OffchainFunds::<Test>::get();
+				if intermediate_issuance !=
+					(previous_issuance.checked_add(*amount_1).unwrap_or(previous_issuance)) ||
+					intermediate_offchain_funds !=
+						previous_offchain_funds + (intermediate_issuance - previous_issuance)
+				{
+					return false
+				}
+				mem::drop(Flip::bridge_out(*amount_2).offset(Flip::mint(*amount_2)));
+				let final_offchain_funds = OffchainFunds::<Test>::get();
+				let final_issuance = TotalIssuance::<Test>::get();
+				if final_issuance !=
+					(intermediate_issuance
+						.checked_add(*amount_2)
+						.unwrap_or(intermediate_issuance)) ||
+					final_offchain_funds !=
+						intermediate_offchain_funds + (final_issuance - intermediate_issuance)
+				{
+					return false
+				}
 			},
+			// Burn from external
+			FlipOperation::BurnExternal(amount_1, amount_2) => {
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				let previous_issuance = TotalIssuance::<Test>::get();
+				mem::drop(Flip::burn(*amount_1).offset(Flip::bridge_in(*amount_1)));
+				let intermediate_offchain_funds = OffchainFunds::<Test>::get();
+				let intermediate_issuance = TotalIssuance::<Test>::get();
+				if intermediate_issuance !=
+					(previous_issuance - (previous_offchain_funds - intermediate_offchain_funds)) ||
+					intermediate_offchain_funds !=
+						previous_offchain_funds.saturating_sub(*amount_1)
+				{
+					return false
+				}
+				mem::drop(Flip::bridge_in(*amount_2).offset(Flip::burn(*amount_2)));
+				let final_offchain_funds = OffchainFunds::<Test>::get();
+				let final_issuance = TotalIssuance::<Test>::get();
+				if final_issuance !=
+					(intermediate_issuance -
+						(intermediate_offchain_funds - final_offchain_funds)) ||
+					final_offchain_funds != intermediate_offchain_funds.saturating_sub(*amount_2)
+				{
+					return false
+				}
+			},
+			FlipOperation::BurnReverts(amount) => {
+				let previous_issuance = TotalIssuance::<Test>::get();
+				mem::drop(Flip::burn(*amount));
+				if TotalIssuance::<Test>::get() != previous_issuance {
+					return false
+				}
+			},
+			FlipOperation::MintReverts(amount) => {
+				let previous_issuance = TotalIssuance::<Test>::get();
+				mem::drop(Flip::mint(*amount));
+				if TotalIssuance::<Test>::get() != previous_issuance {
+					return false
+				}
+			},
+			FlipOperation::CreditReverts(amount) => {
+				let previous_balance = Flip::total_balance_of(&CHARLIE);
+				mem::drop(Flip::credit(&CHARLIE, *amount));
+				if Flip::total_balance_of(&CHARLIE) != previous_balance {
+					return false
+				}
+			},
+			FlipOperation::DebitReverts(amount) => {
+				let previous_balance = Flip::total_balance_of(&ALICE);
+				mem::drop(Flip::debit(&ALICE, *amount));
+				if Flip::total_balance_of(&ALICE) != previous_balance {
+					return false
+				}
+			},
+			FlipOperation::BridgeInReverts(amount) => {
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				mem::drop(Flip::bridge_in(*amount));
+				if OffchainFunds::<Test>::get() != previous_offchain_funds {
+					return false
+				}
+			},
+			FlipOperation::BridgeOutReverts(amount) => {
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				mem::drop(Flip::bridge_out(*amount));
+				if OffchainFunds::<Test>::get() != previous_offchain_funds {
+					return false
+				}
+			},
+			// Mint To Reserve
+			FlipOperation::MintToReserve(amount) => {
+				use crate::ReserveId;
+				const TEST_RESERVE: ReserveId = *b"TEST";
+				let previous_issuance = TotalIssuance::<Test>::get();
+				let previous_reserve = Reserve::<Test>::try_get(TEST_RESERVE).unwrap_or(0);
+
+				let mint = FlipIssuance::<Test>::mint(*amount);
+				let deposit = Flip::deposit_reserves(TEST_RESERVE, *amount);
+				mem::drop(mint.offset(deposit));
+
+				let new_issuance = TotalIssuance::<Test>::get();
+				let new_reserve = Reserve::<Test>::try_get(TEST_RESERVE).unwrap_or(0);
+				if new_issuance !=
+					previous_issuance.checked_add(*amount).unwrap_or(previous_issuance)
+				{
+					return false
+				}
+				if new_reserve != previous_reserve + (new_issuance - previous_issuance) {
+					return false
+				}
+			},
+			// Burn From Reserve
+			FlipOperation::BurnFromReserve(amount) => {
+				use crate::ReserveId;
+				const TEST_RESERVE: ReserveId = *b"TEST";
+				let previous_issuance = TotalIssuance::<Test>::get();
+				let previous_reserve = Reserve::<Test>::try_get(TEST_RESERVE).unwrap_or(0);
+
+				let burn = FlipIssuance::<Test>::burn(*amount);
+				let withdrawal = Flip::withdraw_reserves(TEST_RESERVE, *amount);
+				let _result = burn.offset(withdrawal);
+
+				if Flip::reserved_balance(TEST_RESERVE) != previous_reserve.saturating_sub(*amount)
+				{
+					return false
+				}
+				if FlipIssuance::<Test>::total_issuance() !=
+					previous_issuance.saturating_sub(*amount)
+				{
+					return false
+				}
+			},
+			// Burn From Account
 			FlipOperation::BurnFromAccount(account_id, amount) => {
+				let previous_balance = Flip::total_balance_of(account_id);
+				let previous_issuance = TotalIssuance::<Test>::get();
 				Flip::settle(account_id, Flip::burn(*amount).into());
+				let new_balance = Flip::total_balance_of(account_id);
+				if new_balance != previous_balance.saturating_sub(*amount) {
+					return false
+				}
+				if TotalIssuance::<Test>::get() !=
+					previous_issuance - (previous_balance - new_balance)
+				{
+					return false
+				}
 			},
+			// Mint To Account
 			FlipOperation::MintToAccount(account_id, amount) => {
+				let previous_balance = Flip::total_balance_of(account_id);
+				let previous_issuance = TotalIssuance::<Test>::get();
 				Flip::settle(account_id, Flip::mint(*amount).into());
+				if TotalIssuance::<Test>::get() !=
+					previous_issuance.checked_add(*amount).unwrap_or(previous_issuance)
+				{
+					return false
+				}
+				if Flip::total_balance_of(account_id) !=
+					previous_balance + (TotalIssuance::<Test>::get() - previous_issuance)
+				{
+					return false
+				}
 			},
-			FlipOperation::Claim(account_id, amount) => {
-				<Flip as StakeTransfer>::try_claim(account_id, *amount).unwrap_or_default();
+			// Transfer out of Account to offchain funds
+			FlipOperation::ExternalTransferOut(account_id, amount) => {
+				let previous_balance = Flip::total_balance_of(account_id);
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				Flip::settle(account_id, Flip::bridge_out(*amount).into());
+				let new_balance = Flip::total_balance_of(account_id);
+				let new_offchain_funds = OffchainFunds::<Test>::get();
+				match previous_offchain_funds.checked_add(*amount) {
+					Some(_sum) => {
+						if new_balance != previous_balance.saturating_sub(*amount) ||
+							new_offchain_funds !=
+								previous_offchain_funds + (previous_balance - new_balance)
+						{
+							return false
+						}
+					},
+					None => {
+						if new_balance != previous_balance ||
+							new_offchain_funds != previous_offchain_funds
+						{
+							return false
+						}
+					},
+				}
+			},
+			// Transfer into Account from Offchain funds
+			FlipOperation::ExternalTransferIn(account_id, amount) => {
+				let previous_balance = Flip::total_balance_of(account_id);
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				Flip::settle(account_id, Flip::bridge_in(*amount).into());
+				let new_balance = Flip::total_balance_of(account_id);
+				let new_offchain_funds = OffchainFunds::<Test>::get();
+				if new_balance != previous_balance + (previous_offchain_funds - new_offchain_funds)
+				{
+					return false
+				}
+				if new_offchain_funds != previous_offchain_funds.saturating_sub(*amount) {
+					return false
+				}
+			},
+			// Update stake, Bond and claim
+			FlipOperation::UpdateStakeAndBond(account_id, stake, bond) => {
+				// Update Stake
+				let previous_stake = <Flip as StakeTransfer>::stakeable_balance(account_id);
+				let previous_offchain_funds = OffchainFunds::<Test>::get();
+				<Flip as StakeTransfer>::credit_stake(account_id, *stake);
+				let new_stake = <Flip as StakeTransfer>::stakeable_balance(account_id);
+				let new_offchain_funds = OffchainFunds::<Test>::get();
+				if new_offchain_funds != previous_offchain_funds.saturating_sub(*stake) ||
+					new_stake !=
+						(previous_stake + (previous_offchain_funds - new_offchain_funds)) ||
+					!MockStakeHandler::has_stake_updated(account_id)
+				{
+					return false
+				}
+
+				// Bond all of it
+				Bonder::<Test>::update_bond(account_id, new_stake);
+				if new_stake != (previous_stake + (previous_offchain_funds - new_offchain_funds)) ||
+					<Flip as StakeTransfer>::claimable_balance(account_id) != 0
+				{
+					return false
+				}
+
+				// Now try to claim
+				assert_noop!(
+					<Flip as StakeTransfer>::try_claim(account_id, 1),
+					Error::<Test>::InsufficientLiquidity
+				);
+
+				// Reduce the bond
+				Bonder::<Test>::update_bond(account_id, *bond);
+				let expected_claimable_balance = new_stake.saturating_sub(*bond);
+				if <Flip as StakeTransfer>::claimable_balance(account_id) !=
+					expected_claimable_balance
+				{
+					return false
+				}
+				assert!(
+					<Flip as StakeTransfer>::try_claim(account_id, expected_claimable_balance)
+						.is_ok(),
+					"expexted: {}, claimable: {}",
+					expected_claimable_balance,
+					<Flip as StakeTransfer>::claimable_balance(account_id)
+				);
+				if !MockStakeHandler::has_stake_updated(account_id) {
+					return false
+				}
+			},
+			FlipOperation::SlashAccount(account_id, slashing_rate, bond, blocks_offline, mint) => {
+				let blocks_per_day: u128 = <Test as Config>::BlocksPerDay::get() as u128;
+				// Bound the slashing rate since it represents a percentage.
+				let slashing_rate_bounded = slashing_rate % 50;
+				let expected_slash: u128 =
+					((bond / 100_u128).saturating_mul(slashing_rate_bounded) / blocks_per_day)
+						.saturating_mul(*blocks_offline as u128);
+				// Mint some Flip for testing - 100 is not enough and unrealistic for this usecase
+				Flip::settle(account_id, Flip::mint(*mint).into());
+				let initial_balance: u128 = Flip::total_balance_of(account_id);
+				Bonder::<Test>::update_bond(account_id, *bond);
+
+				SlashingRate::<Test>::set(slashing_rate_bounded);
+				FlipSlasher::<Test>::slash(account_id, *blocks_offline);
+				let balance_after = Flip::total_balance_of(account_id);
+				// Check if the diff between the balances is the expected slash
+				if initial_balance.saturating_sub(expected_slash) != balance_after {
+					return false
+				}
+				assert_eq!(
+					System::events().last().unwrap().event,
+					Event::Flip(crate::Event::<Test>::SlashingPerformed(
+						*account_id,
+						expected_slash
+					)),
+				);
+			},
+			// Account to account transfer
+			FlipOperation::AccountToAccount(account_id_1, account_id_2, amount_1, amount_2) => {
+				let previous_balance_account_1 = Flip::total_balance_of(account_id_1);
+				let previous_balance_account_2 = Flip::total_balance_of(account_id_2);
+
+				// Transfer amount_1 by creating a debit imbalance
+				Flip::settle(account_id_1, Flip::debit(account_id_2, *amount_1).into());
+				let intermediate_balance_account_1 = Flip::total_balance_of(account_id_1);
+				let intermediate_balance_account_2 = Flip::total_balance_of(account_id_2);
+				if account_id_1 != account_id_2 {
+					if intermediate_balance_account_1 !=
+						previous_balance_account_1 +
+							(previous_balance_account_2 - intermediate_balance_account_2) ||
+						intermediate_balance_account_2 !=
+							previous_balance_account_2.saturating_sub(*amount_1)
+					{
+						return false
+					}
+				} else if intermediate_balance_account_1 != previous_balance_account_1 {
+					return false
+				}
+
+				// Transfer amount_2 by creating a credit imbalance
+				// Note: Extra checked_add check in this case due to the fact that credit imbalance
+				// might be 0 due to saturating add reverting even though the real transfer amount
+				// would have been valid. This edge case might need to be addressed properly in Flip
+				// pallet code
+				Flip::settle(account_id_1, Flip::credit(account_id_2, *amount_2).into());
+				let final_balance_account_1 = Flip::total_balance_of(account_id_1);
+				let final_balance_account_2 = Flip::total_balance_of(account_id_2);
+				if account_id_1 != account_id_2 &&
+					intermediate_balance_account_2.checked_add(*amount_2).is_some()
+				{
+					if final_balance_account_2 !=
+						intermediate_balance_account_2 +
+							(intermediate_balance_account_1 - final_balance_account_1) ||
+						final_balance_account_1 !=
+							intermediate_balance_account_1.saturating_sub(*amount_2)
+					{
+						return false
+					}
+				} else if final_balance_account_1 != intermediate_balance_account_1 ||
+					final_balance_account_2 != intermediate_balance_account_2
+				{
+					return false
+				}
 			},
 		}
+		true
 	}
 }
 
 impl Arbitrary for FlipOperation {
 	fn arbitrary(g: &mut Gen) -> FlipOperation {
-		let random_account = match u8::arbitrary(g) % 3 {
-			0 => ALICE,
-			1 => BOB,
-			2 => CHARLIE,
-			_ => unreachable!(),
-		};
-		match u8::arbitrary(g) % 4 {
-			0 => FlipOperation::Stake(random_account, u128::arbitrary(g)),
-			1 => FlipOperation::BurnFromAccount(random_account, u128::arbitrary(g)),
-			2 => FlipOperation::MintToAccount(random_account, u128::arbitrary(g)),
-			3 => FlipOperation::Claim(random_account, u128::arbitrary(g)),
+		let operation_choice = u128::arbitrary(g) % 17;
+		match operation_choice {
+			0 => FlipOperation::MintExternal(u128::arbitrary(g), u128::arbitrary(g)),
+			1 => FlipOperation::BurnExternal(u128::arbitrary(g), u128::arbitrary(g)),
+			2 => FlipOperation::BurnReverts(u128::arbitrary(g)),
+			3 => FlipOperation::MintReverts(u128::arbitrary(g)),
+			4 => FlipOperation::CreditReverts(u128::arbitrary(g)),
+			5 => FlipOperation::DebitReverts(u128::arbitrary(g)),
+			6 => FlipOperation::BridgeInReverts(u128::arbitrary(g)),
+			7 => FlipOperation::BridgeOutReverts(u128::arbitrary(g)),
+			8 => FlipOperation::MintToReserve(u128::arbitrary(g)),
+			9 => FlipOperation::BurnFromReserve(u128::arbitrary(g)),
+			10 => FlipOperation::BurnFromAccount(random_account(g), u128::arbitrary(g)),
+			11 => FlipOperation::MintToAccount(random_account(g), u128::arbitrary(g)),
+			12 => FlipOperation::ExternalTransferOut(random_account(g), u128::arbitrary(g)),
+			13 => FlipOperation::ExternalTransferIn(random_account(g), u128::arbitrary(g)),
+			14 => FlipOperation::UpdateStakeAndBond(
+				random_account(g),
+				u128::arbitrary(g),
+				u128::arbitrary(g),
+			),
+			15 => FlipOperation::SlashAccount(
+				random_account(g),
+				SlashingRateType::arbitrary(g),
+				Bond::arbitrary(g),
+				BlocksOffline::arbitrary(g),
+				Mint::arbitrary(g),
+			),
+			16 => FlipOperation::AccountToAccount(
+				random_account(g),
+				random_account(g),
+				u128::arbitrary(g),
+				u128::arbitrary(g),
+			),
 			_ => unreachable!(),
 		}
+	}
+}
+
+fn random_account(g: &mut Gen) -> u64 {
+	match u8::arbitrary(g) % 3 {
+		0 => ALICE,
+		1 => BOB,
+		2 => CHARLIE,
+		_ => unreachable!(),
 	}
 }
 
 #[quickcheck]
 fn balance_has_integrity(events: Vec<FlipOperation>) -> TestResult {
 	new_test_ext().execute_with(|| -> TestResult {
-		if events.iter().any(|event| {
-			event.execute();
-			!check_balance_integrity()
-		}) {
+		if events.iter().any(|event| !event.execute()) || !check_balance_integrity() {
 			TestResult::failed()
 		} else {
 			TestResult::passed()
 		}
 	})
-}
-
-#[test]
-fn account_to_account() {
-	new_test_ext().execute_with(|| {
-		// Account to account
-		Flip::settle(&ALICE, Flip::debit(&BOB, 1).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 101);
-		assert_eq!(Flip::total_balance_of(&BOB), 49);
-		assert!(check_balance_integrity());
-
-		Flip::settle(&ALICE, Flip::credit(&BOB, 1).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 100);
-		assert_eq!(Flip::total_balance_of(&BOB), 50);
-		assert!(check_balance_integrity());
-	});
 }
 
 #[test]
@@ -101,264 +434,9 @@ fn test_try_debit() {
 	});
 }
 
-#[test]
-fn account_to_external() {
-	new_test_ext().execute_with(|| {
-		// Account to external
-		Flip::settle(&ALICE, Flip::bridge_out(10).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 90);
-		assert_eq!(OffchainFunds::<Test>::get(), 860);
-		assert!(check_balance_integrity());
-
-		// External to account
-		Flip::settle(&ALICE, Flip::bridge_in(10).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 100);
-		assert_eq!(OffchainFunds::<Test>::get(), 850);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn mint_external() {
-	new_test_ext().execute_with(|| {
-		// Mint to external
-		mem::drop(Flip::mint(50).offset(Flip::bridge_out(50)));
-		assert_eq!(TotalIssuance::<Test>::get(), 1050);
-		assert!(check_balance_integrity());
-
-		mem::drop(Flip::bridge_out(50).offset(Flip::mint(50)));
-		assert_eq!(TotalIssuance::<Test>::get(), 1100);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn burn_external() {
-	new_test_ext().execute_with(|| {
-		// Burn from external
-		mem::drop(Flip::burn(50).offset(Flip::bridge_in(50)));
-		assert_eq!(TotalIssuance::<Test>::get(), 950);
-		assert!(check_balance_integrity());
-
-		mem::drop(Flip::bridge_in(50).offset(Flip::burn(50)));
-		assert_eq!(TotalIssuance::<Test>::get(), 900);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn burn_from_account() {
-	new_test_ext().execute_with(|| {
-		// Burn from account
-		Flip::settle(&ALICE, Flip::burn(10).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 90);
-		assert_eq!(TotalIssuance::<Test>::get(), 990);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn mint_to_account() {
-	new_test_ext().execute_with(|| {
-		// Mint to account
-		Flip::settle(&ALICE, Flip::mint(10).into());
-		assert_eq!(Flip::total_balance_of(&ALICE), 110);
-		assert_eq!(TotalIssuance::<Test>::get(), 1_010);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn burn_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::burn(10));
-		assert_eq!(TotalIssuance::<Test>::get(), 1000);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn mint_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::mint(10));
-		assert_eq!(TotalIssuance::<Test>::get(), 1000);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn credit_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::credit(&CHARLIE, 1));
-		assert_eq!(Flip::total_balance_of(&CHARLIE), 0);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn debit_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::debit(&ALICE, 1));
-		assert_eq!(Flip::total_balance_of(&ALICE), 100);
-		assert!(check_balance_integrity());
-
-		mem::drop(Flip::debit(&ALICE, 1000));
-		assert_eq!(Flip::total_balance_of(&ALICE), 100);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn bridge_in_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::bridge_in(100));
-		assert_eq!(OffchainFunds::<Test>::get(), 850);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn bridge_out_reverts() {
-	new_test_ext().execute_with(|| {
-		mem::drop(Flip::bridge_out(100));
-		assert_eq!(OffchainFunds::<Test>::get(), 850);
-		assert!(check_balance_integrity());
-	});
-}
-
-#[test]
-fn stake_transfers() {
-	new_test_ext().execute_with(|| {
-		assert_eq!(<Flip as StakeTransfer>::stakeable_balance(&ALICE), 100);
-		<Flip as StakeTransfer>::credit_stake(&ALICE, 100);
-		assert_eq!(<Flip as StakeTransfer>::stakeable_balance(&ALICE), 200);
-		assert!(MockStakeHandler::has_stake_updated(&ALICE));
-		assert!(check_balance_integrity());
-
-		// Bond all of it
-		Bonder::<Test>::update_bond(&ALICE, 200);
-		assert_eq!(<Flip as StakeTransfer>::stakeable_balance(&ALICE), 200);
-		assert_eq!(<Flip as StakeTransfer>::claimable_balance(&ALICE), 0);
-
-		// Now try to claim
-		assert_noop!(
-			<Flip as StakeTransfer>::try_claim(&ALICE, 1),
-			Error::<Test>::InsufficientLiquidity
-		);
-
-		// Reduce the bond
-		Bonder::<Test>::update_bond(&ALICE, 100);
-		assert_eq!(<Flip as StakeTransfer>::claimable_balance(&ALICE), 100);
-		assert_ok!(<Flip as StakeTransfer>::try_claim(&ALICE, 1));
-		assert!(MockStakeHandler::has_stake_updated(&ALICE));
-
-		assert!(check_balance_integrity());
-	});
-}
-
 #[cfg(test)]
 mod test_issuance {
 	use super::*;
-	use crate::ReserveId;
-
-	fn burn_from_account(account_id: &AccountId, amount: FlipBalance) {
-		Flip::settle_imbalance(account_id, FlipIssuance::<Test>::burn(amount))
-	}
-
-	fn mint_to_account(account_id: &AccountId, amount: FlipBalance) {
-		Flip::settle_imbalance(account_id, FlipIssuance::<Test>::mint(amount))
-	}
-
-	fn burn_from_reserve(reserve_id: ReserveId, amount: FlipBalance) {
-		let burn = FlipIssuance::<Test>::burn(amount);
-		let withdrawal = Flip::withdraw_reserves(reserve_id, amount);
-		let _result = burn.offset(withdrawal);
-	}
-
-	fn mint_to_reserve(reserve_id: ReserveId, amount: FlipBalance) {
-		let mint = FlipIssuance::<Test>::mint(amount);
-		let deposit = Flip::deposit_reserves(reserve_id, amount);
-		let _result = mint.offset(deposit);
-	}
-
-	#[test]
-	fn simple_burn() {
-		new_test_ext().execute_with(|| {
-			// Burn some of Alice's funds
-			burn_from_account(&ALICE, 50);
-			assert_eq!(Flip::total_balance_of(&ALICE), 50);
-			assert_eq!(FlipIssuance::<Test>::total_issuance(), 950);
-			assert!(check_balance_integrity());
-		});
-	}
-
-	#[test]
-	fn simple_mint() {
-		new_test_ext().execute_with(|| {
-			// Mint to Charlie's account.
-			mint_to_account(&CHARLIE, 50);
-			assert_eq!(Flip::total_balance_of(&CHARLIE), 50);
-			assert_eq!(FlipIssuance::<Test>::total_issuance(), 1050);
-			assert!(check_balance_integrity());
-		});
-	}
-
-	#[test]
-	fn test_reserves() {
-		new_test_ext().execute_with(|| {
-			const TEST_RESERVE: ReserveId = *b"TEST";
-			const INIT_RESERVE_BALANCE: u128 = 0;
-			const INIT_TOTAL_ISSUANCE: u128 = 1_000;
-			const DEPOSIT: u128 = 50;
-			const WITHDRAWAL: u128 = 20;
-
-			// Mint to a reserve.
-			mint_to_reserve(TEST_RESERVE, DEPOSIT);
-			assert_eq!(Flip::reserved_balance(TEST_RESERVE), INIT_RESERVE_BALANCE + DEPOSIT);
-			assert_eq!(FlipIssuance::<Test>::total_issuance(), INIT_TOTAL_ISSUANCE + DEPOSIT);
-			assert!(check_balance_integrity());
-
-			// Burn some.
-			burn_from_reserve(TEST_RESERVE, WITHDRAWAL);
-			assert_eq!(
-				Flip::reserved_balance(TEST_RESERVE),
-				INIT_RESERVE_BALANCE + DEPOSIT - WITHDRAWAL
-			);
-			assert_eq!(
-				FlipIssuance::<Test>::total_issuance(),
-				INIT_TOTAL_ISSUANCE + DEPOSIT - WITHDRAWAL
-			);
-
-			// Obliterate the rest.
-			burn_from_reserve(TEST_RESERVE, 1_000_000);
-			assert_eq!(Flip::reserved_balance(TEST_RESERVE), INIT_RESERVE_BALANCE);
-			assert_eq!(FlipIssuance::<Test>::total_issuance(), INIT_TOTAL_ISSUANCE);
-		});
-	}
-
-	#[test]
-	fn cant_burn_too_much() {
-		new_test_ext().execute_with(|| {
-			// Burn some of Alice's funds
-			burn_from_account(&ALICE, 50);
-
-			assert_eq!(Flip::total_balance_of(&ALICE), 50);
-
-			// The slashable balance doesn't include the existential deposit.
-			assert_eq!(
-				Flip::slashable_funds(&ALICE),
-				50 - <Test as Config>::ExistentialDeposit::get()
-			);
-
-			// Force through a burn of all remaining burnable tokens, including the existential
-			// deposit.
-			burn_from_account(&ALICE, 1_000_000);
-
-			assert_eq!(Flip::total_balance_of(&ALICE), 0);
-			assert_eq!(FlipIssuance::<Test>::total_issuance(), 900);
-			assert!(check_balance_integrity());
-		});
-	}
 
 	#[test]
 	fn account_deletion_burns_balance() {
@@ -521,77 +599,6 @@ mod test_tx_payments {
 			assert_eq!(Flip::total_balance_of(&ALICE), 100 - POST_FEE);
 			// The fee was bured.
 			assert_eq!(FlipIssuance::<Test>::total_issuance(), 1000 - POST_FEE);
-		});
-	}
-}
-
-mod test_slashing {
-	use cf_traits::{Bonding, Slashing};
-
-	use crate::{Bonder, FlipSlasher, SlashingRate};
-
-	use super::*;
-	#[test]
-	fn test_slash_validator() {
-		new_test_ext().execute_with(|| {
-			// Amount of blocks the node was offline
-			const BLOCKS_OFFLINE: u64 = 20;
-			// Amount of extra token we need to mint
-			const MINT: u128 = 80_000_000;
-			// Minimum active bid
-			const BOND: u128 = 8_000_000;
-			// Slashing rate is 5 % / slash relates on the BOND
-			const SLASHING_RATE: u128 = 5;
-			const BLOCKS_PER_DAY: u128 = <Test as Config>::BlocksPerDay::get() as u128;
-			const EXPECTED_SLASH: u128 =
-				BOND / 100 * SLASHING_RATE / BLOCKS_PER_DAY * BLOCKS_OFFLINE as u128;
-			// Mint some Flip for testing - 100 is not enough and unrealistic for this usecase
-			Flip::settle(&ALICE, Flip::mint(MINT).into());
-			let initial_balance: u128 = Flip::total_balance_of(&ALICE);
-			Bonder::<Test>::update_bond(&ALICE, BOND);
-			// Set the slashing rate to 5%
-			SlashingRate::<Test>::set(SLASHING_RATE);
-			FlipSlasher::<Test>::slash(&ALICE, BLOCKS_OFFLINE);
-			let balance_after = Flip::total_balance_of(&ALICE);
-			// Check if the diff between the balances is the expected slash
-			assert_eq!(initial_balance - balance_after, EXPECTED_SLASH);
-			assert!(check_balance_integrity());
-			assert_eq!(
-				System::events()
-					.into_iter()
-					.filter_map(|r| {
-						if let Event::Flip(inner) = r.event {
-							Some(inner)
-						} else {
-							None
-						}
-					})
-					.last()
-					.unwrap(),
-				crate::Event::<Test>::SlashingPerformed(ALICE, EXPECTED_SLASH),
-			);
-			// Test case where the slashing rate is set to 0. SlashingPerformed event should still
-			// be emitted.
-			SlashingRate::<Test>::set(0);
-			let initial_balance: u128 = Flip::total_balance_of(&ALICE);
-			FlipSlasher::<Test>::slash(&ALICE, BLOCKS_OFFLINE);
-			let balance_after = Flip::total_balance_of(&ALICE);
-			assert_eq!(initial_balance - balance_after, 0);
-			assert!(check_balance_integrity());
-			assert_eq!(
-				System::events()
-					.into_iter()
-					.filter_map(|r| {
-						if let Event::Flip(inner) = r.event {
-							Some(inner)
-						} else {
-							None
-						}
-					})
-					.last()
-					.unwrap(),
-				crate::Event::<Test>::SlashingPerformed(ALICE, 0),
-			);
 		});
 	}
 }


### PR DESCRIPTION
All (almost) the tests for different operations on the flip pallet are now revamped into a different structure and quickcheck testing framework is applied. Concretely, all the different possible operations that can be applied to the Flip pallet are each a variant of an enum (FlipOperation) introduced in the mock file. Few points to note:

- The variants hold all the associated inputs required for that particular test. These are treated as variables while writing corresponding tests as quickcheck will throw all kinds of values for these variables while testing (this is where the magic happens: quickcheck will stress the system by smartly selecting all kinds of meaningful edge cases and non meaningful inputs)
- A single quickcheck is as follows: A mock runtime is created . Then an arbitrary length of Vec of FlipOperations is created with arbitrary selection of Flip Operations. Each FlipOperation is again initialized with arbitrary inputs in its enum variant. These operations are then applied sequentially on the same runtime.
-This instance of quickcheck test is then repeated n number of times with a new runtime each time.
- Any additional functionality testing can be added as a variant in the FlipOperation enum and corresponding test written as an arm of the match statement on the execute function. 



## State Chain

- [ ] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- Were any changes to the genesis config of any pallets? If yes:
  - [ ] Has the Chainspec been updated accordingly?
- [ ] Is `types.json` up to date? Test this against polka js.
- Have any new dependencies been added? If yes:
  - [ ] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
  - [ ] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- Do the changes require a runtime upgrade? If yes:
  - [ ] Have any storage items or stored data types been modified? If yes:
    - [ ] Has the pallet's storage version been bumped and a storage migration been defined?

### New Pallets

- [ ] Has the top-level workspace `Cargo.toml` been updated?
- [ ] Has a README file been included in the pallet?
- [ ] Has the pallet-level `Cargo.toml` template been edited with pallet-specific details?
- [ ] Have all leftover pallet-template items, comments etc. been removed?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1714"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

