### PR TITLE
fix: no dup chain tracking submissions for reorgs on unsafe stream

### DIFF
--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -197,6 +197,7 @@ where
 	PrewitnessFut: Future<Output = ()> + Send + 'static,
 {
 	let unfinalised_source = DotUnfinalisedSource::new(dot_client.clone())
+		.strictly_monotonic()
 		.then(|header| async move { header.data.iter().filter_map(filter_map_events).collect() })
 		.shared(scope);
 
@@ -225,7 +226,6 @@ where
 
 	// Pre-witnessing
 	unfinalised_source
-		.strictly_monotonic()
 		.chunk_by_vault(vaults.clone(), scope)
 		.deposit_addresses(scope, unfinalized_state_chain_stream, state_chain_client.clone())
 		.await

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -115,7 +115,7 @@ where
 		.map(|(asset, address)| (address, asset.into()))
 		.collect();
 
-	let eth_source = EthSource::new(eth_client.clone()).shared(scope);
+	let eth_source = EthSource::new(eth_client.clone()).strictly_monotonic().shared(scope);
 
 	eth_source
 		.clone()
@@ -127,8 +127,7 @@ where
 	let vaults = epoch_source.vaults().await;
 
 	// ===== Prewitnessing stream =====
-	let prewitness_source =
-		eth_source.clone().strictly_monotonic().chunk_by_vault(vaults.clone(), scope);
+	let prewitness_source = eth_source.clone().chunk_by_vault(vaults.clone(), scope);
 
 	let prewitness_source_deposit_addresses = prewitness_source
 		.clone()
@@ -187,7 +186,6 @@ where
 	// ===== Full witnessing stream =====
 
 	let eth_safe_vault_source = eth_source
-		.strictly_monotonic()
 		.lag_safety(SAFETY_MARGIN)
 		.logging("safe block produced")
 		.chunk_by_vault(vaults, scope);


### PR DESCRIPTION
Seen on berghain.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Because the chain tracking takes the *median* of all the fees witnessed and there's no reliable way to detect which unfinalised block will be finalised, we simply just ensure that one of them is submitted, and allow this median to provide us a close enough estimate when there is conflicting information e.g. on reorg'd blocks.
