### PR TITLE
fix: use system account instead of flip account

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -642,7 +642,7 @@ impl_runtime_apis! {
 		}
 		fn cf_accounts() -> Vec<(AccountId, Vec<u8>)> {
 			let mut vanity_names = Validator::vanity_names();
-			pallet_cf_flip::Account::<Runtime>::iter_keys()
+			frame_system::Account::<Runtime>::iter_keys()
 				.map(|account_id| {
 					let vanity_name = vanity_names.remove(&account_id).unwrap_or_default();
 					(account_id, vanity_name)


### PR DESCRIPTION
This is not a bugfix, just a pre-emptive change to reduce the chance of future regressions. 

In the cf_accounts rpc, we were iterating over the flip `Account` storage item. 

On reflection, this is incorrect, we should instead use the `System::Account` storage item.

The former is a mapping of account_id to balance - but there is no intrinsic reason for this to correspond to an actual validator - it could be an anonymous (sub-)account. 

The latter is the source-of-truth storage location for actual user-owned accounts. 



<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1931"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

