### PR TITLE
fix: don't use tokio::spawn

### DIFF
--- a/engine/src/common.rs
+++ b/engine/src/common.rs
@@ -123,7 +123,7 @@ mod tests {
 /// despite the fact it has been restarted.
 pub async fn start_with_restart_on_failure<StaticState, TaskFut, TaskGenerator>(
 	scope: &Scope<'_, anyhow::Error>,
-	task: TaskGenerator,
+	task_generator: TaskGenerator,
 	mut static_state: StaticState,
 ) -> anyhow::Result<()>
 where
@@ -133,17 +133,21 @@ where
 {
 	scope.spawn(async move {
 		loop {
-			// TODO: Use scope when it can accept any errors, not just anyhow errors
-			let current_task = tokio::spawn(task(static_state));
+			// TODO: We could pass the static_state by-ref to avoid needing to pass static_state out
+			// of task in error case
+
+			let task = task_generator(static_state);
 
 			// Spawn with handle and then wait for future to finish
-			static_state = match current_task.await.unwrap() {
-				Ok(()) => break Ok(()),
-				Err(state) => state,
-			};
+			static_state = match task.await {
+				Ok(()) => return Ok(()),
+				Err(state) => {
+					// give it some time before the restart
+					tokio::time::sleep(Duration::from_secs(2)).await;
 
-			// give it some time before the next restart
-			tokio::time::sleep(Duration::from_secs(2)).await;
+					state
+				},
+			};
 		}
 	});
 


### PR DESCRIPTION
I maybe missing something, but is there any reason this doesn't work? If the spawn is really needed option 1 commit can be used instead.

If this is ok, I assume some code of the witnessers could be simplified due both not needing 'static lifetimes, and also avoiding passing out the static_state in the error (If/When that is done).