### PR TITLE
fix: runtime benchmark features for threshold sig pallet

### DIFF
--- a/state-chain/pallets/cf-staking/src/lib.rs
+++ b/state-chain/pallets/cf-staking/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::OriginFor;
 pub use pallet::*;
-use sp_std::{prelude::*, time::Duration};
+use sp_std::prelude::*;
 
 use cf_traits::SystemStateInfo;
 
@@ -45,11 +45,14 @@ pub const ETH_ZERO_ADDRESS: EthereumAddress = [0xff; 20];
 
 #[frame_support::pallet]
 pub mod pallet {
+
 	use super::*;
 	use cf_chains::{ApiCall, Ethereum};
 	use cf_traits::AccountRoleRegistry;
 	use frame_support::{pallet_prelude::*, Parameter};
 	use frame_system::pallet_prelude::*;
+
+	use sp_std::time::Duration;
 
 	pub type AccountId<T> = <T as frame_system::Config>::AccountId;
 

--- a/state-chain/pallets/cf-threshold-signature/Cargo.toml
+++ b/state-chain/pallets/cf-threshold-signature/Cargo.toml
@@ -87,6 +87,8 @@ std = [
   'log/std',
   'sp-std/std',
   'sp-runtime/std',
+  # for the benchmark tests
+  'pallet-cf-validator/std',
 ]
 runtime-benchmarks = [
   'frame-benchmarking/runtime-benchmarks',
@@ -95,6 +97,7 @@ runtime-benchmarks = [
   'cf-traits/runtime-benchmarks',
   'cf-chains/runtime-benchmarks',
   'pallet-cf-validator',
+  'pallet-cf-validator/runtime-benchmarks',
   'pallet-cf-reputation',
 ]
 try-runtime = ['frame-support/try-runtime']

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -8,6 +8,7 @@ use pallet_session::Config as SessionConfig;
 
 use sp_application_crypto::RuntimeAppPublic;
 use sp_runtime::{Digest, DigestItem};
+use sp_std::vec;
 
 use cf_traits::AuctionOutcome;
 


### PR DESCRIPTION
Running threshold sig tests from vscode would fail, this fixes that.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

