### PR TITLE
refactor: solo keygen shares key generation code with genesis

### DIFF
--- a/engine/src/multisig/client/keygen/keygen_frost.rs
+++ b/engine/src/multisig/client/keygen/keygen_frost.rs
@@ -317,7 +317,7 @@ pub fn derive_aggregate_pubkey<P: ECPoint>(
     if !allow_high_pubkey && !pubkey.is_compatible() {
         Err(anyhow::Error::msg("pubkey is not compatible"))
     } else if check_high_degree_commitments(commitments) {
-        // Sanity check (the chance of this failing is practically zero due to the
+        // Sanity check (the chance of this failing is infinitesimal due to the
         // hash commitment stage at the beginning of the ceremony)
         Err(anyhow::Error::msg("high degree coefficient is zero"))
     } else {
@@ -511,20 +511,17 @@ pub mod genesis {
 
     pub fn generate_key_data<P: ECPoint>(
         signers: &[AccountId],
+        rng: &mut Rng,
     ) -> anyhow::Result<(KeyId, HashMap<AccountId, KeygenResultInfo<P>>)> {
         let params = ThresholdParameters::from_share_count(signers.len() as AuthorityCount);
         let n = params.share_count;
         let t = params.threshold;
 
         use crate::multisig::client::PartyIdxMapping;
-        use rand_legacy::FromEntropy;
-
-        let mut rng = Rng::from_entropy();
 
         let (commitments, outgoing_secret_shares): (BTreeMap<_, _>, BTreeMap<_, _>) = (1..=n)
             .map(|idx| {
-                let (_secret, commitments, shares) =
-                    generate_secret_and_shares::<P>(&mut rng, n, t);
+                let (_secret, commitments, shares) = generate_secret_and_shares::<P>(rng, n, t);
                 ((idx, DKGCommitment { commitments }), (idx, shares))
             })
             .unzip();

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -1446,6 +1446,10 @@ async fn genesis_keys_can_sign() {
         .map(|i| AccountId::new([*i; 32]))
         .collect();
 
+    use rand_legacy::FromEntropy;
+
+    let mut rng = Rng::from_entropy();
+
     // Limit iteration count so we don't loop forever
     // in case there is a bug
     const MAX_KEYGEN_ATTEMPTS: usize = 20;
@@ -1454,7 +1458,7 @@ async fn genesis_keys_can_sign() {
 
     let (key_id, key_data) = loop {
         attempt_counter += 1;
-        match keygen::generate_key_data::<Point>(&account_ids) {
+        match keygen::generate_key_data::<Point>(&account_ids, &mut rng) {
             Ok(result) => break result,
             Err(_) => {
                 if attempt_counter >= MAX_KEYGEN_ATTEMPTS {


### PR DESCRIPTION
Closes #1680. I checked that for a single party `generate_key_data` generates code that's equivalent to the one it is replacing, i.e. the one secret share is exactly the secret key corresponding to the aggregate public key (perhaps unsurprisingly).

Also changed `generate_key_data` to take Rng, so that we can actually use the one provided in `single_party_keygen`.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1716"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

