### PR TITLE
feat: add tx fee multiplier rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -84,8 +84,10 @@ where
 			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
 	}
 	fn cf_tx_fee_multiplier(&self) -> Result<u64, jsonrpc_core::Error> {
-		Ok(TX_FEE_MULTIPLIER.try_into().expect("We never set a fee multiplier greater than u64::MAX"))
-  }
+		Ok(TX_FEE_MULTIPLIER
+			.try_into()
+			.expect("We never set a fee multiplier greater than u64::MAX"))
+	}
 	fn cf_auction_parameters(&self) -> Result<(u32, u32), jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
 		self.client


### PR DESCRIPTION
@YassineFlip 

`cf_tx_fee_multiplier`

For now this won't change, but eventually the under-the-hood calculation of the fee multiplier might be dynamic per-block (or even per-tx) - for now you can call this once and apply it to all extrinsics, in the future you might have to call it once per block, or once per extrinsic, fwiw.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1772"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

