### PR TITLE
chore: use non CI Polkadot image

### DIFF
--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -71,10 +71,26 @@ services:
   polkadot:
     container_name: polkadot
     platform: linux/amd64
-    image: ghcr.io/chainflip-io/chainflip-private-polkadot/polkadot:v0.9.36-ci
+    image: ghcr.io/chainflip-io/chainflip-private-polkadot/polkadot:v0.9.36
     pull_policy: always
     stop_grace_period: 5s
     stop_signal: SIGINT
+    volumes:
+      - ./init/polkadot/chainspec.json:/polkadot/chainspec.json
+    environment:
+      - RUST_BACKTRACE=full
+    command:
+      - --alice
+      - --blocks-pruning=archive 
+      - --chain=/polkadot/chainspec.json 
+      - --force-authoring 
+      - --name=PolkaDocker 
+      - --rpc-cors=all 
+      - --rpc-external 
+      - --rpc-methods=unsafe 
+      - --state-pruning=archive 
+      - --validator 
+      - --ws-external
     ports:
       # - 30333:30333 # p2p port
       - 9934:9933 # rpc port


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

@ahasna was saying that we may want to move away from the CI images now that we can use docker-compose. This PR removes the usage from localnets, which also just makes the whole flow of what we do for creating the images easier to understand, and it's easier to see and modify what flags we use directly within the localnet config, rather than having to build a whole other image in order to modify these flags.
