### PR TITLE
doc: add Correctness and Maintainability to PRACTICES.md

### DIFF
--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -31,7 +31,7 @@ These are the foundation of our practices...
 
 ## Correctness
 
-The Chainflip network will be securing significant amounts of funds for its users. The protocol has been designed with security and token-economic incentives in mind, but none of this matters if the code does not implement the design correctly. Therefore, before merging any code to `develop` we should be able convince ourselves that it is correct.
+The Chainflip network will be securing significant amounts of funds for its users. The protocol has been designed with security and token-economic incentives in mind, but none of this matters if the code does not implement the design correctly. Therefore, before merging any code to `develop` we should be able to reason about its correctness and demonstrate that our code meets requirements.
 
 Correctness in this instance means that we know what the code should do; that it indeed fulfils its stated purpose; that we have considered all edge cases. In the spirit of readability, correctness should be as easy as possible to reason about by anyone reading, reviewing or auditing the code.
 


### PR DESCRIPTION
Adds paragraphs about correctness and maintainability to PRACTICES.md

Added both under principles, we can shuffle/amend as necessary. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

