### PR TITLE
chore: remove update assets

### DIFF
--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -7,13 +7,6 @@ use frame_benchmarking::benchmarks;
 use frame_support::dispatch::UnfilteredDispatchable;
 
 benchmarks! {
-	update_supported_eth_assets {
-		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
-		let asset = EthAsset::Flip;
-		let address = Default::default();
-		let call = Call::<T>::update_supported_eth_assets { asset, address };
-	}: { call.dispatch_bypass_filter(origin)? }
-
 	update_safe_mode {
 		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
 		let call = Call::<T>::update_safe_mode { update: SafeModeUpdate::CodeRed };

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -384,67 +384,6 @@ pub mod pallet {
 
 			Ok(())
 		}
-
-		/// Adds or updates an asset address in the map of supported ETH assets.
-		///
-		/// ## Events
-		///
-		/// - [EthereumSupportedAssetsUpdated](Event::EthereumSupportedAssetsUpdated)
-		///
-		/// ## Errors
-		///
-		/// - [BadOrigin](frame_support::error::BadOrigin)
-		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::update_supported_eth_assets())]
-		pub fn update_supported_eth_assets(
-			origin: OriginFor<T>,
-			asset: EthAsset,
-			address: EthereumAddress,
-		) -> DispatchResult {
-			T::EnsureGovernance::ensure_origin(origin)?;
-			ensure!(asset != EthAsset::Eth, Error::<T>::EthAddressNotUpdateable);
-			Self::deposit_event(if EthereumSupportedAssets::<T>::contains_key(asset) {
-				EthereumSupportedAssets::<T>::mutate(asset, |mapped_address| {
-					mapped_address.replace(address);
-				});
-				Event::UpdatedEthAsset(asset, address)
-			} else {
-				EthereumSupportedAssets::<T>::insert(asset, address);
-				Event::AddedNewEthAsset(asset, address)
-			});
-			Ok(())
-		}
-
-		/// Adds or updates an asset address in the map of supported ARB assets.
-		///
-		/// ## Events
-		///
-		/// - [UpdatedArbAsset](Event::UpdatedArbAsset)
-		/// - [AddedNewArbAsset](Event::AddedNewArbAsset)
-		///
-		/// ## Errors
-		///
-		/// - [BadOrigin](frame_support::error::BadOrigin)
-		#[pallet::call_index(5)]
-		#[pallet::weight(T::WeightInfo::update_supported_eth_assets())]
-		pub fn update_supported_arb_assets(
-			origin: OriginFor<T>,
-			asset: ArbAsset,
-			address: EthereumAddress,
-		) -> DispatchResultWithPostInfo {
-			T::EnsureGovernance::ensure_origin(origin)?;
-			ensure!(asset != ArbAsset::ArbEth, Error::<T>::ArbAddressNotUpdateable);
-			Self::deposit_event(if ArbitrumSupportedAssets::<T>::contains_key(asset) {
-				ArbitrumSupportedAssets::<T>::mutate(asset, |mapped_address| {
-					mapped_address.replace(address);
-				});
-				Event::UpdatedArbAsset(asset, address)
-			} else {
-				ArbitrumSupportedAssets::<T>::insert(asset, address);
-				Event::AddedNewArbAsset(asset, address)
-			});
-			Ok(().into())
-		}
 	}
 
 	#[pallet::genesis_config]

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -1,15 +1,12 @@
 #![cfg(test)]
-use cf_chains::{
-	btc::{api::UtxoSelectionType, deposit_address::DepositAddress, ScriptPubkey, Utxo},
-	eth::Address as EthereumAddress,
-};
-use cf_primitives::{chains::assets::eth::Asset, SemVer};
+use cf_chains::btc::{api::UtxoSelectionType, deposit_address::DepositAddress, ScriptPubkey, Utxo};
+use cf_primitives::SemVer;
 use cf_traits::SafeMode;
-use frame_support::{assert_noop, assert_ok, traits::OriginTrait};
+use frame_support::{assert_ok, traits::OriginTrait};
 
-use crate::{EthereumSupportedAssets, RuntimeSafeMode, SafeModeUpdate};
+use crate::{RuntimeSafeMode, SafeModeUpdate};
 
-use crate::{mock::*, Error};
+use crate::mock::*;
 
 #[test]
 fn genesis_config() {
@@ -19,41 +16,6 @@ fn genesis_config() {
 		assert_eq!(ARB_KEY_MANAGER_ADDRESS, Environment::arb_key_manager_address());
 		assert_eq!(ETH_CHAIN_ID, Environment::ethereum_chain_id());
 		assert_eq!(ARB_CHAIN_ID, Environment::arbitrum_chain_id());
-	});
-}
-
-#[test]
-fn update_supported_eth_assets() {
-	new_test_ext().execute_with(|| {
-		const ADDRESS: EthereumAddress = EthereumAddress::repeat_byte(2);
-		// Expect the FLIP token address to be set after genesis
-		assert!(EthereumSupportedAssets::<Test>::contains_key(Asset::Flip));
-		// Update the address for Usdc
-		assert_ok!(Environment::update_supported_eth_assets(
-			RuntimeOrigin::root(),
-			Asset::Usdc,
-			ADDRESS
-		));
-		assert_eq!(EthereumSupportedAssets::<Test>::get(Asset::Usdc), Some(ADDRESS));
-		assert_eq!(
-			frame_system::Pallet::<Test>::events()
-				.pop()
-				.expect("Event should be emitted!")
-				.event,
-			crate::mock::RuntimeEvent::Environment(crate::Event::UpdatedEthAsset(
-				Asset::Usdc,
-				ADDRESS
-			),)
-		);
-		// Last but not least - verify we can not add an address for ETH
-		assert_noop!(
-			Environment::update_supported_eth_assets(
-				RuntimeOrigin::root(),
-				Asset::Eth,
-				EthereumAddress::repeat_byte(3)
-			),
-			<Error<Test>>::EthAddressNotUpdateable
-		);
 	});
 }
 


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

There's not really any way that using this makes sense. We'd always require a runtime upgrade and/or a CFE upgrade to do anything with adding/removing assets. It doesn't make sense to remove an asset at runtime when we have safe mode. And adding an asset we would need to make a CFE change anyway. 

From this I'm going to look at trying to remove the `EthereumSupportedAssets` and `ArbitrumSupportedAssets` storage items in favour of something more type safe.