### PR TITLE
fix: chain id for egress ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ name = "cf-primitives"
 version = "0.1.0"
 dependencies = [
  "ethabi",
+ "frame-support",
  "hex",
  "parity-scale-codec",
  "scale-info",

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -12,7 +12,8 @@ use state_chain_runtime::{
 
 use cf_primitives::{
 	chains::{assets::eth, Ethereum},
-	AccountId, AccountRole, Asset, AssetAmount, ExchangeRate, ForeignChainAddress, TradingPosition,
+	AccountId, AccountRole, Asset, AssetAmount, ExchangeRate, ForeignChain, ForeignChainAddress,
+	TradingPosition,
 };
 use cf_traits::{AddressDerivationApi, LiquidityPoolApi, LpProvisioningApi};
 use pallet_cf_ingress_egress::IngressWitness;
@@ -156,7 +157,7 @@ fn can_swap_assets() {
 		const EXPECTED_OUTPUT: AssetAmount = 4545;
 		System::assert_has_event(Event::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Event::EgressScheduled {
-				id: 1,
+				id: (ForeignChain::Ethereum, 1),
 				asset: eth::Asset::Flip,
 				amount: EXPECTED_OUTPUT,
 				egress_address: egress_address.into(),
@@ -195,7 +196,7 @@ fn can_swap_assets() {
 		System::assert_has_event(Event::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Event::BatchBroadcastRequested {
 				broadcast_id: 1,
-				egress_ids: vec![1],
+				egress_ids: vec![(ForeignChain::Ethereum, 1)],
 			},
 		));
 	});

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::{DisabledEgressAssets, FetchOrTransfer, ScheduledEgressRequests};
 use cf_chains::benchmarking_value::BenchmarkValue;
+use cf_primitives::ForeignChain;
 use frame_benchmarking::{account, benchmarks_instance_pallet};
 use frame_support::traits::Hooks;
 
@@ -23,7 +24,7 @@ benchmarks_instance_pallet! {
 				});
 			} else {
 				batch.push(FetchOrTransfer::Transfer {
-					egress_id: 1,
+					egress_id: (ForeignChain::Ethereum, 1),
 					asset: egress_asset,
 					to: egress_address.clone(),
 					amount: 1_000,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{mock::*, EarnedRelayerFees, Pallet, Swap, SwapQueue, WeightInfo};
 use cf_chains::AnyChain;
-use cf_primitives::{Asset, ForeignChainAddress};
+use cf_primitives::{Asset, ForeignChain, ForeignChainAddress};
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{mocks::egress_handler::MockEgressHandler, SwapIntentHandler};
 use frame_support::{assert_ok, sp_std::iter};
@@ -209,7 +209,7 @@ fn expect_swap_id_to_be_emitted() {
 			crate::mock::Event::Swapping(crate::Event::SwapExecuted { swap_id: 1 }),
 			crate::mock::Event::Swapping(crate::Event::SwapEgressScheduled {
 				swap_id: 1,
-				egress_id: 1,
+				egress_id: (ForeignChain::Ethereum, 1),
 				egress_amount: 500
 			})
 		);

--- a/state-chain/primitives/Cargo.toml
+++ b/state-chain/primitives/Cargo.toml
@@ -10,6 +10,11 @@ serde = { optional = true, version = '1.0.126', features = ['derive'] }
 hex = { optional = true, version = '0.4'}
 ethabi = {default-features = false, version = '17.0'}
 
+[dependencies.frame-support]
+default-features = false
+git = 'https://github.com/chainflip-io/substrate.git'
+tag = 'chainflip-monthly-2022-06+01'
+
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/chainflip-io/substrate.git'
@@ -47,4 +52,5 @@ std = [
   'sp-runtime/std',
   'sp-std/std',
   'sp-core/std',
+  'frame-support/std',
 ]

--- a/state-chain/primitives/src/chains.rs
+++ b/state-chain/primitives/src/chains.rs
@@ -1,4 +1,5 @@
 use super::*;
+use frame_support::traits::Get;
 
 pub mod assets;
 
@@ -11,6 +12,12 @@ macro_rules! chains {
 			impl AsRef<ForeignChain> for $chain {
 				fn as_ref(&self) -> &ForeignChain {
 					&ForeignChain::$chain
+				}
+			}
+
+			impl Get<ForeignChain> for $chain {
+				fn get() -> ForeignChain {
+					ForeignChain::$chain
 				}
 			}
 		)+
@@ -39,4 +46,10 @@ chains! {
 fn test_chains() {
 	assert_eq!(Ethereum.as_ref(), &ForeignChain::Ethereum);
 	assert_eq!(Polkadot.as_ref(), &ForeignChain::Polkadot);
+}
+
+#[test]
+fn test_get_chain_identifier() {
+	assert_eq!(Ethereum::get(), ForeignChain::Ethereum);
+	assert_eq!(Polkadot::get(), ForeignChain::Polkadot);
 }

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -36,7 +36,9 @@ pub type AuthorityCount = u32;
 
 pub type IntentId = u64;
 
-pub type EgressId = u64;
+pub type EgressCounter = u64;
+
+pub type EgressId = (ForeignChain, EgressCounter);
 
 pub type ExchangeRate = FixedU128;
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -20,7 +20,7 @@ use cf_chains::{
 
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, AuthorityCount, BroadcastId, CeremonyId,
-	EgressId, EpochIndex, EthereumAddress, ForeignChainAddress, IntentId,
+	EgressId, EpochIndex, EthereumAddress, ForeignChain, ForeignChainAddress, IntentId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
@@ -759,7 +759,7 @@ impl<T: frame_system::Config> EgressApi<Ethereum> for T {
 		_amount: AssetAmount,
 		_egress_address: <Ethereum as Chain>::ChainAccount,
 	) -> EgressId {
-		0
+		(ForeignChain::Ethereum, 0)
 	}
 }
 
@@ -770,7 +770,7 @@ impl<T: frame_system::Config> EgressApi<Polkadot> for T {
 		_amount: AssetAmount,
 		_egress_address: <Polkadot as Chain>::ChainAccount,
 	) -> EgressId {
-		0
+		(ForeignChain::Ethereum, 0)
 	}
 }
 

--- a/state-chain/traits/src/mocks/egress_handler.rs
+++ b/state-chain/traits/src/mocks/egress_handler.rs
@@ -1,7 +1,7 @@
 use super::{MockPallet, MockPalletStorage};
 use crate::EgressApi;
 use cf_chains::Chain;
-use cf_primitives::{AssetAmount, EgressId};
+use cf_primitives::{AssetAmount, EgressId, ForeignChain};
 use sp_std::marker::PhantomData;
 
 pub struct MockEgressHandler<C>(PhantomData<C>);
@@ -29,7 +29,7 @@ impl<C: Chain> EgressApi<C> for MockEgressHandler<C> {
 				.map(|v| {
 					let next_id = if let Some((id, _)) = v.last() { id + 1 } else { 1 };
 					v.push((next_id, (foreign_asset, amount, egress_address)));
-					next_id
+					(ForeignChain::Ethereum, next_id)
 				})
 				.unwrap()
 		})


### PR DESCRIPTION
Changed the EgressId so events emitted contain ForeignChain enum as chain identifier.

This allows unique identification of egress transaction from the events

Closes #2626 