### PR TITLE
feat: restructure eth api module hierarchy

### DIFF
--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -1,15 +1,15 @@
-use ethabi::Address;
+use super::{Ethereum, EthereumChannelId, SchnorrVerificationComponents};
+use crate::*;
+use common::*;
+use ethabi::{Address, ParamType, Token, Uint};
 use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, Never, PartialEqNoBound};
-use sp_runtime::{traits::UniqueSaturatedInto, DispatchError};
+use sp_runtime::{
+	traits::{Hash, Keccak256, UniqueSaturatedInto},
+	DispatchError,
+};
 use sp_std::marker::PhantomData;
 
-use crate::*;
-
-use self::all_batch::{
-	EncodableFetchAssetParams, EncodableFetchDeployAssetParams, EncodableTransferAssetParams,
-};
-
-use super::{Ethereum, EthereumChannelId, EthereumTransactionBuilder};
+pub use tokenizable::Tokenizable;
 
 #[cfg(feature = "std")]
 pub mod abi {
@@ -48,11 +48,13 @@ pub mod abi {
 }
 
 pub mod all_batch;
+pub mod common;
 pub mod execute_x_swap_and_call;
 pub mod register_redemption;
 pub mod set_agg_key_with_agg_key;
 pub mod set_comm_key_with_agg_key;
 pub mod set_gov_key_with_agg_key;
+pub mod tokenizable;
 pub mod update_flip_supply;
 
 /// Chainflip api calls available on Ethereum.
@@ -79,6 +81,163 @@ pub struct EthereumReplayProtection {
 	pub chain_id: EthereumChainId,
 	pub key_manager_address: Address,
 	pub contract_address: Address,
+}
+
+impl Tokenizable for EthereumReplayProtection {
+	fn tokenize(self) -> Token {
+		Token::FixedArray(vec![
+			Token::Uint(Uint::from(self.nonce)),
+			Token::Address(self.contract_address),
+			Token::Uint(Uint::from(self.chain_id)),
+			Token::Address(self.key_manager_address),
+		])
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Tuple(vec![
+			ParamType::Uint(256),
+			ParamType::Address,
+			ParamType::Uint(256),
+			ParamType::Address,
+		])
+	}
+}
+
+/// The `SigData` struct used for threshold signatures in the smart contracts.
+/// See [here](https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/interfaces/IShared.sol).
+#[derive(Encode, Decode, TypeInfo, Copy, Clone, RuntimeDebug, PartialEq, Eq, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct SigData {
+	/// The Schnorr signature.
+	sig: Uint,
+	/// The nonce value for the AggKey. Each Signature over an AggKey should have a unique
+	/// nonce to prevent replay attacks.
+	pub nonce: Uint,
+	/// The address value derived from the random nonce value `k`. Also known as
+	/// `nonceTimesGeneratorAddress`.
+	///
+	/// Note this is unrelated to the `nonce` above. The nonce in the context of
+	/// `nonceTimesGeneratorAddress` is a generated as part of each signing round (ie. as part
+	/// of the Schnorr signature) to prevent certain classes of cryptographic attacks.
+	k_times_g_address: Address,
+}
+
+impl SigData {
+	/// Add the actual signature. This method does no verification.
+	pub fn new(nonce: impl Into<Uint>, schnorr: &SchnorrVerificationComponents) -> Self {
+		Self {
+			sig: schnorr.s.into(),
+			nonce: nonce.into(),
+			k_times_g_address: schnorr.k_times_g_address.into(),
+		}
+	}
+}
+
+impl Tokenizable for SigData {
+	fn tokenize(self) -> Token {
+		Token::Tuple(vec![
+			self.sig.tokenize(),
+			self.nonce.tokenize(),
+			self.k_times_g_address.tokenize(),
+		])
+	}
+
+	fn param_type() -> ParamType {
+		ParamType::Tuple(vec![ParamType::Uint(256), ParamType::Uint(256), ParamType::Address])
+	}
+}
+
+pub trait EthereumCall {
+	const FUNCTION_NAME: &'static str;
+
+	/// The function names and parameters, not including sigData.
+	fn function_params() -> Vec<(&'static str, ethabi::ParamType)>;
+	/// The function values to be used as call parameters, no including sigData.
+	fn function_call_args(&self) -> Vec<Token>;
+
+	fn get_function() -> ethabi::Function {
+		#[allow(deprecated)]
+		ethabi::Function {
+			name: Self::FUNCTION_NAME.into(),
+			inputs: core::iter::once(("sigData", SigData::param_type()))
+				.chain(Self::function_params())
+				.map(|(n, t)| ethabi_param(n, t))
+				.collect(),
+			outputs: vec![],
+			constant: None,
+			state_mutability: ethabi::StateMutability::NonPayable,
+		}
+	}
+	/// Encodes the call and signature into Ethereum Abi format.
+	fn abi_encoded(&self, sig_data: &SigData) -> Vec<u8> {
+		Self::get_function()
+			.encode_input(
+				&core::iter::once(sig_data.tokenize())
+					.chain(self.function_call_args())
+					.collect::<Vec<_>>(),
+			)
+			.expect(
+				r#"
+					This can only fail if the parameter types don't match the function signature.
+					Therefore, as long as the tests pass, it can't fail at runtime.
+				"#,
+			)
+	}
+	/// Generates the message hash for this call.
+	fn msg_hash(&self) -> <Keccak256 as Hash>::Output {
+		Keccak256::hash(&ethabi::encode(
+			&core::iter::once(Self::get_function().tokenize())
+				.chain(self.function_call_args())
+				.collect::<Vec<_>>(),
+		))
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Clone, RuntimeDebug, PartialEq, Eq)]
+pub struct EthereumTransactionBuilder<C> {
+	sig_data: Option<SigData>,
+	replay_protection: EthereumReplayProtection,
+	call: C,
+}
+
+impl<C: EthereumCall> EthereumTransactionBuilder<C> {
+	pub fn new_unsigned(replay_protection: EthereumReplayProtection, call: C) -> Self {
+		Self { replay_protection, call, sig_data: None }
+	}
+
+	pub fn replay_protection(&self) -> EthereumReplayProtection {
+		self.replay_protection
+	}
+
+	pub fn chain_id(&self) -> EthereumChainId {
+		self.replay_protection.chain_id
+	}
+}
+
+impl<C: EthereumCall + Parameter + 'static> ApiCall<Ethereum> for EthereumTransactionBuilder<C> {
+	fn threshold_signature_payload(&self) -> <Ethereum as ChainCrypto>::Payload {
+		Keccak256::hash(&ethabi::encode(&[
+			self.call.msg_hash().tokenize(),
+			self.replay_protection.tokenize(),
+		]))
+	}
+
+	fn signed(
+		mut self,
+		threshold_signature: &<Ethereum as ChainCrypto>::ThresholdSignature,
+	) -> Self {
+		self.sig_data = Some(SigData::new(self.replay_protection.nonce, threshold_signature));
+		self
+	}
+
+	fn chain_encoded(&self) -> Vec<u8> {
+		self.call
+			.abi_encoded(&self.sig_data.expect("Unsigned chain encoding is invalid."))
+	}
+
+	fn is_signed(&self) -> bool {
+		self.sig_data.is_some()
+	}
 }
 
 /// Provides the environment data for ethereum-like chains.
