### PR TITLE
Added CFE setting for logging span lifecycles

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
 
 	task_scope(|scope| {
 		async move {
-			let mut start_logger_server_fn = Some(utilities::init_json_logger().await);
+			let mut start_logger_server_fn = Some(utilities::init_json_logger(settings.logging.span_lifecycle).await);
 
 			let ws_rpc_client = jsonrpsee::ws_client::WsClientBuilder::default()
 				.build(&settings.state_chain.ws_endpoint)

--- a/engine/src/settings.rs
+++ b/engine/src/settings.rs
@@ -99,6 +99,11 @@ pub struct HealthCheck {
 }
 
 #[derive(Debug, Deserialize, Clone, Default, PartialEq, Eq)]
+pub struct Logging {
+	pub span_lifecycle: bool,
+}
+
+#[derive(Debug, Deserialize, Clone, Default, PartialEq, Eq)]
 pub struct Prometheus {
 	pub hostname: String,
 	pub port: Port,
@@ -122,6 +127,7 @@ pub struct Settings {
 	pub health_check: Option<HealthCheck>,
 	pub prometheus: Option<Prometheus>,
 	pub signing: Signing,
+	pub logging: Logging,
 }
 
 #[derive(Parser, Debug, Clone, Default)]
@@ -209,6 +215,10 @@ pub struct CommandLineOptions {
 	// Signing Settings
 	#[clap(long = "signing.db_file", parse(from_os_str))]
 	signing_db_file: Option<PathBuf>,
+
+	// Logging settings
+	#[clap(long = "logging.span_lifecycle")]
+	logging_span_lifecycle: bool,
 }
 
 impl Default for CommandLineOptions {
@@ -225,6 +235,7 @@ impl Default for CommandLineOptions {
 			prometheus_hostname: None,
 			prometheus_port: None,
 			signing_db_file: None,
+			logging_span_lifecycle: false,
 		}
 	}
 }
@@ -239,6 +250,8 @@ const STATE_CHAIN_SIGNING_KEY_FILE: &str = "state_chain.signing_key_file";
 const ETH_PRIVATE_KEY_FILE: &str = "eth.private_key_file";
 
 const SIGNING_DB_FILE: &str = "signing.db_file";
+
+const LOGGING_SPAN_LIFECYCLE: &str = "logging.span_lifecycle";
 
 // We use PathBuf because the value must be Sized, Path is not Sized
 fn deser_path<'de, D>(deserializer: D) -> std::result::Result<PathBuf, D::Error>
@@ -358,6 +371,7 @@ impl CfSettings for Settings {
 	) -> Result<ConfigBuilder<config::builder::DefaultState>, ConfigError> {
 		config_builder
 			.set_default(NODE_P2P_ALLOW_LOCAL_IP, false)?
+			.set_default(LOGGING_SPAN_LIFECYCLE, false)?
 			.set_default(
 				NODE_P2P_KEY_FILE,
 				PathBuf::from(config_root)
@@ -416,6 +430,11 @@ impl Source for CommandLineOptions {
 		insert_command_line_option(&mut map, "prometheus.port", &self.prometheus_port);
 
 		insert_command_line_option_path(&mut map, SIGNING_DB_FILE, &self.signing_db_file);
+		insert_command_line_option(
+			&mut map,
+			LOGGING_SPAN_LIFECYCLE,
+			&Some(self.logging_span_lifecycle),
+		);
 
 		Ok(map)
 	}
@@ -701,12 +720,14 @@ mod tests {
 			prometheus_hostname: Some(("prometheus_hostname").to_owned()),
 			prometheus_port: Some(9999),
 			signing_db_file: Some(PathBuf::from_str("also/not/real.db").unwrap()),
+			logging_span_lifecycle: true,
 		};
 
 		// Load the test opts into the settings
 		let settings = Settings::new(opts.clone()).unwrap();
 
 		// Compare the opts and the settings
+		assert_eq!(opts.logging_span_lifecycle, settings.logging.span_lifecycle);
 		assert_eq!(opts.p2p_opts.node_key_file.unwrap(), settings.node_p2p.node_key_file);
 		assert_eq!(opts.p2p_opts.p2p_port.unwrap(), settings.node_p2p.port);
 		assert_eq!(opts.p2p_opts.ip_address.unwrap(), settings.node_p2p.ip_address);

--- a/utilities/src/with_std.rs
+++ b/utilities/src/with_std.rs
@@ -311,9 +311,13 @@ macro_rules! print_starting {
 /// '"debug,warp=off,hyper=off,jsonrpc=off,web3=off,reqwest=off"' 127.0.0.1:36079/tracing
 ///
 /// The full syntax used for specifying filter directives used in both the REST api and in the RUST_LOG environment variable is specified here: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html
-pub async fn init_json_logger() -> impl FnOnce(&task_scope::Scope<'_, anyhow::Error>) {
+pub async fn init_json_logger(
+	log_span_lifecycle: bool,
+) -> impl FnOnce(&task_scope::Scope<'_, anyhow::Error>) {
 	use tracing::metadata::LevelFilter;
 	use tracing_subscriber::EnvFilter;
+
+	let format_span = if log_span_lifecycle { FmtSpan::FULL } else { FmtSpan::NONE };
 
 	let reload_handle = {
 		let builder = tracing_subscriber::fmt()
@@ -323,7 +327,7 @@ pub async fn init_json_logger() -> impl FnOnce(&task_scope::Scope<'_, anyhow::Er
 					.with_default_directive(LevelFilter::INFO.into())
 					.from_env_lossy(),
 			)
-			.with_span_events(FmtSpan::FULL)
+			.with_span_events(format_span)
 			.with_filter_reloading();
 
 		let reload_handle = builder.reload_handle();


### PR DESCRIPTION
# Pull Request

Closes: PRO-764

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We were not able to find an easy solution for changing the span lifecycle logs during runtime (See Linier issue for details), so the best we can do is have it as a startup setting.
I added `--logging.span_lifecycle` command line arg that is `false` by default. This will stop all of the "enter/exit" log messages unless you restart your CFE with the setting enabled:
```sh
./target/debug/chainflip-engine --logging.span_lifecycle
```
