### PR TITLE
temp-fix: stop sc-observer blocking

### DIFF
--- a/engine/src/witness/common/epoch_source.rs
+++ b/engine/src/witness/common/epoch_source.rs
@@ -16,6 +16,7 @@ use utilities::task_scope::Scope;
 
 use super::{ActiveAndFuture, ExternalChain, RuntimeHasChain};
 
+/// https://linear.app/chainflip/issue/PRO-877/external-chain-sources-can-block-sc-observer
 const CHANNEL_BUFFER: usize = 128;
 
 #[derive(Clone)]


### PR DESCRIPTION
This is a temporary fix.

Basically one of the external chain subscriptions stops working (we cannot get one), causing the related witnessers stream to stop receiver epoch updates, causing the associated channel to fill up, causing the epoch source backend to stop receiving new sc blocks (because it is waiting to send down the epoch channel), causing the sc block channel to fill up, causing the sc block producer to stop being able to send new blocks down the channel (i.e. to the sc observer). 