### PR TITLE
fix: add warp sync support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2529,7 +2529,7 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2679,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "log",
@@ -2719,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5200,7 +5200,7 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5620,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5696,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5712,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "jsonrpsee 0.15.1",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5728,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6731,7 +6731,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "env_logger 0.9.0",
  "log",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "log",
  "sp-core 7.0.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7091,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
@@ -7124,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7135,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7175,7 +7175,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "fnv",
  "futures",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7228,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "lazy_static",
  "lru",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7347,7 +7347,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7362,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7382,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -7423,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -7444,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ansi_term",
  "futures",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "cid",
  "futures",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -7569,7 +7569,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ahash",
  "futures",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7608,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "futures",
@@ -7658,7 +7658,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "libp2p",
@@ -7701,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "hash-db",
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "jsonrpsee 0.15.1",
@@ -7763,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "jsonrpsee 0.15.1",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "hex",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "directories",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7880,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "libc",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "chrono",
  "futures",
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ansi_term",
  "atty",
@@ -7948,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7959,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -7986,7 +7986,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -8000,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "hash-db",
  "log",
@@ -8571,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -8583,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8640,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures",
  "log",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8733,7 +8733,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "array-bytes",
  "base58",
@@ -8821,7 +8821,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "blake2",
  "byteorder",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8891,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8914,7 +8914,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8932,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "lazy_static",
  "sp-core 7.0.0",
@@ -9010,7 +9010,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "thiserror",
  "zstd",
@@ -9053,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "sp-api",
  "sp-core 7.0.0",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9084,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9094,7 +9094,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9140,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9216,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "hash-db",
  "log",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 
 [[package]]
 name = "sp-std"
@@ -9295,7 +9295,7 @@ checksum = "af0ee286f98455272f64ac5bb1384ff21ac029fbb669afbaf48477faff12760e"
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "sp-std 5.0.0",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "sp-api",
  "sp-runtime 7.0.0",
@@ -9372,7 +9372,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "log",
@@ -9388,7 +9388,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ahash",
  "hash-db",
@@ -9435,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9717,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "platforms",
 ]
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "futures-util",
  "hyper",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "async-trait",
  "jsonrpsee 0.15.1",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -10496,7 +10496,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12#925a02a96756de9831e0c7fe472e42d951177fd7"
+source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2022-12+2#8b93ab66bbe6b7567dbef19d1bd36d7685837743"
 dependencies = [
  "clap 4.0.32",
  "frame-try-runtime",

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -19,4 +19,4 @@ tokio = {version = "1.13.1", features = ["full"]}
 utilities = {path = "../../../utilities"}
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -34,9 +34,9 @@ pallet-cf-swapping = { path = '../../state-chain/pallets/cf-swapping' }
 pallet-cf-threshold-signature = {path = "../../state-chain/pallets/cf-threshold-signature"}
 pallet-cf-validator = {path = "../../state-chain/pallets/cf-validator"}
 state-chain-runtime = {path = "../../state-chain/runtime"}
-frame-system = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12'}
+frame-system = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2'}
 
 # Substrate key types
-sp-consensus-aura = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12'}
-sp-core = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12'}
-sp-finality-grandpa = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12'}
+sp-consensus-aura = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2'}
+sp-core = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2'}
+sp-finality-grandpa = {git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2'}

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -131,14 +131,14 @@ codec = { package = "parity-scale-codec", version = "3.0.0", features = [
 ] }
 scale-info = { version = "2.1.1", features = ["derive"] }
 frame-metadata = { version = "15.0.0" }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sc-rpc-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-keyring = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sc-rpc-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-keyring = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [dependencies.rocksdb]
 version = "0.19.0"
@@ -158,7 +158,7 @@ ethereum = "0.14"
 rlp = "0.5"
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 integration-test = []

--- a/state-chain/amm/Cargo.toml
+++ b/state-chain/amm/Cargo.toml
@@ -13,8 +13,8 @@ cf-primitives = { path = '../primitives', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/cf-integration-tests/Cargo.toml
+++ b/state-chain/cf-integration-tests/Cargo.toml
@@ -38,33 +38,33 @@ pallet-cf-swapping ={ path = '../pallets/cf-swapping' }
 pallet-cf-pools ={ path = '../pallets/cf-pools' }
 pallet-cf-lp ={ path = '../pallets/cf-lp' }
 # Additional FRAME pallets
-pallet-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", features = ['historical'] }
+pallet-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", features = ['historical'] }
 
 # Substrate dependencies
 codec = { package = "parity-scale-codec", version = "3.1.1", features = ["derive"] }
 scale-info = { version = "2.1.1", features = ["derive"] }
 
-frame-executive = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-frame-system-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+frame-executive = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+frame-system-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
-pallet-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-randomness-collective-flip = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+pallet-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-randomness-collective-flip = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
-sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-offchain = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-offchain = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }

--- a/state-chain/cf-session-benchmarking/Cargo.toml
+++ b/state-chain/cf-session-benchmarking/Cargo.toml
@@ -15,14 +15,14 @@ targets = ['x86_64-unknown-linux-gnu']
 [dependencies]
 rand = { version = '0.7.2', default-features = false }
 
-pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false, features = ['historical'] }
+pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false, features = ['historical'] }
 
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -26,11 +26,11 @@ log = { version = '0.4.16', default-features = false }
 # Substrate packages
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12', default-features = false, optional = true }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2', default-features = false, optional = true }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../test-utilities' }

