### PR TITLE
fix: don't use --release flag for ci tests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -12,7 +12,7 @@ ci-build-ibiza = "build --release --features ibiza"
 
 ci-check = "check --all-targets --all-features --release"
 ci-build = "build --release --features runtime-benchmarks"
-ci-test = "test --lib --all-features --release"
+ci-test = "test --lib --all-features"
 ci-clippy = "clippy --all-targets --all-features -- -D warnings"
 
 # Run just the CFE unit tests

--- a/state-chain/pallets/cf-egress/src/lib.rs
+++ b/state-chain/pallets/cf-egress/src/lib.rs
@@ -328,11 +328,6 @@ impl<T: Config> IngressFetchApi for Pallet<T> {
 	fn schedule_ethereum_ingress_fetch(fetch_details: Vec<(Asset, IntentId)>) {
 		let fetches_added = fetch_details.len() as u32;
 		for (asset, intent_id) in fetch_details {
-			debug_assert!(
-				Self::get_ethereum_asset_identifier(asset).is_some(),
-				"Asset validity is checked by calling functions."
-			);
-
 			EthereumScheduledRequests::<T>::append(EthereumRequest::Fetch { intent_id, asset });
 		}
 		Self::deposit_event(Event::<T>::IngressFetchesScheduled { fetches_added });


### PR DESCRIPTION
The debug assert I've removed here was failing, wasn't caught by CI because debug_assets are removed at compile time when the --release flag is used. We want them active when running tests.

Created #2364 for @syan095  to look into on Monday.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2363"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

