### PR TITLE
Use trait name for broadcast stage

### DIFF
--- a/engine/src/multisig/client/common/broadcast.rs
+++ b/engine/src/multisig/client/common/broadcast.rs
@@ -14,7 +14,10 @@ use crate::{
     multisig_p2p::OutgoingMultisigStageMessages,
 };
 
-use super::ceremony_stage::{CeremonyCommon, CeremonyStage, ProcessMessageResult, StageResult};
+use super::{
+    ceremony_stage::{CeremonyCommon, CeremonyStage, ProcessMessageResult, StageResult},
+    BroadcastStageName,
+};
 
 pub use super::broadcast_verification::verify_broadcasts;
 
@@ -33,6 +36,10 @@ pub trait BroadcastStageProcessor<Data, Result, FailureReason>: Display {
     /// The specific variant of D shared between parties
     /// during this stage
     type Message: Clone + Into<Data> + TryFrom<Data>;
+
+    /// Broadcast Stage Name used for logging.
+    /// A broadcast and its verification will share the same name.
+    const NAME: BroadcastStageName;
 
     /// Init the stage, returning the data to broadcast
     fn init(&mut self) -> DataToSend<Self::Message>;

--- a/engine/src/multisig/client/common/mod.rs
+++ b/engine/src/multisig/client/common/mod.rs
@@ -115,6 +115,8 @@ pub enum BroadcastStageName {
     Complaints,
     #[error("Blame Responses")]
     BlameResponses,
+    #[error("Secret Shares")]
+    SecretShares,
 }
 
 const SIGNING_CEREMONY_FAILED_PREFIX: &str = "Signing ceremony failed";

--- a/engine/src/multisig/client/keygen/keygen_stages.rs
+++ b/engine/src/multisig/client/keygen/keygen_stages.rs
@@ -78,6 +78,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for HashCommitments1<P>
 {
     type Message = HashComm1;
+    const NAME: BroadcastStageName = BroadcastStageName::HashCommitments;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         // We don't want to reveal the public coefficients yet, so sending the hash commitment only
@@ -123,6 +124,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for VerifyHashCommitmentsBroadcast2<P>
 {
     type Message = VerifyHashComm2;
+    const NAME: BroadcastStageName = BroadcastStageName::HashCommitments;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         DataToSend::Broadcast(VerifyHashComm2 {
@@ -143,10 +145,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
             Err((reported_parties, abort_reason)) => {
                 return KeygenStageResult::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::HashCommitments,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };
@@ -154,7 +153,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
         slog::debug!(
             self.common.logger,
             "{} have been correctly broadcast",
-            BroadcastStageName::HashCommitments
+            Self::NAME
         );
 
         // Just saving hash commitments for now. We will use them
@@ -194,6 +193,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for CoefficientCommitments3<P>
 {
     type Message = CoeffComm3<P>;
+    const NAME: BroadcastStageName = BroadcastStageName::CoefficientCommitments;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         DataToSend::Broadcast(self.own_commitment.clone())
@@ -241,6 +241,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for VerifyCommitmentsBroadcast4<P>
 {
     type Message = VerifyCoeffComm4<P>;
+    const NAME: BroadcastStageName = BroadcastStageName::CoefficientCommitments;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         let data = self.commitments.clone();
@@ -261,10 +262,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
             Err((reported_parties, abort_reason)) => {
                 return KeygenStageResult::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::CoefficientCommitments,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };
@@ -284,7 +282,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
         slog::debug!(
             self.common.logger,
             "{} have been correctly broadcast",
-            BroadcastStageName::CoefficientCommitments
+            Self::NAME
         );
 
         // At this point we know everyone's commitments, which can already be
@@ -334,6 +332,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for SecretSharesStage5<P>
 {
     type Message = SecretShare5<P>;
+    const NAME: BroadcastStageName = BroadcastStageName::SecretShares;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         // With everyone committed to their secrets and sharing polynomial coefficients
@@ -419,6 +418,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for ComplaintsStage6<P>
 {
     type Message = Complaints6;
+    const NAME: BroadcastStageName = BroadcastStageName::Complaints;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         DataToSend::Broadcast(Complaints6(self.complaints.clone()))
@@ -462,6 +462,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for VerifyComplaintsBroadcastStage7<P>
 {
     type Message = VerifyComplaints7;
+    const NAME: BroadcastStageName = BroadcastStageName::Complaints;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         let data = self.received_complaints.clone();
@@ -482,10 +483,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
             Err((reported_parties, abort_reason)) => {
                 return KeygenStageResult::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::Complaints,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };
@@ -581,6 +579,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for BlameResponsesStage8<P>
 {
     type Message = BlameResponse8<P>;
+    const NAME: BroadcastStageName = BroadcastStageName::BlameResponses;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         // Indexes at which to reveal/broadcast secret shares
@@ -733,6 +732,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
     for VerifyBlameResponsesBroadcastStage9<P>
 {
     type Message = VerifyBlameResponses9<P>;
+    const NAME: BroadcastStageName = BroadcastStageName::BlameResponses;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         let data = self.blame_responses.clone();
@@ -751,7 +751,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
         slog::debug!(
             self.common.logger,
             "Processing verifications for {}",
-            BroadcastStageName::BlameResponses
+            Self::NAME
         );
 
         let verified_responses = match verify_broadcasts(messages, &self.common.logger) {
@@ -759,10 +759,7 @@ impl<P: ECPoint> BroadcastStageProcessor<KeygenData<P>, KeygenResultInfo<P>, Key
             Err((reported_parties, abort_reason)) => {
                 return KeygenStageResult::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::BlameResponses,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };

--- a/engine/src/multisig/client/signing/frost_stages.rs
+++ b/engine/src/multisig/client/signing/frost_stages.rs
@@ -67,6 +67,7 @@ impl<C: CryptoScheme>
     for AwaitCommitments1<C>
 {
     type Message = Comm1<C::Point>;
+    const NAME: BroadcastStageName = BroadcastStageName::CoefficientCommitments;
 
     fn init(&mut self) -> DataToSend<Self::Message> {
         DataToSend::Broadcast(Comm1 {
@@ -115,6 +116,7 @@ impl<C: CryptoScheme>
     for VerifyCommitmentsBroadcast2<C>
 {
     type Message = VerifyComm2<C::Point>;
+    const NAME: BroadcastStageName = BroadcastStageName::CoefficientCommitments;
 
     /// Simply report all data that we have received from
     /// other parties in the last stage
@@ -136,10 +138,7 @@ impl<C: CryptoScheme>
             Err((reported_parties, abort_reason)) => {
                 return SigningStageResult::<C>::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::CoefficientCommitments,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };
@@ -147,7 +146,7 @@ impl<C: CryptoScheme>
         slog::debug!(
             self.common.logger,
             "{} have been correctly broadcast",
-            BroadcastStageName::CoefficientCommitments
+            Self::NAME
         );
 
         let processor = LocalSigStage3::<C> {
@@ -180,6 +179,7 @@ impl<C: CryptoScheme>
     for LocalSigStage3<C>
 {
     type Message = LocalSig3<C::Point>;
+    const NAME: BroadcastStageName = BroadcastStageName::LocalSignatures;
 
     /// With all nonce commitments verified, we can generate the group commitment
     /// and our share of signature response, which we broadcast to other parties.
@@ -240,6 +240,7 @@ impl<C: CryptoScheme>
     for VerifyLocalSigsBroadcastStage4<C>
 {
     type Message = VerifyLocalSig4<C::Point>;
+    const NAME: BroadcastStageName = BroadcastStageName::LocalSignatures;
 
     /// Broadcast all signature shares sent to us
     fn init(&mut self) -> DataToSend<Self::Message> {
@@ -264,10 +265,7 @@ impl<C: CryptoScheme>
             Err((reported_parties, abort_reason)) => {
                 return SigningStageResult::<C>::Error(
                     reported_parties,
-                    CeremonyFailureReason::BroadcastFailure(
-                        abort_reason,
-                        BroadcastStageName::LocalSignatures,
-                    ),
+                    CeremonyFailureReason::BroadcastFailure(abort_reason, Self::NAME),
                 );
             }
         };
@@ -275,7 +273,7 @@ impl<C: CryptoScheme>
         slog::debug!(
             self.common.logger,
             "{} have been correctly broadcast",
-            BroadcastStageName::LocalSignatures
+            Self::NAME
         );
 
         let all_idxs = &self.common.all_idxs;


### PR DESCRIPTION
Was trying to address a comment on an old PR:
https://github.com/chainflip-io/chainflip-backend/pull/1616#pullrequestreview-975580454

Added a name to the `BroadcastStageProcessor` trait so we don't have to repeat it in the failure reason and any logs. 
I Tried to take it one step further and made the `BroadcastStage` add the name to the failure reason automatically, but the solution was not nice and added complexity. After a discussion with max, we agree that the name on the trait is enough to stop the incorrect stage name being used.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

