### PR TITLE
feat: deposit address creation block height

### DIFF
--- a/engine/src/state_chain_observer/sc_observer/mod.rs
+++ b/engine/src/state_chain_observer/sc_observer/mod.rs
@@ -707,7 +707,8 @@ where
                                     state_chain_runtime::RuntimeEvent::EthereumIngressEgress(
                                         pallet_cf_ingress_egress::Event::StartWitnessing {
                                             deposit_address,
-                                            source_asset
+                                            source_asset,
+                                            ..
                                         }
                                     ) => {
                                         use cf_primitives::chains::assets::eth;
@@ -745,7 +746,8 @@ where
                                     state_chain_runtime::RuntimeEvent::PolkadotIngressEgress(
                                         pallet_cf_ingress_egress::Event::StartWitnessing {
                                             deposit_address,
-                                            source_asset
+                                            source_asset,
+                                            ..
                                         }
                                     ) => {
                                         assert_eq!(source_asset, cf_primitives::chains::assets::dot::Asset::Dot);
@@ -763,7 +765,8 @@ where
                                     state_chain_runtime::RuntimeEvent::BitcoinIngressEgress(
                                         pallet_cf_ingress_egress::Event::StartWitnessing {
                                             deposit_address,
-                                            source_asset
+                                            source_asset,
+                                            ..
                                         }
                                     ) => {
                                         assert_eq!(source_asset, cf_primitives::chains::assets::btc::Asset::Btc);

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -9,7 +9,9 @@ use cf_chains::{
 };
 use cf_primitives::{AccountId, AccountRole, Asset, AssetAmount, STABLE_ASSET};
 use cf_test_utilities::{assert_events_eq, assert_events_match};
-use cf_traits::{AccountRoleRegistry, AddressDerivationApi, EpochInfo, LpBalanceApi};
+use cf_traits::{
+	AccountRoleRegistry, AddressDerivationApi, EpochInfo, GetBlockHeight, LpBalanceApi,
+};
 use frame_support::{
 	assert_ok,
 	traits::{OnFinalize, OnIdle, OnNewAccount},
@@ -22,6 +24,8 @@ use state_chain_runtime::{
 	AccountRoles, EthereumInstance, LiquidityPools, LiquidityProvider, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, Swapping, System, Timestamp, Validator, Weight, Witnesser,
 };
+
+use state_chain_runtime::EthereumChainTracking;
 
 const DORIS: AccountId = AccountId::new([0x11; 32]);
 const ZION: AccountId = AccountId::new([0x22; 32]);
@@ -215,8 +219,11 @@ fn basic_pool_setup_provision_and_swap() {
 			cf_primitives::chains::assets::eth::Asset::Eth,
 			pallet_cf_ingress_egress::ChannelIdCounter::<Runtime, EthereumInstance>::get(),
 		).unwrap();
+
+		let opened_at = EthereumChainTracking::get_block_height();
+
 		assert_events_eq!(Runtime, RuntimeEvent::EthereumIngressEgress(
-			pallet_cf_ingress_egress::Event::StartWitnessing { deposit_address, source_asset: cf_primitives::chains::assets::eth::Asset::Eth },
+			pallet_cf_ingress_egress::Event::StartWitnessing { deposit_address, source_asset: cf_primitives::chains::assets::eth::Asset::Eth, opened_at },
 		));
 		System::reset_events();
 

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -23,6 +23,7 @@ benchmarks_instance_pallet! {
 		DepositAddressDetailsLookup::<T, I>::insert(&deposit_address, DepositAddressDetails {
 				channel_id: 1,
 				source_asset,
+				opened_at: BenchmarkValue::benchmark_value(),
 			});
 		ChannelActions::<T, I>::insert(&deposit_address, ChannelAction::<T::AccountId>::LiquidityProvision {
 			lp_account: account("doogle", 0, 0)

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -14,6 +14,8 @@ pub use weights::WeightInfo;
 
 use cf_primitives::{BasisPoints, EgressCounter, EgressId, ForeignChain};
 
+use cf_traits::GetBlockHeight;
+
 use cf_chains::{address::ForeignChainAddress, CcmDepositMetadata, ChannelIdConstructor};
 
 use cf_chains::{
@@ -105,8 +107,9 @@ pub mod pallet {
 	pub(crate) type TargetChainAsset<T, I> = <<T as Config<I>>::TargetChain as Chain>::ChainAsset;
 	pub(crate) type TargetChainAccount<T, I> =
 		<<T as Config<I>>::TargetChain as Chain>::ChainAccount;
-
 	pub(crate) type TargetChainAmount<T, I> = <<T as Config<I>>::TargetChain as Chain>::ChainAmount;
+	pub(crate) type TargetChainBlockNumber<T, I> =
+		<<T as Config<I>>::TargetChain as Chain>::ChainBlockNumber;
 
 	pub(crate) type DepositFetchIdOf<T, I> =
 		<<T as Config<I>>::TargetChain as Chain>::DepositFetchId;
@@ -123,6 +126,7 @@ pub mod pallet {
 	pub struct DepositAddressDetails<C: Chain> {
 		pub channel_id: ChannelId,
 		pub source_asset: C::ChainAsset,
+		pub opened_at: C::ChainBlockNumber,
 	}
 
 	/// Determines the action to take when a deposit is made to a channel.
@@ -176,6 +180,9 @@ pub mod pallet {
 
 		/// The type of the chain-native transaction.
 		type ChainApiCall: AllBatch<Self::TargetChain> + ExecutexSwapAndCall<Self::TargetChain>;
+
+		/// Get the latest block height of the target chain via Chain Tracking.
+		type ChainTracking: GetBlockHeight<Self::TargetChain>;
 
 		/// A broadcaster instance.
 		type Broadcaster: Broadcaster<
@@ -260,6 +267,7 @@ pub mod pallet {
 		StartWitnessing {
 			deposit_address: TargetChainAccount<T, I>,
 			source_asset: TargetChainAsset<T, I>,
+			opened_at: TargetChainBlockNumber<T, I>,
 		},
 		StopWitnessing {
 			deposit_address: TargetChainAccount<T, I>,
@@ -574,7 +582,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		amount: TargetChainAmount<T, I>,
 		tx_id: <T::TargetChain as ChainCrypto>::TransactionInId,
 	) -> DispatchResult {
-		let DepositAddressDetails { channel_id, source_asset } =
+		let DepositAddressDetails { channel_id, source_asset, .. } =
 			DepositAddressDetailsLookup::<T, I>::get(&deposit_address)
 				.ok_or(Error::<T, I>::InvalidDepositAddress)?;
 		ensure!(source_asset == asset, Error::<T, I>::AssetMismatch);
@@ -640,6 +648,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// Opens a channel for the given asset and registers it with the given action.
+	/// Emits the `StartWitnessing` event so CFEs can start watching for deposits to the address.
 	///
 	/// May re-use an existing deposit address, depending on chain configuration.
 	fn open_channel(
@@ -666,12 +675,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			)
 		};
 		FetchParamDetails::<T, I>::insert(channel_id, (deposit_fetch_id, address.clone()));
+
+		let opened_at = T::ChainTracking::get_block_height();
 		DepositAddressDetailsLookup::<T, I>::insert(
 			&address,
-			DepositAddressDetails { channel_id, source_asset },
+			DepositAddressDetails { channel_id, source_asset, opened_at },
 		);
 		ChannelActions::<T, I>::insert(&address, channel_action);
 		T::DepositHandler::on_channel_opened(address.clone(), channel_id)?;
+
+		Self::deposit_event(Event::StartWitnessing {
+			deposit_address: address.clone(),
+			source_asset,
+			opened_at,
+		});
 		Ok((channel_id, address))
 	}
 
@@ -748,11 +765,6 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 		let (channel_id, deposit_address) =
 			Self::open_channel(source_asset, ChannelAction::LiquidityProvision { lp_account })?;
 
-		Self::deposit_event(Event::StartWitnessing {
-			deposit_address: deposit_address.clone(),
-			source_asset,
-		});
-
 		Ok((channel_id, deposit_address.into()))
 	}
 
@@ -781,11 +793,6 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 				},
 			},
 		)?;
-
-		Self::deposit_event(Event::StartWitnessing {
-			deposit_address: deposit_address.clone(),
-			source_asset,
-		});
 
 		Ok((channel_id, deposit_address.into()))
 	}

--- a/state-chain/pallets/cf-ingress-egress/src/mock.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock.rs
@@ -17,7 +17,7 @@ use cf_traits::{
 		broadcaster::MockBroadcaster,
 		ccm_handler::MockCcmHandler,
 	},
-	DepositApi, DepositHandler,
+	DepositApi, DepositHandler, GetBlockHeight,
 };
 use frame_support::traits::{OriginTrait, UnfilteredDispatchable};
 use frame_system as system;
@@ -78,6 +78,16 @@ impl DepositHandler<Ethereum> for MockDepositHandler {}
 pub type MockEgressBroadcaster =
 	MockBroadcaster<(MockEthereumApiCall<MockEthEnvironment>, RuntimeCall)>;
 
+pub struct BlockNumberProvider;
+
+pub const OPEN_INGRESS_AT: u64 = 420;
+
+impl GetBlockHeight<Ethereum> for BlockNumberProvider {
+	fn get_block_height() -> u64 {
+		OPEN_INGRESS_AT
+	}
+}
+
 impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
@@ -90,6 +100,7 @@ impl crate::Config for Test {
 	type DepositHandler = MockDepositHandler;
 	type WeightInfo = ();
 	type CcmHandler = MockCcmHandler;
+	type ChainTracking = BlockNumberProvider;
 }
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -12,7 +12,7 @@ use cf_traits::{
 		api_call::{MockEthEnvironment, MockEthereumApiCall},
 		ccm_handler::{CcmRequest, MockCcmHandler},
 	},
-	AddressDerivationApi, DepositApi, EgressApi,
+	AddressDerivationApi, DepositApi, EgressApi, GetBlockHeight,
 };
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
 use sp_core::H160;
@@ -438,10 +438,16 @@ fn can_process_ccm_deposit() {
 			Some(ccm.clone()),
 		));
 
+		let opened_at = BlockNumberProvider::get_block_height();
+
 		// CCM action is stored.
 		let deposit_address = hex_literal::hex!("c6b749fe356b08fdde333b41bc77955482380836").into();
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::StartWitnessing { deposit_address, source_asset: from_asset },
+			crate::Event::<Test>::StartWitnessing {
+				deposit_address,
+				source_asset: from_asset,
+				opened_at,
+			},
 		));
 
 		// Making a deposit should trigger CcmHandler.

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -283,6 +283,7 @@ impl pallet_cf_ingress_egress::Config<EthereumInstance> for Runtime {
 	type Broadcaster = EthereumBroadcaster;
 	type DepositHandler = chainflip::EthDepositHandler;
 	type CcmHandler = Swapping;
+	type ChainTracking = EthereumChainTracking;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
 }
 
@@ -297,6 +298,7 @@ impl pallet_cf_ingress_egress::Config<PolkadotInstance> for Runtime {
 	type Broadcaster = PolkadotBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
 	type DepositHandler = chainflip::DotDepositHandler;
+	type ChainTracking = PolkadotChainTracking;
 	type CcmHandler = Swapping;
 }
 
@@ -311,6 +313,7 @@ impl pallet_cf_ingress_egress::Config<BitcoinInstance> for Runtime {
 	type Broadcaster = BitcoinBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
 	type DepositHandler = chainflip::BtcDepositHandler;
+	type ChainTracking = BitcoinChainTracking;
 	type CcmHandler = Swapping;
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-610

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Without this, and the witnessing code that will use this, it's possible that when an ingress address is created let's say block ETH block 20, and someone sends to this address immediately and it gets in block 21. If the CFE witnessing code doesn't receive that address in its set of "watched" addresses, until block 22 then we can miss the witness. By providing the earliest possible ETH block (applies to all other chains too) we can ensure we don't miss any witnesses.

We haven't yet decided exactly how to overcome the race condition of ending witnessing, but however we do that, this works for how we avoid the race condition when starting witnessing.

NB: We can't depend on this (and we don't yet) until we do: https://linear.app/chainflip/issue/PRO-481/bitcoin-chain-tracking-should-return-the-avgfeerate-of-last-block-when
such that we get a BTC block number every block.