### PR TITLE
fix: correct ScriptPubkey for legacy btc (fix PR #3275)

### DIFF
--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -402,27 +402,36 @@ impl SerializeBtc for ScriptPubkey {
 
 impl ScriptPubkey {
 	fn program(&self) -> BitcoinScript {
-		let (version, bytes) = match self {
-			ScriptPubkey::P2PKH(hash) => (None, hash.to_vec().try_into().unwrap()),
-			ScriptPubkey::P2SH(hash) => (None, hash.to_vec().try_into().unwrap()),
-			ScriptPubkey::P2WPKH(hash) =>
-				(Some(SEGWIT_VERSION_ZERO), hash.to_vec().try_into().unwrap()),
-			ScriptPubkey::P2WSH(hash) =>
-				(Some(SEGWIT_VERSION_ZERO), hash.to_vec().try_into().unwrap()),
-			ScriptPubkey::Taproot(hash) =>
-				(Some(SEGWIT_VERSION_TAPROOT), hash.to_vec().try_into().unwrap()),
-			ScriptPubkey::OtherSegwit { version, program } => (Some(*version), program.clone()),
-		};
-
-		BitcoinScript::new(
-			&[
-				version.map(|version| BitcoinOp::PushVersion { version }),
-				Some(BitcoinOp::PushBytes { bytes }),
-			]
-			.into_iter()
-			.flatten()
-			.collect::<Vec<_>>(),
-		)
+		match self {
+			ScriptPubkey::P2PKH(hash) => BitcoinScript::new(&[
+				BitcoinOp::Dup,
+				BitcoinOp::Hash160,
+				BitcoinOp::PushArray20 { bytes: *hash },
+				BitcoinOp::EqualVerify,
+				BitcoinOp::CheckSig,
+			]),
+			ScriptPubkey::P2SH(hash) => BitcoinScript::new(&[
+				BitcoinOp::Hash160,
+				BitcoinOp::PushArray20 { bytes: *hash },
+				BitcoinOp::Equal,
+			]),
+			ScriptPubkey::P2WPKH(hash) => BitcoinScript::new(&[
+				BitcoinOp::PushVersion { version: SEGWIT_VERSION_ZERO },
+				BitcoinOp::PushArray20 { bytes: *hash },
+			]),
+			ScriptPubkey::P2WSH(hash) => BitcoinScript::new(&[
+				BitcoinOp::PushVersion { version: SEGWIT_VERSION_ZERO },
+				BitcoinOp::PushArray32 { bytes: *hash },
+			]),
+			ScriptPubkey::Taproot(hash) => BitcoinScript::new(&[
+				BitcoinOp::PushVersion { version: SEGWIT_VERSION_TAPROOT },
+				BitcoinOp::PushArray32 { bytes: *hash },
+			]),
+			ScriptPubkey::OtherSegwit { version, program } => BitcoinScript::new(&[
+				BitcoinOp::PushVersion { version: *version },
+				BitcoinOp::PushBytes { bytes: program.clone() },
+			]),
+		}
 	}
 
 	pub fn bytes(&self) -> Vec<u8> {
@@ -978,6 +987,8 @@ mod test {
 			("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", BitcoinNetwork::Testnet, &hex_literal::hex!("0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433")[..]),
 			("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", BitcoinNetwork::Testnet, &hex_literal::hex!("5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433")[..]),
 			("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", BitcoinNetwork::Mainnet, &hex_literal::hex!("512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")[..]),
+			("1AKDDsfTh8uY4X3ppy1m7jw1fVMBSMkzjP", BitcoinNetwork::Mainnet, &hex_literal::hex!("76a914662AD25DB00E7BB38BC04831AE48B4B446D1269888ac")[..]),
+			("34nSkinWC9rDDJiUY438qQN1JHmGqBHGW7", BitcoinNetwork::Mainnet, &hex_literal::hex!("a91421EF2F4B1EA1F9ED09C1128D1EBB61D4729CA7D687")[..]),
 		];
 
 		for (valid_address, intended_btc_net, expected_scriptpubkey) in valid_addresses {


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Fixes the `ScriptPubkey` for legacy addresses and adds a couple of test cases.