### PR TITLE
fix(swapping): re-add event

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -870,6 +870,14 @@ pub mod pallet {
 					amount: ccm_output_principal,
 				});
 			}
+			if let Some(swap_id) = ccm_swap.gas_swap_id {
+				Self::deposit_event(Event::<T>::SwapEgressScheduled {
+					swap_id,
+					egress_id,
+					asset: gas_asset,
+					amount: ccm_output_gas,
+				});
+			}
 			Self::deposit_event(Event::<T>::CcmEgressScheduled { ccm_id, egress_id });
 		}
 


### PR DESCRIPTION
# Pull Request

Closes WEB-358

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

This event seems to have been removed in https://github.com/chainflip-io/chainflip-backend/pull/3750.

This might not be the optimal or correct way of doing this, but the immediate consequence of removing this event is that the front ends break.

We need to add this event back in to prevent breakage and implement a different way of doing this before any events are removed.