### PR TITLE
fix: only burn flip if non zero

### DIFF
--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -182,8 +182,8 @@ pub mod pallet {
 							),
 							None,
 						);
+						T::Issuance::burn(flip_to_burn.into());
 					}
-					T::Issuance::burn(flip_to_burn.into());
 					Self::broadcast_update_total_supply(
 						T::Issuance::total_issuance(),
 						current_block,


### PR DESCRIPTION
# Pull Request

This avoid scheduling an egress of zero for the flip buy-and-burn if the collected fees are zero. 