### PR TITLE
fix: dot deposits to watched addresses from/to our vault

### DIFF
--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -412,6 +412,9 @@ mod test {
 		const TRANSFER_FROM_OUR_VAULT_INDEX: u32 = 7;
 		const TRANFER_TO_OUR_VAULT_INDEX: u32 = 8;
 
+		const TRANSFER_TO_SELF_INDEX: u32 = 9;
+		const TRANSFER_TO_SELF_AMOUNT: PolkadotBalance = 30000;
+
 		let block_event_details = phase_and_events(vec![
 			// we'll be witnessing this from the start
 			(
@@ -448,6 +451,14 @@ mod test {
 				TRANFER_TO_OUR_VAULT_INDEX,
 				mock_transfer(&PolkadotAccountId::from_aliased([9; 32]), &our_vault, 93232),
 			),
+			// Example: Someone generates a DOT -> ETH swap, getting the DOT address that we're now
+			// monitoring for inputs. They now generate a BTC -> DOT swap, and set the destination
+			// address of the DOT to the address they generated earlier.
+			// Now our Polakdot vault is sending to an address we're monitoring for deposits.
+			(
+				TRANSFER_TO_SELF_INDEX,
+				mock_transfer(&our_vault, &transfer_2_deposit_address, TRANSFER_TO_SELF_AMOUNT),
+			),
 		]);
 
 		let (deposit_witnesses, broadcast_indices) = deposit_witnesses(
@@ -457,14 +468,16 @@ mod test {
 			&our_vault,
 		);
 
-		assert_eq!(deposit_witnesses.len(), 2);
+		assert_eq!(deposit_witnesses.len(), 3);
 		assert_eq!(deposit_witnesses.get(0).unwrap().amount, TRANSFER_1_AMOUNT);
 		assert_eq!(deposit_witnesses.get(1).unwrap().amount, TRANSFER_2_AMOUNT);
+		assert_eq!(deposit_witnesses.get(2).unwrap().amount, TRANSFER_TO_SELF_AMOUNT);
 
 		// Check the egress and ingress fetch
-		assert_eq!(broadcast_indices.len(), 2);
+		assert_eq!(broadcast_indices.len(), 3);
 		assert!(broadcast_indices.contains(&TRANSFER_FROM_OUR_VAULT_INDEX));
 		assert!(broadcast_indices.contains(&TRANFER_TO_OUR_VAULT_INDEX));
+		assert!(broadcast_indices.contains(&TRANSFER_TO_SELF_INDEX));
 	}
 
 	#[test]


### PR DESCRIPTION
# Pull Request

Closes: PRO-776

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works. - tested example below on localnet.
- [x] I have updated documentation where appropriate.

## Summary

Example: 
Someone generates a DOT -> ETH swap, getting the DOT address that we're now monitoring for inputs. They now generate a BTC -> DOT swap, and set the destination address of the DOT to the address they generated earlier. Now our Polakdot vault is sending to an address we're monitoring for deposits.