### PR TITLE
Renamed refund_address to cf_parameters

### DIFF
--- a/engine/tests/vault_integration.rs
+++ b/engine/tests/vault_integration.rs
@@ -73,7 +73,7 @@ pub async fn test_all_vault_events() {
 				.unwrap(),
 			message: Bytes(vec![164, 85]),
 			gas_amount: 42069,
-			refund_address: Bytes(vec![164, 85]),
+			cf_parameters: Bytes(vec![164, 85]),
 		}
 	));
 
@@ -88,7 +88,7 @@ pub async fn test_all_vault_events() {
 				.unwrap(),
 			message: Bytes(vec![164, 85]),
 			gas_amount: 42069,
-			refund_address: Bytes(vec![164, 85]),
+			cf_parameters: Bytes(vec![164, 85]),
 			source_token: web3::types::H160::from_str("0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9")
 				.unwrap(),
 		}

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -305,7 +305,7 @@ fn can_process_ccm_via_swap_intent() {
 		let message = CcmIngressMetadata {
 			message: vec![0u8, 1u8, 2u8, 3u8, 4u8],
 			gas_budget,
-			refund_address: ForeignChainAddress::Eth([0x01; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -422,7 +422,7 @@ fn can_process_ccm_via_extrinsic_intent() {
 		let message = CcmIngressMetadata {
 			message: vec![0u8, 1u8, 2u8, 3u8, 4u8],
 			gas_budget,
-			refund_address: ForeignChainAddress::Eth([0x01; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20])
 		};
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -308,7 +308,7 @@ pub struct CcmIngressMetadata {
 	/// Amount of ingress funds to be used for gas.
 	pub gas_budget: AssetAmount,
 	/// The address refunds will go to.
-	pub refund_address: ForeignChainAddress,
+	pub cf_parameters: Vec<u8>,
 	/// The address the ingress was sent from.
 	pub source_address: ForeignChainAddress,
 }

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -53,7 +53,7 @@ benchmarks_instance_pallet! {
 				amount: BenchmarkValue::benchmark_value(),
 				egress_address: egress_address.clone(),
 				message: vec![0x00, 0x01, 0x02, 0x03],
-				refund_address: ForeignChainAddress::Eth(Default::default()),
+				cf_parameters: vec![],
 				source_address: ForeignChainAddress::Eth([0xcf; 20]),
 			});
 		}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) struct CrossChainMessage<C: Chain> {
 	// The sender of the ingress transaction.
 	pub source_address: ForeignChainAddress,
 	// Where funds might be returned to if the message fails.
-	pub refund_address: ForeignChainAddress,
+	pub cf_parameters: Vec<u8>,
 }
 
 impl<C: Chain> CrossChainMessage<C> {
@@ -738,14 +738,14 @@ impl<T: Config<I>, I: 'static> EgressApi<T::TargetChain> for Pallet<T, I> {
 		});
 		let egress_id = (<T as Config<I>>::TargetChain::get(), egress_counter);
 		match maybe_message {
-			Some(CcmIngressMetadata { message, refund_address, source_address, .. }) =>
+			Some(CcmIngressMetadata { message, cf_parameters, source_address, .. }) =>
 				ScheduledEgressCcm::<T, I>::append(CrossChainMessage {
 					egress_id,
 					asset,
 					amount,
 					egress_address: egress_address.clone(),
 					message,
-					refund_address,
+					cf_parameters,
 					source_address,
 				}),
 			None => ScheduledEgressFetchOrTransfer::<T, I>::append(FetchOrTransfer::<

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -374,7 +374,7 @@ fn on_idle_does_nothing_if_nothing_to_send() {
 			Some(CcmIngressMetadata {
 				message: vec![],
 				gas_budget: 0,
-				refund_address: ForeignChainAddress::Eth(Default::default()),
+				cf_parameters: vec![],
 				source_address: ForeignChainAddress::Eth([0xcf; 20]),
 			}),
 		);
@@ -523,7 +523,7 @@ fn can_ingress_ccm_swap_intents() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00, 0x01, 0x02],
 			gas_budget: 1_000,
-			refund_address: ForeignChainAddress::Eth(Default::default()),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 		let amount = 5_000;
@@ -575,7 +575,7 @@ fn can_egress_ccm() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00, 0x01, 0x02],
 			gas_budget: 1_000,
-			refund_address: ForeignChainAddress::Eth([0x02; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 		let amount = 5_000;
@@ -594,7 +594,7 @@ fn can_egress_ccm() {
 				amount,
 				egress_address,
 				message: ccm.message.clone(),
-				refund_address: ForeignChainAddress::Eth([0x02; 20]),
+				cf_parameters: vec![],
 				source_address: ForeignChainAddress::Eth([0xcf; 20]),
 			}
 		]);
@@ -642,7 +642,7 @@ fn can_manually_egress_ccm() {
 				amount,
 				egress_address,
 				message: message.clone(),
-				refund_address: ForeignChainAddress::Eth([0x02; 20]),
+				cf_parameters: vec![],
 				source_address: ForeignChainAddress::Eth([0xcf; 20]),
 			}
 		);
