### PR TITLE
fix: toggle asset egress only emits error on change

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -9,7 +9,7 @@ benchmarks_instance_pallet! {
 	disable_asset_egress {
 		let origin = T::EnsureGovernance::successful_origin();
 		let destination_asset: <<T as Config<I>>::TargetChain as Chain>::ChainAsset = BenchmarkValue::benchmark_value();
-	} : { let _ = Pallet::<T, I>::toggle_asset_egress(origin, destination_asset, true); }
+	} : { let _ = Pallet::<T, I>::enable_or_disable_egress(origin, destination_asset, true); }
 	verify {
 		assert!(DisabledEgressAssets::<T, I>::get(
 			destination_asset,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -378,14 +378,14 @@ pub mod pallet {
 		///
 		/// - [On update](Event::AssetEgressStatusChanged)
 		#[pallet::weight(T::WeightInfo::disable_asset_egress())]
-		pub fn toggle_asset_egress(
+		pub fn enable_or_disable_egress(
 			origin: OriginFor<T>,
 			asset: TargetChainAsset<T, I>,
 			set_disabled: bool,
 		) -> DispatchResult {
 			T::EnsureGovernance::ensure_origin(origin)?;
 
-			let is_currently_disabled = DisabledEgressAssets::<T, I>::get(asset).is_some();
+			let is_currently_disabled = DisabledEgressAssets::<T, I>::contains_key(asset);
 
 			let do_disable = !is_currently_disabled && set_disabled;
 			let do_enable = is_currently_disabled && !set_disabled;

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -35,7 +35,7 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 
 		// Cannot egress assets that are blacklisted.
 		assert!(DisabledEgressAssets::<Test>::get(asset).is_none());
-		assert_ok!(IngressEgress::toggle_asset_egress(RuntimeOrigin::root(), asset, true));
+		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, true));
 		assert!(DisabledEgressAssets::<Test>::get(asset).is_some());
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::AssetEgressStatusChanged { asset, disabled: true },
@@ -59,7 +59,7 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 		);
 
 		// re-enable the asset for Egress
-		assert_ok!(IngressEgress::toggle_asset_egress(RuntimeOrigin::root(), asset, false));
+		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, false));
 		assert!(DisabledEgressAssets::<Test>::get(asset).is_none());
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::AssetEgressStatusChanged { asset, disabled: false },
@@ -84,7 +84,7 @@ fn blacklisted_asset_will_not_egress_via_ccm() {
 		};
 
 		assert!(DisabledEgressAssets::<Test>::get(asset).is_none());
-		assert_ok!(IngressEgress::toggle_asset_egress(RuntimeOrigin::root(), asset, true));
+		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, true));
 
 		// Eth should be blocked while Flip can be sent
 		IngressEgress::schedule_egress(asset, 1_000, ALICE_ETH_ADDRESS.into(), Some(ccm.clone()));
@@ -112,7 +112,7 @@ fn blacklisted_asset_will_not_egress_via_ccm() {
 		);
 
 		// re-enable the asset for Egress
-		assert_ok!(IngressEgress::toggle_asset_egress(RuntimeOrigin::root(), asset, false));
+		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, false));
 
 		IngressEgress::on_finalize(2);
 


### PR DESCRIPTION

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Should only emit the event when it changes, seems that was the intention based on the doc comment. Also the function name is a little misleading given it can also enable assets, so changed that.
