### PR TITLE
fix: submit the vault_key_rotated extrinsic when we witness ProxyAdded

### DIFF
--- a/engine/src/eth/key_manager.rs
+++ b/engine/src/eth/key_manager.rs
@@ -240,7 +240,7 @@ impl EthContractWitnesser for KeyManager {
 												new_agg_key.serialize(),
 											),
 										block_number,
-										tx_hash: event.tx_hash,
+										tx_id: event.tx_hash,
 									}
 									.into(),
 								),

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -743,7 +743,13 @@ pub struct PolkadotPublicKey(pub sr25519::Public);
 
 impl Default for PolkadotPublicKey {
 	fn default() -> Self {
-		vec![0; 32].try_into().unwrap()
+		[0; 32].into()
+	}
+}
+
+impl From<[u8; 32]> for PolkadotPublicKey {
+	fn from(pub_key_bytes: [u8; 32]) -> Self {
+		PolkadotPublicKey(sr25519::Public(pub_key_bytes))
 	}
 }
 

--- a/state-chain/pallets/cf-vaults/src/benchmarking.rs
+++ b/state-chain/pallets/cf-vaults/src/benchmarking.rs
@@ -166,7 +166,7 @@ benchmarks_instance_pallet! {
 		let call = Call::<T, I>::vault_key_rotated_externally {
 			new_public_key: AggKeyFor::<T, I>::benchmark_value(),
 			block_number: 5u32.into(),
-			tx_hash: Decode::decode(&mut &TX_HASH[..]).unwrap()
+			tx_id: Decode::decode(&mut &TX_HASH[..]).unwrap()
 		};
 	} : { call.dispatch_bypass_filter(origin)? }
 	verify {

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -633,7 +633,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new_public_key: AggKeyFor<T, I>,
 			block_number: ChainBlockNumberFor<T, I>,
-			_tx_hash: TransactionIdFor<T, I>,
+			_tx_id: TransactionIdFor<T, I>,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureWitnessedAtCurrentEpoch::ensure_origin(origin)?;
 


### PR DESCRIPTION
Targets: #2562 

We were witnessing the broadcast, but weren't witnessing the vault_key_rotated. On Ethereum these are two distinct events, but for Polkadot, they are one and the same transaction and event, so we just submit both upon receiving the ProxyAdded event.