### PR TITLE
fix: always re-use polkadot deposit addresses

### DIFF
--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -228,7 +228,17 @@ impl Chain for Polkadot {
 	type ChainAsset = assets::dot::Asset;
 	type EpochStartData = EpochStartData;
 	type DepositFetchId = PolkadotChannelId;
-	type DepositChannelState = ();
+	type DepositChannelState = PolkadotChannelState;
+}
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq, Default)]
+pub struct PolkadotChannelState;
+
+/// Polkadot channels should always be recycled because we are limited to u16::MAX channels.
+impl ChannelLifecycleHooks for PolkadotChannelState {
+	fn maybe_recycle(self) -> Option<Self> {
+		Some(self)
+	}
 }
 
 impl ChainCrypto for Polkadot {

--- a/state-chain/runtime/src/chainflip/address_derivation/dot.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/dot.rs
@@ -24,10 +24,9 @@ impl AddressDerivationApi<Polkadot> for AddressDerivation {
 			.ok_or(DispatchError::Other("Vault Account does not exist."))?;
 
 		// Because we re-use addresses, we don't expect to hit this case in the wild.
-		// TODO: investigate this claim - we don't re-use addresses for Polkadot.
 		if channel_id > u16::MAX.into() {
 			return Err(DispatchError::Other(
-				"Intent ID too large. Polkadot can only support up to u16 addresses",
+				"Channel ID too large. Polkadot can only support up to u16::MAX addresses",
 			))
 		}
 


### PR DESCRIPTION
Ensures that we always re-use Polkadot addresses (we previously only reused them if they were used at least once).