### PR TITLE
chore: don't compile backup_should fail test if on linux

### DIFF
--- a/engine/src/multisig/db/persistent/persistent_key_db_tests.rs
+++ b/engine/src/multisig/db/persistent/persistent_key_db_tests.rs
@@ -193,6 +193,9 @@ fn backup_should_fail_if_already_exists() {
 }
 
 #[test]
+// TODO: Re-enable this test for linux. We currently do this because Github Actions must run with
+// root user. And so the readonly permissions will be ignored.
+#[cfg(not(target_os = "linux"))]
 fn backup_should_fail_if_cant_copy_files() {
 	let logger = new_test_logger();
 	let (directory, db_path) = new_temp_directory_with_nonexistent_file();


### PR DESCRIPTION
This is a workaround due to the limitations of github actions not being able to run as a non-root user. Rather than disabling the test entirely though, at least we will be running it locally.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2289"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

