### PR TITLE
dry_run always returns OK()

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -149,6 +149,7 @@ impl<
 		_call: RuntimeCall,
 		_at: Option<state_chain_runtime::Hash>,
 	) -> Result<Bytes> {
+		// TODO: PRO-917 fix dry run
 		Ok(Bytes::from(vec![]))
 	}
 }


### PR DESCRIPTION
# Pull Request

Related: PRO-917

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Modified dry_run to always return Ok() until we fixed it 
- Deleted auction check when calling redeem from CLI -> check was preventing redemption during auction_phase even if the validator was not bidding