--- a/state-chain/custom-rpc/Cargo.toml
+++ b/state-chain/custom-rpc/Cargo.toml
@@ -19,7 +19,7 @@ pallet-cf-governance = {path = "../pallets/cf-governance"}
 pallet-cf-pools-runtime-api = {path = "../pallets/cf-pools/runtime-api" }
 hex = '0.4.3'
 
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sc-client-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sc-client-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -35,49 +35,49 @@ hex-literal = "0.3.1"
 # Substrate-node-template dependencies
 clap = { version = "4.0.9", features = ["derive"] }
 
-sc-cli = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-executor = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-service = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-telemetry = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-keystore = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-transaction-pool-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-consensus = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-consensus = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-finality-grandpa-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-client-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-runtime = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-keyring = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+sc-cli = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-executor = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-service = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-telemetry = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-keystore = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-transaction-pool-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-consensus = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-consensus = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-finality-grandpa-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-finality-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-client-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-runtime = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-keyring = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
 
 # These dependencies are used for the node template's RPCs
 jsonrpsee = { version = "0.15.1", features = ["full"] }
-sc-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-rpc-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-blockchain = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-sc-basic-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-substrate-frame-rpc-system = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-pallet-transaction-payment-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+sc-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-rpc-api = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-blockchain = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+sc-basic-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+substrate-frame-rpc-system = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+pallet-transaction-payment-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
-frame-benchmarking-cli = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
+frame-benchmarking-cli = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
 
 # CLI-specific dependencies
