### PR TITLE
refactor: unify claim and claim_all extrinsics

### DIFF
--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -139,7 +139,7 @@ async fn request_claim(
     let tx_hash = state_chain_client
         .submit_signed_extrinsic(
             pallet_cf_staking::Call::claim {
-                amount: atomic_amount,
+                amount: atomic_amount.into(),
                 address: eth_address,
             },
             logger,

--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -1035,7 +1035,11 @@ mod tests {
 
 					// We should be able to claim stake out of an auction
 					for node in &nodes {
-						assert_ok!(Staking::claim(Origin::signed(node.clone()), 1, ETH_DUMMY_ADDR));
+						assert_ok!(Staking::claim(
+							Origin::signed(node.clone()),
+							1.into(),
+							ETH_DUMMY_ADDR
+						));
 					}
 
 					let end_of_claim_period =
@@ -1047,7 +1051,7 @@ mod tests {
 						assert_noop!(
 							Staking::claim(
 								Origin::signed(node.clone()),
-								stake_amount,
+								stake_amount.into(),
 								ETH_DUMMY_ADDR
 							),
 							Error::<Runtime>::AuctionPhase
@@ -1074,7 +1078,7 @@ mod tests {
 					// TODO implement Claims in Contract/Network
 					for node in &nodes {
 						assert_noop!(
-							Staking::claim(Origin::signed(node.clone()), 1, ETH_DUMMY_ADDR),
+							Staking::claim(Origin::signed(node.clone()), 1.into(), ETH_DUMMY_ADDR),
 							Error::<Runtime>::PendingClaim
 						);
 					}


### PR DESCRIPTION
Related issues: #1849 #1897 

This refactor would have been included as part of #1849 but I've put this up as a separate PR because it also makes #1897 easier (and for the sake of smaller PRs).

NB: This doesn't change the CLI's API, that can be addressed in #1897 

## State Chain

- [x] Does this break CFE compatibility (API) - If yes/not sure, have you tagged relevant Engine Echidna on the PR?
- Were any changes to the genesis config of any pallets? If yes:
  - [x] Has the Chainspec been updated accordingly?
- Have any new dependencies been added? If yes:
  - [x] Has `Cargo.toml/std` section been updated accordingly? [Reference](https://www.notion.so/chainflip/Cargo-toml-s-std-section-95e0d5370bc74ecc99fd310bf5b21142)
- Has the external interface been changed? Have any extrinsics been updated or removed? If yes:
  - [x] Has the runtime version been bumped accordingly (`transaction_version` and `spec_version`)
- Do the changes require a runtime upgrade? If yes:
  - [x] Have any storage items or stored data types been modified? If yes:
    - [x] Has the pallet's storage version been bumped and a storage migration been defined?


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1899"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

