### PR TITLE
Chore/fix bouncer ccm

### DIFF
--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -59,8 +59,6 @@ export async function requestNewSwap(
         encodeDestinationAddress(destAddress, destAsset).toLowerCase();
 
       // CF Parameters is always set to '' by the SDK for now
-      console.log('messageMetadata', messageMetadata);
-      console.log('event', event.data);
       const ccmMetadataMatches = messageMetadata
         ? event.data.channelMetadata !== null &&
           event.data.channelMetadata.message === messageMetadata.message &&


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

There were three minor issues:
- When expecting a CCM channel, if `SwapAddressReady` event for a non-CCM channel was emitted we would try to read it's message, which didn't exist and it would throw an error.
- Apparently, if the StateChain event has an `Option<>` parameter, it's not that the parameter won't be in the event but rather that it will be emitted with a `null` value.
- In case of a non-CCM swap it was not checking that the `channelMetadata` wan't null.

I have added a `null` check and in both types of swaps fixing all three issues in one go.