### PR TITLE
chore: enable public docker image creation on tag

### DIFF
--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -96,7 +96,8 @@ jobs:
 
   docker:
     needs: [compile]
-    if: inputs.network == 'development'
+    env:
+      DOCKER_REPO: ghcr.io/${{ github.repository }}
     strategy:
       matrix:
         target:
@@ -113,6 +114,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Update Docker repo for production images
+        if: inputs.network == 'perseverance'
+        run:
+          echo "DOCKER_REPO=ghcr.io/chainflip-io/" >> $GITHUB_ENV
+
       - name: Download binaries
         uses: actions/download-artifact@v3
         with:
@@ -128,12 +134,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}/${{ matrix.target }}
+          images: ${{ env.DOCKER_REPO }}/${{ matrix.target }}
           flavor: |
             latest=true
           tags: |
             type=schedule,pattern={{date 'YYYY-MM-DD'}},prefix=nightly-
-            type=semver,pattern={{raw}}
+            type=pep440,pattern={{version}}
             type=raw,value=${{ inputs.commit_hash }}
             type=raw,value=${{ inputs.network }}
 

--- a/.github/workflows/release-perseverance.yml
+++ b/.github/workflows/release-perseverance.yml
@@ -2,7 +2,7 @@ name: Release Chainflip Perseverance
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 concurrency:
   group: ${{ github.ref }}-release-perseverance
   cancel-in-progress: true


### PR DESCRIPTION
We should start supporting Docker image releases. This will push to our (not yet) public namespace of `chainflip-io`

We will now follow `pep440` standard for tagging as is done in `cargo.toml`