### PR TITLE
Fix: Swaps with output of zero are still processed

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -449,21 +449,22 @@ pub mod pallet {
 						});
 						// Handle swap completion logic.
 						match &swap.swap_type {
-							SwapType::Swap(destination_address) => {
-								let egress_id = T::EgressHandler::schedule_egress(
-									swap.to,
-									egress_amount,
-									destination_address.clone(),
-									None,
-								);
+							SwapType::Swap(destination_address) =>
+								if !egress_amount.is_zero() {
+									let egress_id = T::EgressHandler::schedule_egress(
+										swap.to,
+										egress_amount,
+										destination_address.clone(),
+										None,
+									);
 
-								Self::deposit_event(Event::<T>::SwapEgressScheduled {
-									swap_id: swap.swap_id,
-									egress_id,
-									asset: swap.to,
-									amount: egress_amount,
-								});
-							},
+									Self::deposit_event(Event::<T>::SwapEgressScheduled {
+										swap_id: swap.swap_id,
+										egress_id,
+										asset: swap.to,
+										amount: egress_amount,
+									});
+								},
 							SwapType::CcmPrincipal(ccm_id) => {
 								Self::handle_ccm_swap_result(
 									*ccm_id,

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -1,6 +1,7 @@
 use crate::{self as pallet_cf_swapping, PalletSafeMode, WeightInfo};
 use cf_chains::AnyChain;
 use cf_primitives::{Asset, AssetAmount, SwapLeg, STABLE_ASSET};
+use cf_test_utilities::TestExternalities;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
@@ -15,7 +16,7 @@ use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage, Percent,
+	Percent,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -153,15 +154,15 @@ impl pallet_cf_swapping::Config for Test {
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;
 
 // Build genesis storage according to the mock runtime.
-pub fn new_test_ext() -> sp_io::TestExternalities {
+pub fn new_test_ext() -> TestExternalities<Test, AllPalletsWithSystem> {
 	let config = GenesisConfig {
 		system: Default::default(),
 		swapping: SwappingConfig { swap_ttl: 5, minimum_swap_amounts: vec![] },
 	};
 
-	let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();
+	let mut ext = TestExternalities::<Test, AllPalletsWithSystem>::new(config);
 
-	ext.execute_with(|| {
+	ext = ext.execute_with(|| {
 		<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_broker(&ALICE).unwrap();
 		System::set_block_number(1);
 		System::set_block_number(1);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1778,124 +1778,111 @@ fn ccm_swaps_emits_events() {
 
 #[test]
 fn can_handle_ccm_with_zero_swap_outputs() {
-	new_test_ext().execute_with(|| {
-		let eth_address = ForeignChainAddress::Eth(Default::default());
-		let ccm = CcmDepositMetadata {
-			message: vec![],
-			gas_budget: 1,
-			cf_parameters: vec![],
-			source_address: eth_address.clone(),
-		};
+	new_test_ext()
+		.then_execute_at_next_block(|_| {
+			let eth_address = ForeignChainAddress::Eth(Default::default());
+			let ccm = CcmDepositMetadata {
+				message: vec![],
+				gas_budget: 1,
+				cf_parameters: vec![],
+				source_address: eth_address.clone(),
+			};
 
-		Swapping::on_ccm_deposit(
-			Asset::Usdc,
-			101,
-			Asset::Eth,
-			eth_address,
-			ccm,
-			SwapOrigin::Vault { tx_hash: Default::default() },
-		);
+			Swapping::on_ccm_deposit(
+				Asset::Usdc,
+				101,
+				Asset::Eth,
+				eth_address,
+				ccm,
+				SwapOrigin::Vault { tx_hash: Default::default() },
+			);
 
-		// Change the swap rate so swap output will be 0
-		SwapRate::set(0.01f64);
-		System::reset_events();
+			// Change the swap rate so swap output will be 0
+			SwapRate::set(0.01f64);
+			System::reset_events();
+		})
+		.then_execute_with(|_| {
+			// Swap outputs are zero
+			assert_event_sequence!(
+				Test,
+				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+					swap_id: 1,
+					source_asset: Asset::Usdc,
+					deposit_amount: 100,
+					destination_asset: Asset::Eth,
+					egress_amount: 0,
+					intermediate_amount: None,
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+					swap_id: 2,
+					source_asset: Asset::Usdc,
+					destination_asset: Asset::Eth,
+					deposit_amount: 1,
+					egress_amount: 0,
+					intermediate_amount: None,
+				})
+			);
 
-		Swapping::on_finalize(1);
+			// CCM are processed and egressed even if principal output is zero.
+			assert_eq!(MockEgressHandler::<AnyChain>::get_scheduled_egresses().len(), 1);
+			assert_eq!(SwapQueue::<Test>::decode_len(), None);
 
-		// Swap outputs are zero
-		assert_event_sequence!(
-			Test,
-			RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_id: 1,
-				source_asset: Asset::Usdc,
-				deposit_amount: 100,
-				destination_asset: Asset::Eth,
-				egress_amount: 0,
-				intermediate_amount: None,
-			}),
-			RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_id: 2,
-				source_asset: Asset::Usdc,
-				destination_asset: Asset::Eth,
-				deposit_amount: 1,
-				egress_amount: 0,
-				intermediate_amount: None,
-			})
-		);
-
-		// Swaps are processed even if the output is 0
-		assert_eq!(SwapQueue::<Test>::decode_len(), None);
-
-		assert_eq!(MockEgressHandler::<AnyChain>::get_scheduled_egresses().len(), 1);
-
-		// Zero gas budget are not stored.
-		assert_eq!(CcmGasBudget::<Test>::get(1), None);
-	});
+			// Zero gas budget are not stored.
+			assert_eq!(CcmGasBudget::<Test>::get(1), None);
+		});
 }
 
 #[test]
 fn can_handle_swaps_with_zero_outputs() {
-	new_test_ext().execute_with(|| {
-		let eth_address = ForeignChainAddress::Eth(Default::default());
+	new_test_ext()
+		.then_execute_at_next_block(|_| {
+			let eth_address = ForeignChainAddress::Eth(Default::default());
 
-		Swapping::schedule_swap_from_channel(
-			eth_address.clone(),
-			Asset::Usdc,
-			Asset::Eth,
-			100,
-			eth_address.clone(),
-			Default::default(),
-			0,
-			0,
-		);
-		Swapping::schedule_swap_from_channel(
-			eth_address.clone(),
-			Asset::Usdc,
-			Asset::Eth,
-			1,
-			eth_address,
-			Default::default(),
-			0,
-			0,
-		);
+			Swapping::schedule_swap_from_channel(
+				eth_address.clone(),
+				Asset::Usdc,
+				Asset::Eth,
+				100,
+				eth_address.clone(),
+				Default::default(),
+				0,
+				0,
+			);
+			Swapping::schedule_swap_from_channel(
+				eth_address.clone(),
+				Asset::Usdc,
+				Asset::Eth,
+				1,
+				eth_address,
+				Default::default(),
+				0,
+				0,
+			);
 
-		// Change the swap rate so swap output will be 0
-		SwapRate::set(0.01f64);
-		System::reset_events();
+			// Change the swap rate so swap output will be 0
+			SwapRate::set(0.01f64);
+			System::reset_events();
+		})
+		.then_execute_with(|_| {
+			// Swap outputs are zero
+			assert_event_sequence!(
+				Test,
+				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+					swap_id: 1,
+					destination_asset: Asset::Eth,
+					egress_amount: 0,
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+					swap_id: 2,
+					destination_asset: Asset::Eth,
+					egress_amount: 0,
+					..
+				}),
+			);
 
-		Swapping::on_finalize(1);
-
-		// Swap outputs are zero
-		assert_event_sequence!(
-			Test,
-			RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_id: 1,
-				destination_asset: Asset::Eth,
-				egress_amount: 0,
-				..
-			}),
-			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_id: 1,
-				asset: Asset::Eth,
-				amount: 0,
-				..
-			}),
-			RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_id: 2,
-				destination_asset: Asset::Eth,
-				egress_amount: 0,
-				..
-			}),
-			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_id: 2,
-				asset: Asset::Eth,
-				amount: 0,
-				..
-			}),
-		);
-
-		// Swaps are processed even if the output is 0
-		assert_eq!(SwapQueue::<Test>::decode_len(), None);
-		assert_eq!(MockEgressHandler::<AnyChain>::get_scheduled_egresses().len(), 2);
-	});
+			// Swaps are not egressed when output is 0.
+			assert_eq!(SwapQueue::<Test>::decode_len(), None);
+			assert_eq!(MockEgressHandler::<AnyChain>::get_scheduled_egresses().len(), 0);
+		});
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-716

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Swaps with an output of 0 are still processed and results updated. 
Warnings are only logged for normal Swaps.
Swaps with 0 output are still egressed.