### PR TITLE
fix: generate-genesis-keys file name 🐛

### DIFF
--- a/insert-genesis-keyshare.Dockerfile
+++ b/insert-genesis-keyshare.Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 RUN groupadd chainflip \
     && useradd -g chainflip chainflip
 
-COPY target/release/insert-genesis-keyshare /usr/local/bin
+COPY target/release/generate-genesis-keys /usr/local/bin
 RUN chown chainflip:chainflip /usr/local/bin/generate-genesis-keys
 
 USER chainflip


### PR DESCRIPTION

### What Does this PR Do

- Fix `generate-genesis-keys` in `insert-genesis-keyshare.Dockerfile`

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1765"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

