### PR TITLE
chore: log creation of unauthorised ceremonies

### DIFF
--- a/engine/multisig/src/client/ceremony_manager.rs
+++ b/engine/multisig/src/client/ceremony_manager.rs
@@ -723,7 +723,7 @@ impl<Ceremony: CeremonyTrait> CeremonyStates<Ceremony> {
 		debug!("Received data {data} from [{sender_id}]");
 
 		// If no ceremony exists, create an unauthorised one (with ceremony id tracking
-		if self.ceremony_handles.get(&ceremony_id).is_none() {
+		if !self.ceremony_handles.contains_key(&ceremony_id) {
 			// Only a ceremony id that is within the ceremony id window can create unauthorised
 			// ceremonies
 			let ceremony_id_string = ceremony_id_string::<Ceremony::Crypto>(ceremony_id);
@@ -750,7 +750,8 @@ impl<Ceremony: CeremonyTrait> CeremonyStates<Ceremony> {
 			}
 		}
 
-		let ceremony_handle = self.ceremony_handles.get(&ceremony_id).expect("Should exist");
+		let ceremony_handle =
+			self.ceremony_handles.get(&ceremony_id).expect("Entry is inserted above");
 
 		// NOTE: There is a short delay between dropping the ceremony runner (and any channels
 		// associated with it) and dropping the corresponding ceremony handle, which makes it


### PR DESCRIPTION
# Pull Request

Closes: PRO-362

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Add a trace log when an unauthorised ceremony is created. ~~I wanted to log the total unauthorised ceremonies as well, but could not find an easy way to do it that did not compromise the existing code. Because its inside the `entry` i can't look at the list of ceremonies, and i don't want to calculate it every time the function runs whether we use it or not. So i decided it was not worth the time. Maye in the future we can get some sort of tool for retrieving information like this.~~
