### PR TITLE
feat: Handle failed vault transfers

### DIFF
--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -27,8 +27,8 @@ use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::crypto::Pair;
 use state_chain_runtime::{
 	constants::common::*, opaque::SessionKeys, AccountId, BitcoinVault, Emissions, EthereumVault,
-	Flip, Funding, Governance, PolkadotVault, Reputation, Runtime, RuntimeOrigin, System,
-	Validator,
+	Flip, Funding, Governance, PolkadotVault, Reputation, Runtime, RuntimeCall, RuntimeOrigin,
+	System, Validator, Witnesser,
 };
 
 type NodeId = AccountId32;
@@ -68,3 +68,16 @@ pub enum ChainflipAccountState {
 }
 
 pub type AllVaults = <Runtime as pallet_cf_validator::Config>::VaultRotator;
+
+/// Helper function that dispatches a call that requires EnsureWitnessed origin.
+pub fn witness_call(call: RuntimeCall) {
+	let epoch = Validator::epoch_index();
+	let boxed_call = Box::new(call);
+	for node in Validator::current_authorities() {
+		assert_ok!(Witnesser::witness_at_epoch(
+			RuntimeOrigin::signed(node),
+			boxed_call.clone(),
+			epoch,
+		));
+	}
+}

--- a/state-chain/cf-integration-tests/src/network.rs
+++ b/state-chain/cf-integration-tests/src/network.rs
@@ -17,7 +17,7 @@ use sp_consensus_aura::SlotDuration;
 use sp_std::collections::btree_set::BTreeSet;
 use state_chain_runtime::{
 	AccountRoles, AllPalletsWithSystem, BitcoinInstance, PolkadotInstance, Runtime, RuntimeCall,
-	RuntimeEvent, RuntimeOrigin, Weight,
+	RuntimeEvent, RuntimeOrigin, Validator, Weight,
 };
 use std::{
 	cell::RefCell,

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -2,6 +2,7 @@
 use crate::{
 	genesis,
 	network::{setup_account_and_peer_mapping, Cli, Network},
+	witness_call,
 };
 use cf_amm::{
 	common::{price_at_tick, Price, Tick},
@@ -245,23 +246,15 @@ fn basic_pool_setup_provision_and_swap() {
 		).unwrap();
 
 		System::reset_events();
-
-		let current_epoch = Validator::current_epoch();
-		for node in Validator::current_authorities() {
-			assert_ok!(Witnesser::witness_at_epoch(
-				RuntimeOrigin::signed(node),
-				Box::new(RuntimeCall::EthereumIngressEgress(pallet_cf_ingress_egress::Call::process_deposits {
-					deposit_witnesses: vec![DepositWitness {
-						deposit_address,
-						asset: cf_primitives::chains::assets::eth::Asset::Eth,
-						amount: 50,
-						deposit_details: (),
-					}],
-					block_height: 0,
-				})),
-				current_epoch
-			));
-		}
+		witness_call(RuntimeCall::EthereumIngressEgress(pallet_cf_ingress_egress::Call::process_deposits {
+			deposit_witnesses: vec![DepositWitness {
+				deposit_address,
+				asset: cf_primitives::chains::assets::eth::Asset::Eth,
+				amount: 50,
+				deposit_details: (),
+			}],
+			block_height: 0,
+		}));
 
 		let swap_id = assert_events_match!(Runtime, RuntimeEvent::Swapping(pallet_cf_swapping::Event::SwapScheduled {
 			swap_id,
@@ -350,24 +343,17 @@ fn can_process_ccm_via_swap_deposit_address() {
 				pallet_cf_ingress_egress::ChannelIdCounter::<Runtime, EthereumInstance>::get(),
 			)
 			.unwrap();
-		let current_epoch = Validator::current_epoch();
-		for node in Validator::current_authorities() {
-			assert_ok!(Witnesser::witness_at_epoch(
-				RuntimeOrigin::signed(node),
-				Box::new(RuntimeCall::EthereumIngressEgress(
-					pallet_cf_ingress_egress::Call::process_deposits {
-						deposit_witnesses: vec![DepositWitness {
-							deposit_address,
-							asset: cf_primitives::chains::assets::eth::Asset::Flip,
-							amount: 1_000,
-							deposit_details: (),
-						}],
-						block_height: 0,
-					}
-				)),
-				current_epoch
-			));
-		}
+		witness_call(RuntimeCall::EthereumIngressEgress(
+			pallet_cf_ingress_egress::Call::process_deposits {
+				deposit_witnesses: vec![DepositWitness {
+					deposit_address,
+					asset: cf_primitives::chains::assets::eth::Asset::Flip,
+					amount: 1_000,
+					deposit_details: (),
+				}],
+				block_height: 0,
+			}
+		));
 		let (principal_swap_id, gas_swap_id) = assert_events_match!(Runtime, RuntimeEvent::Swapping(pallet_cf_swapping::Event::CcmDepositReceived {
 			ccm_id,
 			principal_swap_id: Some(principal_swap_id),
@@ -447,7 +433,7 @@ fn can_process_ccm_via_direct_deposit() {
 			},
 		};
 
-		let ccm_call = Box::new(RuntimeCall::Swapping(pallet_cf_swapping::Call::ccm_deposit{
+		witness_call(RuntimeCall::Swapping(pallet_cf_swapping::Call::ccm_deposit{
 			source_asset: Asset::Flip,
 			deposit_amount,
 			destination_asset: Asset::Usdc,
@@ -455,14 +441,7 @@ fn can_process_ccm_via_direct_deposit() {
 			deposit_metadata,
 			tx_hash: Default::default(),
 		}));
-		let current_epoch = Validator::current_epoch();
-		for node in Validator::current_authorities() {
-			assert_ok!(Witnesser::witness_at_epoch(
-				RuntimeOrigin::signed(node),
-				ccm_call.clone(),
-				current_epoch
-			));
-		}
+
 		let (principal_swap_id, gas_swap_id) = assert_events_match!(Runtime, RuntimeEvent::Swapping(pallet_cf_swapping::Event::CcmDepositReceived {
 			ccm_id,
 			principal_swap_id: Some(principal_swap_id),
@@ -538,7 +517,7 @@ fn failed_swaps_are_rolled_back() {
 
 		let witness_swap_ingress =
 			|from: Asset, to: Asset, amount: AssetAmount, destination_address: EncodedAddress| {
-				let swap_call = Box::new(RuntimeCall::Swapping(
+				witness_call(RuntimeCall::Swapping(
 					pallet_cf_swapping::Call::schedule_swap_from_contract {
 						from,
 						to,
@@ -546,15 +525,7 @@ fn failed_swaps_are_rolled_back() {
 						destination_address,
 						tx_hash: Default::default(),
 					},
-				));
-				let current_epoch = Validator::current_epoch();
-				for node in Validator::current_authorities() {
-					assert_ok!(Witnesser::witness_at_epoch(
-						RuntimeOrigin::signed(node),
-						swap_call.clone(),
-						current_epoch
-					));
-				}
+				))
 			};
 
 		witness_swap_ingress(
@@ -667,7 +638,6 @@ fn failed_swaps_are_rolled_back() {
 #[test]
 fn ethereum_ccm_can_calculate_gas_limits() {
 	super::genesis::default().build().execute_with(|| {
-		let current_epoch = Validator::current_epoch();
 		let chain_state = ChainState::<Ethereum> {
 			block_height: 1,
 			tracked_data: EthereumTrackedData {
@@ -676,17 +646,11 @@ fn ethereum_ccm_can_calculate_gas_limits() {
 			},
 		};
 
-		for node in Validator::current_authorities() {
-			assert_ok!(Witnesser::witness_at_epoch(
-				RuntimeOrigin::signed(node),
-				Box::new(RuntimeCall::EthereumChainTracking(
-					pallet_cf_chain_tracking::Call::update_chain_state {
-						new_chain_state: chain_state.clone(),
-					}
-				)),
-				current_epoch
-			));
-		}
+		witness_call(RuntimeCall::EthereumChainTracking(
+			pallet_cf_chain_tracking::Call::update_chain_state {
+				new_chain_state: chain_state.clone(),
+			},
+		));
 		assert_eq!(EthereumChainTracking::chain_state(), Some(chain_state));
 
 		let make_ccm_call = |gas_budget: u128| {
@@ -725,17 +689,11 @@ fn ethereum_ccm_can_calculate_gas_limits() {
 			tracked_data: EthereumTrackedData { base_fee: 0u128, priority_fee: 0u128 },
 		};
 
-		for node in Validator::current_authorities() {
-			assert_ok!(Witnesser::witness_at_epoch(
-				RuntimeOrigin::signed(node),
-				Box::new(RuntimeCall::EthereumChainTracking(
-					pallet_cf_chain_tracking::Call::update_chain_state {
-						new_chain_state: chain_state.clone(),
-					}
-				)),
-				current_epoch
-			));
-		}
+		witness_call(RuntimeCall::EthereumChainTracking(
+			pallet_cf_chain_tracking::Call::update_chain_state {
+				new_chain_state: chain_state.clone(),
+			},
+		));
 
 		assert_eq!(
 			EthTransactionBuilder::calculate_gas_limit(&make_ccm_call(1_000_000_000u128)),
@@ -811,7 +769,7 @@ fn can_resign_failed_ccm() {
 				},
 			};
 
-			let ccm_call = Box::new(RuntimeCall::Swapping(pallet_cf_swapping::Call::ccm_deposit {
+			witness_call(RuntimeCall::Swapping(pallet_cf_swapping::Call::ccm_deposit {
 				source_asset: Asset::Flip,
 				deposit_amount: 10_000,
 				destination_asset: Asset::Usdc,
@@ -819,16 +777,9 @@ fn can_resign_failed_ccm() {
 				deposit_metadata,
 				tx_hash: Default::default(),
 			}));
-			let starting_epoch = Validator::current_epoch();
-			for node in Validator::current_authorities() {
-				assert_ok!(Witnesser::witness_at_epoch(
-					RuntimeOrigin::signed(node),
-					ccm_call.clone(),
-					starting_epoch
-				));
-			}
 
 			// Process the swap -> egress -> threshold sign -> broadcast
+			let starting_epoch = Validator::current_epoch();
 			testnet.move_forward_blocks(3);
 			let broadcast_id = BroadcastIdCounter::<Runtime, Instance1>::get();
 			let mut broadcast_attempt_id = BroadcastAttemptId { broadcast_id, attempt_count: 0 };
@@ -929,20 +880,13 @@ fn can_handle_failed_vault_transfer() {
 			let destination_address = [0x00; 20].into();
 			let broadcast_id = 2;
 
-			let call = Box::new(RuntimeCall::EthereumIngressEgress(
+			witness_call(RuntimeCall::EthereumIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_transfer_failed {
 					asset,
 					amount,
 					destination_address,
 				},
 			));
-			for node in Validator::current_authorities() {
-				assert_ok!(Witnesser::witness_at_epoch(
-					RuntimeOrigin::signed(node),
-					call.clone(),
-					starting_epoch
-				));
-			}
 
 			System::assert_last_event(RuntimeEvent::EthereumIngressEgress(
 				pallet_cf_ingress_egress::Event::<Runtime, Instance1>::TransferFallbackRequested {

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -115,6 +115,13 @@ impl<E: ReplayProtectionProvider<Bitcoin>> ExecutexSwapAndCall<Bitcoin> for Bitc
 	}
 }
 
+// transfer_fallback is unsupported for Bitcoin.
+impl<E: ReplayProtectionProvider<Bitcoin>> TransferFallback<Bitcoin> for BitcoinApi<E> {
+	fn new_unsigned(_transfer_param: TransferAssetParams<Bitcoin>) -> Result<Self, DispatchError> {
+		Err(DispatchError::Other("Bitcoin's TransferFallback is not supported."))
+	}
+}
+
 impl<E> ApiCall<BitcoinCrypto> for BitcoinApi<E> {
 	fn threshold_signature_payload(&self) -> <BitcoinCrypto as ChainCrypto>::Payload {
 		match self {

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -116,6 +116,15 @@ where
 	}
 }
 
+impl<E> TransferFallback<Polkadot> for PolkadotApi<E>
+where
+	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
+{
+	fn new_unsigned(_transfer_param: TransferAssetParams<Polkadot>) -> Result<Self, DispatchError> {
+		Err(DispatchError::Other("TransferFallback is not supported for the Polkadot chain."))
+	}
+}
+
 macro_rules! map_over_api_variants {
 	( $self:expr, $var:pat_param, $var_method:expr $(,)* ) => {
 		match $self {

--- a/state-chain/chains/src/evm/api.rs
+++ b/state-chain/chains/src/evm/api.rs
@@ -11,6 +11,7 @@ pub mod execute_x_swap_and_call;
 pub mod set_agg_key_with_agg_key;
 pub mod set_comm_key_with_agg_key;
 pub mod set_gov_key_with_agg_key;
+pub mod transfer_fallback;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Default)]
 pub struct EvmReplayProtection {

--- a/state-chain/chains/src/evm/api/transfer_fallback.rs
+++ b/state-chain/chains/src/evm/api/transfer_fallback.rs
@@ -1,0 +1,105 @@
+use super::*;
+use codec::{Decode, Encode};
+use ethabi::Token;
+use frame_support::sp_runtime::RuntimeDebug;
+use scale_info::TypeInfo;
+use sp_std::{vec, vec::Vec};
+
+/// Struct containing info for the TransferFallback call in the Vault contract.
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, PartialEq, Eq)]
+pub struct TransferFallback {
+	/// The failed transfer that needs to be addressed.
+	transfer_param: EncodableTransferAssetParams,
+}
+
+impl TransferFallback {
+	pub(crate) fn new(transfer_param: EncodableTransferAssetParams) -> Self {
+		Self { transfer_param }
+	}
+}
+
+impl EvmCall for TransferFallback {
+	const FUNCTION_NAME: &'static str = "transferFallback";
+
+	fn function_params() -> Vec<(&'static str, ethabi::ParamType)> {
+		vec![("transferParams", EncodableTransferAssetParams::param_type())]
+	}
+
+	fn function_call_args(&self) -> Vec<Token> {
+		vec![self.transfer_param.clone().tokenize()]
+	}
+}
+
+#[cfg(test)]
+mod test_transfer_fallback {
+	use super::*;
+	use crate::{
+		eth::api::abi::load_abi,
+		evm::{
+			api::{ApiCall, EvmReplayProtection, EvmTransactionBuilder},
+			SchnorrVerificationComponents,
+		},
+	};
+	use ethabi::Address;
+
+	#[test]
+	fn test_payload() {
+		use crate::evm::tests::asymmetrise;
+		use ethabi::Token;
+		const FAKE_KEYMAN_ADDR: [u8; 20] = asymmetrise([0xcf; 20]);
+		const FAKE_VAULT_ADDR: [u8; 20] = asymmetrise([0xdf; 20]);
+		const FAKE_NONCE_TIMES_G_ADDR: [u8; 20] = asymmetrise([0x7f; 20]);
+		const FAKE_SIG: [u8; 32] = asymmetrise([0xe1; 32]);
+		const CHAIN_ID: u64 = 1337;
+		const NONCE: u64 = 54321;
+
+		let dummy_transfer_asset_param = EncodableTransferAssetParams {
+			asset: Address::from_slice(&[5; 20]),
+			to: Address::from_slice(&[7; 20]),
+			amount: 10,
+		};
+
+		let eth_vault = load_abi("IVault");
+
+		let function_reference = eth_vault.function("transferFallback").unwrap();
+
+		let function_runtime = EvmTransactionBuilder::new_unsigned(
+			EvmReplayProtection {
+				nonce: NONCE,
+				chain_id: CHAIN_ID,
+				key_manager_address: FAKE_KEYMAN_ADDR.into(),
+				contract_address: FAKE_VAULT_ADDR.into(),
+			},
+			super::TransferFallback::new(dummy_transfer_asset_param.clone()),
+		);
+
+		let expected_msg_hash = function_runtime.threshold_signature_payload();
+		let runtime_payload = function_runtime
+			.clone()
+			.signed(&SchnorrVerificationComponents {
+				s: FAKE_SIG,
+				k_times_g_address: FAKE_NONCE_TIMES_G_ADDR,
+			})
+			.chain_encoded();
+
+		// Ensure signing payload isn't modified by signature.
+		assert_eq!(function_runtime.threshold_signature_payload(), expected_msg_hash);
+
+		assert_eq!(
+			// Our encoding:
+			runtime_payload,
+			// "Canonical" encoding based on the abi definition above and using the ethabi crate:
+			function_reference
+				.encode_input(&[
+					// sigData: SigData(uint, uint, address)
+					Token::Tuple(vec![
+						Token::Uint(FAKE_SIG.into()),
+						Token::Uint(NONCE.into()),
+						Token::Address(FAKE_NONCE_TIMES_G_ADDR.into()),
+					]),
+					dummy_transfer_asset_param.tokenize(),
+				])
+				.unwrap()
+		);
+	}
+}

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -298,7 +298,6 @@ pub enum SetAggKeyWithAggKeyError {
 }
 
 /// Constructs the `SetAggKeyWithAggKey` api call.
-#[allow(clippy::result_unit_err)]
 pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 	fn new_unsigned(
 		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
@@ -342,7 +341,6 @@ pub enum AllBatchError {
 	Other,
 }
 
-#[allow(clippy::result_unit_err)]
 pub trait AllBatch<C: Chain>: ApiCall<C::ChainCrypto> {
 	fn new_unsigned(
 		fetch_params: Vec<FetchAssetParams<C>>,
@@ -350,7 +348,6 @@ pub trait AllBatch<C: Chain>: ApiCall<C::ChainCrypto> {
 	) -> Result<Self, AllBatchError>;
 }
 
-#[allow(clippy::result_unit_err)]
 pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
 	fn new_unsigned(
 		transfer_param: TransferAssetParams<C>,
@@ -359,6 +356,10 @@ pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
 		gas_budget: C::ChainAmount,
 		message: Vec<u8>,
 	) -> Result<Self, DispatchError>;
+}
+
+pub trait TransferFallback<C: Chain>: ApiCall<C::ChainCrypto> {
+	fn new_unsigned(transfer_param: TransferAssetParams<C>) -> Result<Self, DispatchError>;
 }
 
 pub trait FeeRefundCalculator<C: Chain> {

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -537,8 +537,8 @@ pub trait CustomApi {
 	#[method(name = "supported_assets")]
 	fn cf_supported_assets(&self) -> RpcResult<HashMap<ForeignChain, Vec<Asset>>>;
 
-	#[method(name = "failed_ccm")]
-	fn cf_failed_ccm_call(
+	#[method(name = "failed_call")]
+	fn cf_failed_call(
 		&self,
 		broadcast_id: BroadcastId,
 	) -> RpcResult<Option<<cf_chains::Ethereum as Chain>::Transaction>>;
@@ -1192,13 +1192,13 @@ where
 		Ok(chain_to_asset)
 	}
 
-	fn cf_failed_ccm_call(
+	fn cf_failed_call(
 		&self,
 		broadcast_id: BroadcastId,
 	) -> RpcResult<Option<<cf_chains::Ethereum as Chain>::Transaction>> {
 		self.client
 			.runtime_api()
-			.cf_failed_ccm_call(self.unwrap_or_best(None), broadcast_id)
+			.cf_failed_call(self.unwrap_or_best(None), broadcast_id)
 			.map_err(to_rpc_error)
 	}
 }

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -194,6 +194,10 @@ impl Broadcaster<MockEthereum> for MockBroadcast {
 		unimplemented!()
 	}
 
+	fn threshold_sign(_api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId) {
+		unimplemented!()
+	}
+
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(_broadcast_id: BroadcastId) {
 		unimplemented!()

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -123,6 +123,10 @@ impl Broadcaster<Polkadot> for MockPolkadotBroadcaster {
 		unimplemented!()
 	}
 
+	fn threshold_sign(_api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId) {
+		unimplemented!()
+	}
+
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(_broadcast_id: BroadcastId) {
 		unimplemented!()

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -177,6 +177,10 @@ impl Broadcaster<Ethereum> for MockBroadcaster {
 		unimplemented!()
 	}
 
+	fn threshold_sign(_api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId) {
+		unimplemented!()
+	}
+
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(_broadcast_id: BroadcastId) {
 		unimplemented!()

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -81,16 +81,14 @@ benchmarks_instance_pallet! {
 	}: { let _ = Pallet::<T, I>::finalise_ingress(origin, addresses); }
 
 	vault_transfer_failed {
+		let epoch = T::EpochInfo::epoch_index();
 		let origin = T::EnsureWitnessedAtCurrentEpoch::try_successful_origin().unwrap();
 		let asset: TargetChainAsset<T, I> = BenchmarkValue::benchmark_value();
 		let amount: TargetChainAmount<T, I> = BenchmarkValue::benchmark_value();
 		let destination_address: TargetChainAccount<T, I> = BenchmarkValue::benchmark_value();
 	}: { let _ = Pallet::<T, I>::vault_transfer_failed(origin, asset, amount, destination_address.clone()); }
 	verify {
-		assert_eq!(FailedVaultTransfers::<T, I>::get(),
-		vec![VaultTransfer {
-			asset, amount, destination_address,
-		}]);
+		assert_eq!(FailedForeignChainCalls::<T, I>::get(epoch).len(), 1);
 	}
 
 	ccm_broadcast_failed {
@@ -98,8 +96,8 @@ benchmarks_instance_pallet! {
 	verify {
 		let current_epoch = T::EpochInfo::epoch_index();
 		assert_eq!(
-			FailedCcms::<T, I>::get(current_epoch),
-			vec![FailedCcm {
+			FailedForeignChainCalls::<T, I>::get(current_epoch),
+			vec![FailedForeignChainCall {
 				broadcast_id:Default::default(),
 				original_epoch: current_epoch
 			}]);

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -85,18 +85,13 @@ impl<C: Chain> CrossChainMessage<C> {
 	}
 }
 
-#[derive(RuntimeDebug, Eq, PartialEq, Clone, Encode, Decode, TypeInfo)]
-pub struct VaultTransfer<C: Chain> {
-	asset: C::ChainAsset,
-	amount: C::ChainAmount,
-	destination_address: C::ChainAccount,
-}
-
 pub const PALLET_VERSION: StorageVersion = StorageVersion::new(2);
-/// Struct that contains information about a CCM transaction that has failed to broadcast.
-/// User can use information stored here to query for relevant information.
+
+/// Calls to the external chains that has failed to be broadcast/accepted by the target chain.
+/// User can use information stored here to query for relevant information to broadcast
+/// the call themselves.
 #[derive(Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-pub struct FailedCcm {
+pub struct FailedForeignChainCall {
 	/// Broadcast ID used in the broadcast pallet. Use it to query broadcast information,
 	/// such as the threshold signature, the API call etc.
 	pub broadcast_id: BroadcastId,
@@ -107,7 +102,7 @@ pub struct FailedCcm {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use cf_chains::ExecutexSwapAndCall;
+	use cf_chains::{ExecutexSwapAndCall, TransferFallback};
 	use cf_primitives::{BroadcastId, EpochIndex};
 	use core::marker::PhantomData;
 	use frame_support::{
@@ -272,7 +267,9 @@ pub mod pallet {
 		type CcmHandler: CcmHandler;
 
 		/// The type of the chain-native transaction.
-		type ChainApiCall: AllBatch<Self::TargetChain> + ExecutexSwapAndCall<Self::TargetChain>;
+		type ChainApiCall: AllBatch<Self::TargetChain>
+			+ ExecutexSwapAndCall<Self::TargetChain>
+			+ TransferFallback<Self::TargetChain>;
 
 		/// Get the latest block height of the target chain via Chain Tracking.
 		type ChainTracking: GetBlockHeight<Self::TargetChain>;
@@ -342,23 +339,15 @@ pub mod pallet {
 	pub type DepositChannelLifetime<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, TargetChainBlockNumber<T, I>, ValueQuery>;
 
-	/// Stores any failed transfers by the Vault contract.
-	/// Without dealing with the underlying reason for the failure, retrying is unlike to succeed.
-	/// Therefore these calls are stored here, until we can react to the reason for failure and
-	/// respond appropriately.
+	/// Stores information about Calls to external chains that have failed to be broadcasted.
+	/// These calls are signed and stored on-chain so that the user can broadcast the call
+	/// themselves. These messages will be re-threshold-signed once during the next epoch, and
+	/// removed from storage in the epoch after that.
+	/// Hashmap: last_signed_epoch -> Vec<FailedForeignChainCall>
 	#[pallet::storage]
-	pub type FailedVaultTransfers<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, Vec<VaultTransfer<T::TargetChain>>, ValueQuery>;
-
-	/// Stores information about CCM messages that have failed to be broadcasted.
-	/// User can broadcast the call themselves using the signature stored on the State chain.
-	/// The messages will be re-threshold-signed once during the next epoch, and removed
-	/// from storage in the epoch after that.
-	/// Hashmap: last_signed_epoch -> Vec<FailedCcm>
-	#[pallet::storage]
-	#[pallet::getter(fn failed_ccms)]
-	pub type FailedCcms<T: Config<I>, I: 'static = ()> =
-		StorageMap<_, Twox64Concat, EpochIndex, Vec<FailedCcm>, ValueQuery>;
+	#[pallet::getter(fn failed_foreign_chain_calls)]
+	pub type FailedForeignChainCalls<T: Config<I>, I: 'static = ()> =
+		StorageMap<_, Twox64Concat, EpochIndex, Vec<FailedForeignChainCall>, ValueQuery>;
 
 	#[pallet::storage]
 	pub type DepositBalances<T: Config<I>, I: 'static = ()> =
@@ -420,10 +409,11 @@ pub mod pallet {
 			amount: TargetChainAmount<T, I>,
 			deposit_details: <T::TargetChain as Chain>::DepositDetails,
 		},
-		VaultTransferFailed {
+		TransferFallbackRequested {
 			asset: TargetChainAsset<T, I>,
 			amount: TargetChainAmount<T, I>,
 			destination_address: TargetChainAccount<T, I>,
+			broadcast_id: BroadcastId,
 		},
 		/// The deposit witness was rejected.
 		DepositWitnessRejected {
@@ -435,13 +425,13 @@ pub mod pallet {
 			broadcast_id: BroadcastId,
 		},
 		/// A failed CCM call has been re-threshold-signed for the current epoch.
-		FailedCcmCallResigned {
+		FailedForeignChainCallCallResigned {
 			broadcast_id: BroadcastId,
 			threshold_signature_id: ThresholdSignatureRequestId,
 		},
 		/// A failed CCM has been in the system storage for more than 1 epoch.
 		/// It's broadcast data has been cleaned from storage.
-		FailedCcmExpired {
+		FailedForeignChainCallExpired {
 			broadcast_id: BroadcastId,
 		},
 	}
@@ -507,42 +497,45 @@ pub mod pallet {
 			// Egress all scheduled Cross chain messages
 			Self::do_egress_scheduled_ccm();
 
-			// Process failed CCM requires resigning or culling. Take 1 call per block to avoid
-			// spike.
+			// Process failed external chain calls: re-sign or cull storage.
+			// Take 1 call per block to avoid weight spike.
 			let current_epoch = T::EpochInfo::epoch_index();
-			if let Some(ccm) =
-				FailedCcms::<T, I>::mutate(current_epoch.saturating_sub(1), |ccms| ccms.pop())
-			{
-				match current_epoch.saturating_sub(ccm.original_epoch) {
-					// The CCM message is stale, clean up storage.
+			if let Some(call) =
+				FailedForeignChainCalls::<T, I>::mutate(current_epoch.saturating_sub(1), |ccms| {
+					ccms.pop()
+				}) {
+				match current_epoch.saturating_sub(call.original_epoch) {
+					// The call is stale, clean up storage.
 					n if n >= 2 => {
-						T::Broadcaster::clean_up_broadcast_storage(ccm.broadcast_id);
-						Self::deposit_event(Event::<T, I>::FailedCcmExpired {
-							broadcast_id: ccm.broadcast_id,
+						T::Broadcaster::clean_up_broadcast_storage(call.broadcast_id);
+						Self::deposit_event(Event::<T, I>::FailedForeignChainCallExpired {
+							broadcast_id: call.broadcast_id,
 						});
 					},
 					// Previous epoch, signature is invalid. Re-sign and store.
 					n if n == 1 => {
 						if let Some(threshold_signature_id) =
-							T::Broadcaster::threshold_resign(ccm.broadcast_id)
+							T::Broadcaster::threshold_resign(call.broadcast_id)
 						{
-							Self::deposit_event(Event::<T, I>::FailedCcmCallResigned {
-								broadcast_id: ccm.broadcast_id,
-								threshold_signature_id,
-							});
-							FailedCcms::<T, I>::append(current_epoch, ccm);
+							Self::deposit_event(
+								Event::<T, I>::FailedForeignChainCallCallResigned {
+									broadcast_id: call.broadcast_id,
+									threshold_signature_id,
+								},
+							);
+							FailedForeignChainCalls::<T, I>::append(current_epoch, call);
 						} else {
-							// We are here if the CCM needs to be resigned, yet no API call data is
+							// We are here if the Call needs to be resigned, yet no API call data is
 							// available to use. In this situation, there's nothing else that can be
 							// done.
-							log::error!("Ccm message cannot be re-signed: Call data unavailable. Broadcast Id: {:?}", ccm.broadcast_id);
+							log::error!("Foreign Chain Call message cannot be re-signed: Call data unavailable. Broadcast Id: {:?}", call.broadcast_id);
 						}
 					},
 					// Current epoch, shouldn't be possible.
 					_ => {
 						log_or_panic!(
-							"Unexpected CCM message for current epoch. Broadcast Id: {:?}",
-							ccm.broadcast_id,
+							"Unexpected Call for the current epoch. Broadcast Id: {:?}",
+							call.broadcast_id,
 						);
 					},
 				}
@@ -669,7 +662,7 @@ pub mod pallet {
 		///
 		/// ## Events
 		///
-		/// - [on_success](Event::VaultTransferFailed)
+		/// - [on_success](Event::TransferFallbackRequested)
 		#[pallet::weight(T::WeightInfo::vault_transfer_failed())]
 		#[pallet::call_index(4)]
 		pub fn vault_transfer_failed(
@@ -680,17 +673,32 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::EnsureWitnessed::ensure_origin(origin)?;
 
-			FailedVaultTransfers::<T, I>::append(VaultTransfer {
-				asset,
-				amount,
-				destination_address: destination_address.clone(),
-			});
-
-			Self::deposit_event(Event::<T, I>::VaultTransferFailed {
-				asset,
-				amount,
-				destination_address,
-			});
+			let current_epoch = T::EpochInfo::epoch_index();
+			match <T::ChainApiCall as TransferFallback<T::TargetChain>>::new_unsigned(
+				TransferAssetParams { asset, amount, to: destination_address.clone() },
+			) {
+				Ok(api_call) => {
+					let (broadcast_id, _) = T::Broadcaster::threshold_sign(api_call);
+					FailedForeignChainCalls::<T, I>::append(
+						current_epoch,
+						FailedForeignChainCall { broadcast_id, original_epoch: current_epoch },
+					);
+					Self::deposit_event(Event::<T, I>::TransferFallbackRequested {
+						asset,
+						amount,
+						destination_address,
+						broadcast_id,
+					});
+				},
+				// The only way this can fail is if the target chain is unsupported, which should
+				// never happen.
+				Err(_) => {
+					log_or_panic!(
+						"Failed to construct TransferFallback call. Asset: {:?}, amount: {:?}, Destination: {:?}",
+						asset, amount, destination_address
+					);
+				},
+			};
 			Ok(())
 		}
 
@@ -713,9 +721,9 @@ pub mod pallet {
 
 			// Stores the broadcast ID, so the user can use it to query for
 			// information such as Threshold Signature etc.
-			FailedCcms::<T, I>::append(
+			FailedForeignChainCalls::<T, I>::append(
 				current_epoch,
-				FailedCcm { broadcast_id, original_epoch: current_epoch },
+				FailedForeignChainCall { broadcast_id, original_epoch: current_epoch },
 			);
 
 			Self::deposit_event(Event::<T, I>::CcmBroadcastFailed { broadcast_id });
@@ -1070,9 +1078,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok((channel_id, deposit_address, expiry_height))
 	}
 
-	pub fn get_failed_ccm(broadcast_id: BroadcastId) -> Option<FailedCcm> {
+	pub fn get_failed_call(broadcast_id: BroadcastId) -> Option<FailedForeignChainCall> {
 		let epoch = T::EpochInfo::epoch_index();
-		FailedCcms::<T, I>::get(epoch)
+		FailedForeignChainCalls::<T, I>::get(epoch)
 			.iter()
 			.find(|ccm| ccm.broadcast_id == broadcast_id)
 			.cloned()

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1,9 +1,8 @@
 use crate::{
 	mock::*, Call as PalletCall, ChannelAction, ChannelIdCounter, CrossChainMessage,
 	DepositChannelLookup, DepositChannelPool, DepositWitness, DisabledEgressAssets,
-	Event as PalletEvent, FailedCcm, FailedCcms, FailedVaultTransfers, FetchOrTransfer,
+	Event as PalletEvent, FailedForeignChainCall, FailedForeignChainCalls, FetchOrTransfer,
 	MinimumDeposit, Pallet, ScheduledEgressCcm, ScheduledEgressFetchOrTransfer, TargetChainAccount,
-	VaultTransfer,
 };
 use cf_chains::{
 	address::AddressConverter, evm::EvmFetchId, mocks::MockEthereum, CcmChannelMetadata,
@@ -1034,25 +1033,31 @@ fn ingress_finalisation_succeeds_after_channel_expired_but_not_recycled() {
 #[test]
 fn can_store_failed_vault_transfers() {
 	new_test_ext().execute_with(|| {
-		let vault_transfer = VaultTransfer::<Ethereum> {
-			asset: eth::Asset::Eth,
-			amount: 1_000_000u128,
-			destination_address: [0xcf; 20].into(),
-		};
+		let epoch = MockEpochInfo::epoch_index();
+		let asset = eth::Asset::Eth;
+		let amount = 1_000_000u128;
+		let destination_address = [0xcf; 20].into();
 
 		assert_ok!(IngressEgress::vault_transfer_failed(
 			RuntimeOrigin::root(),
-			vault_transfer.asset,
-			vault_transfer.amount,
-			vault_transfer.destination_address,
+			asset,
+			amount,
+			destination_address,
 		));
 
-		assert_has_event::<Test>(RuntimeEvent::IngressEgress(PalletEvent::VaultTransferFailed {
-			asset: vault_transfer.asset,
-			amount: vault_transfer.amount,
-			destination_address: vault_transfer.destination_address,
-		}));
-		assert_eq!(FailedVaultTransfers::<Test>::get(), vec![vault_transfer]);
+		let broadcast_id = 1;
+		assert_has_event::<Test>(RuntimeEvent::IngressEgress(
+			PalletEvent::TransferFallbackRequested {
+				asset,
+				amount,
+				destination_address,
+				broadcast_id,
+			},
+		));
+		assert_eq!(
+			FailedForeignChainCalls::<Test>::get(epoch),
+			vec![FailedForeignChainCall { broadcast_id, original_epoch: epoch }]
+		);
 	});
 }
 
@@ -1219,13 +1224,13 @@ fn failed_ccm_is_stored() {
 	new_test_ext().execute_with(|| {
 		let epoch = MockEpochInfo::epoch_index();
 		let broadcast_id = 1;
-		assert_eq!(FailedCcms::<Test>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
 
 		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), broadcast_id,));
 
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch),
-			vec![FailedCcm { broadcast_id, original_epoch: epoch }]
+			FailedForeignChainCalls::<Test>::get(epoch),
+			vec![FailedForeignChainCall { broadcast_id, original_epoch: epoch }]
 		);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::<Test>::CcmBroadcastFailed { broadcast_id },
@@ -1234,21 +1239,29 @@ fn failed_ccm_is_stored() {
 }
 
 #[test]
-fn on_finalize_handles_failed_ccms() {
+fn on_finalize_handles_failed_calls() {
 	new_test_ext().execute_with(|| {
 		// Advance to Epoch 1 so the expiry logic start to work.
 		let epoch = 1u32;
 		MockEpochInfo::set_epoch(epoch);
-		assert_eq!(FailedCcms::<Test>::get(epoch), vec![]);
+		let destination_address = [0xcf; 20].into();
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
 
-		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), 1,));
-		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), 2,));
+		assert_ok!(IngressEgress::vault_transfer_failed(
+			RuntimeOrigin::root(),
+			eth::Asset::Eth,
+			1_000_000,
+			destination_address
+		));
+		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), 12,));
+		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), 13,));
 
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch),
+			FailedForeignChainCalls::<Test>::get(epoch),
 			vec![
-				FailedCcm { broadcast_id: 1, original_epoch: epoch },
-				FailedCcm { broadcast_id: 2, original_epoch: epoch }
+				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }
 			]
 		);
 
@@ -1256,10 +1269,11 @@ fn on_finalize_handles_failed_ccms() {
 		IngressEgress::on_finalize(0);
 
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch),
+			FailedForeignChainCalls::<Test>::get(epoch),
 			vec![
-				FailedCcm { broadcast_id: 1, original_epoch: epoch },
-				FailedCcm { broadcast_id: 2, original_epoch: epoch }
+				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }
 			]
 		);
 
@@ -1269,56 +1283,95 @@ fn on_finalize_handles_failed_ccms() {
 		// Resign 1 call per block
 		IngressEgress::on_finalize(1);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedCcmCallResigned {
-				broadcast_id: 2,
-				threshold_signature_id: 1,
+			crate::Event::<Test>::FailedForeignChainCallCallResigned {
+				broadcast_id: 13,
+				threshold_signature_id: 2,
 			},
 		));
-		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(2u32));
+		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(13u32));
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch),
-			vec![FailedCcm { broadcast_id: 1, original_epoch: epoch }]
+			FailedForeignChainCalls::<Test>::get(epoch),
+			vec![
+				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
+			]
 		);
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch + 1),
-			vec![FailedCcm { broadcast_id: 2, original_epoch: epoch }]
+			FailedForeignChainCalls::<Test>::get(epoch + 1),
+			vec![FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }]
 		);
 
 		// Resign the 2nd call
 		IngressEgress::on_finalize(2);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedCcmCallResigned {
+			crate::Event::<Test>::FailedForeignChainCallCallResigned {
+				broadcast_id: 12,
+				threshold_signature_id: 3,
+			},
+		));
+		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(12u32));
+		assert_eq!(
+			FailedForeignChainCalls::<Test>::get(epoch),
+			vec![FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch }]
+		);
+		assert_eq!(
+			FailedForeignChainCalls::<Test>::get(epoch + 1),
+			vec![
+				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch }
+			]
+		);
+		// Resign the last call
+		IngressEgress::on_finalize(3);
+		System::assert_last_event(RuntimeEvent::IngressEgress(
+			crate::Event::<Test>::FailedForeignChainCallCallResigned {
 				broadcast_id: 1,
-				threshold_signature_id: 2,
+				threshold_signature_id: 4,
 			},
 		));
 		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(1u32));
-		assert_eq!(FailedCcms::<Test>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
 		assert_eq!(
-			FailedCcms::<Test>::get(epoch + 1),
+			FailedForeignChainCalls::<Test>::get(epoch + 1),
 			vec![
-				FailedCcm { broadcast_id: 2, original_epoch: epoch },
-				FailedCcm { broadcast_id: 1, original_epoch: epoch }
+				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch }
 			]
 		);
 
 		// Failed calls are removed in the next epoch, 1 at a time.
 		MockEpochInfo::set_epoch(epoch + 2);
-		IngressEgress::on_finalize(3);
-		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedCcmExpired { broadcast_id: 1 },
-		));
-		assert_eq!(FailedCcms::<Test>::get(epoch), vec![]);
-		assert_eq!(
-			FailedCcms::<Test>::get(epoch + 1),
-			vec![FailedCcm { broadcast_id: 2, original_epoch: 1 }]
-		);
-
 		IngressEgress::on_finalize(4);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedCcmExpired { broadcast_id: 2 },
+			crate::Event::<Test>::FailedForeignChainCallExpired { broadcast_id: 1 },
 		));
-		assert_eq!(FailedCcms::<Test>::get(epoch), vec![]);
-		assert_eq!(FailedCcms::<Test>::get(epoch + 1), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
+		assert_eq!(
+			FailedForeignChainCalls::<Test>::get(epoch + 1),
+			vec![
+				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
+				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch }
+			]
+		);
+
+		IngressEgress::on_finalize(5);
+		System::assert_last_event(RuntimeEvent::IngressEgress(
+			crate::Event::<Test>::FailedForeignChainCallExpired { broadcast_id: 12 },
+		));
+		assert_eq!(
+			FailedForeignChainCalls::<Test>::get(epoch + 1),
+			vec![FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }]
+		);
+
+		IngressEgress::on_finalize(6);
+		System::assert_last_event(RuntimeEvent::IngressEgress(
+			crate::Event::<Test>::FailedForeignChainCallExpired { broadcast_id: 13 },
+		));
+
+		// All calls are culled from storage.
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch + 1), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch + 2), vec![]);
 	});
 }

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1283,7 +1283,7 @@ fn on_finalize_handles_failed_calls() {
 		// Resign 1 call per block
 		IngressEgress::on_finalize(1);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedForeignChainCallCallResigned {
+			crate::Event::<Test>::FailedForeignChainCallResigned {
 				broadcast_id: 13,
 				threshold_signature_id: 2,
 			},
@@ -1304,7 +1304,7 @@ fn on_finalize_handles_failed_calls() {
 		// Resign the 2nd call
 		IngressEgress::on_finalize(2);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedForeignChainCallCallResigned {
+			crate::Event::<Test>::FailedForeignChainCallResigned {
 				broadcast_id: 12,
 				threshold_signature_id: 3,
 			},
@@ -1324,7 +1324,7 @@ fn on_finalize_handles_failed_calls() {
 		// Resign the last call
 		IngressEgress::on_finalize(3);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test>::FailedForeignChainCallCallResigned {
+			crate::Event::<Test>::FailedForeignChainCallResigned {
 				broadcast_id: 1,
 				threshold_signature_id: 4,
 			},

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -170,6 +170,10 @@ impl Broadcaster<MockEthereum> for MockBroadcaster {
 		unimplemented!()
 	}
 
+	fn threshold_sign(_api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId) {
+		unimplemented!()
+	}
+
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(_broadcast_id: BroadcastId) {
 		unimplemented!()

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1275,8 +1275,8 @@ impl_runtime_apis! {
 			}
 		}
 
-		fn cf_failed_ccm_call(broadcast_id: BroadcastId) -> Option<<cf_chains::Ethereum as cf_chains::Chain>::Transaction> {
-			if EthereumIngressEgress::get_failed_ccm(broadcast_id).is_some() {
+		fn cf_failed_call(broadcast_id: BroadcastId) -> Option<<cf_chains::Ethereum as cf_chains::Chain>::Transaction> {
+			if EthereumIngressEgress::get_failed_call(broadcast_id).is_some() {
 				EthereumBroadcaster::threshold_signature_data(broadcast_id).map(|(api_call, _)|{
 					chainflip::EthTransactionBuilder::build_transaction(&api_call)
 				})

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -140,7 +140,7 @@ decl_runtime_apis!(
 		fn cf_account_role(account_id: AccountId32) -> Option<AccountRole>;
 		fn cf_redemption_tax() -> AssetAmount;
 		fn cf_network_environment() -> NetworkEnvironment;
-		fn cf_failed_ccm_call(
+		fn cf_failed_call(
 			broadcast_id: BroadcastId,
 		) -> Option<<cf_chains::Ethereum as Chain>::Transaction>;
 	}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -473,6 +473,10 @@ pub trait Broadcaster<C: Chain> {
 	/// Resign a call, and update the signature data storage, but do not broadcast.
 	fn threshold_resign(broadcast_id: BroadcastId) -> Option<ThresholdSignatureRequestId>;
 
+	/// Request a call to be threshold signed, but do not broadcast.
+	/// The caller must manage storage cleanup, so signatures are not stored indefinitely.
+	fn threshold_sign(api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId);
+
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(broadcast_id: BroadcastId);
 }

--- a/state-chain/traits/src/mocks/broadcaster.rs
+++ b/state-chain/traits/src/mocks/broadcaster.rs
@@ -55,6 +55,17 @@ impl<
 		id
 	}
 
+	fn threshold_sign(_api_call: Self::ApiCall) -> (BroadcastId, ThresholdSignatureRequestId) {
+		(
+			<Self as MockPalletStorage>::mutate_value(b"BROADCAST_ID", |v: &mut Option<u32>| {
+				let v = v.get_or_insert(0);
+				*v += 1;
+				*v
+			}),
+			Self::next_threshold_id(),
+		)
+	}
+
 	fn threshold_resign(broadcast_id: BroadcastId) -> Option<ThresholdSignatureRequestId> {
 		Self::put_value(b"RESIGNED_CALLBACKS", broadcast_id);
 		Some(Self::next_threshold_id())


### PR DESCRIPTION
# Pull Request

Closes: PRO-789

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added pathway to handle failed vault transfers.
Basic workflow:
* When one transfer fails in BatchAll call, the Vault contract emits an event, which is observed by Engine and the Statechain is notified:
    - pallet_cf_ingress_egress::Call::vault_transfer_failed()
* Here the TransferFallback EthApi call is constructed with the transfer details included.
* The call is delegated to the Broadcast pallet to be signed, but NOT broadcasted. 
* After threshold signature is completed, the details are saved in the Broadcast pallet, the same way Failed CCM are handled.
* In the next epoch, the call is re-threshold signed, using the same mechanism as Failed CCM.
* In the epoch after that, all call data are culled from on-chain storage.


