### PR TITLE
Fix script-pub-key to BTC-address code

### DIFF
--- a/state-chain/chains/src/address.rs
+++ b/state-chain/chains/src/address.rs
@@ -12,8 +12,8 @@ use sp_std::vec::Vec;
 
 use crate::{
 	btc::{
-		deposit_address::derive_btc_deposit_address_from_script, scriptpubkey_from_address,
-		BitcoinNetwork, BitcoinScriptBounded,
+		deposit_address::derive_btc_address_from_script, scriptpubkey_from_address, BitcoinNetwork,
+		BitcoinScriptBounded,
 	},
 	dot::PolkadotAccountId,
 };
@@ -198,7 +198,7 @@ pub fn try_to_encoded_address<GetBitcoinNetwork: FnOnce() -> BitcoinNetwork>(
 		ForeignChainAddress::Eth(address) => Ok(EncodedAddress::Eth(address)),
 		ForeignChainAddress::Dot(address) => Ok(EncodedAddress::Dot(*address.aliased_ref())),
 		ForeignChainAddress::Btc(address) => Ok(EncodedAddress::Btc(
-			derive_btc_deposit_address_from_script(address.into(), bitcoin_network())
+			derive_btc_address_from_script(address.into(), bitcoin_network())
 				.bytes()
 				.collect::<Vec<u8>>(),
 		)),

--- a/state-chain/chains/src/btc/deposit_address.rs
+++ b/state-chain/chains/src/btc/deposit_address.rs
@@ -1,4 +1,5 @@
 use super::*;
+use base58::ToBase58;
 use sp_std::iter;
 
 pub fn tweaked_pubkey(pubkey_x: [u8; 32], salt: u32) -> PublicKey {
@@ -19,26 +20,94 @@ pub fn derive_btc_deposit_bitcoin_script(pubkey_x: [u8; 32], salt: u32) -> Bitco
 		.push_bytes(tweaked_pubkey(pubkey_x, salt).serialize_compressed().into_iter().skip(1))
 }
 
-pub fn derive_btc_deposit_address_from_script(
+pub fn derive_btc_address_from_script(
 	bitcoin_script: BitcoinScript,
 	network: BitcoinNetwork,
 ) -> String {
-	bech32::encode(
-		network.bech32_and_bech32m_address_hrp(),
-		itertools::chain!(
-			iter::once(u5::try_from_u8(SEGWIT_VERSION).unwrap()),
-			(&bitcoin_script.data[2..]).to_base32()
+	const CHECKSUM_LENGTH: usize = 4;
+	match bitcoin_script.data[0] {
+		0x00 => bech32::encode(
+			network.bech32_and_bech32m_address_hrp(),
+			itertools::chain!(
+				iter::once(u5::try_from_u8(0u8).unwrap()),
+				(&bitcoin_script.data[2..]).to_base32()
+			)
+			.collect::<Vec<_>>(),
+			Variant::Bech32,
 		)
-		.collect::<Vec<_>>(),
-		Variant::Bech32m,
-	)
-	.unwrap()
+		.unwrap(),
+		0x51..=0x60 => bech32::encode(
+			network.bech32_and_bech32m_address_hrp(),
+			itertools::chain!(
+				iter::once(u5::try_from_u8(bitcoin_script.data[0] - 0x50).unwrap()),
+				(&bitcoin_script.data[2..]).to_base32()
+			)
+			.collect::<Vec<_>>(),
+			Variant::Bech32m,
+		)
+		.unwrap(),
+		0xa9 => {
+			let mut payload = Vec::<u8>::default();
+			payload.push(network.p2sh_address_version());
+			payload.extend(&bitcoin_script.data[2..bitcoin_script.data.len().saturating_sub(1)]);
+			payload.extend(&sha2_256(&sha2_256(&payload))[..CHECKSUM_LENGTH]);
+			payload.to_base58()
+		},
+		0x76 => {
+			let mut payload = Vec::<u8>::default();
+			payload.push(network.p2pkh_address_version());
+			payload.extend(&bitcoin_script.data[3..bitcoin_script.data.len().saturating_sub(2)]);
+			payload.extend(&sha2_256(&sha2_256(&payload))[..CHECKSUM_LENGTH]);
+			payload.to_base58()
+		},
+		_ => "".into(),
+	}
 }
 
 #[test]
 fn test_btc_derive_deposit_address() {
 	assert_eq!(
-		derive_btc_deposit_address_from_script(
+		derive_btc_address_from_script(
+			BitcoinScript {
+				data: hex_literal::hex!("76a914de89566b3cda1c4b7ef85db035d747eaad0d408188ac")
+					.into()
+			},
+			BitcoinNetwork::Regtest
+		),
+		"n1ocq2FF95qopwbEsjUTy3ZrawwXDJ6UsX"
+	);
+	assert_eq!(
+		derive_btc_address_from_script(
+			BitcoinScript {
+				data: hex_literal::hex!("a914730d0dabce13a92834c990e24a5b6a1ffb72e9ef87").into()
+			},
+			BitcoinNetwork::Regtest
+		),
+		"2N3jZLJyhrHxG54nRRUszvbKHifGT4xGi2n"
+	);
+	assert_eq!(
+		derive_btc_address_from_script(
+			BitcoinScript {
+				data: hex_literal::hex!("0014de89566b3cda1c4b7ef85db035d747eaad0d4081").into()
+			},
+			BitcoinNetwork::Regtest
+		),
+		"bcrt1qm6y4v6eumgwyklhctkcrt468a2ks6sypxrkghx"
+	);
+	assert_eq!(
+		derive_btc_address_from_script(
+			BitcoinScript {
+				data: hex_literal::hex!(
+					"00207d2d92da7b87a9fd6c9fb71e86de597953e9dc3e17bddde498af8197fbe22d25"
+				)
+				.into()
+			},
+			BitcoinNetwork::Regtest
+		),
+		"bcrt1q05ke9knms75l6mylku0gdhje09f7nhp7z77ameyc47qe07lz95jsldtm4e"
+	);
+	assert_eq!(
+		derive_btc_address_from_script(
 			derive_btc_deposit_bitcoin_script(
 				hex_literal::hex!(
 					"2E897376020217C8E385A30B74B758293863049FA66A3FD177E012B076059105"
@@ -50,7 +119,7 @@ fn test_btc_derive_deposit_address() {
 		"bc1p4syuuy97f96lfah764w33ru9v5u3uk8n8jk9xsq684xfl8sxu82sdcvdcx"
 	);
 	assert_eq!(
-		derive_btc_deposit_address_from_script(
+		derive_btc_address_from_script(
 			derive_btc_deposit_bitcoin_script(
 				hex_literal::hex!(
 					"FEDBDC04F4666AF03167E2EF5FA5405BB012BC62A3B3180088E63972BD06EAD8"
@@ -62,7 +131,7 @@ fn test_btc_derive_deposit_address() {
 		"bc1phgs87wzfdqp9amtyc6darrhk3sm38tpf9a39mgjycthcet7vxl3qktqz86"
 	);
 	assert_eq!(
-		derive_btc_deposit_address_from_script(
+		derive_btc_address_from_script(
 			derive_btc_deposit_bitcoin_script(
 				hex_literal::hex!(
 					"FEDBDC04F4666AF03167E2EF5FA5405BB012BC62A3B3180088E63972BD06EAD8"
@@ -74,7 +143,7 @@ fn test_btc_derive_deposit_address() {
 		"bc1p2uf6vzdzmv0u7wyfnljnrctr5qr6hy6mmzyjpr6z7x8yt39gppfq3a54c9"
 	);
 	assert_eq!(
-		derive_btc_deposit_address_from_script(
+		derive_btc_address_from_script(
 			derive_btc_deposit_bitcoin_script(
 				hex_literal::hex!(
 					"FEDBDC04F4666AF03167E2EF5FA5405BB012BC62A3B3180088E63972BD06EAD8"


### PR DESCRIPTION
# Pull Request

Closes: PRO-538

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The conversion from script-pub-key to BTC address assumed all scripts to be for taproot addresses. This caused incorrect addresses to be reported in the swapping.SwapEgressScheduled event. This PR fixes that
