### PR TITLE
refactor: change panic to bail on LP and Broker API's

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -360,7 +360,7 @@ pub trait BrokerApi: SignedExtrinsicApi {
 				source_chain_expiry_block: *source_chain_expiry_block,
 			})
 		} else {
-			panic!("SwapDepositAddressReady must have been generated");
+			bail!("No SwapDepositAddressReady event was found");
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-908

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The panic was caused by the assumption that if the extrinsic submit successfully, then the event must be present. But in this case, the event was only deposited if the withdrawal amount is larger than 0, causing the LP API server to panic.
- Changed the places where we `expect` an event to just bail if it is not there.
- Added a simple check to return an error early if the amount is 0.

