### PR TITLE
chore: make swapping tests fail if swapping.ts fails

### DIFF
--- a/bouncer/tests/swapping.sh
+++ b/bouncer/tests/swapping.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "=== Testing all swap combinations ==="
 pnpm tsx ./tests/swapping.ts
 


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Swapping.sh was not failing if the swapping tests were failing, so on CI the swapping tests were always green even when there were errors in the test. This will make it fail.
