### PR TITLE
fix: remove duplicate stakers from dev chainspec

### DIFF
--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -201,8 +201,6 @@ pub fn development_config() -> Result<ChainSpec, String> {
 					get_account_id_from_seed::<sr25519::Public>("Bob"),
 					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					get_account_id_from_seed::<sr25519::Public>("Bob"),
 				],
 				1,
 				EnvironmentConfig {


### PR DESCRIPTION
Strange that this was ever the case.... this was causing an error at genesis if you try to run it, since staking will try to activate the account twice, which we shouldn't do.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