@@ -220,7 +379,7 @@ where
 					.into_iter()
 					.map(|TransferAssetParams { asset, to, amount }| {
 						E::token_address(asset)
-							.map(|address| all_batch::EncodableTransferAssetParams {
+							.map(|address| EncodableTransferAssetParams {
 								to,
 								amount,
 								asset: address,
@@ -351,17 +510,6 @@ impl<E> ApiCall<Ethereum> for EthereumApi<E> {
 
 	fn is_signed(&self) -> bool {
 		map_over_api_variants!(self, call, call.is_signed())
-	}
-}
-
-pub(super) fn ethabi_function(name: &'static str, params: Vec<ethabi::Param>) -> ethabi::Function {
-	#[allow(deprecated)]
-	ethabi::Function {
-		name: name.into(),
-		inputs: params,
-		outputs: vec![],
-		constant: None,
-		state_mutability: ethabi::StateMutability::NonPayable,
 	}
 }
 

--- a/state-chain/chains/src/eth/api/common.rs
+++ b/state-chain/chains/src/eth/api/common.rs
@@ -1,0 +1,61 @@
+use super::*;
+use crate::eth::deposit_address::get_salt;
+use cf_primitives::{AssetAmount, ChannelId};
+use ethabi::{Address, ParamType, Token, Uint};
+
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq)]
+pub(crate) struct EncodableFetchAssetParams {
+	pub contract_address: Address,
+	pub asset: Address,
+}
+
+impl Tokenizable for EncodableFetchAssetParams {
+	fn tokenize(self) -> Token {
+		Token::Tuple(vec![Token::Address(self.contract_address), Token::Address(self.asset)])
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Tuple(vec![ParamType::Address, ParamType::Address])
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq)]
+pub(crate) struct EncodableFetchDeployAssetParams {
+	pub channel_id: ChannelId,
+	pub asset: Address,
+}
+
+impl Tokenizable for EncodableFetchDeployAssetParams {
+	fn tokenize(self) -> Token {
+		Token::Tuple(vec![
+			Token::FixedBytes(get_salt(self.channel_id).to_vec()),
+			Token::Address(self.asset),
+		])
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Tuple(vec![ParamType::FixedBytes(32), ParamType::Address])
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq)]
+pub(crate) struct EncodableTransferAssetParams {
+	/// For Ethereum, the asset is encoded as a contract address.
+	pub asset: Address,
+	pub to: Address,
+	pub amount: AssetAmount,
+}
+
+impl Tokenizable for EncodableTransferAssetParams {
+	fn tokenize(self) -> Token {
+		Token::Tuple(vec![
+			Token::Address(self.asset),
+			Token::Address(self.to),
+			Token::Uint(Uint::from(self.amount)),
+		])
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Tuple(vec![ParamType::Address, ParamType::Address, ParamType::Uint(256)])
+	}
+}

--- a/state-chain/chains/src/eth/api/register_redemption.rs
+++ b/state-chain/chains/src/eth/api/register_redemption.rs
@@ -1,12 +1,10 @@
 //! Definitions for the "registerRedemption" transaction.
-
-use crate::eth::{EthereumCall, Tokenizable};
-
+use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use ethabi::{Address, ParamType, Token, Uint};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
-use sp_std::{prelude::*, vec};
+use sp_std::vec;
 
 /// Represents all the arguments required to build the call to StateChainGateway's
 /// 'requestRedemption' function.
@@ -64,8 +62,8 @@ impl EthereumCall for RegisterRedemption {
 #[cfg(test)]
 mod test_register_redemption {
 	use crate::eth::{
-		api::{abi::load_abi, EthereumReplayProtection},
-		ApiCall, EthereumTransactionBuilder, SchnorrVerificationComponents,
+		api::{abi::load_abi, ApiCall, EthereumReplayProtection, EthereumTransactionBuilder},
+		SchnorrVerificationComponents,
 	};
 
 	use super::*;
@@ -97,7 +95,7 @@ mod test_register_redemption {
 				key_manager_address: FAKE_KEYMAN_ADDR.into(),
 				contract_address: FAKE_SCGW_ADDR.into(),
 			},
-			RegisterRedemption::new(&TEST_ACCT, AMOUNT, &TEST_ADDR, EXPIRY_SECS),
+			super::RegisterRedemption::new(&TEST_ACCT, AMOUNT, &TEST_ADDR, EXPIRY_SECS),
 		);
 
 		let expected_msg_hash = register_redemption_runtime.threshold_signature_payload();
@@ -138,6 +136,6 @@ mod test_register_redemption {
 
 	#[test]
 	fn test_max_encoded_len() {
-		cf_test_utilities::ensure_max_encoded_len_is_exact::<RegisterRedemption>();
+		cf_test_utilities::ensure_max_encoded_len_is_exact::<super::RegisterRedemption>();
 	}
 }

--- a/state-chain/chains/src/eth/api/set_agg_key_with_agg_key.rs
+++ b/state-chain/chains/src/eth/api/set_agg_key_with_agg_key.rs
@@ -1,12 +1,10 @@
-//! Definitions for the "registerRedemption" transaction.
-
-use crate::eth::{AggKey, EthereumCall, Tokenizable};
-
+use super::*;
+use crate::eth::AggKey;
 use codec::{Decode, Encode, MaxEncodedLen};
 use ethabi::Token;
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
-use sp_std::{prelude::*, vec};
+use sp_std::vec;
 
 /// Represents all the arguments required to build the call to StateChainGateway's
 /// 'requestRedemption' function.
@@ -37,8 +35,8 @@ impl EthereumCall for SetAggKeyWithAggKey {
 #[cfg(test)]
 mod test_set_agg_key_with_agg_key {
 	use crate::eth::{
-		api::{abi::load_abi, EthereumReplayProtection},
-		ApiCall, EthereumTransactionBuilder, SchnorrVerificationComponents,
+		api::{abi::load_abi, ApiCall, EthereumReplayProtection, EthereumTransactionBuilder},
+		SchnorrVerificationComponents,
 	};
 
 	use super::*;
@@ -57,7 +55,7 @@ mod test_set_agg_key_with_agg_key {
 				key_manager_address,
 				contract_address: key_manager_address,
 			},
-			SetAggKeyWithAggKey::new(AggKey::from_pubkey_compressed(hex_literal::hex!(
+			super::SetAggKeyWithAggKey::new(AggKey::from_pubkey_compressed(hex_literal::hex!(
 				"01 1742daacd4dbfbe66d4c8965550295873c683cb3b65019d3a53975ba553cc31d"
 			))),
 		);
@@ -87,7 +85,7 @@ mod test_set_agg_key_with_agg_key {
 				key_manager_address: FAKE_KEYMAN_ADDR.into(),
 				contract_address: FAKE_KEYMAN_ADDR.into(),
 			},
-			SetAggKeyWithAggKey::new(AggKey {
+			super::SetAggKeyWithAggKey::new(AggKey {
 				pub_key_x: FAKE_NEW_KEY_X,
 				pub_key_y_parity: FAKE_NEW_KEY_Y,
 			}),

--- a/state-chain/chains/src/eth/api/set_comm_key_with_agg_key.rs
+++ b/state-chain/chains/src/eth/api/set_comm_key_with_agg_key.rs
@@ -1,4 +1,4 @@
-use crate::eth::{EthereumCall, Tokenizable};
+use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use ethabi::{Address, Token};
 use frame_support::RuntimeDebug;
@@ -31,17 +31,15 @@ impl EthereumCall for SetCommKeyWithAggKey {
 
 #[cfg(test)]
 mod test_set_comm_key_with_agg_key {
-
 	use super::*;
 	use crate::{
 		eth::{
-			api::abi::load_abi, tests::asymmetrise, EthereumTransactionBuilder,
+			api::{abi::load_abi, EthereumTransactionBuilder},
+			tests::asymmetrise,
 			SchnorrVerificationComponents,
 		},
 		ApiCall,
 	};
-	use ethabi::Token;
-	use ethereum_types::H160;
 
 	use crate::eth::api::EthereumReplayProtection;
 
@@ -63,7 +61,7 @@ mod test_set_comm_key_with_agg_key {
 				key_manager_address: FAKE_KEYMAN_ADDR.into(),
 				contract_address: FAKE_KEYMAN_ADDR.into(),
 			},
-			SetCommKeyWithAggKey::new(H160::from(TEST_ADDR)),
+			super::SetCommKeyWithAggKey::new(Address::from(TEST_ADDR)),
 		);
 
 		assert_eq!(

--- a/state-chain/chains/src/eth/api/set_gov_key_with_agg_key.rs
+++ b/state-chain/chains/src/eth/api/set_gov_key_with_agg_key.rs
@@ -1,4 +1,4 @@
-use crate::eth::{EthereumCall, Tokenizable};
+use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use ethabi::{Address, Token};
 use frame_support::RuntimeDebug;
@@ -31,20 +31,11 @@ impl EthereumCall for SetGovKeyWithAggKey {
 
 #[cfg(test)]
 mod test_set_gov_key_with_agg_key {
-
 	use super::*;
-	use crate::{
-		eth::{
-			api::abi::load_abi, tests::asymmetrise, EthereumTransactionBuilder,
-			SchnorrVerificationComponents,
-		},
-		ApiCall,
-	};
-	use ethabi::Token;
-	use ethereum_types::H160;
-
-	use crate::eth::api::{
-		set_gov_key_with_agg_key::SetGovKeyWithAggKey, EthereumReplayProtection,
+	use crate::eth::{
+		api::{abi::load_abi, ApiCall, EthereumTransactionBuilder},
+		tests::asymmetrise,
+		SchnorrVerificationComponents,
 	};
 
 	#[test]
@@ -65,7 +56,7 @@ mod test_set_gov_key_with_agg_key {
 				key_manager_address: FAKE_KEYMAN_ADDR.into(),
 				contract_address: FAKE_KEYMAN_ADDR.into(),
 			},
-			SetGovKeyWithAggKey::new(H160::from(TEST_ADDR)),
+			super::SetGovKeyWithAggKey::new(Address::from(TEST_ADDR)),
 		);
 
 		assert_eq!(

--- a/state-chain/chains/src/eth/api/tokenizable.rs
+++ b/state-chain/chains/src/eth/api/tokenizable.rs
@@ -1,0 +1,97 @@
+use ethabi::{ParamType, Token};
+use sp_std::prelude::*;
+
+pub trait Tokenizable {
+	fn param_type() -> ethabi::ParamType;
+	fn tokenize(self) -> Token;
+}
+
+impl Tokenizable for ethereum_types::U256 {
+	fn tokenize(self) -> Token {
+		Token::Uint(self)
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Uint(256)
+	}
+}
+
+impl Tokenizable for ethereum_types::H256 {
+	fn tokenize(self) -> Token {
+		Token::FixedBytes(self.0.into())
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Uint(256)
+	}
+}
+
+impl Tokenizable for u64 {
+	fn tokenize(self) -> Token {
+		Token::Uint(self.into())
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Uint(256)
+	}
+}
+
+impl Tokenizable for ethereum_types::Address {
+	fn tokenize(self) -> Token {
+		Token::Address(self)
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Address
+	}
+}
+
+impl Tokenizable for ethabi::Function {
+	fn tokenize(self) -> Token {
+		Token::FixedBytes(self.short_signature().to_vec())
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::FixedBytes(4)
+	}
+}
+
+impl<const S: usize> Tokenizable for [u8; S] {
+	fn param_type() -> ethabi::ParamType {
+		ParamType::FixedBytes(S)
+	}
+
+	fn tokenize(self) -> Token {
+		Token::FixedBytes(self.to_vec())
+	}
+}
+
+impl Tokenizable for Vec<u8> {
+	fn tokenize(self) -> Token {
+		Token::Bytes(self)
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Bytes
+	}
+}
+
+impl Tokenizable for u32 {
+	fn tokenize(self) -> Token {
+		Token::Uint(self.into())
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Uint(32)
+	}
+}
+
+impl<T: Tokenizable> Tokenizable for Vec<T> {
+	fn tokenize(self) -> Token {
+		Token::Array(self.into_iter().map(|t| t.tokenize()).collect())
+	}
+
+	fn param_type() -> ethabi::ParamType {
+		ParamType::Array(Box::new(T::param_type()))
+	}
+}

--- a/state-chain/chains/src/eth/api/update_flip_supply.rs
+++ b/state-chain/chains/src/eth/api/update_flip_supply.rs
@@ -1,6 +1,5 @@
-use crate::eth::{EthereumCall, Tokenizable};
+use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
-use ethabi::Uint;
 use frame_support::RuntimeDebug;
 use scale_info::TypeInfo;
 use sp_std::{vec, vec::Vec};
@@ -39,12 +38,9 @@ impl EthereumCall for UpdateFlipSupply {
 
 #[cfg(test)]
 mod test_update_flip_supply {
-	use crate::{
-		eth::{
-			api::{abi::load_abi, EthereumReplayProtection},
-			EthereumTransactionBuilder, SchnorrVerificationComponents,
-		},
-		ApiCall,
+	use crate::eth::{
+		api::{abi::load_abi, ApiCall, EthereumReplayProtection, EthereumTransactionBuilder},
+		SchnorrVerificationComponents,
 	};
 
 	use super::*;
@@ -73,7 +69,7 @@ mod test_update_flip_supply {
 				key_manager_address: FAKE_KEYMAN_ADDR.into(),
 				contract_address: FAKE_STATE_CHAIN_GATEWAY_ADDRESS.into(),
 			},
-			UpdateFlipSupply::new(NEW_TOTAL_SUPPLY, STATE_CHAIN_BLOCK_NUMBER),
+			super::UpdateFlipSupply::new(NEW_TOTAL_SUPPLY, STATE_CHAIN_BLOCK_NUMBER),
 		);
 
 		let expected_msg_hash = update_flip_supply_runtime.threshold_signature_payload();
@@ -110,6 +106,6 @@ mod test_update_flip_supply {
 
 	#[test]
 	fn test_max_encoded_len() {
-		cf_test_utilities::ensure_max_encoded_len_is_exact::<UpdateFlipSupply>();
+		cf_test_utilities::ensure_max_encoded_len_is_exact::<super::UpdateFlipSupply>();
 	}
 }

--- a/state-chain/chains/src/eth/benchmarking.rs
+++ b/state-chain/chains/src/eth/benchmarking.rs
@@ -1,3 +1,4 @@
+use super::{api::EthereumTransactionBuilder, TransactionFee};
 use crate::{
 	benchmarking_value::BenchmarkValue,
 	eth::{
@@ -7,15 +8,12 @@ use crate::{
 	},
 	ApiCall,
 };
-
-const SIG_NONCE: [u8; 32] = [1u8; 32];
-const PRIVATE_KEY: [u8; 32] = [2u8; 32];
-
 use cf_primitives::EthAmount;
 use ethabi::Uint;
 use libsecp256k1::{PublicKey, SecretKey};
 
-use super::{EthereumTransactionBuilder, TransactionFee};
+const SIG_NONCE: [u8; 32] = [1u8; 32];
+const PRIVATE_KEY: [u8; 32] = [2u8; 32];
 
 impl BenchmarkValue for SchnorrVerificationComponents {
 	fn benchmark_value() -> Self {

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1,5 +1,4 @@
 use cf_amm::common::SqrtPriceQ64F96;
-use cf_chains::eth::SigData;
 use cf_primitives::{Asset, AssetAmount, EthereumAddress, SwapOutput};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::error::CallError};
 use pallet_cf_governance::GovCallHash;
@@ -42,14 +41,6 @@ pub struct RpcAccountInfoV2 {
 	pub is_qualified: bool,
 	pub is_online: bool,
 	pub is_bidding: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct RpcPendingRedemption {
-	amount: NumberOrHex,
-	address: String,
-	expiry: NumberOrHex,
-	sig_data: SigData,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/state-chain/pallets/cf-tokenholder-governance/src/lib.rs
+++ b/state-chain/pallets/cf-tokenholder-governance/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use cf_chains::{eth::ethabi::Address, ForeignChain};
+use cf_chains::{eth::Address, ForeignChain};
 use cf_traits::{BroadcastAnyChainGovKey, Chainflip, CommKeyBroadcaster, FeePayment, FundingInfo};
 use codec::{Decode, Encode};
 use frame_support::{

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -254,14 +254,14 @@ impl ReplayProtectionProvider<Ethereum> for EthEnvironment {
 }
 
 impl EthEnvironmentProvider for EthEnvironment {
-	fn token_address(asset: assets::eth::Asset) -> Option<eth::ethabi::Address> {
+	fn token_address(asset: assets::eth::Asset) -> Option<eth::Address> {
 		match asset {
 			assets::eth::Asset::Eth => Some(ETHEREUM_ETH_ADDRESS.into()),
 			erc20 => Environment::supported_eth_assets(erc20).map(Into::into),
 		}
 	}
 
-	fn contract_address(contract: EthereumContract) -> eth::ethabi::Address {
+	fn contract_address(contract: EthereumContract) -> eth::Address {
 		match contract {
 			EthereumContract::StateChainGateway =>
 				Environment::state_chain_gateway_address().into(),

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -1,13 +1,11 @@
 use crate::chainflip::Offence;
 use cf_amm::common::SqrtPriceQ64F96;
-use cf_chains::eth::SigData;
 use cf_primitives::{Asset, AssetAmount, EpochIndex, EthereumAddress, SwapOutput};
 use codec::{Decode, Encode};
 use pallet_cf_governance::GovCallHash;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_api::decl_runtime_apis;
-use sp_core::U256;
 use sp_runtime::{AccountId32, DispatchError};
 use sp_std::vec::Vec;
 
@@ -55,14 +53,6 @@ pub struct RuntimeApiAccountInfoV2 {
 	pub is_qualified: bool,
 	pub is_online: bool,
 	pub is_bidding: bool,
-}
-
-#[derive(Encode, Decode, Eq, PartialEq)]
-pub struct RuntimeApiPendingRedemption {
-	pub amount: U256,
-	pub address: EthereumAddress,
-	pub expiry: U256,
-	pub sig_data: SigData,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq)]

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -12,8 +12,8 @@ use core::fmt::Debug;
 pub use async_result::AsyncResult;
 
 use cf_chains::{
-	address::ForeignChainAddress, eth::ethabi::Address, ApiCall, CcmDepositMetadata, Chain,
-	ChainAbi, ChainCrypto, Ethereum, Polkadot,
+	address::ForeignChainAddress, eth::Address, ApiCall, CcmDepositMetadata, Chain, ChainAbi,
+	ChainCrypto, Ethereum, Polkadot,
 };
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, AuthorityCount, BasisPoints, BroadcastId,

--- a/state-chain/traits/src/mocks/eth_environment_provider.rs
+++ b/state-chain/traits/src/mocks/eth_environment_provider.rs
@@ -1,4 +1,4 @@
-use cf_chains::eth::{api::EthEnvironmentProvider, ethabi::Address};
+use cf_chains::eth::{api::EthEnvironmentProvider, Address};
 
 /// A mock that just returns defaults for the KeyManager and Chain ID.
 pub struct MockEthEnvironment;


### PR DESCRIPTION
# Pull Request

Closes: PRO-324

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This does not change anything functionally but makes the module structure more sensible and generally tidies things up:

- moved primitive/foreign tokenizable impls into own module
- move common api type to `common` module
- moved other tokenizable impls next to struct defs
- deleted some unused types and code (impl TryInto for AggKey)
- move api stuff into api module
- generally tidied up imports