### PR TITLE
fix: late messages are no longer crashing a timed-out ceremony

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -590,7 +590,12 @@ impl<Ceremony: CeremonyTrait> CeremonyStates<Ceremony> {
 			hash_map::Entry::Occupied(entry) => entry.into_mut(),
 		};
 
-		ceremony_handle.message_sender.send((sender_id, data)).unwrap();
+		// NOTE: There is a short delay between dropping the ceremony runner (and any channels
+		// associated with it) and dropping the corresponding ceremony handle, which makes it
+		// possible for the following `send` to fail
+		if ceremony_handle.message_sender.send((sender_id, data)).is_err() {
+			slog::debug!(logger, "Could not send message: ceremony runner has been dropped");
+		}
 	}
 
 	/// Returns the state for the given ceremony id if it exists,

--- a/engine/src/multisig/client/keygen/keygen_stages.rs
+++ b/engine/src/multisig/client/keygen/keygen_stages.rs
@@ -160,11 +160,17 @@ impl<Crypto: CryptoScheme> BroadcastStageProcessor<KeygenCeremony<Crypto>>
 	) -> StageResult<KeygenCeremony<Crypto>> {
 		let hash_commitments = match verify_broadcasts(messages, &self.common.logger) {
 			Ok(hash_commitments) => hash_commitments,
-			Err((reported_parties, abort_reason)) =>
+			Err((reported_parties, abort_reason)) => {
+				slog::debug!(
+					self.common.logger,
+					"Broadcast verification is not successful for {}",
+					Self::NAME
+				);
 				return KeygenStageResult::Error(
 					reported_parties,
 					KeygenFailureReason::BroadcastFailure(abort_reason, Self::NAME),
-				),
+				)
+			},
 		};
 
 		slog::debug!(self.common.logger, "{} is successful", Self::NAME);


### PR DESCRIPTION
There is a small window between dropping a ceremony runner and dropping the corresponding ceremony handle. If a late message arrives (which often happens in case the ceremony times out) in that window, the thread will panic on trying to send the message through a channel, becase the receiving half of the channel is already gone while the sending still exists. 

The fix is simply to acknowledge that this window exists and not treat it as (an unrecoverable) error.

I also added a log for when broadcast verification fails to match "broadcast verification success", which would have been helpful in this case.

This should also go into `develop`.