### PR TITLE
fix: querying for polkadot events at any block number

### DIFF
--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use cf_chains::dot::{PolkadotHash, RuntimeVersion};
 use cf_primitives::PolkadotBlockNumber;
 use futures::{Stream, StreamExt, TryStreamExt};
+use sp_core::H256;
 use std::sync::Arc;
 use subxt::{
 	events::Events,
@@ -95,7 +96,7 @@ pub trait DotRpcApi: Send + Sync {
 
 	async fn events(&self, block_hash: PolkadotHash) -> Result<Option<Events<PolkadotConfig>>>;
 
-	async fn current_runtime_version(&self) -> Result<RuntimeVersion>;
+	async fn runtime_version(&self, at: Option<H256>) -> Result<RuntimeVersion>;
 
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash>;
 }
@@ -114,8 +115,8 @@ impl DotRpcApi for DotRpcClient {
 		self.http_client.block(block_hash).await
 	}
 
-	async fn current_runtime_version(&self) -> Result<RuntimeVersion> {
-		self.http_client.current_runtime_version().await
+	async fn runtime_version(&self, at: Option<H256>) -> Result<RuntimeVersion> {
+		self.http_client.runtime_version(at).await
 	}
 
 	async fn extrinsics(

--- a/engine/src/witness/dot/dot_chain_tracking.rs
+++ b/engine/src/witness/dot/dot_chain_tracking.rs
@@ -40,7 +40,7 @@ impl<T: DotRetryRpcApi + Send + Sync + Clone>
 				tips.sort();
 				tips.get(tips.len().saturating_sub(1) / 2).cloned().unwrap_or_default()
 			},
-			runtime_version: self.current_runtime_version().await,
+			runtime_version: self.runtime_version(None).await,
 		})
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-781

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Fixes issue where we couldn't query for events at blocks before or after the runtime version that we had at the time of client initialisation.
