### PR TITLE
feat: create new connection on subscribe

### DIFF
--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -21,7 +21,7 @@ use crate::retrier::RetrierClient;
 
 use super::{
 	http_rpc::DotHttpRpcClient,
-	rpc::{DotRpcClient, PolkadotHeader},
+	rpc::{DotSubClient, PolkadotHeader},
 };
 
 use crate::dot::rpc::DotRpcApi;
@@ -29,9 +29,7 @@ use crate::dot::rpc::DotRpcApi;
 #[derive(Clone)]
 pub struct DotRetryRpcClient {
 	rpc_retry_client: RetrierClient<DotHttpRpcClient>,
-	// TODO: this will become just the subscription client, once we no longer need the unified
-	// client after we merge the witnessing refactor
-	sub_retry_client: RetrierClient<DotRpcClient>,
+	sub_retry_client: RetrierClient<DotSubClient>,
 }
 
 const POLKADOT_RPC_TIMEOUT: Duration = Duration::from_millis(1000);
@@ -41,7 +39,7 @@ impl DotRetryRpcClient {
 	pub fn new(
 		scope: &Scope<'_, anyhow::Error>,
 		dot_rpc_client: DotHttpRpcClient,
-		dot_sub_client: DotRpcClient,
+		dot_sub_client: DotSubClient,
 	) -> Self {
 		Self {
 			rpc_retry_client: RetrierClient::new(
@@ -228,11 +226,11 @@ mod tests {
 	async fn my_test() {
 		task_scope(|scope| {
 			async move {
-				let url = "ws://127.0.0.1:9945";
-				let dot_http_rpc_client = DotHttpRpcClient::new(url).await.unwrap();
-				let dot_client = DotRpcClient::new(url, dot_http_rpc_client.clone()).await.unwrap();
+				let dot_http_rpc_client =
+					DotHttpRpcClient::new("http://127.0.0.1:9945").await.unwrap();
+				let dot_sub_client = DotSubClient::new("ws://127.0.0.1:9945").await.unwrap();
 				let dot_retry_rpc_client =
-					DotRetryRpcClient::new(scope, dot_http_rpc_client, dot_client);
+					DotRetryRpcClient::new(scope, dot_http_rpc_client, dot_sub_client);
 
 				let hash = dot_retry_rpc_client.block_hash(1).await.unwrap();
 				println!("Block hash: {}", hash);

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -140,6 +140,68 @@ impl DotRpcApi for DotRpcClient {
 	}
 }
 
+#[derive(Clone)]
+pub struct DotSubClient {
+	pub ws_endpoint: String,
+}
+
+impl DotSubClient {
+	pub async fn new(ws_endpoint: &str) -> Result<Self> {
+		Ok(Self { ws_endpoint: ws_endpoint.to_string() })
+	}
+}
+
+#[async_trait]
+impl DotSubscribeApi for DotSubClient {
+	async fn subscribe_best_heads(
+		&self,
+	) -> Result<Pin<Box<dyn Stream<Item = Result<PolkadotHeader>> + Send>>> {
+		let client = OnlineClient::<PolkadotConfig>::from_url(self.ws_endpoint.clone()).await?;
+		Ok(Box::pin(
+			client
+				.blocks()
+				.subscribe_best()
+				.await?
+				.map(|block| block.map(|block| block.header().clone()))
+				.map_err(|e| anyhow!("Error in best head stream: {e}")),
+		))
+	}
+
+	async fn subscribe_finalized_heads(
+		&self,
+	) -> Result<Pin<Box<dyn Stream<Item = Result<PolkadotHeader>> + Send>>> {
+		let client = OnlineClient::<PolkadotConfig>::from_url(self.ws_endpoint.clone()).await?;
+		Ok(Box::pin(
+			client
+				.blocks()
+				.subscribe_finalized()
+				.await?
+				.map(|block| block.map(|block| block.header().clone()))
+				.map_err(|e| anyhow!("Error in finalised head stream: {e}")),
+		))
+	}
+
+	async fn subscribe_runtime_version(
+		&self,
+	) -> Result<Pin<Box<dyn Stream<Item = RuntimeVersion> + Send>>> {
+		let client = OnlineClient::<PolkadotConfig>::from_url(self.ws_endpoint.clone()).await?;
+		let subxt_v_to_sc_v = |v: subxt::rpc::types::RuntimeVersion| RuntimeVersion {
+			spec_version: v.spec_version,
+			transaction_version: v.transaction_version,
+		};
+		let current_runtime_version =
+			client.rpc().runtime_version(None).await.map(subxt_v_to_sc_v)?;
+		let raw_runtime_version_stream = client
+			.rpc()
+			.subscribe_runtime_version()
+			.await?
+			.map(move |item| item.map_err(anyhow::Error::new).map(subxt_v_to_sc_v));
+		safe_runtime_version_stream(current_runtime_version, raw_runtime_version_stream)
+			.await
+			.map_err(|e| anyhow!("Failed to subscribe to Polkadot runtime version with error: {e}"))
+	}
+}
+
 #[async_trait]
 impl DotSubscribeApi for DotRpcClient {
 	async fn subscribe_best_heads(


### PR DESCRIPTION
# Pull Request

Closes: PRO-633

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

In the same way we create a new client on subscribe for Ethereum, we want to do the same for Polkadot. This is to ensure, it's not just the subscribe *calls* that aren't working, but that the websocket connection established itself wasn't broken. 
