### PR TITLE
Feature: Added expiry for DepositAddressReady and NewSwapIntent

### DIFF
--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -104,7 +104,7 @@ pub mod pallet {
 		DepositAddressReady {
 			intent_id: IntentId,
 			ingress_address: EncodedAddress,
-			expiry: T::BlockNumber,
+			expiry_block: T::BlockNumber,
 		},
 		DepositAddressExpired {
 			address: EncodedAddress,
@@ -173,17 +173,17 @@ pub mod pallet {
 			let (intent_id, ingress_address) =
 				T::IngressHandler::register_liquidity_ingress_intent(account_id, asset)?;
 
-			let expiry =
+			let expiry_block =
 				frame_system::Pallet::<T>::current_block_number().saturating_add(LpTTL::<T>::get());
 			IngressIntentExpiries::<T>::append(
-				expiry,
+				expiry_block,
 				(intent_id, ForeignChain::from(asset), ingress_address.clone()),
 			);
 
 			Self::deposit_event(Event::DepositAddressReady {
 				intent_id,
 				ingress_address: T::AddressConverter::try_to_encoded_address(ingress_address)?,
-				expiry,
+				expiry_block,
 			});
 
 			Ok(())

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -131,7 +131,7 @@ fn ingress_intents_expires() {
 		let (intent_id, ingress_address) = assert_events_match!(Test, RuntimeEvent::LiquidityProvider(crate::Event::DepositAddressReady {
 			intent_id,
 			ingress_address,
-			expiry: expiry_block,
+			expiry_block,
 		}) if expiry_block == expiry => (intent_id, ingress_address));
 		let lp_intent = LpIntent {
 			ingress_address: MockAddressConverter::try_from_encoded_address(ingress_address.clone()).unwrap(),

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -168,7 +168,7 @@ pub mod pallet {
 		/// An new swap intent has been registered.
 		NewSwapIntent {
 			ingress_address: EncodedAddress,
-			expiry: T::BlockNumber,
+			expiry_block: T::BlockNumber,
 		},
 		/// The swap ingress was received.
 		SwapIngressReceived {
@@ -340,16 +340,16 @@ pub mod pallet {
 				message_metadata,
 			)?;
 
-			let expiry = frame_system::Pallet::<T>::current_block_number()
+			let expiry_block = frame_system::Pallet::<T>::current_block_number()
 				.saturating_add(SwapTTL::<T>::get());
 			SwapIntentExpiries::<T>::append(
-				expiry,
+				expiry_block,
 				(intent_id, ForeignChain::from(ingress_asset), ingress_address.clone()),
 			);
 
 			Self::deposit_event(Event::<T>::NewSwapIntent {
 				ingress_address: T::AddressConverter::try_to_encoded_address(ingress_address)?,
-				expiry,
+				expiry_block,
 			});
 
 			Ok(())

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -206,7 +206,7 @@ fn expect_swap_id_to_be_emitted() {
 			Test,
 			crate::mock::RuntimeEvent::Swapping(crate::Event::NewSwapIntent {
 				ingress_address: EncodedAddress::Eth(Default::default()),
-				expiry: SwapTTL::<Test>::get() + System::current_block_number(),
+				expiry_block: SwapTTL::<Test>::get() + System::current_block_number(),
 			}),
 			crate::mock::RuntimeEvent::Swapping(crate::Event::SwapIngressReceived {
 				ingress_address: EncodedAddress::Eth(Default::default()),


### PR DESCRIPTION
# Pull Request
Linear issue(s): PRO-186

## Summary
Added expiry for event DepositAddressReady and NewSwapIntent.

Closes [PRO-186](https://linear.app/chainflip/issue/PRO-186)

