### PR TITLE
chore: set redemption delay to correct value

### DIFF
--- a/state-chain/runtime/src/constants.rs
+++ b/state-chain/runtime/src/constants.rs
@@ -66,7 +66,7 @@ pub mod common {
 	pub const SECS_PER_MINUTE: u64 = 60;
 	// This should be the same as the `REDEMPTION_DELAY` in:
 	// https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/StateChainGateway.sol
-	pub const REDEMPTION_DELAY_SECS: u64 = 5 * SECS_PER_MINUTE;
+	pub const REDEMPTION_DELAY_SECS: u64 = 2 * SECS_PER_MINUTE;
 
 	// NOTE: Currently it is not possible to change the slot duration after the chain has started.
 	//       Attempting to do so will brick block production.


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Having this "3x" is confusing and error prone. Because the code suggested the TTL is 3x the delay, I thought the execution delay was 5 minutes, but it's actually 2. There's no reason to arbitrarily specify 3x, we can just set the TTL to whatever we want, as long as it's greater than the delay - for a long enough time it gives redeemers a chance to redeem.
