### PR TITLE
chore: update docs in Validator pallet

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -553,7 +553,8 @@ pub mod pallet {
 
 		/// Allow a node to set a "Vanity Name" for themselves. This is functionally
 		/// useless but can be used to make the network a bit more friendly for
-		/// observers.
+		/// observers. Names are required to be <= MAX_LENGTH_FOR_VANITY_NAME (64)
+		/// UTF-8 bytes.
 		///
 		/// The dispatch origin of this function must be signed.
 		///


### PR DESCRIPTION
Did a bit of doc gardening in the Validator pallet.

Closes #1693. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1780"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

