### PR TITLE
chore: localnets shouldn't prune chain state

### DIFF
--- a/localnet/init/scripts/start-node.sh
+++ b/localnet/init/scripts/start-node.sh
@@ -13,4 +13,6 @@ $binary_location/chainflip-node --chain=dev \
   --ws-external \
   --rpc-methods=Unsafe \
   --name=bashful \
+  --blocks-pruning=archive \
+  --state-pruning=archive \
   --state-cache-size=0 > /tmp/chainflip/chainflip-node.log 2>&1 &


### PR DESCRIPTION
Was debugging and then I couldn't because the state was deleted 😢 