### PR TITLE
feat: try-runtime loop

### DIFF
--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -4,7 +4,7 @@
 // hook checks to ensure the upgrade will be successful.
 // To increase certainty, you can select to run *all* the migrations until the latest block, or the last N blocks.
 // For specific debugging purposes you can run on one specific block, or just the latest block.
-// 
+//
 // PRE-REQUISITES:
 // - You must have the `try-runtime-cli` installed: https://paritytech.github.io/try-runtime-cli/try_runtime/
 //
@@ -16,32 +16,41 @@
 // --compile: If set, it will compile the runtime to do the upgrade. If false it will use the pre-compiled runtime. Defaults to false.
 
 import path from 'path';
-import { tryRuntimeUpgrade } from "../shared/try_runtime_upgrade";
-import { getChainflipApi, runWithTimeout } from "../shared/utils";
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import { tryRuntimeUpgrade } from '../shared/try_runtime_upgrade';
+import { getChainflipApi, runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-    const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false).argv;
+  const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false).argv;
 
-    const block = argv.block;
+  const block = argv.block;
 
-    if (block == undefined) {
-        console.error('Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` of `last-n <number>` to use the latest block number on the network.');
-        process.exit(-1);
-    }
+  if (block === undefined) {
+    console.error(
+      'Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` of `last-n <number>` to use the latest block number on the network.',
+    );
+    process.exit(-1);
+  }
 
-    const endpoint = process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944';
-    let chainflipApi = await getChainflipApi();
+  const endpoint = process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944';
+  const chainflipApi = await getChainflipApi();
 
-    const lastN = argv.lastN = argv.lastN ?? 100;
+  const lastN = argv.lastN ?? 100;
 
-    await tryRuntimeUpgrade(block, chainflipApi, endpoint, path.dirname(process.cwd()), argv.compile, lastN);
+  await tryRuntimeUpgrade(
+    block,
+    chainflipApi,
+    endpoint,
+    path.dirname(process.cwd()),
+    argv.compile,
+    lastN,
+  );
 
-    process.exit(0);
+  process.exit(0);
 }
 
 runWithTimeout(main(), 1200000).catch((error) => {
-    console.error(error);
-    process.exit(-1);
+  console.error(error);
+  process.exit(-1);
 });

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -9,10 +9,10 @@
 // - You must have the `try-runtime-cli` installed: https://paritytech.github.io/try-runtime-cli/try_runtime/
 //
 // Args
-// --block <number, latest, lastN, all>
+// --block <number, latest, last-n, all>
 
 // Optional args:
-// --lastN <number>: If block is lastN, this is the number of blocks to run the migration on. Default is 50.
+// --last-n <number>: If block is lastN, this is the number of blocks to run the migration on. Default is 50.
 // --compile: If set, it will compile the runtime to do the upgrade. If false it will use the pre-compiled runtime. Defaults to false.
 
 import path from 'path';

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -1,6 +1,19 @@
 #!/usr/bin/env -S pnpm tsx
+// INSTRUCTIONS
+// Runs try-runtime upgrade on a particular network of choice. This means it simulates the runtime upgrade, running pre and post upgrade
+// hook checks to ensure the upgrade will be successful.
+// To increase certainty, you can select to run *all* the migrations until the latest block, or the last N blocks.
+// For specific debugging purposes you can run on one specific block, or just the latest block.
+// 
+// PRE-REQUISITES:
+// - You must have the `try-runtime-cli` installed: https://paritytech.github.io/try-runtime-cli/try_runtime/
+//
+// Args
+// --block <number, latest, lastN, all>
 
-// TODO: Document how to use the command.
+// Optional args:
+// --lastN <number>: If block is lastN, this is the number of blocks to run the migration on. Default is 50.
+// --compile: If set, it will compile the runtime to do the upgrade. If false it will use the pre-compiled runtime. Defaults to false.
 
 import path from 'path';
 import { tryRuntimeUpgrade } from "../shared/try_runtime_upgrade";
@@ -8,10 +21,8 @@ import { getChainflipApi, runWithTimeout } from "../shared/utils";
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-
 async function main(): Promise<void> {
     const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false).argv;
-
 
     const block = argv.block;
 

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -16,19 +16,21 @@ async function main(): Promise<void> {
     const block = argv.block;
 
     if (block == undefined) {
-        console.error('Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` to use the latest block number on the network.');
+        console.error('Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` of `last-n <number>` to use the latest block number on the network.');
         process.exit(-1);
     }
 
     const endpoint = process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944';
     let chainflipApi = await getChainflipApi();
 
-    await tryRuntimeUpgrade(block, chainflipApi, endpoint, path.dirname(process.cwd()), argv.compile);
+    const lastN = argv.lastN = argv.lastN ?? 100;
+
+    await tryRuntimeUpgrade(block, chainflipApi, endpoint, path.dirname(process.cwd()), argv.compile, lastN);
 
     process.exit(0);
 }
 
