### PR TITLE
fix: use a more generous default for keygen timeouts

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -340,7 +340,9 @@ pub mod pallet {
 		fn on_runtime_upgrade() -> Weight {
 			// For new pallet instances, genesis items need to be set.
 			if !KeygenResponseTimeout::<T, I>::exists() {
-				KeygenResponseTimeout::<T, I>::set(KEYGEN_CEREMONY_RESPONSE_TIMEOUT_BLOCKS_DEFAULT.into());
+				KeygenResponseTimeout::<T, I>::set(
+					KEYGEN_CEREMONY_RESPONSE_TIMEOUT_BLOCKS_DEFAULT.into(),
+				);
 			}
 			if !CurrentVaultEpochAndState::<T, I>::exists() {
 				CurrentVaultEpochAndState::<T, I>::put(VaultEpochAndState {


### PR DESCRIPTION
This is a minor update to ensure we don't accidentally set the keygen timeouts too aggressively when upgrading.