### PR TITLE
feat: add testnet profile to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,10 +106,15 @@ panic = "unwind"
 
 [profile.production]
 inherits = "release"
-
 # Sacrifice compile speed for execution speed by using optimization flags:
-
 # https://doc.rust-lang.org/rustc/linker-plugin-lto.html
 lto = "fat"
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1
+
+[profile.testnet]
+inherits = "release"
+# debug symbols are useful for profilers
+debug = 1
+debug-assertions = true
+overflow-checks = true


### PR DESCRIPTION
This simply adds an optional testnet profile (`cargo build --profile=testnet`) that keeps debug assertions, debug symbols and overflow checks. 

We could use this for Sisyphos/Perseverance, and could use the `debug_assertions` to enable/disable testnet-only functionality. 

(i'm not entirely convinced that debug_assertions is a good idea, there are a few scenarios where this could cause a runtime panic...).

This is the same approach that is used by parity for polkadot testnets. 