### PR TITLE
fix: rpc encodings for polkajs

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -46,11 +46,11 @@ pub trait CustomApi {
 	#[rpc(name = "cf_is_auction_phase")]
 	fn cf_is_auction_phase(&self) -> Result<bool, jsonrpc_core::Error>;
 	#[rpc(name = "cf_eth_key_manager_address")]
-	fn cf_eth_key_manager_address(&self) -> Result<[u8; 20], jsonrpc_core::Error>;
+	fn cf_eth_key_manager_address(&self) -> Result<String, jsonrpc_core::Error>;
 	#[rpc(name = "cf_eth_stake_manager_address")]
-	fn cf_eth_stake_manager_address(&self) -> Result<[u8; 20], jsonrpc_core::Error>;
+	fn cf_eth_stake_manager_address(&self) -> Result<String, jsonrpc_core::Error>;
 	#[rpc(name = "cf_eth_flip_token_address")]
-	fn cf_eth_flip_token_address(&self) -> Result<[u8; 20], jsonrpc_core::Error>;
+	fn cf_eth_flip_token_address(&self) -> Result<String, jsonrpc_core::Error>;
 	#[rpc(name = "cf_eth_chain_id")]
 	fn cf_eth_chain_id(&self) -> Result<u64, jsonrpc_core::Error>;
 	/// Returns the eth vault in the form [agg_key, active_from_eth_block]
@@ -62,15 +62,15 @@ pub trait CustomApi {
 	#[rpc(name = "cf_auction_parameters")]
 	fn cf_auction_parameters(&self) -> Result<(u32, u32), jsonrpc_core::Error>;
 	#[rpc(name = "cf_min_stake")]
-	fn cf_min_stake(&self) -> Result<u64, jsonrpc_core::Error>;
+	fn cf_min_stake(&self) -> Result<NumberOrHex, jsonrpc_core::Error>;
 	#[rpc(name = "cf_current_epoch")]
 	fn cf_current_epoch(&self) -> Result<u32, jsonrpc_core::Error>;
 	#[rpc(name = "cf_current_epoch_started_at")]
 	fn cf_current_epoch_started_at(&self) -> Result<u32, jsonrpc_core::Error>;
 	#[rpc(name = "cf_authority_emission_per_block")]
-	fn cf_authority_emission_per_block(&self) -> Result<u64, jsonrpc_core::Error>;
+	fn cf_authority_emission_per_block(&self) -> Result<NumberOrHex, jsonrpc_core::Error>;
 	#[rpc(name = "cf_backup_emission_per_block")]
-	fn cf_backup_emission_per_block(&self) -> Result<u64, jsonrpc_core::Error>;
+	fn cf_backup_emission_per_block(&self) -> Result<NumberOrHex, jsonrpc_core::Error>;
 	#[rpc(name = "cf_flip_supply")]
 	fn cf_flip_supply(&self) -> Result<(NumberOrHex, NumberOrHex), jsonrpc_core::Error>;
 	#[rpc(name = "cf_accounts")]
@@ -110,26 +110,32 @@ where
 			.cf_is_auction_phase(&at)
 			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
 	}
-	fn cf_eth_flip_token_address(&self) -> Result<[u8; 20], jsonrpc_core::Error> {
+	fn cf_eth_flip_token_address(&self) -> Result<String, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let eth_flip_token_address = self
+			.client
 			.runtime_api()
 			.cf_eth_flip_token_address(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(hex::encode(eth_flip_token_address))
 	}
-	fn cf_eth_stake_manager_address(&self) -> Result<[u8; 20], jsonrpc_core::Error> {
+	fn cf_eth_stake_manager_address(&self) -> Result<String, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let eth_stake_manager_address = self
+			.client
 			.runtime_api()
 			.cf_eth_stake_manager_address(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(hex::encode(eth_stake_manager_address))
 	}
-	fn cf_eth_key_manager_address(&self) -> Result<[u8; 20], jsonrpc_core::Error> {
+	fn cf_eth_key_manager_address(&self) -> Result<String, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let eth_key_manager_address = self
+			.client
 			.runtime_api()
 			.cf_eth_key_manager_address(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(hex::encode(eth_key_manager_address))
 	}
 	fn cf_eth_chain_id(&self) -> Result<u64, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
@@ -160,12 +166,14 @@ where
 			.cf_auction_parameters(&at)
 			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
 	}
-	fn cf_min_stake(&self) -> Result<u64, jsonrpc_core::Error> {
+	fn cf_min_stake(&self) -> Result<NumberOrHex, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let min_stake = self
+			.client
 			.runtime_api()
 			.cf_min_stake(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(min_stake.into())
 	}
 	fn cf_current_epoch(&self) -> Result<u32, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
@@ -181,19 +189,23 @@ where
 			.cf_current_epoch_started_at(&at)
 			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
 	}
-	fn cf_authority_emission_per_block(&self) -> Result<u64, jsonrpc_core::Error> {
+	fn cf_authority_emission_per_block(&self) -> Result<NumberOrHex, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let authority_emission_per_block = self
+			.client
 			.runtime_api()
 			.cf_authority_emission_per_block(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(authority_emission_per_block.into())
 	}
-	fn cf_backup_emission_per_block(&self) -> Result<u64, jsonrpc_core::Error> {
+	fn cf_backup_emission_per_block(&self) -> Result<NumberOrHex, jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);
-		self.client
+		let backup_emission_per_block = self
+			.client
 			.runtime_api()
 			.cf_backup_emission_per_block(&at)
-			.map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::ServerError(0)))
+			.expect("The runtime API should not return error.");
+		Ok(backup_emission_per_block.into())
 	}
 	fn cf_flip_supply(&self) -> Result<(NumberOrHex, NumberOrHex), jsonrpc_core::Error> {
 		let at = sp_api::BlockId::hash(self.client.info().best_hash);

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -627,7 +627,7 @@ impl_runtime_apis! {
 			let auction_params = Auction::auction_parameters();
 			(auction_params.min_size, auction_params.max_size)
 		}
-		fn cf_min_stake() -> u64 {
+		fn cf_min_stake() -> u128 {
 			MinimumStake::<Runtime>::get().unique_saturated_into()
 		}
 		fn cf_current_epoch() -> u32 {
@@ -636,11 +636,11 @@ impl_runtime_apis! {
 		fn cf_current_epoch_started_at() -> u32 {
 			Validator::current_epoch_started_at()
 		}
-		fn cf_authority_emission_per_block() -> u64 {
-			Emissions::current_authority_emission_per_block().unique_saturated_into()
+		fn cf_authority_emission_per_block() -> u128 {
+			Emissions::current_authority_emission_per_block()
 		}
-		fn cf_backup_emission_per_block() -> u64 {
-			Emissions::backup_node_emission_per_block().unique_saturated_into()
+		fn cf_backup_emission_per_block() -> u128 {
+			Emissions::backup_node_emission_per_block()
 		}
 		fn cf_flip_supply() -> (u128, u128) {
 			(Flip::total_issuance(), Flip::offchain_funds())

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -47,11 +47,11 @@ decl_runtime_apis!(
 		fn cf_eth_vault() -> ([u8; 33], u32);
 		/// Returns the Auction params in the form [min_set_size, max_set_size]
 		fn cf_auction_parameters() -> (u32, u32);
-		fn cf_min_stake() -> u64;
+		fn cf_min_stake() -> u128;
 		fn cf_current_epoch() -> u32;
 		fn cf_current_epoch_started_at() -> u32;
-		fn cf_authority_emission_per_block() -> u64;
-		fn cf_backup_emission_per_block() -> u64;
+		fn cf_authority_emission_per_block() -> u128;
+		fn cf_backup_emission_per_block() -> u128;
 		/// Returns the flip supply in the form [total_issuance, offchain_funds]
 		fn cf_flip_supply() -> (u128, u128);
 		fn cf_accounts() -> Vec<(AccountId32, VanityName)>;


### PR DESCRIPTION
Some of the types were not able to be deserialised by Polkajs, not sure why - was a little difficult to parse the error messages.

Changed the u64s to u128s in the Runtime API, and then serialise them to NumberOrHex for passing over the RPC.

Also changed some of the `[u8;20]` serialisations for the address types to `String` - encoding them with `hex::encode`.

This should fix the errors I was experiencing yesterday @cdrn.

This should go into the next release candidate.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1872"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

