### PR TITLE
fix: don't exit when CFE version no longer compatible

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -130,11 +130,10 @@ async fn main() -> anyhow::Result<()> {
 					CfeStatus::Active(_) =>
 						if !compatible {
 							tracing::info!(
-								"Runtime version ({runtime_compatibility_version:?}) is no longer compatible, shutting down the engine!"
+								"Runtime version ({runtime_compatibility_version:?}) is no longer compatible, moving to idle state. It is now safe to stop this process."
 							);
-							// This will exit the scope, dropping the handle and thus terminating
-							// the main task
-							break Err(anyhow::anyhow!("Incompatible runtime version"))
+							// This will drop the handle and terminate the main task.
+							cfe_status = CfeStatus::Idle;
 						},
 					CfeStatus::Idle =>
 						if compatible {


### PR DESCRIPTION
# Pull Request

Related to PRO-904

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Because most operators run with auto-restart enabled in their systemd files, if we exit the whole loop when the CFE is no longer compatible, then the CFE will shut down and restart. This shutdown could raise some alerts that operators have setup. We can prevent this by not shutting down, and just returning to the idle state.
