### PR TITLE
fix: exchange rate for asset pair

### DIFF
--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -65,7 +65,7 @@ fn can_swap_assets() {
 			}
 		));
 		assert_eq!(
-			LiquidityPools::swap_rate(&Asset::Flip, 0u128),
+			LiquidityPools::swap_rate(Asset::Flip, Asset::Usdc, 0u128),
 			ExchangeRate::from_rational(10, 1)
 		);
 
@@ -80,7 +80,7 @@ fn can_swap_assets() {
 			}
 		));
 		assert_eq!(
-			LiquidityPools::swap_rate(&Asset::Eth, 0u128),
+			LiquidityPools::swap_rate(Asset::Eth, Asset::Usdc, 0u128),
 			ExchangeRate::from_rational(5, 1)
 		);
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -454,7 +454,8 @@ pub trait PoolsApi {
 	fn cf_swap_rate(
 		&self,
 		at: Option<state_chain_runtime::Hash>,
-		asset: Asset,
+		input_asset: Asset,
+		output_asset: Asset,
 		input_amount: AssetAmount,
 	) -> RpcResult<ExchangeRate>;
 }
@@ -469,12 +470,13 @@ where
 	fn cf_swap_rate(
 		&self,
 		at: Option<state_chain_runtime::Hash>,
-		asset: Asset,
+		input_asset: Asset,
+		output_asset: Asset,
 		input_amount: AssetAmount,
 	) -> RpcResult<ExchangeRate> {
 		self.client
 			.runtime_api()
-			.cf_swap_rate(&self.query_block_id(at), &asset, input_amount)
+			.cf_swap_rate(&self.query_block_id(at), input_asset, output_asset, input_amount)
 			.map_err(to_rpc_error)
 	}
 }

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -185,9 +185,9 @@ fn cannot_manage_liquidity_during_maintenance() {
 #[test]
 fn can_open_and_close_liquidity() {
 	new_test_ext().execute_with(|| {
-		let asset = Asset::Flip;
+		const ASSET: Asset = Asset::Flip;
 		LiquidityPools::deploy(
-			&asset,
+			&ASSET,
 			TradingPosition::ClassicV3 {
 				range: Default::default(),
 				volume_0: 1_000_000,
@@ -195,11 +195,11 @@ fn can_open_and_close_liquidity() {
 			},
 		);
 		assert_eq!(
-			LiquidityPools::swap_rate(&asset, 0),
+			LiquidityPools::swap_rate(ASSET, Asset::Usdc, 0),
 			ExchangeRate::from_rational(5_000_000, 1_000_000)
 		);
 
-		FreeBalances::<Test>::insert(LP_ACCOUNT, asset, 1_000_000);
+		FreeBalances::<Test>::insert(LP_ACCOUNT, ASSET, 1_000_000);
 		FreeBalances::<Test>::insert(LP_ACCOUNT, Asset::Usdc, 1_000_000);
 
 		// Can open position
@@ -208,10 +208,10 @@ fn can_open_and_close_liquidity() {
 			volume_0: 1_000,
 			volume_1: 2_000,
 		};
-		assert_ok!(LiquidityProvider::open_position(Origin::signed(LP_ACCOUNT), asset, position,));
+		assert_ok!(LiquidityProvider::open_position(Origin::signed(LP_ACCOUNT), ASSET, position,));
 
 		assert_eq!(
-			LiquidityPools::swap_rate(&asset, 0),
+			LiquidityPools::swap_rate(ASSET, Asset::Usdc, 0),
 			ExchangeRate::from_rational(5_002_000, 1_001_000)
 		);
 
@@ -219,7 +219,7 @@ fn can_open_and_close_liquidity() {
 			crate::Event::<Test>::TradingPositionOpened {
 				account_id: LP_ACCOUNT,
 				position_id: 0,
-				asset,
+				asset: ASSET,
 				position,
 			},
 		));
@@ -227,10 +227,10 @@ fn can_open_and_close_liquidity() {
 		// Test close position
 		assert_ok!(LiquidityProvider::close_position(Origin::signed(LP_ACCOUNT), 0,));
 
-		assert_eq!(FreeBalances::<Test>::get(LP_ACCOUNT, asset), Some(1_000_000));
+		assert_eq!(FreeBalances::<Test>::get(LP_ACCOUNT, ASSET), Some(1_000_000));
 		assert_eq!(FreeBalances::<Test>::get(LP_ACCOUNT, Asset::Usdc), Some(1_000_000));
 		assert_eq!(
-			LiquidityPools::swap_rate(&asset, 0),
+			LiquidityPools::swap_rate(ASSET, Asset::Usdc, 0),
 			ExchangeRate::from_rational(5_000_000, 1_000_000)
 		);
 	});

--- a/state-chain/pallets/cf-pools/runtime-api/src/lib.rs
+++ b/state-chain/pallets/cf-pools/runtime-api/src/lib.rs
@@ -6,6 +6,10 @@ use sp_api::decl_runtime_apis;
 
 decl_runtime_apis!(
 	pub trait PoolsApi {
-		fn cf_swap_rate(asset: &Asset, input_amount: AssetAmount) -> ExchangeRate;
+		fn cf_swap_rate(
+			input_asset: Asset,
+			output_asset: Asset,
+			input_amount: AssetAmount,
+		) -> ExchangeRate;
 	}
 );

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -995,10 +995,10 @@ impl_runtime_apis! {
 
 	#[cfg(feature = "ibiza")]
 	impl pallet_cf_pools_runtime_api::PoolsApi<Block> for Runtime {
-		fn cf_swap_rate(asset: &Asset, input_amount: AssetAmount) -> ExchangeRate {
+		fn cf_swap_rate(input_asset: Asset, output_asset: Asset, input_amount: AssetAmount) -> ExchangeRate {
 			use cf_traits::LiquidityPoolApi;
 
-			LiquidityPools::swap_rate(asset, input_amount)
+			LiquidityPools::swap_rate(input_asset, output_asset, input_amount)
 		}
 	}
 

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -53,7 +53,11 @@ pub trait LiquidityPoolApi {
 	fn get_liquidity(asset: &Asset) -> (AssetAmount, AssetAmount);
 
 	/// Gets the current swap rate for an pool
-	fn swap_rate(asset: &Asset, input_amount: AssetAmount) -> ExchangeRate;
+	fn swap_rate(
+		input_asset: Asset,
+		output_asset: Asset,
+		input_amount: AssetAmount,
+	) -> ExchangeRate;
 
 	/// Calculates the liquidity that corresponds to a given trading position.
 	fn get_liquidity_amount_by_position(


### PR DESCRIPTION
Changes the exchange rate rpc so that it takes an asset pair instead of a single asset.