### PR TITLE
fixed annoying typo which showed up in the explorer

### DIFF
--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -234,7 +234,7 @@ pub mod pallet {
 		PolkadotVaultAccountSet { polkadot_vault_account_id: PolkadotAccountId },
 		/// The Polkadot Runtime Version stored on chain was updated.
 		PolkadotRuntimeVersionUpdated { runtime_version: RuntimeVersion },
-		/// The block number for set for new Bitcoin vault
+		/// The starting block number for the new Bitcoin vault was set
 		BitcoinBlockNumberSetForVault { block_number: cf_chains::btc::BlockNumber },
 	}
 


### PR DESCRIPTION
# Pull Request

Just a typo fix

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary
This doc string had a typo. It showed up in the explorer as a description of the emitted event.