### PR TITLE
fix: error when inner dot stream ends

### DIFF
--- a/engine/src/dot/witnesser.rs
+++ b/engine/src/dot/witnesser.rs
@@ -516,7 +516,14 @@ where
 			block_events_stream,
 			Duration::from_secs(DOT_AVERAGE_BLOCK_TIME_SECONDS * BLOCK_PULL_TIMEOUT_MULTIPLIER),
 		)
-		.map_err(|err| anyhow::anyhow!("Error while fetching Polkadot events: {:?}", err));
+		.map_err(|err| {
+			error!("Error while fetching Polkadot events: {:?}", err);
+			anyhow::anyhow!("Error while fetching Polkadot events: {:?}", err)
+		})
+		.chain(stream::once(async {
+			error!("Stream ended unexpectedly");
+			Err(anyhow::anyhow!("Stream ended unexpectedly"))
+		}));
 
 		Ok(Box::pin(block_events_stream))
 	}

--- a/engine/src/witnesser/epoch_process_runner.rs
+++ b/engine/src/witnesser/epoch_process_runner.rs
@@ -245,7 +245,7 @@ where
 				}
 
 			},
-			Some(block) = block_stream.next().instrument(tracing::debug_span!("Eth-Block-Stream-Future")) => {
+			Some(block) = block_stream.next().instrument(tracing::debug_span!("Block-Stream-Future")) => {
 				// This will be an error if the stream times out. When it does, we return
 				// an error so that we restart the witnesser.
 				let block = block.map_err(|e| {


### PR DESCRIPTION
## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Fixes swallowed connection dropped issue. 

Will rebase the connection restart #2837  onto this, then the dot witnessers will restart on error.