### PR TITLE
chore(bouncer): bump cli version

### DIFF
--- a/bouncer/package.json
+++ b/bouncer/package.json
@@ -6,7 +6,7 @@
     "prettier:write": "prettier --write ."
   },
   "dependencies": {
-    "@chainflip-io/cli": "^0.0.5",
+    "@chainflip-io/cli": "^0.0.6",
     "@polkadot/api": "10.7.2",
     "@polkadot/keyring": "12.2.1",
     "@polkadot/util": "12.2.1",

--- a/bouncer/pnpm-lock.yaml
+++ b/bouncer/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@chainflip-io/cli':
-    specifier: ^0.0.5
-    version: 0.0.5
+    specifier: ^0.0.6
+    version: 0.0.6
   '@polkadot/api':
     specifier: 10.7.2
     version: 10.7.2
@@ -91,8 +91,8 @@ devDependencies:
 
 packages:
 
-  /@chainflip-io/cli@0.0.5:
-    resolution: {integrity: sha512-G0tQpFpQIAdmW/THii6BuXoppb8wYn7KojcDHQn6zcYcPHaG4CEVYhp95eR1Hep/iMh81ZyEzc4Aj+tdF7xwAw==, tarball: https://npm.pkg.github.com/download/@chainflip-io/cli/0.0.5/9ecd13a1ae219b1429999c24d9ba4d32c3d8d517}
+  /@chainflip-io/cli@0.0.6:
+    resolution: {integrity: sha512-maCFe/JdojJTlKlT0vZGZwdyIu9MAId0qIe3Tb5BpXdsbTHYbmLkn5aTG3Qe/5054rJb3Lf5arWtmsKuEZC3VA==, tarball: https://npm.pkg.github.com/download/@chainflip-io/cli/0.0.6/a5c06e44469dfd326fb792b9ac76376fdee8b6ee}
     hasBin: true
     dependencies:
       ethers: 5.7.2


### PR DESCRIPTION
The old sdk monorepo was archived and its packages had to be deleted