### PR TITLE
fix: isolate multisig to its own thread

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -172,8 +172,11 @@ async fn main() {
             &root_logger,
         );
 
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Handle::current().block_on(eth_multisig_client_backend_future)
+    });
+
     tokio::join!(
-        eth_multisig_client_backend_future,
         async {
             multisig_p2p::start(
                 &settings,

--- a/engine/src/multisig/client/common/ceremony_stage.rs
+++ b/engine/src/multisig/client/common/ceremony_stage.rs
@@ -14,7 +14,9 @@ use super::CeremonyFailureReason;
 /// Outcome of a given ceremony stage
 pub enum StageResult<M, Result, FailureReason> {
     /// Ceremony proceeds to the next stage
-    NextStage(Box<dyn CeremonyStage<Message = M, Result = Result, FailureReason = FailureReason>>),
+    NextStage(
+        Box<dyn CeremonyStage<Message = M, Result = Result, FailureReason = FailureReason> + Send>,
+    ),
     /// Ceremony aborted (contains parties to report)
     Error(
         BTreeSet<AuthorityCount>,

--- a/engine/src/multisig/client/state_runner.rs
+++ b/engine/src/multisig/client/state_runner.rs
@@ -31,10 +31,10 @@ pub struct StateAuthorised<CeremonyData, CeremonyResult, FailureReason> {
     pub stage: Option<
         Box<
             dyn CeremonyStage<
-                Message = CeremonyData,
-                Result = CeremonyResult,
-                FailureReason = FailureReason,
-            >,
+                    Message = CeremonyData,
+                    Result = CeremonyResult,
+                    FailureReason = FailureReason,
+                > + Send,
         >,
     >,
     pub result_sender: CeremonyResultSender<CeremonyResult, FailureReason>,
@@ -76,10 +76,10 @@ where
         &mut self,
         mut stage: Box<
             dyn CeremonyStage<
-                Message = CeremonyData,
-                Result = CeremonyResult,
-                FailureReason = FailureReason,
-            >,
+                    Message = CeremonyData,
+                    Result = CeremonyResult,
+                    FailureReason = FailureReason,
+                > + Send,
         >,
         idx_mapping: Arc<PartyIdxMapping>,
         result_sender: CeremonyResultSender<CeremonyResult, FailureReason>,

--- a/engine/src/multisig/mod.rs
+++ b/engine/src/multisig/mod.rs
@@ -54,7 +54,10 @@ pub fn start_client<C>(
     mut incoming_p2p_message_receiver: UnboundedReceiver<(AccountId, Vec<u8>)>,
     outgoing_p2p_message_sender: UnboundedSender<OutgoingMultisigStageMessages>,
     logger: &slog::Logger,
-) -> (Arc<MultisigClient<C>>, impl futures::Future)
+) -> (
+    Arc<MultisigClient<C>>,
+    impl futures::Future<Output = ()> + Send,
+)
 where
     C: CryptoScheme,
 {


### PR DESCRIPTION
This is how I intended, this will work better with the async error handling PR I'm finishing up.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1768"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

