### PR TITLE
chore: make json warnings go away again

### DIFF
--- a/bouncer/shared/approve_erc20.ts
+++ b/bouncer/shared/approve_erc20.ts
@@ -2,8 +2,10 @@ import Web3 from 'web3';
 import { Asset } from '@chainflip-io/cli';
 import { amountToFineAmount } from '../shared/utils';
 import { getEthContractAddress } from './utils';
-import erc20abi from '../../eth-contract-abis/IERC20.json';
 import { signAndSendTxEth } from './send_eth';
+import { getErc20abi } from './eth_abis';
+
+const erc20abi = await getErc20abi();
 
 export async function approveErc20(asset: Asset, toAddress: string, amount: string) {
   const ethEndpoint = process.env.ETH_ENDPOINT ?? 'http://127.0.0.1:8545';

--- a/bouncer/shared/eth_abis.ts
+++ b/bouncer/shared/eth_abis.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises';
+
+async function loadContract(abiPath: string): Promise<JSON> {
+  const abi = await fs.readFile(abiPath, 'utf-8');
+  return JSON.parse(abi);
+}
+
+function loadContractCached(abiPath: string) {
+  let cached: JSON | undefined;
+  return async () => {
+    if (!cached) {
+      cached = await loadContract(abiPath);
+    }
+    return cached;
+  };
+}
+
+export const getErc20abi = loadContractCached('../eth-contract-abis/IERC20.json');
+export const getGatewayAbi = loadContractCached(
+  '../eth-contract-abis/perseverance-0.9-rc3/IStateChainGateway.json',
+);
+export const getCFTesterAbi = loadContractCached(
+  '../eth-contract-abis/perseverance-0.9-rc3/CFTester.json',
+);

--- a/bouncer/shared/get_erc20_balance.ts
+++ b/bouncer/shared/get_erc20_balance.ts
@@ -1,6 +1,8 @@
 import Web3 from 'web3';
-import erc20abi from '../../eth-contract-abis/IERC20.json';
 import { fineAmountToAmount } from './utils';
+import { getErc20abi } from './eth_abis';
+
+const erc20abi = await getErc20abi();
 
 export async function getErc20Balance(
   walletAddress: string,

--- a/bouncer/shared/get_usdc_balance.ts
+++ b/bouncer/shared/get_usdc_balance.ts
@@ -1,6 +1,8 @@
 import Web3 from 'web3';
 import { getEthContractAddress } from './utils';
-import erc20abi from '../../eth-contract-abis/IERC20.json';
+import { getErc20abi } from './eth_abis';
+
+const erc20abi = await getErc20abi();
 
 export async function getUsdcBalance(ethereumAddress: string): Promise<string> {
   const ethEndpoint = process.env.ETH_ENDPOINT ?? 'http://127.0.0.1:8545';

--- a/bouncer/shared/redeem_flip.ts
+++ b/bouncer/shared/redeem_flip.ts
@@ -3,6 +3,7 @@ import { HexString } from '@polkadot/util/types';
 import { Wallet, ethers } from 'ethers';
 import Keyring from '@polkadot/keyring';
 import { getNextEthNonce } from './send_eth';
+import { getGatewayAbi } from './eth_abis';
 import {
   sleep,
   observeEvent,
@@ -12,7 +13,8 @@ import {
   amountToFineAmount,
   observeEVMEvent,
 } from './utils';
-import gatewayAbi from '../../eth-contract-abis/perseverance-0.9-rc3/IStateChainGateway.json';
+
+const gatewayAbi = await getGatewayAbi();
 
 export async function redeemFlip(flipSeed: string, ethAddress: HexString, flipAmount: string) {
   const chainflip = await getChainflipApi();

--- a/bouncer/shared/send.ts
+++ b/bouncer/shared/send.ts
@@ -5,8 +5,10 @@ import { sendBtc } from './send_btc';
 import { sendErc20 } from './send_erc20';
 import { sendEth, signAndSendTxEth } from './send_eth';
 import { getEthContractAddress, defaultAssetAmounts, amountToFineAmount } from './utils';
-import cfTesterAbi from '../../eth-contract-abis/perseverance-0.9-rc3/CFTester.json';
 import { approveErc20 } from './approve_erc20';
+import { getCFTesterAbi } from './eth_abis';
+
+const cfTesterAbi = await getCFTesterAbi();
 
 export async function send(asset: Asset, address: string, amount?: string) {
   switch (asset) {

--- a/bouncer/shared/send_erc20.ts
+++ b/bouncer/shared/send_erc20.ts
@@ -1,7 +1,9 @@
 import Web3 from 'web3';
 import { signAndSendTxEth } from './send_eth';
-import erc20abi from '../../eth-contract-abis/IERC20.json';
 import { amountToFineAmount } from './utils';
+import { getErc20abi } from './eth_abis';
+
+const erc20abi = await getErc20abi();
 
 export async function sendErc20(
   destinationAddress: string,

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -11,7 +11,9 @@ import { BtcAddressType, newBtcAddress } from './new_btc_address';
 import { getBalance } from './get_balance';
 import { newEthAddress } from './new_eth_address';
 import { CcmDepositMetadata } from './new_swap';
-import cfTesterAbi from '../../eth-contract-abis/perseverance-0.9-rc3/CFTester.json';
+import { getCFTesterAbi } from './eth_abis';
+
+const cfTesterAbi = await getCFTesterAbi();
 
 export const lpMutex = new Mutex();
 export const ethNonceMutex = new Mutex();


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Warnings having to do with loading json files with `import` never dissappeared, so I'm bringing back my solution with `readFile`, which seems very appropriate for reading data files. One additional advantage of this approach is that the paths are all provided in one place, and we don't need to copy-paste them into different files.

@martin-chainflip you previously had concerns about this doing redundant work, so I made contract loading "lazy" (a contract will only be loaded at most once, but only when actually needed). Note that calling `getErc20abi()` in global (module's) scope is equivalent to using `import` as before (the file will be read in both cases).

We could even move these "getAbi" calls closer to where they are called, but I didn't think it was necessary and decided instead to keep the clode closer to what it was.
