### PR TITLE
fix: duplicate updates to the checkpointing

### DIFF
--- a/engine/src/dot/witnesser.rs
+++ b/engine/src/dot/witnesser.rs
@@ -401,6 +401,8 @@ where
 						break
 					}
 
+					slog::trace!(logger, "Checking block: {block_number}, with hash: {block_hash:?} for interesting events");
+
 					let (
 						interesting_indices,
 						ingress_witnesses,
@@ -509,6 +511,7 @@ where
 						epoch_index: epoch_start.epoch_index,
 						block_number: block_number as u64,
 					})
+					.await
 					.unwrap();
 				}
 				Ok((monitored_ingress_addresses, ingress_address_receiver, monitored_signatures, signature_receiver))
@@ -732,7 +735,7 @@ mod tests {
 	#[ignore = "This test is helpful for local testing. Requires connection to westend"]
 	#[tokio::test]
 	async fn start_witnessing() {
-		let url = "url";
+		let url = "ws://localhost:9944";
 
 		let logger = new_test_logger();
 
@@ -781,8 +784,8 @@ mod tests {
 		// proxy type governance
 		epoch_starts_sender
 			.broadcast(EpochStart {
-				epoch_index: 3,
-				block_number: 534,
+				epoch_index: 1,
+				block_number: 0,
 				current: true,
 				participant: true,
 				data: dot::EpochStartData {

--- a/engine/src/eth/eth_block_witnessing.rs
+++ b/engine/src/eth/eth_block_witnessing.rs
@@ -126,6 +126,7 @@ pub async fn start(
 							epoch_index: epoch.epoch_index,
 							block_number: block.block_number.as_u64(),
 						})
+						.await
 						.unwrap();
 				}
 


### PR DESCRIPTION
Fixes bug where the checkpointing watch channel would call `.borrow()` but not actually read the value. This meant that if the loop continued, without receiving an update from the witnesser, it would loop again, and read the *same* value, causing the assert to be hit.

Instead of using the watch channel, we just use a tokio::mpsc channel, which makes it clearly correct, and easier to reason about.

We haven't seen the necessity of throttling the checkpointing, so doesn't make sense to have more complex code to do so.