### PR TITLE
fix: remove duplicate role check

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -237,7 +237,7 @@ pub async fn force_rotation(state_chain_settings: &settings::StateChain) -> Resu
 				.await
 				.expect("Should submit sudo governance proposal");
 
-			println!("Rotation should begin soon :)");
+			println!("If you're the governance dictator, the rotation will begin soon.");
 
 			Ok(())
 		}


### PR DESCRIPTION
The role is already checked in the StateChainClient::new(), no need to check it again.