### PR TITLE
Fix formatting in CFE main

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> anyhow::Result<()> {
 				.await
 				.context("Failed to submit version to state chain")?;
 
-			// Rustfmt struggles with this
+			// Rustfmt breaks otherwise
 			#[rustfmt::skip]
 			let (
 				epoch_start_sender,


### PR DESCRIPTION
(The PR is meant to be reviewed by individual commits)

While working on https://github.com/chainflip-io/chainflip-backend/pull/2672 I noticed that `build_broadcast_channel` was preventing main.rs from being properly formatted (seems to only be the problem if the number of receivers is high).

~~In #2672 it was also clear that it is more convenient to simply clone the receiver as needed instead of having the helper function generate all clones beforehand. For example, I have a function in that PR that spawns all witnessers, and it is much easier to simply pass one receiver and have that function create as many clones as it needs. I also don't see any advantages to the original approach.~~

~~With all that in mind, I removed the `build_broadcast_channel` wrapper in this PR, replacing it with `async_broadcast::broadcast` which does the same without making clones, and reformatted `main.rs`, which should make #2672 more clear.~~

EDIT: instead of removing `build_broadcast_channel` which could be problematic, I solved the problem with `#[rustfmt::skip]`.

