### PR TITLE
Witnesser checkpointing failure causes restart

### DIFF
--- a/engine/src/dot/witnesser.rs
+++ b/engine/src/dot/witnesser.rs
@@ -292,7 +292,7 @@ where
 			let state_chain_client = state_chain_client.clone();
 			let db = db.clone();
 			async move {
-				let (from_block, witnessed_until_sender) = match get_witnesser_start_block_with_checkpointing(ChainTag::Polkadot, &epoch_start, db, &logger).await{
+				let (from_block, witnessed_until_sender) = match get_witnesser_start_block_with_checkpointing(ChainTag::Polkadot, &epoch_start, db, &logger).await?{
 					StartCheckpointing::Started((from_block, witnessed_until_sender)) => (from_block, witnessed_until_sender),
 					StartCheckpointing::AlreadyWitnessedEpoch => return Ok((monitored_ingress_addresses, ingress_address_receiver, monitored_signatures, signature_receiver)),
 				};
@@ -479,11 +479,10 @@ where
 					}
 
 					witnessed_until_sender
-					.send(WitnessedUntil {
-						epoch_index: epoch_start.epoch_index,
-						block_number: block_number as u64,
-					})
-					.unwrap();
+						.send(WitnessedUntil {
+							epoch_index: epoch_start.epoch_index,
+							block_number: block_number as u64,
+						})?;
 				}
 				Ok((monitored_ingress_addresses, ingress_address_receiver, monitored_signatures, signature_receiver))
 			}

--- a/engine/src/eth/witnessing.rs
+++ b/engine/src/eth/witnessing.rs
@@ -42,14 +42,14 @@ async fn create_witnessers(
 	state_chain_client: &Arc<StateChainClient>,
 	eth_dual_rpc: &EthDualRpcClient,
 	latest_block_hash: sp_core::H256,
-	ingress_adddress_receivers: IngressAddressReceivers,
+	ingress_address_receivers: IngressAddressReceivers,
 	logger: &slog::Logger,
 ) -> anyhow::Result<AllWitnessers> {
 	let IngressAddressReceivers {
 		eth: eth_address_receiver,
 		flip: flip_address_receiver,
 		usdc: usdc_address_receiver,
-	} = ingress_adddress_receivers;
+	} = ingress_address_receivers;
 
 	let key_manager_witnesser = ContractWitnesser::new(
 		KeyManager::new(


### PR DESCRIPTION
Targets my other witnesser checkpointing PR #2818
Addresses #2778

- Changed `get_witnesser_start_block_with_checkpointing` to return a result instead of continuing with a default value.
	- An error in starting checkpointing (including migration and db loading) will cause the witnesser to be restarted
- Changed the `witnessed_until_sender.send()` to return result instead of unwrap.
	-  If the checkpointing task panics, then the next time the witnesser tries to send an updated witness, it will cause a restart.
