### PR TITLE
refactor: use macro instead of trait

### DIFF
--- a/engine/src/witness/chain_source/dot_source.rs
+++ b/engine/src/witness/chain_source/dot_source.rs
@@ -19,26 +19,53 @@ use subxt::config::Header as SubxtHeader;
 
 use anyhow::Result;
 
-#[async_trait::async_trait]
-pub trait GetPolkadotStream {
-	async fn get_stream(
-		&self,
-	) -> Pin<Box<dyn Stream<Item = anyhow::Result<PolkadotHeader>> + Send>>;
+macro_rules! polkadot_source {
+	($self:expr, $func: ident) => {{
+		struct State<C> {
+			client: C,
+			stream: Pin<Box<dyn Stream<Item = Result<PolkadotHeader>> + Send>>,
+		}
+
+		let client = $self.client.clone();
+		let stream = client.$func().await;
+
+		(
+			Box::pin(stream::unfold(State { client, stream }, |mut state| async move {
+				loop {
+					while let Ok(Some(header)) =
+						tokio::time::timeout(TIMEOUT, state.stream.next()).await
+					{
+						if let Ok(header) = header {
+							let Some(events) = state.client.events(header.hash()).await else {
+
+								continue;
+							};
+
+							return Some((
+								Header {
+									index: header.number,
+									hash: header.hash(),
+									parent_hash: Some(header.parent_hash),
+									data: events,
+								},
+								state,
+							))
+						}
+					}
+					// We don't want to spam retries if the node returns a stream that's empty
+					// immediately.
+					tokio::time::sleep(RESTART_STREAM_DELAY).await;
+					let stream = state.client.$func().await;
+					state = State { client: state.client, stream };
+				}
+			})),
+			$self.client.clone(),
+		)
+	}};
 }
 
 pub struct DotUnfinalisedSource<C> {
 	client: C,
-}
-
-#[async_trait::async_trait]
-impl<C: DotRetrySubscribeApi + DotRetryRpcApi + Send + Sync> GetPolkadotStream
-	for DotUnfinalisedSource<C>
-{
-	async fn get_stream(
-		&self,
-	) -> Pin<Box<dyn Stream<Item = anyhow::Result<PolkadotHeader>> + Send>> {
-		self.client.subscribe_best_heads().await
-	}
 }
 
 impl<C> DotUnfinalisedSource<C> {
@@ -54,7 +81,6 @@ const RESTART_STREAM_DELAY: Duration = Duration::from_secs(6);
 impl<C> ChainSource for DotUnfinalisedSource<C>
 where
 	C: ChainClient<Index = PolkadotBlockNumber, Hash = PolkadotHash, Data = Events<PolkadotConfig>>
-		+ GetPolkadotStream
 		+ DotRetryRpcApi
 		+ DotRetrySubscribeApi
 		+ Clone
@@ -68,8 +94,22 @@ where
 	async fn stream_and_client(
 		&self,
 	) -> (BoxChainStream<'_, Self::Index, Self::Hash, Self::Data>, Self::Client) {
-		(polkadot_source(self.client.clone()).await, self.client.clone())
+		polkadot_source!(self, subscribe_best_heads)
 	}
+}
+
+impl<
+		C: ChainClient<
+				Index = PolkadotBlockNumber,
+				Hash = PolkadotHash,
+				Data = Events<PolkadotConfig>,
+			> + DotRetryRpcApi
+			+ DotRetrySubscribeApi
+			+ Clone
+			+ 'static,
+	> ExternalChainSource for DotUnfinalisedSource<C>
+{
+	type Chain = cf_chains::Polkadot;
 }
 
 pub struct DotFinalisedSource<C> {
@@ -83,24 +123,12 @@ impl<C> DotFinalisedSource<C> {
 }
 
 #[async_trait::async_trait]
-impl<C: DotRetrySubscribeApi + DotRetryRpcApi + Send + Sync> GetPolkadotStream
-	for DotFinalisedSource<C>
-{
-	async fn get_stream(
-		&self,
-	) -> Pin<Box<dyn Stream<Item = anyhow::Result<PolkadotHeader>> + Send>> {
-		self.client.subscribe_finalized_heads().await
-	}
-}
-
-#[async_trait::async_trait]
 impl<
 		C: ChainClient<
 				Index = PolkadotBlockNumber,
 				Hash = PolkadotHash,
 				Data = Events<PolkadotConfig>,
-			> + GetPolkadotStream
-			+ DotRetryRpcApi
+			> + DotRetryRpcApi
 			+ DotRetrySubscribeApi
 			+ Clone
 			+ 'static,
@@ -114,7 +142,7 @@ impl<
 	async fn stream_and_client(
 		&self,
 	) -> (BoxChainStream<'_, Self::Index, Self::Hash, Self::Data>, Self::Client) {
-		(polkadot_source(self.client.clone()).await, self.client.clone())
+		polkadot_source!(self, subscribe_finalized_heads)
 	}
 }
 
@@ -123,57 +151,11 @@ impl<
 				Index = PolkadotBlockNumber,
 				Hash = PolkadotHash,
 				Data = Events<PolkadotConfig>,
-			> + GetPolkadotStream
-			+ DotRetryRpcApi
+			> + DotRetryRpcApi
 			+ DotRetrySubscribeApi
 			+ Clone
 			+ 'static,
 	> ExternalChainSource for DotFinalisedSource<C>
 {
 	type Chain = cf_chains::Polkadot;
-}
-
-async fn polkadot_source<
-	'a,
-	C: ChainClient<Index = PolkadotBlockNumber, Hash = PolkadotHash, Data = Events<PolkadotConfig>>
-		+ GetPolkadotStream
-		+ DotRetrySubscribeApi
-		+ DotRetryRpcApi
-		+ Clone
-		+ 'static,
->(
-	client: C,
-) -> BoxChainStream<'a, C::Index, C::Hash, C::Data> {
-	pub struct State<C> {
-		client: C,
-		stream: Pin<Box<dyn Stream<Item = Result<PolkadotHeader>> + Send>>,
-	}
-	let client = client.clone();
-	let stream = client.get_stream().await;
-	Box::pin(stream::unfold(State { client, stream }, |mut state| async move {
-		loop {
-			while let Ok(Some(header)) = tokio::time::timeout(TIMEOUT, state.stream.next()).await {
-				if let Ok(header) = header {
-					let Some(events) = state.client.events(header.hash()).await else {
-						continue;
-					};
-
-					return Some((
-						Header {
-							index: header.number,
-							hash: header.hash(),
-							parent_hash: Some(header.parent_hash),
-							data: events,
-						},
-						state,
-					))
-				}
-			}
-			// We don't want to spam retries if the node returns a stream that's empty
-			// immediately.
-			tokio::time::sleep(RESTART_STREAM_DELAY).await;
-			let stream = state.client.get_stream().await;
-			state = State { client: state.client, stream };
-		}
-	}))
 }


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Step on the way to dot chain tracking. Realised using a trait is kind impossible if the same client needs to be used for both streams in the end... so just used a macro instead. 
