### PR TITLE
feat: polkadot http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ dependencies = [
  "httparse",
  "itertools",
  "jsonrpsee 0.15.1",
+ "jsonrpsee 0.16.2",
  "lazy_static",
  "mockall",
  "multisig",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -49,8 +49,10 @@ hex = "0.4.3"
 httparse = "1.4.1"
 itertools = "0.10"
 
-# Same version of jsonrpsee as substrate
+# Same version of jsonrpsee as the substrate version our StateChain is on.
 jsonrpsee = {version = "0.15.1", features = ["full"]}
+
+jsonrpsee_subxt = { package = "jsonrpsee", version = "0.16.0", features = ["full"] }
 
 dyn-clone = "1.0.4"
 ethbloom = "0.12.1"

--- a/engine/config/Template.toml
+++ b/engine/config/Template.toml
@@ -20,6 +20,7 @@ private_key_file = "/etc/chainflip/keys/eth_private_key_file"
 [dot]
 # NB: You will need to manually add :443 to the url provided by the provider, as jsonrpsee wants one.
 ws_node_endpoint = "wss://my_fake_polkadot_rpc:443/<secret_key>"
+http_node_endpoint = "https://my_fake_polkadot_rpc:443/<secret_key>"
 
 [signing]
 db_file = "/etc/chainflip/data.db"

--- a/engine/config/testing/config/Settings.toml
+++ b/engine/config/testing/config/Settings.toml
@@ -15,6 +15,7 @@ ws_node_endpoint = "ws://localhost:8545"
 [dot]
 # NB: You will need to manually add :443 to the url provided by the provider, as jsonrpsee wants one.
 ws_node_endpoint = "wss://my_fake_polkadot_rpc:443/<secret_key>"
+http_node_endpoint = "http://my_fake_polkadot_rpc:443/<secret_key>"
 
 [health_check]
 hostname = "127.0.0.1"

--- a/engine/src/constants.rs
+++ b/engine/src/constants.rs
@@ -53,6 +53,9 @@ pub const BTC_HTTP_NODE_ENDPOINT: &str = "BTC__HTTP_NODE_ENDPOINT";
 pub const BTC_RPC_USER: &str = "BTC__RPC_USER";
 pub const BTC_RPC_PASSWORD: &str = "BTC__RPC_PASSWORD";
 
+pub const DOT_WS_NODE_ENDPOINT: &str = "DOT__WS_NODE_ENDPOINT";
+pub const DOT_HTTP_NODE_ENDPOINT: &str = "DOT__HTTP_NODE_ENDPOINT";
+
 /// IP Address and port on which we listen for incoming p2p connections
 pub const NODE_P2P_IP_ADDRESS: &str = "NODE_P2P__IP_ADDRESS";
 pub const NODE_P2P_PORT: &str = "NODE_P2P__PORT";

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -1,0 +1,174 @@
+use std::sync::Arc;
+
+use cf_chains::dot::{PolkadotHash, RuntimeVersion};
+use cf_primitives::PolkadotBlockNumber;
+use jsonrpsee_subxt::{
+	core::{client::ClientT, traits::ToRpcParams, Error as JsonRpseeError},
+	http_client::{HttpClient, HttpClientBuilder},
+};
+use reqwest::header::{HeaderMap, AUTHORIZATION};
+use serde_json::value::RawValue;
+use subxt::{
+	error::{BlockError, RpcError},
+	events::{Events, EventsClient},
+	rpc::{
+		types::{Bytes, ChainBlockExtrinsic, ChainBlockResponse},
+		RpcClientT, RpcFuture, RpcSubscription,
+	},
+	rpc_params, OnlineClient, PolkadotConfig,
+};
+
+use anyhow::Result;
+
+use super::rpc::DotRpcApi;
+
+pub struct PolkadotHttpClient(HttpClient);
+
+impl PolkadotHttpClient {
+	pub fn new(url: &str) -> Result<Self> {
+		let token = format!("Bearer {}", "TOKEN");
+		let mut headers = HeaderMap::new();
+		headers.insert(AUTHORIZATION, token.parse().unwrap());
+		let client = HttpClientBuilder::default().set_headers(headers).build(url)?;
+
+		Ok(Self(client))
+	}
+}
+
+struct Params(Option<Box<RawValue>>);
+
+impl ToRpcParams for Params {
+	fn to_rpc_params(self) -> Result<Option<Box<RawValue>>, JsonRpseeError> {
+		Ok(self.0)
+	}
+}
+
+impl RpcClientT for PolkadotHttpClient {
+	fn request_raw<'a>(
+		&'a self,
+		method: &'a str,
+		params: Option<Box<RawValue>>,
+	) -> RpcFuture<'a, Box<RawValue>> {
+		Box::pin(async move {
+			let res = self
+				.0
+				.request(method, Params(params))
+				.await
+				.map_err(|e| RpcError::ClientError(Box::new(e)))?;
+			Ok(res)
+		})
+	}
+
+	fn subscribe_raw<'a>(
+		&'a self,
+		_sub: &'a str,
+		_params: Option<Box<RawValue>>,
+		_unsub: &'a str,
+	) -> RpcFuture<'a, RpcSubscription> {
+		unimplemented!("HTTP Client does not support subscription");
+	}
+}
+
+#[derive(Clone)]
+pub struct DotHttpRpcClient {
+	online_client: OnlineClient<PolkadotConfig>,
+}
+
+impl DotHttpRpcClient {
+	pub async fn new(url: &str) -> Result<Self> {
+		let polkadot_http_client = PolkadotHttpClient::new(url)?;
+		let online_client =
+			OnlineClient::<PolkadotConfig>::from_rpc_client(Arc::new(polkadot_http_client)).await?;
+
+		Ok(Self { online_client })
+	}
+
+	pub async fn metadata(&self, block_hash: PolkadotHash) -> Result<subxt::Metadata> {
+		Ok(self.online_client.rpc().metadata(Some(block_hash)).await?)
+	}
+}
+
+#[async_trait::async_trait]
+impl DotRpcApi for DotHttpRpcClient {
+	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Result<Option<PolkadotHash>> {
+		Ok(self.online_client.rpc().block_hash(Some(block_number.into())).await?)
+	}
+
+	async fn block(
+		&self,
+		block_hash: PolkadotHash,
+	) -> Result<Option<ChainBlockResponse<PolkadotConfig>>> {
+		Ok(self.online_client.rpc().block(Some(block_hash)).await?)
+	}
+
+	async fn extrinsics(
+		&self,
+		block_hash: PolkadotHash,
+	) -> Result<Option<Vec<ChainBlockExtrinsic>>> {
+		Ok(self.block(block_hash).await?.map(|block| block.block.extrinsics))
+	}
+
+	async fn events(&self, block_hash: PolkadotHash) -> Result<Option<Events<PolkadotConfig>>> {
+		let chain_runtime_version = self.current_runtime_version().await?;
+
+		let client_runtime_version = self.online_client.runtime_version();
+
+		// We set the metadata and runtime version we need to decode this block's events.
+		// The metadata from the OnlineClient is used within the EventsClient to decode the
+		// events.
+		if chain_runtime_version.spec_version != client_runtime_version.spec_version ||
+			chain_runtime_version.transaction_version !=
+				client_runtime_version.transaction_version
+		{
+			let new_metadata = self.metadata(block_hash).await?;
+
+			self.online_client.set_runtime_version(subxt::rpc::types::RuntimeVersion {
+				spec_version: chain_runtime_version.spec_version,
+				transaction_version: chain_runtime_version.transaction_version,
+				other: Default::default(),
+			});
+			self.online_client.set_metadata(new_metadata);
+		}
+
+		// If we've succeeded in getting the current runtime version then we assume
+		// the connection is stable (or has just been refreshed), no need to retry again.
+		match EventsClient::new(self.online_client.clone()).at(Some(block_hash)).await {
+			Ok(events) => Ok(Some(events)),
+			Err(e) => match e {
+				subxt::Error::Block(BlockError::BlockHashNotFound(_)) => Ok(None),
+				_ => Err(e.into()),
+			},
+		}
+	}
+
+	async fn current_runtime_version(&self) -> Result<RuntimeVersion> {
+		Ok(self.online_client.rpc().runtime_version(None).await.map(|v| RuntimeVersion {
+			spec_version: v.spec_version,
+			transaction_version: v.transaction_version,
+		})?)
+	}
+
+	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash> {
+		let encoded_bytes: Bytes = encoded_bytes.into();
+		Ok(self
+			.online_client
+			.rpc()
+			.request("author_submitExtrinsic", rpc_params![encoded_bytes.clone()])
+			.await?)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[ignore = "requires local node"]
+	#[tokio::test]
+	async fn test_http_rpc() {
+		let url = "http://localhost:9945";
+		let dot_http_rpc = DotHttpRpcClient::new(url).await.unwrap();
+		let block_hash = dot_http_rpc.block_hash(1).await.unwrap();
+		println!("block_hash: {:?}", block_hash);
+	}
+}

--- a/engine/src/dot/mod.rs
+++ b/engine/src/dot/mod.rs
@@ -1,3 +1,4 @@
+pub mod http_rpc;
 pub mod retry_rpc;
 pub mod rpc;
 pub mod runtime_version_updater;

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -7,10 +7,9 @@ use cf_primitives::PolkadotBlockNumber;
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::sync::Arc;
 use subxt::{
-	error::BlockError,
-	events::{Events, EventsClient},
-	rpc::types::{Bytes, ChainBlockExtrinsic, ChainBlockResponse},
-	rpc_params, Config, OnlineClient, PolkadotConfig,
+	events::Events,
+	rpc::types::{ChainBlockExtrinsic, ChainBlockResponse},
+	Config, OnlineClient, PolkadotConfig,
 };
 use tokio::sync::RwLock;
 
@@ -19,11 +18,14 @@ use anyhow::{anyhow, Result};
 #[cfg(test)]
 use mockall::automock;
 
+use super::http_rpc::DotHttpRpcClient;
+
 pub type PolkadotHeader = <PolkadotConfig as Config>::Header;
 
 #[derive(Clone)]
 pub struct DotRpcClient {
 	online_client: Arc<RwLock<OnlineClient<PolkadotConfig>>>,
+	http_client: DotHttpRpcClient,
 	polkadot_network_ws_url: String,
 }
 
@@ -51,15 +53,15 @@ macro_rules! refresh_connection_on_error {
 }
 
 impl DotRpcClient {
-	pub async fn new(polkadot_network_ws_url: &str) -> Result<Self> {
+	pub async fn new(polkadot_network_ws_url: &str, http_client: DotHttpRpcClient) -> Result<Self> {
 		let online_client = Arc::new(RwLock::new(
 			OnlineClient::<PolkadotConfig>::from_url(polkadot_network_ws_url).await?,
 		));
-		Ok(Self { online_client, polkadot_network_ws_url: polkadot_network_ws_url.to_string() })
-	}
-
-	async fn metadata(&self, block_hash: PolkadotHash) -> Result<subxt::Metadata> {
-		refresh_connection_on_error!(self, rpc, metadata, Some(block_hash))
+		Ok(Self {
+			online_client,
+			http_client,
+			polkadot_network_ws_url: polkadot_network_ws_url.to_string(),
+		})
 	}
 }
 
@@ -102,80 +104,39 @@ pub trait DotRpcApi: Send + Sync {
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash>;
 }
 
+// Just pass through to the underlying http client
 #[async_trait]
 impl DotRpcApi for DotRpcClient {
 	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Result<Option<PolkadotHash>> {
-		refresh_connection_on_error!(self, rpc, block_hash, Some(block_number.into()))
+		self.http_client.block_hash(block_number).await
 	}
 
 	async fn block(
 		&self,
 		block_hash: PolkadotHash,
 	) -> Result<Option<ChainBlockResponse<PolkadotConfig>>> {
-		refresh_connection_on_error!(self, rpc, block, Some(block_hash))
+		self.http_client.block(block_hash).await
 	}
 
 	async fn current_runtime_version(&self) -> Result<RuntimeVersion> {
-		refresh_connection_on_error!(self, rpc, runtime_version, None).map(|rv| RuntimeVersion {
-			spec_version: rv.spec_version,
-			transaction_version: rv.transaction_version,
-		})
+		self.http_client.current_runtime_version().await
 	}
 
 	async fn extrinsics(
 		&self,
 		block_hash: PolkadotHash,
 	) -> Result<Option<Vec<ChainBlockExtrinsic>>> {
-		refresh_connection_on_error!(self, rpc, block, Some(block_hash))
-			.map(|o| o.map(|b| b.block.extrinsics))
+		self.http_client.extrinsics(block_hash).await
 	}
 
 	/// Returns the events for a particular block hash.
 	/// If the block for the given block hash does not exist, then this returns `Ok(None)`.
 	async fn events(&self, block_hash: PolkadotHash) -> Result<Option<Events<PolkadotConfig>>> {
-		let chain_runtime_version = self.current_runtime_version().await?;
-
-		let client = self.online_client.read().await;
-
-		let client_runtime_version = client.runtime_version();
-
-		// We set the metadata and runtime version we need to decode this block's events.
-		// The metadata from the OnlineClient is used within the EventsClient to decode the
-		// events.
-		if chain_runtime_version.spec_version != client_runtime_version.spec_version ||
-			chain_runtime_version.transaction_version !=
-				client_runtime_version.transaction_version
-		{
-			let new_metadata = self.metadata(block_hash).await?;
-
-			client.set_runtime_version(subxt::rpc::types::RuntimeVersion {
-				spec_version: chain_runtime_version.spec_version,
-				transaction_version: chain_runtime_version.transaction_version,
-				other: Default::default(),
-			});
-			client.set_metadata(new_metadata);
-		}
-
-		// If we've succeeded in getting the current runtime version then we assume
-		// the connection is stable (or has just been refreshed), no need to retry again.
-		match EventsClient::new(client.clone()).at(Some(block_hash)).await {
-			Ok(events) => Ok(Some(events)),
-			Err(e) => match e {
-				subxt::Error::Block(BlockError::BlockHashNotFound(_)) => Ok(None),
-				_ => Err(e.into()),
-			},
-		}
+		self.http_client.events(block_hash).await
 	}
 
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash> {
-		let encoded_bytes: Bytes = encoded_bytes.into();
-		refresh_connection_on_error!(
-			self,
-			rpc,
-			request,
-			"author_submitExtrinsic",
-			rpc_params![encoded_bytes.clone()]
-		)
+		self.http_client.submit_raw_encoded_extrinsic(encoded_bytes).await
 	}
 }
 
@@ -218,36 +179,5 @@ impl DotSubscribeApi for DotRpcClient {
 		)
 		.await
 		.map_err(|e| anyhow!("Failed to subscribe to Polkadot runtime version with error: {e}"))
-	}
-}
-
-#[cfg(test)]
-mod tests {
-
-	use crate::dot::DotBroadcaster;
-
-	use super::*;
-
-	#[tokio::test]
-	#[ignore = "Testing raw broadcast to live network"]
-	async fn broadcast_tx() {
-		let dot_broadcaster = DotBroadcaster::new(DotRpcClient::new("URL").await.unwrap());
-
-		// Can get these bytes from the `create_test_extrinsic()` in state-chain/chains/src/dot.rs
-		// Will have to ensure the nonce for the account is correct and westend versions are correct
-		// for the transaction to be valid
-		let balances_signed_encoded_bytes: Vec<u8> = vec![
-			61, 2, 132, 0, 86, 204, 74, 248, 255, 159, 185, 124, 96, 50, 10, 228, 61, 53, 189, 131,
-			27, 20, 240, 183, 6, 95, 51, 133, 219, 13, 191, 76, 181, 216, 118, 111, 1, 248, 49, 73,
-			4, 246, 220, 141, 169, 139, 169, 179, 156, 141, 168, 221, 129, 139, 217, 69, 138, 202,
-			21, 226, 229, 249, 205, 183, 253, 121, 63, 133, 124, 0, 52, 146, 100, 192, 219, 76,
-			144, 138, 123, 47, 117, 101, 73, 139, 71, 255, 94, 99, 144, 186, 185, 34, 46, 165, 13,
-			183, 107, 235, 223, 12, 139, 0, 48, 0, 4, 0, 0, 190, 185, 195, 240, 174, 91, 218, 121,
-			141, 211, 182, 95, 227, 69, 253, 249, 3, 25, 70, 132, 157, 137, 37, 174, 123, 231, 62,
-			233, 64, 124, 103, 55, 7, 0, 158, 41, 38, 8,
-		];
-
-		let tx_hash = dot_broadcaster.send(balances_signed_encoded_bytes).await.unwrap();
-		println!("Tx hash: {tx_hash:?}");
 	}
 }

