### PR TITLE
bug: Address re-use issues new intent id

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1,10 +1,11 @@
 use crate::{
 	mock::*, AddressPool, AddressStatus, DeploymentStatus, DisabledEgressAssets, FetchOrTransfer,
-	IntentActions, IntentExpiries, IntentIngressDetails, ScheduledEgressRequests, WeightInfo,
+	IntentAction, IntentActions, IntentExpiries, IntentIngressDetails, ScheduledEgressRequests,
+	WeightInfo,
 };
 
-use cf_primitives::{chains::assets::eth, ForeignChain};
-use cf_traits::{EgressApi, IngressApi};
+use cf_primitives::{chains::assets::eth, ForeignChain, IntentId};
+use cf_traits::{AddressDerivationApi, EgressApi, IngressApi};
 
 use frame_support::{assert_ok, instances::Instance1, traits::Hooks, weights::Weight};
 const ALICE_ETH_ADDRESS: EthereumAddress = [100u8; 20];
@@ -441,5 +442,28 @@ fn create_new_address_while_pool_is_empty() {
 		);
 		IngressEgress::on_initialize(EXPIRY_BLOCK);
 		assert_eq!(AddressPool::<Test, Instance1>::get().len(), 2);
+	});
+}
+
+#[test]
+fn reused_address_intent_id_matches() {
+	new_test_ext().execute_with(|| {
+		const INTENT_ID: IntentId = 0;
+		let eth_address =
+			<<Test as crate::Config<Instance1>>::AddressDerivation as AddressDerivationApi<
+				Ethereum,
+			>>::generate_address(eth::Asset::Eth, INTENT_ID)
+			.unwrap();
+		AddressPool::<Test, _>::append((INTENT_ID, eth_address));
+
+		let (reused_intent_id, reused_address) = IngressEgress::register_ingress_intent(
+			eth::Asset::Eth,
+			IntentAction::LiquidityProvision { lp_account: 0 },
+		)
+		.unwrap();
+
+		// The reused details should be the same as before.
+		assert_eq!(reused_intent_id, INTENT_ID);
+		assert_eq!(eth_address, reused_address);
 	});
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -13,7 +13,8 @@ pub use async_result::AsyncResult;
 use sp_std::collections::btree_set::BTreeSet;
 
 use cf_chains::{
-	benchmarking_value::BenchmarkValue, ApiCall, Chain, ChainAbi, ChainCrypto, Ethereum, Polkadot,
+	benchmarking_value::BenchmarkValue, eth::H256, ApiCall, Chain, ChainAbi, ChainCrypto, Ethereum,
+	Polkadot,
 };
 
 use cf_primitives::{
@@ -690,19 +691,19 @@ pub trait AddressDerivationApi<C: Chain> {
 
 impl AddressDerivationApi<Ethereum> for () {
 	fn generate_address(
-		_ingress_asset: <Ethereum as Chain>::ChainAsset,
-		_intent_id: IntentId,
+		ingress_asset: <Ethereum as Chain>::ChainAsset,
+		intent_id: IntentId,
 	) -> Result<<Ethereum as Chain>::ChainAccount, DispatchError> {
-		Ok(Default::default())
+		Ok(H256((ingress_asset, intent_id).encode().blake2_256()).into())
 	}
 }
 
 impl AddressDerivationApi<Polkadot> for () {
 	fn generate_address(
-		_ingress_asset: <Polkadot as Chain>::ChainAsset,
-		_intent_id: IntentId,
+		ingress_asset: <Polkadot as Chain>::ChainAsset,
+		intent_id: IntentId,
 	) -> Result<<Polkadot as Chain>::ChainAccount, DispatchError> {
-		Ok([0u8; 32].into())
+		Ok((ingress_asset, intent_id).encode().blake2_256().into())
 	}
 }
 


### PR DESCRIPTION
@Janislav I think this might be a bug? 

When we re-issue an address from the pool, we increment the id counter, and now the intent_id doesn't match the address. Let's discuss tomorrow. 