### PR TITLE
chore/update sisydot genesis hash

### DIFF
--- a/state-chain/node/src/chain_spec/sisyphos.rs
+++ b/state-chain/node/src/chain_spec/sisyphos.rs
@@ -27,10 +27,10 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	genesis_funding_amount: GENESIS_FUNDING_AMOUNT,
 	min_funding: MIN_FUNDING,
 	dot_genesis_hash: H256(hex_literal::hex!(
-		"1665348821496e14ed56718d4d078e7f85b163bf4e45fa9afbeb220b34ed475a"
+		"5a7ebe8e4d69752907aef5a79e1908e2ceadd7f91cbe1e424d80621f7916ea24"
 	)),
 	dot_vault_account_id: None,
-	dot_runtime_version: RuntimeVersion { spec_version: 9360, transaction_version: 19 },
+	dot_runtime_version: RuntimeVersion { spec_version: 10000, transaction_version: 25 },
 };
 
 pub const BASHFUL_ACCOUNT_ID: &str = "cFLbasoV5juCGacy9LvvwSgkupFiFmwt8RmAuA3xcaY5YmkBe";


### PR DESCRIPTION
To verify the RuntimeVersion run:
```bash
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getRuntimeVersion"}' https://sisydot.chainflip.xyz | jq
```

To verify the genesis hash run:
```bash
curl -s -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlockHash", "params": [0]}' https://sisydot.chainflip.xyz | jq
```