### PR TITLE
feat: ensure the deafult 0.0.0.0 ip address is overwritten

### DIFF
--- a/engine/src/p2p.rs
+++ b/engine/src/p2p.rs
@@ -2,7 +2,11 @@ mod core;
 mod muxer;
 mod peer_info_submitter;
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{
+	marker::PhantomData,
+	net::{IpAddr, Ipv4Addr},
+	sync::Arc,
+};
 
 use crate::{
 	common::read_clean_and_decode_hex_str_file,
@@ -66,6 +70,10 @@ pub async fn start(
 	UnboundedSender<PeerUpdate>,
 	impl Future<Output = anyhow::Result<()>>,
 )> {
+	if settings.ip_address == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
+		anyhow::bail!("Should provide a valid IP address");
+	}
+
 	let node_key = {
 		let secret =
 			read_clean_and_decode_hex_str_file(&settings.node_key_file, "Node Key", |str| {


### PR DESCRIPTION
At one point we decided to use `0.0.0.0` in Default.toml as placeholder. This PR checks that it is not actually used to ensure that operators provide a different (hopefully correct) value.

(#2327 that I just opened will likely cover this, but it has an open question, so merging this first)

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2328"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

