### PR TITLE
Revert "feat: remove randomness collective flip (#2383)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "pallet-cf-vaults",
  "pallet-cf-witnesser",
  "pallet-grandpa",
+ "pallet-randomness-collective-flip",
  "pallet-session",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -5515,6 +5516,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-randomness-collective-flip"
+version = "4.0.0-dev"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-06+01#2e0ebad1febc40db4eceaaab04dcfe66cf266c32"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "safe-mix",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-06+01#2e0ebad1febc40db4eceaaab04dcfe66cf266c32"
@@ -6910,6 +6925,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safe-mix"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
+dependencies = [
+ "rustc_version 0.2.3",
+]
 
 [[package]]
 name = "safemem"
@@ -9018,6 +9042,7 @@ dependencies = [
  "pallet-cf-vaults",
  "pallet-cf-witnesser",
  "pallet-grandpa",
+ "pallet-randomness-collective-flip",
  "pallet-session",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/state-chain/cf-integration-tests/Cargo.toml
+++ b/state-chain/cf-integration-tests/Cargo.toml
@@ -78,6 +78,10 @@ tag = 'chainflip-monthly-2022-06+01'
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'
 
+[dev-dependencies.pallet-randomness-collective-flip]
+git = 'https://github.com/chainflip-io/substrate.git'
+tag = 'chainflip-monthly-2022-06+01'
+
 [dev-dependencies.pallet-timestamp]
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -108,6 +108,11 @@ default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
 tag = 'chainflip-monthly-2022-06+01'
 
+[dependencies.pallet-randomness-collective-flip]
+default-features = false
+git = 'https://github.com/chainflip-io/substrate.git'
+tag = 'chainflip-monthly-2022-06+01'
+
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
@@ -254,6 +259,7 @@ std = [
   'pallet-cf-vaults/std',
   'pallet-cf-witnesser/std',
   'pallet-grandpa/std',
+  'pallet-randomness-collective-flip/std',
   'pallet-session/std',
   'pallet-timestamp/std',
   'pallet-transaction-payment/std',

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -350,6 +350,8 @@ impl frame_system::Config for Runtime {
 	type MaxConsumers = ConstU32<16>;
 }
 
+impl pallet_randomness_collective_flip::Config for Runtime {}
+
 impl frame_system::offchain::SigningTypes for Runtime {
 	type Public = <Signature as Verify>::Signer;
 	type Signature = Signature;
@@ -566,6 +568,7 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		System: frame_system,
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
 		Timestamp: pallet_timestamp,
 		Environment: pallet_cf_environment,
 		Flip: pallet_cf_flip,
@@ -599,6 +602,7 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		System: frame_system,
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
 		Timestamp: pallet_timestamp,
 		Environment: pallet_cf_environment,
 		Flip: pallet_cf_flip,


### PR DESCRIPTION
This reverts commit 2735e4074c641452a5c0e23f91b3e6fe9ada004d.

For context: this was causing issues with the `test-single-node` step on CI. It was failing to submit the `cfe_version` extrinsic, despite a testnet built against the same binaries working fine.


<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2390"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

