### PR TITLE
feat: 0.7 preinst file for engine

### DIFF
--- a/engine/package/preinst
+++ b/engine/package/preinst
@@ -21,7 +21,7 @@ echo "Renaming to Settings.toml"
 UPDATED_ENGINE_CONFIG_LOCATION="$ENGINE_CONFIG_ROOT/Settings.toml"
 mv "$ENGINE_CONFIG_LOCATION" "$UPDATED_ENGINE_CONFIG_LOCATION"
 
-if grep "[dot]" "$UPDATED_ENGINE_CONFIG_LOCATION" > /dev/null; then
+if grep "\[dot\]" "$UPDATED_ENGINE_CONFIG_LOCATION" > /dev/null; then
   echo "Dot config already present. Exiting"
   exit 0
 fi


### PR DESCRIPTION
With the release of new config there comes the inevitable nightmare of getting our less bash inclined users to do all the steps correctly. We have the possibility of releasing the next version with a `preinst` script which will do the follwing:
1. Find and rename the engine config file from `Default.toml` to `Settings.toml`
2. Add the appropriate Polkadot configuration.

This script handles the cases where:
1. users have managed to put their engine config somewhere other than the default.
2. users have already updated their config with the Polkadot settings.