### PR TITLE
chore: add .cargo cf-test-no-amm

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,6 +5,8 @@
 # Run unit tests but not integration tests
 cf-test = "test --lib --all-features"
 
+cf-test-no-amm = "test --lib --all-features --workspace --exclude cf-amm"
+
 ci-check = "check --all-targets --all-features --release"
 
 cf-clippy = "clippy --all-targets --all-features"


### PR DESCRIPTION
The AMM tests take a long time to run so it's annoying to run them locally when not touching the AMM.

Now you can just run `cargo cf-test-no-amm`