### PR TITLE
fix: connections can become stale when reconnecting

### DIFF
--- a/engine/src/p2p/core.rs
+++ b/engine/src/p2p/core.rs
@@ -521,7 +521,7 @@ impl P2PContext {
 				state: ConnectionState::Connected(connected_socket),
 				info: peer,
 				last_activity: Cell::new(
-					previous_activity.unwrap_or_else(|| tokio::time::Instant::now()),
+					previous_activity.unwrap_or_else(tokio::time::Instant::now),
 				),
 			},
 		) {

--- a/engine/src/p2p/core.rs
+++ b/engine/src/p2p/core.rs
@@ -385,7 +385,7 @@ impl P2PContext {
 					// This is guaranteed by construction of `active_connections`:
 					assert_eq!(peer.info.account_id, account_id);
 
-					self.connect_to_peer(peer.info.clone());
+					self.connect_to_peer(peer.info.clone(), Some(peer.last_activity.get()));
 					self.send_message(account_id, payload);
 				},
 			}
@@ -479,7 +479,7 @@ impl P2PContext {
 			match peer.state {
 				ConnectionState::ReconnectionScheduled => {
 					info!("Reconnecting to peer: {account_id}");
-					self.connect_to_peer(peer.info.clone());
+					self.connect_to_peer(peer.info.clone(), Some(peer.last_activity.get()));
 				},
 				ConnectionState::Connected(_) => {
 					// It is possible that while we were waiting to reconnect,
@@ -506,7 +506,7 @@ impl P2PContext {
 		}
 	}
 
-	fn connect_to_peer(&mut self, peer: PeerInfo) {
+	fn connect_to_peer(&mut self, peer: PeerInfo, previous_activity: Option<tokio::time::Instant>) {
 		let account_id = peer.account_id.clone();
 
 		let socket = OutgoingSocket::new(&self.zmq_context, &self.key);
@@ -520,7 +520,9 @@ impl P2PContext {
 			ConnectionStateInfo {
 				state: ConnectionState::Connected(connected_socket),
 				info: peer,
-				last_activity: Cell::new(tokio::time::Instant::now()),
+				last_activity: Cell::new(
+					previous_activity.unwrap_or_else(|| tokio::time::Instant::now()),
+				),
 			},
 		) {
 			if !matches!(connection.state, ConnectionState::Stale) {
@@ -539,12 +541,16 @@ impl P2PContext {
 			return
 		}
 
+		let mut previous_activity = None;
+
 		if let Some(existing_peer_state) = self.active_connections.remove(&peer.account_id) {
 			debug!(
 				peer_info = peer.to_string(),
 				"Received info for known peer with account id {}, updating info and reconnecting",
 				&peer.account_id
 			);
+
+			previous_activity = Some(existing_peer_state.last_activity.get());
 
 			match existing_peer_state.state {
 				ConnectionState::Connected(socket) => {
@@ -571,7 +577,7 @@ impl P2PContext {
 
 		self.x25519_to_account_id.insert(peer.pubkey, peer.account_id.clone());
 
-		self.connect_to_peer(peer);
+		self.connect_to_peer(peer, previous_activity);
 	}
 
 	/// Start listening for incoming p2p messages on a separate thread


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Previously in some cases it was possible for connections to never become "stale" (preventing reconnections when inactive). Specifically, when we fail to connect to a node due to some authentication error, this would result us reconnecting to the node manually (rather than this being done by zmq internally), but this also reset activity for that node to "now" on every restart, preventing us from detecting the connection as stale. I changed the code to carry over any previous activity state when reconnecting, so inactive connections should now always enter "stale" state.

Writing a proper unit test for this is a bit cumbersome and I'm not sure if worth it, but I have tested this manually by changing some parameters and observing logs that the bug was present initially and that the new code fixes the incorrect behaviour.
