### PR TITLE
feat: emit events to link swap / withdrawal with egress

### DIFF
--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -156,6 +156,7 @@ fn can_swap_assets() {
 		const EXPECTED_OUTPUT: AssetAmount = 4545;
 		System::assert_has_event(Event::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Event::EgressScheduled {
+				id: 1,
 				asset: eth::Asset::Flip,
 				amount: EXPECTED_OUTPUT,
 				egress_address: egress_address.into(),
@@ -193,8 +194,6 @@ fn can_swap_assets() {
 
 		System::assert_has_event(Event::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Event::BatchBroadcastRequested {
-				fetch_batch_size: 1,
-				egress_batch_size: 1,
 				broadcast_id: 1,
 				egress_ids: vec![1],
 			},

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -57,6 +57,7 @@ fn can_schedule_egress_to_batch() {
 		IngressEgress::schedule_egress(ETH_ETH, 1_000, ALICE_ETH_ADDRESS.into());
 		IngressEgress::schedule_egress(ETH_ETH, 2_000, ALICE_ETH_ADDRESS.into());
 		System::assert_last_event(Event::IngressEgress(crate::Event::EgressScheduled {
+			id: 2,
 			asset: ETH_ETH,
 			amount: 2_000,
 			egress_address: ALICE_ETH_ADDRESS.into(),
@@ -65,6 +66,7 @@ fn can_schedule_egress_to_batch() {
 		IngressEgress::schedule_egress(ETH_FLIP, 3_000, BOB_ETH_ADDRESS.into());
 		IngressEgress::schedule_egress(ETH_FLIP, 4_000, BOB_ETH_ADDRESS.into());
 		System::assert_last_event(Event::IngressEgress(crate::Event::EgressScheduled {
+			id: 4,
 			asset: ETH_FLIP,
 			amount: 4_000,
 			egress_address: BOB_ETH_ADDRESS.into(),
@@ -175,8 +177,6 @@ fn on_idle_can_send_batch_all() {
 		IngressEgress::on_idle(1, 1_000_000_000_000u64);
 
 		System::assert_has_event(Event::IngressEgress(crate::Event::BatchBroadcastRequested {
-			fetch_batch_size: 5u32,
-			egress_batch_size: 8u32,
 			broadcast_id: 1,
 			egress_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
 		}));
@@ -237,8 +237,6 @@ fn can_manually_send_batch_all() {
 		// Send only 2 requests
 		assert_ok!(IngressEgress::egress_scheduled_assets_for_chain(Origin::root(), Some(2)));
 		System::assert_has_event(Event::IngressEgress(crate::Event::BatchBroadcastRequested {
-			fetch_batch_size: 1u32,
-			egress_batch_size: 1u32,
 			broadcast_id: 1,
 			egress_ids: vec![1],
 		}));
@@ -248,8 +246,6 @@ fn can_manually_send_batch_all() {
 		assert_ok!(IngressEgress::egress_scheduled_assets_for_chain(Origin::root(), None));
 
 		System::assert_has_event(Event::IngressEgress(crate::Event::BatchBroadcastRequested {
-			fetch_batch_size: 3u32,
-			egress_batch_size: 7u32,
 			broadcast_id: 1,
 			egress_ids: vec![2, 3, 4, 5, 6, 7, 8],
 		}));
@@ -278,8 +274,6 @@ fn on_idle_batch_size_is_limited_by_weight() {
 		);
 
 		System::assert_has_event(Event::IngressEgress(crate::Event::BatchBroadcastRequested {
-			fetch_batch_size: 1u32,
-			egress_batch_size: 2u32,
 			broadcast_id: 1,
 			egress_ids: vec![1, 2],
 		}));
@@ -291,8 +285,6 @@ fn on_idle_batch_size_is_limited_by_weight() {
 		);
 
 		System::assert_has_event(Event::IngressEgress(crate::Event::BatchBroadcastRequested {
-			fetch_batch_size: 1u32,
-			egress_batch_size: 2u32,
 			broadcast_id: 1,
 			egress_ids: vec![3, 4],
 		}));

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Swap {
 pub mod pallet {
 
 	use cf_chains::AnyChain;
-	use cf_primitives::{Asset, AssetAmount, BasisPoints};
+	use cf_primitives::{Asset, AssetAmount, BasisPoints, EgressId};
 	use cf_traits::{AccountRoleRegistry, Chainflip, EgressApi, SwapIntentHandler};
 
 	use super::*;
@@ -95,7 +95,7 @@ pub mod pallet {
 		/// A swap was executed.
 		SwapExecuted { swap_id: u64 },
 		/// A swap egress was scheduled.
-		SwapEgressScheduled { swap_id: u64, egress_amount: AssetAmount },
+		SwapEgressScheduled { swap_id: u64, egress_id: EgressId, egress_amount: AssetAmount },
 	}
 	#[pallet::error]
 	pub enum Error<T> {
@@ -191,11 +191,16 @@ pub mod pallet {
 					bundle_input,
 					Rounding::Down,
 				) {
+					let egress_id = T::EgressHandler::schedule_egress(
+						egress_asset,
+						swap_output,
+						egress_address,
+					);
 					Self::deposit_event(Event::<T>::SwapEgressScheduled {
 						swap_id: id,
+						egress_id,
 						egress_amount: swap_output,
 					});
-					T::EgressHandler::schedule_egress(egress_asset, swap_output, egress_address);
 				} else {
 					log::error!(
 						"Unable to calculate valid swap output for swap {:?}!",

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -209,6 +209,7 @@ fn expect_swap_id_to_be_emitted() {
 			crate::mock::Event::Swapping(crate::Event::SwapExecuted { swap_id: 1 }),
 			crate::mock::Event::Swapping(crate::Event::SwapEgressScheduled {
 				swap_id: 1,
+				egress_id: 1,
 				egress_amount: 500
 			})
 		);

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -297,7 +297,7 @@ impl EgressApi<AnyChain> for AnyChainIngressEgressHandler {
 		asset: Asset,
 		amount: AssetAmount,
 		egress_address: <AnyChain as Chain>::ChainAccount,
-	) {
+	) -> cf_primitives::EgressId {
 		match asset.into() {
 			ForeignChain::Ethereum => crate::EthereumIngressEgress::schedule_egress(
 				asset.try_into().expect("Checked for asset compatibility"),

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -20,7 +20,7 @@ use cf_chains::{
 
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, AuthorityCount, BroadcastId, CeremonyId,
-	EpochIndex, EthereumAddress, ForeignChainAddress, IntentId,
+	EgressId, EpochIndex, EthereumAddress, ForeignChainAddress, IntentId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
@@ -750,7 +750,7 @@ pub trait EgressApi<C: Chain> {
 		foreign_asset: C::ChainAsset,
 		amount: AssetAmount,
 		egress_address: C::ChainAccount,
-	);
+	) -> EgressId;
 }
 
 impl<T: frame_system::Config> EgressApi<Ethereum> for T {
@@ -758,7 +758,8 @@ impl<T: frame_system::Config> EgressApi<Ethereum> for T {
 		_foreign_asset: assets::eth::Asset,
 		_amount: AssetAmount,
 		_egress_address: <Ethereum as Chain>::ChainAccount,
-	) {
+	) -> EgressId {
+		0
 	}
 }
 
@@ -768,7 +769,8 @@ impl<T: frame_system::Config> EgressApi<Polkadot> for T {
 		_foreign_asset: assets::dot::Asset,
 		_amount: AssetAmount,
 		_egress_address: <Polkadot as Chain>::ChainAccount,
-	) {
+	) -> EgressId {
+		0
 	}
 }
 


### PR DESCRIPTION
Adds the egress id to events for swaps and lp withdrawals. 

This allows us to link these to an egress id and hence to a broadcast id. 