### PR TITLE
fix: add ibiza ff to chainflip-node

### DIFF
--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -89,6 +89,9 @@ try-runtime = [
   "state-chain-runtime/try-runtime",
   "try-runtime-cli",
 ]
+ibiza = [
+  "state-chain-runtime/ibiza"
+]
 
 [package.metadata.deb]
 depends = "$auto"


### PR DESCRIPTION
Good find by @ramizhasan111 

This doesn't really do anything most of the time, because we'll normally compile with the state-chain-runtime as a dependency of another crate, so rustc will take a union of the features, meaning that even if we haven't explicitly enabled ibiza, if it's enabled for another crate that uses state-chain-runtime as a dep, (and that dep enables the feature), then it will be enabled everywhere.

This is just to make the feature explicit on the binary.