### PR TITLE
chore: useless runtime upgrade for soundcheck two

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 111,
+	spec_version: 112,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
A useless runtime upgrade to push out to the folks running Soundcheck Two so that they can collect the "Validator successfully participates in a Runtime Upgrade" points.

I will push this out tomorrow.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1720"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

