### PR TITLE
fix: CLI redeem amount rounding error

### DIFF
--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -144,6 +144,20 @@ async fn run_cli() -> Result<()> {
 	.await
 }
 
+/// Turns the amount of FLIP into a RedemptionAmount in Flipperinos.
+fn flip_to_redemption_amount(amount: Option<f64>) -> RedemptionAmount {
+	// Using a set number of decimal places of accuracy to avoid floating point rounding errors
+	const DECIMAL_PLACES: u32 = 6;
+	match amount {
+		Some(amount_float) => {
+			let atomic_amount = ((amount_float * 10_f64.powi(DECIMAL_PLACES as i32)) as u128) *
+				10_u128.pow(18 - DECIMAL_PLACES);
+			RedemptionAmount::Exact(atomic_amount)
+		},
+		None => RedemptionAmount::Max,
+	}
+}
+
 async fn request_redemption(
 	api: StateChainApi,
 	amount: Option<f64>,
@@ -166,20 +180,15 @@ async fn request_redemption(
 	};
 
 	// Calculate the redemption amount
-	let amount = match amount {
-		Some(amount_float) => {
-			let atomic_amount = (amount_float * 10_f64.powi(18)) as u128;
-
+	let redeem_amount = flip_to_redemption_amount(amount);
+	match redeem_amount {
+		RedemptionAmount::Exact(amount_float) => {
 			println!(
-				"Submitting redemption with amount `{amount_float}` FLIP (`{atomic_amount}` Flipperinos) to ETH address `{redeem_address:?}`."
+				"Submitting redemption with amount `{}` FLIP (`{amount_float}` Flipperinos) to ETH address `{redeem_address:?}`.", amount.expect("Exact must be some")
 			);
-
-			RedemptionAmount::Exact(atomic_amount)
 		},
-		None => {
+		RedemptionAmount::Max => {
 			println!("Submitting redemption with MAX amount to ETH address `{redeem_address:?}`.");
-
-			RedemptionAmount::Max
 		},
 	};
 
@@ -189,7 +198,7 @@ async fn request_redemption(
 
 	let tx_hash = api
 		.operator_api()
-		.request_redemption(amount, redeem_address, executor_address)
+		.request_redemption(redeem_amount, redeem_address, executor_address)
 		.await?;
 
 	println!(
@@ -411,4 +420,23 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 	}
 
 	Ok(())
+}
+
+#[test]
+fn test_flip_to_redemption_amount() {
+	assert_eq!(flip_to_redemption_amount(None), RedemptionAmount::Max);
+	assert_eq!(flip_to_redemption_amount(Some(0.0)), RedemptionAmount::Exact(0));
+	assert_eq!(flip_to_redemption_amount(Some(-1000.0)), RedemptionAmount::Exact(0));
+	assert_eq!(
+		flip_to_redemption_amount(Some(199995.0)),
+		RedemptionAmount::Exact(199995000000000000000000)
+	);
+	assert_eq!(
+		flip_to_redemption_amount(Some(69420.123456)),
+		RedemptionAmount::Exact(69420123456000000000000)
+	);
+	assert_eq!(
+		flip_to_redemption_amount(Some(123456789.000001)),
+		RedemptionAmount::Exact(123456789000001000000000000)
+	);
 }

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -182,9 +182,9 @@ async fn request_redemption(
 	// Calculate the redemption amount
 	let redeem_amount = flip_to_redemption_amount(amount);
 	match redeem_amount {
-		RedemptionAmount::Exact(amount_float) => {
+		RedemptionAmount::Exact(atomic_amount) => {
 			println!(
-				"Submitting redemption with amount `{}` FLIP (`{amount_float}` Flipperinos) to ETH address `{redeem_address:?}`.", amount.expect("Exact must be some")
+				"Submitting redemption with amount `{}` FLIP (`{atomic_amount}` Flipperinos) to ETH address `{redeem_address:?}`.", amount.expect("Exact must be some")
 			);
 		},
 		RedemptionAmount::Max => {

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -11,8 +11,10 @@ use crate::settings::{
 	LiquidityProviderSubcommands,
 };
 use api::{
-	lp::LpApi, primitives::RedemptionAmount, queries::QueryApi, AccountId32, BrokerApi,
-	GovernanceApi, KeyPair, OperatorApi, StateChainApi, SwapDepositAddress,
+	lp::LpApi,
+	primitives::{RedemptionAmount, FLIP_DECIMALS},
+	queries::QueryApi,
+	AccountId32, BrokerApi, GovernanceApi, KeyPair, OperatorApi, StateChainApi, SwapDepositAddress,
 };
 use cf_chains::eth::Address as EthereumAddress;
 use chainflip_api as api;
@@ -151,7 +153,7 @@ fn flip_to_redemption_amount(amount: Option<f64>) -> RedemptionAmount {
 	match amount {
 		Some(amount_float) => {
 			let atomic_amount = ((amount_float * 10_f64.powi(MAX_DECIMAL_PLACES as i32)) as u128) *
-				10_u128.pow(18 - MAX_DECIMAL_PLACES);
+				10_u128.pow(FLIP_DECIMALS - MAX_DECIMAL_PLACES);
 			RedemptionAmount::Exact(atomic_amount)
 		},
 		None => RedemptionAmount::Max,

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -112,7 +112,7 @@ pub enum CliCommand {
 	)]
 	Redeem {
 		#[clap(
-			help = "Amount to redeem in FLIP (omit this option to redeem all available FLIP)",
+			help = "Amount to redeem in FLIP (omit this option to redeem all available FLIP). Only accepts up to 6 decimal places of precision.",
 			long = "exact"
 		)]
 		amount: Option<f64>,

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -112,7 +112,7 @@ pub enum CliCommand {
 	)]
 	Redeem {
 		#[clap(
-			help = "Amount to redeem in FLIP (omit this option to redeem all available FLIP). Only accepts up to 6 decimal places of precision.",
+			help = "Amount to redeem in FLIP (omit this option to redeem all available FLIP). Up to 6 decimal places, any more are rounded.",
 			long = "exact"
 		)]
 		amount: Option<f64>,

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -50,7 +50,7 @@ pub type ThresholdSignatureRequestId = u32;
 
 pub type PolkadotBlockNumber = u32;
 
-const FLIP_DECIMALS: u32 = 18;
+pub const FLIP_DECIMALS: u32 = 18;
 pub const FLIPPERINOS_PER_FLIP: FlipBalance = 10u128.pow(FLIP_DECIMALS);
 
 // Bitcoin default fee, in sats per bytes, to be used if current fee is not available via chain

--- a/utilities/src/with_std.rs
+++ b/utilities/src/with_std.rs
@@ -328,6 +328,7 @@ fn test_round_f64() {
 	assert_eq!(round_f64(1.23456789, 1), 1.2);
 	assert_eq!(round_f64(1.23456789, 2), 1.23);
 	assert_eq!(round_f64(1.23456789, 6), 1.234568);
+	assert_eq!(round_f64(1.22223333, 6), 1.222233);
 	assert_eq!(round_f64(1.23, 6), 1.23);
 }
 

--- a/utilities/src/with_std.rs
+++ b/utilities/src/with_std.rs
@@ -317,6 +317,20 @@ pub fn read_clean_and_decode_hex_str_file<V, T: FnOnce(&str) -> Result<V, anyhow
 		.with_context(|| format!("Failed to decode {} file at {}", context, file.display()))
 }
 
+pub fn round_f64(x: f64, decimals: u32) -> f64 {
+	let y = 10i32.pow(decimals) as f64;
+	(x * y).round() / y
+}
+
+#[test]
+fn test_round_f64() {
+	assert_eq!(round_f64(1.23456789, 0), 1.0);
+	assert_eq!(round_f64(1.23456789, 1), 1.2);
+	assert_eq!(round_f64(1.23456789, 2), 1.23);
+	assert_eq!(round_f64(1.23456789, 6), 1.234568);
+	assert_eq!(round_f64(1.23, 6), 1.23);
+}
+
 #[cfg(test)]
 mod tests_read_clean_and_decode_hex_str_file {
 	use crate::{assert_ok, testing::with_file};


### PR DESCRIPTION
# Pull Request

Closes: PRO-1003

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

limits the precision of the amount of flip the user can specify to 6 decimal places. But now we don't get bad rounding errors.
We can set the number of decimal places to whatever we want, I think it starts to get rounding errors if it's >11. Hard to test, so i just left it at 6, seems like plenty for now.

```sh
./target/debug/chainflip-cli redeem --exact 199995 0x835012efffe34fabf82f26a9712d3eff1b2d5145
Connecting to state chain node at: `ws://localhost:9944` and using private key located at: `/Users/jamieford/...`
Submitting redemption with amount `199995` FLIP (`199995000000000000000000` Flipperinos) to ETH address `0x835012efffe34fabf82f26a9712d3eff1b2d5145`.
```
