### PR TITLE
refactor: add epoch index to rotation state

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -402,9 +402,9 @@ pub mod pallet {
 						// We have successfully done keygen verification
 						AsyncResult::Ready(VaultStatus::KeygenComplete) => {
 							let new_authorities = rotation_state.authority_candidates::<Vec<_>>();
-							HistoricalAuthorities::<T>::insert(rotation_state.epoch_index, new_authorities.clone());
+							HistoricalAuthorities::<T>::insert(rotation_state.new_epoch_index, new_authorities.clone());
 							EpochAuthorityCount::<T>::insert(
-								rotation_state.epoch_index,
+								rotation_state.new_epoch_index,
 								new_authorities.len() as AuthorityCount,
 							);
 							T::VaultRotator::activate();
@@ -1133,7 +1133,7 @@ impl<T: Config> Pallet<T> {
 			);
 			Self::set_rotation_phase(RotationPhase::Idle);
 		} else {
-			let new_epoch_index = rotation_state.epoch_index;
+			let new_epoch_index = rotation_state.new_epoch_index;
 			Self::set_rotation_phase(RotationPhase::KeygensInProgress(rotation_state));
 			T::VaultRotator::keygen(candidates, new_epoch_index);
 			log::info!(target: "cf-validator", "Vault rotation initiated.");

--- a/state-chain/pallets/cf-validator/src/rotation_state.rs
+++ b/state-chain/pallets/cf-validator/src/rotation_state.rs
@@ -11,7 +11,7 @@ pub struct RotationState<Id, Amount> {
 	secondary_candidates: Vec<Id>,
 	banned: BTreeSet<Id>,
 	pub bond: Amount,
-	pub epoch_index: EpochIndex,
+	pub new_epoch_index: EpochIndex,
 }
 
 impl<Id: Ord + Clone, Amount: AtLeast32BitUnsigned + Copy> RotationState<Id, Amount> {
@@ -49,7 +49,7 @@ impl<Id: Ord + Clone, Amount: AtLeast32BitUnsigned + Copy> RotationState<Id, Amo
 				.collect(),
 			banned: Default::default(),
 			bond,
-			epoch_index: T::EpochInfo::epoch_index() + 1,
+			new_epoch_index: T::EpochInfo::epoch_index() + 1,
 		}
 	}
 
@@ -100,7 +100,7 @@ mod rotation_state_tests {
 			secondary_candidates: (20..30).collect(),
 			banned: Default::default(),
 			bond: 500,
-			epoch_index: 2,
+			new_epoch_index: 2,
 		};
 
 		let first_ban = BTreeSet::from([8, 9, 7]);
@@ -122,7 +122,7 @@ mod rotation_state_tests {
 			secondary_candidates: (20..30).collect(),
 			banned: BTreeSet::from([1, 2, 4]),
 			bond: 500,
-			epoch_index: 2,
+			new_epoch_index: 2,
 		};
 
 		let candidates: Vec<_> = rotation_state.authority_candidates();
@@ -138,7 +138,7 @@ mod rotation_state_tests {
 				secondary_candidates: (20..30).collect(),
 				banned: BTreeSet::from([0, 1, 3]),
 				bond: Default::default(),
-				epoch_index: 2,
+				new_epoch_index: 2,
 			};
 			QualifyAll::<Id>::except([1, 2, 4]);
 			rotation_state.qualify_nodes::<QualifyAll<_>>();


### PR DESCRIPTION
Removes duplicate +1, and makes correctness more clear. There would be another +1 case incoming in the key handover PR too without this PR :)