### PR TITLE
fix: make restricted address storage optional

### DIFF
--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -147,7 +147,7 @@ pub mod pallet {
 	/// List of restricted addresses
 	#[pallet::storage]
 	pub type RestrictedAddresses<T: Config> =
-		StorageMap<_, Blake2_128Concat, EthereumAddress, (), ValueQuery>;
+		StorageMap<_, Blake2_128Concat, EthereumAddress, (), OptionQuery>;
 
 	/// Map that bookkeeps the restricted balances for each address
 	#[pallet::storage]


### PR DESCRIPTION
This is a very small fix but reduces the chance of future regressions. It also makes it possible to find a restricted address using polkaJS (otherwise they all default to `()` so it looks like the same whether the address is present or not). 
