### PR TITLE
chore: redundant logs

### DIFF
--- a/engine/src/state_chain/sc_observer.rs
+++ b/engine/src/state_chain/sc_observer.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     eth::{rpc::EthRpcApi, EthBroadcaster, ObserveInstruction},
-    logging::COMPONENT_KEY,
+    logging::{CEREMONY_ID_KEY, COMPONENT_KEY},
     multisig::{
         client::{CeremonyFailureReason, KeygenFailureReason, MultisigClientApi},
         KeyId, MessageHash,
@@ -60,19 +60,13 @@ async fn handle_keygen_request<MultisigClient, RpcClient>(
                         signature.into(),
                     ),
                     // Report keygen failure if we failed to sign
-                    Err((bad_account_ids, reason)) => {
-                        slog::debug!(
-                            logger,
-                            "Keygen ceremony {} verification failed: {}",
-                            ceremony_id,
-                            reason
-                        );
+                    Err((bad_account_ids, _reason)) => {
+                        slog::debug!(logger, "Keygen ceremony verification failed"; CEREMONY_ID_KEY => ceremony_id);
                         ReportedKeygenOutcome::Failure(BTreeSet::from_iter(bad_account_ids))
                     }
                 }
             }
             Err((bad_account_ids, reason)) => {
-                slog::debug!(logger, "Keygen ceremony {} failed: {}", ceremony_id, reason);
                 if let CeremonyFailureReason::<KeygenFailureReason>::Other(
                     KeygenFailureReason::KeyNotCompatible,
                 ) = reason
@@ -315,8 +309,7 @@ pub async fn start<BlockStream, RpcClient, EthRpc, MultisigClient>(
                                                                     )
                                                                     .await;
                                                             }
-                                                            Err((bad_account_ids, reason)) => {
-                                                                slog::debug!(logger, "Threshold signing ceremony {} failed: {}", ceremony_id, reason);
+                                                            Err((bad_account_ids, _reason)) => {
                                                                 let _result = state_chain_client
                                                                     .submit_signed_extrinsic(
                                                                         pallet_cf_threshold_signature::Call::report_signature_failed {


### PR DESCRIPTION
When debugging I noticed these logs are redundant as we log them elsewhere now.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1823"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