--- a/engine/src/dot/witnesser.rs
+++ b/engine/src/dot/witnesser.rs
@@ -539,7 +539,8 @@ mod tests {
 	use std::collections::BTreeSet;
 
 	use crate::{
-		dot::rpc::DotRpcClient, state_chain_observer::client::mocks::MockStateChainClient,
+		dot::{http_rpc::DotHttpRpcClient, rpc::DotRpcClient},
+		state_chain_observer::client::mocks::MockStateChainClient,
 		witnesser::MonitorCommand,
 	};
 
@@ -784,7 +785,8 @@ mod tests {
 		let url = "ws://localhost:9944";
 
 		println!("Connecting to: {url}");
-		let dot_rpc_client = DotRpcClient::new(url).await.unwrap();
+		let dot_http_client = DotHttpRpcClient::new(url).await.unwrap();
+		let dot_rpc_client = DotRpcClient::new(url, dot_http_client).await.unwrap();
 
 		let (epoch_starts_sender, epoch_starts_receiver) = async_broadcast::broadcast(10);
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -3,7 +3,7 @@ use cf_primitives::AccountRole;
 use chainflip_engine::{
 	btc::{self, rpc::BtcRpcClient, BtcBroadcaster},
 	db::{KeyStore, PersistentKeyDB},
-	dot::{self, rpc::DotRpcClient, DotBroadcaster},
+	dot::{self, http_rpc::DotHttpRpcClient, DotBroadcaster},
 	eth::{
 		self, broadcaster::EthBroadcaster, build_broadcast_channel, ethers_rpc::EthersRpcClient,
 	},
@@ -66,10 +66,6 @@ async fn main() -> anyhow::Result<()> {
 					.await
 					.context("Failed to get EthereumChainId from state chain")?,
 			);
-
-			let dot_rpc_client = DotRpcClient::new(&settings.dot.ws_node_endpoint)
-				.await
-				.context("Failed to create Polkadot Client")?;
 
 			let btc_rpc_client =
 				BtcRpcClient::new(&settings.btc).context("Failed to create Bitcoin Client")?;
@@ -230,7 +226,7 @@ async fn main() -> anyhow::Result<()> {
 					)
 					.await?,
 				),
-				DotBroadcaster::new(dot_rpc_client.clone()),
+				DotBroadcaster::new(DotHttpRpcClient::new(&settings.dot.http_node_endpoint).await?),
 				BtcBroadcaster::new(btc_rpc_client.clone()),
 				eth_multisig_client,
 				dot_multisig_client,

--- a/localnet/init/config/Settings.toml
+++ b/localnet/init/config/Settings.toml
@@ -25,6 +25,7 @@ db_file = "/tmp/chainflip/bashful.db"
 
 [dot]
 ws_node_endpoint = "ws://localhost:9945"
+http_node_endpoint = "http://localhost:9945"
 
 [btc]
 http_node_endpoint = "http://localhost:8332"


### PR DESCRIPTION
# Pull Request

Closes: PRO-602

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Adds a Polkadot HTTP client, so we can use it for the stateless queries we make.

Not done here: https://linear.app/chainflip/issue/PRO-633/polkadot-subscription-client-should-create-client-on-subscribe