### PR TITLE
refactor: use btc rpc client for mempool tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ graph
 *terraform.tfstate*
 tfplan
 .tfvars
+
+*rustc-ice*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitcoin",
  "cf-chains",
  "cf-primitives",
  "chainflip-engine",

--- a/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
+++ b/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.72"
 async-trait = "0.1.73"
+bitcoin = { version = "0.30.0", features = ["serde"] }
 futures = "0.3.28"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 reqwest = { version = "0.11.18", features = ["json"] }
@@ -24,7 +25,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 ] }
 
 # Local dependencies
-chainflip-engine = { path = "../../../engine/"}
+chainflip-engine = { path = "../../../engine/" }
 utilities = { path = "../../../utilities" }
 cf-primitives = { path = "../../../state-chain/primitives" }
 pallet-cf-environment = { path = "../../../state-chain/pallets/cf-environment" }

--- a/api/bin/chainflip-ingress-egress-tracker/src/main.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/main.rs
@@ -102,10 +102,10 @@ async fn main() -> anyhow::Result<()> {
 		eth_key_path: eth_key_temp_file.path().into(),
 		dot_node: WsHttpEndpoints {
 			ws_endpoint: env::var("DOT_WS_ENDPOINT")
-				.unwrap_or("ws://localhost:9945".to_string())
+				.unwrap_or("ws://localhost:9947".to_string())
 				.into(),
 			http_endpoint: env::var("DOT_HTTP_ENDPOINT")
-				.unwrap_or("http://localhost:9945".to_string())
+				.unwrap_or("http://localhost:9947".to_string())
 				.into(),
 		},
 		state_chain_ws_endpoint: env::var("SC_WS_ENDPOINT")

--- a/engine/src/btc/retry_rpc.rs
+++ b/engine/src/btc/retry_rpc.rs
@@ -29,11 +29,11 @@ impl BtcRetryRpcClient {
 		nodes: NodeContainer<HttpBasicAuthEndpoint>,
 		expected_btc_network: BitcoinNetwork,
 	) -> Result<Self> {
-		let rpc_client = BtcRpcClient::new(nodes.primary, expected_btc_network)?;
+		let rpc_client = BtcRpcClient::new(nodes.primary, Some(expected_btc_network))?;
 
 		let backup_rpc_client = nodes
 			.backup
-			.map(|backup_endpoint| BtcRpcClient::new(backup_endpoint, expected_btc_network))
+			.map(|backup_endpoint| BtcRpcClient::new(backup_endpoint, Some(expected_btc_network)))
 			.transpose()?;
 
 		Ok(Self {

--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -206,7 +206,7 @@ impl DotRetrySubscribeApi for DotRetryRpcClient {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.subscribe_best_heads().await })
 				}),
-				RequestLog::new("subscribe_best_head".to_string(), None),
+				RequestLog::new("subscribe_best_heads".to_string(), None),
 			)
 			.await
 	}


### PR DESCRIPTION
Diff looks worse than it is, a bit of boilerplate in the tests and what not that may be able to be reduced further. Core logic and interfaces are all the same, so nothing breaking for web guys. Was just type wrangling mostly.

# Pull Request

Closes: PRO-909

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works - have tested it running against localnet.
- [x] I have updated documentation where appropriate.

## Summary

Unifies the two btc clients we use so we only use one method of calling a BTC node. We also now share the same types making things more consistent.

Think there's more to do here, but this is a start.
