### PR TITLE
feat: add rpc for current eth vault

### DIFF
--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -212,9 +212,17 @@ impl From<ParityBit> for Uint {
 	}
 }
 
+impl Default for ParityBit {
+	/// Default ParityBit is even (zero)
+	fn default() -> Self {
+		ParityBit::Even
+	}
+}
+
 /// For encoding the `Key` type as defined in <https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/interfaces/IShared.sol>
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(
+	Default,
 	Encode,
 	Decode,
 	TypeInfo,

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -53,6 +53,9 @@ pub trait CustomApi {
 	fn cf_eth_flip_token_address(&self) -> Result<[u8; 20], jsonrpc_core::Error>;
 	#[rpc(name = "cf_eth_chain_id")]
 	fn cf_eth_chain_id(&self) -> Result<u64, jsonrpc_core::Error>;
+	/// Returns the eth vault in the form [agg_key, active_from_eth_block]
+	#[rpc(name = "cf_eth_vault")]
+	fn cf_eth_vault(&self) -> Result<(String, u32), jsonrpc_core::Error>;
 	#[rpc(name = "cf_tx_fee_multiplier")]
 	fn cf_tx_fee_multiplier(&self) -> Result<u64, jsonrpc_core::Error>;
 	// Returns the Auction params in the form [min_set_size, max_set_size]
@@ -134,6 +137,16 @@ where
 			.runtime_api()
 			.cf_eth_chain_id(&at)
 			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+	}
+	fn cf_eth_vault(&self) -> Result<(String, u32), jsonrpc_core::Error> {
+		let at = sp_api::BlockId::hash(self.client.info().best_hash);
+		let eth_vault = self
+			.client
+			.runtime_api()
+			.cf_eth_vault(&at)
+			.expect("The runtime API should not return error.");
+
+		Ok((hex::encode(eth_vault.0), eth_vault.1))
 	}
 	fn cf_tx_fee_multiplier(&self) -> Result<u64, jsonrpc_core::Error> {
 		Ok(TX_FEE_MULTIPLIER

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -265,7 +265,7 @@ impl<T: Config<I>, I: 'static> VaultRotationStatus<T, I> {
 }
 
 /// A single vault.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug)]
+#[derive(Default, PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug)]
 pub struct Vault<T: ChainAbi> {
 	/// The vault's public key.
 	pub public_key: T::AggKey,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -68,6 +68,7 @@ use constants::common::*;
 use pallet_cf_flip::{Bonder, FlipSlasher};
 pub use pallet_cf_staking::WithdrawalAddresses;
 use pallet_cf_validator::PercentageRange;
+use pallet_cf_vaults::Vault;
 pub use pallet_transaction_payment::ChargeTransactionPayment;
 
 // Make the WASM binary available.
@@ -598,13 +599,20 @@ impl_runtime_apis! {
 		fn cf_eth_chain_id() -> u64 {
 			Environment::ethereum_chain_id()
 		}
+		fn cf_eth_vault() -> ([u8; 33], BlockNumber) {
+			let epoch_index = Self::cf_current_epoch();
+			// We should always have a Vault for the current epoch, but in case we do
+			// not, just return an empty Vault.
+			let vault: Vault<Ethereum> = EthereumVault::vaults(&epoch_index).unwrap_or_default();
+			(vault.public_key.to_pubkey_compressed(), vault.active_from_block.unique_saturated_into())
+		}
 		fn cf_auction_parameters() -> (u32, u32) {
 			let auction_params = Auction::auction_parameters();
 			(auction_params.min_size, auction_params.max_size)
 		}
 		fn cf_min_stake() -> u64 {
 			MinimumStake::<Runtime>::get().unique_saturated_into()
-	}
+		}
 		fn cf_current_epoch() -> u32 {
 			Validator::current_epoch()
 		}

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -43,6 +43,8 @@ decl_runtime_apis!(
 		fn cf_eth_stake_manager_address() -> [u8; 20];
 		fn cf_eth_key_manager_address() -> [u8; 20];
 		fn cf_eth_chain_id() -> u64;
+		/// Returns the eth vault in the form [agg_key, active_from_eth_block]
+		fn cf_eth_vault() -> ([u8; 33], u32);
 		/// Returns the Auction params in the form [min_set_size, max_set_size]
 		fn cf_auction_parameters() -> (u32, u32);
 		fn cf_min_stake() -> u64;


### PR DESCRIPTION
Not sure if I really needed to implement `Default` for `ParityBit` and derive it for `AggKey` but it seemed like the correct-ish thing to do. Happy to change.

This one should mean you don't have to do any weird parsing of extrinsics @YassineFlip. Hold off on implementing this piece on the block explorer until we can get this code deployed for you in staging (hopefully this week).

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1859"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

