### PR TITLE
refactor: remove decode_log_closure

### DIFF
--- a/engine/src/eth/erc20_witnesser.rs
+++ b/engine/src/eth/erc20_witnesser.rs
@@ -6,7 +6,7 @@ use state_chain_runtime::EthereumInstance;
 use tokio::sync::Mutex;
 use web3::types::H160;
 
-use ethers::{abi::RawLog, prelude::*};
+use ethers::prelude::*;
 
 use crate::{
 	state_chain_observer::client::extrinsic_api::signed::SignedExtrinsicApi, witnesser::ItemMonitor,
@@ -14,9 +14,7 @@ use crate::{
 
 abigen!(Erc20, "eth-contract-abis/IERC20.json");
 
-use super::{
-	core_h256, event::Event, rpc::EthRpcApi, BlockWithItems, DecodeLogClosure, EthContractWitnesser,
-};
+use super::{core_h256, event::Event, rpc::EthRpcApi, BlockWithItems, EthContractWitnesser};
 use pallet_cf_ingress_egress::DepositWitness;
 
 use anyhow::Result;
@@ -102,11 +100,5 @@ impl EthContractWitnesser for Erc20Witnesser {
 
 	fn contract_address(&self) -> H160 {
 		self.deployed_address
-	}
-
-	fn decode_log_closure(&self) -> DecodeLogClosure<Self::EventParameters> {
-		Box::new(move |raw_log: RawLog| -> Result<Self::EventParameters> {
-			Ok(Erc20Events::decode_log(&raw_log)?)
-		})
 	}
 }

--- a/engine/src/eth/event.rs
+++ b/engine/src/eth/event.rs
@@ -23,11 +23,8 @@ impl<EventParameters: Debug> std::fmt::Display for Event<EventParameters> {
 	}
 }
 
-impl<EventParameters: Debug> Event<EventParameters> {
-	pub fn new_from_unparsed_logs<LogDecoder>(decode_log: &LogDecoder, log: Log) -> Result<Self>
-	where
-		LogDecoder: Fn(RawLog) -> Result<EventParameters>,
-	{
+impl<EventParameters: Debug + ethers::contract::EthLogDecode> Event<EventParameters> {
+	pub fn new_from_unparsed_logs(log: Log) -> Result<Self> {
 		Ok(Self {
 			tx_hash: log
 				.transaction_hash
@@ -35,7 +32,7 @@ impl<EventParameters: Debug> Event<EventParameters> {
 			log_index: log
 				.log_index
 				.ok_or_else(|| anyhow!("Could not get log index from ETH log"))?,
-			event_parameters: decode_log(RawLog {
+			event_parameters: EventParameters::decode_log(&RawLog {
 				topics: log.topics.into_iter().map(core_h256).collect(),
 				data: log.data.0,
 			})?,

--- a/engine/src/eth/key_manager.rs
+++ b/engine/src/eth/key_manager.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use cf_chains::eth::{SchnorrVerificationComponents, TransactionFee};
 use cf_primitives::EpochIndex;
-use ethers::{abi::RawLog, contract::EthLogDecode};
 use state_chain_runtime::EthereumInstance;
 use std::sync::Arc;
 use tracing::{info, trace};
@@ -20,7 +19,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 
-use super::{event::Event, BlockWithItems, DecodeLogClosure, EthContractWitnesser};
+use super::{event::Event, BlockWithItems, EthContractWitnesser};
 
 use ethers::prelude::*;
 use num_traits::Zero;
@@ -193,12 +192,6 @@ impl EthContractWitnesser for KeyManager {
 		}
 
 		Ok(())
-	}
-
-	fn decode_log_closure(&self) -> DecodeLogClosure<Self::EventParameters> {
-		Box::new(move |raw_log: RawLog| -> Result<KeyManagerEvents> {
-			Ok(KeyManagerEvents::decode_log(&raw_log)?)
-		})
 	}
 
 	fn contract_address(&self) -> H160 {

--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -23,7 +23,6 @@ pub mod witnessing;
 use anyhow::{anyhow, Context, Result};
 
 use cf_primitives::EpochIndex;
-use ethers::abi::RawLog;
 use futures::FutureExt;
 use regex::Regex;
 
@@ -231,11 +230,9 @@ where
 
 #[async_trait]
 pub trait EthContractWitnesser {
-	type EventParameters: Debug + Send + Sync + 'static;
+	type EventParameters: ethers::contract::EthLogDecode + Debug + Send + Sync + 'static;
 
 	fn contract_name(&self) -> String;
-
-	fn decode_log_closure(&self) -> DecodeLogClosure<Self::EventParameters>;
 
 	async fn handle_block_events<StateChainClient, EthRpcClient>(
 		&mut self,
@@ -251,9 +248,6 @@ pub trait EthContractWitnesser {
 
 	fn contract_address(&self) -> H160;
 }
-
-pub type DecodeLogClosure<EventParameters> =
-	Box<dyn Fn(RawLog) -> Result<EventParameters> + Send + Sync + 'static>;
 
 const MAX_SECRET_CHARACTERS_REVEALED: usize = 3;
 const SCHEMA_PADDING_LEN: usize = 3;

--- a/engine/src/eth/state_chain_gateway.rs
+++ b/engine/src/eth/state_chain_gateway.rs
@@ -1,11 +1,9 @@
-use super::{event::Event, BlockWithItems, DecodeLogClosure, EthContractWitnesser};
+use super::{event::Event, BlockWithItems, EthContractWitnesser};
 use crate::{
 	eth::EthRpcApi, state_chain_observer::client::extrinsic_api::signed::SignedExtrinsicApi,
 };
-use anyhow::Result;
 use async_trait::async_trait;
 use cf_primitives::EpochIndex;
-use ethers::{abi::RawLog, contract::EthLogDecode};
 use std::sync::Arc;
 use tracing::{info, trace};
 use web3::types::H160;
@@ -111,12 +109,6 @@ impl EthContractWitnesser for StateChainGateway {
 
 	fn contract_address(&self) -> H160 {
 		self.deployed_address
-	}
-
-	fn decode_log_closure(&self) -> DecodeLogClosure<Self::EventParameters> {
-		Box::new(move |raw_log: RawLog| -> Result<Self::EventParameters> {
-			Ok(StateChainGatewayEvents::decode_log(&raw_log)?)
-		})
 	}
 }
 

--- a/engine/src/eth/vault.rs
+++ b/engine/src/eth/vault.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cf_primitives::{Asset, EpochIndex, EthereumAddress};
-use ethers::{abi::RawLog, contract::EthLogDecode};
 use tracing::info;
 use web3::types::H160;
 
@@ -81,12 +80,6 @@ impl EthContractWitnesser for Vault {
 			}
 		}
 		Ok(())
-	}
-
-	fn decode_log_closure(&self) -> super::DecodeLogClosure<Self::EventParameters> {
-		Box::new(move |raw_log: RawLog| -> Result<Self::EventParameters> {
-			Ok(VaultEvents::decode_log(&raw_log)?)
-		})
 	}
 
 	fn contract_address(&self) -> H160 {


### PR DESCRIPTION
Preparing for some log sources, as the code is now more similar to what we will use for the log sources in the witnessing refactor.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We no longer need the closure since `ethers-rs` has both an included decoder on each event enum, and that enum has a trait. 
