### PR TITLE
refactor: remove next compatibility version

### DIFF
--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -15,14 +15,5 @@ benchmarks! {
 	verify {
 		assert_eq!(RuntimeSafeMode::<T>::get(), SafeMode::CODE_RED);
 	}
-
-	set_next_compatibility_version {
-		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
-		let version = SemVer { major: 1u8, minor: 1u8, patch: 1u8 };
-		let call = Call::<T>::set_next_compatibility_version { version: Some(version) };
-	}: { call.dispatch_bypass_filter(origin)? }
-	verify {
-		assert_eq!(NextCompatibilityVersion::<T>::get(), Some(version));
-	}
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -154,11 +154,6 @@ pub mod pallet {
 	pub type RuntimeSafeMode<T> = StorageValue<_, <T as Config>::RuntimeSafeMode, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn next_compatibility_version)]
-	/// If this storage is set, a new version of Chainflip is available for upgrade.
-	pub type NextCompatibilityVersion<T> = StorageValue<_, Option<SemVer>, ValueQuery>;
-
-	#[pallet::storage]
 	#[pallet::getter(fn network_environment)]
 	/// Contains the network environment for this runtime.
 	pub type ChainflipNetworkEnvironment<T> = StorageValue<_, NetworkEnvironment, ValueQuery>;
@@ -176,27 +171,16 @@ pub mod pallet {
 		BitcoinBlockNumberSetForVault { block_number: cf_chains::btc::BlockNumber },
 		/// The Safe Mode settings for the chain has been updated
 		RuntimeSafeModeUpdated { safe_mode: SafeModeUpdate<T> },
-		/// A new Chainflip runtime will soon be deployed at this version.
-		NextCompatibilityVersionSet { version: Option<SemVer> },
 	}
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_runtime_upgrade() -> Weight {
-			let weight = migrations::PalletMigration::<T>::on_runtime_upgrade();
-			NextCompatibilityVersion::<T>::kill();
-			weight
+			migrations::PalletMigration::<T>::on_runtime_upgrade()
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, DispatchError> {
-			if let Some(next_version) = NextCompatibilityVersion::<T>::get() {
-				if next_version != T::CurrentCompatibilityVersion::get() {
-					return Err("NextCompatibilityVersion does not match the current runtime".into())
-				}
-			} else {
-				return Err("NextCompatibilityVersion is not set".into())
-			}
 			migrations::PalletMigration::<T>::pre_upgrade()
 		}
 
@@ -301,35 +285,6 @@ pub mod pallet {
 			});
 
 			Self::deposit_event(Event::<T>::RuntimeSafeModeUpdated { safe_mode: update });
-
-			Ok(())
-		}
-
-		/// Sets the next Chainflip compatiblity version.
-		///
-		/// This is used to signal to CFE operators that a new version of the runtime will soon be
-		/// deployed.
-		///
-		/// Requires governance origin.
-		///
-		/// ## Events
-		///
-		/// - [Success](Event::NextCompatibilityVersionSet)
-		///
-		/// ## Errors
-		///
-		/// - [BadOrigin](frame_support::error::BadOrigin)
-		#[pallet::call_index(4)]
-		#[pallet::weight(T::WeightInfo::set_next_compatibility_version())]
-		pub fn set_next_compatibility_version(
-			origin: OriginFor<T>,
-			version: Option<SemVer>,
-		) -> DispatchResult {
-			T::EnsureGovernance::ensure_origin(origin)?;
-
-			NextCompatibilityVersion::<T>::put(version);
-
-			Self::deposit_event(Event::<T>::NextCompatibilityVersionSet { version });
 
 			Ok(())
 		}
