### PR TITLE
chore: remove as_u128()

### DIFF
--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -569,8 +569,14 @@ impl FeeRefundCalculator<Ethereum> for Transaction {
 		&self,
 		fee_paid: <Ethereum as Chain>::TransactionFee,
 	) -> <Ethereum as Chain>::ChainAmount {
-		min(self.max_fee_per_gas.unwrap_or_default().as_u128(), fee_paid.effective_gas_price)
-			.saturating_mul(fee_paid.gas_used)
+		min(
+			self.max_fee_per_gas
+				.unwrap_or_default()
+				.try_into()
+				.expect("In practice `max_fee_per_gas` is always less than u128::MAX"),
+			fee_paid.effective_gas_price,
+		)
+		.saturating_mul(fee_paid.gas_used)
 	}
 }
 


### PR DESCRIPTION
These are the only usages left that's not in the tests or AMM (which is about to change quite a bit, so didn't bother). Closes #2704 
