### PR TITLE
feat: use custom zmq binding to increase socket limit (#2521)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
 dependencies = [
  "cc",
 ]
@@ -10788,8 +10788,7 @@ dependencies = [
 [[package]]
 name = "zmq"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
+source = "git+https://github.com/chainflip-io/rust-zmq.git?tag=chainflip-v0.9.2+1#3fb5e132ddd7c3ed40da8a93c3a2fdeef2853e69"
 dependencies = [
  "bitflags",
  "libc",
@@ -10800,8 +10799,7 @@ dependencies = [
 [[package]]
 name = "zmq-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
+source = "git+https://github.com/chainflip-io/rust-zmq.git?tag=chainflip-v0.9.2+1#3fb5e132ddd7c3ed40da8a93c3a2fdeef2853e69"
 dependencies = [
  "libc",
  "metadeps",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -85,7 +85,7 @@ typenum = "1.15"
 schnorrkel = "0.9.1"
 rayon = "1.5"
 pin-project = "1.0.11"
-zmq = {version ="0.9.2", features = ["vendored"]}
+zmq = {git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1", features = ["vendored"]}
 ed25519-dalek = "*"
 x25519-dalek = {version ="*", features = ["serde"]}
 rand = "0.8.4"

--- a/engine/src/p2p/core.rs
+++ b/engine/src/p2p/core.rs
@@ -164,8 +164,7 @@ pub fn start(
 
 	let zmq_context = zmq::Context::new();
 
-	// TODO: consider if we need to change the default limit for open sockets
-	// (the default is 1024)
+	zmq_context.set_max_sockets(65536).expect("should update socket limit");
 
 	// TODO: consider keeping track of "last activity" on any outgoing
 	// socket connection and disconnecting inactive peers (see proxy_expire_idle_peers


### PR DESCRIPTION
Just cherry-picking the socket limit fix from develop. With this, we should probably revert #2500 (and potentially also #2497) for reasons discussed in https://github.com/chainflip-io/chainflip-backend/pull/2521#issuecomment-1347758192. 