### PR TITLE
CFE detect duplicate signers earlier

### DIFF
--- a/engine/src/multisig/client/keygen/keygen_frost.rs
+++ b/engine/src/multisig/client/keygen/keygen_frost.rs
@@ -576,7 +576,8 @@ pub mod genesis {
 
         let agg_pubkey = derive_aggregate_pubkey(&commitments, allow_high_pubkey)?;
 
-        let validator_map = PartyIdxMapping::from_unsorted_signers(signers);
+        let validator_map = PartyIdxMapping::from_unsorted_signers(signers)
+            .expect("Should be valid list of signers");
 
         let keygen_result_infos: HashMap<_, _> = (1..=n)
             .map(|idx| {

--- a/engine/src/multisig/client/tests/helpers.rs
+++ b/engine/src/multisig/client/tests/helpers.rs
@@ -1192,7 +1192,7 @@ pub fn gen_invalid_keygen_stage_2_state<P: ECPoint>(
     mut rng: Rng,
     logger: Logger,
 ) -> CeremonyRunner<KeygenCeremony<EthSigning>> {
-    let validator_mapping = Arc::new(PartyIdxMapping::from_unsorted_signers(account_ids));
+    let validator_mapping = Arc::new(PartyIdxMapping::from_unsorted_signers(account_ids).unwrap());
     let common = CeremonyCommon {
         ceremony_id,
         own_idx: 0,

--- a/engine/src/multisig/client/tests/keygen_unit_tests.rs
+++ b/engine/src/multisig/client/tests/keygen_unit_tests.rs
@@ -217,7 +217,8 @@ async fn should_report_on_invalid_blame_response6() {
     let mut ceremony = KeygenCeremonyRunner::new_with_default();
     let party_idx_mapping = PartyIdxMapping::from_unsorted_signers(
         &ceremony.nodes.keys().cloned().collect::<Vec<_>>()[..],
-    );
+    )
+    .unwrap();
     let [bad_node_id_1, bad_node_id_2, target_node_id] = ceremony.select_account_ids();
 
     let messages = ceremony.request().await;
@@ -575,7 +576,8 @@ async fn should_report_on_inconsistent_broadcast_blame_responses6() {
 
     let party_idx_mapping = PartyIdxMapping::from_unsorted_signers(
         &ceremony.nodes.keys().cloned().collect::<Vec<_>>()[..],
-    );
+    )
+    .unwrap();
 
     let messages = ceremony.request().await;
 


### PR DESCRIPTION
This PR is pointing to my parallel ceremonies branch #2042 because i made these changes while working on the branch but wanted to keep them seperate in the end.

- `from_unsorted_signers` now returns an error if it detects a duplicate account id.

Notes:
- `map_ceremony_parties` also detects duplicates.
- `from_unsorted_signers` is not ran on a signing ceremony. Signing ceremonies use the validator map from keygen.

It's a bit strange to have the check in both places, but i think it still makes sense to detect it early and not have rely on `map_ceremony_parties` to be called. But still not sure sure, so if we don't like it, we can reject this PR.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2051"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

