### PR TITLE
Fix/broadcast retry

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -505,7 +505,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn start_next_broadcast_attempt(broadcast_attempt: BroadcastAttempt<T, I>) {
 		let broadcast_id = broadcast_attempt.broadcast_attempt_id.broadcast_id;
 		if let Some((api_call, signature)) = ThresholdSignatureData::<T, I>::get(broadcast_id) {
-			let EpochKey { key, .. } = T::KeyProvider::current_key_epoch_index();
+			let EpochKey { key, .. } = T::KeyProvider::current_epoch_key();
 			if <T::TargetChain as ChainCrypto>::verify_threshold_signature(
 				&key,
 				&api_call.threshold_signature_payload(),

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -104,7 +104,7 @@ thread_local! {
 pub struct MockKeyProvider;
 
 impl cf_traits::KeyProvider<MockEthereum> for MockKeyProvider {
-	fn current_key_epoch_index() -> EpochKey<<MockEthereum as ChainCrypto>::AggKey> {
+	fn current_epoch_key() -> EpochKey<<MockEthereum as ChainCrypto>::AggKey> {
 		EpochKey {
 			key: if VALIDKEY.with(|cell| *cell.borrow()) { VALID_AGG_KEY } else { INVALID_AGG_KEY },
 			epoch_index: Default::default(),

--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -651,8 +651,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					ThresholdCeremonyType::KeygenVerification,
 				)
 			} else {
-				let EpochKey { key, epoch_index, key_state } =
-					T::KeyProvider::current_key_epoch_index();
+				let EpochKey { key, epoch_index, key_state } = T::KeyProvider::current_epoch_key();
 				(
 					match key_state {
 						KeyState::Active =>

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -142,7 +142,7 @@ pub const MOCK_AGG_KEY: [u8; 4] = *b"AKEY";
 pub struct MockKeyProvider;
 
 impl cf_traits::KeyProvider<MockEthereum> for MockKeyProvider {
-	fn current_key_epoch_index() -> EpochKey<<MockEthereum as ChainCrypto>::AggKey> {
+	fn current_epoch_key() -> EpochKey<<MockEthereum as ChainCrypto>::AggKey> {
 		EpochKey { key: MOCK_AGG_KEY, epoch_index: Default::default(), key_state: KeyState::Active }
 	}
 }

--- a/state-chain/pallets/cf-threshold-signature/src/tests.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/tests.rs
@@ -250,7 +250,7 @@ fn keygen_verification_ceremony_calls_callback_on_failure() {
 		.build()
 		.execute_with(|| {
 			const PAYLOAD: &[u8; 4] = b"OHAI";
-			let EpochKey { key: current_key_id, .. } = MockKeyProvider::current_key_epoch_index();
+			let EpochKey { key: current_key_id, .. } = MockKeyProvider::current_epoch_key();
 			let (request_id, _) = EthereumThresholdSigner::request_keygen_verification_signature(
 				*PAYLOAD,
 				current_key_id.into(),
@@ -484,7 +484,7 @@ mod unsigned_validation {
 
 				let (_request_id, ceremony_id) =
 					<EthereumThresholdSigner as ThresholdSigner<_>>::request_signature(PAYLOAD);
-				let EpochKey { key: current_key, .. } = MockKeyProvider::current_key_epoch_index();
+				let EpochKey { key: current_key, .. } = MockKeyProvider::current_epoch_key();
 
 				assert!(
 					Test::validate_unsigned(
@@ -494,7 +494,7 @@ mod unsigned_validation {
 					)
 					.is_ok(),
 					"Validation Failed: {:?} / {:?}",
-					MockKeyProvider::current_key_epoch_index(),
+					MockKeyProvider::current_epoch_key(),
 					current_key
 				);
 			});
@@ -571,7 +571,7 @@ mod failure_reporting {
 	) -> CeremonyContext<Test, Instance1> {
 		const PAYLOAD: <MockEthereum as ChainCrypto>::Payload = *b"OHAI";
 		MockEpochInfo::set_authorities(Vec::from_iter(validator_set));
-		let EpochKey { key: current_key_id, .. } = MockKeyProvider::current_key_epoch_index();
+		let EpochKey { key: current_key_id, .. } = MockKeyProvider::current_epoch_key();
 		CeremonyContext::<Test, Instance1> {
 			request_context: RequestContext { request_id: 1, attempt_count: 0, payload: PAYLOAD },
 			threshold_ceremony_type: ThresholdCeremonyType::Standard,

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -913,7 +913,7 @@ impl<T: Config<I>, I: 'static> VaultRotator for Pallet<T, I> {
 }
 
 impl<T: Config<I>, I: 'static> KeyProvider<T::Chain> for Pallet<T, I> {
-	fn current_key_epoch_index() -> EpochKey<<T::Chain as ChainCrypto>::AggKey> {
+	fn current_epoch_key() -> EpochKey<<T::Chain as ChainCrypto>::AggKey> {
 		let current_vault_epoch_and_state = CurrentVaultEpochAndState::<T, I>::get();
 
 		EpochKey {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -265,7 +265,7 @@ impl ChainEnvironment<cf_chains::dot::api::SystemAccounts, PolkadotAccountId> fo
 		use sp_runtime::{traits::IdentifyAccount, MultiSigner};
 		match query {
 			cf_chains::dot::api::SystemAccounts::Proxy => {
-				match <PolkadotVault as KeyProvider<Polkadot>>::current_key_epoch_index() {
+				match <PolkadotVault as KeyProvider<Polkadot>>::current_epoch_key() {
 					EpochKey { key, key_state, .. } if key_state == KeyState::Active =>
 						Some(MultiSigner::Sr25519(key.0).into_account()),
 					_ => None,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -386,8 +386,9 @@ pub struct EpochKey<Key> {
 
 /// Provides the currently valid key for multisig ceremonies.
 pub trait KeyProvider<C: ChainCrypto> {
-	/// Get the chain's current agg key and the epoch index for the current key.
-	fn current_key_epoch_index() -> EpochKey<C::AggKey>;
+	/// Get the chain's current agg key, the epoch index for the current key and the state of that
+	/// key.
+	fn current_epoch_key() -> EpochKey<C::AggKey>;
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_key(_key: C::AggKey) {

--- a/state-chain/traits/src/mocks/key_provider.rs
+++ b/state-chain/traits/src/mocks/key_provider.rs
@@ -6,7 +6,7 @@ use crate::EpochKey;
 pub struct MockKeyProvider<Chain: cf_chains::Chain>(PhantomData<Chain>);
 
 impl<C: cf_chains::ChainCrypto> crate::KeyProvider<C> for MockKeyProvider<C> {
-	fn current_key_epoch_index() -> EpochKey<C::AggKey> {
+	fn current_epoch_key() -> EpochKey<C::AggKey> {
 		EpochKey::default()
 	}
 }


### PR DESCRIPTION
There was a bug where if the broadcast transaction of the rotation activation failed, then we wouldn't retry, because we'd attempt the retry and hit "key unavailable". This fixes this by always attempt to verify the signature, even if the key is unavailable. This might result in a few more failed broadcasts, but this is pretty unavoidable. Note that we do still halt threshold signing if the key is unavailable, which should limit most of the transactions that would otherwise fail.