### PR TITLE
fix: add missing spans in multisig logs

### DIFF
--- a/engine/multisig/src/client/ceremony_runner.rs
+++ b/engine/multisig/src/client/ceremony_runner.rs
@@ -113,12 +113,7 @@ where
 		if let Some(start_instant) = ceremony_start {
 			let duration = start_instant.elapsed().as_millis();
 			runner.metrics.ceremony_duration.set(duration);
-			tracing::info!(
-				"Ceremony {} ({}) took {}ms to complete",
-				Ceremony::CEREMONY_TYPE,
-				ceremony_id,
-				duration
-			);
+			span.in_scope(|| tracing::info!("Ceremony took {}ms to complete", duration));
 		}
 		let _result = runner.outcome_sender.send((ceremony_id, outcome));
 		Ok(())
@@ -222,7 +217,8 @@ where
 	}
 
 	/// Process message from a peer, returning ceremony outcome if
-	/// the ceremony stage machine cannot progress any further
+	/// the ceremony stage machine cannot progress any further.
+	/// Note: this is only public because of tests.
 	pub async fn process_or_delay_message(
 		&mut self,
 		sender_id: AccountId,

--- a/engine/multisig/src/client/mod.rs
+++ b/engine/multisig/src/client/mod.rs
@@ -371,6 +371,7 @@ impl<C: ChainSigning, KeyStore: KeyStoreAPI<C>> MultisigClientApi<C::CryptoSchem
 						(reported_parties, failure_reason)
 					})
 			}
+			.instrument(span.clone())
 			.boxed()
 		} else {
 			// No key was found for the given key_id


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added spans containing cermeony id to a few logs that were missing them (or in one case it the chain was missing), which made it hard to link these messages to a particluar ceremony.