### PR TITLE
feat: try runtime in upgrade tool

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,7 +14,7 @@ cf-test-cfe = "test --lib --package chainflip-engine --package multisig"
 cf-clippy = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings"
 cf-clippy-ci = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings"
 
-cf-build = "build --features runtime-benchmarks"
+cf-build = "build --features runtime-benchmarks,try-runtime"
 cf-build-release = "build --release"
 cf-build-production = "build --profile=production"
 # Check for feature inconsistencies.

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -14,15 +14,23 @@
 // Optional args:
 // --last-n <number>: If block is lastN, this is the number of blocks to run the migration on. Default is 50.
 // --compile: If set, it will compile the runtime to do the upgrade. If false it will use the pre-compiled runtime. Defaults to false.
+// --runtimePath: Path to the runtime wasm file. Defaults to ./target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
 
 import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { tryRuntimeUpgrade } from '../shared/try_runtime_upgrade';
+import { tryRuntimeUpgrade, tryRuntimeUpgradeWithCompileRuntime } from '../shared/try_runtime_upgrade';
 import { getChainflipApi, runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-  const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false).argv;
+  const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false)
+    .option('runtime', {
+      describe: 'path to the runtime wasm file. Required when compile is not set.',
+      type: 'string',
+      demandOption: false,
+      requiresArg: true,
+    })
+    .argv;
 
   const block = argv.block;
 
@@ -38,14 +46,27 @@ async function main(): Promise<void> {
 
   const lastN = argv.lastN ?? 100;
 
-  await tryRuntimeUpgrade(
-    block,
-    chainflipApi,
-    endpoint,
-    path.dirname(process.cwd()),
-    argv.compile,
-    lastN,
-  );
+  if (argv.compile) {
+    console.log("Try runtime after compiling.");
+    await tryRuntimeUpgradeWithCompileRuntime(
+      block,
+      chainflipApi,
+      endpoint,
+      path.dirname(process.cwd()),
+      lastN,
+    );
+  } else {
+    console.log("Try runtime using runtime at " + argv.runtime);
+    await tryRuntimeUpgrade(
+      block,
+      chainflipApi,
+      endpoint,
+      argv.runtime,
+      lastN,
+    );
+  }
+
+
 
   process.exit(0);
 }

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -19,18 +19,22 @@
 import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { tryRuntimeUpgrade, tryRuntimeUpgradeWithCompileRuntime } from '../shared/try_runtime_upgrade';
+import {
+  tryRuntimeUpgrade,
+  tryRuntimeUpgradeWithCompileRuntime,
+} from '../shared/try_runtime_upgrade';
 import { getChainflipApi, runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-  const argv = yargs(hideBin(process.argv)).boolean('compile').default('compile', false)
+  const argv = yargs(hideBin(process.argv))
+    .boolean('compile')
+    .default('compile', false)
     .option('runtime', {
       describe: 'path to the runtime wasm file. Required when compile is not set.',
       type: 'string',
       demandOption: false,
       requiresArg: true,
-    })
-    .argv;
+    }).argv;
 
   const block = argv.block;
 
