### PR TITLE
feat: Dot Fee Witnessing

### DIFF
--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -48,31 +48,6 @@ pub type PolkadotUncheckedExtrinsic =
 /// The payload being signed in transactions.
 pub type PolkadotPayload = SignedPayload<PolkadotRuntimeCall, PolkadotSignedExtra>;
 
-// ====== Copied from the Transaction Payment Pallet Definitions =======
-// Keeping only what we actually need.
-
-#[derive(Encode, Decode, TypeInfo, Copy, Clone, Default, PartialEq, Eq, Debug)]
-pub struct InclusionFee {
-	pub base_fee: PolkadotBalance,
-	pub len_fee: PolkadotBalance,
-	pub adjusted_weight_fee: PolkadotBalance,
-}
-
-impl InclusionFee {
-	pub fn inclusion_fee(&self) -> PolkadotBalance {
-		self.base_fee
-			.saturating_add(self.len_fee)
-			.saturating_add(self.adjusted_weight_fee)
-	}
-}
-
-#[derive(Encode, Decode, TypeInfo, Copy, Clone, Default, PartialEq, Eq, Debug)]
-pub struct FeeDetails {
-	pub inclusion_fee: Option<InclusionFee>,
-}
-
-// ====== Copied from the Transaction Payment Pallet Definitions =======
-
 // Westend testnet
 pub const WESTEND_METADATA: PolkadotMetadata = PolkadotMetadata {
 	spec_version: 9340,


### PR DESCRIPTION
Introduces Polkadot Fee witnessing.

As part of this PR I added a trait which all the subxt queries sit behind. This will make testing easier, and also will lower the impact to the witnesser code should we move away from subxt.

Next will write some unit tests for the witnesser.

Tested against a localnet and works as expected:
![Screenshot 2022-12-20 at 16 35 59](https://user-images.githubusercontent.com/8342557/208705731-b0708067-29a9-4521-b36a-3771c4df20fd.png)

