### PR TITLE
chore: add `protobuf-compiler` system dep 🪄

### DIFF
--- a/docker/rust-base.Dockerfile
+++ b/docker/rust-base.Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     lld \
     python3-dev \
     jq \
-    gcc-multilib
+    gcc-multilib \
+    protobuf-compiler
 
 # Set environment
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
This OR adds `protobuf-compiler` system dependency to the runst base image used in CI.
Related to: #2682 