### PR TITLE
feat: prototype array utilities

### DIFF
--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -116,7 +116,7 @@ impl<T, const N: usize> PartialArray<T, N> {
 	fn into_array(mut self) -> [T; N] {
 		assert_eq!(N, self.initialized_length);
 		assert_eq!(core::mem::size_of::<[T; N]>(), core::mem::size_of::<[MaybeUninit<T>; N]>());
-        // Don't drop the copied elements when PartialArray is dropped
+		// Don't drop the copied elements when PartialArray is dropped
 		self.initialized_length = 0;
 		unsafe { core::mem::transmute_copy::<_, [T; N]>(&self.array) }
 	}


### PR DESCRIPTION
See the tests.

You just need to import the two traits `SliceToArray` and `ArrayCollect` from the utilities crate to use these two functions (as_array and collect_array).

My intention here is that as_array() can be used to split array, like:

```rust
let array = [...];

let first = array[0..4].as_array<4>();
let second = array[4..8].as_array<4>();
...
```

And to concat into arrays like:

```rust
let vector = vec![...];
let array = [...];
let slice = &array[3..5];
let iterator = std::iter::once(4);

itertools::chain!(iterator, slice.iter().copied(), vector, array).collect_array::<N>()
```