### PR TITLE
Fix/broadcast storage state

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -343,6 +343,13 @@ fn test_bad_signature() {
 			AwaitingTransactionSignature::<Test, Instance1>::get(broadcast_attempt_id).is_none()
 		);
 		assert!(AwaitingTransmission::<Test, Instance1>::get(broadcast_attempt_id).is_none());
+		// if we have a bad sig then we want to remove the attempt number for that failed attempt
+		// before we retry too
+		assert!(BroadcastIdToAttemptNumbers::<Test, Instance1>::get(
+			broadcast_attempt_id.broadcast_id
+		)
+		.unwrap()
+		.is_empty());
 		assert_eq!(BroadcastRetryQueue::<Test, Instance1>::decode_len().unwrap_or_default(), 1);
 
 		// The nominee was reported.


### PR DESCRIPTION
Was able to reproduce this issue. Basically it can occur if someone submits a tx signature that fails to verify. This meant that we'd delete the `AwaitingTransactionSignature` item, but we'd still have a dangling `attempt_count` in `BroadcastIdToAttemptNumbers`.

Then when we get a signature accepted, the clean up method will try to remove AwaitingTransactionSignature associated with an attempt number that should have been deleted earlier.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2005"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

