### PR TITLE
feat: Abort Functionality for ScopedJoinHandle

### DIFF
--- a/engine/src/task_scope.rs
+++ b/engine/src/task_scope.rs
@@ -515,4 +515,19 @@ mod tests {
 
         receiver.await.unwrap_err(); // we expect sender to be dropped when task is cancelled
     }
+
+    #[test]
+    fn dropping_scoped_join_handle_cancels_task() {
+        let _result = with_main_task_scope(|scope| {
+            async {
+                let _handle = scope.spawn_with_handle(async {
+                    wait_forever().await;
+                    Ok(())
+                });
+
+                Ok(())
+            }
+            .boxed()
+        });
+    }
 }


### PR DESCRIPTION
Abort the spawned task on dropping of the ScopedJoinHandle, as requested @j4m1ef0rd.

I also removed the internal spawn_with_manual_error_handling function as it was just confusing.

FYI The term "Abort" really means cancel (As in wait for the future to get to an await point). I don't know why they inconsistently use both terms.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

