### PR TITLE
fix: use old aggkey in btc rotation apicall

### DIFF
--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -52,6 +52,7 @@ where
 		});
 		Ok(Self::BatchTransfer(batch_transfer::BatchTransfer::new_unsigned(
 			&agg_key,
+			agg_key.current,
 			selected_input_utxos,
 			btc_outputs,
 		)))
@@ -63,7 +64,7 @@ where
 	E: ChainEnvironment<<Bitcoin as Chain>::ChainAmount, SelectedUtxos>,
 {
 	fn new_unsigned(
-		_maybe_old_key: Option<<Bitcoin as ChainCrypto>::AggKey>,
+		maybe_old_key: Option<<Bitcoin as ChainCrypto>::AggKey>,
 		new_key: <Bitcoin as ChainCrypto>::AggKey,
 	) -> Result<Self, ()> {
 		// We will use the bitcoin address derived with the salt of 0 as the vault address where we
@@ -77,7 +78,8 @@ where
 			<E as ChainEnvironment<BtcAmount, SelectedUtxos>>::lookup(u64::MAX).ok_or(())?;
 
 		Ok(Self::BatchTransfer(batch_transfer::BatchTransfer::new_unsigned(
-			&new_key,
+			&maybe_old_key.ok_or(())?,
+			new_key.current,
 			all_input_utxos,
 			vec![BitcoinOutput {
 				amount: total_spendable_amount_in_vault,

--- a/state-chain/chains/src/btc/api/batch_transfer.rs
+++ b/state-chain/chains/src/btc/api/batch_transfer.rs
@@ -14,12 +14,13 @@ use sp_runtime::RuntimeDebug;
 pub struct BatchTransfer {
 	/// The handler for creating and signing polkadot extrinsics
 	pub bitcoin_transaction: BitcoinTransaction,
-	pub agg_key: AggKey,
+	pub change_utxo_key: [u8; 32],
 }
 
 impl BatchTransfer {
 	pub fn new_unsigned(
 		agg_key: &AggKey,
+		change_utxo_key: [u8; 32],
 		input_utxos: Vec<Utxo>,
 		outputs: Vec<BitcoinOutput>,
 	) -> Self {
@@ -29,7 +30,7 @@ impl BatchTransfer {
 				input_utxos,
 				outputs,
 			),
-			agg_key: *agg_key,
+			change_utxo_key,
 		}
 	}
 }

--- a/state-chain/chains/src/btc/benchmarking.rs
+++ b/state-chain/chains/src/btc/benchmarking.rs
@@ -74,6 +74,7 @@ impl<E> BenchmarkValue for BitcoinApi<E> {
 	fn benchmark_value() -> Self {
 		BitcoinApi::BatchTransfer(BatchTransfer::new_unsigned(
 			&BenchmarkValue::benchmark_value(),
+			BenchmarkValue::benchmark_value(),
 			vec![Utxo {
 				amount: Default::default(),
 				txid: Default::default(),

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -597,7 +597,7 @@ impl OnBroadcastReady<Bitcoin> for BroadcastReadyProvider {
 					change_output.amount,
 					UtxoId { tx_hash, vout: vout as u32 },
 					CHANGE_ADDRESS_SALT,
-					batch_transfer.agg_key.current,
+					batch_transfer.change_utxo_key,
 				);
 			},
 			_ => unreachable!(),


### PR DESCRIPTION
# Pull Request

Closes: PRO-378

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