@@ -686,7 +686,7 @@ fn can_manually_egress_ccm_by_id() {
 				amount,
 				egress_address,
 				message: message.clone(),
-				refund_address: ForeignChainAddress::Eth([0x02; 20]),
+				cf_parameters: vec![],
 				source_address: ForeignChainAddress::Eth([0xcf; 20]),
 			}
 		};

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -96,7 +96,7 @@ benchmarks! {
 		let metadata = CcmIngressMetadata {
 			message: vec![0x00],
 			gas_budget: 1,
-			refund_address: ForeignChainAddress::benchmark_value(),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::benchmark_value(),
 		};
 		let call = Call::<T>::ccm_ingress{

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -352,7 +352,7 @@ fn can_reject_invalid_ccms() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00],
 			gas_budget,
-			refund_address: ForeignChainAddress::Dot(Default::default()),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -443,7 +443,7 @@ fn can_process_ccms_via_swap_intent() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x01],
 			gas_budget,
-			refund_address: ForeignChainAddress::Dot([0x01; 32]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -508,7 +508,7 @@ fn can_process_ccms_via_swap_intent() {
 				amount: ingress_amount - gas_budget,
 				egress_address: ForeignChainAddress::Eth(Default::default()),
 				message: vec![0x01],
-				refund_address: ForeignChainAddress::Dot([0x01; 32]),
+				cf_parameters: vec![],
 			},]
 		);
 
@@ -536,7 +536,7 @@ fn can_process_ccms_via_extrinsic() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x02],
 			gas_budget,
-			refund_address: ForeignChainAddress::Dot([0x02; 32]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -593,7 +593,7 @@ fn can_process_ccms_via_extrinsic() {
 				amount: ingress_amount - gas_budget,
 				egress_address: ForeignChainAddress::Eth(Default::default()),
 				message: vec![0x02],
-				refund_address: ForeignChainAddress::Dot([0x02; 32]),
+				cf_parameters: vec![],
 			},]
 		);
 
@@ -630,7 +630,7 @@ fn can_handle_ccms_with_gas_asset_as_ingress() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00],
 			gas_budget,
-			refund_address: ForeignChainAddress::Eth([0x01; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 		assert_ok!(Swapping::ccm_ingress(
@@ -679,7 +679,7 @@ fn can_handle_ccms_with_gas_asset_as_ingress() {
 				amount: ingress_amount - gas_budget,
 				egress_address: ForeignChainAddress::Eth(Default::default()),
 				message: vec![0x00],
-				refund_address: ForeignChainAddress::Eth([0x01; 20]),
+				cf_parameters: vec![],
 			},]
 		);
 
@@ -716,7 +716,7 @@ fn can_handle_ccms_with_principal_asset_as_ingress() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00],
 			gas_budget,
-			refund_address: ForeignChainAddress::Eth([0x01; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -766,7 +766,7 @@ fn can_handle_ccms_with_principal_asset_as_ingress() {
 				amount: ingress_amount - gas_budget,
 				egress_address: ForeignChainAddress::Eth(Default::default()),
 				message: vec![0x00],
-				refund_address: ForeignChainAddress::Eth([0x01; 20]),
+				cf_parameters: vec![],
 			},]
 		);
 
@@ -803,7 +803,7 @@ fn can_handle_ccms_with_no_swaps_needed() {
 		let ccm = CcmIngressMetadata {
 			message: vec![0x00],
 			gas_budget,
-			refund_address: ForeignChainAddress::Eth([0x01; 20]),
+			cf_parameters: vec![],
 			source_address: ForeignChainAddress::Eth([0xcf; 20]),
 		};
 
@@ -834,7 +834,7 @@ fn can_handle_ccms_with_no_swaps_needed() {
 				amount: ingress_amount - gas_budget,
 				egress_address: ForeignChainAddress::Eth(Default::default()),
 				message: vec![0x00],
-				refund_address: ForeignChainAddress::Eth([0x01; 20]),
+				cf_parameters: vec![],
 			},]
 		);
 

--- a/state-chain/traits/src/mocks/egress_handler.rs
+++ b/state-chain/traits/src/mocks/egress_handler.rs
@@ -1,6 +1,6 @@
 use super::{MockPallet, MockPalletStorage};
 use crate::EgressApi;
-use cf_chains::{address::ForeignChainAddress, CcmIngressMetadata, Chain};
+use cf_chains::{CcmIngressMetadata, Chain};
 use cf_primitives::{AssetAmount, EgressId, ForeignChain};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -24,7 +24,7 @@ pub enum MockEgressParameter<C: Chain> {
 		amount: C::ChainAmount,
 		egress_address: C::ChainAccount,
 		message: Vec<u8>,
-		refund_address: ForeignChainAddress,
+		cf_parameters: Vec<u8>,
 	},
 }
 
@@ -73,7 +73,7 @@ impl<C: Chain> EgressApi<C> for MockEgressHandler<C> {
 						amount,
 						egress_address,
 						message: message.message,
-						refund_address: message.refund_address,
+						cf_parameters: message.cf_parameters,
 					},
 					None => MockEgressParameter::<C>::Swap { asset, amount, egress_address },
 				});


### PR DESCRIPTION
Renamed RefundAddress to CfParameters
Changed the type of refund_address from ForeignChainAddress to Vec<u8>

Closes: PRO-274