### PR TITLE
fix: key manager no longer witnesses previous epochs

### DIFF
--- a/engine/src/eth/contract_witnesser.rs
+++ b/engine/src/eth/contract_witnesser.rs
@@ -21,7 +21,7 @@ pub async fn start<ContractWitnesser, StateChainRpc>(
     epoch_starts_receiver: broadcast::Receiver<EpochStart>,
     // In some cases there is no use witnessing older epochs since any actions that could be taken either have already
     // been taken, or can no longer be taken.
-    witness_only_current_epoch: bool,
+    witness_historical_epochs: bool,
     state_chain_client: Arc<StateChainClient<StateChainRpc>>,
     logger: &slog::Logger,
 ) -> anyhow::Result<()>
@@ -34,13 +34,7 @@ where
     super::epoch_witnesser::start(
         contract_witnesser.contract_name(),
         epoch_starts_receiver,
-        move |epoch_start| {
-            if witness_only_current_epoch {
-                epoch_start.current
-            } else {
-                true
-            }
-        },
+        move |epoch_start| witness_historical_epochs || epoch_start.current,
         (),
         move |end_witnessing_signal, epoch_start, (), logger| {
             let eth_ws_rpc = eth_ws_rpc.clone();

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -212,7 +212,7 @@ fn main() -> anyhow::Result<()> {
                     eth_ws_rpc_client.clone(),
                     eth_http_rpc_client.clone(),
                     witnessing_instruction_receiver_1,
-                    false,
+                    true,
                     state_chain_client.clone(),
                     &root_logger,
                 )
@@ -223,7 +223,7 @@ fn main() -> anyhow::Result<()> {
                     eth_ws_rpc_client,
                     eth_http_rpc_client,
                     witnessing_instruction_receiver_2,
-                    true,
+                    false,
                     state_chain_client.clone(),
                     &root_logger,
                 )


### PR DESCRIPTION
Targets #2127 

Previously we were witnessing events on the key manager in old epochs (active epochs that aren't the current one). However, in the case of the key manager this doesn't make sense, since we can only take action on the most recent events, since they are relevant only to the latest agg key.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