-try-runtime-cli = { optional = true, git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+try-runtime-cli = { optional = true, git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12' }
+substrate-build-script-utils = { git = "https://github.com/chainflip-io/substrate.git", tag = 'chainflip-monthly-2022-12+2' }
 
 [features]
 default = []

--- a/state-chain/pallets/cf-account-roles/Cargo.toml
+++ b/state-chain/pallets/cf-account-roles/Cargo.toml
@@ -24,15 +24,15 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false, optional = true }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false, optional = true }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-broadcast/Cargo.toml
+++ b/state-chain/pallets/cf-broadcast/Cargo.toml
@@ -25,15 +25,15 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-chain-tracking/Cargo.toml
+++ b/state-chain/pallets/cf-chain-tracking/Cargo.toml
@@ -24,15 +24,15 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12', default-features = false, optional = true }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2', default-features = false, optional = true }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12' }
+sp-core = { git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2' }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-emissions/Cargo.toml
+++ b/state-chain/pallets/cf-emissions/Cargo.toml
@@ -26,17 +26,17 @@ codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = 
 
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 pallet-cf-flip = { path = '../cf-flip' }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-environment/Cargo.toml
+++ b/state-chain/pallets/cf-environment/Cargo.toml
@@ -24,15 +24,15 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-flip/Cargo.toml
+++ b/state-chain/pallets/cf-flip/Cargo.toml
@@ -22,18 +22,18 @@ cf-primitives = { path = '../../primitives', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 quickcheck = '1'
 quickcheck_macros = '1'
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-governance/Cargo.toml
+++ b/state-chain/pallets/cf-governance/Cargo.toml
@@ -19,17 +19,17 @@ cf-traits = { path = '../../traits', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities'}
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-ingress-egress/Cargo.toml
+++ b/state-chain/pallets/cf-ingress-egress/Cargo.toml
@@ -19,15 +19,15 @@ cf-chains = { path ='../../chains', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-lp/Cargo.toml
+++ b/state-chain/pallets/cf-lp/Cargo.toml
@@ -24,13 +24,13 @@ serde = { version = '1.0.126', default-features = false, optional = true, featur
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 quickcheck = '1'

--- a/state-chain/pallets/cf-pools/Cargo.toml
+++ b/state-chain/pallets/cf-pools/Cargo.toml
@@ -24,16 +24,16 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-pools/runtime-api/Cargo.toml
+++ b/state-chain/pallets/cf-pools/runtime-api/Cargo.toml
@@ -11,7 +11,7 @@ repository = 'https://github.com/chainflip-io/chainflip-backend'
 
 [dependencies]
 cf-primitives = {path = "../../../../state-chain/primitives", default-features = false}
-sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ["std"]

--- a/state-chain/pallets/cf-reputation/Cargo.toml
+++ b/state-chain/pallets/cf-reputation/Cargo.toml
@@ -21,12 +21,12 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-staking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-staking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 
 # Benchmark deps
@@ -35,9 +35,9 @@ cf-primitives = { path = '../../primitives', default-features = false, optional 
 
 [dev-dependencies]
 serde = { version = '1.0.126', features = ['derive'] }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-staking/Cargo.toml
+++ b/state-chain/pallets/cf-staking/Cargo.toml
@@ -27,17 +27,17 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 pallet-cf-flip = {path = '../cf-flip'}
 cf-test-utilities = { path = '../../test-utilities' }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-swapping/Cargo.toml
+++ b/state-chain/pallets/cf-swapping/Cargo.toml
@@ -24,18 +24,18 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-arithmetic = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities'}
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-threshold-signature/Cargo.toml
+++ b/state-chain/pallets/cf-threshold-signature/Cargo.toml
@@ -27,16 +27,16 @@ pallet-cf-reputation = { path = '../cf-reputation', optional = true, default-fea
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 hex-literal = { version = '0.3' }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-tokenholder-governance/Cargo.toml
+++ b/state-chain/pallets/cf-tokenholder-governance/Cargo.toml
@@ -21,17 +21,17 @@ cf-primitives = { path ='../../primitives', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities'}
 pallet-cf-flip = { path = '../cf-flip' }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-validator/Cargo.toml
+++ b/state-chain/pallets/cf-validator/Cargo.toml
@@ -29,21 +29,21 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-application-crypto = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false, optional = true }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-application-crypto = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false, optional = true }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities' }
 simple_logger = '4.0.0'
 nanorand = { version = '0.7.0', default-features = false, features = ['wyrand']}
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-vaults/Cargo.toml
+++ b/state-chain/pallets/cf-vaults/Cargo.toml
@@ -26,17 +26,17 @@ log = { version = '0.4.16', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 hex = {version = '0.4'}
 cf-test-utilities = { path = '../../test-utilities' }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/pallets/cf-witnesser/Cargo.toml
+++ b/state-chain/pallets/cf-witnesser/Cargo.toml
@@ -29,16 +29,16 @@ bitvec = { default-features = false, version = '0.20', features = ['alloc'] }
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities' }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12" }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }
 
 [features]
 default = ['std']

--- a/state-chain/primitives/Cargo.toml
+++ b/state-chain/primitives/Cargo.toml
@@ -10,10 +10,10 @@ serde = { optional = true, version = '1.0.126', features = ['derive'] }
 hex = { optional = true, version = '0.4'}
 ethabi = {default-features = false, version = '18.0'}
 
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 codec = { package = 'parity-scale-codec', version = '3.1.1', default-features = false, features = ['derive'] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }

--- a/state-chain/runtime-upgrade-utilities/Cargo.toml
+++ b/state-chain/runtime-upgrade-utilities/Cargo.toml
@@ -8,9 +8,9 @@ description = 'Chainflip utilities for runtime upgrades.'
 [dependencies]
 log = { version = '0.4.16', default-features = false }
 
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/runtime-utilities/Cargo.toml
+++ b/state-chain/runtime-utilities/Cargo.toml
@@ -11,11 +11,11 @@ cf-runtime-macros = { path = './macros', optional = true, default-features = fal
 
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false, features = ['derive'] }
 
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 # Not used in this crate but required in order to import sp-io without conflicts.
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -12,7 +12,7 @@ repository = 'https://github.com/chainflip-io/chainflip-backend'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-substrate-wasm-builder = { version = "5.0.0-dev", git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12' }
+substrate-wasm-builder = { version = "5.0.0-dev", git = 'https://github.com/chainflip-io/substrate.git', tag = 'chainflip-monthly-2022-12+2' }
 
 [dependencies]
 # Required to get wasm to compile.
@@ -57,39 +57,39 @@ codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = 
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
 # Additional FRAME pallets
-pallet-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false, features = ['historical'] }
+pallet-authorship = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false, features = ['historical'] }
 
 # Substrate dependencies
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
-frame-executive = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
+frame-executive = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", optional = true, default-features = false }
 
-pallet-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+pallet-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-grandpa = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-timestamp = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-offchain = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-block-builder = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-consensus-aura = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-inherents = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-offchain = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { version = "7.0.0", git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-session = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-transaction-pool = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-version = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-frame-try-runtime = { optional = true, tag = 'chainflip-monthly-2022-12', default-features = false, git = 'https://github.com/chainflip-io/substrate.git' }
+frame-try-runtime = { optional = true, tag = 'chainflip-monthly-2022-12+2', default-features = false, git = 'https://github.com/chainflip-io/substrate.git' }
 
 # Used for RPCs
-frame-system-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/test-utilities/Cargo.toml
+++ b/state-chain/test-utilities/Cargo.toml
@@ -8,7 +8,7 @@ description = 'Chainflip test utilities used in multiple crates'
 [dependencies]
 codec = { package = 'parity-scale-codec', version = '3.0.0', default-features = false }
 
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']

--- a/state-chain/traits/Cargo.toml
+++ b/state-chain/traits/Cargo.toml
@@ -16,13 +16,13 @@ cf-primitives = { path ='../primitives', default-features = false }
 codec = { package = 'parity-scale-codec', version = '3.2.1', default-features = false, features = ['derive'] }
 scale-info = { version = '2.1.1', default-features = false, features = ['derive'] }
 
-frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false, optional = true }
-frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+frame-benchmarking = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false, optional = true }
+frame-support = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+frame-system = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
-sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
-sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12", default-features = false }
+sp-io = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
+sp-std = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2", default-features = false }
 
 [features]
 default = ['std']


### PR DESCRIPTION
Adds support for warp sync (see https://github.com/paritytech/substrate/pull/13221).

Combined with #2760, allow the latest node to sync with perseverance network.  

See latest three commits in https://github.com/chainflip-io/substrate/commits/chainflip/monthly-2022-12.