### PR TITLE
fix: ceremony-id not updated on unknown key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5031,7 +5031,6 @@ dependencies = [
  "cf-chains",
  "cf-primitives",
  "curve25519-dalek 2.1.3",
- "derivative",
  "ed25519-consensus",
  "futures",
  "futures-core",

--- a/engine/multisig/Cargo.toml
+++ b/engine/multisig/Cargo.toml
@@ -62,7 +62,6 @@ cf-chains = { path = "../../state-chain/chains" }
 cf-primitives = { path = "../../state-chain/primitives" }
 state-chain-runtime = { path = "../../state-chain/runtime" }
 utilities = {package = "utilities", path = "../../utilities" }
-derivative = "2.2.0"
 
 # substrate deps
 sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2022-12+2" }

--- a/engine/multisig/src/client/common/mod.rs
+++ b/engine/multisig/src/client/common/mod.rs
@@ -10,7 +10,6 @@ pub use ceremony_stage::{
 pub use broadcast_verification::BroadcastVerificationMessage;
 
 use cf_primitives::{AccountId, AuthorityCount};
-use derivative::Derivative;
 pub use failure_reason::{
 	BroadcastFailureReason, CeremonyFailureReason, KeygenFailureReason, SigningFailureReason,
 };
@@ -101,8 +100,7 @@ type SecretShare<C> = <<C as CryptoScheme>::Point as ECPoint>::Scalar;
 type PublicKeyShares<C> = BTreeMap<AccountId, <C as CryptoScheme>::Point>;
 
 /// Holds state relevant to the role in the handover ceremony.
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub enum ParticipantStatus<C: CryptoScheme> {
 	Sharing(SecretShare<C>, PublicKeyShares<C>),
 	/// This becomes `NonSharingReceivedKeys` after shares are broadcast
@@ -110,8 +108,7 @@ pub enum ParticipantStatus<C: CryptoScheme> {
 	NonSharingReceivedKeys(PublicKeyShares<C>),
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub struct ResharingContext<C: CryptoScheme> {
 	/// Participants who contribute their (existing) secret shares
 	pub sharing_participants: BTreeSet<AuthorityCount>,

--- a/engine/multisig/src/client/mod.rs
+++ b/engine/multisig/src/client/mod.rs
@@ -17,7 +17,6 @@ pub mod ceremony_manager;
 
 use std::collections::BTreeSet;
 
-use derivative::Derivative;
 use utilities::{format_iterator, threshold_from_share_count};
 
 use cf_primitives::{AuthorityCount, CeremonyId, EpochIndex, KeyId};
@@ -135,14 +134,12 @@ pub trait MultisigClientApi<C: CryptoScheme> {
 
 /// The ceremony details are optional to alow the updating of the ceremony id tracking
 /// when we are not participating in the ceremony.
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub struct CeremonyRequest<C: CryptoScheme> {
 	pub ceremony_id: CeremonyId,
 	pub details: Option<CeremonyRequestDetails<C>>,
 }
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub enum CeremonyRequestDetails<C>
 where
 	C: CryptoScheme,
@@ -151,8 +148,7 @@ where
 	Sign(SigningRequestDetails<C>),
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub struct KeygenRequestDetails<C: CryptoScheme> {
 	pub participants: BTreeSet<AccountId>,
 	pub rng: Rng,
@@ -162,8 +158,7 @@ pub struct KeygenRequestDetails<C: CryptoScheme> {
 	pub resharing_context: Option<ResharingContext<C>>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
+#[derive(Debug)]
 pub struct SigningRequestDetails<C>
 where
 	C: CryptoScheme,
@@ -306,9 +301,10 @@ impl<C: CryptoScheme, KeyStore: KeyStoreAPI<C>> MultisigClientApi<C>
 			.boxed()
 		} else {
 			self.update_latest_ceremony_id(ceremony_id);
+			let reported_parties = Default::default();
 			let failure_reason = SigningFailureReason::UnknownKey;
-			failure_reason.log(&Default::default());
-			futures::future::ready(Err((Default::default(), failure_reason))).boxed()
+			failure_reason.log(&reported_parties);
+			futures::future::ready(Err((reported_parties, failure_reason))).boxed()
 		}
 	}
 

--- a/engine/multisig/src/client/multisig_client_tests.rs
+++ b/engine/multisig/src/client/multisig_client_tests.rs
@@ -27,7 +27,7 @@ async fn should_ignore_rts_for_unknown_key() {
 	let mut mock_key_store = MockKeyStoreAPI::new();
 	mock_key_store.expect_get_key().once().returning(|_| None);
 
-	let (ceremony_request_sender, _ceremony_request_receiver) =
+	let (ceremony_request_sender, mut ceremony_request_receiver) =
 		tokio::sync::mpsc::unbounded_channel();
 
 	// Create a client
@@ -49,6 +49,10 @@ async fn should_ignore_rts_for_unknown_key() {
 	// Check that the signing request fails immediately with an "unknown key" error
 	let (_, failure_reason) = assert_err!(assert_future_can_complete(signing_request_fut));
 	assert_eq!(failure_reason, SigningFailureReason::UnknownKey);
+	assert!(matches!(
+		assert_ok!(assert_future_can_complete(ceremony_request_receiver.recv())),
+		CeremonyRequest { ceremony_id: DEFAULT_SIGNING_CEREMONY_ID, details: None }
+	));
 }
 
 #[tokio::test]


### PR DESCRIPTION
One the health check should only start functioning once all the cfe's systems have started.

Two the ceremony id was not being updated on a signing reuqest when the client couldn't find the associated key.