### PR TITLE
chore: use compatible instead of compatibility

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -66,19 +66,19 @@ async fn main() -> anyhow::Result<()> {
 			loop {
 				poll_interval.tick().await;
 
-				let runtime_compatibility_version: SemVer = ws_rpc_client
-					.request("cf_current_compatibility_version", Vec::<()>::new())
+				let runtime_compatible_version: SemVer = ws_rpc_client
+					.request("cf_current_compatible_version", Vec::<()>::new())
 					.await
 					.unwrap();
 
 				let compatible =
-					CFE_VERSION.is_compatible_with(runtime_compatibility_version);
+					CFE_VERSION.is_compatible_with(runtime_compatible_version);
 
 				match cfe_status {
 					CfeStatus::Active(_) =>
 						if !compatible {
 							tracing::info!(
-								"Runtime version ({runtime_compatibility_version:?}) is no longer compatible, shutting down the engine!"
+								"Runtime version ({runtime_compatible_version:?}) is no longer compatible, shutting down the engine!"
 							);
 							// This will exit the scope, dropping the handle and thus terminating
 							// the main task
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
 					CfeStatus::Idle =>
 						if compatible {
 							start_logger_server_fn.take().expect("only called once")(scope);
-							tracing::info!("Runtime version ({runtime_compatibility_version:?}) is compatible, starting the engine!");
+							tracing::info!("Runtime version ({runtime_compatible_version:?}) is compatible, starting the engine!");
 
 							let settings = settings.clone();
 							let handle = scope.spawn_with_handle(

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -241,8 +241,8 @@ pub trait CustomApi {
 	) -> RpcResult<Option<Result<AssetsMap<Amount>, DispatchError>>>;
 	#[method(name = "environment")]
 	fn cf_environment(&self, at: Option<state_chain_runtime::Hash>) -> RpcResult<RpcEnvironment>;
-	#[method(name = "current_compatibility_version")]
-	fn cf_current_compatibility_version(&self) -> RpcResult<SemVer>;
+	#[method(name = "current_compatible_version")]
+	fn cf_current_compatible_version(&self) -> RpcResult<SemVer>;
 	#[method(name = "min_swap_amount")]
 	fn cf_min_swap_amount(&self, asset: Asset) -> RpcResult<AssetAmount>;
 }
@@ -625,10 +625,10 @@ where
 			.map(RpcEnvironment::from)
 	}
 
-	fn cf_current_compatibility_version(&self) -> RpcResult<SemVer> {
+	fn cf_current_compatible_version(&self) -> RpcResult<SemVer> {
 		self.client
 			.runtime_api()
-			.cf_current_compatibility_version(self.unwrap_or_best(None))
+			.cf_current_compatible_version(self.unwrap_or_best(None))
 			.map_err(to_rpc_error)
 	}
 

--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -16,13 +16,13 @@ benchmarks! {
 		assert_eq!(RuntimeSafeMode::<T>::get(), SafeMode::CODE_RED);
 	}
 
-	set_next_compatibility_version {
+	set_next_compatible_version {
 		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
 		let version = SemVer { major: 1u8, minor: 1u8, patch: 1u8 };
-		let call = Call::<T>::set_next_compatibility_version { version: Some(version) };
+		let call = Call::<T>::set_next_compatible_version { version: Some(version) };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
-		assert_eq!(NextCompatibilityVersion::<T>::get(), Some(version));
+		assert_eq!(NextCompatibleVersion::<T>::get(), Some(version));
 	}
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -135,7 +135,7 @@ impl VaultKeyWitnessedHandler<Bitcoin> for MockBitcoinVaultKeyWitnessedHandler {
 
 parameter_types! {
 	pub const BitcoinNetworkParam: BitcoinNetwork = BitcoinNetwork::Testnet;
-	pub CurrentCompatibilityVersion: SemVer = SemVer {
+	pub CurrentCompatibleVersion: SemVer = SemVer {
 		major: env!("CARGO_PKG_VERSION_MAJOR").parse::<u8>().unwrap(),
 		minor: env!("CARGO_PKG_VERSION_MINOR").parse::<u8>().unwrap(),
 		patch: env!("CARGO_PKG_VERSION_PATCH").parse::<u8>().unwrap(),
@@ -163,7 +163,7 @@ impl pallet_cf_environment::Config for Test {
 	type BitcoinVaultKeyWitnessedHandler = MockBitcoinVaultKeyWitnessedHandler;
 	type BitcoinFeeInfo = MockBitcoinFeeInfo;
 	type RuntimeSafeMode = MockRuntimeSafeMode;
-	type CurrentCompatibilityVersion = CurrentCompatibilityVersion;
+	type CurrentCompatibleVersion = CurrentCompatibleVersion;
 	type WeightInfo = ();
 }
 

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -119,23 +119,23 @@ fn update_safe_mode() {
 }
 
 #[test]
-fn can_set_next_compatibility_version() {
+fn can_set_next_compatible_version() {
 	new_test_ext().execute_with(|| {
-		assert!(Environment::next_compatibility_version().is_none());
+		assert!(Environment::next_compatible_version().is_none());
 
 		// Set the next cfe version
 		let version = Some(SemVer { major: 1u8, minor: 3u8, patch: 10u8 });
-		assert_ok!(Environment::set_next_compatibility_version(RuntimeOrigin::root(), version));
-		assert_eq!(Environment::next_compatibility_version(), version);
+		assert_ok!(Environment::set_next_compatible_version(RuntimeOrigin::root(), version));
+		assert_eq!(Environment::next_compatible_version(), version);
 		System::assert_last_event(RuntimeEvent::Environment(
-			crate::Event::<Test>::NextCompatibilityVersionSet { version },
+			crate::Event::<Test>::NextCompatibleVersionSet { version },
 		));
 
 		// Unset the net cfe version
-		assert_ok!(Environment::set_next_compatibility_version(RuntimeOrigin::root(), None));
-		assert!(Environment::next_compatibility_version().is_none());
+		assert_ok!(Environment::set_next_compatible_version(RuntimeOrigin::root(), None));
+		assert!(Environment::next_compatible_version().is_none());
 		System::assert_last_event(RuntimeEvent::Environment(
-			crate::Event::<Test>::NextCompatibilityVersionSet { version: None },
+			crate::Event::<Test>::NextCompatibleVersionSet { version: None },
 		));
 	});
 }

--- a/state-chain/pallets/cf-environment/src/weights.rs
+++ b/state-chain/pallets/cf-environment/src/weights.rs
@@ -34,7 +34,7 @@ pub trait WeightInfo {
 	fn update_supported_eth_assets() -> Weight;
 	fn update_polkadot_runtime_version() -> Weight;
 	fn update_safe_mode() -> Weight;
-	fn set_next_compatibility_version() -> Weight;
+	fn set_next_compatible_version() -> Weight;
 }
 
 /// Weights for pallet_cf_environment using the Substrate node and recommended hardware.
@@ -67,7 +67,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	fn set_next_compatibility_version() -> Weight {
+	fn set_next_compatible_version() -> Weight {
 		Weight::from_parts(1_000, 0)
 	}
 }
@@ -102,7 +102,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 
-	fn set_next_compatibility_version() -> Weight {
+	fn set_next_compatible_version() -> Weight {
 		Weight::from_parts(1_000, 0)
 	}
 }

--- a/state-chain/pallets/cf-governance/src/lib.rs
+++ b/state-chain/pallets/cf-governance/src/lib.rs
@@ -310,7 +310,7 @@ pub mod pallet {
 			ensure!(T::UpgradeCondition::is_satisfied(), Error::<T>::UpgradeConditionsNotMet);
 
 			if let Some(percent) = required_up_to_date_cfes {
-				let next_version = T::CompatibleCfeVersions::next_compatibility_version()
+				let next_version = T::CompatibleCfeVersions::next_compatible_version()
 					.ok_or(Error::<T>::TargetCfeVersionNotSet)?;
 				ensure!(
 					T::AuthoritiesCfeVersions::precent_authorities_at_version(next_version) >=

--- a/state-chain/pallets/cf-governance/src/mock.rs
+++ b/state-chain/pallets/cf-governance/src/mock.rs
@@ -112,10 +112,10 @@ impl AuthoritiesCfeVersions for MockAuthoritiesCfeVersions {
 
 pub struct MockCompatibleCfeVersions;
 impl CompatibleCfeVersions for MockCompatibleCfeVersions {
-	fn current_compatibility_version() -> SemVer {
+	fn current_compatible_version() -> SemVer {
 		SemVer { major: 1, minor: 0, patch: 0 }
 	}
-	fn next_compatibility_version() -> Option<SemVer> {
+	fn next_compatible_version() -> Option<SemVer> {
 		NextCfeVersion::get()
 	}
 }

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -193,7 +193,7 @@ parameter_types! {
 
 	pub const BitcoinNetworkParam: BitcoinNetwork = BitcoinNetwork::Testnet;
 
-	pub CurrentCompatibilityVersion: SemVer = SemVer {
+	pub CurrentCompatibleVersion: SemVer = SemVer {
 		major: env!("CARGO_PKG_VERSION_MAJOR").parse::<u8>().expect("Cargo version must be set"),
 		minor: env!("CARGO_PKG_VERSION_MINOR").parse::<u8>().expect("Cargo version must be set"),
 		patch: env!("CARGO_PKG_VERSION_PATCH").parse::<u8>().expect("Cargo version must be set"),
@@ -207,7 +207,7 @@ impl pallet_cf_environment::Config for Runtime {
 	type BitcoinNetwork = BitcoinNetworkParam;
 	type BitcoinFeeInfo = chainflip::BitcoinFeeGetter;
 	type RuntimeSafeMode = chainflip::RuntimeSafeMode;
-	type CurrentCompatibilityVersion = CurrentCompatibilityVersion;
+	type CurrentCompatibleVersion = CurrentCompatibleVersion;
 	type WeightInfo = pallet_cf_environment::weights::PalletWeight<Runtime>;
 }
 
@@ -888,9 +888,9 @@ impl_runtime_apis! {
 		fn cf_current_epoch() -> u32 {
 			Validator::current_epoch()
 		}
-		fn cf_current_compatibility_version() -> SemVer {
+		fn cf_current_compatible_version() -> SemVer {
 			use cf_traits::CompatibleCfeVersions;
-			Environment::current_compatibility_version()
+			Environment::current_compatible_version()
 		}
 		fn cf_epoch_duration() -> u32 {
 			Validator::blocks_per_epoch()

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -96,7 +96,7 @@ decl_runtime_apis!(
 		fn cf_auction_parameters() -> (u32, u32);
 		fn cf_min_funding() -> u128;
 		fn cf_current_epoch() -> u32;
-		fn cf_current_compatibility_version() -> SemVer;
+		fn cf_current_compatible_version() -> SemVer;
 		fn cf_epoch_duration() -> u32;
 		fn cf_current_epoch_started_at() -> u32;
 		fn cf_authority_emission_per_block() -> u128;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -816,8 +816,8 @@ pub trait GetBlockHeight<C: Chain> {
 	fn get_block_height() -> C::ChainBlockNumber;
 }
 pub trait CompatibleCfeVersions {
-	fn current_compatibility_version() -> SemVer;
-	fn next_compatibility_version() -> Option<SemVer>;
+	fn current_compatible_version() -> SemVer;
+	fn next_compatible_version() -> Option<SemVer>;
 }
 
 pub trait AuthoritiesCfeVersions {


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Realised we were using "compatibility" when "compatible" makes more sense here. Will require a small migration.