### PR TITLE
chore: remove dependencies from cli by reexporting them in api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "cf-chains",
  "cf-primitives",
  "chainflip-engine",
+ "chainflip-node",
  "frame-system",
  "futures 0.3.21",
  "hex",
@@ -941,18 +942,14 @@ name = "chainflip-cli"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "cf-primitives",
  "chainflip-api",
  "chainflip-engine",
- "chainflip-node",
  "clap",
  "config",
  "futures 0.3.21",
  "hex",
- "pallet-cf-governance",
  "serde",
  "slog",
- "state-chain-runtime",
  "tokio",
  "utilities",
 ]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -16,9 +16,3 @@ serde = {version = "1.0", features = ["derive", "rc"]}
 slog = {version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"]}
 tokio = {version = "1.13.1", features = ["full"]}
 utilities = {path = "../../../utilities"}
-
-# State chain
-chainflip-node = {path = "../../../state-chain/node"}
-cf-primitives = {path = "../../../state-chain/primitives"}
-pallet-cf-governance = {path = "../../../state-chain/pallets/cf-governance"}
-state-chain-runtime = {path = "../../../state-chain/runtime"}

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -1,5 +1,4 @@
 use chainflip_api as api;
-use chainflip_node::chain_spec::use_chainflip_account_id_encoding;
 use clap::Parser;
 use settings::{CLICommandLineOptions, CLISettings};
 
@@ -11,8 +10,8 @@ mod settings;
 
 #[tokio::main]
 async fn main() {
-	// TODO: move this to API
-	use_chainflip_account_id_encoding();
+	// TODO: call this implicitly from within the API?
+	api::use_chainflip_account_id_encoding();
 
 	std::process::exit(match run_cli().await {
 		Ok(_) => 0,

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-
-use cf_primitives::AccountRole;
+use chainflip_api::primitives::{AccountRole, Hash, ProposalId};
 use chainflip_engine::settings::{CfSettings, Eth, EthOptions, StateChain, StateChainOptions};
 use clap::Parser;
 use config::{ConfigError, Source, Value};
-use pallet_cf_governance::ProposalId;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Parser, Clone, Debug)]
 pub struct CLICommandLineOptions {
@@ -82,7 +80,7 @@ pub enum CFCommand {
 	#[clap(about = "Submit a query to the State Chain")]
 	Query {
 		#[clap(help = "Block hash to be queried")]
-		block_hash: state_chain_runtime::Hash,
+		block_hash: Hash,
 	},
 	#[clap(
         // this is only useful for testing. No need to show to the end user.

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -16,6 +16,7 @@ chainflip-engine = {path = "../../engine/"}
 
 # State Chain
 state-chain-runtime = {path = "../../state-chain/runtime"}
+chainflip-node = {path = "../../state-chain/node"}
 cf-chains = {path = "../../state-chain/chains"}
 pallet-cf-environment = {path = "../../state-chain/pallets/cf-environment"}
 cf-primitives = {path = "../../state-chain/primitives"}

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -11,6 +11,14 @@ use sp_finality_grandpa::AuthorityId as GrandpaId;
 use state_chain_runtime::opaque::SessionKeys;
 use web3::types::H160;
 
+pub mod primitives {
+	pub use cf_primitives::*;
+	pub use pallet_cf_governance::ProposalId;
+	pub use state_chain_runtime::Hash;
+}
+
+pub use chainflip_node::chain_spec::use_chainflip_account_id_encoding;
+
 use chainflip_engine::{
 	eth::{rpc::EthDualRpcClient, EthBroadcaster},
 	settings,


### PR DESCRIPTION
I ended up putting everything under the same namespace (`chainflip_api::primitives`) which extends on `cf_primitives`.

Removing `chainflip-engine` is a little bit more involved (I'm not yet sure if simply re-exporting everything is the correct approach there) so I'm saving it for another PR.

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2425"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

