### PR TITLE
feat: re-enable ceremony id tracking

### DIFF
--- a/engine/src/multisig/client/tests/ceremony_manager_tests.rs
+++ b/engine/src/multisig/client/tests/ceremony_manager_tests.rs
@@ -201,9 +201,8 @@ async fn should_ignore_rts_with_unknown_signer_id() {
     );
 }
 
-#[test]
-#[ignore = "temporarily disabled - see issue #1972"]
-fn should_not_create_unauthorized_ceremony_with_invalid_ceremony_id() {
+#[tokio::test]
+async fn should_not_create_unauthorized_ceremony_with_invalid_ceremony_id() {
     let latest_ceremony_id = 1; // Invalid, because the CeremonyManager starts with this value as the latest
     let past_ceremony_id = latest_ceremony_id - 1; // Invalid, because it was used in the past
     let future_ceremony_id = latest_ceremony_id + CEREMONY_ID_WINDOW; // Valid, because its within the window
@@ -252,6 +251,6 @@ fn should_not_create_unauthorized_ceremony_with_invalid_ceremony_id() {
         },
     );
 
-    // Check that the message was not ignored and unauthorised ceremony was created
+    // Check that the message was not ignored and an unauthorised ceremony was created
     assert_eq!(ceremony_manager.get_keygen_states_len(), 1);
 }


### PR DESCRIPTION
Closes #1972

Now that keygen verification is requested from the SC, the ceremony ids should all be unique, allowing us to re-enable ceremony id tracking.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2124"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

