### PR TITLE
fix: fix underflow panic

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1075,7 +1075,7 @@ impl<T: Config> Pallet<T> {
 
 		let limit = Self::backup_reward_nodes_limit();
 		if limit < backups.len() {
-			backups.select_nth_unstable_by_key(limit - 1, |(_, amount)| Reverse(*amount));
+			backups.select_nth_unstable_by_key(limit, |(_, amount)| Reverse(*amount));
 			backups.truncate(limit);
 		}
 


### PR DESCRIPTION
Removes the possibility of an underflow panic.
Note we truncate the `backups` vec to `limit` items, and whether we use `select_nth_unstable(limit - 1)` or `select_nth_unstable(limit)`, first `limit` number of items will still be the correct ones.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

