### PR TITLE
feat: add redeeming to LP API

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -3,10 +3,8 @@ use std::{str::FromStr, sync::Arc};
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use cf_chains::{
-	address::EncodedAddress,
-	dot::PolkadotAccountId,
-	evm::{to_evm_address, Address as EthereumAddress},
-	AnyChain, CcmChannelMetadata, ForeignChain,
+	address::EncodedAddress, dot::PolkadotAccountId, evm::to_evm_address, AnyChain,
+	CcmChannelMetadata, ForeignChain,
 };
 use cf_primitives::{AccountRole, Asset, BasisPoints, ChannelId};
 use futures::FutureExt;
@@ -30,6 +28,7 @@ pub mod primitives {
 		CcmChannelMetadata, CcmDepositMetadata,
 	};
 }
+pub use cf_chains::eth::Address as EthereumAddress;
 pub use chainflip_engine::state_chain_observer::client::{
 	base_rpc_api::{BaseRpcApi, RawRpcApi},
 	extrinsic_api::signed::{SignedExtrinsicApi, UntilFinalized},


### PR DESCRIPTION
# Pull Request

Closes: PRO-959

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

TODO: Add new command to the docs

- Didn't add this command to the bouncer test. Would be quite a bit of work to do the full redeem flow or reuse any of the fundRedem test code. Not sure if it's worth the time.

Sample usage, redeem all:
```sh
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "lp_request_redemption", "params": ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", null, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"]}' http://localhost:10589
```