-runWithTimeout(main(), 120000).catch((error) => {
+runWithTimeout(main(), 1200000).catch((error) => {
     console.error(error);
     process.exit(-1);
 });

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S pnpm tsx
+
+// TODO: Document how to use the command.
+
+import path from 'path';
+import { tryRuntimeUpgrade } from "../shared/try_runtime_upgrade";
+import { getChainflipApi, runWithTimeout } from "../shared/utils";
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+
+async function main(): Promise<void> {
+    const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false).argv;
+
+
+    const block = argv.block;
+
+    if (block == undefined) {
+        console.error('Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` to use the latest block number on the network.');
+        process.exit(-1);
+    }
+
+    const endpoint = process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944';
+    let chainflipApi = await getChainflipApi();
+
+    await tryRuntimeUpgrade(block, chainflipApi, endpoint, path.dirname(process.cwd()), argv.compile);
+
+    process.exit(0);
+}
+
+runWithTimeout(main(), 120000).catch((error) => {
+    console.error(error);
+    process.exit(-1);
+});

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -6,9 +6,12 @@ import { execSync } from "child_process";
 import { compileBinaries } from "./utils/compile_binaries";
 
 
-
-// Either we perform one at the head of a live chain, or we perform one at a particular block number.
-export async function tryRuntimeUpgrade(block: number | 'latest', api: ApiPromise, networkUrl: string, projectRoot: string, shouldCompile: boolean = true) {
+// 4 options:
+// - Live chain, 
+// - Specific block
+// - All - goes from block 0 to the latest block when the script was started - this is useful for testing the upgrade on a local chain.
+// - last-n, must also specify a number of blocks. This goes backwards from the latest block, running the migration on each block down the chain.
+export async function tryRuntimeUpgrade(block: number | 'latest' | 'all' | 'last-n', api: ApiPromise, networkUrl: string, projectRoot: string, shouldCompile: boolean = true, lastN: number = 50) {
 
     if (shouldCompile) {
         compileBinaries('runtime', projectRoot);
@@ -16,12 +19,61 @@ export async function tryRuntimeUpgrade(block: number | 'latest', api: ApiPromis
         console.log("Using pre-compiled state chain runtime for try-runtime upgrade.")
     }
 
-    let blockParam;
-    if (block == 'latest') {
-        blockParam = 'live'
+    if (block == 'all') {
+        const latestBlock = await api.rpc.chain.getBlockHash();
+
+        console.log("Running migrations until we reach block with hash: " + latestBlock);
+
+        let blockNumber = 1;
+        while (true) {
+            const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
+
+            try {
+                tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
+                console.log(`try-runtime success for block ${blockNumber}, block hash: ${blockHash}`);
+            } catch (e) {
+                console.error(`try-runtime failed for block ${blockNumber}, block hash: ${blockHash}`);
+                console.error(e);
+                process.exit(-1);
+            }
+
+            if (blockHash.eq(latestBlock)) {
+                console.log(`Block ${latestBlock} has been reached, exiting.`);
+                break
+            }
+            blockNumber++;
+        }
+    } else if (block == 'last-n') {
+        console.log(`Running migrations for the last ${lastN} blocks.`);
+        let blocksProcessed = 0;
+
+        let nextHash = await api.rpc.chain.getBlockHash();
+
+        while (blocksProcessed < lastN) {
+
+            try {
+                tryRuntimeCommand(projectRoot, `live --at ${nextHash}`, networkUrl);
+                console.log(`try-runtime success for block hash: ${nextHash}`);
+            } catch (e) {
+                console.error(`try-runtime failed for block hash: ${nextHash}`);
+                console.error(e);
+                process.exit(-1);
+            }
+
+            let currentBlockHeader = await api.rpc.chain.getHeader(nextHash);
+            nextHash = currentBlockHeader.parentHash;
+            blocksProcessed++;
+        }
+    } else if (block == 'latest') {
+        tryRuntimeCommand(projectRoot, 'live', networkUrl);
     } else {
         const blockHash = await api.rpc.chain.getBlockHash(block);
-        blockParam = `live --at ${blockHash}`;
+        tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
     }
-    execSync(`try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`);
+
+    console.log("try-runtime upgrade successful.");
+}
+
+function tryRuntimeCommand(projectRoot: string, blockParam: string, networkUrl: string) {
+    execSync(`try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`, { stdio: 'ignore' });
 }

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -36,7 +36,7 @@ export async function tryRuntimeUpgrade(
 
     console.log('Running migrations until we reach block with hash: ' + latestBlock);
 
-    let blockNumber = 536;
+    let blockNumber = 1;
     let blockHash = await api.rpc.chain.getBlockHash(blockNumber);
     while (!blockHash.eq(latestBlock)) {
       blockHash = await api.rpc.chain.getBlockHash(blockNumber);

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -1,79 +1,84 @@
 // This requirse the try-runtime cli to be installed globally
 // https://github.com/paritytech/try-runtime-cli
 
-import { ApiPromise } from "@polkadot/api";
-import { execSync } from "child_process";
-import { compileBinaries } from "./utils/compile_binaries";
+import { ApiPromise } from '@polkadot/api';
+import { execSync } from 'child_process';
+import { compileBinaries } from './utils/compile_binaries';
 
+function tryRuntimeCommand(projectRoot: string, blockParam: string, networkUrl: string) {
+  execSync(
+    `try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`,
+    { stdio: 'ignore' },
+  );
+}
 
 // 4 options:
-// - Live chain, 
+// - Live chain,
 // - Specific block
 // - All - goes from block 0 to the latest block when the script was started - this is useful for testing the upgrade on a local chain.
 // - last-n, must also specify a number of blocks. This goes backwards from the latest block, running the migration on each block down the chain.
-export async function tryRuntimeUpgrade(block: number | 'latest' | 'all' | 'last-n', api: ApiPromise, networkUrl: string, projectRoot: string, shouldCompile: boolean = true, lastN: number = 50) {
+export async function tryRuntimeUpgrade(
+  block: number | 'latest' | 'all' | 'last-n',
+  api: ApiPromise,
+  networkUrl: string,
+  projectRoot: string,
+  shouldCompile = true,
+  lastN = 50,
+) {
+  if (shouldCompile) {
+    compileBinaries('runtime', projectRoot);
+  } else {
+    console.log('Using pre-compiled state chain runtime for try-runtime upgrade.');
+  }
 
-    if (shouldCompile) {
-        compileBinaries('runtime', projectRoot);
-    } else {
-        console.log("Using pre-compiled state chain runtime for try-runtime upgrade.")
-    }
+  if (block === 'all') {
+    const latestBlock = await api.rpc.chain.getBlockHash();
 
-    if (block == 'all') {
-        const latestBlock = await api.rpc.chain.getBlockHash();
+    console.log('Running migrations until we reach block with hash: ' + latestBlock);
 
-        console.log("Running migrations until we reach block with hash: " + latestBlock);
+    let blockNumber = 536;
+    let blockHash = await api.rpc.chain.getBlockHash(blockNumber);
+    while (!blockHash.eq(latestBlock)) {
+      blockHash = await api.rpc.chain.getBlockHash(blockNumber);
 
-        let blockNumber = 1;
-        while (true) {
-            const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
-
-            try {
-                tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
-                console.log(`try-runtime success for block ${blockNumber}, block hash: ${blockHash}`);
-            } catch (e) {
-                console.error(`try-runtime failed for block ${blockNumber}, block hash: ${blockHash}`);
-                console.error(e);
-                process.exit(-1);
-            }
-
-            if (blockHash.eq(latestBlock)) {
-                console.log(`Block ${latestBlock} has been reached, exiting.`);
-                break
-            }
-            blockNumber++;
-        }
-    } else if (block == 'last-n') {
-        console.log(`Running migrations for the last ${lastN} blocks.`);
-        let blocksProcessed = 0;
-
-        let nextHash = await api.rpc.chain.getBlockHash();
-
-        while (blocksProcessed < lastN) {
-
-            try {
-                tryRuntimeCommand(projectRoot, `live --at ${nextHash}`, networkUrl);
-                console.log(`try-runtime success for block hash: ${nextHash}`);
-            } catch (e) {
-                console.error(`try-runtime failed for block hash: ${nextHash}`);
-                console.error(e);
-                process.exit(-1);
-            }
-
-            let currentBlockHeader = await api.rpc.chain.getHeader(nextHash);
-            nextHash = currentBlockHeader.parentHash;
-            blocksProcessed++;
-        }
-    } else if (block == 'latest') {
-        tryRuntimeCommand(projectRoot, 'live', networkUrl);
-    } else {
-        const blockHash = await api.rpc.chain.getBlockHash(block);
+      try {
         tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
+        console.log(`try-runtime success for block ${blockNumber}, block hash: ${blockHash}`);
+      } catch (e) {
+        console.error(`try-runtime failed for block ${blockNumber}, block hash: ${blockHash}`);
+        console.error(e);
+        process.exit(-1);
+      }
+
+      blockNumber++;
     }
+    console.log(`Block ${latestBlock} has been reached, exiting.`);
+  } else if (block === 'last-n') {
+    console.log(`Running migrations for the last ${lastN} blocks.`);
+    let blocksProcessed = 0;
 
-    console.log("try-runtime upgrade successful.");
-}
+    let nextHash = await api.rpc.chain.getBlockHash();
 
-function tryRuntimeCommand(projectRoot: string, blockParam: string, networkUrl: string) {
-    execSync(`try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`, { stdio: 'ignore' });
+    while (blocksProcessed < lastN) {
+      try {
+        tryRuntimeCommand(projectRoot, `live --at ${nextHash}`, networkUrl);
+        console.log(`try-runtime success for block hash: ${nextHash}`);
+      } catch (e) {
+        console.error(`try-runtime failed for block hash: ${nextHash}`);
+        console.error(e);
+        process.exit(-1);
+      }
+
+      const currentBlockHeader = await api.rpc.chain.getHeader(nextHash);
+      nextHash = currentBlockHeader.parentHash;
+      blocksProcessed++;
+    }
+  } else if (block === 'latest') {
+    tryRuntimeCommand(projectRoot, 'live', networkUrl);
+  } else {
+    const blockHash = await api.rpc.chain.getBlockHash(block);
+    tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
+  }
+
+  console.log('try-runtime upgrade successful.');
 }

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -1,0 +1,27 @@
+// This requirse the try-runtime cli to be installed globally
+// https://github.com/paritytech/try-runtime-cli
+
+import { ApiPromise } from "@polkadot/api";
+import { execSync } from "child_process";
+import { compileBinaries } from "./utils/compile_binaries";
+
+
+
+// Either we perform one at the head of a live chain, or we perform one at a particular block number.
+export async function tryRuntimeUpgrade(block: number | 'latest', api: ApiPromise, networkUrl: string, projectRoot: string, shouldCompile: boolean = true) {
+
+    if (shouldCompile) {
+        compileBinaries('runtime', projectRoot);
+    } else {
+        console.log("Using pre-compiled state chain runtime for try-runtime upgrade.")
+    }
+
+    let blockParam;
+    if (block == 'latest') {
+        blockParam = 'live'
+    } else {
+        const blockHash = await api.rpc.chain.getBlockHash(block);
+        blockParam = `live --at ${blockHash}`;
+    }
+    execSync(`try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`);
+}

--- a/bouncer/shared/utils/compile_binaries.ts
+++ b/bouncer/shared/utils/compile_binaries.ts
@@ -1,12 +1,14 @@
 import { execSync } from 'child_process';
 
+
+// TODO: Maybe only compile with try-runtime if we need to.
 export async function compileBinaries(type: 'runtime' | 'all', projectRoot: string) {
   if (type === 'all') {
     console.log('Building all the binaries...');
-    execSync(`cd ${projectRoot} && cargo build --release`);
+    execSync(`cd ${projectRoot} && cargo build --release --features try-runtime`);
   } else {
     console.log('Building the new runtime...');
-    execSync(`cd ${projectRoot}/state-chain/runtime && cargo build --release`);
+    execSync(`cd ${projectRoot}/state-chain/runtime && cargo build --release --features try-runtime`);
   }
 
   console.log('Build complete.');

--- a/bouncer/shared/utils/compile_binaries.ts
+++ b/bouncer/shared/utils/compile_binaries.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 
-// Returns the expected next version of the runtime.
 export async function compileBinaries(type: 'runtime' | 'all', projectRoot: string) {
   if (type === 'all') {
     console.log('Building all the binaries...');

--- a/bouncer/shared/utils/compile_binaries.ts
+++ b/bouncer/shared/utils/compile_binaries.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
 
-
 // TODO: Maybe only compile with try-runtime if we need to.
 export async function compileBinaries(type: 'runtime' | 'all', projectRoot: string) {
   if (type === 'all') {
@@ -8,7 +7,9 @@ export async function compileBinaries(type: 'runtime' | 'all', projectRoot: stri
     execSync(`cd ${projectRoot} && cargo build --release --features try-runtime`);
   } else {
     console.log('Building the new runtime...');
-    execSync(`cd ${projectRoot}/state-chain/runtime && cargo build --release --features try-runtime`);
+    execSync(
+      `cd ${projectRoot}/state-chain/runtime && cargo build --release --features try-runtime`,
+    );
   }
 
   console.log('Build complete.');


### PR DESCRIPTION
# Pull Request

Part one of: PRO-956

- Will include in the upgrade tool next, this is useful as is, so thought I'd get this out now. Small PRs etc.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Provides an easy way to test migrations more thoroughly. This currently just uses `live` which might be quite slow for non-localnets, but we can optimise this later to use snapshots. Being able to start a localnet run bouncer and then test the migration for all the blocks super simply is already quite powerful.

Will also look at including something in CI.