### PR TITLE
fix: reduce max retry delay

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -115,10 +115,10 @@ impl SubmissionHolder {
 	}
 }
 
-const MAX_DELAY_TIME_MILLIS: Duration = Duration::from_secs(60 * 20);
+const MAX_DELAY_TIME: Duration = Duration::from_secs(30);
 
 fn max_sleep_duration(initial_request_timeout: Duration, attempt: u32) -> Duration {
-	min(MAX_DELAY_TIME_MILLIS, initial_request_timeout.saturating_mul(2u32.saturating_pow(attempt)))
+	min(MAX_DELAY_TIME, initial_request_timeout.saturating_mul(2u32.saturating_pow(attempt)))
 }
 
 // Creates a future of a particular submission.


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

As discussed, we want a much smaller max delay to ensure that we can recover somewhat quickly after the network comes back online.