### PR TITLE
chore: publish Ibiza to APT 🚀

### DIFF
--- a/.github/workflows/.deb-publish.yaml
+++ b/.github/workflows/.deb-publish.yaml
@@ -68,9 +68,14 @@ jobs:
           aptly repo add local packages/*.deb
           aptly snapshot create snap from repo local
           aptly publish -gpg-key=${{ steps.import_gpg.outputs.keyid }} -distribution=${{ steps.vars.outputs.codename }} snapshot -force-overwrite snap "s3:chainflip-dev:${{ inputs.s3-prefix }}/${{ steps.vars.outputs.sha_long }}/"
+      - name: Set Summary Title
+        if: ${{ !contains(inputs.artifacts, 'ibiza') }}
+        run: echo "### Packages Published! :rocket:" >> $GITHUB_STEP_SUMMARY
+      - name: Set Summary Title
+        if: contains(inputs.artifacts, 'ibiza')
+        run: echo "### Ibiza Packages Published! :rocket:" >> $GITHUB_STEP_SUMMARY
       - name: Summary
         run: |
-          echo "### Packages published! :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "Packages can be installed with the following commands: " >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -283,7 +283,7 @@ jobs:
             chainflip-docgen/generated
 
   deb-publish:
-    name: Publish to APT repo
+    name: Publish Packages to APT repo
     needs: [test-single-node]
     uses: ./.github/workflows/.deb-publish.yaml
     with:
@@ -292,7 +292,7 @@ jobs:
     secrets: inherit
 
   deb-publish-ibiza:
-    name: Publish to APT repo
+    name: Publish Ibiza Packages to APT repo
     needs: [build-ibiza]
     uses: ./.github/workflows/.deb-publish.yaml
     with:


### PR DESCRIPTION
closes: chainflip-io/chainflip-testnet-tools#714