### PR TITLE
refactor(custom-rpc): add RPC alias

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -387,7 +387,7 @@ pub trait CustomApi {
 		&self,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<IngressEgressEnvironment>;
-	#[method(name = "pools_environment")]
+	#[method(name = "pools_environment", aliases = ["cf_pool_environment"])]
 	fn cf_pools_environment(
 		&self,
 		at: Option<state_chain_runtime::Hash>,


### PR DESCRIPTION
We started using the RPC before the rename was released and now I don't want all of our stuff to break immediately.