### PR TITLE
chore: log idxs of missing messages on stage timeout

### DIFF
--- a/engine/src/multisig/client/common/broadcast.rs
+++ b/engine/src/multisig/client/common/broadcast.rs
@@ -1,13 +1,8 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Display,
-    marker::PhantomData,
-};
+use std::{collections::BTreeMap, fmt::Display, marker::PhantomData};
 
 use cf_traits::AuthorityCount;
 
 use crate::{
-    common::format_iterator,
     multisig::{
         client::{MultisigData, MultisigMessage},
         crypto::ECPoint,
@@ -225,10 +220,7 @@ where
         self.processor.should_delay(m)
     }
 
-    fn finalize(
-        mut self: Box<Self>,
-        logger: &slog::Logger,
-    ) -> StageResult<Data, Result, FailureReason> {
+    fn finalize(mut self: Box<Self>) -> StageResult<Data, Result, FailureReason> {
         // Because we might want to finalize the stage before
         // all data has been received (e.g. due to a timeout),
         // we insert None for any missing data
@@ -244,34 +236,9 @@ where
             .map(|idx| (*idx, received_messages.remove(idx)))
             .collect();
 
-        // Log the idxs of the missing messages
-        let missing_messages_idxs: BTreeSet<AuthorityCount> = messages
-            .iter()
-            .filter_map(
-                |(idx, message)| {
-                    if message.is_none() {
-                        Some(*idx)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .collect();
-
-        if !missing_messages_idxs.is_empty() {
-            slog::debug!(
-                logger,
-                "Stage `{}` is missing messages from {} parties",
-                self.get_stage_name(),
-                missing_messages_idxs.len();
-                "missing_idxs" => format_iterator(missing_messages_idxs).to_string()
-            )
-        }
-
         self.processor.process(messages)
     }
 
-    #[cfg(test)]
     fn awaited_parties(&self) -> std::collections::BTreeSet<AuthorityCount> {
         let mut awaited = std::collections::BTreeSet::new();
 

--- a/engine/src/multisig/client/common/ceremony_stage.rs
+++ b/engine/src/multisig/client/common/ceremony_stage.rs
@@ -62,13 +62,9 @@ pub trait CeremonyStage {
 
     /// Verify data for this stage after it is received from all other parties,
     /// either abort or proceed to the next stage based on the result
-    fn finalize(
-        self: Box<Self>,
-        logger: &slog::Logger,
-    ) -> StageResult<Self::Message, Self::Result, Self::FailureReason>;
+    fn finalize(self: Box<Self>) -> StageResult<Self::Message, Self::Result, Self::FailureReason>;
 
     /// Parties we haven't heard from for the current stage
-    #[cfg(test)]
     fn awaited_parties(&self) -> BTreeSet<AuthorityCount>;
 
     fn get_stage_name(&self) -> super::CeremonyStageName;

--- a/engine/src/multisig/client/state_runner.rs
+++ b/engine/src/multisig/client/state_runner.rs
@@ -126,7 +126,7 @@ where
             .take()
             .expect("Stage must be present to be finalized");
 
-        match stage.finalize(&self.logger) {
+        match stage.finalize() {
             StageResult::NextStage(mut next_stage) => {
                 slog::debug!(
                     self.logger,
@@ -283,7 +283,7 @@ where
                         CeremonyFailureReason::ExpiredBeforeBeingAuthorized,
                     )))
                 }
-                Some(_authorised_state) => {
+                Some(authorised_state) => {
                     // We can't simply abort here as we don't know whether other
                     // participants are going to do the same (e.g. if a malicious
                     // node targeted us by communicating with everyone but us, it
@@ -295,6 +295,20 @@ where
                         self.logger,
                         "Ceremony stage timed out before all messages collected; trying to finalize current stage anyway"
                     );
+
+                    // Log the account ids of the missing messages
+                    if let Some(stage) = &authorised_state.stage {
+                        let missing_messages_from_accounts = authorised_state
+                            .idx_mapping
+                            .get_ids(stage.awaited_parties());
+                        slog::debug!(
+                            self.logger,
+                            "Stage `{}` is missing messages from {} parties",
+                            stage.get_stage_name(),
+                            missing_messages_from_accounts.len();
+                            "missing_ids" => format_iterator(missing_messages_from_accounts).to_string()
+                        )
+                    }
 
                     self.finalize_current_stage()
                 }


### PR DESCRIPTION
closes #1977.

```sh
[DEBG] Stage `Verify Blame Responses` is missing messages from 1 parties (chainflip_engine::multisig::client::state_runner)
    | missing_ids = 5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt
    | ceremony_id = 1
```

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1982"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

