### PR TITLE
fix: set_fees

### DIFF
--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -561,6 +561,14 @@ mod test {
 		assert_eq!(mul_div(2.into(), 2.into(), 6), (0.into(), 1.into()));
 	}
 
+	#[cfg(feature = "slow-tests")]
+	#[test]
+	fn test_conversion_sqrt_price_back_and_forth() {
+		for tick in MIN_TICK..=MAX_TICK {
+			assert_eq!(tick, tick_at_sqrt_price(sqrt_price_at_tick(tick)));
+		}
+	}
+
 	#[test]
 	fn test_sqrt_price_at_tick() {
 		assert_eq!(sqrt_price_at_tick(MIN_TICK), MIN_SQRT_PRICE);

--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -244,7 +244,7 @@ pub const PRICE_FRACTIONAL_BITS: u32 = 128;
 ///
 /// Will panic for `sqrt_price`'s outside `MIN_SQRT_PRICE..=MAX_SQRT_PRICE`
 pub(super) fn sqrt_price_to_price(sqrt_price: SqrtPriceQ64F96) -> Price {
-	assert!((MIN_SQRT_PRICE..=MAX_SQRT_PRICE).contains(&sqrt_price));
+	assert!(is_sqrt_price_valid(sqrt_price));
 
 	// Note the value here cannot ever be zero as MIN_SQRT_PRICE has its 33th bit set, so sqrt_price
 	// will always include a bit pass the 64th bit that is set, so when we shift down below that set
@@ -305,7 +305,7 @@ pub(super) const MAX_SQRT_PRICE: SqrtPriceQ64F96 =
 	U256([0x5d951d5263988d26u64, 0xefd1fc6a50648849u64, 0xfffd8963u64, 0x0u64]);
 
 pub(super) fn is_sqrt_price_valid(sqrt_price: SqrtPriceQ64F96) -> bool {
-	(MIN_SQRT_PRICE..MAX_SQRT_PRICE).contains(&sqrt_price)
+	(MIN_SQRT_PRICE..=MAX_SQRT_PRICE).contains(&sqrt_price)
 }
 
 pub fn is_tick_valid(tick: Tick) -> bool {
@@ -721,5 +721,6 @@ mod test {
 			276324
 		);
 		assert_eq!(tick_at_sqrt_price(MAX_SQRT_PRICE - 1), MAX_TICK - 1);
+		assert_eq!(tick_at_sqrt_price(MAX_SQRT_PRICE), MAX_TICK);
 	}
 }


### PR DESCRIPTION
The recent addition of set_fees and one of the new lp rpcs added a bug:

Basically the conversion from sqrt_price to tick, would assert for the max sqrt_price, but the conversion from tick to sqrt_price could output the max sqrt_price, so you couldn't freely/safely convert between them (i.e. tick_at_sqrt_price(sqrt_price_at_tick(TICK)) may panic even if the TICK was considered valid, which is dumb). In the original AMM code this was fine (and matched Uniswap's asserts/restrictiveness), but the assert is unnecessarily restrictive, as the function behaves correctly even for the max sqrt_price value (i.e. it outputs the max tick). So to make the function safer to use I've made the assert less restrictive. The only behavioural effect is that range order pools can be initialised at the max price now (which is a totally valid state) instead of -1 the max price.

In the set_fees extrinsic we do this conversion, where we may use the max sqrt_price, which would then panic, before this change. The only other place there was a problem is the pool_liquidity rpc. Both are fixed here.