### PR TITLE
fix: lock runner version 🐛

### DIFF
--- a/.github/workflows/.deb-publish.yaml
+++ b/.github/workflows/.deb-publish.yaml
@@ -27,7 +27,7 @@ env:
 jobs:
   build-deb:
     name: Build Deb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/.docker-build.yaml
+++ b/.github/workflows/.docker-build.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   set-variables:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       commit_hash: ${{ steps.commit_hash.outputs.commit_hash }}
       branch_name: ${{ steps.branch_name.outputs.branch_name }}

--- a/.github/workflows/ext-release.yaml
+++ b/.github/workflows/ext-release.yaml
@@ -18,7 +18,7 @@ on:
 #     types: [published]
 jobs:
   call-external-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Call external release repository
     steps:
       - name: Repository Dispatch

--- a/.github/workflows/release-prod.yaml
+++ b/.github/workflows/release-prod.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   set-variables:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       commit_hash: ${{ steps.commit_hash.outputs.commit_hash }}
       branch_name: ${{ steps.branch_name.outputs.branch_name }}


### PR DESCRIPTION
Due to GitHub migrating of their `ubuntu-latest` runner to `22.04` as explained [here](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/), the OS release name in [`.deb-publish.yaml`](https://github.com/chainflip-io/chainflip-backend/blob/develop/.github/workflows/.deb-publish.yaml#L47) now resolves to `jammy` instead of `focal` which broke testnet-tools [here](https://github.com/chainflip-io/chainflip-testnet-tools/actions/runs/3652700379/jobs/6171384990#step:29:284) because `ansible` is expecting `focal` as release name for getting the binaries into the nodes.