@@ -47,7 +51,7 @@ async function main(): Promise<void> {
   const lastN = argv.lastN ?? 100;
 
   if (argv.compile) {
-    console.log("Try runtime after compiling.");
+    console.log('Try runtime after compiling.');
     await tryRuntimeUpgradeWithCompileRuntime(
       block,
       chainflipApi,
@@ -56,17 +60,9 @@ async function main(): Promise<void> {
       lastN,
     );
   } else {
-    console.log("Try runtime using runtime at " + argv.runtime);
-    await tryRuntimeUpgrade(
-      block,
-      chainflipApi,
-      endpoint,
-      argv.runtime,
-      lastN,
-    );
+    console.log('Try runtime using runtime at ' + argv.runtime);
+    await tryRuntimeUpgrade(block, chainflipApi, endpoint, argv.runtime, lastN);
   }
-
-
 
   process.exit(0);
 }

--- a/bouncer/shared/simple_runtime_upgrade.ts
+++ b/bouncer/shared/simple_runtime_upgrade.ts
@@ -3,12 +3,12 @@ import { bumpSpecVersionAgainstNetwork, getCurrentSpecVersion } from './utils/bu
 import { compileBinaries } from './utils/compile_binaries';
 
 // Do a runtime upgrade using the code in the projectRoot directory.
-export async function simpleRuntimeUpgrade(projectRoot: string): Promise<void> {
+export async function simpleRuntimeUpgrade(projectRoot: string, tryRuntime = false): Promise<void> {
   const nextSpecVersion = await bumpSpecVersionAgainstNetwork(projectRoot);
 
   await compileBinaries('runtime', projectRoot);
 
-  await submitRuntimeUpgrade(projectRoot);
+  await submitRuntimeUpgrade(projectRoot, tryRuntime);
 
   const newSpecVersion = await getCurrentSpecVersion();
   console.log('New spec_version: ' + newSpecVersion);
@@ -16,9 +16,9 @@ export async function simpleRuntimeUpgrade(projectRoot: string): Promise<void> {
   if (newSpecVersion !== nextSpecVersion) {
     console.error(
       'After submitting the runtime upgrade, the new spec_version is not what we expected. Expected: ' +
-        nextSpecVersion +
-        ' Got: ' +
-        newSpecVersion,
+      nextSpecVersion +
+      ' Got: ' +
+      newSpecVersion,
     );
   }
 

--- a/bouncer/shared/simple_runtime_upgrade.ts
+++ b/bouncer/shared/simple_runtime_upgrade.ts
@@ -16,9 +16,9 @@ export async function simpleRuntimeUpgrade(projectRoot: string, tryRuntime = fal
   if (newSpecVersion !== nextSpecVersion) {
     console.error(
       'After submitting the runtime upgrade, the new spec_version is not what we expected. Expected: ' +
-      nextSpecVersion +
-      ' Got: ' +
-      newSpecVersion,
+        nextSpecVersion +
+        ' Got: ' +
+        newSpecVersion,
     );
   }
 

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -24,7 +24,7 @@ export async function submitRuntimeUpgradeWithRestrictions(
 
   if (tryRuntime) {
     console.log('Running try-runtime before submitting the runtime upgrade.');
-    await tryRuntimeUpgrade("last-n", chainflip, networkUrl, wasmPath);
+    await tryRuntimeUpgrade('last-n', chainflip, networkUrl, wasmPath);
   }
 
   let versionPercentRestriction;
@@ -39,7 +39,7 @@ export async function submitRuntimeUpgradeWithRestrictions(
     chainflip.tx.governance.chainflipRuntimeUpgrade(versionPercentRestriction, runtimeWasm),
   );
 
-  console.log("Submitted runtime upgrade. Waiting for the runtime upgrade to complete.");
+  console.log('Submitted runtime upgrade. Waiting for the runtime upgrade to complete.');
 
   // TODO: Check if there were any errors in the submission, like `UpgradeConditionsNotMet` and `NotEnoughAuthoritiesCfesAtTargetVersion`.
   // and exit with error.

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -2,6 +2,7 @@ import { compactAddLength } from '@polkadot/util';
 import { promises as fs } from 'fs';
 import { submitGovernanceExtrinsic } from './cf_governance';
 import { getChainflipApi, observeEvent } from '../shared/utils';
+import { tryRuntimeUpgrade } from './try_runtime_upgrade';
 
 async function readRuntimeWasmFromFile(filePath: string): Promise<Uint8Array> {
   return compactAddLength(new Uint8Array(await fs.readFile(filePath)));
@@ -12,11 +13,19 @@ export async function submitRuntimeUpgradeWithRestrictions(
   wasmPath: string,
   semverRestriction?: Record<string, number>,
   percentNodesUpgraded = 0,
+  // default to false, because try-runtime feature is not always available.
+  tryRuntime = false,
 ) {
   const runtimeWasm = await readRuntimeWasmFromFile(wasmPath);
 
-  console.log('Submitting runtime upgrade.');
   const chainflip = await getChainflipApi();
+
+  const networkUrl = process.env.CF_NODE_ENDPOINT ?? 'ws://localhost:9944';
+
+  if (tryRuntime) {
+    console.log('Running try-runtime before submitting the runtime upgrade.');
+    await tryRuntimeUpgrade("last-n", chainflip, networkUrl, wasmPath);
+  }
 
   let versionPercentRestriction;
   if (semverRestriction && percentNodesUpgraded) {
@@ -25,9 +34,12 @@ export async function submitRuntimeUpgradeWithRestrictions(
     versionPercentRestriction = undefined;
   }
 
+  console.log('Submitting runtime upgrade.');
   await submitGovernanceExtrinsic(
     chainflip.tx.governance.chainflipRuntimeUpgrade(versionPercentRestriction, runtimeWasm),
   );
+
+  console.log("Submitted runtime upgrade. Waiting for the runtime upgrade to complete.");
 
   // TODO: Check if there were any errors in the submission, like `UpgradeConditionsNotMet` and `NotEnoughAuthoritiesCfesAtTargetVersion`.
   // and exit with error.
@@ -42,8 +54,11 @@ export async function submitRuntimeUpgradeWasmPath(wasmPath: string) {
 }
 
 // Restrictions not provided.
-export async function submitRuntimeUpgrade(projectRoot: string) {
+export async function submitRuntimeUpgrade(projectRoot: string, tryRuntime = false) {
   await submitRuntimeUpgradeWithRestrictions(
     `${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm`,
+    undefined,
+    0,
+    tryRuntime,
   );
 }

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -76,8 +76,6 @@ export async function tryRuntimeUpgrade(
   console.log('try-runtime upgrade successful.');
 }
 
-
-
 export async function tryRuntimeUpgradeWithCompileRuntime(
   block: number | 'latest' | 'all' | 'last-n',
   api: ApiPromise,
@@ -86,5 +84,11 @@ export async function tryRuntimeUpgradeWithCompileRuntime(
   lastN = 50,
 ) {
   compileBinaries('runtime', projectRoot);
-  tryRuntimeUpgrade(block, api, networkUrl, `${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm`, lastN);
+  tryRuntimeUpgrade(
+    block,
+    api,
+    networkUrl,
+    `${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm`,
+    lastN,
+  );
 }

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -5,9 +5,9 @@ import { ApiPromise } from '@polkadot/api';
 import { execSync } from 'child_process';
 import { compileBinaries } from './utils/compile_binaries';
 
-function tryRuntimeCommand(projectRoot: string, blockParam: string, networkUrl: string) {
+function tryRuntimeCommand(runtimePath: string, blockParam: string, networkUrl: string) {
   execSync(
-    `try-runtime --runtime ${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm on-runtime-upgrade --disable-spec-version-check --checks all ${blockParam} --uri ${networkUrl}`,
+    `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --checks all ${blockParam} --uri ${networkUrl}`,
     { stdio: 'ignore' },
   );
 }
@@ -21,16 +21,9 @@ export async function tryRuntimeUpgrade(
   block: number | 'latest' | 'all' | 'last-n',
   api: ApiPromise,
   networkUrl: string,
-  projectRoot: string,
-  shouldCompile = true,
+  runtimePath: string,
   lastN = 50,
 ) {
-  if (shouldCompile) {
-    compileBinaries('runtime', projectRoot);
-  } else {
-    console.log('Using pre-compiled state chain runtime for try-runtime upgrade.');
-  }
-
   if (block === 'all') {
     const latestBlock = await api.rpc.chain.getBlockHash();
 
@@ -42,7 +35,7 @@ export async function tryRuntimeUpgrade(
       blockHash = await api.rpc.chain.getBlockHash(blockNumber);
 
       try {
-        tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
+        tryRuntimeCommand(runtimePath, `live --at ${blockHash}`, networkUrl);
         console.log(`try-runtime success for block ${blockNumber}, block hash: ${blockHash}`);
       } catch (e) {
         console.error(`try-runtime failed for block ${blockNumber}, block hash: ${blockHash}`);
@@ -61,7 +54,7 @@ export async function tryRuntimeUpgrade(
 
     while (blocksProcessed < lastN) {
       try {
-        tryRuntimeCommand(projectRoot, `live --at ${nextHash}`, networkUrl);
+        tryRuntimeCommand(runtimePath, `live --at ${nextHash}`, networkUrl);
         console.log(`try-runtime success for block hash: ${nextHash}`);
       } catch (e) {
         console.error(`try-runtime failed for block hash: ${nextHash}`);
@@ -74,11 +67,24 @@ export async function tryRuntimeUpgrade(
       blocksProcessed++;
     }
   } else if (block === 'latest') {
-    tryRuntimeCommand(projectRoot, 'live', networkUrl);
+    tryRuntimeCommand(runtimePath, 'live', networkUrl);
   } else {
     const blockHash = await api.rpc.chain.getBlockHash(block);
-    tryRuntimeCommand(projectRoot, `live --at ${blockHash}`, networkUrl);
+    tryRuntimeCommand(runtimePath, `live --at ${blockHash}`, networkUrl);
   }
 
   console.log('try-runtime upgrade successful.');
+}
+
+
+
+export async function tryRuntimeUpgradeWithCompileRuntime(
+  block: number | 'latest' | 'all' | 'last-n',
+  api: ApiPromise,
+  projectRoot: string,
+  networkUrl: string,
+  lastN = 50,
+) {
+  compileBinaries('runtime', projectRoot);
+  tryRuntimeUpgrade(block, api, networkUrl, `${projectRoot}/target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm`, lastN);
 }

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -68,11 +68,11 @@ async function incompatibleUpgradeNoBuild(
   );
 
   // let the engines do what they gotta do
-  sleep(7000);
+  await sleep(7000);
 
   console.log('Engines started');
 
-  await submitRuntimeUpgradeWithRestrictions(runtimePath);
+  await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);
 
   console.log(
     'Check that the old engine has now shut down, and that the new engine is now running.',
@@ -143,7 +143,7 @@ export async function upgradeNetworkGit(
 
   if (isCompatible) {
     console.log('The versions are compatible.');
-    await simpleRuntimeUpgrade(nextVersionWorkspacePath);
+    await simpleRuntimeUpgrade(nextVersionWorkspacePath, true);
     console.log('Upgrade complete.');
   } else if (!isCompatible) {
     console.log('The versions are incompatible.');
@@ -201,7 +201,7 @@ export async function upgradeNetworkPrebuilt(
     await incompatibleUpgradeNoBuild(localnetInitPath, binariesPath, runtimePath, numberOfNodes);
   } else {
     console.log('The versions are compatible.');
-    await submitRuntimeUpgradeWithRestrictions(runtimePath);
+    await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);
   }
 
   console.log('Upgrade complete.');


### PR DESCRIPTION
Review #4280 first - this targets that.

Would try it out locally.

# Pull Request

Closes: PRO-956

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Conveniently runs the `try-runtime` command as part of the network upgrade on the last 50 blocks from the time the script starts.

Next step - putting this in the CI 🚀 