### PR TITLE
chore: update to latest geth contracts

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -38,7 +38,7 @@ jobs:
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        image: ghcr.io/chainflip-io/chainflip-eth-contracts/geth:perseverance-rc13-1-node
+        image: ghcr.io/chainflip-io/chainflip-eth-contracts/geth:v0.7.0-1-node
         ports:
           - 30303:30303
           - 30303:30303/udp

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   geth:
-    image: ghcr.io/chainflip-io/chainflip-eth-contracts/geth:perseverance-rc13-1-node
+    image: ghcr.io/chainflip-io/chainflip-eth-contracts/geth:v0.7.0-1-node
     pull_policy: always
     stop_grace_period: 5s
     stop_signal: SIGINT


### PR DESCRIPTION
# Pull Request

Closes: PRO-383

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Updated the geth image to 0.7.0 tag from the eth-contracts repo. That will include the deployment of the CfReceiverMock contract to run end-to-end CCM tests.

