### PR TITLE
Fix: request broadcaster nonce for pending block

### DIFF
--- a/engine/src/eth/ethers_rpc.rs
+++ b/engine/src/eth/ethers_rpc.rs
@@ -55,7 +55,10 @@ impl EthersRpcClient {
 		let nonce_info = match nonce_info_lock.as_mut() {
 			Some(nonce_info) => nonce_info,
 			None => {
-				let tx_count = self.signer.get_transaction_count(self.address(), None).await?;
+				let tx_count = self
+					.signer
+					.get_transaction_count(self.address(), Some(BlockNumber::Pending.into()))
+					.await?;
 				nonce_info_lock
 					.insert(NonceInfo { next_nonce: tx_count, requested_at: Instant::now() })
 			},


### PR DESCRIPTION
# Pull Request

Closes: PRO-647

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

As mentioned on Linear, this returns a nonce that takes into account any pending transactions, which solves the original problem. Tested with bouncer with CCM swaps with frequent nonce resetting and it passed.