@@ -472,8 +427,5 @@ impl<T: Config> Pallet<T> {
 impl<T: Config> CompatibleCfeVersions for Pallet<T> {
 	fn current_compatibility_version() -> SemVer {
 		<T as Config>::CurrentCompatibilityVersion::get()
-	}
-	fn next_compatibility_version() -> Option<SemVer> {
-		NextCompatibilityVersion::<T>::get()
 	}
 }

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 use cf_chains::btc::{api::UtxoSelectionType, deposit_address::DepositAddress, Utxo};
-use cf_primitives::SemVer;
 use cf_traits::SafeMode;
 use frame_support::{assert_ok, traits::OriginTrait};
 
@@ -120,28 +119,6 @@ fn update_safe_mode() {
 			crate::Event::<Test>::RuntimeSafeModeUpdated {
 				safe_mode: SafeModeUpdate::CodeAmber(mock_code_amber),
 			},
-		));
-	});
-}
-
-#[test]
-fn can_set_next_compatibility_version() {
-	new_test_ext().execute_with(|| {
-		assert!(Environment::next_compatibility_version().is_none());
-
-		// Set the next cfe version
-		let version = Some(SemVer { major: 1u8, minor: 3u8, patch: 10u8 });
-		assert_ok!(Environment::set_next_compatibility_version(RuntimeOrigin::root(), version));
-		assert_eq!(Environment::next_compatibility_version(), version);
-		System::assert_last_event(RuntimeEvent::Environment(
-			crate::Event::<Test>::NextCompatibilityVersionSet { version },
-		));
-
-		// Unset the net cfe version
-		assert_ok!(Environment::set_next_compatibility_version(RuntimeOrigin::root(), None));
-		assert!(Environment::next_compatibility_version().is_none());
-		System::assert_last_event(RuntimeEvent::Environment(
-			crate::Event::<Test>::NextCompatibilityVersionSet { version: None },
 		));
 	});
 }

--- a/state-chain/pallets/cf-environment/src/weights.rs
+++ b/state-chain/pallets/cf-environment/src/weights.rs
@@ -34,7 +34,6 @@ pub trait WeightInfo {
 	fn update_supported_eth_assets() -> Weight;
 	fn update_polkadot_runtime_version() -> Weight;
 	fn update_safe_mode() -> Weight;
-	fn set_next_compatibility_version() -> Weight;
 }
 
 /// Weights for pallet_cf_environment using the Substrate node and recommended hardware.
@@ -67,9 +66,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	fn set_next_compatibility_version() -> Weight {
-		Weight::from_parts(1_000, 0)
-	}
 }
 
 // For backwards compatibility and tests
@@ -100,9 +96,5 @@ impl WeightInfo for () {
 		Weight::from_parts(20_000_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(1))
 			.saturating_add(RocksDbWeight::get().writes(1))
-	}
-
-	fn set_next_compatibility_version() -> Weight {
-		Weight::from_parts(1_000, 0)
 	}
 }

