### PR TITLE
Chore: update openssl and cargo audit config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,7 +35,6 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2020-0168: This advisory comes from `mach`, which is unmaintained but not a security issue. It's a dependency of `subxt`.
 # - RUSTSEC-2022-0080: This advisory comes from `parity-util-mem`, which is unmaintained but not a security issue. It's a dependency of `substrate`.
 # - RUSTSEC-2022-0061: This advisory is related to the deprecated `parity-wasm`, not a security issue. It's a dependency of `substrate`.
-# - RUSTSEC-2023-0044: This advisory is related to a potential buffer overread in openssl. We use rustls feature, not openssl.
 cf-audit = '''
 audit --ignore RUSTSEC-2022-0070
       --ignore RUSTSEC-2021-0145
@@ -47,5 +46,4 @@ audit --ignore RUSTSEC-2022-0070
       --ignore RUSTSEC-2020-0168
       --ignore RUSTSEC-2022-0080
       --ignore RUSTSEC-2022-0061
-      --ignore RUSTSEC-2023-0044
 '''

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.53"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -6219,9 +6219,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
# Pull Request

Closes: (too small to create an issue for this)

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

OpenSSL is still in our dependencies and it is hard to be sure how it is used by other crates that we rely on. Safer to update it rather than ignore the cargo audit message.
