### PR TITLE
refactor: use replay protection provider trait for ETH

### DIFF
--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -288,6 +288,8 @@ fn verify_single_threshold_signature(
 impl ChainAbi for Bitcoin {
 	type Transaction = BitcoinTransactionData;
 
+	// There is no need for replay protection on Bitcoin since it is a UTXO chain.
+	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
 }
 

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -308,6 +308,7 @@ impl FeeRefundCalculator<Polkadot> for PolkadotTransactionData {
 
 impl ChainAbi for Polkadot {
 	type Transaction = PolkadotTransactionData;
+	type ReplayProtectionParams = ();
 	type ReplayProtection = PolkadotReplayProtection;
 }
 

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -64,7 +64,7 @@ where
 		transfer_params: Vec<TransferAssetParams<Polkadot>>,
 	) -> Result<Self, AllBatchError> {
 		Ok(Self::BatchFetchAndTransfer(batch_fetch_and_transfer::extrinsic_builder(
-			E::replay_protection(),
+			E::replay_protection(()),
 			fetch_params,
 			transfer_params,
 			E::try_vault_account().ok_or(AllBatchError::Other)?,
@@ -83,7 +83,7 @@ where
 		let vault = E::try_vault_account().ok_or(())?;
 
 		Ok(Self::ChangeGovKey(rotate_vault_proxy::extrinsic_builder(
-			E::replay_protection(),
+			E::replay_protection(()),
 			maybe_old_key,
 			new_key,
 			vault,
@@ -102,7 +102,7 @@ where
 		let vault = E::try_vault_account().ok_or(SetAggKeyWithAggKeyError::Failed)?;
 
 		Ok(Self::RotateVaultProxy(rotate_vault_proxy::extrinsic_builder(
-			E::replay_protection(),
+			E::replay_protection(()),
 			maybe_old_key,
 			new_key,
 			vault,

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -268,15 +268,6 @@ pub trait EthEnvironmentProvider {
 	fn chain_id() -> EthereumChainId;
 	fn next_nonce() -> u64;
 
-	fn replay_protection(contract: EthereumContract) -> EthereumReplayProtection {
-		EthereumReplayProtection {
-			nonce: Self::next_nonce(),
-			chain_id: Self::chain_id(),
-			key_manager_address: Self::key_manager_address(),
-			contract_address: Self::contract_address(contract),
-		}
-	}
-
 	fn key_manager_address() -> eth::Address {
 		Self::contract_address(EthereumContract::KeyManager)
 	}
@@ -292,19 +283,20 @@ pub trait EthEnvironmentProvider {
 
 impl ChainAbi for Ethereum {
 	type Transaction = eth::Transaction;
+	type ReplayProtectionParams = Self::ChainAccount;
 	type ReplayProtection = EthereumReplayProtection;
 }
 
 impl<E> SetAggKeyWithAggKey<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(
 		_old_key: Option<<Ethereum as ChainCrypto>::AggKey>,
 		new_key: <Ethereum as ChainCrypto>::AggKey,
 	) -> Result<Self, SetAggKeyWithAggKeyError> {
 		Ok(Self::SetAggKeyWithAggKey(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::KeyManager),
+			E::replay_protection(E::contract_address(EthereumContract::KeyManager)),
 			set_agg_key_with_agg_key::SetAggKeyWithAggKey::new(new_key),
 		)))
 	}
@@ -312,14 +304,14 @@ where
 
 impl<E> SetGovKeyWithAggKey<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(
 		_maybe_old_key: Option<<Ethereum as ChainCrypto>::GovKey>,
 		new_gov_key: <Ethereum as ChainCrypto>::GovKey,
 	) -> Result<Self, ()> {
 		Ok(Self::SetGovKeyWithAggKey(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::KeyManager),
+			E::replay_protection(E::contract_address(EthereumContract::KeyManager)),
 			set_gov_key_with_agg_key::SetGovKeyWithAggKey::new(new_gov_key),
 		)))
 	}
@@ -327,11 +319,11 @@ where
 
 impl<E> SetCommKeyWithAggKey<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(new_comm_key: <Ethereum as ChainCrypto>::GovKey) -> Self {
 		Self::SetCommKeyWithAggKey(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::KeyManager),
+			E::replay_protection(E::contract_address(EthereumContract::KeyManager)),
 			set_comm_key_with_agg_key::SetCommKeyWithAggKey::new(new_comm_key),
 		))
 	}
@@ -339,11 +331,11 @@ where
 
 impl<E> RegisterRedemption<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(node_id: &[u8; 32], amount: u128, address: &[u8; 20], expiry: u64) -> Self {
 		Self::RegisterRedemption(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::StateChainGateway),
+			E::replay_protection(E::contract_address(EthereumContract::StateChainGateway)),
 			register_redemption::RegisterRedemption::new(node_id, amount, address, expiry),
 		))
 	}
@@ -359,11 +351,11 @@ where
 
 impl<E> UpdateFlipSupply<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(new_total_supply: u128, block_number: u64) -> Self {
 		Self::UpdateFlipSupply(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::StateChainGateway),
+			E::replay_protection(E::contract_address(EthereumContract::StateChainGateway)),
 			update_flip_supply::UpdateFlipSupply::new(new_total_supply, block_number),
 		))
 	}
@@ -371,7 +363,7 @@ where
 
 impl<E> AllBatch<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(
 		fetch_params: Vec<FetchAssetParams<Ethereum>>,
@@ -401,7 +393,7 @@ where
 			}
 		}
 		Ok(Self::AllBatch(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::Vault),
+			E::replay_protection(E::contract_address(EthereumContract::Vault)),
 			all_batch::AllBatch::new(
 				fetch_deploy_params,
 				fetch_only_params,
@@ -424,7 +416,7 @@ where
 
 impl<E> ExecutexSwapAndCall<Ethereum> for EthereumApi<E>
 where
-	E: EthEnvironmentProvider,
+	E: EthEnvironmentProvider + ReplayProtectionProvider<Ethereum>,
 {
 	fn new_unsigned(
 		egress_id: EgressId,
@@ -440,7 +432,7 @@ where
 		};
 
 		Ok(Self::ExecutexSwapAndCall(EthereumTransactionBuilder::new_unsigned(
-			E::replay_protection(EthereumContract::Vault),
+			E::replay_protection(E::contract_address(EthereumContract::Vault)),
 			execute_x_swap_and_call::ExecutexSwapAndCall::new(
 				egress_id,
 				transfer_param,

--- a/state-chain/chains/src/eth/api/all_batch.rs
+++ b/state-chain/chains/src/eth/api/all_batch.rs
@@ -62,7 +62,7 @@ mod test_all_batch {
 	};
 	use cf_primitives::chains::assets;
 
-	use super::{EthEnvironmentProvider, EthereumApi};
+	use super::EthereumApi;
 
 	#[test]
 	fn test_payload() {
@@ -166,6 +166,17 @@ mod test_all_batch {
 	const CHAIN_ID: u64 = 1337;
 	const NONCE: u64 = 54321;
 	const CHANNEL_ID: u64 = 12345;
+
+	impl ReplayProtectionProvider<Ethereum> for MockEnvironment {
+		fn replay_protection(contract_address: eth::Address) -> EthereumReplayProtection {
+			EthereumReplayProtection {
+				nonce: Self::next_nonce(),
+				chain_id: Self::chain_id(),
+				key_manager_address: Self::key_manager_address(),
+				contract_address,
+			}
+		}
+	}
 
 	impl EthEnvironmentProvider for MockEnvironment {
 		fn token_address(asset: assets::eth::Asset) -> Option<eth::Address> {

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -170,12 +170,14 @@ pub trait ChainCrypto: Chain {
 /// Common abi-related types and operations for some external chain.
 pub trait ChainAbi: ChainCrypto {
 	type Transaction: Member + Parameter + BenchmarkValue + FeeRefundCalculator<Self>;
+	/// Passed in to construct the replay protection.
+	type ReplayProtectionParams: Member + Parameter;
 	type ReplayProtection: Member + Parameter;
 }
 
 /// Provides chain-specific replay protection data.
 pub trait ReplayProtectionProvider<Abi: ChainAbi> {
-	fn replay_protection() -> Abi::ReplayProtection;
+	fn replay_protection(params: Abi::ReplayProtectionParams) -> Abi::ReplayProtection;
 }
 
 /// A call or collection of calls that can be made to the Chainflip api on an external chain.

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -225,6 +225,7 @@ pub const ETH_TX_FEE: <MockEthereum as Chain>::TransactionFee =
 
 impl ChainAbi for MockEthereum {
 	type Transaction = MockTransaction;
+	type ReplayProtectionParams = ();
 	type ReplayProtection = EthereumReplayProtection;
 }
 

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -277,8 +277,13 @@ impl RuntimeUpgrade for RuntimeUpgradeManager {
 pub struct EthEnvironment;
 
 impl ReplayProtectionProvider<Ethereum> for EthEnvironment {
-	fn replay_protection() -> EthereumReplayProtection {
-		unimplemented!()
+	fn replay_protection(contract_address: eth::Address) -> EthereumReplayProtection {
+		EthereumReplayProtection {
+			nonce: Self::next_nonce(),
+			chain_id: Self::chain_id(),
+			key_manager_address: Self::key_manager_address(),
+			contract_address,
+		}
 	}
 }
 
@@ -313,7 +318,7 @@ pub struct DotEnvironment;
 impl ReplayProtectionProvider<Polkadot> for DotEnvironment {
 	// Get the Environment values for vault_account, NetworkChoice and the next nonce for the
 	// proxy_account
-	fn replay_protection() -> PolkadotReplayProtection {
+	fn replay_protection(_params: ()) -> PolkadotReplayProtection {
 		PolkadotReplayProtection {
 			genesis_hash: Environment::polkadot_genesis_hash(),
 			nonce: Environment::next_polkadot_proxy_account_nonce(),
@@ -343,7 +348,7 @@ impl ChainEnvironment<cf_chains::dot::api::SystemAccounts, PolkadotAccountId> fo
 pub struct BtcEnvironment;
 
 impl ReplayProtectionProvider<Bitcoin> for BtcEnvironment {
-	fn replay_protection() {}
+	fn replay_protection(_params: ()) {}
 }
 
 impl ChainEnvironment<UtxoSelectionType, SelectedUtxosAndChangeAmount> for BtcEnvironment {


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Implements the unimplemented ReplayProtectionProvider for Ethereum, making it more consistent with the other chains. This should help to deduplicate some of the environment stuff between Arbitrum and Eth.
