### PR TITLE
fix: complete dot runtime version update cherrypick

### DIFF
--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
 	update_polkadot_runtime_version {
 		let origin = T::EnsureWitnessed::successful_origin();
 		// Same as in chain_spec.rs
-		const POLKADOT_TEST_RUNTIME_VERSION: RuntimeVersion = RuntimeVersion { spec_version: 9320, transaction_version: 16 };
+		const POLKADOT_TEST_RUNTIME_VERSION: RuntimeVersion = RuntimeVersion { spec_version: 9360, transaction_version: 19 };
 		assert_eq!(PolkadotRuntimeVersion::<T>::get(), POLKADOT_TEST_RUNTIME_VERSION);
 		let runtime_version = RuntimeVersion { spec_version: POLKADOT_TEST_RUNTIME_VERSION.spec_version + 1, transaction_version: 1 };
 		let call = Call::<T>::update_polkadot_runtime_version { runtime_version };


### PR DESCRIPTION
Completes the cherry pick of: #3301 to release/0.8

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.


