### PR TITLE
Feat Disabled request deposit_address/withdraw liquidity during system maintenance

### DIFF
--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -286,6 +286,7 @@ pub mod pallet {
 			pool_id: PoolId,
 			position: TradingPosition<AssetAmount>,
 		) -> DispatchResult {
+			T::SystemState::ensure_no_maintenance()?;
 			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
 
 			// Ensure the liquidity pool is enabled.
@@ -336,6 +337,7 @@ pub mod pallet {
 			id: PositionId,
 			new_position: TradingPosition<AssetAmount>,
 		) -> DispatchResultWithPostInfo {
+			T::SystemState::ensure_no_maintenance()?;
 			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
 
 			TradingPositions::<T>::try_mutate(id, |maybe_position| {
@@ -402,6 +404,7 @@ pub mod pallet {
 
 		#[pallet::weight(0)]
 		pub fn close_position(who: OriginFor<T>, id: PositionId) -> DispatchResult {
+			T::SystemState::ensure_no_maintenance()?;
 			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(who)?;
 
 			// Remove the position.


### PR DESCRIPTION
For the LP pallet,`request_deposit_address` and `withdraw_liquidity` extrinsics are disabled during system maintenance.
Added unit test accordingly.

Closes #2253 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2287"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

