### PR TITLE
fix: use SigningFailureReason in new test

### DIFF
--- a/engine/src/multisig/client/ceremony_runner/tests.rs
+++ b/engine/src/multisig/client/ceremony_runner/tests.rs
@@ -13,6 +13,7 @@ use crate::{
 				gen_signing_data_stage1, gen_signing_data_stage2, gen_signing_data_stage4,
 				SigningData,
 			},
+			SigningFailureReason,
 		},
 		crypto::CryptoScheme,
 		eth::{EthSigning, Point},
@@ -184,7 +185,7 @@ async fn should_process_delayed_messages_after_finishing_a_stage() {
 			.await,
 		Some(Err((
 			_,
-			CeremonyFailureReason::BroadcastFailure(
+			SigningFailureReason::BroadcastFailure(
 				_,
 				SigningStageName::VerifyCommitmentsBroadcast2
 			)


### PR DESCRIPTION
Not sure how this error made it into develop. 
New test was introduced in #2311. The enum was changed in #2318.
One of them should have failed in the CI? Probably a result of the ongoing changes to the CI.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2329"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

