### PR TITLE
feat: cargo check-features command

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -18,7 +18,7 @@ ci-test-ibiza = "test --lib --features ibiza --features runtime-benchmarks"
 ci-clippy = "clippy --all-targets --all-features -- -D warnings"
 
 # Check for feature inconsistencies.
-check-features = '''
+check-sc-features = '''
 tree --no-default-features --depth 1 --edges=features,normal
     -p state-chain-*
     -p pallet-cf-*


### PR DESCRIPTION
Adds a command to sanity-check the activated features on our crates. 

`cargo check-features | grep default` should list any dependencies that incorrectly have the default feature activated.

There are still some false positives unfortunately so I don't recommend using this in CI, but it can help when debugging build issues. 