### PR TITLE
feat: update secp256k1; remove rand-legacy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
- "autocfg 1.1.0",
+ "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
@@ -243,7 +243,7 @@ checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
 dependencies = [
  "async-io",
  "async-lock",
- "autocfg 1.1.0",
+ "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
@@ -350,15 +350,6 @@ dependencies = [
  "hermit-abi 0.1.19",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -843,7 +834,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "secp256k1 0.20.3",
+ "secp256k1 0.27.0",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 7.0.0",
@@ -1016,9 +1007,9 @@ dependencies = [
  "pallet-cf-swapping",
  "pallet-cf-threshold-signature",
  "pallet-cf-validator",
- "rand 0.6.5",
  "rand 0.7.3",
- "secp256k1 0.20.3",
+ "rand 0.8.5",
+ "secp256k1 0.27.0",
  "serde",
  "sp-consensus-aura",
  "sp-core 7.0.0",
@@ -1119,7 +1110,6 @@ dependencies = [
  "pallet-cf-witnesser",
  "parity-scale-codec",
  "pin-project",
- "rand 0.6.5",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -1127,8 +1117,8 @@ dependencies = [
  "rocksdb",
  "sc-rpc-api",
  "scale-info",
- "secp256k1 0.20.3",
  "secp256k1 0.21.3",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -1339,15 +1329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1620,7 +1601,7 @@ version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset 0.7.1",
@@ -2890,12 +2871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,7 +3023,7 @@ dependencies = [
  "csv",
  "hex",
  "multisig",
- "rand 0.6.5",
+ "rand 0.8.5",
  "rocksdb",
  "serde",
  "serde_json",
@@ -3632,7 +3607,7 @@ version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
  "serde",
 ]
@@ -4701,7 +4676,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
@@ -4831,7 +4806,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -4840,7 +4815,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -5045,11 +5020,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "public-ip",
- "rand 0.6.5",
  "rand 0.8.5",
  "rayon",
  "schnorrkel",
- "secp256k1 0.20.3",
+ "secp256k1 0.27.0",
  "serde",
  "sha2 0.9.9",
  "sp-core 7.0.0",
@@ -5266,7 +5240,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -5307,7 +5281,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -5317,7 +5291,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -5329,7 +5303,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm 0.2.6",
 ]
 
@@ -5429,7 +5403,7 @@ version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -6328,7 +6302,7 @@ version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "libc",
  "log",
@@ -6676,25 +6650,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg 0.1.2",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -6703,7 +6658,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
  "rand_pcg 0.2.1",
 ]
 
@@ -6716,16 +6671,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -6747,21 +6692,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -6793,64 +6723,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -6869,15 +6746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -6906,15 +6774,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -8408,17 +8267,6 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
-dependencies = [
- "rand 0.6.5",
- "secp256k1-sys 0.4.2",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
@@ -8438,6 +8286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys 0.8.1",
+ "serde",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8451,6 +8310,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -8723,7 +8591,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -10369,7 +10237,7 @@ version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -9,10 +9,10 @@ async-trait = "0.1.49"
 futures = "0.3.14"
 hex = "0.4.3"
 ed25519-dalek = "1.0"
-rand = "0.7"
+rand-v7 = { package = "rand", version = "0.7" }
 tiny-bip39 = "1.0.0"
-secp256k1 = {version = "0.20"}
-rand_legacy = { package = "rand", version = "0.6" }
+secp256k1 = {version = "0.27"}
+rand = "0.8.5"
 zeroize = "1.5.4"
 serde = { version = "1.0", features = ["derive"] }
 base58 = '0.2.0'

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -4,7 +4,6 @@ use cf_chains::{address::EncodedAddress, eth::H256, CcmDepositMetadata, ForeignC
 use cf_primitives::{AccountRole, Asset, BasisPoints};
 use futures::FutureExt;
 use pallet_cf_validator::MAX_LENGTH_FOR_VANITY_NAME;
-use rand_legacy::FromEntropy;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{ed25519::Public as EdPublic, sr25519::Public as SrPublic, Bytes, Pair};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
@@ -404,9 +403,9 @@ pub struct KeyPair {
 /// Generate a new random node key.
 /// This key is used for secure communication between Validators.
 pub fn generate_node_key() -> KeyPair {
-	use rand::SeedableRng;
+	use rand_v7::SeedableRng;
 
-	let mut rng = rand::rngs::StdRng::from_entropy();
+	let mut rng = rand_v7::rngs::StdRng::from_entropy();
 	let keypair = ed25519_dalek::Keypair::generate(&mut rng);
 
 	KeyPair {
@@ -443,7 +442,8 @@ pub fn generate_signing_key(seed_phrase: Option<&str>) -> Result<(KeyPair, Strin
 pub fn generate_ethereum_key() -> KeyPair {
 	use secp256k1::Secp256k1;
 
-	let mut rng = rand_legacy::rngs::StdRng::from_entropy();
+	use rand::SeedableRng;
+	let mut rng = rand::rngs::StdRng::from_entropy();
 
 	let (secret_key, public_key) = Secp256k1::new().generate_keypair(&mut rng);
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -40,8 +40,6 @@ futures-util = "0.3.14"
 hex = "0.4.3"
 httparse = "1.4.1"
 itertools = "0.10"
-# have to use the older version until secp256k1 updates its dependency (https://github.com/rust-bitcoin/rust-secp256k1/issues/328)
-rand_legacy = {package = "rand", version = "0.6"}
 
 # Same version of jsonrpsee as substrate
 jsonrpsee = {version = "0.15.1", features = ["full"]}
@@ -54,11 +52,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 regex = "1"
 reqwest = {version = "0.11.4", features = ["json"]}
-secp256k1 = {version = "0.20", features = [
-  "serde",
-  "rand-std",
-  "global-context",
-]}
+secp256k1 = "0.27"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_json = "1.0"
 sha2 = "0.9.5"

--- a/engine/generate-genesis-keys/Cargo.toml
+++ b/engine/generate-genesis-keys/Cargo.toml
@@ -21,7 +21,7 @@ csv = "1.1.6"
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 # have to use the older version until secp256k1 updates its dependency (https://github.com/rust-bitcoin/rust-secp256k1/issues/328)
-rand_legacy = { package = "rand", version = "0.6" }
+rand = "0.8.5"
 
 # Local deps
 chainflip-engine = {path = "../../engine"}

--- a/engine/generate-genesis-keys/src/main.rs
+++ b/engine/generate-genesis-keys/src/main.rs
@@ -6,7 +6,7 @@ use multisig::{
 	client::keygen::generate_key_data, eth::EthSigning, polkadot::PolkadotSigning,
 	CanonicalEncoding, CryptoScheme, KeyId, Rng,
 };
-use rand_legacy::FromEntropy;
+use rand::SeedableRng;
 use state_chain_runtime::AccountId;
 use std::{
 	collections::{BTreeSet, HashMap},

--- a/engine/multisig/Cargo.toml
+++ b/engine/multisig/Cargo.toml
@@ -20,10 +20,8 @@ futures-core = "0.3.14"
 futures-util = "0.3.14"
 hex = "0.4.3"
 itertools = "0.10"
-# have to use the older version until secp256k1 updates its dependency (https://github.com/rust-bitcoin/rust-secp256k1/issues/328)
-rand_legacy = { package = "rand", version = "0.6" }
 lazy_static = "1.4"
-secp256k1 = { version = "0.20", features = [
+secp256k1 = { version = "0.27", features = [
   "serde",
   "rand-std",
   "global-context",

--- a/engine/multisig/src/client/ceremony_manager/tests.rs
+++ b/engine/multisig/src/client/ceremony_manager/tests.rs
@@ -25,7 +25,7 @@ use anyhow::Result;
 use cf_primitives::{AccountId, CeremonyId};
 use client::MultisigMessage;
 use futures::{Future, FutureExt};
-use rand_legacy::SeedableRng;
+use rand::SeedableRng;
 use sp_runtime::AccountId32;
 use tokio::sync::{mpsc, oneshot};
 use utilities::{task_scope::task_scope, threshold_from_share_count};

--- a/engine/multisig/src/client/ceremony_runner/tests.rs
+++ b/engine/multisig/src/client/ceremony_runner/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 	Rng,
 };
 
-use rand_legacy::SeedableRng;
+use rand::SeedableRng;
 use sp_runtime::AccountId32;
 use tokio::sync::mpsc;
 

--- a/engine/multisig/src/client/helpers.rs
+++ b/engine/multisig/src/client/helpers.rs
@@ -12,7 +12,7 @@ use itertools::{Either, Itertools};
 
 use async_trait::async_trait;
 
-use rand_legacy::{RngCore, SeedableRng};
+use rand::{RngCore, SeedableRng};
 
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, debug_span, Instrument};
@@ -638,7 +638,7 @@ impl<C: CryptoScheme> KeygenCeremonyRunner<C> {
 	}
 
 	pub fn keygen_ceremony_details(&mut self) -> KeygenCeremonyDetails {
-		use rand_legacy::Rng as _;
+		use rand::Rng as _;
 
 		KeygenCeremonyDetails {
 			ceremony_id: self.ceremony_id,
@@ -745,7 +745,7 @@ impl<C: CryptoScheme> SigningCeremonyRunner<C> {
 	}
 
 	fn signing_ceremony_details(&mut self, account_id: &AccountId) -> SigningCeremonyDetails<C> {
-		use rand_legacy::Rng as _;
+		use rand::Rng as _;
 
 		let payloads = self
 			.ceremony_runner_data

--- a/engine/multisig/src/client/keygen/keygen_data/tests.rs
+++ b/engine/multisig/src/client/keygen/keygen_data/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use cf_primitives::AuthorityCount;
-use rand_legacy::SeedableRng;
+use rand::SeedableRng;
 
 use crate::{
 	client::{

--- a/engine/multisig/src/client/keygen/keygen_detail.rs
+++ b/engine/multisig/src/client/keygen/keygen_detail.rs
@@ -499,7 +499,7 @@ mod tests {
 
 		let params = ThresholdParameters { share_count: 7, threshold: 5 };
 
-		use rand_legacy::SeedableRng;
+		use rand::SeedableRng;
 		let mut rng = Rng::from_seed([0; 32]);
 
 		let (secret, _commitments, shares) = generate_secret_and_shares::<Point>(
@@ -520,7 +520,7 @@ mod tests {
 
 		let context = HashContext([0; 32]);
 
-		use rand_legacy::SeedableRng;
+		use rand::SeedableRng;
 		let mut rng = Rng::from_seed([0; 32]);
 
 		let (commitments, hash_commitments, outgoing_shares): (
@@ -672,7 +672,7 @@ pub fn get_key_data_for_test<C: CryptoScheme>(
 ) -> KeygenResultInfo<C> {
 	super::generate_key_data::<C>(
 		signers.clone(),
-		&mut <Rng as rand_legacy::SeedableRng>::from_seed([8; 32]),
+		&mut <Rng as rand::SeedableRng>::from_seed([8; 32]),
 	)
 	.1
 	.get(signers.iter().next().unwrap())

--- a/engine/multisig/src/client/keygen/tests.rs
+++ b/engine/multisig/src/client/keygen/tests.rs
@@ -1,5 +1,5 @@
 use cf_primitives::{AccountId, AuthorityCount};
-use rand_legacy::{FromEntropy, SeedableRng};
+use rand::SeedableRng;
 use std::collections::BTreeSet;
 
 use crate::{

--- a/engine/multisig/src/client/mod.rs
+++ b/engine/multisig/src/client/mod.rs
@@ -209,7 +209,7 @@ impl<C: CryptoScheme, KeyStore: KeyStoreAPI<C>> MultisigClient<C, KeyStore> {
 		participants: BTreeSet<AccountId>,
 		resharing_context: Option<ResharingContext<C>>,
 	) -> BoxFuture<'_, Result<C::PublicKey, (BTreeSet<AccountId>, KeygenFailureReason)>> {
-		use rand_legacy::FromEntropy;
+		use rand::SeedableRng;
 		let rng = Rng::from_entropy();
 
 		let (result_sender, result_receiver) = tokio::sync::oneshot::channel();
@@ -336,7 +336,7 @@ impl<C: CryptoScheme, KeyStore: KeyStoreAPI<C>> MultisigClientApi<C>
 			"Received a request to sign",
 		);
 
-		use rand_legacy::FromEntropy;
+		use rand::SeedableRng;
 		let rng = Rng::from_entropy();
 
 		if let Some(keygen_result_info) = self.key_store.lock().unwrap().get_key(&key_id) {

--- a/engine/multisig/src/client/signing/signing_data.rs
+++ b/engine/multisig/src/client/signing/signing_data.rs
@@ -118,7 +118,7 @@ mod tests {
 		Rng,
 	};
 
-	use rand_legacy::SeedableRng;
+	use rand::SeedableRng;
 
 	use super::*;
 

--- a/engine/multisig/src/client/signing/signing_detail.rs
+++ b/engine/multisig/src/client/signing/signing_detail.rs
@@ -275,7 +275,7 @@ mod tests {
 
 	#[test]
 	fn bindings_are_backwards_compatible() {
-		use rand_legacy::SeedableRng;
+		use rand::SeedableRng;
 		// The seed must not change or the test will break.
 		let mut rng = Rng::from_seed([0; 32]);
 
@@ -294,15 +294,15 @@ mod tests {
 		// `gen_rho_i` has not changed.
 		assert_eq!(
 			hex::encode(bindings.get(&1u32).unwrap().as_bytes()),
-			"d21e9745014dedea06fc653b93845b17c20737ef9fe1bac189c70ffb2794250a"
+			"1c6b0bd5287db93cbdfb2c48ff3ca912524305c10fc9913496eebf806a1bfedf"
 		);
 		assert_eq!(
 			hex::encode(bindings.get(&2u32).unwrap().as_bytes()),
-			"87c25a1056df0e55a359468f76822a7244232e8a339700d24293d7ea3547aad9"
+			"ad5bcd9508fc34734acb54863b471d615acacfc38704817e02d025ac4e473164"
 		);
 		assert_eq!(
 			hex::encode(bindings.get(&3u32).unwrap().as_bytes()),
-			"d74a3892851b2f4114fb58cd0a7813dec65a7b5c1bfe6c512091e627a92f512d"
+			"d3f02a27695281149197594e831d0f02d7ff34cfe8442943d7af8a771982f4aa"
 		);
 	}
 }

--- a/engine/multisig/src/client/signing/tests.rs
+++ b/engine/multisig/src/client/signing/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use rand_legacy::SeedableRng;
+use rand::SeedableRng;
 
 use crate::{
 	client::{

--- a/engine/multisig/src/crypto.rs
+++ b/engine/multisig/src/crypto.rs
@@ -67,9 +67,8 @@ pub struct KeyShare<P: ECPoint> {
 }
 
 // Ideally, we want to use a concrete implementation (like ChaCha20) instead of StdRng
-// to prevent it from potentially changing from under us (but it needs to be compatible
-// with rand_legacy)
-pub type Rng = rand_legacy::rngs::StdRng;
+// to prevent it from potentially changing from under us
+pub type Rng = rand::rngs::StdRng;
 
 pub trait ECPoint:
 	Clone

--- a/engine/multisig/src/crypto/curve25519.rs
+++ b/engine/multisig/src/crypto/curve25519.rs
@@ -18,13 +18,10 @@ mod scalar_impls {
 
 	impl ECScalar for Scalar {
 		fn random(rng: &mut crate::crypto::Rng) -> Self {
-			use rand_legacy::RngCore;
+			use rand::RngCore;
 
 			// Instead of calling SK::random() directly, we copy its
 			// implementation so we can use our own (version of) Rng
-			// TODO: might as well use a more recent version of Rng
-			// and apply this trick where an older version is expected
-			// (instead of the other way around)
 			let mut scalar_bytes = [0u8; 64];
 			rng.fill_bytes(&mut scalar_bytes);
 			Scalar(SK::from_bytes_mod_order_wide(&scalar_bytes))

--- a/engine/multisig/src/crypto/polkadot.rs
+++ b/engine/multisig/src/crypto/polkadot.rs
@@ -157,7 +157,7 @@ impl CryptoScheme for PolkadotSigning {
 fn signature_should_be_valid() {
 	use super::{curve25519::Scalar, ECPoint, ECScalar};
 	use crate::crypto::Rng;
-	use rand_legacy::SeedableRng;
+	use rand::SeedableRng;
 	use utilities::assert_ok;
 
 	let mut rng = Rng::from_seed([0; 32]);

--- a/engine/multisig/src/crypto/tests.rs
+++ b/engine/multisig/src/crypto/tests.rs
@@ -3,7 +3,7 @@ use crate::{
 	crypto::{generate_single_party_signature, ECPoint, ECScalar, KeyShare},
 	CryptoScheme, Rng,
 };
-use rand_legacy::SeedableRng;
+use rand::SeedableRng;
 
 /// This test covers the specifics of signature generation
 /// for a given scheme

--- a/engine/src/db/mod.rs
+++ b/engine/src/db/mod.rs
@@ -41,7 +41,7 @@ mod tests {
 	use crate::db::PersistentKeyDB;
 	use cf_primitives::AccountId;
 	use multisig::{client::keygen, eth::EthSigning, CanonicalEncoding, Rng};
-	use rand_legacy::FromEntropy;
+	use rand::SeedableRng;
 	use std::collections::BTreeSet;
 
 	// The `new` function of the keystore should load all keys from the db.

--- a/state-chain/cf-integration-tests/Cargo.toml
+++ b/state-chain/cf-integration-tests/Cargo.toml
@@ -15,11 +15,7 @@ targets = ['x86_64-unknown-linux-gnu']
 libsecp256k1 = { version = "0.7", features = ['static-context'] }
 rand = "0.8.4"
 hex-literal = "0.3.1"
-secp256k1 = { version = "0.20", features = [
-  "serde",
-  "rand-std",
-  "global-context",
-] }
+secp256k1 = "0.27"
 arrayref = '0.3.6'
 
 # Chainflip local dependencies

--- a/state-chain/cf-integration-tests/src/threshold_signing.rs
+++ b/state-chain/cf-integration-tests/src/threshold_signing.rs
@@ -180,7 +180,7 @@ impl KeyUtils for DotKeyComponents {
 	}
 }
 
-pub type BtcKeyComponents = KeyComponents<secp256k1::schnorrsig::KeyPair, cf_chains::btc::AggKey>;
+pub type BtcKeyComponents = KeyComponents<secp256k1::KeyPair, cf_chains::btc::AggKey>;
 
 pub type BtcThresholdSigner = ThresholdSigner<BtcKeyComponents, btc::Signature>;
 
@@ -202,15 +202,15 @@ impl KeyUtils for BtcKeyComponents {
 	fn sign(&self, message: &[u8]) -> Self::SigVerification {
 		let secp = secp256k1::Secp256k1::new();
 		let signature =
-			secp.schnorrsig_sign(&secp256k1::Message::from_slice(message).unwrap(), &self.secret);
+			secp.sign_schnorr(&secp256k1::Message::from_slice(message).unwrap(), &self.secret);
 		*array_ref!(signature[..], 0, 64)
 	}
 
 	fn generate(seed: u64, epoch_index: EpochIndex) -> Self {
 		let priv_seed: [u8; 32] = StdRng::seed_from_u64(seed).gen();
 		let secp = secp256k1::Secp256k1::new();
-		let keypair = secp256k1::schnorrsig::KeyPair::from_seckey_slice(&secp, &priv_seed).unwrap();
-		let pubkey_x = secp256k1::schnorrsig::PublicKey::from_keypair(&secp, &keypair).serialize();
+		let keypair = secp256k1::KeyPair::from_seckey_slice(&secp, &priv_seed).unwrap();
+		let pubkey_x = secp256k1::PublicKey::from_keypair(&keypair).serialize();
 		let agg_key = btc::AggKey { pubkey_x: *array_ref!(pubkey_x, 0, 32) };
 
 		KeyComponents { seed, secret: keypair, agg_key, epoch_index }


### PR DESCRIPTION
# Pull Request

Closes: PRO-295

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Apart from updating their version of rand (which allows us to remove `rand_legacy`), they slightly changed the API, but was relatively easy to change our code accordingly. I also thought this would change how secp256k1 are serialized, so wanted to make this change before the release, but the serialization didn't change due to the way we use it. (We might still want to change how primitives are serialized, but can be done separately).

Note that rand updated their algorithm, so the one test that relied on the seed had to be updated.
