### PR TITLE
silence the curl output in the localnet manage script

### DIFF
--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -89,11 +89,11 @@ build-localnet() {
   DOT_GENESIS_HASH=$(echo $REPLY | grep -o '\"result\":\"0x[^"]*' | grep -o '0x.*')
   DOT_GENESIS_HASH=${DOT_GENESIS_HASH:2} ./$LOCALNET_INIT_DIR/scripts/start-node.sh $BINARIES_LOCATION
   echo "🚧 Waiting for chainflip-node to start"
-  check_endpoint_health -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock"}' 'http://localhost:9933' > /dev/null
+  check_endpoint_health -s -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock"}' 'http://localhost:9933' > /dev/null
 
   ./$LOCALNET_INIT_DIR/scripts/start-engine.sh $BINARIES_LOCATION
   echo "🚗 Waiting for chainflip-engine to start"
-  check_endpoint_health 'http://localhost:5555/health' > /dev/null
+  check_endpoint_health -s 'http://localhost:5555/health' > /dev/null
 
   print_success
 }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The localnet manage script uses curl the check when the node and engine binaries are running. To make the output nicer, stdout is piped into /dev/null, but curl notices this and thinks that we're trying to download a file, so it prints a progress display to stderr. This change adds the "-s" flag to curl to silence this progress output and makes the localnet manage script nicer.
