### PR TITLE
Fix: correctly handle peer updates while waiting to reconnect

### DIFF
--- a/engine/src/p2p/core/socket.rs
+++ b/engine/src/p2p/core/socket.rs
@@ -93,8 +93,4 @@ impl ConnectedOutgoingSocket {
 			warn!("Failed to send a message to {}: {e}", self.peer.account_id,);
 		}
 	}
-
-	pub fn peer(&self) -> &PeerInfo {
-		&self.peer
-	}
 }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

In existing code it is hard to differentiate between "unknown peer" and "peer scheduled for reconnection, entry temporarily removed", so now `active_connections` stores `ConnectionState` enum with `ReconnectionScheduled` as a placeholder for when we don't have an actual ZMQ socket. This made it more clear what edge cases we have around reconnecting and how to best handle them, leading to the following fixes/improvements:

- when trying to send a message we no longer incorrectly log "Peer not registered" if in fact we are just reconnecting to it
- we now correctly clean up the state after a node that deregisters while we are waiting to reconnect to it (and the reconnection will be cancelled too)
- when node updates their peer info record while we are waiting to reconnect to it, it used to be possible that old state wasn't correctly cleared, but now it is done correctly


