### PR TITLE
chore: Remove nonstandard macro braces option from clippy

### DIFF
--- a/clippy.sh
+++ b/clippy.sh
@@ -1,6 +1,6 @@
 cat <<\EOF
-Running: cargo clippy --all-targets -- -D warnings -A clippy::boxed_local -A clippy::nonstandard_macro_braces
+Running: cargo clippy --all-targets -- -D warnings -A clippy::boxed_local
 EOF
 
 set -e
-cargo clippy --all-targets -- -D warnings -A clippy::boxed_local -A clippy::nonstandard_macro_braces
+cargo clippy --all-targets -- -D warnings -A clippy::boxed_local


### PR DESCRIPTION
Works in CI and locally with cargo 1.58.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1958"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

