### PR TITLE
feat: CLI generate keys outputs peer id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac-sha512",
+ "libp2p-identity 0.2.8",
  "libsecp256k1",
  "pallet-cf-account-roles",
  "pallet-cf-environment",
@@ -1706,7 +1707,7 @@ checksum = "b9b68e3193982cd54187d71afdb2a271ad4cf8af157858e9cb911b91321de143"
 dependencies = [
  "core2",
  "multibase",
- "multihash",
+ "multihash 0.17.0",
  "serde",
  "unsigned-varint",
 ]
@@ -5647,7 +5648,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
@@ -5672,7 +5673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
 dependencies = [
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "void",
 ]
@@ -5684,7 +5685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
 dependencies = [
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "void",
 ]
@@ -5700,10 +5701,10 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "multiaddr",
- "multihash",
+ "multihash 0.17.0",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
@@ -5742,7 +5743,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "log",
  "lru",
@@ -5763,11 +5764,28 @@ dependencies = [
  "ed25519-dalek 2.0.0",
  "log",
  "multiaddr",
- "multihash",
+ "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999ec70441b2fb35355076726a6bc466c932e9bdc66f6a11c6c0aa17c7ab9be0"
+dependencies = [
+ "bs58 0.5.0",
+ "ed25519-dalek 2.0.0",
+ "hkdf",
+ "multihash 0.19.1",
+ "quick-protobuf",
+ "sha2 0.10.8",
+ "thiserror",
+ "tracing",
  "zeroize",
 ]
 
@@ -5786,7 +5804,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "log",
  "quick-protobuf",
@@ -5809,7 +5827,7 @@ dependencies = [
  "futures",
  "if-watch",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "log",
  "rand 0.8.5",
@@ -5844,7 +5862,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "futures",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "once_cell",
  "quick-protobuf",
@@ -5885,7 +5903,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
@@ -5906,7 +5924,7 @@ dependencies = [
  "futures",
  "instant",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
@@ -5924,7 +5942,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-swarm-derive",
  "log",
  "rand 0.8.5",
@@ -5969,7 +5987,7 @@ dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "rcgen 0.10.0",
  "ring 0.16.20",
  "rustls 0.20.9",
@@ -6007,10 +6025,10 @@ dependencies = [
  "hex",
  "if-watch",
  "libp2p-core",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "libp2p-noise",
  "log",
- "multihash",
+ "multihash 0.17.0",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
@@ -6553,7 +6571,7 @@ dependencies = [
  "data-encoding",
  "log",
  "multibase",
- "multihash",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -6586,6 +6604,16 @@ dependencies = [
  "multihash-derive",
  "sha2 0.10.8",
  "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+dependencies = [
+ "core2",
  "unsigned-varint",
 ]
 
@@ -9369,7 +9397,7 @@ dependencies = [
  "clap 4.4.7",
  "fdlimit",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "names",
  "parity-scale-codec",
@@ -9458,7 +9486,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "mockall",
  "parking_lot 0.12.1",
@@ -9718,7 +9746,7 @@ dependencies = [
  "async-channel 1.9.0",
  "cid",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "prost",
  "prost-build",
@@ -9738,7 +9766,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "parity-scale-codec",
  "prost-build",
  "sc-consensus",
@@ -9773,7 +9801,7 @@ dependencies = [
  "array-bytes 6.1.0",
  "async-channel 1.9.0",
  "futures",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "log",
  "parity-scale-codec",
  "prost",

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -308,6 +308,7 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 	#[derive(Serialize)]
 	struct Keys {
 		node_key: KeyPair,
+		peer_id: String,
 		seed_phrase: String,
 		ethereum_key: KeyPair,
 		#[serde(with = "hex")]
@@ -319,6 +320,7 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 	impl std::fmt::Display for Keys {
 		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 			writeln!(f, "🔑 Node Public Key: 0x{}", hex::encode(&self.node_key.public_key))?;
+			writeln!(f, "👤 Node Peer ID: {}", self.peer_id)?;
 			writeln!(
 				f,
 				"🔑 Ethereum Public Key: 0x{}",
@@ -346,8 +348,12 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 				api::generate_ethereum_key(Some(&seed_phrase))
 					.context("Error while generating Ethereum key.")?;
 			assert_eq!(seed_phrase, seed_phrase_eth);
+			let (node_key, peer_id) =
+				api::generate_node_key().context("Error while generating node key.")?;
+
 			Ok(Keys {
-				node_key: api::generate_node_key(),
+				node_key,
+				peer_id: peer_id.to_string(),
 				seed_phrase,
 				ethereum_key,
 				ethereum_address,

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -19,6 +19,7 @@ tiny-bip39 = "1.0.0"
 tokio = "1.28"
 tracing = "0.1"
 zeroize = "1.5.4"
+libp2p-identity = { version = "0.2", features = ["ed25519", "peerid"] }
 
 # Local
 chainflip-engine = { path = "../../engine/" }


### PR DESCRIPTION
# Pull Request

Closes: PRO-958

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

[Documentation PR](https://github.com/chainflip-io/chainflip-docs/pull/83)

Ouputs the peer id with the node key. I confirmed that the peer id is correct by using the `inspect-node-key` command on the generated key and got the same ID:
```sh
➜  alt-chainflip-backend git:(main) ✗ ./target/debug/chainflip-cli generate-keys -p test_keys

Generated fresh Validator keys for your Chainflip Node!

🔑 Node Public Key: 0x5fc8ea5dd16e0bbc273eedfe5406d548cdbcdaf66fe86a2643bace5045fe2edf
👤 Node Peer ID: 12D3KooWGGGbDdkegvsc1m5vkNppHtXZJqSMNQRH7AKE7cxRuuSe
🔑 Ethereum Public Key: 0x033b48e368ae9069413d443c7a52b1e340c6aa0a8a76aac507d62b5ede51dfa368
👤 Ethereum Address: 0x6b98c154357297d0459ede9e98e586a60bee55c3
🔑 Validator Public Key: 0x685b0a76f54c25e2bf03aa8f69450eb863f2ea23b16e93a2317282485e86a723
👤 Validator Account ID: cFLEJrTKtoHDWbRb1Yc8fqhNrEd2u1WPjUemVXjZQ1THxb5p6

🌱 Seed Phrase: slender pilot fiber auction junk sting ozone push shop reduce defense stamp

...


 💾 Saved all secret keys to '/Users/jamieford/alt-chainflip-backend/test_keys'.
➜  alt-chainflip-backend git:(main) ✗ ./target/debug/chainflip-node key inspect-node-key --file  "/Users/jamieford/alt-chainflip-backend/test_keys/node_key_file"
12D3KooWGGGbDdkegvsc1m5vkNppHtXZJqSMNQRH7AKE7cxRuuSe
```
