### PR TITLE
Fix: avoid breaking change when submitting Node version

### DIFF
--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -230,13 +230,6 @@ fn send_node_cfe_version() {
 				new_version: cfe_version,
 			},
 		));
-		assert_has_event::<Test>(mock::RuntimeEvent::ValidatorPallet(
-			crate::Event::NodeVersionUpdated {
-				account_id: authority,
-				old_version: SemVer::default(),
-				new_version: node_version,
-			},
-		));
 
 		assert_eq!(
 			NodeCFEVersions { cfe: cfe_version, node: node_version },
@@ -259,13 +252,6 @@ fn send_node_cfe_version() {
 				new_version: new_cfe_version,
 			},
 		));
-		assert_has_event::<Test>(mock::RuntimeEvent::ValidatorPallet(
-			crate::Event::NodeVersionUpdated {
-				account_id: authority,
-				old_version: node_version,
-				new_version: new_node_version,
-			},
-		));
 
 		assert_eq!(
 			NodeCFEVersions { cfe: new_cfe_version, node: new_node_version },
@@ -273,8 +259,7 @@ fn send_node_cfe_version() {
 			"node and cfe new versions should be stored"
 		);
 
-		// When we submit the same version we should see no `CFEVersionUpdated` event or
-		// `NodeVersionUpdated`
+		// When we submit the same version, we should see no `CFEVersionUpdated` event
 		frame_system::Pallet::<Test>::reset_events();
 		assert_ok!(ValidatorPallet::set_node_cfe_version(
 			RuntimeOrigin::signed(authority),
@@ -1264,13 +1249,6 @@ fn submitting_multiple_versions_ensuring_compatibility() {
 		assert_ok!(ValidatorPallet::set_node_cfe_version(
 			RuntimeOrigin::signed(VALIDATOR),
 			higher_compatible_version
-		));
-		assert_has_event::<Test>(mock::RuntimeEvent::ValidatorPallet(
-			crate::Event::NodeVersionUpdated {
-				account_id: VALIDATOR,
-				old_version: compatible_version.node,
-				new_version: higher_compatible_version.node,
-			},
 		));
 		assert_has_event::<Test>(mock::RuntimeEvent::ValidatorPallet(
 			crate::Event::CFEVersionUpdated {

--- a/state-chain/pallets/cf-validator/src/weights.rs
+++ b/state-chain/pallets/cf-validator/src/weights.rs
@@ -35,6 +35,7 @@ pub trait WeightInfo {
 	fn update_pallet_config() -> Weight;
 	fn set_authority_set_min_size() -> Weight;
 	fn set_node_cfe_version() -> Weight;
+	fn cfe_version() -> Weight;
 	fn register_peer_id() -> Weight;
 	fn set_vanity_name() -> Weight;
 	fn expire_epoch(a: u32, ) -> Weight;
@@ -74,6 +75,14 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	// Storage: AccountRoles AccountRoles (r:1 w:0)
 	// Storage: Validator NodeCFEVersion (r:1 w:1)
 	fn set_node_cfe_version() -> Weight {
+		// Minimum execution time: 27_000 nanoseconds.
+		Weight::from_parts(27_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(1))
+	}
+	// Storage: AccountRoles AccountRoles (r:1 w:0)
+	// Storage: Validator NodeCFEVersion (r:1 w:1)
+	fn cfe_version() -> Weight {
 		// Minimum execution time: 27_000 nanoseconds.
 		Weight::from_parts(27_000_000, 0)
 			.saturating_add(T::DbWeight::get().reads(2))
@@ -365,6 +374,14 @@ impl WeightInfo for () {
 	// Storage: AccountRoles AccountRoles (r:1 w:0)
 	// Storage: Validator NodeCFEVersion (r:1 w:1)
 	fn set_node_cfe_version() -> Weight {
+		// Minimum execution time: 27_000 nanoseconds.
+		Weight::from_parts(27_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(2))
+			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+	// Storage: AccountRoles AccountRoles (r:1 w:0)
+	// Storage: Validator NodeCFEVersion (r:1 w:1)
+	fn cfe_version() -> Weight {
 		// Minimum execution time: 27_000 nanoseconds.
 		Weight::from_parts(27_000_000, 0)
 			.saturating_add(RocksDbWeight::get().reads(2))


### PR DESCRIPTION
# Pull Request

Closes: PRO-970

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Removed the NodeVersionUpdated event, which is not used and is only introducing a breaking change
- Added back old extrinsic to only report the cfe version to ensure compatibility of old engines (not sure if this is required since we are not going to use it, because this extrinsic gets called only when a new version of the cfe is used, hence the new cfe knows already to use the new extrinsic)