### PR TITLE
fix(broker): return struct instead of string [WEB-207]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,6 @@ dependencies = [
  "clap 3.2.23",
  "hex",
  "jsonrpsee 0.16.2",
- "serde",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.16",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -27,7 +27,6 @@ anyhow = "1.0.66"
 clap = { version = "3.2.23", features = ["derive"] }
 hex = "0.4.3"
 jsonrpsee = { version = "0.16.2", features = ["full"] }
-serde = "1.0.126"
 tokio = "1.20.1"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -10,15 +10,7 @@ use jsonrpsee::{
 	proc_macros::rpc,
 	server::ServerBuilder,
 };
-use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-
-#[derive(Serialize, Deserialize)]
-pub struct SwapDepositAddress {
-	address: String,
-	expiry_block: chainflip_api::primitives::BlockNumber,
-	issued_block: chainflip_api::primitives::BlockNumber,
-}
 
 #[rpc(server, client, namespace = "broker")]
 pub trait Rpc {
@@ -33,7 +25,7 @@ pub trait Rpc {
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
 		message_metadata: Option<CcmDepositMetadata>,
-	) -> Result<SwapDepositAddress, Error>;
+	) -> Result<chainflip_api::SwapDepositAddress, Error>;
 }
 
 pub struct RpcServerImpl {
@@ -60,7 +52,7 @@ impl RpcServer for RpcServerImpl {
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
 		message_metadata: Option<CcmDepositMetadata>,
-	) -> Result<SwapDepositAddress, Error> {
+	) -> Result<chainflip_api::SwapDepositAddress, Error> {
 		Ok(chainflip_api::request_swap_deposit_address(
 			&self.state_chain_settings,
 			source_asset,
@@ -70,11 +62,6 @@ impl RpcServer for RpcServerImpl {
 			message_metadata,
 		)
 		.await
-		.map(|(address, expiry_block, issued_block)| SwapDepositAddress {
-			address: address.to_string(),
-			expiry_block,
-			issued_block,
-		})
 		.map_err(|e| anyhow!("{}:{}", e, e.root_cause()))?)
 	}
 }

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -65,7 +65,7 @@ pub async fn request_swap_deposit_address(
 	state_chain_settings: &settings::StateChain,
 	params: settings::SwapRequestParams,
 ) -> Result<()> {
-	let (address, expiry_block, ..) = api::request_swap_deposit_address(
+	let api::SwapDepositAddress { address, expiry_block, .. } = api::request_swap_deposit_address(
 		state_chain_settings,
 		params.source_asset,
 		params.destination_asset,

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -4,6 +4,7 @@ use cf_chains::{address::EncodedAddress, CcmDepositMetadata, ForeignChain};
 use cf_primitives::{AccountRole, Asset, BasisPoints};
 use futures::FutureExt;
 use pallet_cf_validator::MAX_LENGTH_FOR_VANITY_NAME;
+use serde::{Deserialize, Serialize};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{ed25519::Public as EdPublic, sr25519::Public as SrPublic, Bytes, Pair, H256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
@@ -344,6 +345,13 @@ pub async fn set_vanity_name(
 	.await
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct SwapDepositAddress {
+	pub address: String,
+	pub expiry_block: state_chain_runtime::BlockNumber,
+	pub issued_block: state_chain_runtime::BlockNumber,
+}
+
 pub async fn request_swap_deposit_address(
 	state_chain_settings: &settings::StateChain,
 	source_asset: Asset,
@@ -351,7 +359,7 @@ pub async fn request_swap_deposit_address(
 	destination_address: EncodedAddress,
 	broker_commission_bps: BasisPoints,
 	message_metadata: Option<CcmDepositMetadata>,
-) -> Result<(EncodedAddress, state_chain_runtime::BlockNumber, state_chain_runtime::BlockNumber)> {
+) -> Result<SwapDepositAddress> {
 	let (events, block_number) = connect_submit_and_get_events(
 		state_chain_settings,
 		pallet_cf_swapping::Call::request_swap_deposit_address {
@@ -377,7 +385,11 @@ pub async fn request_swap_deposit_address(
 			)
 		)
 	}) {
-		Ok(((*deposit_address).clone(), *expiry_block, block_number))
+		Ok(SwapDepositAddress {
+			address: deposit_address.to_string(),
+			expiry_block: *expiry_block,
+			issued_block: block_number,
+		})
 	} else {
 		panic!("SwapDepositAddressReady must have been generated");
 	}


### PR DESCRIPTION
# Pull Request

Closes: WEB-207

## Checklist

Please conduct a through self-review before opening the PR.

- [X] I am confident that the code works.
- [X] I have updated documentation where appropriate.

## Summary

Returning a string returns nested JSON which then has to be double parsed. A serializable struct will be properly transformed into a JSON string.