### PR TITLE
chore: update eth-contracts tag for engine tests

### DIFF
--- a/engine/tests/scripts/setup.sh
+++ b/engine/tests/scripts/setup.sh
@@ -7,7 +7,7 @@ set -ex
 #
 # =============================================================
 
-readonly CONTRACT_VERSION_TAG="perseverance-rc13"
+readonly CONTRACT_VERSION_TAG="perseverance-rc14"
 
 if ! which poetry; then
   curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
# Pull Request

I spotted that the eth-contracts tag in the engine witnesser tests is quite old. We probably should refactor it so we don't have this tag and then another manual tag when running `eth-contracts-abi/download-eth-contract-abis.sh`. But I think it's not worth spending time on it now, I'd just update this tag and move on. We maybe end up merging the repos anyway.

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

*Please include a succinct description of the purpose and content of the PR. What problem does it solve, and how? Link issues, discussions, other PRs, and anything else that will help the reviewer.*
