### PR TITLE
fix: build chainspec with no benchmarks runtime 🐛

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: build-chainspec-sisyphos
 build-chainspec-sisyphos:
-	cargo cf-build-ci
+	cargo build --release
 	./target/release/chainflip-node build-spec --chain sisyphos-new --disable-default-bootnode > state-chain/node/chainspecs/sisyphos.chainspec.json
 	./target/release/chainflip-node build-spec --chain state-chain/node/chainspecs/sisyphos.chainspec.json --disable-default-bootnode --raw > state-chain/node/chainspecs/sisyphos.chainspec.raw.json
 
 .PHONY: build-chainspec-perseverance
 build-chainspec-perseverance:
-	cargo cf-build-ci
+	cargo build --release
 	./target/release/chainflip-node build-spec --chain perseverance-new --disable-default-bootnode > state-chain/node/chainspecs/perseverance.chainspec.json
 	./target/release/chainflip-node build-spec --chain ./state-chain/node/chainspecs/perseverance.chainspec.json --raw --disable-default-bootnode > state-chain/node/chainspecs/perseverance.chainspec.raw.json
 
 .PHONY: build-chainspec-partnernet
 build-chainspec-partnernet:
-	cargo cf-build-ci
+	cargo build --release
 	./target/release/chainflip-node build-spec --chain partnernet-new --disable-default-bootnode > state-chain/node/chainspecs/partnernet.chainspec.json
 	./target/release/chainflip-node build-spec --chain ./state-chain/node/chainspecs/partnernet.chainspec.json --raw --disable-default-bootnode > state-chain/node/chainspecs/partnernet.chainspec.raw.json


### PR DESCRIPTION
I remember we had some issues before when generating the chainspec with a binary build with `--features runtime-benchmarks` which results in binaries build without it to not be able to join the network. 

@dandanlen Is that still the case?