### PR TITLE
fix: reset nonce to 1 instead of 0

### DIFF
--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -475,6 +475,6 @@ impl<T: Config> Pallet<T> {
 
 	#[cfg(feature = "ibiza")]
 	pub fn reset_polkadot_proxy_account_nonce() {
-		PolkadotProxyAccountNonce::<T>::set(0);
+		PolkadotProxyAccountNonce::<T>::set(1);
 	}
 }


### PR DESCRIPTION
The 0 nonce for the first polkadot aggkey is used up to do the polkadot vault creation apicall and when we witness the vault creation call, we start the next vault which includes resetting the nonce to 0. This would mean that the next call for the first polkadot aggkey will again be constructed using nonce 0 which is invalid since it has been already used. We instead reset the nonce to 1 instead of 0 so that we dont use nonce 0 for the first aggkey. This also means that all future polkadot aggkey will start from nonce 1 but this should be fine since there is necessity to start the nonce from 0.