### PR TITLE
fix: polling should start immediately

### DIFF
--- a/engine/src/eth/chain_data_witnessing/util.rs
+++ b/engine/src/eth/chain_data_witnessing/util.rs
@@ -4,6 +4,8 @@ use futures::{future, stream, Stream, StreamExt};
 use sp_runtime::traits::Bounded;
 use tokio::sync::oneshot;
 
+use crate::common::make_periodic_tick;
+
 /// Returns a stream that yields `()` at regular intervals. Uses tokio's [MissedTickBehavior::Delay] tick strategy,
 /// meaning ticks will always be at least `interval` duration apart.
 ///
@@ -12,8 +14,7 @@ use tokio::sync::oneshot;
 /// Note that in order for this to work as expected, due to the underlying implementation of [Interval::poll_tick], the
 /// polling interval should be >> 5ms.
 pub fn periodic_tick_stream(tick_interval: Duration) -> impl Stream<Item = ()> {
-    let mut interval = tokio::time::interval(tick_interval);
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let interval = make_periodic_tick(tick_interval, true);
     stream::unfold(interval, |mut interval| async {
         interval.tick().await;
         Some(((), interval))

--- a/engine/src/eth/http_safe_stream.rs
+++ b/engine/src/eth/http_safe_stream.rs
@@ -34,7 +34,7 @@ where
         option_last_block_yielded: None,
         option_last_head_fetched: None,
         eth_http_rpc,
-        poll_interval: make_periodic_tick(poll_interval),
+        poll_interval: make_periodic_tick(poll_interval, false),
         logger: logger.new(o!(COMPONENT_KEY => "ETH_HTTPSafeStream")),
     };
 

--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -734,13 +734,13 @@ pub trait EthObserver {
         let init_state = StreamState::<BlockEventsStreamWs, BlockEventsStreamHttp> {
             ws_state: ProtocolState {
                 last_block_pulled: 0,
-                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL),
+                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL, false),
                 protocol: TransportProtocol::Ws,
             },
             ws_stream: safe_ws_block_events_stream,
             http_state: ProtocolState {
                 last_block_pulled: 0,
-                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL),
+                log_ticker: make_periodic_tick(ETH_STILL_BEHIND_LOG_INTERVAL, false),
                 protocol: TransportProtocol::Http,
             },
             http_stream: safe_http_block_events_stream,

--- a/engine/src/multisig/mod.rs
+++ b/engine/src/multisig/mod.rs
@@ -86,7 +86,8 @@ where
 
         async move {
             // Stream outputs () approximately every ten seconds
-            let mut check_timeouts_tick = common::make_periodic_tick(Duration::from_secs(10));
+            let mut check_timeouts_tick =
+                common::make_periodic_tick(Duration::from_secs(10), false);
 
             loop {
                 tokio::select! {

--- a/engine/src/multisig_p2p.rs
+++ b/engine/src/multisig_p2p.rs
@@ -317,7 +317,8 @@ pub async fn start<RpcClient: 'static + StateChainRpcApi + Sync + Send>(
         .map_err(rpc_error_into_anyhow_error)?
         .map_err(rpc_error_into_anyhow_error);
 
-    let mut check_listener_address_tick = common::make_periodic_tick(Duration::from_secs(60));
+    let mut check_listener_address_tick =
+        common::make_periodic_tick(Duration::from_secs(60), false);
 
     loop {
         tokio::select! {


### PR DESCRIPTION
Figured this didn't merit a single-use `make_immediate_periodic_tick` function since it's only used in one place. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

