### PR TITLE
feat: add asset type to primitives (#2119)

### DIFF
--- a/state-chain/pallets/cf-relayer/src/benchmarking.rs
+++ b/state-chain/pallets/cf-relayer/src/benchmarking.rs
@@ -12,8 +12,8 @@ benchmarks! {
 		let caller: T::AccountId = whitelisted_caller();
 	}: _(
 		RawOrigin::Signed(caller.clone()),
-		ForeignChainAsset { chain: ForeignChain::Eth, asset: Asset::Eth },
-		ForeignChainAsset { chain: ForeignChain::Eth, asset: Asset::Usdc },
+		ForeignChainAsset { chain: ForeignChain::Ethereum, asset: Asset::Eth },
+		ForeignChainAsset { chain: ForeignChain::Ethereum, asset: Asset::Usdc },
 		ForeignChainAddress::Eth(Default::default()),
 		0
 	)

--- a/state-chain/pallets/cf-relayer/src/tests.rs
+++ b/state-chain/pallets/cf-relayer/src/tests.rs
@@ -7,8 +7,8 @@ fn request_swap_intent() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Relayer::register_swap_intent(
 			Origin::signed(ALICE),
-			ForeignChainAsset { chain: ForeignChain::Eth, asset: Asset::Eth },
-			ForeignChainAsset { chain: ForeignChain::Eth, asset: Asset::Usdc },
+			ForeignChainAsset { chain: ForeignChain::Ethereum, asset: Asset::Eth },
+			ForeignChainAsset { chain: ForeignChain::Ethereum, asset: Asset::Usdc },
 			ForeignChainAddress::Eth(Default::default()),
 			0,
 		));

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -55,8 +55,8 @@ impl Default for ChainflipAccountData {
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Copy)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ForeignChain {
-	Eth,
-	Dot,
+	Ethereum,
+	Polkadot,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Copy)]


### PR DESCRIPTION
A bit pedantic, but `Ethereum` is the chain, `Eth` is the currency.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2143"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

