### PR TITLE
fix: ensure validator for set_key

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -576,6 +576,7 @@ pub mod pallet {
 			keys: T::Keys,
 			proof: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
+			T::AccountRoleRegistry::ensure_validator(origin.clone())?;
 			<pallet_session::Pallet<T>>::set_keys(origin, keys, proof)?;
 			Ok(().into())
 		}


### PR DESCRIPTION
A small thing - only validators need to set their session keys.