### PR TITLE
Fix: Compare Balances as Numbers in Bouncer

### DIFF
--- a/bouncer/shared/get_balance.ts
+++ b/bouncer/shared/get_balance.ts
@@ -1,13 +1,14 @@
+import { Asset } from '@chainflip-io/cli';
 import { getEthContractAddress } from "./utils";
 import { getBtcBalance } from "./get_btc_balance";
 import { getDotBalance } from "./get_dot_balance";
 import { getEthBalance } from "./get_eth_balance";
 import { getErc20Balance } from "./get_erc20_balance";
-import { Asset } from '@chainflip-io/cli';
 
-export async function getBalance(token: Asset, address: string): Promise<number> {
+export async function getBalance(token: Asset, address: string): Promise<string> {
+    // eslint-disable-next-line no-param-reassign
     address = address.trim();
-    let result: any;
+    let result: string;
     switch (token) {
         case 'FLIP':
         case 'USDC':
@@ -21,10 +22,10 @@ export async function getBalance(token: Asset, address: string): Promise<number>
             result = await getDotBalance(address);
             break;
         case "BTC":
-            result = await getBtcBalance(address);
+            result = (await getBtcBalance(address)).toString().trim();
             break;
         default:
             throw new Error(`Unexpected token: ${token}`);
     }
-    return result.toString().trim();
+    return result;
 }

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -203,12 +203,13 @@ export function chainFromAsset(asset: Asset): Chain {
   throw new Error('unexpected asset');
 }
 
-export async function observeBalanceIncrease(dstCcy: string, address: string, oldBalance: number): Promise<number> {
+export async function observeBalanceIncrease(dstCcy: string, address: string, oldBalance: string): Promise<number> {
+
 
   for (let i = 0; i < 120; i++) {
-    const newBalance = await getBalance(dstCcy as Asset, address);
-    if (newBalance > oldBalance) {
-      return Number(newBalance);
+    const newBalance = Number(await getBalance(dstCcy as Asset, address));
+    if (newBalance > Number(oldBalance)) {
+      return newBalance;
     }
 
     await sleep(1000);


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This was causing some swapping tests to fail when running them a second time. Basically we were comparing balances as strings before and got lucky that initial balances were '0' most of the time. `getBalance` was incorrectly stating that it returns a number and typescript didn't catch that...
