### PR TITLE
feat: remove add_details_for_btc_deposit_script

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -219,7 +219,7 @@ mod tests {
 				channel_id: 1,
 				address,
 				asset: btc::Asset::Btc,
-				state: Default::default(),
+				state: DepositAddress::new([0; 32], 1),
 			},
 		}
 	}

--- a/state-chain/amm/src/limit_orders.rs
+++ b/state-chain/amm/src/limit_orders.rs
@@ -7,6 +7,7 @@ use sp_std::collections::btree_map::BTreeMap;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::{U256, U512};
 use sp_std::vec::Vec;

--- a/state-chain/chains/src/address.rs
+++ b/state-chain/chains/src/address.rs
@@ -18,6 +18,11 @@ pub trait AddressDerivationApi<C: Chain> {
 		source_asset: C::ChainAsset,
 		channel_id: ChannelId,
 	) -> Result<C::ChainAccount, DispatchError>;
+
+	fn generate_address_and_state(
+		source_asset: C::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<(C::ChainAccount, C::DepositChannelState), DispatchError>;
 }
 
 #[derive(

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -184,7 +184,7 @@ impl Chain for Bitcoin {
 	type ChainAccount = ScriptPubkey;
 	type EpochStartData = EpochStartData;
 	type DepositFetchId = BitcoinFetchId;
-	type DepositChannelState = ();
+	type DepositChannelState = DepositAddress;
 	type DepositDetails = UtxoId;
 }
 

--- a/state-chain/chains/src/btc/deposit_address.rs
+++ b/state-chain/chains/src/btc/deposit_address.rs
@@ -1,3 +1,5 @@
+use crate::ChannelLifecycleHooks;
+
 use super::*;
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, RuntimeDebug, PartialEq, Eq)]
@@ -65,6 +67,10 @@ impl DepositAddress {
 			0xC1
 		}
 	}
+}
+
+impl ChannelLifecycleHooks for DepositAddress {
+	// Default implentations are fine.
 }
 
 #[test]

