### PR TITLE
fix: remove unused websocket dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "opaque-debug 0.3.0",
@@ -70,7 +70,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.7",
  "once_cell",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -197,14 +197,14 @@ dependencies = [
  "concurrent-queue",
  "futures-lite",
  "libc",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parking",
  "polling",
  "slab",
  "socket2",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -224,13 +224,13 @@ checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
 dependencies = [
  "async-io",
  "blocking",
- "cfg-if 1.0.0",
+ "cfg-if",
  "event-listener",
  "futures-lite",
  "libc",
  "once_cell",
  "signal-hook",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -244,14 +244,14 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-lite",
  "gloo-timers",
  "kv-log-macro",
- "log 0.4.17",
+ "log",
  "memchr",
  "once_cell",
  "pin-project-lite 0.2.9",
@@ -298,7 +298,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb8f2cd6962fa53c0e2a9d3f97eaa7dbd1e3cbbeeb4745403515b42ae07b3ff6"
 dependencies = [
  "tempfile",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -355,7 +355,7 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -379,25 +379,6 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "base64"
@@ -518,7 +499,7 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
 ]
 
@@ -628,16 +609,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
@@ -730,7 +701,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "rlp",
@@ -821,7 +792,7 @@ name = "cf-runtime-upgrade-utilities"
 version = "0.1.0"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log",
  "sp-io 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-std 5.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
 ]
@@ -832,7 +803,7 @@ version = "0.1.0"
 dependencies = [
  "cf-runtime-macros",
  "frame-support",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-io 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-runtime 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -869,7 +840,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -884,14 +855,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
 dependencies = [
- "smallvec 1.9.0",
+ "smallvec",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -911,7 +876,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "zeroize",
@@ -943,7 +908,7 @@ dependencies = [
  "custom-rpc",
  "ed25519-dalek",
  "frame-system",
- "futures 0.3.21",
+ "futures",
  "hex",
  "pallet-cf-account-roles",
  "pallet-cf-environment",
@@ -975,7 +940,7 @@ dependencies = [
  "chainflip-engine",
  "clap 3.2.23",
  "config",
- "futures 0.3.21",
+ "futures",
  "hex",
  "serde",
  "slog",
@@ -1015,7 +980,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "fs_extra",
- "futures 0.3.21",
+ "futures",
  "futures-core",
  "futures-util",
  "generic-array 0.14.6",
@@ -1025,7 +990,7 @@ dependencies = [
  "jsonrpsee 0.15.1",
  "lazy_format",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "mockall",
  "num-bigint",
  "num-derive",
@@ -1082,7 +1047,6 @@ dependencies = [
  "url 1.7.2",
  "utilities",
  "web3",
- "websocket",
  "x25519-dalek",
  "zeroize",
  "zmq",
@@ -1099,7 +1063,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",
- "futures 0.3.21",
+ "futures",
  "hex",
  "hex-literal",
  "jsonrpsee 0.15.1",
@@ -1164,7 +1128,7 @@ dependencies = [
  "num-traits",
  "time 0.1.44",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1312,7 +1276,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1403,7 +1367,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1438,9 +1402,9 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "log 0.4.17",
+ "log",
  "regalloc2",
- "smallvec 1.9.0",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -1475,8 +1439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34897538b36b216cc8dd324e73263596d51b8cf610da6498322838b2546baf8a"
 dependencies = [
  "cranelift-codegen",
- "log 0.4.17",
- "smallvec 1.9.0",
+ "log",
+ "smallvec",
  "target-lexicon",
 ]
 
@@ -1507,8 +1471,8 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "itertools",
- "log 0.4.17",
- "smallvec 1.9.0",
+ "log",
+ "smallvec",
  "wasmparser",
  "wasmtime-types",
 ]
@@ -1519,7 +1483,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1528,8 +1492,8 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1538,9 +1502,9 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1550,22 +1514,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg 1.1.0",
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "cfg-if",
+ "crossbeam-utils",
  "memoffset",
  "once_cell",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.1.0",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -1574,7 +1527,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -1988,7 +1941,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -2000,7 +1953,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2011,7 +1964,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2026,10 +1979,10 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2182,7 +2135,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2241,7 +2194,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "log 0.4.17",
+ "log",
  "regex",
 ]
 
@@ -2253,7 +2206,7 @@ checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.17",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -2272,7 +2225,7 @@ checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2359,7 +2312,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a89fb87a9e103f71b903b80b670200b54cc67a07578f070681f1fffb7396fb7"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "ethereum-types 0.14.1",
  "hash-db",
  "hash256-std-hasher",
@@ -2413,7 +2366,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.21",
+ "futures",
 ]
 
 [[package]]
@@ -2463,7 +2416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e16290574b39ee41c71aeb90ae960c504ebaf1e2a1c87bd52aa56ed6e1a02f"
 dependencies = [
  "env_logger 0.9.0",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -2472,9 +2425,9 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "windows-sys 0.42.0",
 ]
 
@@ -2485,9 +2438,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
 dependencies = [
  "either",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -2597,7 +2550,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -2632,7 +2585,7 @@ dependencies = [
  "kvdb",
  "lazy_static",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
@@ -2687,7 +2640,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -2703,13 +2656,13 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-api",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -2767,7 +2720,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -2822,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2838,22 +2791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,12 +2801,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -3040,7 +2971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -3050,7 +2981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3059,7 +2990,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
@@ -3072,7 +3003,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -3115,7 +3046,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "fnv",
- "log 0.4.17",
+ "log",
  "regex",
 ]
 
@@ -3179,7 +3110,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -3198,7 +3129,7 @@ version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360d9740069b2f6cbb63ce2dbaa71a20d3185350cbb990d7bebeb9318415eb17"
 dependencies = [
- "log 0.4.17",
+ "log",
  "pest",
  "pest_derive",
  "serde",
@@ -3236,13 +3167,13 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitflags",
- "bytes 1.2.1",
+ "bytes",
  "headers-core",
  "http",
  "httpdate",
- "mime 0.3.16",
+ "mime",
  "sha-1 0.10.0",
 ]
 
@@ -3339,7 +3270,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3348,7 +3279,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "fnv",
  "itoa 1.0.5",
 ]
@@ -3359,7 +3290,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "http",
  "pin-project-lite 0.2.9",
 ]
@@ -3384,30 +3315,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
-dependencies = [
- "base64 0.9.3",
- "httparse",
- "language-tags",
- "log 0.3.9",
- "mime 0.2.6",
- "num_cpus",
- "time 0.1.44",
- "traitobject",
- "typeable",
- "unicase 1.4.2",
- "url 1.7.2",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3432,8 +3344,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
- "hyper 0.14.20",
- "log 0.4.17",
+ "hyper",
+ "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
@@ -3449,7 +3361,7 @@ checksum = "6eea26c5d0b6ab9d72219f65000af310f042a740926f7b2fa3553e774036e2e7"
 dependencies = [
  "derive_builder",
  "dns-lookup",
- "hyper 0.14.20",
+ "hyper",
  "tokio",
  "tower-service",
  "tracing",
@@ -3461,8 +3373,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.2.1",
- "hyper 0.14.20",
+ "bytes",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -3503,7 +3415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3515,10 +3427,10 @@ dependencies = [
  "async-io",
  "core-foundation",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "if-addrs",
  "ipnet",
- "log 0.4.17",
+ "log",
  "rtnetlink",
  "system-configuration",
  "windows",
@@ -3588,7 +3500,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3617,15 +3529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,7 +3542,7 @@ checksum = "723519edce41262b05d4143ceb95050e4c614f483e78e9fd9e39a8275a84ad98"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
  "winreg 0.7.0",
 ]
 
@@ -3717,10 +3620,10 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-executor",
  "futures-util",
- "log 0.4.17",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3827,7 +3730,7 @@ dependencies = [
  "futures-util",
  "globset",
  "http",
- "hyper 0.14.20",
+ "hyper",
  "jsonrpsee-types 0.15.1",
  "lazy_static",
  "parking_lot 0.12.1",
@@ -3840,7 +3743,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "unicase 2.6.0",
+ "unicase",
  "wasm-bindgen-futures",
 ]
 
@@ -3859,7 +3762,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "globset",
- "hyper 0.14.20",
+ "hyper",
  "jsonrpsee-types 0.16.2",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3880,7 +3783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f7c0e2333ab2115c302eeb4f137c8a4af5ab609762df68bbda8f06496677c9"
 dependencies = [
  "async-trait",
- "hyper 0.14.20",
+ "hyper",
  "hyper-rustls",
  "jsonrpsee-core 0.15.1",
  "jsonrpsee-types 0.15.1",
@@ -3900,7 +3803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
 dependencies = [
  "async-trait",
- "hyper 0.14.20",
+ "hyper",
  "hyper-rustls",
  "jsonrpsee-core 0.16.2",
  "jsonrpsee-types 0.16.2",
@@ -3920,7 +3823,7 @@ checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
 dependencies = [
  "futures-channel",
  "futures-util",
- "hyper 0.14.20",
+ "hyper",
  "jsonrpsee-core 0.15.1",
  "jsonrpsee-types 0.15.1",
  "serde",
@@ -3964,7 +3867,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "hyper 0.14.20",
+ "hyper",
  "jsonrpsee-core 0.16.2",
  "jsonrpsee-types 0.16.2",
  "serde",
@@ -4077,7 +3980,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.2",
@@ -4090,22 +3993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -4115,7 +4008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585089ceadba0197ffe9af6740ab350b325e3c1f5fccfbc3522e0250c750409b"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.9.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4136,20 +4029,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c076cc2cdbac89b9910c853a36c957d3862a779f31c2661174222cefb49ee597"
 dependencies = [
  "kvdb",
- "log 0.4.17",
+ "log",
  "num_cpus",
  "parity-util-mem",
  "parking_lot 0.12.1",
  "regex",
  "rocksdb",
- "smallvec 1.9.0",
+ "smallvec",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_format"
@@ -4181,8 +4068,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -4197,8 +4084,8 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
 dependencies = [
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "futures-timer",
  "getrandom 0.2.7",
  "instant",
@@ -4222,7 +4109,7 @@ dependencies = [
  "multiaddr",
  "parking_lot 0.12.1",
  "pin-project",
- "smallvec 1.9.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -4236,11 +4123,11 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multiaddr",
  "multihash",
  "multistream-select",
@@ -4251,7 +4138,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "sha2 0.10.2",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "unsigned-varint",
  "void",
@@ -4265,11 +4152,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
 dependencies = [
  "async-std-resolver",
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
- "smallvec 1.9.0",
+ "smallvec",
  "trust-dns-resolver",
 ]
 
@@ -4280,16 +4167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
 dependencies = [
  "asynchronous-codec",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "lru",
  "prost",
  "prost-build",
  "prost-codec",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "void",
 ]
@@ -4302,20 +4189,20 @@ checksum = "6721c200e2021f6c3fab8b6cf0272ead8912d871610ee194ebd628cecf428f22"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes",
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "prost",
  "prost-build",
  "rand 0.8.5",
  "sha2 0.10.2",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "uint",
  "unsigned-varint",
@@ -4331,13 +4218,13 @@ dependencies = [
  "async-io",
  "data-encoding",
  "dns-parser",
- "futures 0.3.21",
+ "futures",
  "if-watch",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "socket2",
  "void",
 ]
@@ -4363,14 +4250,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692664acfd98652de739a8acbb0a0d670f1d67190a49be6b4395e22c37337d89"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -4380,12 +4267,12 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048155686bd81fe6cb5efdef0c6290f25ad32a0a42e8f4f72625cf6a505a206f"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "curve25519-dalek 3.2.0",
- "futures 0.3.21",
+ "futures",
  "lazy_static",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "prost",
  "prost-build",
  "rand 0.8.5",
@@ -4402,12 +4289,12 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7228b9318d34689521349a86eb39a3c3a802c9efc99a0568062ffb80913e3f91"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
  "void",
 ]
@@ -4419,14 +4306,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8827af16a017b65311a410bb626205a9ad92ec0473967618425039fa5231adc1"
 dependencies = [
  "async-trait",
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "instant",
  "libp2p-core",
  "libp2p-swarm",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -4438,14 +4325,14 @@ checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "instant",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "pin-project",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "void",
 ]
@@ -4468,12 +4355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9839d96761491c6d3e238e70554b856956fca0ab60feb9de2cd08eed4473fa92"
 dependencies = [
  "async-io",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "socket2",
 ]
 
@@ -4483,7 +4370,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b5b8e7a73e379e47b1b77f8a82c4721e97eca01abcd18e9cd91a23ca6ce97"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -4498,10 +4385,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3758ae6f89b2531a24b6d9f5776bda6a626b60a57600d7185d43dfa75ca5ecc4"
 dependencies = [
  "either",
- "futures 0.3.21",
+ "futures",
  "futures-rustls",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "quicksink",
  "rw-stream-sink",
@@ -4516,9 +4403,9 @@ version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6874d66543c4f7e26e3b8ca9a6bead351563a13ab4fafd43c7927f7c0d6c12"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p-core",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "thiserror",
  "yamux",
@@ -4546,7 +4433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64 0.13.0",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -4646,15 +4533,6 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
@@ -4665,20 +4543,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
-]
-
-[[package]]
-name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "value-bag",
 ]
 
@@ -4769,12 +4638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4849,15 +4712,6 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-dependencies = [
- "log 0.3.9",
-]
-
-[[package]]
-name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
@@ -4879,45 +4733,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log 0.4.17",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
- "log 0.4.17",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -4926,7 +4749,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "downcast",
  "fragile",
  "lazy_static",
@@ -4941,7 +4764,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn",
@@ -5019,11 +4842,11 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
 dependencies = [
- "bytes 1.2.1",
- "futures 0.3.21",
- "log 0.4.17",
+ "bytes",
+ "futures",
+ "log",
  "pin-project",
- "smallvec 1.9.0",
+ "smallvec",
  "unsigned-varint",
 ]
 
@@ -5079,7 +4902,7 @@ checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -5087,17 +4910,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5144,9 +4956,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
- "bytes 1.2.1",
- "futures 0.3.21",
- "log 0.4.17",
+ "bytes",
+ "futures",
+ "log",
  "netlink-packet-core",
  "netlink-sys",
  "thiserror",
@@ -5160,10 +4972,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
  "async-io",
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "libc",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -5172,7 +4984,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec 1.9.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -5182,7 +4994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
 ]
 
@@ -5337,7 +5149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -5432,7 +5244,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5452,7 +5264,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5471,7 +5283,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5491,7 +5303,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-cf-flip",
  "parity-scale-codec",
  "scale-info",
@@ -5513,7 +5325,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -5612,7 +5424,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5639,7 +5451,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-grandpa",
  "parity-scale-codec",
  "scale-info",
@@ -5663,7 +5475,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-cf-account-roles",
  "pallet-cf-flip",
  "parity-scale-codec",
@@ -5685,7 +5497,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5706,7 +5518,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex-literal",
- "log 0.4.17",
+ "log",
  "pallet-cf-reputation",
  "pallet-cf-validator",
  "parity-scale-codec",
@@ -5748,7 +5560,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "nanorand",
  "pallet-cf-reputation",
  "pallet-cf-staking",
@@ -5779,7 +5591,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -5818,7 +5630,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -5855,7 +5667,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5876,7 +5688,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -5941,7 +5753,7 @@ dependencies = [
  "fs2",
  "hex",
  "libc",
- "log 0.4.17",
+ "log",
  "lz4",
  "memmap2",
  "parking_lot 0.12.1",
@@ -5958,7 +5770,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "bitvec 1.0.1",
  "byte-slice-cast",
- "bytes 1.2.1",
+ "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
@@ -5988,14 +5800,14 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "hashbrown",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.12.1",
  "primitive-types 0.12.1",
- "smallvec 1.9.0",
- "winapi 0.3.9",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -6023,23 +5835,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.7",
+ "lock_api",
  "parking_lot_core 0.8.5",
 ]
 
@@ -6049,23 +5850,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.7",
+ "lock_api",
  "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6074,12 +5860,12 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.16",
- "smallvec 1.9.0",
- "winapi 0.3.9",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -6088,10 +5874,10 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
- "smallvec 1.9.0",
+ "redox_syscall",
+ "smallvec",
  "windows-sys 0.36.1",
 ]
 
@@ -6272,11 +6058,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "log 0.4.17",
+ "log",
  "wepoll-ffi",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6296,7 +6082,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
@@ -6396,7 +6182,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -6407,7 +6193,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -6425,7 +6211,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
@@ -6462,7 +6248,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "prost-derive",
 ]
 
@@ -6472,11 +6258,11 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "heck",
  "itertools",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "multimap",
  "petgraph",
  "prettyplease",
@@ -6495,7 +6281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes",
  "prost",
  "thiserror",
  "unsigned-varint",
@@ -6520,7 +6306,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "prost",
 ]
 
@@ -6543,7 +6329,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "hyper 0.14.20",
+ "hyper",
  "hyper-system-resolver",
  "pin-project-lite 0.2.9",
  "thiserror",
@@ -6567,7 +6353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
 ]
 
@@ -6640,7 +6426,7 @@ dependencies = [
  "rand_os",
  "rand_pcg 0.1.2",
  "rand_xorshift",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6776,7 +6562,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6790,7 +6576,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6856,7 +6642,7 @@ checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
  "num_cpus",
 ]
 
@@ -6868,12 +6654,6 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -6891,7 +6671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.7",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -6922,9 +6702,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
 dependencies = [
  "fxhash",
- "log 0.4.17",
+ "log",
  "slice-group-by",
- "smallvec 1.9.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -6959,7 +6739,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "env_logger 0.9.0",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde",
  "serde_json",
@@ -6976,7 +6756,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6985,21 +6765,21 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.2.1",
+ "base64",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
  "http",
  "http-body",
- "hyper 0.14.20",
+ "hyper",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
- "log 0.4.17",
- "mime 0.3.16",
+ "log",
+ "mime",
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.9",
@@ -7049,7 +6829,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -7058,7 +6838,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "rlp-derive",
  "rustc-hex",
 ]
@@ -7090,7 +6870,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "serde",
 ]
@@ -7103,7 +6883,7 @@ checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
 dependencies = [
  "libc",
  "rtoolbox",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -7113,8 +6893,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
  "async-global-executor",
- "futures 0.3.21",
- "log 0.4.17",
+ "futures",
+ "log",
  "netlink-packet-route",
  "netlink-proto",
  "nix",
@@ -7128,7 +6908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -7137,7 +6917,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ordered-multimap",
 ]
 
@@ -7211,7 +6991,7 @@ version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
- "log 0.4.17",
+ "log",
  "ring",
  "sct",
  "webpki",
@@ -7235,7 +7015,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -7250,7 +7030,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "pin-project",
  "static_assertions",
 ]
@@ -7271,12 +7051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7290,7 +7064,7 @@ name = "sc-allocator"
 version = "4.1.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "log 0.4.17",
+ "log",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-wasm-interface 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "thiserror",
@@ -7301,9 +7075,9 @@ name = "sc-basic-authorship"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -7372,9 +7146,9 @@ dependencies = [
  "chrono",
  "clap 4.0.32",
  "fdlimit",
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "names",
  "parity-scale-codec",
  "rand 0.7.3",
@@ -7409,9 +7183,9 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "fnv",
- "futures 0.3.21",
+ "futures",
  "hash-db",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor",
@@ -7441,7 +7215,7 @@ dependencies = [
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -7462,10 +7236,10 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-utils",
@@ -7486,8 +7260,8 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
- "log 0.4.17",
+ "futures",
+ "log",
  "parity-scale-codec",
  "sc-block-builder",
  "sc-client-api",
@@ -7515,9 +7289,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus",
@@ -7580,7 +7354,7 @@ name = "sc-executor-wasmi"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
@@ -7595,9 +7369,9 @@ name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parity-scale-codec",
  "parity-wasm",
@@ -7621,9 +7395,9 @@ dependencies = [
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -7657,9 +7431,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "finality-grandpa",
- "futures 0.3.21",
+ "futures",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-finality-grandpa",
@@ -7678,9 +7452,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "ansi_term",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-util-mem",
  "sc-client-api",
  "sc-network-common",
@@ -7713,18 +7487,18 @@ dependencies = [
  "async-trait",
  "asynchronous-codec",
  "bitflags",
- "bytes 1.2.1",
+ "bytes",
  "cid",
  "either",
  "fnv",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "ip_network",
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
- "log 0.4.17",
+ "log",
  "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -7739,7 +7513,7 @@ dependencies = [
  "sc-utils",
  "serde",
  "serde_json",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-blockchain",
  "sp-consensus",
@@ -7757,9 +7531,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "cid",
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "prost",
  "prost-build",
  "sc-client-api",
@@ -7778,8 +7552,8 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "async-trait",
  "bitflags",
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "futures-timer",
  "libp2p",
  "linked_hash_set",
@@ -7788,7 +7562,7 @@ dependencies = [
  "sc-consensus",
  "sc-peerset",
  "serde",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-blockchain",
  "sp-consensus",
  "sp-finality-grandpa",
@@ -7803,10 +7577,10 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "ahash",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "libp2p",
- "log 0.4.17",
+ "log",
  "lru",
  "sc-network-common",
  "sc-peerset",
@@ -7821,9 +7595,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "array-bytes",
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "prost",
  "prost-build",
@@ -7844,9 +7618,9 @@ dependencies = [
  "array-bytes",
  "async-trait",
  "fork-tree",
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "lru",
  "mockall",
  "parity-scale-codec",
@@ -7857,7 +7631,7 @@ dependencies = [
  "sc-network-common",
  "sc-peerset",
  "sc-utils",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-blockchain",
  "sp-consensus",
@@ -7873,10 +7647,10 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "array-bytes",
- "futures 0.3.21",
+ "futures",
  "hex",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "pin-project",
  "sc-network-common",
@@ -7892,11 +7666,11 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "array-bytes",
- "bytes 1.2.1",
+ "bytes",
  "fnv",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "hyper 0.14.20",
+ "hyper",
  "hyper-rustls",
  "libp2p",
  "num_cpus",
@@ -7921,9 +7695,9 @@ name = "sc-peerset"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "sc-utils",
  "serde_json",
  "wasm-timer",
@@ -7934,7 +7708,7 @@ name = "sc-proposer-metrics"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "log 0.4.17",
+ "log",
  "substrate-prometheus-endpoint",
 ]
 
@@ -7943,10 +7717,10 @@ name = "sc-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-block-builder",
@@ -7973,9 +7747,9 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-chain-spec",
@@ -7996,9 +7770,9 @@ name = "sc-rpc-server"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -8009,7 +7783,7 @@ name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "hex",
  "jsonrpsee 0.15.1",
  "parity-scale-codec",
@@ -8031,11 +7805,11 @@ dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "hash-db",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.1",
@@ -8099,7 +7873,7 @@ name = "sc-state-db"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parity-util-mem-derive",
@@ -8113,9 +7887,9 @@ name = "sc-sysinfo"
 version = "6.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "libc",
- "log 0.4.17",
+ "log",
  "rand 0.7.3",
  "rand_pcg 0.2.1",
  "regex",
@@ -8133,9 +7907,9 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "chrono",
- "futures 0.3.21",
+ "futures",
  "libp2p",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.7.3",
@@ -8155,7 +7929,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parking_lot 0.12.1",
  "regex",
@@ -8193,10 +7967,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.12.1",
@@ -8220,8 +7994,8 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
- "log 0.4.17",
+ "futures",
+ "log",
  "serde",
  "sp-blockchain",
  "sp-runtime 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -8233,10 +8007,10 @@ name = "sc-utils"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parking_lot 0.12.1",
  "prometheus",
 ]
@@ -8271,7 +8045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "bitvec 1.0.1",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
@@ -8548,7 +8322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -8560,25 +8334,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -8599,7 +8358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -8611,7 +8370,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -8690,7 +8449,7 @@ checksum = "e190a521c2044948158666916d9e872cbb9984f755e9bb3b5b75a836205affcd"
 dependencies = [
  "atty",
  "colored",
- "log 0.4.17",
+ "log",
  "time 0.3.17",
  "windows-sys 0.42.0",
 ]
@@ -8742,15 +8501,6 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
@@ -8785,7 +8535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -8794,13 +8544,13 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.2.1",
+ "base64",
+ "bytes",
  "flate2",
- "futures 0.3.21",
+ "futures",
  "http",
  "httparse",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -8811,7 +8561,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -8922,8 +8672,8 @@ name = "sp-blockchain"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "futures 0.3.21",
- "log 0.4.17",
+ "futures",
+ "log",
  "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -8941,9 +8691,9 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-inherents",
@@ -8999,13 +8749,13 @@ dependencies = [
  "byteorder",
  "dyn-clonable",
  "ed25519-zebra",
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "hash256-std-hasher",
  "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "merlin",
  "num-traits",
  "parity-scale-codec",
@@ -9044,13 +8794,13 @@ dependencies = [
  "byteorder",
  "dyn-clonable",
  "ed25519-zebra",
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "hash256-std-hasher",
  "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "merlin",
  "num-traits",
  "parity-scale-codec",
@@ -9176,7 +8926,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "finality-grandpa",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -9208,11 +8958,11 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6280bd3643354f7ff0b2abd36c687745455779231a7a86d90945608f0d4924c4"
 dependencies = [
- "bytes 1.2.1",
- "futures 0.3.21",
+ "bytes",
+ "futures",
  "hash-db",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "secp256k1 0.24.2",
@@ -9234,12 +8984,12 @@ name = "sp-io"
 version = "7.0.0"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "ed25519-dalek",
- "futures 0.3.21",
+ "futures",
  "hash-db",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "secp256k1 0.24.2",
@@ -9274,7 +9024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44bec4f0d036b6993c14bbee4216781f21275e5c201e43e45fed4a434bf0e5a"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9290,7 +9040,7 @@ version = "0.13.0"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9360,7 +9110,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -9383,7 +9133,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -9404,7 +9154,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b886a5d34400b0e0c12d389e3bb48b7a93d651cddf7e248124b81fe64c339251"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types 0.12.1",
@@ -9422,7 +9172,7 @@ name = "sp-runtime-interface"
 version = "7.0.0"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types 0.12.1",
@@ -9465,7 +9215,7 @@ name = "sp-sandbox"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-io 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -9506,12 +9256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5c2d97ad69011d34ca257f0383532b80096d53f889f5894ae2b24a211bec66f"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-core 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-externalities 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-panic-handler 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9528,12 +9278,12 @@ version = "0.13.0"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.7.3",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-externalities 0.13.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-panic-handler 5.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -9589,7 +9339,7 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "async-trait",
  "futures-timer",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
@@ -9638,7 +9388,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "async-trait",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -9730,7 +9480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f43c40afab6ecac20505907631c929957ed636b7af8795984649bbaa6ff38c3"
 dependencies = [
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-std 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi",
@@ -9742,7 +9492,7 @@ version = "7.0.0"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-std 5.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "wasmi",
@@ -9759,7 +9509,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-arithmetic 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-core 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-debug-derive 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9775,7 +9525,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "smallvec 1.9.0",
+ "smallvec",
  "sp-arithmetic 6.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-core 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
  "sp-debug-derive 5.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -9836,7 +9586,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "getrandom 0.2.7",
- "log 0.4.17",
+ "log",
  "nanorand",
  "pallet-aura",
  "pallet-authorship",
@@ -9901,7 +9651,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "parking_lot_core 0.8.5",
  "static_init_macro",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -9991,9 +9741,9 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.21",
+ "futures",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sc-client-api",
  "sc-rpc-api",
@@ -10012,8 +9762,8 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
 dependencies = [
  "futures-util",
- "hyper 0.14.20",
- "log 0.4.17",
+ "hyper",
+ "log",
  "prometheus",
  "thiserror",
  "tokio",
@@ -10026,7 +9776,7 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "async-trait",
  "jsonrpsee 0.15.1",
- "log 0.4.17",
+ "log",
  "sc-rpc-api",
  "serde",
  "sp-runtime 7.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12)",
@@ -10070,7 +9820,7 @@ dependencies = [
  "bitvec 1.0.1",
  "derivative",
  "frame-metadata",
- "futures 0.3.21",
+ "futures",
  "getrandom 0.2.7",
  "hex",
  "jsonrpsee 0.16.2",
@@ -10202,12 +9952,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -10294,7 +10044,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -10395,10 +10145,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg 1.1.0",
- "bytes 1.2.1",
+ "bytes",
  "libc",
  "memchr",
- "mio 0.8.4",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
@@ -10406,39 +10156,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log 0.4.17",
+ "winapi",
 ]
 
 [[package]]
@@ -10460,25 +10178,6 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.31",
- "lazy_static",
- "log 0.4.17",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
 ]
 
 [[package]]
@@ -10505,51 +10204,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
-dependencies = [
- "futures 0.1.31",
- "native-tls",
- "tokio-io",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "log 0.4.17",
+ "log",
  "pin-project-lite 0.2.9",
  "tokio",
 ]
@@ -10560,7 +10224,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.2.1",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -10613,8 +10277,8 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
- "cfg-if 1.0.0",
- "log 0.4.17",
+ "cfg-if",
+ "log",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
@@ -10647,7 +10311,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "futures-task",
  "pin-project",
  "tracing",
@@ -10660,7 +10324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
- "log 0.4.17",
+ "log",
  "tracing-core",
 ]
 
@@ -10689,7 +10353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.9.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -10708,18 +10372,12 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.9.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
 ]
-
-[[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trie-db"
@@ -10729,9 +10387,9 @@ checksum = "004e1e8f92535694b4cb1444dc5a8073ecf0815e3357f729638b9f8fc4062908"
 dependencies = [
  "hash-db",
  "hashbrown",
- "log 0.4.17",
+ "log",
  "rustc-hex",
- "smallvec 1.9.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -10759,12 +10417,12 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b4ef9b9bde0559b78a4abb00339143750085f05e5a453efb7b8bef1061f09dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "data-encoding",
  "futures-channel",
  "futures-util",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "radix_trie",
  "rand 0.8.5",
  "thiserror",
@@ -10780,7 +10438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if",
  "data-encoding",
  "enum-as-inner 0.3.4",
  "futures-channel",
@@ -10789,9 +10447,9 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -10805,7 +10463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if",
  "data-encoding",
  "enum-as-inner 0.5.1",
  "futures-channel",
@@ -10815,7 +10473,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "rand 0.8.5",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "tinyvec",
  "tracing",
@@ -10828,14 +10486,14 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
  "lru-cache",
  "parking_lot 0.12.1",
  "resolv-conf",
- "smallvec 1.9.0",
+ "smallvec",
  "thiserror",
  "tracing",
  "trust-dns-proto 0.22.0",
@@ -10854,7 +10512,7 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "clap 4.0.32",
  "frame-try-runtime",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "remote-externalities",
  "sc-chain-spec",
@@ -10886,17 +10544,11 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",
 ]
-
-[[package]]
-name = "typeable"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
@@ -10924,20 +10576,11 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
-name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -10990,7 +10633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.2.1",
+ "bytes",
  "futures-io",
  "futures-util",
 ]
@@ -11029,7 +10672,7 @@ name = "utilities"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "futures 0.3.21",
+ "futures",
  "hex",
  "lazy_format",
  "mockall",
@@ -11050,7 +10693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
- "version_check 0.9.4",
+ "version_check",
 ]
 
 [[package]]
@@ -11058,12 +10701,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -11090,7 +10727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -11100,7 +10737,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.17",
+ "log",
  "try-lock",
 ]
 
@@ -11128,7 +10765,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -11141,7 +10778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
+ "log",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -11155,7 +10792,7 @@ version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -11246,7 +10883,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -11305,10 +10942,10 @@ checksum = "4ad5af6ba38311282f2a21670d96e78266e8c8e2f38cbcd52c254df6ccbc7731"
 dependencies = [
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "libc",
- "log 0.4.17",
+ "log",
  "object",
  "once_cell",
  "paste",
@@ -11331,7 +10968,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45de63ddfc8b9223d1adc8f7b2ee5f35d1f6d112833934ad7ea66e4f4339e597"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -11341,11 +10978,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcd849399d17d2270141cfe47fa0d91ee52d5f8ea9b98cf7ddde0d53e5f79882"
 dependencies = [
  "anyhow",
- "base64 0.13.0",
+ "base64",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
- "log 0.4.17",
+ "log",
  "rustix 0.35.13",
  "serde",
  "sha2 0.9.9",
@@ -11367,7 +11004,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-wasm",
  "gimli",
- "log 0.4.17",
+ "log",
  "object",
  "target-lexicon",
  "thiserror",
@@ -11385,7 +11022,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "indexmap",
- "log 0.4.17",
+ "log",
  "object",
  "serde",
  "target-lexicon",
@@ -11403,10 +11040,10 @@ dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpp_demangle",
  "gimli",
- "log 0.4.17",
+ "log",
  "object",
  "rustc-demangle",
  "rustix 0.35.13",
@@ -11438,10 +11075,10 @@ checksum = "ee8f92ad4b61736339c29361da85769ebc200f184361959d1792832e592a1afd"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "libc",
- "log 0.4.17",
+ "log",
  "mach",
  "memfd",
  "memoffset",
@@ -11483,18 +11120,18 @@ version = "0.19.0"
 source = "git+https://github.com/tomusdrw/rust-web3.git?rev=8796c88#8796c88c4cb95864bdfeffb40ebb061c283aca74"
 dependencies = [
  "arrayvec 0.7.2",
- "base64 0.13.0",
- "bytes 1.2.1",
+ "base64",
+ "bytes",
  "derive_more",
  "ethabi 17.1.0",
  "ethereum-types 0.13.1",
- "futures 0.3.21",
+ "futures",
  "futures-timer",
  "headers",
  "hex",
  "idna 0.2.3",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
@@ -11544,47 +11181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "websocket"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b37840b9e27b340ce91b319ede10731de8c72f5bc4cb0206ec1ca4ce581d0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "hyper 0.10.16",
- "native-tls",
- "rand 0.6.5",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-tls",
- "unicase 1.4.2",
- "url 1.7.2",
- "websocket-base",
-]
-
-[[package]]
-name = "websocket-base"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3810f0d00c4dccb54c30a4eee815e703232819dec7b007db115791c42aa374"
-dependencies = [
- "base64 0.10.1",
- "bitflags",
- "byteorder",
- "bytes 0.4.12",
- "futures 0.1.31",
- "native-tls",
- "rand 0.6.5",
- "sha1",
- "tokio-codec",
- "tokio-io",
- "tokio-tcp",
- "tokio-tls",
-]
-
-[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11612,12 +11208,6 @@ checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -11625,12 +11215,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -11644,7 +11228,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -11802,7 +11386,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -11811,17 +11395,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]
@@ -11866,8 +11440,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
 dependencies = [
- "futures 0.3.21",
- "log 0.4.17",
+ "futures",
+ "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -11917,7 +11491,7 @@ source = "git+https://github.com/chainflip-io/rust-zmq.git?tag=chainflip-v0.9.2+
 dependencies = [
  "bitflags",
  "libc",
- "log 0.4.17",
+ "log",
  "zmq-sys",
 ]
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,10 +14,8 @@ name = "chainflip-engine"
 priority = "required"
 section = "rust"
 maintainer-scripts = "package/"
-systemd-units = {enable = false}
-assets = [
-  ["target/release/chainflip-engine", "usr/bin/", "755"],
-]
+systemd-units = { enable = false }
+assets = [["target/release/chainflip-engine", "usr/bin/", "755"]]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -46,37 +44,45 @@ rand_legacy = { package = "rand", version = "0.6" }
 # Same version of jsonrpsee as substrate
 jsonrpsee = { version = "0.15.1", features = ["full"] }
 
-websocket = "0.24"
 ethbloom = "0.12.1"
 dyn-clone = "1.0.4"
 lazy_static = "1.4"
 parking_lot = "0.12"
 regex = "1"
-reqwest = {version = "0.11.4", features = ["json"]}
-secp256k1 = {version = "0.20", features = ["serde", "rand-std", "global-context"]}
-serde = {version = "1.0", features = ["derive", "rc"]}
+reqwest = { version = "0.11.4", features = ["json"] }
+secp256k1 = { version = "0.20", features = [
+  "serde",
+  "rand-std",
+  "global-context",
+] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.9.5"
-slog = {version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"]}
-slog-async = {version = "2.6.0"}
-slog-json = {version = "2.3.0"}
+slog = { version = "2.7.0", features = [
+  "max_level_trace",
+  "release_max_level_trace",
+] }
+slog-async = { version = "2.6.0" }
+slog-json = { version = "2.3.0" }
 subxt = "0.25.0"
 thiserror = "1.0.26"
-tokio = {version = "1.13.1", features = ["full", "test-util"]}
-tokio-stream = {version = "0.1.5", features = ["sync"]}
+tokio = { version = "1.13.1", features = ["full", "test-util"] }
+tokio-stream = { version = "0.1.5", features = ["sync"] }
 url = "1.7.2"
 num-bigint = "0.4"
 num-traits = "0.2"
 num-derive = "0.3"
-web3 = {git = 'https://github.com/tomusdrw/rust-web3.git', rev = '8796c88', features = ['signing']}
+web3 = { git = 'https://github.com/tomusdrw/rust-web3.git', rev = '8796c88', features = [
+  'signing',
+] }
 zeroize = "1.5.4"
 # Required so that we can create a web3-compatible secret key.
-web3-secp256k1 = {package = 'secp256k1', version = '0.21'}
-generic-array= "0.14"
+web3-secp256k1 = { package = 'secp256k1', version = '0.21' }
+generic-array = "0.14"
 public-ip = "0.2.2"
 lazy_format = "2.0"
 # We will update curve25519-dalek when we can update schnorrkel
-curve25519-dalek = {version = "2.1", features = ["serde"]}
+curve25519-dalek = { version = "2.1", features = ["serde"] }
 typenum = "1.15"
 # Note: we don't use the most recent version of schnorrkel since 0.10 switches
 # to curve25519-dalek-ng, but it is not clear at all why that fork of
@@ -88,35 +94,40 @@ typenum = "1.15"
 schnorrkel = "0.9.1"
 rayon = "1.5"
 pin-project = "1.0.12"
-zmq = {git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1", features = ["vendored"]}
+zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1", features = [
+  "vendored",
+] }
 ed25519-dalek = "1.0"
-x25519-dalek = {version ="1.1", features = ["serde"]}
+x25519-dalek = { version = "1.1", features = ["serde"] }
 rand = "0.8.4"
 ed25519-consensus = "2.0"
 
 # Local deps
-cf-chains = {path = "../state-chain/chains"}
-cf-primitives = {path = "../state-chain/primitives"}
-pallet-cf-account-roles = {path = "../state-chain/pallets/cf-account-roles"}
-pallet-cf-broadcast = {path = "../state-chain/pallets/cf-broadcast"}
-pallet-cf-chain-tracking = {path = "../state-chain/pallets/cf-chain-tracking"}
-pallet-cf-environment = {path = "../state-chain/pallets/cf-environment"}
-pallet-cf-flip = {path = "../state-chain/pallets/cf-flip"}
-pallet-cf-governance = {path = "../state-chain/pallets/cf-governance"}
-pallet-cf-ingress-egress = {path = "../state-chain/pallets/cf-ingress-egress" }
-pallet-cf-reputation = {path = "../state-chain/pallets/cf-reputation"}
-pallet-cf-staking = {path = "../state-chain/pallets/cf-staking"}
-pallet-cf-threshold-signature = {path = "../state-chain/pallets/cf-threshold-signature"}
-pallet-cf-validator = {path = "../state-chain/pallets/cf-validator"}
-pallet-cf-vaults = {path = "../state-chain/pallets/cf-vaults"}
-pallet-cf-witnesser = {path = "../state-chain/pallets/cf-witnesser"}
-custom-rpc = {path = "../state-chain/custom-rpc"}
-state-chain-runtime = {path = "../state-chain/runtime"}
-chainflip-node = {path = "../state-chain/node"}
-utilities = {path = "../utilities"}
+cf-chains = { path = "../state-chain/chains" }
+cf-primitives = { path = "../state-chain/primitives" }
+pallet-cf-account-roles = { path = "../state-chain/pallets/cf-account-roles" }
+pallet-cf-broadcast = { path = "../state-chain/pallets/cf-broadcast" }
+pallet-cf-chain-tracking = { path = "../state-chain/pallets/cf-chain-tracking" }
+pallet-cf-environment = { path = "../state-chain/pallets/cf-environment" }
+pallet-cf-flip = { path = "../state-chain/pallets/cf-flip" }
+pallet-cf-governance = { path = "../state-chain/pallets/cf-governance" }
+pallet-cf-ingress-egress = { path = "../state-chain/pallets/cf-ingress-egress" }
+pallet-cf-reputation = { path = "../state-chain/pallets/cf-reputation" }
+pallet-cf-staking = { path = "../state-chain/pallets/cf-staking" }
+pallet-cf-threshold-signature = { path = "../state-chain/pallets/cf-threshold-signature" }
+pallet-cf-validator = { path = "../state-chain/pallets/cf-validator" }
+pallet-cf-vaults = { path = "../state-chain/pallets/cf-vaults" }
+pallet-cf-witnesser = { path = "../state-chain/pallets/cf-witnesser" }
+custom-rpc = { path = "../state-chain/custom-rpc" }
+state-chain-runtime = { path = "../state-chain/runtime" }
+chainflip-node = { path = "../state-chain/node" }
+utilities = { path = "../utilities" }
 
 # substrate deps
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive", "full"] }
+codec = { package = "parity-scale-codec", version = "3.0.0", features = [
+  "derive",
+  "full",
+] }
 scale-info = { version = "2.1.1", features = ["derive"] }
 frame-metadata = { version = "15.0.0" }
 frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }


### PR DESCRIPTION
This dependency was unused and causing a compiler warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: traitobject v0.1.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 16`
```