### PR TITLE
feat: add tracing span events to logs

### DIFF
--- a/engine/src/witnesser/block_witnesser.rs
+++ b/engine/src/witnesser/block_witnesser.rs
@@ -81,9 +81,9 @@ where
 			.instrument(tracing::debug_span!("process_block"))
 			.await?;
 
-		tracing::debug!("Checkpointing {} at block {}", Self::Chain::NAME, block_number);
 		self.witnessed_until_sender
 			.send(WitnessedUntil { epoch_index: self.epoch_index, block_number })
+			.instrument(tracing::debug_span!("send_witnessed_until"))
 			.await
 			.unwrap();
 

--- a/engine/src/witnesser/checkpointing.rs
+++ b/engine/src/witnesser/checkpointing.rs
@@ -75,6 +75,7 @@ where
 				new_witnessed_until > prev_witnessed_until,
 				"Expected {new_witnessed_until:?} > {prev_witnessed_until:?}."
 			);
+			tracing::debug!("Checkpointing {chain_tag} at {new_witnessed_until:?}.");
 			db.update_checkpoint(chain_tag, &new_witnessed_until);
 			prev_witnessed_until = new_witnessed_until;
 		}

--- a/utilities/src/with_std.rs
+++ b/utilities/src/with_std.rs
@@ -7,6 +7,7 @@ use sp_rpc::number::NumberOrHex;
 use std::path::PathBuf;
 #[doc(hidden)]
 pub use tokio::select as internal_tokio_select;
+use tracing_subscriber::fmt::format::FmtSpan;
 use warp::{Filter, Reply};
 
 pub mod task_scope;
@@ -402,6 +403,7 @@ pub async fn init_json_logger(scope: &task_scope::Scope<'_, anyhow::Error>) {
 					.with_default_directive(LevelFilter::INFO.into())
 					.from_env_lossy(),
 			)
+			.with_span_events(FmtSpan::FULL)
 			.with_filter_reloading();
 
 		let reload_handle = builder.reload_handle();


### PR DESCRIPTION
# Pull Request

This adds additional log info including timing of entry and exit from tracing spans. 

It's noisy but effective. 


Example:

```
{"timestamp":"2023-06-07T14:43:20.013135Z","level":"INFO","fields":{"message":"enter"},"target":"chainflip_engine::db::persistent","span":{"name":"PersistentKeyDB"},"spans":[{"name":"PersistentKeyDB"}]}
{"timestamp":"2023-06-07T14:43:20.020703Z","level":"INFO","fields":{"message":"Found db_schema_version of 0"},"target":"chainflip_engine::db::persistent","span":{"name":"PersistentKeyDB"},"spans":[{"name":"PersistentKeyDB"}]}
{"timestamp":"2023-06-07T14:43:20.020793Z","level":"INFO","fields":{"message":"Database already at target version of: 0"},"target":"chainflip_engine::db::persistent","span":{"name":"PersistentKeyDB"},"spans":[{"name":"PersistentKeyDB"}]}
{"timestamp":"2023-06-07T14:43:20.020803Z","level":"INFO","fields":{"message":"exit"},"target":"chainflip_engine::db::persistent","span":{"name":"PersistentKeyDB"},"spans":[]}
{"timestamp":"2023-06-07T14:43:20.020811Z","level":"INFO","fields":{"message":"close","time.busy":"7.67ms","time.idle":"978µs"},"target":"chainflip_engine::db::persistent","span":{"name":"PersistentKeyDB"},"spans":[]}
{"timestamp":"2023-06-07T14:43:20.021627Z","level":"DEBUG","fields":{"message":"Our derived x25519 pubkey: \"2a8d5a13173175f7225bb553682916208838864bf6d27faef3ff58adb0a0d82e\""},"target":"chainflip_engine::p2p::core"}
{"timestamp":"2023-06-07T14:43:20.022301Z","level":"INFO","fields":{"message":"new"},"target":"chainflip_engine::p2p::core::auth","span":{"name":"p2p"},"spans":[]}
{"timestamp":"2023-06-07T14:43:20.022315Z","level":"INFO","fields":{"message":"enter"},"target":"chainflip_engine::p2p::core::auth","span":{"name":"p2p"},"spans":[{"name":"p2p"}]}
```