### PR TITLE
feat: upgrade_network command using prebuilt binaries

### DIFF
--- a/bouncer/commands/upgrade_network.ts
+++ b/bouncer/commands/upgrade_network.ts
@@ -17,7 +17,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-import { upgradeNetworkGit } from '../shared/upgrade_network_git';
+import { upgradeNetworkGit, upgradeNetworkPrebuilt } from '../shared/upgrade_network';
 import { runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
     })
   }, async (args) => {
     console.log("prebuilt subcommand with args: " + args.bins + " " + args.runtime);
-    console.log("Not implemented yet.");
+    await upgradeNetworkPrebuilt(args.bins, args.runtime, "1.0.0");
   }).demandCommand(1).help().argv;
 
   process.exit(0);
@@ -70,3 +70,9 @@ runWithTimeout(main(), 15 * 60 * 1000).catch((error) => {
   console.error(error);
   process.exit(-1);
 });
+
+
+// /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
+
+
+// ./commands/upgrade_network.ts prebuilt --bins /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug --runtime /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm

--- a/bouncer/commands/upgrade_network.ts
+++ b/bouncer/commands/upgrade_network.ts
@@ -57,10 +57,24 @@ async function main(): Promise<void> {
       type: 'string',
       demandOption: true,
       requiresArg: true,
+    }).option('localnet_init', {
+      describe: "path to the localnet init directory",
+      type: 'string',
+      demandOption: true,
+      requiresArg: true,
+    }).option('nodes', {
+      describe: "The number of nodes running on your localnet. Defaults to 1.",
+      type: 'number',
+      default: 1,
+    }).option('oldVersion', {
+      describe: "The version of the network you wish to upgrade *from*.",
+      type: 'string',
+      demandOption: true,
+      requiresArg: true,
     })
   }, async (args) => {
     console.log("prebuilt subcommand with args: " + args.bins + " " + args.runtime);
-    await upgradeNetworkPrebuilt(args.bins, args.runtime, "1.0.0");
+    await upgradeNetworkPrebuilt(args.bins, args.runtime, args.localnet_init, args.oldVersion, args.nodes);
   }).demandCommand(1).help().argv;
 
   process.exit(0);

--- a/bouncer/commands/upgrade_network.ts
+++ b/bouncer/commands/upgrade_network.ts
@@ -6,13 +6,23 @@
 // PRE-REQUISITES:
 // - cargo workspaces must be installed - `cargo install cargo-workspaces`
 //
-// Optional args:
-// --git <git ref>: The git reference (commit, branch, tag) you wish to upgrade to.
-// --bump <patch/minor/major>: If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level.
+// Subcommands:
+// git: Upgrades a bouncer network from the commit currently running on localnet to the provided git reference (commit, branch, tag).
+// Args:
+// --ref <git ref>: The git reference (commit, branch, tag) you wish to upgrade to.
+// --bump <patch/minor/major>: If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level. Defaults to patch.
 // --nodes <1 or 3>: The number of nodes running on your localnet. Defaults to 1.
+// 
+// prebuilt: Upgrades a bouncer network from the commit currently running on localnet to the provided prebuilt binaries and runtime.
+// Args:
+// --bins <path to directory containing node and CFE binaries>.
+// --runtime <path to runtime wasm>.
+// --localnet_init <path to localnet init directory>.
+// --oldVersion <version of the network you wish to upgrade *from*>.
 //
 // For example: 
 // ./commands/upgrade_network.ts git --ref 0.10.1 --bump major --nodes 3
+// ./commands/upgrade_network.ts prebuilt --runtime ./target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.wasm --bins ./target/debug --localnet_init ./localnet/init --oldVersion 0.10.1 --nodes 3
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -84,9 +94,3 @@ runWithTimeout(main(), 15 * 60 * 1000).catch((error) => {
   console.error(error);
   process.exit(-1);
 });
-
-
-// /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
-
-
-// ./commands/upgrade_network.ts prebuilt --bins /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug --runtime /Users/kylezs/Documents/cf-repos/chainflip-backend/target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm

--- a/bouncer/commands/upgrade_network.ts
+++ b/bouncer/commands/upgrade_network.ts
@@ -12,7 +12,7 @@
 // --ref <git ref>: The git reference (commit, branch, tag) you wish to upgrade to.
 // --bump <patch/minor/major>: If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level. Defaults to patch.
 // --nodes <1 or 3>: The number of nodes running on your localnet. Defaults to 1.
-// 
+//
 // prebuilt: Upgrades a bouncer network from the commit currently running on localnet to the provided prebuilt binaries and runtime.
 // Args:
 // --bins <path to directory containing node and CFE binaries>.
@@ -20,7 +20,7 @@
 // --localnet_init <path to localnet init directory>.
 // --oldVersion <version of the network you wish to upgrade *from*>.
 //
