### PR TITLE
fix: ensure non-zero binding for signing

### DIFF
--- a/engine/multisig/src/client/signing/signing_detail.rs
+++ b/engine/multisig/src/client/signing/signing_detail.rs
@@ -105,7 +105,16 @@ fn gen_rho_i<P: ECPoint>(
 
 	let x: [u8; 32] = result.as_slice().try_into().expect("Invalid hash size");
 
-	P::Scalar::from_bytes_mod_order(&x)
+	let mut rho_i = P::Scalar::from_bytes_mod_order(&x);
+
+	// The protocol requires rho_i != 0. Note that this slightly biases the hash,
+	// which should be safe as this doesn't meaningfully impact collision resistance
+	// (especially since parties have no or little control over the inputs)
+	if rho_i == P::Scalar::zero() {
+		rho_i = P::Scalar::from(1);
+	}
+
+	rho_i
 }
 
 type SigningResponse<P> = <P as ECPoint>::Scalar;


### PR DESCRIPTION
# Pull Request

Closes: PRO-216

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This ensures that binding values are never 0 (by setting them to 1 instead). A more elegant solution would be to introduce a function similar to `from_bytes_mod_order` but excluding zero values, but it seems more work than it is worth (curve implementations like `curve25519_dalek` expose `from_bytes_mod_order`, but we would have to write our own implementations if we wanted custom ranges).
