### PR TITLE
Chore: reorganise curve25519 modules

### DIFF
--- a/engine/src/multisig/crypto.rs
+++ b/engine/src/multisig/crypto.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 mod helpers;
 mod curve25519;
-pub mod curve25519_edwards;
-pub mod curve25519_ristretto;
 pub mod ed25519;
 pub mod eth;
 pub mod polkadot;

--- a/engine/src/multisig/crypto/curve25519.rs
+++ b/engine/src/multisig/crypto/curve25519.rs
@@ -1,3 +1,6 @@
+pub mod edwards;
+pub mod ristretto;
+
 use serde::{Deserialize, Serialize};
 
 use super::ECScalar;

--- a/engine/src/multisig/crypto/curve25519/edwards.rs
+++ b/engine/src/multisig/crypto/curve25519/edwards.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::ECPoint;
-
-pub type Scalar = super::curve25519::Scalar;
+use super::{super::ECPoint, Scalar};
 
 type PK = curve25519_dalek::edwards::EdwardsPoint;
 

--- a/engine/src/multisig/crypto/curve25519/ristretto.rs
+++ b/engine/src/multisig/crypto/curve25519/ristretto.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use super::ECPoint;
+use super::super::ECPoint;
 
 type PK = curve25519_dalek::ristretto::RistrettoPoint;
 
-use super::curve25519::Scalar;
+use super::Scalar;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Point(PK);

--- a/engine/src/multisig/crypto/ed25519.rs
+++ b/engine/src/multisig/crypto/ed25519.rs
@@ -1,4 +1,4 @@
-use super::{curve25519_edwards::Point, ChainTag, CryptoScheme, ECPoint};
+use super::{curve25519::edwards::Point, ChainTag, CryptoScheme, ECPoint};
 use ed25519_consensus::VerificationKeyBytes;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +38,7 @@ impl AsRef<[u8]> for SigningPayload {
 }
 
 impl CryptoScheme for Ed25519Signing {
-	type Point = super::curve25519_edwards::Point;
+	type Point = super::curve25519::edwards::Point;
 
 	type Signature = Signature;
 

--- a/engine/src/multisig/crypto/polkadot.rs
+++ b/engine/src/multisig/crypto/polkadot.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::{curve25519_ristretto::Point, ChainTag, CryptoScheme, ECPoint};
+use super::{curve25519::ristretto::Point, ChainTag, CryptoScheme, ECPoint};
 use cf_chains::dot::PolkadotPublicKey;
 use schnorrkel::context::{SigningContext, SigningTranscript};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Now that we have both edwards and ristretto variants of the curve, it makes sense to reorganise the modules by putting shared code (Scalar) in the parent module.