### PR TITLE
chore: tie attempt count to authority count

### DIFF
--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -18,8 +18,8 @@ use scale_info::TypeInfo;
 
 use cf_chains::{Chain, ChainCrypto};
 use cf_traits::{
-	offence_reporting::OffenceReporter, AsyncResult, CeremonyIdProvider, Chainflip, EpochInfo,
-	KeyProvider, RetryPolicy, SignerNomination,
+	offence_reporting::OffenceReporter, AsyncResult, AuthorityCount, CeremonyIdProvider, Chainflip,
+	EpochInfo, KeyProvider, RetryPolicy, SignerNomination,
 };
 use frame_support::{
 	dispatch::UnfilteredDispatchable,
@@ -47,7 +47,7 @@ pub type CeremonyId = u64;
 pub type RequestId = u32;
 
 /// The type used for counting signing attempts.
-type AttemptCount = u32;
+type AttemptCount = AuthorityCount;
 
 type SignatureFor<T, I> = <<T as Config<I>>::TargetChain as ChainCrypto>::ThresholdSignature;
 type PayloadFor<T, I> = <<T as Config<I>>::TargetChain as ChainCrypto>::Payload;


### PR DESCRIPTION
Closes: #1479 

It doesn't make sense to make attempt count u16 (as suggested in linked issue), when the number of attempts is directly tied to the authority count. So this PR just makes that explicit.