### PR TITLE
Remove hardcoded credentials to allow auth in URL

### DIFF
--- a/api/bin/chainflip-btc-deposit-tracker/src/main.rs
+++ b/api/bin/chainflip-btc-deposit-tracker/src/main.rs
@@ -120,7 +120,6 @@ impl BtcRpc {
 			.post(url)
 			.header("Content-Type", "text/plain")
 			.body(format!("[{}]", body))
-			.basic_auth("flip", Some("0ZfkAn8O39ZD8yRU5aSi6Y4Iowjbaaw+PKkV8ur50io="))
 			.send()
 			.await?
 			.json::<Vec<T>>()


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The password can be provided in the URL via "http://username:password@address.com" This is much better than hardcoding it, obviously
