### PR TITLE
fix: continue to retry at poll interval on chain data rpc query errors

### DIFF
--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -23,6 +23,19 @@ macro_rules! assert_err {
 	};
 }
 
+#[macro_export]
+macro_rules! unwrap_or_continue {
+	($res:expr, $logger:expr) => {
+		match $res {
+			Ok(val) => val,
+			Err(e) => {
+				slog::warn!($logger, "{}; skipped.", e);
+				continue
+			},
+		}
+	};
+}
+
 #[cfg(test)]
 mod test_asserts {
 	use crate::assert_panics;


### PR DESCRIPTION
This is a bit of a robustness improvement to the chain data witnesser. Instead of exiting on an error from the RPC, we will just wait until the next time we are scheduled to poll and try again.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2279"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

