### PR TITLE
chore: add checks and increase timeout

### DIFF
--- a/bouncer/shared/contract_swap.ts
+++ b/bouncer/shared/contract_swap.ts
@@ -93,7 +93,10 @@ export async function performSwapViaContract(
     const receipt = await executeContractSwap(sourceAsset, destAsset, destAddress, messageMetadata);
     await observeEvent('swapping:SwapScheduled', api, (event) => {
       if ('Vault' in event.data.origin) {
-        return event.data.origin.Vault.txHash === receipt.transactionHash;
+        const sourceAssetMatches = sourceAsset === (event.data.sourceAsset.toUpperCase() as Asset);
+        const destAssetMatches = destAsset === (event.data.destinationAsset.toUpperCase() as Asset);
+        const txHashMatches = event.data.origin.Vault.txHash === receipt.transactionHash;
+        return sourceAssetMatches && destAssetMatches && txHashMatches;
       }
       // Otherwise it was a swap scheduled by requesting a deposit address
       return false;

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -281,7 +281,7 @@ export async function observeBalanceIncrease(
   address: string,
   oldBalance: string,
 ): Promise<number> {
-  for (let i = 0; i < 120; i++) {
+  for (let i = 0; i < 1200; i++) {
     const newBalance = Number(await getBalance(dstCcy as Asset, address));
     if (newBalance > Number(oldBalance)) {
       return newBalance;
@@ -338,7 +338,7 @@ export async function observeEVMEvent(
   // Get the parameter names of the event
   const parameterNames = eventAbi.inputs.map((input) => input.name);
 
-  for (let i = 0; i < 120; i++) {
+  for (let i = 0; i < 1200; i++) {
     if (stopObserve()) return undefined;
     const currentBlockNumber = await web3.eth.getBlockNumber();
     if (currentBlockNumber >= initBlockNumber) {


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Add contract swaps checks.
- CCM swaps are signed and broadcasted separately (not batched). This makes it so both the `swapping` and the `gas_limit` test takes long time to execute. For this reason we sometimes see failures in the observeEvent and observeBalance, it times out before the swap has been signed and broadcasted.
- Timeouts might be a bit excessive now but doesn't change the time that passing tests take and I want to avoid hitting this issue again with future tests.