### PR TITLE
fix: clean up broadcaster state on polkadot init

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -15,12 +15,13 @@ pub use weights::WeightInfo;
 
 use cf_chains::{ApiCall, Chain, ChainAbi, ChainCrypto, FeeRefundCalculator, TransactionBuilder};
 use cf_traits::{
-	offence_reporting::OffenceReporter, Broadcaster, Chainflip, EpochInfo, EpochKey,
-	SingleSignerNomination, ThresholdSigner,
+	offence_reporting::OffenceReporter, BroadcastCleanup, Broadcaster, Chainflip, EpochInfo,
+	EpochKey, SingleSignerNomination, ThresholdSigner,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
-	dispatch::DispatchResultWithPostInfo, sp_runtime::traits::Saturating, traits::Get, Twox64Concat,
+	dispatch::DispatchResultWithPostInfo, pallet_prelude::DispatchResult,
+	sp_runtime::traits::Saturating, traits::Get, Twox64Concat,
 };
 
 use cf_traits::KeyProvider;
@@ -638,5 +639,13 @@ impl<T: Config<I>, I: 'static> Broadcaster<T::TargetChain> for Pallet<T, I> {
 	type ApiCall = T::ApiCall;
 	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> BroadcastId {
 		Self::threshold_sign_and_broadcast(api_call)
+	}
+}
+
+impl<T: Config<I>, I: 'static> BroadcastCleanup<T::TargetChain> for Pallet<T, I> {
+	fn clean_up_broadcast(broadcast_id: BroadcastId) -> DispatchResult {
+		Self::clean_up_broadcast_storage(broadcast_id);
+		Self::deposit_event(Event::<T, I>::BroadcastSuccess { broadcast_id });
+		Ok(())
 	}
 }

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -7,7 +7,7 @@ use cf_chains::{
 use cf_primitives::{AuthorityCount, BroadcastId};
 use cf_traits::{
 	mocks::{ensure_origin_mock::NeverFailingOriginCheck, system_state_info::MockSystemStateInfo},
-	Broadcaster, Chainflip, VaultKeyWitnessedHandler,
+	BroadcastCleanup, Broadcaster, Chainflip, VaultKeyWitnessedHandler,
 };
 
 use frame_support::parameter_types;
@@ -102,6 +102,12 @@ impl Broadcaster<Polkadot> for MockPolkadotBroadcaster {
 		unimplemented!()
 	}
 }
+impl BroadcastCleanup<Polkadot> for MockPolkadotBroadcaster {
+	fn clean_up_broadcast(_broadcast_id: BroadcastId) -> sp_runtime::DispatchResult {
+		unimplemented!()
+	}
+}
+
 pub struct MockPolkadotVaultKeyWitnessedHandler;
 impl VaultKeyWitnessedHandler<Polkadot> for MockPolkadotVaultKeyWitnessedHandler {
 	fn on_new_key_activated(

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -459,6 +459,11 @@ pub trait Broadcaster<Api: ChainAbi> {
 	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> BroadcastId;
 }
 
+pub trait BroadcastCleanup<C: Chain> {
+	/// Triggers any necessary cleanup.
+	fn clean_up_broadcast(broadcast_id: BroadcastId) -> DispatchResult;
+}
+
 /// The heartbeat of the network
 pub trait Heartbeat {
 	type ValidatorId;


### PR DESCRIPTION
We weren't removing broadcast state on dot vault initialisation, so the initial create_pure broadcast kept getting repeated. 

This fix should be cherry-picked to the release branch.