### PR TITLE
fix localnet polkadot after renaming

### DIFF
--- a/localnet/init/polkadot/chainspec.json
+++ b/localnet/init/polkadot/chainspec.json
@@ -86,7 +86,7 @@
           ]
         ]
       },
-      "funding": {
+      "staking": {
         "validatorCount": 1,
         "minimumValidatorCount": 1,
         "invulnerables": [
@@ -95,7 +95,7 @@
         "forceEra": "NotForcing",
         "slashRewardFraction": 100000000,
         "canceledPayout": 0,
-        "funders": [
+        "stakers": [
           [
             "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
             "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
@@ -152,8 +152,8 @@
         "phantom": null
       },
       "treasury": null,
-      "redemptions": {
-        "redemptions": [],
+      "claims": {
+        "claims": [],
         "vesting": []
       },
       "vesting": {


### PR DESCRIPTION
we renamed some items in the localnet polkadot chainspec. this change undoes that renaming