### PR TITLE
fix: ignore extra btc vouts

### DIFF
--- a/engine/src/witness/btc/btc_deposits.rs
+++ b/engine/src/witness/btc/btc_deposits.rs
@@ -80,11 +80,14 @@ fn deposit_witnesses(
 	let mut deposit_witnesses = Vec::new();
 	for tx in txs {
 		let tx_hash = tx.txid().as_raw_hash().to_byte_array();
+
+		let mut deposits_for_this_tx = vec![];
 		for (vout, tx_out) in (0..).zip(&tx.output) {
 			if tx_out.value > 0 {
 				let tx_script_pubkey_bytes = tx_out.script_pubkey.to_bytes();
 				if let Some(bitcoin_script) = script_addresses.get(&tx_script_pubkey_bytes) {
-					deposit_witnesses.push(DepositWitness {
+					// we have a deposit to our address
+					deposits_for_this_tx.push(DepositWitness {
 						deposit_address: bitcoin_script.clone(),
 						asset: btc::Asset::Btc,
 						amount: tx_out.value,
@@ -92,6 +95,17 @@ fn deposit_witnesses(
 					});
 				}
 			}
+		}
+
+		// We only take the largest output of a tx as a deposit witness. This is to avoid attackers
+		// spamming us with many small outputs in a tx. Inputs are more expensive than outputs -
+		// thus, the attacker could send many outputs (cheap for them) which results in us needing
+		// to sign many *inputs*, expensive for us. sort by descending by amount
+		deposits_for_this_tx.sort_by(|a: &DepositWitness<Bitcoin>, b: &DepositWitness<Bitcoin>| {
+			b.amount.cmp(&a.amount)
+		});
+		if let Some(deposit) = deposits_for_this_tx.get(0) {
+			deposit_witnesses.push(deposit.clone());
 		}
 	}
 	deposit_witnesses
@@ -177,20 +191,25 @@ mod tests {
 
 	#[test]
 	fn deposit_witnesses_several_same_tx() {
-		const UTXO_WITNESSED_1: u64 = 2324;
-		const UTXO_WITNESSED_2: u64 = 1234;
+		const LARGEST_UTXO_TO_DEPOSIT: u64 = 2324;
+		const UTXO_TO_DEPOSIT_2: u64 = 1234;
+		const UTXO_TO_DEPOSIT_3: u64 = 2000;
 
 		let btc_deposit_script: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
 
 		let txs = vec![
 			fake_transaction(vec![
 				TxOut {
-					value: UTXO_WITNESSED_1,
+					value: UTXO_TO_DEPOSIT_2,
 					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
 				},
 				TxOut { value: 12223, script_pubkey: ScriptBuf::from(vec![0, 32, 121, 9]) },
 				TxOut {
-					value: UTXO_WITNESSED_2,
+					value: LARGEST_UTXO_TO_DEPOSIT,
+					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
+				},
+				TxOut {
+					value: UTXO_TO_DEPOSIT_3,
 					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
 				},
 			]),
@@ -199,9 +218,8 @@ mod tests {
 
 		let deposit_witnesses =
 			deposit_witnesses(&txs, script_addresses(vec![fake_details(btc_deposit_script)]));
-		assert_eq!(deposit_witnesses.len(), 2);
-		assert_eq!(deposit_witnesses[0].amount, UTXO_WITNESSED_1);
-		assert_eq!(deposit_witnesses[1].amount, UTXO_WITNESSED_2);
+		assert_eq!(deposit_witnesses.len(), 1);
+		assert_eq!(deposit_witnesses[0].amount, LARGEST_UTXO_TO_DEPOSIT);
 	}
 
 	#[test]
@@ -212,13 +230,28 @@ mod tests {
 		const UTXO_WITNESSED_2: u64 = 1234;
 		let txs = vec![
 			fake_transaction(vec![
-				TxOut { value: 2324, script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()) },
+				TxOut {
+					value: UTXO_WITNESSED_1,
+					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
+				},
 				TxOut { value: 12223, script_pubkey: ScriptBuf::from(vec![0, 32, 121, 9]) },
+				TxOut {
+					// smaller value, so we will only take the largest one
+					value: UTXO_WITNESSED_1 - 1,
+					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
+				},
 			]),
-			fake_transaction(vec![TxOut {
-				value: 1234,
-				script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
-			}]),
+			fake_transaction(vec![
+				TxOut {
+					// smaller, so we only take the largest (different order to above)
+					value: UTXO_WITNESSED_2 - 10,
+					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
+				},
+				TxOut {
+					value: UTXO_WITNESSED_2,
+					script_pubkey: ScriptBuf::from(btc_deposit_script.bytes()),
+				},
+			]),
 		];
 
 		let deposit_witnesses =


### PR DESCRIPTION
# Pull Request

Closes: PRO-1007

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Ignores extra BTC vouts in a single transaction.
