### PR TITLE
refactor: use ceremony type instead of retry policy

### DIFF
--- a/state-chain/pallets/cf-staking/src/mock.rs
+++ b/state-chain/pallets/cf-staking/src/mock.rs
@@ -5,7 +5,7 @@ use cf_chains::{
 };
 use cf_primitives::{AuthorityCount, CeremonyId};
 use cf_traits::{
-	impl_mock_waived_fees, mocks::system_state_info::MockSystemStateInfo, AsyncResult, RequestType,
+	impl_mock_waived_fees, mocks::system_state_info::MockSystemStateInfo, AsyncResult,
 	ThresholdSigner, WaivedFees,
 };
 use frame_support::{dispatch::DispatchResultWithPostInfo, parameter_types, traits::ConstU64};
@@ -161,10 +161,17 @@ impl ThresholdSigner<Ethereum> for MockThresholdSigner {
 
 	fn request_signature(
 		payload: <Ethereum as ChainCrypto>::Payload,
-		_request_type: RequestType<Self::KeyId, BTreeSet<Self::ValidatorId>>,
 	) -> (Self::RequestId, CeremonyId) {
 		SIGNATURE_REQUESTS.with(|cell| cell.borrow_mut().push(payload));
 		(0, 1)
+	}
+
+	fn request_keygen_verification_signature(
+		payload: <Ethereum as ChainCrypto>::Payload,
+		_key_id: Self::KeyId,
+		_participants: BTreeSet<Self::ValidatorId>,
+	) -> (Self::RequestId, CeremonyId) {
+		Self::request_signature(payload)
 	}
 
 	fn register_callback(_: Self::RequestId, _: Self::Callback) -> Result<(), Self::Error> {

--- a/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
@@ -5,7 +5,7 @@ use super::*;
 
 use cf_chains::{benchmarking_value::BenchmarkValue, ChainCrypto};
 use cf_primitives::AccountRole;
-use cf_traits::{AccountRoleRegistry, Chainflip, RequestType, ThresholdSigner};
+use cf_traits::{AccountRoleRegistry, Chainflip, ThresholdSigner};
 use frame_benchmarking::{account, benchmarks_instance_pallet, whitelist_account};
 use frame_support::{
 	assert_ok,
@@ -49,7 +49,7 @@ benchmarks_instance_pallet! {
 
 		add_authorities::<T, _>(all_accounts);
 
-		let (request_id, ceremony_id) = <Pallet::<T, I> as ThresholdSigner<_>>::request_signature(PayloadFor::<T, I>::benchmark_value(), RequestType::Standard);
+		let (request_id, ceremony_id) = <Pallet::<T, I> as ThresholdSigner<_>>::request_signature(PayloadFor::<T, I>::benchmark_value());
 		let signature = SignatureFor::<T, I>::benchmark_value();
 	} : _(RawOrigin::None, ceremony_id, signature)
 	verify {
@@ -63,7 +63,7 @@ benchmarks_instance_pallet! {
 
 		add_authorities::<T, _>(all_accounts);
 
-		let (request_id, ceremony_id) = <Pallet::<T, I> as ThresholdSigner<_>>::request_signature(PayloadFor::<T, I>::benchmark_value(), RequestType::Standard);
+		let (request_id, ceremony_id) = <Pallet::<T, I> as ThresholdSigner<_>>::request_signature(PayloadFor::<T, I>::benchmark_value());
 
 		let mut threshold_set = PendingCeremonies::<T, I>::get(ceremony_id).unwrap().remaining_respondents.into_iter();
 

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -14,7 +14,7 @@ use cf_traits::{
 		ceremony_id_provider::MockCeremonyIdProvider, signer_nomination::MockNominator,
 		system_state_info::MockSystemStateInfo,
 	},
-	AsyncResult, Chainflip, RequestType, ThresholdSigner,
+	AsyncResult, Chainflip, ThresholdSigner,
 };
 use codec::{Decode, Encode};
 use frame_support::{
@@ -220,15 +220,12 @@ impl ExtBuilder {
 		self.ext.execute_with(|| {
 			// Initiate request
 			let (request_id, ceremony_id) =
-				<EthereumThresholdSigner as ThresholdSigner<_>>::request_signature(
-					*message,
-					RequestType::Standard,
-				);
+				<EthereumThresholdSigner as ThresholdSigner<_>>::request_signature(*message);
 
 			let maybe_pending_ceremony = EthereumThresholdSigner::pending_ceremonies(ceremony_id);
 			assert!(
 				maybe_pending_ceremony.is_some() !=
-					EthereumThresholdSigner::pending_requests(request_id).is_some(), 
+					EthereumThresholdSigner::pending_requests(request_id).is_some(),
 					"The request should be either a pending ceremony OR a pending request at this point"
 			);
 			if let Some(pending_ceremony) = maybe_pending_ceremony {

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -750,10 +750,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		participants: BTreeSet<T::ValidatorId>,
 	) -> (<T::ThresholdSigner as ThresholdSigner<T::Chain>>::RequestId, CeremonyId) {
 		let byte_key: Vec<u8> = new_public_key.into();
-		let (request_id, signing_ceremony_id) = T::ThresholdSigner::request_signature(
-			T::Chain::agg_key_to_payload(new_public_key),
-			RequestType::KeygenVerification { key_id: byte_key.into(), participants },
-		);
+		let (request_id, signing_ceremony_id) =
+			T::ThresholdSigner::request_keygen_verification_signature(
+				T::Chain::agg_key_to_payload(new_public_key),
+				byte_key.into(),
+				participants,
+			);
 		T::ThresholdSigner::register_callback(request_id, {
 			Call::on_keygen_verification_result {
 				keygen_ceremony_id,

--- a/state-chain/traits/src/mocks/threshold_signer.rs
+++ b/state-chain/traits/src/mocks/threshold_signer.rs
@@ -1,4 +1,4 @@
-use crate::{AsyncResult, CeremonyId, RequestType};
+use crate::{AsyncResult, CeremonyId};
 
 use super::{MockPallet, MockPalletStorage};
 use cf_chains::ChainCrypto;
@@ -71,10 +71,7 @@ where
 
 	type ValidatorId = MockValidatorId;
 
-	fn request_signature(
-		payload: <C as ChainCrypto>::Payload,
-		_request_type: RequestType<Self::KeyId, BTreeSet<Self::ValidatorId>>,
-	) -> (Self::RequestId, CeremonyId) {
+	fn request_signature(payload: <C as ChainCrypto>::Payload) -> (Self::RequestId, CeremonyId) {
 		let req_id = {
 			let payload = payload.clone();
 			payload.using_encoded(|bytes| bytes[0]) as u32
@@ -87,6 +84,14 @@ where
 		Self::put_storage(REQUEST, req_id, payload);
 		Self::put_value(LAST_REQ_ID, req_id);
 		(req_id, 1)
+	}
+
+	fn request_keygen_verification_signature(
+		payload: <C as ChainCrypto>::Payload,
+		_key_id: Self::KeyId,
+		_participants: BTreeSet<Self::ValidatorId>,
+	) -> (Self::RequestId, CeremonyId) {
+		Self::request_signature(payload)
 	}
 
 	fn register_callback(


### PR DESCRIPTION
The abstractions around signing with a specific key and the retry policy were colliding, making it hard to use them, so makes sense to combine them. 

Feels much nicer now, and removes the potential source of bugs raised here: https://github.com/chainflip-io/chainflip-backend/pull/2426#discussion_r1016830223

This also resolves the issue around returning the CeremonyId (as discussed here: https://github.com/chainflip-io/chainflip-backend/pull/2426#discussion_r1016840449 ) since now we actually do use the CeremonyId in both the code and the tests. 

<a href="https://gitpod.io/#https://github.com/chainflip-io/chainflip-backend/pull/2447"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

