### PR TITLE
Set default pool fee in bouncer to 20 basis points

### DIFF
--- a/bouncer/shared/create_lp_pool.ts
+++ b/bouncer/shared/create_lp_pool.ts
@@ -23,7 +23,7 @@ export async function createLpPool(ccy: Asset, initialPrice: number) {
       chainflip,
       (event) => event.data.pairAsset.toUpperCase() === ccy,
     );
-    const extrinsic = chainflip.tx.liquidityPools.newPool('usdc', ccy.toLowerCase(), 0, price);
+    const extrinsic = chainflip.tx.liquidityPools.newPool('usdc', ccy.toLowerCase(), 20, price);
     await submitGovernanceExtrinsic(extrinsic);
     await poolCreatedEvent;
   }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Previously, the default fee was 0. Now, bouncer will use 20 bps as a pool fee
