### PR TITLE
feat: :sparkles: remove map entry when an account is deleted

### DIFF
--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -515,5 +515,6 @@ impl<T: Config> ReputationResetter for Pallet<T> {
 impl<T: Config> OnKilledAccount<T::ValidatorId> for Pallet<T> {
 	fn on_killed_account(who: &T::ValidatorId) {
 		Reputations::<T>::remove(who);
+		LastHeartbeat::<T>::remove(who);
 	}
 }


### PR DESCRIPTION
Fix for #2217.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

