### PR TITLE
chore: drop btc safety margin to 6 block confirmations

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -24,7 +24,8 @@ use super::common::{chain_source::extension::ChainSourceExt, epoch_source::Epoch
 
 use anyhow::Result;
 
-const SAFETY_MARGIN: usize = 6;
+// safety margin of 5 implies 6 block confirmations
+const SAFETY_MARGIN: usize = 5;
 
 pub async fn start<
 	StateChainClient,


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Comes out of mainnet readiness meeting. We decided to use the typical "confirmed" block time for btc which is 6 "block confirmations" which is equivalent to a safety margin of 5.