### PR TITLE
feat: more forgiving dot address parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
 name = "cf-chains"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrayref",
  "base58",
  "bech32 0.9.1",

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -25,6 +25,7 @@ bech32 = { default-features = false, version = '0.9.1' }
 base58 = '0.2.0'
 
 # Other
+anyhow = { version = '1.0', default-features = false, optional = true }
 hex = { default-features = false, version = '0.4' }
 hex-literal = { version = '0.4.1', default-features = false }
 serde = { version = '1.0.126', default-features = false, features = [
@@ -73,6 +74,7 @@ std = [
   'sp-core/std',
   'sp-core/full_crypto',
   'dep:ss58-registry',
+  'dep:anyhow',
 ]
 runtime-benchmarks = [
   'cf-primitives/runtime-benchmarks',

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -7,6 +7,7 @@ pub mod benchmarking;
 #[cfg(feature = "std")]
 pub mod serializable_address;
 
+use cf_utilities::SliceToArray;
 #[cfg(feature = "std")]
 pub use serializable_address::*;
 
@@ -103,6 +104,17 @@ impl PolkadotPair {
 	serde(try_from = "SubstrateNetworkAddress", into = "SubstrateNetworkAddress")
 )]
 pub struct PolkadotAccountId([u8; 32]);
+
+impl TryFrom<Vec<u8>> for PolkadotAccountId {
+	type Error = ();
+
+	fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+		if value.len() != 32 {
+			return Err(())
+		}
+		Ok(Self(value.as_array()))
+	}
+}
 
 impl PolkadotAccountId {
 	pub const fn from_aliased(account_id: [u8; 32]) -> Self {

--- a/state-chain/chains/src/dot/serializable_address.rs
+++ b/state-chain/chains/src/dot/serializable_address.rs
@@ -1,10 +1,29 @@
 use super::*;
+use anyhow::anyhow;
 use frame_support::sp_runtime::AccountId32;
 
 #[derive(Debug, Clone)]
 pub struct SubstrateNetworkAddress {
 	format_specifier: ss58_registry::Ss58AddressFormat,
 	account_id: AccountId32,
+}
+
+impl FromStr for PolkadotAccountId {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		from_ss58check_with_version(s)
+			.and_then(TryInto::try_into)
+			.or_else(|base58_err| {
+				cf_utilities::clean_hex_address::<PolkadotAccountId>(s).map_err(|hex_err| {
+					anyhow!(
+						"Address is neither valid ss58: '{}' nor hex: '{}'",
+						base58_err,
+						hex_err.root_cause()
+					)
+				})
+			})
+	}
 }
 
 impl SubstrateNetworkAddress {
@@ -23,15 +42,21 @@ impl serde::Serialize for SubstrateNetworkAddress {
 	}
 }
 
+fn from_ss58check_with_version(
+	s: &str,
+) -> Result<SubstrateNetworkAddress, sp_core::crypto::PublicError> {
+	use sp_core::crypto::Ss58Codec;
+	<AccountId32 as Ss58Codec>::from_ss58check_with_version(s).map(
+		|(account_id, format_specifier)| SubstrateNetworkAddress { format_specifier, account_id },
+	)
+}
+
 impl<'de> serde::Deserialize<'de> for SubstrateNetworkAddress {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
 	{
-		use sp_core::crypto::Ss58Codec;
-		let s = String::deserialize(deserializer)?;
-		<AccountId32 as Ss58Codec>::from_ss58check_with_version(&s)
-			.map(|(account_id, format_specifier)| Self { format_specifier, account_id })
+		from_ss58check_with_version(&String::deserialize(deserializer)?)
 			.map_err(|_| serde::de::Error::custom("Invalid SS58 address"))
 	}
 }


### PR DESCRIPTION
# Pull Request

This came up while testing some stuff with Assem.

We currently require polkadot addresses in the broker api to be input as hex. 

This PR adds the possibility to use ss58 encoding.
