### PR TITLE
refactor: fix name

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -250,7 +250,7 @@ pub mod pallet {
 		/// A swap deposit has been received.
 		SwapScheduled {
 			swap_id: u64,
-			deposit_asset: Asset,
+			source_asset: Asset,
 			deposit_amount: AssetAmount,
 			destination_asset: Asset,
 			destination_address: EncodedAddress,
@@ -567,7 +567,7 @@ pub mod pallet {
 			) {
 				Self::deposit_event(Event::<T>::SwapScheduled {
 					swap_id,
-					deposit_asset: from,
+					source_asset: from,
 					deposit_amount,
 					destination_asset: to,
 					destination_address,
@@ -863,7 +863,7 @@ pub mod pallet {
 			{
 				Self::deposit_event(Event::<T>::SwapScheduled {
 					swap_id,
-					deposit_asset: from,
+					source_asset: from,
 					deposit_amount: amount,
 					destination_asset: to,
 					destination_address: encoded_destination_address,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -222,7 +222,7 @@ fn expect_swap_id_to_be_emitted() {
 			RuntimeEvent::Swapping(Event::SwapScheduled {
 				swap_id: 1,
 				deposit_amount: 500,
-				deposit_asset: Asset::Eth,
+				source_asset: Asset::Eth,
 				destination_asset: Asset::Usdc,
 				destination_address: EncodedAddress::Eth(Default::default()),
 				origin: SwapOrigin::DepositChannel {
@@ -287,7 +287,7 @@ fn can_swap_using_witness_origin() {
 
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
-			deposit_asset: from,
+			source_asset: from,
 			deposit_amount: amount,
 			destination_asset: to,
 			destination_address: EncodedAddress::Eth(Default::default()),
@@ -986,7 +986,7 @@ fn swap_by_witnesser_happy_path() {
 		);
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
-			deposit_asset: from,
+			source_asset: from,
 			deposit_amount: amount,
 			destination_asset: to,
 			destination_address: EncodedAddress::Eth(Default::default()),
@@ -1058,7 +1058,7 @@ fn swap_by_deposit_happy_path() {
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
 			deposit_amount: amount,
-			deposit_asset: from,
+			source_asset: from,
 			destination_asset: to,
 			destination_address: EncodedAddress::Eth(Default::default()),
 			origin: SwapOrigin::DepositChannel {


### PR DESCRIPTION
`deposit_asset` doesn't exist anywhere else, but `source_asset` is used instead.