### PR TITLE
refactor: use "witness" vault types

### DIFF
--- a/engine/src/eth/mod.rs
+++ b/engine/src/eth/mod.rs
@@ -12,7 +12,6 @@ mod ws_safe_stream;
 
 pub mod address_checker;
 pub mod broadcaster;
-pub mod eth_ingresses_at_block;
 pub mod ethers_rpc;
 pub mod ethers_vault;
 pub mod retry_rpc;

--- a/engine/src/witness.rs
+++ b/engine/src/witness.rs
@@ -9,6 +9,7 @@ pub mod dot_chain_tracking;
 pub mod epoch_source;
 pub mod eth;
 pub mod eth_chain_tracking;
+pub mod eth_ingresses_at_block;
 pub mod key_manager;
 pub mod start;
 pub mod state_chain_gateway;

--- a/engine/src/witness/eth_ingresses_at_block.rs
+++ b/engine/src/witness/eth_ingresses_at_block.rs
@@ -1,13 +1,15 @@
 use std::collections::BTreeMap;
 
-use super::{address_checker::*, ethers_vault::*};
+use crate::eth::address_checker::*;
 use ethers::prelude::*;
 use itertools::Itertools;
 use sp_core::U256;
 
+use crate::witness::vault::FetchedNativeFilter;
+
 // TODO: Write a comment describing why we do this once this has stabilised a bit: PRO-573
 #[allow(unused)]
-fn eth_ingresses_at_block(
+pub fn eth_ingresses_at_block(
 	addresses: Vec<H160>,
 	previous_block_balances: Vec<U256>,
 	address_states: Vec<AddressState>,
@@ -58,6 +60,7 @@ mod tests {
 	use crate::{
 		eth::ethers_rpc::{EthersRpcApi, EthersRpcClient},
 		settings::Settings,
+		witness::vault::{VaultApi, VaultRpc},
 	};
 
 	use super::*;


### PR DESCRIPTION
changes the ingresses_at_block code to use the types (generated by the ether-rs macro) from the vault rpc impl under "witness".