### PR TITLE
fix: re-enable runtime benchmarks requirement on CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -167,7 +167,6 @@ jobs:
       group: ${{ github.ref }}-run-benchmarks
       cancel-in-progress: true
     needs: [build-and-test]
-    if: github.ref_name == 'main'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Will allow us to enable runtime-benchmarks on CI 🚀 