### PR TITLE
refactor: remove generic from AssetPair types

### DIFF
--- a/state-chain/pallets/cf-pools/src/migrations/v1.rs
+++ b/state-chain/pallets/cf-pools/src/migrations/v1.rs
@@ -24,7 +24,7 @@ mod old {
 	#[cfg(feature = "try-runtime")]
 	#[frame_support::storage_alias]
 	pub type Pools<T: Config> =
-		StorageMap<Pallet<T>, Twox64Concat, CanonicalAssetPair<T>, Pool<T>, OptionQuery>;
+		StorageMap<Pallet<T>, Twox64Concat, CanonicalAssetPair, Pool<T>, OptionQuery>;
 }
 
 impl<T: Config> OnRuntimeUpgrade for Migration<T> {

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -420,7 +420,7 @@ fn pallet_limit_order_is_in_sync_with_pool() {
 	new_test_ext().execute_with(|| {
 		let fee = 500_000u32;
 		let tick = 100;
-		let asset_pair = AssetPair::<Test>::new(Asset::Eth, STABLE_ASSET).unwrap();
+		let asset_pair = AssetPair::new(Asset::Eth, STABLE_ASSET).unwrap();
 
 		// Create a new pool.
 		assert_ok!(LiquidityPools::new_pool(


### PR DESCRIPTION
Makes it easier to use the type in the lp api.