### PR TITLE
chore: add gas limits to gaslimit test

### DIFF
--- a/bouncer/shared/gaslimit_ccm.ts
+++ b/bouncer/shared/gaslimit_ccm.ts
@@ -1,31 +1,42 @@
 import Web3 from 'web3';
 import { Asset } from '@chainflip-io/cli/.';
-import { newCcmMetadata, prepareSwap } from './swapping';
+import { newCcmMetadata, prepareSwap, testSwap } from './swapping';
 import { getChainflipApi, observeCcmReceived, observeEvent, observeSwapScheduled } from './utils';
 import { requestNewSwap } from './perform_swap';
 import { send } from './send';
 import { BtcAddressType } from './new_btc_address';
 
+// Currently, gasLimit for CCM calls is hardcoded to 400k. Default gas overhead ~115k. Extra margin of
+// 215k (CFTester loop step). Should be broadcasted up to ~220k according to contract tests, but the
+// parameter values affect that. 210k is a safe bet for a call being broadcasted, 230k won't be.
+const maximumGasReceived = 210000;
+const tagSuffix = ' CcmGasLimit';
+
 let stopObserving = false;
+
+function gasTestCcmMetadata(sourceAsset: Asset, gasToUse: number) {
+  const web3 = new Web3(process.env.ETH_ENDPOINT ?? 'http://127.0.0.1:8545');
+  return newCcmMetadata(
+    sourceAsset,
+    web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasToUse]),
+    1,
+  );
+}
 
 async function testGasLimitSwap(
   sourceAsset: Asset,
   destAsset: Asset,
+  gasToUse: number,
   addressType?: BtcAddressType,
 ) {
-  const web3 = new Web3(process.env.ETH_ENDPOINT ?? 'http://127.0.0.1:8545');
-  const messageMetadata = newCcmMetadata(
-    sourceAsset,
-    web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', 0]),
-    1,
-  );
+  const messageMetadata = gasTestCcmMetadata(sourceAsset, gasToUse);
 
   const { destAddress, tag } = await prepareSwap(
     sourceAsset,
     destAsset,
     addressType,
     messageMetadata,
-    ' CcmGasLimit',
+    tagSuffix,
   );
 
   const { depositAddress, channelId } = await requestNewSwap(
@@ -55,22 +66,27 @@ async function testGasLimitSwap(
 export async function testGasLimitCcmSwaps() {
   console.log('=== Testing GasLimit CCM swaps ===');
 
-  const gasLimitTests = [
-    testGasLimitSwap('DOT', 'FLIP'),
-    testGasLimitSwap('ETH', 'USDC'),
-    testGasLimitSwap('FLIP', 'ETH'),
+  const gasLimitSwapsNotBroadcasted = [
+    testGasLimitSwap('DOT', 'FLIP', maximumGasReceived + 20000),
+    testGasLimitSwap('ETH', 'USDC', maximumGasReceived + 20000),
+    testGasLimitSwap('FLIP', 'ETH', maximumGasReceived + 20000),
+  ];
+  const gasLimitSwapsBroadcasted = [
+    testSwap('DOT', 'FLIP', undefined, gasTestCcmMetadata('DOT', maximumGasReceived), tagSuffix),
+    testSwap('ETH', 'USDC', undefined, gasTestCcmMetadata('ETH', maximumGasReceived), tagSuffix),
+    testSwap('FLIP', 'ETH', undefined, gasTestCcmMetadata('FLIP', maximumGasReceived), tagSuffix),
   ];
 
   let broadcastAborted = 0;
   await observeEvent(
     'ethereumBroadcaster:BroadcastAborted',
     await getChainflipApi(),
-    (_) => ++broadcastAborted === gasLimitTests.length,
+    (_) => ++broadcastAborted === gasLimitSwapsNotBroadcasted.length,
   );
 
   stopObserving = true;
 
-  await Promise.all(gasLimitTests);
+  await Promise.all([gasLimitSwapsNotBroadcasted, gasLimitSwapsBroadcasted]);
 
   console.log('=== GasLimit CCM test completed ===');
 }


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Add gas limit and gas received values to check that the gas received after a CCM swap is correct with the current hardcoded gas limit and ensuring that it won't be broadcasted if the gas consumption is too high.
A more extensive test will be done afterwards with gasPricing and other bells & whistles (PRO-712)