### PR TITLE
fix: don't submit ingress witnesses if no ingresses

### DIFF
--- a/engine/src/eth/erc20_witnesser.rs
+++ b/engine/src/eth/erc20_witnesser.rs
@@ -86,7 +86,7 @@ impl EthContractWitnesser for Erc20Witnesser {
 			self.monitored_addresses.insert(address);
 		}
 
-		let ingress_witnesses = block
+		let ingress_witnesses: Vec<_> = block
 			.block_items
 			.into_iter()
 			.filter_map(|event| match event.event_parameters {
@@ -102,20 +102,22 @@ impl EthContractWitnesser for Erc20Witnesser {
 			})
 			.collect();
 
-		let _result = state_chain_client
-			.submit_signed_extrinsic(
-				pallet_cf_witnesser::Call::witness_at_epoch {
-					call: Box::new(
-						pallet_cf_ingress_egress::Call::<_, EthereumInstance>::do_ingress {
-							ingress_witnesses,
-						}
-						.into(),
-					),
-					epoch_index: epoch,
-				},
-				logger,
-			)
-			.await;
+		if !ingress_witnesses.is_empty() {
+			let _result = state_chain_client
+				.submit_signed_extrinsic(
+					pallet_cf_witnesser::Call::witness_at_epoch {
+						call: Box::new(
+							pallet_cf_ingress_egress::Call::<_, EthereumInstance>::do_ingress {
+								ingress_witnesses,
+							}
+							.into(),
+						),
+						epoch_index: epoch,
+					},
+					logger,
+				)
+				.await;
+		}
 
 		Ok(())
 	}

--- a/engine/src/eth/ingress_witnesser.rs
+++ b/engine/src/eth/ingress_witnesser.rs
@@ -152,20 +152,22 @@ where
 								})
 								.collect::<Vec<IngressWitness<Ethereum>>>();
 
-								let _result = state_chain_client
-									.submit_signed_extrinsic(
-										pallet_cf_witnesser::Call::witness_at_epoch {
-											call: Box::new(
-												pallet_cf_ingress_egress::Call::<_, EthereumInstance>::do_ingress {
-													ingress_witnesses
-												}
-												.into(),
-											),
-											epoch_index: epoch_start.epoch_index,
-										},
-										&logger,
-									)
-									.await;
+								if !ingress_witnesses.is_empty() {
+									let _result = state_chain_client
+										.submit_signed_extrinsic(
+											pallet_cf_witnesser::Call::witness_at_epoch {
+												call: Box::new(
+													pallet_cf_ingress_egress::Call::<_, EthereumInstance>::do_ingress {
+														ingress_witnesses
+													}
+													.into(),
+												),
+												epoch_index: epoch_start.epoch_index,
+											},
+											&logger,
+										)
+										.await;
+								}
 						},
 						else => break,
 					};


### PR DESCRIPTION
Noticed a lot of failing witness calls on testnet, this is why (they're all identical, submitting duplicate witnesses)