### PR TITLE
fix: use correct nonce in submission watcher

### DIFF
--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -139,10 +139,11 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 			match self.base_rpc_client.submit_extrinsic(signed_extrinsic).await {
 				Ok(tx_hash) => {
 					request.pending_submissions += 1;
-					self.submissions_by_nonce
-						.entry(self.anticipated_nonce)
-						.or_default()
-						.push(Submission { lifetime, tx_hash, request_id: request.id });
+					self.submissions_by_nonce.entry(nonce).or_default().push(Submission {
+						lifetime,
+						tx_hash,
+						request_id: request.id,
+					});
 					break Ok(Ok(tx_hash))
 				},
 				Err(rpc_err) => {


### PR DESCRIPTION
# Pull Request

Closes: PRO-535

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The `submit_extrinsic_at_nonce` function was submitting the extrinsic using the given nonce but then watching for it on a different nonce. This would only be a problem during some sort of edge case (like a re-org), which is why it has not manifested as a bug yet (that we know of).
