### PR TITLE
refactor: store the script pub key in the output

### DIFF
--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -358,7 +358,7 @@ impl BitcoinTransaction {
 	}
 }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct BitcoinScript {
 	data: Vec<u8>,
 }


### PR DESCRIPTION
Nice side effect of this is we don't have to store the network in the Transaction struct