### PR TITLE
fix: banning on keygen/keyhandover

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -406,7 +406,7 @@ pub mod pallet {
 							Self::set_rotation_phase(RotationPhase::ActivatingKeys(rotation_state));
 						},
 						AsyncResult::Ready(VaultStatus::Failed(offenders)) => {
-							let num_failed_candidates = offenders.union(&rotation_state.authority_candidates()).count();
+							let num_failed_candidates = offenders.intersection(&rotation_state.authority_candidates()).count();
 							rotation_state.ban(offenders);
 							if rotation_state.unbanned_current_authorities::<T>().len() as u32 <= Self::current_consensus_threshold() {
 								log::warn!(

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -261,7 +261,6 @@ impl TestExternalitiesWithCheck {
 	pub fn execute_with_unchecked_invariants<R>(&mut self, execute: impl FnOnce() -> R) -> R {
 		self.ext.execute_with(|| {
 			System::set_block_number(1);
-			QualifyAll::<u64>::except([UNQUALIFIED_NODE]);
 			execute()
 		})
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-571

## Checklist

Please conduct a through self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The second commit ensures that we handle key handover failures gracefully:
- If we ban to any *new* validators, we abort.
- If we ban any *current* authorities, we retry Handover as long as 2/3 are still available.

Note that there is still a minor issue: if we abort, the banned nodes are (in effect) un-banned. This may or may not be desirable. We should discuss before the runtime upgrade. 