### PR TITLE
fix: late messages are no longer crashing a timed-out ceremony (#2535)

### DIFF
--- a/engine/src/multisig/client/ceremony_manager.rs
+++ b/engine/src/multisig/client/ceremony_manager.rs
@@ -591,7 +591,7 @@ impl<Ceremony: CeremonyTrait> CeremonyStates<Ceremony> {
 		// associated with it) and dropping the corresponding ceremony handle, which makes it
 		// possible for the following `send` to fail
 		if ceremony_handle.message_sender.send((sender_id, data)).is_err() {
-			slog::debug!(logger, "Could not send message: ceremony runner has been dropped");
+			slog::debug!(logger, "Ignoring data: ceremony runner has been dropped");
 		}
 	}
 

--- a/engine/src/multisig/client/keygen/keygen_stages.rs
+++ b/engine/src/multisig/client/keygen/keygen_stages.rs
@@ -161,7 +161,7 @@ impl<Crypto: CryptoScheme> BroadcastStageProcessor<KeygenCeremony<Crypto>>
 		let hash_commitments = match verify_broadcasts(messages, &self.common.logger) {
 			Ok(hash_commitments) => hash_commitments,
 			Err((reported_parties, abort_reason)) => {
-				slog::debug!(
+				slog::warn!(
 					self.common.logger,
 					"Broadcast verification is not successful for {}",
 					Self::NAME


### PR DESCRIPTION
Cherry picking an important fix from perseverance into develop.