### PR TITLE
refactor(custom-rpc): rename RPC

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -388,7 +388,7 @@ pub trait CustomApi {
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<IngressEgressEnvironment>;
 	#[method(name = "pool_environment")]
-	fn cf_pool_environment(
+	fn cf_pools_environment(
 		&self,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<PoolsEnvironment>;
@@ -895,7 +895,7 @@ where
 		})
 	}
 
-	fn cf_pool_environment(
+	fn cf_pools_environment(
 		&self,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<PoolsEnvironment> {
@@ -919,7 +919,7 @@ where
 			ingress_egress: self.cf_ingress_egress_environment(at)?,
 			swapping: self.cf_swapping_environment(at)?,
 			funding: self.cf_funding_environment(at)?,
-			pools: self.cf_pool_environment(at)?,
+			pools: self.cf_pools_environment(at)?,
 		})
 	}
 


### PR DESCRIPTION
It should be `pools` to match the pallet name.