### PR TITLE
chore: CFE tracing, don't log current span twice

### DIFF
--- a/utilities/src/with_std/logging.rs
+++ b/utilities/src/with_std/logging.rs
@@ -110,6 +110,8 @@ pub async fn init_json_logger(
 	let reload_handle = {
 		let builder = tracing_subscriber::fmt()
 			.json()
+			.with_current_span(false)
+			.with_span_list(true)
 			.with_env_filter(
 				EnvFilter::builder()
 					.with_default_directive(LevelFilter::INFO.into())


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Every log message that was in a span was outputting the current span`span: ...` and also the list of active`spans:[ ...]`.
So i just disabled the current span from being output seems its shown in the list of spans anyway.
Explicitly enabled `with_span_list` even though its on by default, just for clarity, so it doesn't look like we are not showing spans at all.

before:
```
{"timestamp":"2023-11-13T07:27:55.952455Z","level":"DEBUG","fields":{"message":"Processing a keygen request"},"target":"multisig::client::ceremony_manager","span":{"ceremony_id":"Bitcoin(1)","name":"Keygen Ceremony"},"spans":[{"chain":"Bitcoin","name":"MultisigClient"},{"chain":"Bitcoin","name":"MultisigClient"},{"ceremony_id":"Bitcoin(1)","name":"Keygen Ceremony"}]}
```

After:
```
{"timestamp":"2023-11-13T07:27:55.952455Z","level":"DEBUG","fields":{"message":"Processing a keygen request"},"target":"multisig::client::ceremony_manager","spans":[{"chain":"Bitcoin","name":"MultisigClient"},{"chain":"Bitcoin","name":"MultisigClient"},{"ceremony_id":"Bitcoin(1)","name":"Keygen Ceremony"}]}
```