### PR TITLE
fix: delete auction phase check for redeem cli command

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -171,16 +171,10 @@ pub trait OperatorApi: SignedExtrinsicApi + RotateSessionKeysApi + AuctionPhaseA
 		address: EthereumAddress,
 		executor: Option<EthereumAddress>,
 	) -> Result<H256> {
-		// Are we in a current auction phase
-		if self.is_auction_phase().await? {
-			bail!("We are currently in an auction phase. Please wait until the auction phase is over.");
-		}
+		let call = RuntimeCall::from(pallet_cf_funding::Call::redeem { amount, address, executor });
+		self.dry_run(call.clone(), None).await?;
 
-		let (tx_hash, ..) = self
-			.submit_signed_extrinsic(pallet_cf_funding::Call::redeem { amount, address, executor })
-			.await
-			.until_in_block()
-			.await?;
+		let (tx_hash, ..) = self.submit_signed_extrinsic(call).await.until_in_block().await?;
 
 		Ok(tx_hash)
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-891

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Deleted check (which was causing the command to always bail during auction phase)
- Added dry_run check instead 