--- a/state-chain/pallets/cf-governance/src/lib.rs
+++ b/state-chain/pallets/cf-governance/src/lib.rs
@@ -39,6 +39,7 @@ pub mod pallet {
 
 	use super::*;
 
+	use cf_primitives::SemVer;
 	use cf_traits::{Chainflip, ExecutionCondition, RuntimeUpgrade};
 	use codec::Encode;
 	use frame_support::{
@@ -230,8 +231,6 @@ pub mod pallet {
 		CallHashNotWhitelisted,
 		/// Insufficient number of CFEs are at the target version to receive the runtime upgrade.
 		NotEnoughAuthoritiesCfesAtTargetVersion,
-		/// The target CFE version required for the runtime upgrade is not set.
-		TargetCfeVersionNotSet,
 	}
 
 	#[pallet::call]
@@ -303,17 +302,17 @@ pub mod pallet {
 		#[pallet::weight((T::BlockWeights::get().max_block, DispatchClass::Operational))]
 		pub fn chainflip_runtime_upgrade(
 			origin: OriginFor<T>,
-			required_up_to_date_cfes: Option<Percent>,
+			// The version that the percent of nodes need to be compatible with in order for the
+			// runtime upgrade to go through.
+			cfe_version_restriction: Option<(SemVer, Percent)>,
 			code: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
 			ensure!(T::UpgradeCondition::is_satisfied(), Error::<T>::UpgradeConditionsNotMet);
 
-			if let Some(percent) = required_up_to_date_cfes {
-				let next_version = T::CompatibleCfeVersions::next_compatibility_version()
-					.ok_or(Error::<T>::TargetCfeVersionNotSet)?;
+			if let Some((required_version, percent)) = cfe_version_restriction {
 				ensure!(
-					T::AuthoritiesCfeVersions::precent_authorities_at_version(next_version) >=
+					T::AuthoritiesCfeVersions::precent_authorities_at_version(required_version) >=
 						percent,
 					Error::<T>::NotEnoughAuthoritiesCfesAtTargetVersion,
 				);

--- a/state-chain/pallets/cf-governance/src/mock.rs
+++ b/state-chain/pallets/cf-governance/src/mock.rs
@@ -99,7 +99,6 @@ impl RuntimeUpgradeMock {
 cf_traits::impl_mock_ensure_witnessed_for_origin!(RuntimeOrigin);
 
 parameter_types! {
-	pub static NextCfeVersion: Option<SemVer> = Some(SemVer{major: 1, minor: 2, patch: 3});
 	pub static PercentCfeAtTargetVersion: Percent = Percent::from_percent(100);
 }
 
@@ -114,9 +113,6 @@ pub struct MockCompatibleCfeVersions;
 impl CompatibleCfeVersions for MockCompatibleCfeVersions {
 	fn current_compatibility_version() -> SemVer {
 		SemVer { major: 1, minor: 0, patch: 0 }
-	}
-	fn next_compatibility_version() -> Option<SemVer> {
-		NextCfeVersion::get()
 	}
 }
 

--- a/state-chain/pallets/cf-governance/src/tests.rs
+++ b/state-chain/pallets/cf-governance/src/tests.rs
@@ -2,6 +2,7 @@ use crate::{
 	mock::*, ActiveProposals, Error, ExecutionMode, ExecutionPipeline, ExpiryTime, Members,
 	PreAuthorisedGovCalls, ProposalIdCounter,
 };
+use cf_primitives::SemVer;
 use cf_test_utilities::last_event;
 use cf_traits::mocks::time_source;
 use frame_support::{assert_err, assert_noop, assert_ok};
@@ -271,31 +272,23 @@ fn error_during_runtime_upgrade() {
 fn runtime_upgrade_requires_up_to_date_authorities_cfes() {
 	RuntimeUpgradeMock::upgrade_success(true);
 	UpgradeConditionMock::set(true);
+	const DESIRED_CFE_VERSION: SemVer = SemVer { major: 1, minor: 2, patch: 3 };
 	new_test_ext().execute_with(|| {
+		// This is how many nodes are *at* the required version.
 		PercentCfeAtTargetVersion::set(Percent::from_percent(50));
 		assert_ok!(Governance::chainflip_runtime_upgrade(
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
-			Some(Percent::from_percent(50)),
+			Some((DESIRED_CFE_VERSION, Percent::from_percent(50))),
 			DUMMY_WASM_BLOB,
 		));
 
 		assert_noop!(
 			Governance::chainflip_runtime_upgrade(
 				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
-				Some(Percent::from_percent(51)),
+				Some((DESIRED_CFE_VERSION, Percent::from_percent(51))),
 				DUMMY_WASM_BLOB,
 			),
 			crate::Error::<Test>::NotEnoughAuthoritiesCfesAtTargetVersion
-		);
-
-		NextCfeVersion::set(None);
-		assert_noop!(
-			Governance::chainflip_runtime_upgrade(
-				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
-				Some(Percent::from_percent(50)),
-				DUMMY_WASM_BLOB,
-			),
-			crate::Error::<Test>::TargetCfeVersionNotSet
 		);
 	});
 }
@@ -307,13 +300,6 @@ fn runtime_upgrade_can_have_no_cfes_version_requirement() {
 	new_test_ext().execute_with(|| {
 		PercentCfeAtTargetVersion::set(Percent::from_percent(0));
 
-		assert_ok!(Governance::chainflip_runtime_upgrade(
-			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
-			None,
-			DUMMY_WASM_BLOB,
-		));
-
-		NextCfeVersion::set(None);
 		assert_ok!(Governance::chainflip_runtime_upgrade(
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 			None,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -800,7 +800,6 @@ pub trait GetBlockHeight<C: Chain> {
 }
 pub trait CompatibleCfeVersions {
 	fn current_compatibility_version() -> SemVer;
-	fn next_compatibility_version() -> Option<SemVer>;
 }
 
 pub trait AuthoritiesCfeVersions {


### PR DESCRIPTION
# Pull Request

Closes: PRO-901

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We can simply set the version that we want at the time we need it.

This:
- Reduces amount and complexity of the code
- Reduces storage space
- Removes one step of the upgrade process. We don't need to remember to set the compatibility version *before* a runtime upgrade. We can set it as part of the runtime upgrade, when we want such a restriction.
