### PR TITLE
refactor(custom-rpc): simplify return types

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -290,7 +290,7 @@ fn to_rpc_error<E: std::error::Error + Send + Sync + 'static>(e: E) -> jsonrpsee
 }
 
 fn map_dispatch_error(e: DispatchError) -> jsonrpsee::core::Error {
-	jsonrpsee::core::Error::from(anyhow::anyhow!("Dispatch error: {e:?}"))
+	jsonrpsee::core::Error::from(anyhow::anyhow!("Dispatch error: {}", <&'static str>::from(e)))
 }
 
 impl<C, B> CustomApiServer for CustomRpc<C, B>


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

The level of nesting is a bit unwieldy. I've flattened it out a bit by converting any dispatch error in to an RPC error
