### PR TITLE
test: bouncer noop runtime upgrade test

### DIFF
--- a/bouncer/commands/noop_runtime_upgrade.ts
+++ b/bouncer/commands/noop_runtime_upgrade.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env -S pnpm tsx
+// INSTRUCTIONS
+//
+// Performs a noop runtime upgrade. You will bump the runtime `spec_version` and nothing else.
+// This should not affect the CFEs in any way. Everything should just function straight through the upgrade.
+// For example ./commands/noop_runtime_upgrade.ts
+// NB: It *must* be run from the bouncer directory.
+
+import { noopRuntimeUpgrade } from '../shared/noop_runtime_upgrade';
+import { promptUser } from '../shared/prompt_user';
+import { testAllSwaps } from '../shared/swapping';
+import { runWithTimeout } from '../shared/utils';
+
+async function main(): Promise<void> {
+  await noopRuntimeUpgrade();
+
+  await promptUser(
+    'Would you like to test all swaps after the upgrade now? The vaults and liquidity must be set up already.',
+  );
+
+  await testAllSwaps();
+
+  process.exit(0);
+}
+
+// 15 minutes. We need to wait for user input, compile, and potentially run tests. This is deliberatly quite long.
+// This won't be run on CI, so it's not a problem if it takes a while.
+runWithTimeout(main(), 15 * 60 * 1000).catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});

--- a/bouncer/shared/noop_runtime_upgrade.ts
+++ b/bouncer/shared/noop_runtime_upgrade.ts
@@ -1,0 +1,52 @@
+// Do a runtime upgrade that does nothing - the runtime should be identical except for the `spec_version` field.
+// Needs to be run from the bouncer directory.
+import { execSync } from 'node:child_process';
+
+import { submitRuntimeUpgrade } from './submit_runtime_upgrade';
+import { jsonRpc } from './json_rpc';
+import { getChainflipApi, observeEvent } from './utils';
+import { promptUser } from './prompt_user';
+
+async function getCurrentSpecVersion(): Promise<number> {
+  return Number((await jsonRpc('state_getRuntimeVersion', [], 9944)).specVersion);
+}
+
+export async function noopRuntimeUpgrade(): Promise<void> {
+  const chainflip = await getChainflipApi();
+
+  const currentSpecVersion = await getCurrentSpecVersion();
+
+  console.log('Current spec_version: ' + currentSpecVersion);
+
+  const nextSpecVersion = currentSpecVersion + 1;
+
+  await promptUser(
+    'Go to state-chain/runtime/src/lib.rs and then in that file go to #[sp_version::runtime_version]. Set the `spec_version` to ' +
+      nextSpecVersion +
+      ' and save the file.',
+  );
+
+  console.log('Building the new runtime');
+  execSync('cd ../state-chain/runtime && cargo build --release');
+
+  console.log('Built the new runtime. Applying runtime upgrade.');
+  await submitRuntimeUpgrade(
+    '../target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm',
+  );
+
+  await observeEvent('system:CodeUpdated', chainflip);
+
+  const newSpecVersion = await getCurrentSpecVersion();
+  console.log('New spec_version: ' + newSpecVersion);
+
+  if (newSpecVersion !== nextSpecVersion) {
+    console.error(
+      'After submitting the runtime upgrade, the new spec_version is not what we expected. Expected: ' +
+        nextSpecVersion +
+        ' Got: ' +
+        newSpecVersion,
+    );
+  }
+
+  console.log('Runtime upgrade complete.');
+}

--- a/bouncer/shared/prompt_user.ts
+++ b/bouncer/shared/prompt_user.ts
@@ -1,0 +1,17 @@
+import { createInterface } from 'readline/promises';
+
+export async function promptUser(prompt: string) {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    const completePrompt = prompt + '\nEnter to continue. Ctrl + C to exit.\n';
+    const ans = await rl.question(completePrompt);
+    rl.close();
+    return ans;
+  } finally {
+    rl.close();
+  }
+}


### PR DESCRIPTION
# Pull Request

Part of PRO-646.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Would appreciate any reviewer to run this to make sure it works locally for them too.

This PR basically just gives us an easy way to ensure the CFEs don't die when there's a runtime upgrade that does nothing, a base case for testing upgrades in general. Future PRs will expand on these ideas to include multi-CFE upgrades.

There's a manual step which is unavoidable (atm), but this makes it a lot less tedious to do since it guides you.

Note this is slightly different to PRO-899 (which I'll do next) since we aren't actually bumping the "CompatibilityVersion" - we're just pushing a runtime upgrade.

There's a limitation that we can only run this against localnets atm because of this: PRO-919