### PR TITLE
fix: dont reset vault state on handover retry

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -408,7 +408,7 @@ pub mod pallet {
 								log::warn!(
 									"Key handover attempt failed. Retrying with a new participant set.",
 								);
-								Self::try_restart_key_handover(rotation_state, block_number)
+								Self::try_start_key_handover(rotation_state, block_number)
 							};
 						},
 						AsyncResult::Pending => {
@@ -1064,14 +1064,6 @@ impl<T: Config> Pallet<T> {
 			Self::set_rotation_phase(RotationPhase::KeygensInProgress(rotation_state));
 			log::info!(target: "cf-validator", "Vault rotation initiated.");
 		}
-	}
-
-	fn try_restart_key_handover(
-		rotation_state: RuntimeRotationState<T>,
-		block_number: BlockNumberFor<T>,
-	) {
-		T::VaultRotator::reset_vault_rotation();
-		Self::try_start_key_handover(rotation_state, block_number);
 	}
 
 	fn try_start_key_handover(


### PR DESCRIPTION
I think this should also go into the 0.9 release. 

It's a change that is pending in PR #3909 (Thanks @syan095)

Not including this means that key handovers can't recover properly from failures. 