### PR TITLE
fix: remove vanity name when account killed

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1268,6 +1268,16 @@ impl<T: Config> OnKilledAccount<T::AccountId> for DeletePeerMapping<T> {
 	}
 }
 
+pub struct DeleteVanityName<T: Config>(PhantomData<T>);
+
+impl<T: Config> OnKilledAccount<T::AccountId> for DeleteVanityName<T> {
+	fn on_killed_account(account_id: &T::AccountId) {
+		let mut vanity_names = VanityNames::<T>::get();
+		vanity_names.remove(account_id);
+		VanityNames::<T>::put(vanity_names);
+	}
+}
+
 pub struct PeerMapping<T>(PhantomData<T>);
 
 impl<T: Config> QualifyNode for PeerMapping<T> {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -287,6 +287,7 @@ impl frame_system::Config for Runtime {
 	type OnKilledAccount = (
 		pallet_cf_flip::BurnFlipAccount<Self>,
 		pallet_cf_validator::DeletePeerMapping<Self>,
+		pallet_cf_validator::DeleteVanityName<Self>,
 		GrandpaOffenceReporter<Self>,
 	);
 	/// The data to be stored in an account.


### PR DESCRIPTION
Nice find by @Janislav , we weren't ever removing the vanity names of the accounts. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

