### PR TITLE
chore: remove unnecessary subcommand

### DIFF
--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -6,7 +6,7 @@ use chainflip_api as api;
 use clap::Parser;
 use settings::{CLICommandLineOptions, CLISettings};
 
-use crate::settings::{Claim, CliCommand::*, LiquidityProviderSubcommands, RelayerSubcommands};
+use crate::settings::{CliCommand::*, LiquidityProviderSubcommands, RelayerSubcommands};
 use anyhow::{anyhow, Result};
 use utilities::clean_eth_address;
 
@@ -47,8 +47,7 @@ async fn run_cli() -> Result<()> {
 			swap_intent(&cli_settings.state_chain, params).await,
 		LiquidityProvider(LiquidityProviderSubcommands::Deposit { asset }) =>
 			liquidity_deposit(&cli_settings.state_chain, asset).await,
-		Claim(Claim::Request { amount, eth_address }) =>
-			request_claim(amount, &eth_address, &cli_settings).await,
+		Claim { amount, eth_address } => request_claim(amount, &eth_address, &cli_settings).await,
 		RegisterAccountRole { role } => register_account_role(role, &cli_settings).await,
 		Rotate {} => rotate_keys(&cli_settings.state_chain).await,
 		Retire {} => api::retire_account(&cli_settings.state_chain).await,

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -84,20 +84,6 @@ pub enum LiquidityProviderSubcommands {
 	},
 }
 
-#[derive(clap::Subcommand, Clone, Debug)]
-pub enum Claim {
-	#[clap(about = "Submit an extrinsic to request generation of a claim certificate")]
-	Request {
-		#[clap(
-			help = "Amount to claim in FLIP (omit this option to claim all available FLIP)",
-			long = "exact"
-		)]
-		amount: Option<f64>,
-		#[clap(help = "The Ethereum address you wish to claim your FLIP to")]
-		eth_address: String,
-	},
-}
-
 #[derive(Parser, Clone, Debug)]
 pub enum CliCommand {
 	/// Relayer specific commands
@@ -106,9 +92,18 @@ pub enum CliCommand {
 	/// Liquidity provider specific commands
 	#[clap(subcommand, name = "lp")]
 	LiquidityProvider(LiquidityProviderSubcommands),
-	#[clap(about = "Requesting and checking claims")]
-	#[clap(subcommand)]
-	Claim(Claim),
+	#[clap(
+		about = "Request a claim. After requesting the claim, please proceed to the Staking app to complete the claiming process."
+	)]
+	Claim {
+		#[clap(
+			help = "Amount to claim in FLIP (omit this option to claim all available FLIP)",
+			long = "exact"
+		)]
+		amount: Option<f64>,
+		#[clap(help = "The Ethereum address you wish to claim your FLIP to")]
+		eth_address: String,
+	},
 	#[clap(
 		about = "Submit an extrinsic to request generation of a claim certificate (claiming all available FLIP)"
 	)]


### PR DESCRIPTION
After doing #2457 the statement that matches against the Check variant was removed, but actually we can remove the whole enum.