### PR TITLE
fix: add missing features on dep in utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.16",
  "url 1.7.2",
  "utilities",
  "web3",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -79,7 +79,6 @@ ed25519-dalek = "1.0"
 pin-project = "1.0.12"
 rand = "0.8.4"
 tracing = "0.1"
-tracing-subscriber = {version = "0.3", features = ["json", "env-filter"]}
 x25519-dalek = {version = "1.1", features = ["serde"]}
 zmq = {git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1", features = [
   "vendored",

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -21,7 +21,7 @@ async-channel = { version = "1.7.1", optional = true}
 tempfile = { version = "3.3.0", optional = true}
 itertools = {version = "0.10", default_features = false}
 tracing = { version = "0.1", optional = true}
-tracing-subscriber = {version = "0.3", optional = true}
+tracing-subscriber = {version = "0.3", features = ["json", "env-filter"], optional = true}
 pin-project = {version = "1.0.12", optional = true}
 
 [features]
@@ -38,4 +38,6 @@ std = [
   'async-channel',
   'itertools/use_std',
   'pin-project',
+  'tracing',
+  'tracing-subscriber',
 ]


### PR DESCRIPTION
## Summary

Not sure how this one made it past the CI. A missing feature on the tracing-subscriber dep causes a build error in the utilities crate, but not all the time. I'm guessing that this is something to do with the feature flag that is it under. 