-// For example: 
+// For example:
 // ./commands/upgrade_network.ts git --ref 0.10.1 --bump major --nodes 3
 // ./commands/upgrade_network.ts prebuilt --runtime ./target/debug/wbuild/state-chain-runtime/state_chain_runtime.compact.wasm --bins ./target/debug --localnet_init ./localnet/init --oldVersion 0.10.1 --nodes 3
 
@@ -31,61 +31,90 @@ import { upgradeNetworkGit, upgradeNetworkPrebuilt } from '../shared/upgrade_net
 import { runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-  await yargs(hideBin(process.argv)).command('git', "specify a git reference to test the new version you wish to upgrade to", (args) => {
-    console.log('git selected, parsing options');
+  await yargs(hideBin(process.argv))
+    .command(
+      'git',
+      'specify a git reference to test the new version you wish to upgrade to',
+      (args) => {
+        console.log('git selected, parsing options');
 
-    return args.option('ref', {
-      describe: "git reference to test the new version you wish to upgrade to",
-      type: 'string',
-      demandOption: true,
-      requiresArg: true,
-    }).option('bump', {
-      describe: "If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level.",
-      type: 'string',
-      default: 'patch',
-    }).option('nodes', {
-      describe: "The number of nodes running on your localnet. Defaults to 1.",
-      type: 'number',
-      default: 1,
-    })
-  }, async (argv) => {
-    console.log("git subcommand with args: " + argv.ref);
-    try {
-      await upgradeNetworkGit(argv.ref, argv.bump, argv.nodes);
-    } catch (error) {
-      console.error(`Error: ${error}`);
-    }
-  }).command('prebuilt', "specify paths to the prebuilt binaries and runtime you wish to upgrade to", (args) => {
-    console.log('prebuilt selected');
-    return args.option('bins', {
-      describe: "paths to the binaries and runtime you wish to upgrade to",
-      type: 'string',
-      demandOption: true,
-      requiresArg: true
-    }).option('runtime', {
-      describe: "paths to the binaries and runtime you wish to upgrade to",
-      type: 'string',
-      demandOption: true,
-      requiresArg: true,
-    }).option('localnet_init', {
-      describe: "path to the localnet init directory",
-      type: 'string',
-      demandOption: true,
-      requiresArg: true,
-    }).option('nodes', {
-      describe: "The number of nodes running on your localnet. Defaults to 1.",
-      type: 'number',
-      default: 1,
-    }).option('oldVersion', {
-      describe: "The version of the network you wish to upgrade *from*.",
-      type: 'string',
-      demandOption: true,
-      requiresArg: true,
-    })
-  }, async (args) => {
-    console.log("prebuilt subcommand with args: " + args.bins + " " + args.runtime);
-    await upgradeNetworkPrebuilt(args.bins, args.runtime, args.localnet_init, args.oldVersion, args.nodes);
-  }).demandCommand(1).help().argv;
+        return args
+          .option('ref', {
+            describe: 'git reference to test the new version you wish to upgrade to',
+            type: 'string',
+            demandOption: true,
+            requiresArg: true,
+          })
+          .option('bump', {
+            describe:
+              "If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level.",
+            type: 'string',
+            default: 'patch',
+          })
+          .option('nodes', {
+            describe: 'The number of nodes running on your localnet. Defaults to 1.',
+            type: 'number',
+            default: 1,
+          });
+      },
+      async (argv) => {
+        console.log('git subcommand with args: ' + argv.ref);
+        try {
+          await upgradeNetworkGit(argv.ref, argv.bump, argv.nodes);
+        } catch (error) {
+          console.error(`Error: ${error}`);
+        }
+      },
+    )
+    .command(
+      'prebuilt',
+      'specify paths to the prebuilt binaries and runtime you wish to upgrade to',
+      (args) => {
+        console.log('prebuilt selected');
+        return args
+          .option('bins', {
+            describe: 'paths to the binaries and runtime you wish to upgrade to',
+            type: 'string',
+            demandOption: true,
+            requiresArg: true,
+          })
+          .option('runtime', {
+            describe: 'paths to the binaries and runtime you wish to upgrade to',
+            type: 'string',
+            demandOption: true,
+            requiresArg: true,
+          })
+          .option('localnet_init', {
+            describe: 'path to the localnet init directory',
+            type: 'string',
+            demandOption: true,
+            requiresArg: true,
+          })
+          .option('nodes', {
+            describe: 'The number of nodes running on your localnet. Defaults to 1.',
+            type: 'number',
+            default: 1,
+          })
+          .option('oldVersion', {
+            describe: 'The version of the network you wish to upgrade *from*.',
+            type: 'string',
+            demandOption: true,
+            requiresArg: true,
+          });
+      },
+      async (args) => {
+        console.log('prebuilt subcommand with args: ' + args.bins + ' ' + args.runtime);
+        await upgradeNetworkPrebuilt(
+          args.bins,
+          args.runtime,
+          args.localnet_init,
+          args.oldVersion,
+          args.nodes,
+        );
+      },
+    )
+    .demandCommand(1)
+    .help().argv;
 
   process.exit(0);
 }

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -37,6 +37,12 @@ export async function submitRuntimeUpgradeWithRestrictions(
   console.log('Runtime upgrade completed.');
 }
 
