### PR TITLE
Extend BTC broadcast timeout

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -691,7 +691,7 @@ impl pallet_cf_broadcast::Config<BitcoinInstance> for Runtime {
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, BitcoinInstance>;
 	type RotationCallbackProvider = RotationCallbackProvider;
 	type BroadcastReadyProvider = BroadcastReadyProvider;
-	type BroadcastTimeout = ConstU32<{ 10 * MINUTES }>;
+	type BroadcastTimeout = ConstU32<{ 90 * MINUTES }>;
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type KeyProvider = BitcoinVault;
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-596

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

With a typical block time of 10 minutes on BTC, a safety margin of 6 blocks and a safety factor of 1.5, the BTC broadcast timeout is now set to 90 minutes
