### PR TITLE
chore: remove StaleRetryDiscarded

### DIFF
--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -351,10 +351,6 @@ pub mod pallet {
 			request_id: RequestId,
 			ceremony_id: CeremonyId,
 		},
-		/// The threshold signature has already succeeded or failed, so this retry is discarded
-		StaleRetryDiscarded {
-			ceremony_id: CeremonyId,
-		},
 		FailureReportProcessed {
 			request_id: RequestId,
 			ceremony_id: CeremonyId,
@@ -436,8 +432,6 @@ pub mod pallet {
 							}
 						},
 					})
-				} else {
-					Self::deposit_event(Event::<T, I>::StaleRetryDiscarded { ceremony_id })
 				}
 			}
 


### PR DESCRIPTION
## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This is a noisy event. It's an event that occurs if there was a success or failure of a request elsewhere, so we can delete it and reduce some event noise.
