### PR TITLE
fix: tweak cli generate-keys output

### DIFF
--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -282,7 +282,7 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 				"🔑 Ethereum Public Key: 0x{}",
 				hex::encode(&self.ethereum_key.public_key)
 			)?;
-			writeln!(f, "👤 Ethereum Address: 0x{:?}", self.ethereum_address)?;
+			writeln!(f, "👤 Ethereum Address: {:?}", self.ethereum_address)?;
 			writeln!(
 				f,
 				"🔑 Validator Public Key: 0x{}",


### PR DESCRIPTION
I noticed while writing the documenation that some of the command output was wrong. Also Slightly modified some spelling / capitalisation. 

- Capitalised `Account ID` etc.
- Display the whole Ethereum Key insteaf of `0xabcd...1234`
- Use the correct command line arguments in the help output: --seed-phrase and --path.