### PR TITLE
feat: added cargo cfe-test alias

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,7 +2,7 @@
 # `rustup completions --help` to find out how to set this up.
 
 [alias]
-# run unit tests but not integration tests
+# Run unit tests but not integration tests
 cf-test = "test --lib --all-features"
 # TODO: add all-features and clean up benchmarks.
 cf-clippy = "clippy --all-targets"
@@ -11,3 +11,6 @@ ci-check = "check --all-targets --all-features --release"
 ci-build = "build --release --features runtime-benchmarks"
 ci-test = "test --lib --all-features --release"
 ci-clippy = "clippy --all-targets -- -D warnings"
+
+# Run just the CFE unit tests
+cfe-test = "test --package chainflip-engine --lib"


### PR DESCRIPTION
I use this command every day to run the CFE unit tests, so I thought it might be useful to add an alias.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2147"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