+export async function submitRuntimeUpgradeWasmPath(
+  wasmPath: string,
+) {
+  await submitRuntimeUpgradeWithRestrictions(wasmPath);
+}
+
 // Restrictions not provided.
 export async function submitRuntimeUpgrade(projectRoot: string) {
   await submitRuntimeUpgradeWithRestrictions(

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -37,9 +37,7 @@ export async function submitRuntimeUpgradeWithRestrictions(
   console.log('Runtime upgrade completed.');
 }
 
-export async function submitRuntimeUpgradeWasmPath(
-  wasmPath: string,
-) {
+export async function submitRuntimeUpgradeWasmPath(wasmPath: string) {
   await submitRuntimeUpgradeWithRestrictions(wasmPath);
 }
 

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -49,7 +49,6 @@ async function incompatibleUpgradeNoBuild(
   runtimePath: string,
   numberOfNodes: 1 | 3,
 ) {
-
   let selectedNodes;
   if (numberOfNodes === 1) {
     selectedNodes = ['bashful'];
@@ -90,7 +89,12 @@ async function incompatibleUpgrade(
 
   await compileBinaries('all', nextVersionWorkspacePath);
 
-  await incompatibleUpgradeNoBuild(localnetInitPath, `${nextVersionWorkspacePath}/target/release`, `${nextVersionWorkspacePath}/target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm`, numberOfNodes);
+  await incompatibleUpgradeNoBuild(
+    localnetInitPath,
+    `${nextVersionWorkspacePath}/target/release`,
+    `${nextVersionWorkspacePath}/target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm`,
+    numberOfNodes,
+  );
 }
 
 // Upgrades a bouncer network from the commit currently running on localnet to the provided git reference (commit, branch, tag).
@@ -101,7 +105,6 @@ export async function upgradeNetworkGit(
   bumpByIfEqual: SemVerLevel = 'patch',
   numberOfNodes: 1 | 3 = 1,
 ) {
-
   console.log('Upgrading network to git ref: ' + toGitRef);
 
   const currentVersionWorkspacePath = path.dirname(process.cwd());
@@ -147,7 +150,11 @@ export async function upgradeNetworkGit(
     console.log('Upgrade complete.');
   } else if (!isCompatible) {
     console.log('The versions are incompatible.');
-    await incompatibleUpgrade(`${currentVersionWorkspacePath}/localnet/init`, nextVersionWorkspacePath, numberOfNodes);
+    await incompatibleUpgrade(
+      `${currentVersionWorkspacePath}/localnet/init`,
+      nextVersionWorkspacePath,
+      numberOfNodes,
+    );
   }
 
   console.log('Cleaning up...');
@@ -168,20 +175,18 @@ export async function upgradeNetworkPrebuilt(
 
   numberOfNodes: 1 | 3 = 1,
 ) {
-
   const versionRegex = /\d+\.\d+\.\d+/;
 
-  let cfeBinaryVersion = execSync(`${binariesPath}/chainflip-engine --version`).toString();
+  const cfeBinaryVersion = execSync(`${binariesPath}/chainflip-engine --version`).toString();
 
   const cfeVersion = cfeBinaryVersion.match(versionRegex)[0];
   console.log("CFE version we're upgrading to: " + cfeVersion);
 
+  const nodeBinaryVersion = execSync(`${binariesPath}/chainflip-node --version`).toString();
+  const nodeVersion = nodeBinaryVersion.match(versionRegex)[0];
+  console.log("Node version we're upgrading to: " + nodeVersion);
 
-  let nodeBinaryVersion = execSync(`${binariesPath}/chainflip-node --version`).toString();
-  const node_version = nodeBinaryVersion.match(versionRegex)[0];
-  console.log("Node version we're upgrading to: " + node_version);
-
-  if (cfeVersion !== node_version) {
+  if (cfeVersion !== nodeVersion) {
     throw new Error(
       "The CFE version and the node version don't match. Ensure you selected the correct binaries.",
     );

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -141,11 +141,8 @@ export async function upgradeNetworkGit(
   const isCompatible = isCompatibleWith(fromTomlVersion, newToTomlVersion);
   console.log('Is compatible: ' + isCompatible);
 
-  // For some reason shit isn't working here. Keeps thinking it's compatible or something.
   if (isCompatible) {
-    // The CFE could be upgraded too. But an incompatible CFE upgrade would mean it's... incompatible, so covered in the other path.
     console.log('The versions are compatible.');
-
     await simpleRuntimeUpgrade(nextVersionWorkspacePath);
     console.log('Upgrade complete.');
   } else if (!isCompatible) {
@@ -162,7 +159,6 @@ export async function upgradeNetworkGit(
   console.log('Done.');
 }
 
-// How to get the old version? Could use the same method --version, or query the chain?
 export async function upgradeNetworkPrebuilt(
   // Directory where the node and CFE binaries of the new version are located
   binariesPath: string,

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -43,7 +43,7 @@ function createGitWorkspaceAt(nextVersionWorkspacePath: string, toGitRef: string
   }
 }
 
-async function incompatibleUpgradeNoBuild(currentVersionWorkspacePath: string,
+async function incompatibleUpgradeNoBuild(localnetInitPath: string,
   nextVersionWorkspacePath: string,
   numberOfNodes: 1 | 3,
 ) {
@@ -63,7 +63,7 @@ async function incompatibleUpgradeNoBuild(currentVersionWorkspacePath: string,
   execSync(
     `LOG_SUFFIX="-upgrade" NODE_COUNT=${nodeCount} SELECTED_NODES="${selectedNodes.join(
       ' ',
-    )}" LOCALNET_INIT_DIR=${currentVersionWorkspacePath}/localnet/init BINARY_ROOT_PATH=${nextVersionWorkspacePath}/target/release ${currentVersionWorkspacePath}/localnet/init/scripts/start-all-engines.sh`,
+    )}" LOCALNET_INIT_DIR=${localnetInitPath} BINARY_ROOT_PATH=${nextVersionWorkspacePath}/target/release ${localnetInitPath}/scripts/start-all-engines.sh`,
   );
 
   // let the engines do what they gotta do
@@ -80,7 +80,7 @@ async function incompatibleUpgradeNoBuild(currentVersionWorkspacePath: string,
 
 async function incompatibleUpgrade(
   // could we pass localnet/init instead of this.
-  currentVersionWorkspacePath: string,
+  localnetInitPath: string,
   nextVersionWorkspacePath: string,
   numberOfNodes: 1 | 3,
 ) {
@@ -88,7 +88,7 @@ async function incompatibleUpgrade(
 
   await compileBinaries('all', nextVersionWorkspacePath);
 
-  await incompatibleUpgradeNoBuild(currentVersionWorkspacePath, nextVersionWorkspacePath, numberOfNodes);
+  await incompatibleUpgradeNoBuild(localnetInitPath, nextVersionWorkspacePath, numberOfNodes);
 }
 
 // Upgrades a bouncer network from the commit currently running on localnet to the provided git reference (commit, branch, tag).
@@ -145,7 +145,7 @@ export async function upgradeNetworkGit(
     console.log('Upgrade complete.');
   } else if (!isCompatible) {
     console.log('The versions are incompatible.');
-    await incompatibleUpgrade(currentVersionWorkspacePath, nextVersionWorkspacePath, numberOfNodes);
+    await incompatibleUpgrade(`${currentVersionWorkspacePath}/localnet/init`, nextVersionWorkspacePath, numberOfNodes);
   }
 
   console.log('Cleaning up...');

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -85,7 +85,7 @@ async function incompatibleUpgrade(
 // Upgrades a bouncer network from the commit currently running on localnet to the provided git reference (commit, branch, tag).
 // If the version of the commit we're upgrading to is the same as the version of the commit we're upgrading from, we bump the version by the specified level.
 // Only the incompatible upgrade requires the number of nodes.
-export async function upgradeNetwork(
+export async function upgradeNetworkGit(
   toGitRef: string,
   bumpByIfEqual: SemVerLevel = 'patch',
   numberOfNodes: 1 | 3 = 1,

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -90,6 +90,9 @@ export async function upgradeNetworkGit(
   bumpByIfEqual: SemVerLevel = 'patch',
   numberOfNodes: 1 | 3 = 1,
 ) {
+
+  console.log('Upgrading network to git ref: ' + toGitRef);
+
   const currentVersionWorkspacePath = path.dirname(process.cwd());
 
   const fromTomlVersion = await readPackageTomlVersion(currentVersionWorkspacePath);


### PR DESCRIPTION
# Pull Request

Part of: PRO-973

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Allows us to do an upgrade from prebuilt binaries, rather than having to use the git method (which involves locally building). On CI, and in particular on a nighly upgrade job, we already have the binaries on main built, so we can use them. Can use this locally too of course.