### PR TITLE
chore: add delay for chain fees to increase

### DIFF
--- a/bouncer/shared/gaslimit_ccm.ts
+++ b/bouncer/shared/gaslimit_ccm.ts
@@ -167,6 +167,10 @@ async function testGasLimitSwap(
 
   const minGasLimitRequired = gasConsumption + MIN_BASE_GAS_OVERHEAD + byteLength * GAS_PER_BYTE;
 
+  console.log(
+    `${tag} baseFee: ${baseFee}, priorityFee: ${priorityFee}, maxFeePerGas: ${maxFeePerGas}`,
+  );
+
   // This is a very rough approximation for the gas limit required. A buffer is added to account for that.
   if (minGasLimitRequired + BASE_GAS_OVERHEAD_BUFFER >= gasLimitBudget) {
     observeCcmReceived(


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We've seen failures in this test along these lines:
```
[1 : DOT->FLIP CCM GasLimit] tx.maxFeePerGas: 1000000014 maxFeePerGas: 14
Error: [1 : DOT->FLIP CCM GasLimit] Max fee per gas in the transaction is different than the one expected!
```
Seems like the transaction `maxFeePerGas` is different than expected. This most likely happens because the gas price increase (due to spamming the network) is not deterministic. I have added a check to wait starting transactions until the fees have increased to the expected value.
It can be that this doesn't fully fix the issue because the gas price might fluctuate during the actual test but the continued spamming should achieve that.
Also taken the opportunity to do some small improvements in that test.
