### PR TITLE
chore: improve logs around witnesser checkpointing

### DIFF
--- a/engine/src/witnesser/block_witnesser.rs
+++ b/engine/src/witnesser/block_witnesser.rs
@@ -138,6 +138,8 @@ where
 				StartCheckpointing::AlreadyWitnessedEpoch => return Ok(WitnesserInitResult::EpochSkipped),
 			};
 
+		tracing::info!("{} block witnesser is starting from block {}", <Generator::Witnesser as BlockWitnesser>::Chain::NAME, from_block);
+
 		let block_stream = self.generator.get_block_stream(from_block).await?;
 
 		let witnesser = BlockWitnesserWrapper {

--- a/engine/src/witnesser/checkpointing.rs
+++ b/engine/src/witnesser/checkpointing.rs
@@ -55,10 +55,7 @@ where
 			checkpoint
 		},
 		None => {
-			info!(
-				"No {chain_tag} witnesser checkpoint found, using default of {:?}",
-				WitnessedUntil::default()
-			);
+			info!("No {chain_tag} witnesser checkpoint found");
 			WitnessedUntil::default()
 		},
 	};


### PR DESCRIPTION
I found that the original log message what somewhat confusing (I had to double check that we don't actually start witnessing from the default block 0). I added a separate message to say where we start instead.