### PR TITLE
fix: polkadot nonce reset to 0

### DIFF
--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -343,13 +343,15 @@ pub mod pallet {
 				});
 
 				// Witness the agg_key rotation manually in the vaults pallet for polkadot
-				T::PolkadotVaultKeyWitnessedHandler::on_new_key_activated(
+				let dispatch_result = T::PolkadotVaultKeyWitnessedHandler::on_new_key_activated(
 					dot_witnessed_aggkey.to_vec().try_into().expect(
 						"This should not fail since the size of vec is guaranteed to be 32",
 					),
 					block_number,
 					tx_hash,
-				)
+				)?;
+				Self::next_polkadot_proxy_account_nonce();
+				Ok(dispatch_result)
 			}
 			#[cfg(not(feature = "ibiza"))]
 			{
@@ -475,6 +477,6 @@ impl<T: Config> Pallet<T> {
 
 	#[cfg(feature = "ibiza")]
 	pub fn reset_polkadot_proxy_account_nonce() {
-		PolkadotProxyAccountNonce::<T>::set(1);
+		PolkadotProxyAccountNonce::<T>::set(0);
 	}
 }


### PR DESCRIPTION
we reset the polkadot nonce again to 0, but in the first aggkey case where the first nonce is already used up in creating the polkadot vault, we increase the nonce by 1 after manually witnessing the first aggkey so that it doesnt reuse nonce 0. The nonces for all future aggkeys will reset to 0. This PR follows up the following PR: https://github.com/chainflip-io/chainflip-backend/pull/2602