### PR TITLE
fix: keygen verification should request with the new key

### DIFF
--- a/state-chain/pallets/cf-vaults/src/benchmarking.rs
+++ b/state-chain/pallets/cf-vaults/src/benchmarking.rs
@@ -128,7 +128,7 @@ benchmarks_instance_pallet! {
 		let caller: T::AccountId = whitelisted_caller();
 		let agg_key = AggKeyFor::<T, I>::benchmark_value();
 		let keygen_participants = generate_authority_set::<T, I>(150, caller.into());
-		let request_id = Pallet::<T, I>::trigger_keygen_verification(CEREMONY_ID, agg_key, keygen_participants.into_iter().collect());
+		let request_id = Pallet::<T, I>::trigger_keygen_verification(CEREMONY_ID, agg_key, keygen_participants.into_iter().collect(), 2);
 		T::ThresholdSigner::insert_signature(
 			request_id,
 			ThresholdSignatureFor::<T, I>::benchmark_value(),

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -116,16 +116,17 @@ fn keygen_success_triggers_keygen_verification() {
 	let btree_candidates = BTreeSet::from_iter(ALL_CANDIDATES.iter().cloned());
 
 	new_test_ext().execute_with(|| {
-		<VaultsPallet as VaultRotator>::keygen(btree_candidates.clone(), GENESIS_EPOCH);
+		let rotation_epoch_index = <MockRuntime as Chainflip>::EpochInfo::epoch_index() + 1;
+		<VaultsPallet as VaultRotator>::keygen(btree_candidates.clone(), rotation_epoch_index);
 		let ceremony_id = current_ceremony_id();
 
-		VaultsPallet::trigger_keygen_verification(ceremony_id, NEW_AGG_PUB_KEY, btree_candidates);
-
-		assert!(matches!(
-			PendingVaultRotation::<MockRuntime, _>::get().unwrap(),
-			VaultRotationStatus::<MockRuntime, _>::AwaitingKeygenVerification { new_public_key: k } if k == NEW_AGG_PUB_KEY
-		));
-	});
+		VaultsPallet::trigger_keygen_verification(
+			ceremony_id,
+			NEW_AGG_PUB_KEY,
+			btree_candidates,
+			rotation_epoch_index,
+		);
+	})
 }
 
 fn keygen_failure(bad_candidates: &[<MockRuntime as Chainflip>::ValidatorId]) {
@@ -186,6 +187,7 @@ fn keygen_called_after_keygen_failure_restarts_rotation_at_keygen() {
 #[test]
 fn keygen_verification_failure() {
 	new_test_ext().execute_with(|| {
+		let rotation_epoch_index = <MockRuntime as Chainflip>::EpochInfo::epoch_index() + 1;
 		let participants = (5u64..15).into_iter().collect::<BTreeSet<_>>();
 		let keygen_ceremony_id = 12;
 
@@ -193,6 +195,7 @@ fn keygen_verification_failure() {
 			keygen_ceremony_id,
 			NEW_AGG_PUB_KEY,
 			participants.clone(),
+			rotation_epoch_index,
 		);
 
 		let blamed = vec![5, 6, 7, 8];
@@ -647,6 +650,7 @@ fn vault_key_rotated() {
 			ceremony_id,
 			NEW_AGG_PUB_KEY,
 			btree_candidates.clone(),
+			rotation_epoch_index,
 		);
 
 		EthMockThresholdSigner::execute_signature_result_against_last_request(Ok(ETH_DUMMY_SIG));


### PR DESCRIPTION
## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

When requesting keygen verification, we need to request for the *new* epoch. Where as previously we were requesting for the old one. 
