### PR TITLE
feat: enable signing stress test (cherry-picked from `release/0.6`)

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -467,6 +467,19 @@ pub mod pallet {
 			Self::deposit_event(Event::<T, I>::BroadcastSuccess { broadcast_id });
 			Ok(().into())
 		}
+
+		#[pallet::weight(0)]
+		pub fn stress_test(origin: OriginFor<T>, how_many: u32) -> DispatchResult {
+			ensure_root(origin)?;
+
+			let payload = PayloadFor::<T, I>::decode(&mut &[0xcf; 32][..])
+				.map_err(|_| Error::<T, I>::InvalidPayload)?;
+			for _ in 0..how_many {
+				T::ThresholdSigner::request_signature(payload.clone());
+			}
+
+			Ok(())
+		}
 	}
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 2,
+	spec_version: 3,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
To keep them in sync, so we don't lose it when runtime upgrading for 0.7