### PR TITLE
chore: change here! to provide a github link, and the commit hash of the binary

### DIFF
--- a/engine/src/errors.rs
+++ b/engine/src/errors.rs
@@ -1,15 +1,15 @@
-// Add a special cool method for adding line numbers
-// Ripped from: https://github.com/dtolnay/anyhow/issues/22
-
 macro_rules! here {
     () => {
         lazy_format::lazy_format!(
+            // CIRCLE_SHA1 is CircleCI's environment variable exposing the git commit hash
             if let Some(commit_hash) = core::option_env!("CIRCLE_SHA1") => (
                 "https://github.com/chainflip-io/chainflip-backend/tree/{commit_hash}/{}#L{}#C{}",
                 file!(),
                 line!(),
                 column!()
             )
+            // Add a special cool method for adding line numbers
+            // Ripped from: https://github.com/dtolnay/anyhow/issues/22
             else => ("{}", concat!(file!(), " line ", line!(), " column ", column!()))
         )
     };


### PR DESCRIPTION
I could alternatively use a rust build step to get the commit hash without relying on CircleCI, but I'm not sure there's much benefit?

Also I tried to not hard code the github repo url , but the appropiate environment variables don't exist.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/1989"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