--- a/state-chain/chains/src/deposit_channel.rs
+++ b/state-chain/chains/src/deposit_channel.rs
@@ -63,12 +63,8 @@ impl<C: Chain> DepositChannel<C> {
 		channel_id: ChannelId,
 		asset: C::ChainAsset,
 	) -> Result<Self, DispatchError> {
-		Ok(Self {
-			channel_id,
-			address: A::generate_address(asset, channel_id)?,
-			asset,
-			state: Default::default(),
-		})
+		let (address, state) = A::generate_address_and_state(asset, channel_id)?;
+		Ok(Self { channel_id, address, asset, state })
 	}
 
 	pub fn fetch_id(&self) -> C::DepositFetchId {

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -123,7 +123,7 @@ pub trait Chain: Member + Parameter {
 		+ BenchmarkValueExtended
 		+ for<'a> From<&'a DepositChannel<Self>>;
 
-	type DepositChannelState: Member + Parameter + Default + ChannelLifecycleHooks + Unpin;
+	type DepositChannelState: Member + Parameter + ChannelLifecycleHooks + Unpin;
 
 	/// Extra data associated with a deposit.
 	type DepositDetails: Member + Parameter + BenchmarkValue;

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use cf_chains::{
-	btc::{api::UtxoSelectionType, deposit_address::DepositAddress, ScriptPubkey, Utxo},
+	btc::{api::UtxoSelectionType, deposit_address::DepositAddress, BtcAmount, Utxo},
 	eth::Address as EthereumAddress,
 };
 use cf_primitives::{chains::assets::eth::Asset, SemVer};
@@ -57,7 +57,13 @@ fn update_supported_eth_assets() {
 
 #[test]
 fn test_btc_utxo_selection() {
-	const SCRIPT_PUBKEY: ScriptPubkey = ScriptPubkey::Taproot([0u8; 32]);
+	fn add_utxo_amount(amount: BtcAmount) {
+		Environment::add_bitcoin_utxo_to_list(
+			amount,
+			Default::default(),
+			DepositAddress::new(Default::default(), Default::default()),
+		);
+	}
 
 	let utxo = |amount| Utxo {
 		amount,
@@ -73,11 +79,11 @@ fn test_btc_utxo_selection() {
 		);
 
 		// add some UTXOs to the available utxos list.
-		Environment::add_bitcoin_utxo_to_list(10000, Default::default(), SCRIPT_PUBKEY);
-		Environment::add_bitcoin_utxo_to_list(5000, Default::default(), SCRIPT_PUBKEY);
-		Environment::add_bitcoin_utxo_to_list(100000, Default::default(), SCRIPT_PUBKEY);
-		Environment::add_bitcoin_utxo_to_list(5000000, Default::default(), SCRIPT_PUBKEY);
-		Environment::add_bitcoin_utxo_to_list(25000, Default::default(), SCRIPT_PUBKEY);
+		add_utxo_amount(10000);
+		add_utxo_amount(5000);
+		add_utxo_amount(100000);
+		add_utxo_amount(5000000);
+		add_utxo_amount(25000);
 
 		// select some utxos for a tx
 		assert_eq!(
@@ -90,7 +96,7 @@ fn test_btc_utxo_selection() {
 		);
 
 		// add the change utxo back to the available utxo list
-		Environment::add_bitcoin_utxo_to_list(120080, Default::default(), SCRIPT_PUBKEY);
+		add_utxo_amount(120080);
 
 		// select all remaining utxos
 		assert_eq!(
@@ -100,8 +106,8 @@ fn test_btc_utxo_selection() {
 		);
 
 		// add some more utxos to the list
-		Environment::add_bitcoin_utxo_to_list(5000, Default::default(), SCRIPT_PUBKEY);
-		Environment::add_bitcoin_utxo_to_list(15000, Default::default(), SCRIPT_PUBKEY);
+		add_utxo_amount(5000);
+		add_utxo_amount(15000);
 
 		// request a larger amount than what is available
 		assert!(Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::Some {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -721,11 +721,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			),
 		};
 
+		// Add the deposit to the balance.
 		T::DepositHandler::on_deposit_made(
 			deposit_details.clone(),
 			amount,
-			deposit_address.clone(),
-			asset,
+			deposit_channel_details.deposit_channel,
 		);
 
 		Self::deposit_event(Event::DepositReceived {
@@ -769,7 +769,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let deposit_address = deposit_channel.address.clone();
 
 		ChannelActions::<T, I>::insert(&deposit_address, channel_action);
-		T::DepositHandler::on_channel_opened(deposit_address.clone(), channel_id)?;
 
 		let opened_at = T::ChainTracking::get_block_height();
 

--- a/state-chain/pallets/cf-ingress-egress/src/mock.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock.rs
@@ -93,6 +93,16 @@ impl AddressDerivationApi<Ethereum> for MockAddressDerivation {
 	) -> Result<<Ethereum as Chain>::ChainAccount, sp_runtime::DispatchError> {
 		Ok([channel_id as u8; 20].into())
 	}
+
+	fn generate_address_and_state(
+		source_asset: <Ethereum as Chain>::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<
+		(<Ethereum as Chain>::ChainAccount, <Ethereum as Chain>::DepositChannelState),
+		sp_runtime::DispatchError,
+	> {
+		Ok((Self::generate_address(source_asset, channel_id)?, Default::default()))
+	}
 }
 
 impl crate::Config for Test {

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -29,6 +29,16 @@ impl AddressDerivationApi<Ethereum> for MockAddressDerivation {
 	) -> Result<<Ethereum as Chain>::ChainAccount, sp_runtime::DispatchError> {
 		Ok(H160::from_str("F29aB9EbDb481BE48b80699758e6e9a3DBD609C6").unwrap())
 	}
+
+	fn generate_address_and_state(
+		source_asset: <Ethereum as Chain>::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<
+		(<Ethereum as Chain>::ChainAccount, <Ethereum as Chain>::DepositChannelState),
+		sp_runtime::DispatchError,
+	> {
+		Ok((Self::generate_address(source_asset, channel_id)?, Default::default()))
+	}
 }
 type Block = frame_system::mocking::MockBlock<Test>;
 

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -22,7 +22,7 @@ use cf_chains::{
 	},
 	btc::{
 		api::{BitcoinApi, SelectedUtxosAndChangeAmount, UtxoSelectionType},
-		Bitcoin, BitcoinFeeInfo, BitcoinTransactionData, ScriptPubkey, UtxoId,
+		Bitcoin, BitcoinFeeInfo, BitcoinTransactionData, UtxoId,
 	},
 	dot::{
 		api::PolkadotApi, Polkadot, PolkadotAccountId, PolkadotReplayProtection,
@@ -35,7 +35,7 @@ use cf_chains::{
 		Ethereum,
 	},
 	AnyChain, ApiCall, CcmChannelMetadata, CcmDepositMetadata, Chain, ChainAbi, ChainCrypto,
-	ChainEnvironment, ForeignChain, ReplayProtectionProvider, SetCommKeyWithAggKey,
+	ChainEnvironment, DepositChannel, ForeignChain, ReplayProtectionProvider, SetCommKeyWithAggKey,
 	SetGovKeyWithAggKey, TransactionBuilder,
 };
 use cf_primitives::{chains::assets, AccountRole, Asset, BasisPoints, ChannelId, EgressId};
@@ -480,9 +480,6 @@ macro_rules! impl_deposit_api_for_anychain {
 			}
 
 			fn expire_channel(address: ForeignChainAddress) {
-				if address.chain() == ForeignChain::Bitcoin {
-					Environment::cleanup_bitcoin_deposit_address_details(address.clone().try_into().expect("Checked for address compatibility"));
-				}
 				match address.chain() {
 					$(
 						ForeignChain::$chain => {
@@ -551,29 +548,9 @@ impl DepositHandler<Bitcoin> for BtcDepositHandler {
 	fn on_deposit_made(
 		utxo_id: <Bitcoin as Chain>::DepositDetails,
 		amount: <Bitcoin as Chain>::ChainAmount,
-		address: <Bitcoin as Chain>::ChainAccount,
-		_asset: <Bitcoin as Chain>::ChainAsset,
+		channel: DepositChannel<Bitcoin>,
 	) {
-		Environment::add_bitcoin_utxo_to_list(amount, utxo_id, address)
-	}
-
-	fn on_channel_opened(
-		script_pubkey: ScriptPubkey,
-		salt: ChannelId,
-	) -> Result<(), DispatchError> {
-		Environment::add_details_for_btc_deposit_script(
-			script_pubkey,
-			salt.try_into().expect("The salt/channel_id is not expected to exceed u32 max"), /* Todo: Confirm
-			                                                                                  * this assumption.
-			                                                                                  * Consider this in
-			                                                                                  * conjunction with
-			                                                                                  * #2354 */
-			BitcoinVault::vaults(Validator::epoch_index())
-				.ok_or(DispatchError::Other("No vault for epoch"))?
-				.public_key
-				.current,
-		);
-		Ok(())
+		Environment::add_bitcoin_utxo_to_list(amount, utxo_id, channel.state)
 	}
 }
 

--- a/state-chain/runtime/src/chainflip/address_derivation/btc.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/btc.rs
@@ -1,32 +1,45 @@
 use super::AddressDerivation;
-use crate::{BitcoinVault, Validator};
+use crate::BitcoinVault;
 use cf_chains::{
 	address::AddressDerivationApi, btc::deposit_address::DepositAddress, Bitcoin, Chain,
 };
-use cf_primitives::{chains::assets::btc, ChannelId};
-use cf_traits::EpochInfo;
+use cf_primitives::ChannelId;
+use cf_traits::KeyProvider;
 use frame_support::sp_runtime::DispatchError;
 
 impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 	fn generate_address(
-		_source_asset: btc::Asset,
+		source_asset: <Bitcoin as Chain>::ChainAsset,
 		channel_id: ChannelId,
 	) -> Result<<Bitcoin as Chain>::ChainAccount, DispatchError> {
-		// We don't expect to hit this case in the wild because we reuse addresses.
-		// TODO: investigate this claim - we don't re-use addresses for Bitcoin.
+		<Self as AddressDerivationApi<Bitcoin>>::generate_address_and_state(
+			source_asset,
+			channel_id,
+		)
+		.map(|(address, _)| address)
+	}
+
+	fn generate_address_and_state(
+		_source_asset: <Bitcoin as Chain>::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<
+		(<Bitcoin as Chain>::ChainAccount, <Bitcoin as Chain>::DepositChannelState),
+		DispatchError,
+	> {
 		let channel_id: u32 = channel_id
 			.try_into()
 			.map_err(|_| "Intent ID is too large for BTC address derivation")?;
 
-		Ok(DepositAddress::new(
-			// TODO: Check if this is correct. Should maybe use CurrentVaultEpochAndState.
-			BitcoinVault::vaults(Validator::epoch_index())
+		let channel_state = DepositAddress::new(
+			// TODO: The key should be passed as an argument (or maybe KeyProvider type arg).
+			BitcoinVault::active_epoch_key()
 				.ok_or(DispatchError::Other("No vault for epoch"))?
-				.public_key
+				.key
 				.current,
 			channel_id,
-		)
-		.script_pubkey())
+		);
+
+		Ok((channel_state.script_pubkey(), channel_state))
 	}
 }
 
@@ -34,8 +47,11 @@ impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 fn test_address_generation() {
 	use crate::Runtime;
 	use cf_chains::Bitcoin;
+	use cf_primitives::chains::assets::btc;
+	use cf_traits::KeyState;
+	use cf_utilities::assert_ok;
 	use pallet_cf_validator::CurrentEpoch;
-	use pallet_cf_vaults::{Vault, Vaults};
+	use pallet_cf_vaults::{CurrentVaultEpochAndState, Vault, VaultEpochAndState, Vaults};
 
 	frame_support::sp_io::TestExternalities::new_empty().execute_with(|| {
 		CurrentEpoch::<Runtime>::set(1);
@@ -51,10 +67,13 @@ fn test_address_generation() {
 				active_from_block: 1,
 			},
 		);
-		assert!(<AddressDerivation as AddressDerivationApi<Bitcoin>>::generate_address(
+		CurrentVaultEpochAndState::<Runtime, crate::BitcoinInstance>::put(VaultEpochAndState {
+			epoch_index: 1,
+			key_state: KeyState::Unlocked,
+		});
+		assert_ok!(<AddressDerivation as AddressDerivationApi<Bitcoin>>::generate_address(
 			btc::Asset::Btc,
 			1
-		)
-		.is_ok());
+		));
 	});
 }

--- a/state-chain/runtime/src/chainflip/address_derivation/dot.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/dot.rs
@@ -1,6 +1,6 @@
 use crate::Vec;
 use cf_chains::{address::AddressDerivationApi, dot::PolkadotAccountId, Chain, Polkadot};
-use cf_primitives::{chains::assets::dot, ChannelId};
+use cf_primitives::ChannelId;
 use frame_support::sp_runtime::{
 	traits::{BlakeTwo256, Hash},
 	DispatchError,
@@ -13,7 +13,7 @@ use super::AddressDerivation;
 
 impl AddressDerivationApi<Polkadot> for AddressDerivation {
 	fn generate_address(
-		_source_asset: dot::Asset,
+		_source_asset: <Polkadot as Chain>::ChainAsset,
 		channel_id: ChannelId,
 	) -> Result<<Polkadot as Chain>::ChainAccount, DispatchError> {
 		const PREFIX: &[u8; 16] = b"modlpy/utilisuba";
@@ -43,11 +43,25 @@ impl AddressDerivationApi<Polkadot> for AddressDerivation {
 
 		Ok(PolkadotAccountId::from_aliased(*payload_hash.as_fixed_bytes()))
 	}
+
+	fn generate_address_and_state(
+		source_asset: <Polkadot as Chain>::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<
+		(<Polkadot as Chain>::ChainAccount, <Polkadot as Chain>::DepositChannelState),
+		DispatchError,
+	> {
+		Ok((
+			<Self as AddressDerivationApi<Polkadot>>::generate_address(source_asset, channel_id)?,
+			Default::default(),
+		))
+	}
 }
 
 #[test]
 fn test_dot_derive() {
 	use crate::Runtime;
+	use cf_primitives::chains::assets::dot;
 	use frame_support::sp_runtime::app_crypto::Ss58Codec;
 	use pallet_cf_environment::PolkadotVaultAccountId;
 

--- a/state-chain/runtime/src/chainflip/address_derivation/eth.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/eth.rs
@@ -20,6 +20,19 @@ impl AddressDerivationApi<Ethereum> for AddressDerivation {
 			channel_id,
 		))
 	}
+
+	fn generate_address_and_state(
+		source_asset: <Ethereum as Chain>::ChainAsset,
+		channel_id: ChannelId,
+	) -> Result<
+		(<Ethereum as Chain>::ChainAccount, <Ethereum as Chain>::DepositChannelState),
+		DispatchError,
+	> {
+		Ok((
+			<Self as AddressDerivationApi<Ethereum>>::generate_address(source_asset, channel_id)?,
+			Default::default(),
+		))
+	}
 }
 
 #[test]

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -15,7 +15,7 @@ pub use async_result::AsyncResult;
 
 use cf_chains::{
 	address::ForeignChainAddress, ApiCall, CcmChannelMetadata, CcmDepositMetadata, Chain, ChainAbi,
-	ChainCrypto, Ethereum, Polkadot, SwapOrigin,
+	ChainCrypto, DepositChannel, Ethereum, Polkadot, SwapOrigin,
 };
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, AuthorityCount, BasisPoints, BroadcastId,
@@ -770,15 +770,8 @@ pub trait DepositHandler<C: Chain> {
 	fn on_deposit_made(
 		_deposit_details: C::DepositDetails,
 		_amount: C::ChainAmount,
-		_address: C::ChainAccount,
-		_asset: C::ChainAsset,
+		_channel: DepositChannel<C>,
 	) {
-	}
-	fn on_channel_opened(
-		_address: C::ChainAccount,
-		_channel_id: ChannelId,
-	) -> Result<(), DispatchError> {
-		Ok(())
 	}
 }
 


### PR DESCRIPTION
Uses the channel details stored in the ingerss pallet instead.

Allows us to remove `BitcoinActiveDepositAddressDetails` from the environment pallet.

First step on the road to balance tracking.