### PR TITLE
chore: use rayon to parallelize the final step of keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "public-ip",
  "rand 0.6.5",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "reqwest",
  "rocksdb",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -79,7 +79,7 @@ typenum = "1.15"
 # We might eventually update, but for now let's just
 # use the same version as polkadot. 
 schnorrkel = "0.9.1"
-
+rayon = "1.5"
 
 # Local deps
 cf-chains = {path = "../state-chain/chains"}

--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -503,7 +503,8 @@ where
     #[cfg(test)]
     fn expire_all(&mut self) {
         for state in self.inner.values_mut() {
-            state.set_expiry_time(std::time::Instant::now());
+            let one_second_ago = std::time::Instant::now() - std::time::Duration::from_secs(1);
+            state.set_expiry_time(one_second_ago);
         }
     }
 

--- a/engine/src/multisig/client/keygen/keygen_frost.rs
+++ b/engine/src/multisig/client/keygen/keygen_frost.rs
@@ -341,7 +341,10 @@ pub fn derive_local_pubkeys_for_parties<P: ECPoint>(
     // I.e. y_i = G * f_1(i) + G * f_2(i) + ... G * f_n(i), where
     // G * f_j(i) = G * s_j + G * c_j_1(i) + G * c_j_2(i) + ... + c_j_{t-1}(i)
 
+    use rayon::prelude::*;
+
     (1..=n)
+        .into_par_iter()
         .map(|idx| {
             (1..=n)
                 .map(|j| {


### PR DESCRIPTION
Seems reasonable to utilise all cores to perform this expensive computation (all iteration are independent so this is trivial with rayon). Note that curve25519 seems even slower than secp256k1: it took 70s on my M1 Max (might be closer to 2 mins on a VPS), but only 9s with rayon. This is still blocking of course, so this doesn't address the issue of keygen blocking other ceremonies.

Note that there was a very subtle bug in tests which seemed to materialize more often with rayon for whatever reason: it was possible in rare circumstances for a ceremony not to time out when forced to do so if the time elapsed between `expire_all` and `check_all_timeouts` was smaller than 1ns. Fixed here by setting expiry time in the past.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1858"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

