### PR TITLE
fix: disable spec version check for try-runtime

### DIFF
--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -7,7 +7,7 @@ import { compileBinaries } from './utils/compile_binaries';
 
 function tryRuntimeCommand(projectRoot: string, blockParam: string, networkUrl: string) {
   execSync(
-    `try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --checks all ${blockParam} --uri ${networkUrl}`,
+    `try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks all ${blockParam} --uri ${networkUrl}`,
     { stdio: 'ignore' },
   );
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-991

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

When testing try-runtime we don't really care about the spec-version - and this is slightly better than auto-bumping the spec version, since the bump would require a re-compile.
