### PR TITLE
fix: remove bound addresses on account deletion

### DIFF
--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -819,5 +819,7 @@ impl<T: Config> OnKilledAccount<T::AccountId> for Pallet<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
 		ActiveBidder::<T>::remove(account_id);
 		RestrictedBalances::<T>::remove(account_id);
+		BoundExecutorAddress::<T>::remove(account_id);
+		BoundRedeemAddress::<T>::remove(account_id);
 	}
 }


### PR DESCRIPTION
This deletes the bound addresses when an account is killed.