### PR TITLE
feat: prewitnessing uses unfinalised sc stream

### DIFF
--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -59,7 +59,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 
 			let has_completed_initialising = Arc::new(AtomicBool::new(false));
 
-			let (state_chain_stream, _, state_chain_client) =
+			let (state_chain_stream, unfinalised_state_chain_stream, state_chain_client) =
 				state_chain_observer::client::StateChainClient::connect_with_account(
 					scope,
 					&settings.state_chain.ws_endpoint,
@@ -212,6 +212,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 				dot_client.clone(),
 				state_chain_client.clone(),
 				state_chain_stream.clone(),
+				unfinalised_state_chain_stream.clone(),
 				db.clone(),
 			)
 			.await?;

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -78,6 +78,7 @@ pub async fn start<
 	prewitness_call: PrewitnessCall,
 	state_chain_client: Arc<StateChainClient>,
 	state_chain_stream: StateChainStream,
+	unfinalised_state_chain_stream: impl StateChainStreamApi<false>,
 	epoch_source: EpochSourceBuilder<'_, '_, StateChainClient, (), ()>,
 	db: Arc<PersistentKeyDB>,
 ) -> Result<()>
@@ -127,7 +128,7 @@ where
 	strictly_monotonic_source
 		.clone()
 		.chunk_by_vault(vaults.clone())
-		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.deposit_addresses(scope, unfinalised_state_chain_stream, state_chain_client.clone())
 		.await
 		.btc_deposits(prewitness_call)
 		.logging("pre-witnessing")

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -48,6 +48,7 @@ pub async fn start<
 	prewitness_call: PrewitnessCall,
 	state_chain_client: Arc<StateChainClient>,
 	state_chain_stream: StateChainStream,
+	unfinalized_state_chain_stream: impl StateChainStreamApi<false>,
 	epoch_source: EpochSourceBuilder<'_, '_, StateChainClient, (), ()>,
 	db: Arc<PersistentKeyDB>,
 ) -> Result<()>
@@ -135,7 +136,7 @@ where
 
 	let prewitness_source_deposit_addresses = prewitness_source
 		.clone()
-		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.deposit_addresses(scope, unfinalized_state_chain_stream, state_chain_client.clone())
 		.await;
 
 	prewitness_source_deposit_addresses

--- a/engine/src/witness/start.rs
+++ b/engine/src/witness/start.rs
@@ -23,17 +23,17 @@ use anyhow::Result;
 // to any or all chains. This implies that the `start` function for each chain should not be
 // blocking. The chains must be able to witness independently, and if this blocks at any
 // point it means that on start up this will block, and the state chain observer will not start.
-pub async fn start<StateChainClient, StateChainStream>(
+pub async fn start<StateChainClient>(
 	scope: &Scope<'_, anyhow::Error>,
 	eth_client: EthersRetryRpcClient,
 	btc_client: BtcRetryRpcClient,
 	dot_client: DotRetryRpcClient,
 	state_chain_client: Arc<StateChainClient>,
-	state_chain_stream: StateChainStream,
+	state_chain_stream: impl StateChainStreamApi + Clone,
+	unfinalised_state_chain_stream: impl StateChainStreamApi<false> + Clone,
 	db: Arc<PersistentKeyDB>,
 ) -> Result<()>
 where
-	StateChainStream: StateChainStreamApi + Clone,
 	StateChainClient: StorageApi + ChainApi + SignedExtrinsicApi + 'static + Send + Sync,
 {
 	let epoch_source =
@@ -81,6 +81,7 @@ where
 		prewitness_call.clone(),
 		state_chain_client.clone(),
 		state_chain_stream.clone(),
+		unfinalised_state_chain_stream.clone(),
 		epoch_source.clone(),
 		db.clone(),
 	);
@@ -92,6 +93,7 @@ where
 		prewitness_call.clone(),
 		state_chain_client.clone(),
 		state_chain_stream.clone(),
+		unfinalised_state_chain_stream.clone(),
 		epoch_source.clone(),
 		db.clone(),
 	);
@@ -103,6 +105,7 @@ where
 		prewitness_call,
 		state_chain_client,
 		state_chain_stream,
+		unfinalised_state_chain_stream,
 		epoch_source,
 		db,
 	);


### PR DESCRIPTION
# Pull Request

Closes: PRO-929

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Pretty straightforward change. Tested on localnet and seems to behave as expected. The only thing that's still unclear to me is whether we also want to specialise `is_header_ready` somehow so that we don't pessimistically wait for the next block (which could be a long time for BTC). Figured it is worth discussing this before making more changes.