### PR TITLE
feat: remove randomness collective flip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,6 @@ dependencies = [
  "pallet-cf-vaults",
  "pallet-cf-witnesser",
  "pallet-grandpa",
- "pallet-randomness-collective-flip",
  "pallet-session",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -5515,20 +5514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-randomness-collective-flip"
-version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-06+01#2e0ebad1febc40db4eceaaab04dcfe66cf266c32"
-dependencies = [
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "safe-mix",
- "scale-info",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-06+01#2e0ebad1febc40db4eceaaab04dcfe66cf266c32"
@@ -6924,15 +6909,6 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "safe-mix"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
-dependencies = [
- "rustc_version 0.2.3",
-]
 
 [[package]]
 name = "safemem"
@@ -9041,7 +9017,6 @@ dependencies = [
  "pallet-cf-vaults",
  "pallet-cf-witnesser",
  "pallet-grandpa",
- "pallet-randomness-collective-flip",
  "pallet-session",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/state-chain/cf-integration-tests/Cargo.toml
+++ b/state-chain/cf-integration-tests/Cargo.toml
@@ -78,10 +78,6 @@ tag = 'chainflip-monthly-2022-06+01'
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'
 
-[dev-dependencies.pallet-randomness-collective-flip]
-git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'chainflip-monthly-2022-06+01'
-
 [dev-dependencies.pallet-timestamp]
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -108,11 +108,6 @@ default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'
 
-[dependencies.pallet-randomness-collective-flip]
-default-features = false
-git = 'https://github.com/chainflip-io/substrate.git'
-tag = 'chainflip-monthly-2022-06+01'
-
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
@@ -259,7 +254,6 @@ std = [
   'pallet-cf-vaults/std',
   'pallet-cf-witnesser/std',
   'pallet-grandpa/std',
-  'pallet-randomness-collective-flip/std',
   'pallet-session/std',
   'pallet-timestamp/std',
   'pallet-transaction-payment/std',

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -350,8 +350,6 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = ConstU32<16>;
 }
 
-impl pallet_randomness_collective_flip::Config for Runtime {}
-
 impl frame_system::offchain::SigningTypes for Runtime {
 	type Public = <Signature as Verify>::Signer;
 	type Signature = Signature;
@@ -568,7 +566,6 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		System: frame_system,
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
 		Timestamp: pallet_timestamp,
 		Environment: pallet_cf_environment,
 		Flip: pallet_cf_flip,
@@ -602,7 +599,6 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		System: frame_system,
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
 		Timestamp: pallet_timestamp,
 		Environment: pallet_cf_environment,
 		Flip: pallet_cf_flip,


### PR DESCRIPTION
We don't use this pallet anywhere, no idea why it was still included in the runtime. 


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2383"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

