### PR TITLE
fix: make non essential ci tasks non blocking 🐛

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: Upload Localnet Logs 💾
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v3
         with:
           name: localnet-logs


### PR DESCRIPTION
Closes: PRO-520