### PR TITLE
fix: set expected default ss58 prefix

### DIFF
--- a/state-chain/node/src/service.rs
+++ b/state-chain/node/src/service.rs
@@ -10,7 +10,10 @@ use sc_keystore::LocalKeystore;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use state_chain_runtime::{self, opaque::Block, RuntimeApi};
+use sp_core::crypto::{set_default_ss58_version, Ss58AddressFormat};
+use state_chain_runtime::{
+	self, constants::common::CHAINFLIP_SS58_PREFIX, opaque::Block, RuntimeApi,
+};
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 // Our native executor instance.
@@ -64,6 +67,8 @@ pub fn new_partial(
 	if config.keystore_remote.is_some() {
 		return Err(ServiceError::Other("Remote Keystores are not supported.".to_string()))
 	}
+
+	set_default_ss58_version(Ss58AddressFormat::custom(CHAINFLIP_SS58_PREFIX));
 
 	let telemetry = config
 		.telemetry_endpoints


### PR DESCRIPTION
Extrinsic submission is currently borked via the PolkaJS UI. This fixes the problem. I was able to submit an extrinsic via the PolkaJS UI.

This might not be the correct place to put the code. If there are any strong objections please feel free to just overwrite my branch.