### PR TITLE
feat: add an optional limit to retrier requests

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -295,9 +295,11 @@ impl<Client: Clone + Send + Sync + 'static> RetrierClient<Client> {
 		let rx = self
 			.send_request(specific_closure, request_log.clone(), RetryLimit::Limit(retry_limit))
 			.await;
-		let result: BoxAny = rx
-			.await
-			.map_err(|_| anyhow::anyhow!("Maximum attempts for request {request_log} reached."))?;
+		let result: BoxAny = rx.await.map_err(|_| {
+			anyhow::anyhow!(
+				"Maximum attempt of `{retry_limit}` reached for request `{request_log}`."
+			)
+		})?;
 		Ok(*result.downcast::<T>().expect("We know we cast the T into an any, and it is a T that we are receiving. Hitting this is a programmer error."))
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-788

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We want to be able to specify a maximum number of retry attempts in cases like broadcasting. Given that we have a global, state chain controlled retry, we needn't ensure infallibility. This is also important because it's not necessarily the node's fault for failures of a broadcast, e.g. an invalid signature. No matter how many times the broadcast is requested it will still fail, so we allow it to fail out to the global, SC retry mechanism.
