### PR TITLE
fix: don't panic on missing author

### DIFF
--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -208,7 +208,7 @@ impl RewardsDistribution for BlockAuthorRewardDistribution {
 			if let Some(current_block_author) = Authorship::author() {
 				Flip::settle(&current_block_author, Self::Issuance::mint(reward_amount).into());
 			} else {
-				log::warn!("No block author block {}.", System::current_block_number());
+				log::warn!("No block author for block {}.", System::current_block_number());
 			}
 		}
 	}


### PR DESCRIPTION
I managed to trigger this panic when playing with the benchmark features - the genesis block apparently doesn't have an author. This changes simply emits a warning instead of panicking.