### PR TITLE
chore: shorten signature offence suspension

### DIFF
--- a/state-chain/node/src/chain_spec/common.rs
+++ b/state-chain/node/src/chain_spec/common.rs
@@ -34,7 +34,7 @@ const REPUTATION_PENALTY_LARGE: i32 = REPUTATION_PER_HEARTBEAT * 8; // Two hours
 pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
 	(Offence::MissedHeartbeat, (REPUTATION_PENALTY_SMALL, 0)),
 	(Offence::ParticipateKeygenFailed, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
-	(Offence::ParticipateSigningFailed, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
+	(Offence::ParticipateSigningFailed, (REPUTATION_PENALTY_MEDIUM, MINUTES / 2)),
 	(Offence::MissedAuthorshipSlot, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL)),
 	(Offence::FailedToBroadcastTransaction, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
 	(Offence::GrandpaEquivocation, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL * 5)),


### PR DESCRIPTION
Based on observations in perseverance, I think it makes sense to shorten this.

When have a lot of false positives (which can happen due to network conditions), we risk banning 'good' nodes. This tens to happen particularly when there is a large volume of simultaneous signature requests.

150 blocks is a long time to wait to recover, and in the meantime, more requests accumulate, making the situation worse.

We still need to suspend misbehaving nodes though, so removing the suspension altogether is not an option. 

5 blocks is a decent compromise: it allows for up to 5 retries before the banned nodes come back into play, meaning we strike a balance between flushing out bad nodes, and recovering from network degradation.

In future we might want to consider some form of escalation whereby we hand out longer suspensions for repeat offenders. 