### PR TITLE
feat: bouncer, auto bump spec version for runtime upgrades

### DIFF
--- a/bouncer/commands/noop_runtime_upgrade.ts
+++ b/bouncer/commands/noop_runtime_upgrade.ts
@@ -16,7 +16,7 @@ import { runWithTimeout } from '../shared/utils';
 async function main(): Promise<void> {
   await noopRuntimeUpgrade();
 
-  if (process.argv[2] === "-test") {
+  if (process.argv[2] === '-test') {
     await testAllSwaps();
   }
 

--- a/bouncer/shared/noop_runtime_upgrade.ts
+++ b/bouncer/shared/noop_runtime_upgrade.ts
@@ -38,9 +38,9 @@ export async function noopRuntimeUpgrade(): Promise<void> {
   if (newSpecVersion !== nextSpecVersion) {
     console.error(
       'After submitting the runtime upgrade, the new spec_version is not what we expected. Expected: ' +
-      nextSpecVersion +
-      ' Got: ' +
-      newSpecVersion,
+        nextSpecVersion +
+        ' Got: ' +
+        newSpecVersion,
     );
   }
 

--- a/bouncer/shared/utils/bump_spec_version.ts
+++ b/bouncer/shared/utils/bump_spec_version.ts
@@ -1,45 +1,45 @@
 import fs from 'fs';
 
 export function bumpSpecVersion(filePath: string, nextSpecVersion?: number) {
-    console.log("Bumping the spec version");
-    try {
-        const fileContent = fs.readFileSync(filePath, 'utf-8');
-        const lines = fileContent.split('\n');
+  console.log('Bumping the spec version');
+  try {
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    const lines = fileContent.split('\n');
 
-        let incrementedVersion;
-        let foundMacro = false;
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
+    let incrementedVersion;
+    let foundMacro = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
 
-            if (line.trim() === '#[sp_version::runtime_version]') {
-                foundMacro = true;
-            }
+      if (line.trim() === '#[sp_version::runtime_version]') {
+        foundMacro = true;
+      }
 
-            if (foundMacro && line.includes('spec_version:')) {
-                const specVersionLine = line.match(/(spec_version:\s*)(\d+)/);
+      if (foundMacro && line.includes('spec_version:')) {
+        const specVersionLine = line.match(/(spec_version:\s*)(\d+)/);
 
-                if (specVersionLine) {
-                    if (nextSpecVersion) {
-                        incrementedVersion = nextSpecVersion;
-                    } else {
-                        incrementedVersion = parseInt(specVersionLine[2]) + 1;
-                    }
-                    lines[i] = `	spec_version: ${incrementedVersion},`;
-                    break;
-                }
-            }
+        if (specVersionLine) {
+          if (nextSpecVersion) {
+            incrementedVersion = nextSpecVersion;
+          } else {
+            incrementedVersion = parseInt(specVersionLine[2]) + 1;
+          }
+          lines[i] = `	spec_version: ${incrementedVersion},`;
+          break;
         }
-
-        if (!foundMacro) {
-            console.error('spec_version within #[sp_version::runtime_version] not found.');
-            return;
-        }
-
-        const updatedContent = lines.join('\n');
-        fs.writeFileSync(filePath, updatedContent);
-
-        console.log(`Successfully updated spec_version to ${incrementedVersion}.`);
-    } catch (error) {
-        console.error(`An error occurred: ${error.message}`);
+      }
     }
+
+    if (!foundMacro) {
+      console.error('spec_version within #[sp_version::runtime_version] not found.');
+      return;
+    }
+
+    const updatedContent = lines.join('\n');
+    fs.writeFileSync(filePath, updatedContent);
+
+    console.log(`Successfully updated spec_version to ${incrementedVersion}.`);
+  } catch (error) {
+    console.error(`An error occurred: ${error.message}`);
+  }
 }


### PR DESCRIPTION
# Pull Request

Extends the work of #4129 

Part of the ongoing upgrade test automation. 

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Automagically bumps the spec version in the runtime file for you. Saving that valuable time and thought energy.
- Removes interactivity from the `noop_runtime_upgrade` test

One step closer to end to end one click upgrade testing....