### PR TITLE
chore: remove stale env vars

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -242,8 +242,6 @@ jobs:
           npm install
       - name: Generate State Chain docs
         run: |
-          export WS_ENDPOINT="ws://127.0.0.1:9944"
-          export TYPES_FILE="../state-chain/types.json"
           cd chainflip-docgen/
           npm run generate
       - name: Install graphviz


### PR DESCRIPTION
Not sure who's best to check this, so assigned all of you

CI builds fine, so I guess alles gut ?