### PR TITLE
chore: localnet asks binary locations before destroying 

### DIFF
--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -66,16 +66,17 @@ get-workflow() {
     fi
     echo "You have chosen $NODE_COUNT node(s) network"
     NODE_COUNT="$NODE_COUNT-node"
-fi
-}
 
-build-localnet() {
-  if [[ -z "${BINARY_ROOT_PATH}" ]]; then
+    if [[ -z "${BINARY_ROOT_PATH}" ]]; then
       echo "💻 Please provide the location to the binaries you would like to use."
       read -p "(default: ./target/debug/) " BINARY_ROOT_PATH
       echo
       export BINARY_ROOT_PATH=${BINARY_ROOT_PATH:-"./target/debug"}
+    fi
   fi
+}
+
+build-localnet() {
 
   if [[ ! -d $BINARY_ROOT_PATH ]]; then
     echo "❌  Couldn't find directory at $BINARY_ROOT_PATH"


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

I often find myself recreating localnets, responding to initial prompts and then coming back only to find out that there was an extra prompt (asking for binary path) some time later (after the existing net has been destroyed) and the new network isn't ready yet.

Having that prompt to come earlier seemed like an easy change to make, and this would be a good quality-of-life improvement IMO. I don't think this should break any existing workflows, but feel free to close this if it does.

