### PR TITLE
`cf_pool_orders` RPC call can return all Pool Orders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ dependencies = [
  "pallet-cf-pools",
  "serde",
  "serde_json",
+ "sp-core 21.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+3)",
  "sp-rpc",
  "tokio",
  "tracing",

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -27,6 +27,7 @@ jsonrpsee = { version = "0.20", features = ["full"] }
 serde = { version = '1.0', features = ['derive'] }
 serde_json = "1.0"
 sp-rpc = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2023-08+3" }
+sp-core = { git = "https://github.com/chainflip-io/substrate.git", tag = "chainflip-monthly-2023-08+3" }
 tokio = "1.20.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -28,6 +28,7 @@ use jsonrpsee::{
 };
 use pallet_cf_pools::{AssetPair, AssetsMap, IncreaseOrDecrease, OrderId, RangeOrderSize};
 use rpc_types::{AssetBalance, OpenSwapChannels, OrderIdJson, RangeOrderSizeJson};
+use sp_core::U256;
 use std::{
 	collections::{BTreeMap, HashMap, HashSet},
 	ops::Range,
@@ -223,21 +224,21 @@ pub enum OrderFilled {
 		base_asset: Asset,
 		quote_asset: Asset,
 		side: Order,
-		id: NumberOrHex,
+		id: U256,
 		tick: Tick,
-		sold: NumberOrHex,
-		bought: NumberOrHex,
-		fees: NumberOrHex,
-		remaining: NumberOrHex,
+		sold: U256,
+		bought: U256,
+		fees: U256,
+		remaining: U256,
 	},
 	RangeOrder {
 		lp: AccountId,
 		base_asset: Asset,
 		quote_asset: Asset,
-		id: NumberOrHex,
+		id: U256,
 		range: Range<Tick>,
-		fees: AssetsMap<NumberOrHex>,
-		liquidity: NumberOrHex,
+		fees: AssetsMap<U256>,
+		liquidity: U256,
 	},
 }
 
@@ -527,7 +528,7 @@ impl RpcServer for RpcServerImpl {
 								if fees.is_zero() && sold.is_zero() && bought.is_zero() {
 									None
 								} else {
-									Some(OrderFilled::LimitOrder { lp, base_asset: asset_pair.assets().base, quote_asset: asset_pair.assets().quote, side, id: id.into(), tick, sold: sold.into(), bought: bought.into(), fees: fees.into(), remaining: position_info.amount.into() })
+									Some(OrderFilled::LimitOrder { lp, base_asset: asset_pair.assets().base, quote_asset: asset_pair.assets().quote, side, id: id.into(), tick, sold, bought, fees, remaining: position_info.amount })
 								}
 							})
 						}).chain(
@@ -555,7 +556,7 @@ impl RpcServer for RpcServerImpl {
 										quote_asset: asset_pair.assets().quote,
 										id: id.into(),
 										range: range.clone(),
-										fees: fees.map(|_, fees| fees.into()).into(),
+										fees: fees.map(|_, fees| fees).into(),
 										liquidity: position_info.liquidity.into()
 									})
 								}

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -12,10 +12,9 @@ use chainflip_engine::state_chain_observer::client::{
 };
 use pallet_cf_pools::{AssetsMap, IncreaseOrDecrease, OrderId, RangeOrderSize};
 use serde::{Deserialize, Serialize};
-use sp_core::H256;
+use sp_core::{H256, U256};
 use state_chain_runtime::RuntimeCall;
 use std::ops::Range;
-use utilities::rpc::NumberOrHex;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -48,17 +47,17 @@ pub mod types {
 	pub struct RangeOrder {
 		pub base_asset: Asset,
 		pub quote_asset: Asset,
-		pub id: OrderId,
+		pub id: U256,
 		pub tick_range: Range<Tick>,
-		pub liquidity_total: NumberOrHex,
-		pub collected_fees: AssetsMap<NumberOrHex>,
+		pub liquidity_total: U256,
+		pub collected_fees: AssetsMap<U256>,
 		pub size_change: Option<IncreaseOrDecrease<RangeOrderChange>>,
 	}
 
 	#[derive(Serialize, Deserialize, Clone)]
 	pub struct RangeOrderChange {
-		pub liquidity: NumberOrHex,
-		pub amounts: AssetsMap<NumberOrHex>,
+		pub liquidity: U256,
+		pub amounts: AssetsMap<U256>,
 	}
 
 	#[derive(Serialize, Deserialize, Clone)]
@@ -66,12 +65,12 @@ pub mod types {
 		pub base_asset: Asset,
 		pub quote_asset: Asset,
 		pub side: Order,
-		pub id: OrderId,
+		pub id: U256,
 		pub tick: Tick,
-		pub sell_amount_total: NumberOrHex,
-		pub collected_fees: NumberOrHex,
-		pub bought_amount: NumberOrHex,
-		pub sell_amount_change: Option<IncreaseOrDecrease<NumberOrHex>>,
+		pub sell_amount_total: U256,
+		pub collected_fees: U256,
+		pub bought_amount: U256,
+		pub sell_amount_change: Option<IncreaseOrDecrease<U256>>,
 	}
 }
 
@@ -95,7 +94,7 @@ fn collect_range_order_returns(
 			) => Some(types::RangeOrder {
 				base_asset,
 				quote_asset,
-				id,
+				id: id.into(),
 				size_change: size_change.map(|increase_or_decrese| {
 					increase_or_decrese.map(|range_order_change| types::RangeOrderChange {
 						liquidity: range_order_change.liquidity.into(),
@@ -134,7 +133,7 @@ fn collect_limit_order_returns(
 				base_asset,
 				quote_asset,
 				side,
-				id,
+				id: id.into(),
 				tick,
 				sell_amount_total: sell_amount_total.into(),
 				collected_fees: collected_fees.into(),

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -421,7 +421,7 @@ pub trait CustomApi {
 		&self,
 		base_asset: RpcAsset,
 		quote_asset: RpcAsset,
-		maybe_lp: Option<state_chain_runtime::AccountId>,
+		lp: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<pallet_cf_pools::PoolOrders<state_chain_runtime::Runtime>>;
 	#[method(name = "pool_range_order_liquidity_value")]
@@ -910,7 +910,7 @@ where
 		&self,
 		base_asset: RpcAsset,
 		quote_asset: RpcAsset,
-		maybe_lp: Option<state_chain_runtime::AccountId>,
+		lp: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<pallet_cf_pools::PoolOrders<state_chain_runtime::Runtime>> {
 		self.client
@@ -919,7 +919,7 @@ where
 				self.unwrap_or_best(at),
 				base_asset.try_into()?,
 				quote_asset.try_into()?,
-				maybe_lp,
+				lp,
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -277,66 +277,6 @@ pub struct RpcEnvironment {
 	pools: PoolsEnvironment,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct LimitOrder {
-	id: NumberOrHex,
-	tick: Tick,
-	sell_amount: NumberOrHex,
-	fees_earned: NumberOrHex,
-	original_sell_amount: NumberOrHex,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct RangeOrder {
-	id: NumberOrHex,
-	range: Range<Tick>,
-	liquidity: NumberOrHex,
-	fees_earned: AssetsMap<NumberOrHex>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PoolOrders {
-	/// Limit orders are groups by which asset they are selling.
-	pub limit_orders: AskBidMap<Vec<LimitOrder>>,
-	/// Range orders can be both buy and/or sell therefore they not split. The current range order
-	/// price determines if they are buy and/or sell.
-	pub range_orders: Vec<RangeOrder>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PoolOrder {
-	amount: NumberOrHex,
-	sqrt_price: NumberOrHex,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PoolOrderbook {
-	asks: Vec<PoolOrder>,
-	bids: Vec<PoolOrder>,
-}
-impl From<pallet_cf_pools::PoolOrderbook> for PoolOrderbook {
-	fn from(value: pallet_cf_pools::PoolOrderbook) -> Self {
-		Self {
-			asks: value
-				.asks
-				.into_iter()
-				.map(|ask| PoolOrder {
-					amount: ask.amount.into(),
-					sqrt_price: ask.sqrt_price.into(),
-				})
-				.collect(),
-			bids: value
-				.bids
-				.into_iter()
-				.map(|bid| PoolOrder {
-					amount: bid.amount.into(),
-					sqrt_price: bid.sqrt_price.into(),
-				})
-				.collect(),
-		}
-	}
-}
-
 #[rpc(server, client, namespace = "cf")]
 /// The custom RPC endpoints for the state chain node.
 pub trait CustomApi {
@@ -453,7 +393,7 @@ pub trait CustomApi {
 		quote_asset: RpcAsset,
 		orders: u32,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<PoolOrderbook>;
+	) -> RpcResult<pallet_cf_pools::PoolOrderbook>;
 	#[method(name = "pool_info")]
 	fn cf_pool_info(
 		&self,
@@ -481,9 +421,9 @@ pub trait CustomApi {
 		&self,
 		base_asset: RpcAsset,
 		quote_asset: RpcAsset,
-		lp: state_chain_runtime::AccountId,
+		maybe_lp: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<PoolOrders>;
+	) -> RpcResult<pallet_cf_pools::PoolOrders<state_chain_runtime::Runtime>>;
 	#[method(name = "pool_range_order_liquidity_value")]
 	fn cf_pool_range_order_liquidity_value(
 		&self,
@@ -953,7 +893,7 @@ where
 		quote_asset: RpcAsset,
 		orders: u32,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<PoolOrderbook> {
+	) -> RpcResult<pallet_cf_pools::PoolOrderbook> {
 		self.client
 			.runtime_api()
 			.cf_pool_orderbook(
@@ -970,48 +910,19 @@ where
 		&self,
 		base_asset: RpcAsset,
 		quote_asset: RpcAsset,
-		lp: state_chain_runtime::AccountId,
+		maybe_lp: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<PoolOrders> {
+	) -> RpcResult<pallet_cf_pools::PoolOrders<state_chain_runtime::Runtime>> {
 		self.client
 			.runtime_api()
 			.cf_pool_orders(
 				self.unwrap_or_best(at),
 				base_asset.try_into()?,
 				quote_asset.try_into()?,
-				lp,
+				maybe_lp,
 			)
 			.map_err(to_rpc_error)
-			.and_then(|result| {
-				result
-					.map(|pool_orders| PoolOrders {
-						limit_orders: pool_orders.limit_orders.map(|limit_orders| {
-							limit_orders
-								.into_iter()
-								.map(|limit_order| LimitOrder {
-									id: limit_order.id.into(),
-									tick: limit_order.tick,
-									sell_amount: limit_order.sell_amount.into(),
-									fees_earned: limit_order.fees_earned.into(),
-									original_sell_amount: limit_order.original_sell_amount.into(),
-								})
-								.collect()
-						}),
-						range_orders: pool_orders
-							.range_orders
-							.into_iter()
-							.map(|range_order| RangeOrder {
-								id: range_order.id.into(),
-								range: range_order.range,
-								liquidity: range_order.liquidity.into(),
-								fees_earned: range_order
-									.fees_earned
-									.map(|fees_earned| fees_earned.into()),
-							})
-							.collect(),
-					})
-					.map_err(map_dispatch_error)
-			})
+			.and_then(|result| result.map_err(map_dispatch_error))
 	}
 
 	fn cf_pool_range_order_liquidity_value(

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1163,7 +1163,7 @@ pub struct PoolInfo {
 #[serde(bound = "")]
 pub struct LimitOrder<T: Config> {
 	pub lp: T::AccountId,
-	pub id: OrderId,
+	pub id: Amount, // TODO: Intro type alias
 	pub tick: Tick,
 	pub sell_amount: Amount,
 	pub fees_earned: Amount,
@@ -1174,7 +1174,7 @@ pub struct LimitOrder<T: Config> {
 #[serde(bound = "")]
 pub struct RangeOrder<T: Config> {
 	pub lp: T::AccountId,
-	pub id: OrderId,
+	pub id: Amount,
 	pub range: Range<Tick>,
 	pub liquidity: Liquidity,
 	pub fees_earned: AssetsMap<Amount>,
@@ -1826,7 +1826,7 @@ impl<T: Config> Pallet<T> {
 									.unwrap();
 								LimitOrder {
 									lp: lp.clone(),
-									id: *id,
+									id: (*id).into(),
 									tick: *tick,
 									sell_amount: position_info.amount,
 									fees_earned: collected.accumulative_fees,
@@ -1849,7 +1849,7 @@ impl<T: Config> Pallet<T> {
 							.unwrap();
 						RangeOrder {
 							lp: lp.clone(),
-							id: *id,
+							id: (*id).into(),
 							range: tick_range.clone(),
 							liquidity: position_info.liquidity,
 							fees_earned: collected.accumulative_fees.into(),
@@ -1886,7 +1886,7 @@ impl<T: Config> Pallet<T> {
 										.unwrap();
 									LimitOrder {
 										lp: lp.clone(),
-										id: *order_id,
+										id: (*order_id).into(),
 										tick: *tick,
 										sell_amount: position_info.amount,
 										fees_earned: collected.accumulative_fees,
@@ -1911,7 +1911,7 @@ impl<T: Config> Pallet<T> {
 								.unwrap();
 							RangeOrder {
 								lp: lp.clone(),
-								id: *id,
+								id: (*id).into(),
 								range: tick_range.clone(),
 								liquidity: position_info.liquidity,
 								fees_earned: collected.accumulative_fees.into(),

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1159,8 +1159,10 @@ pub struct PoolInfo {
 	pub range_order_fee_hundredth_pips: u32,
 }
 
-#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
-pub struct LimitOrder {
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct LimitOrder<T: Config> {
+	pub lp: T::AccountId,
 	pub id: OrderId,
 	pub tick: Tick,
 	pub sell_amount: Amount,
@@ -1168,21 +1170,37 @@ pub struct LimitOrder {
 	pub original_sell_amount: Amount,
 }
 
-#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
-pub struct RangeOrder {
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct RangeOrder<T: Config> {
+	pub lp: T::AccountId,
 	pub id: OrderId,
 	pub range: Range<Tick>,
 	pub liquidity: Liquidity,
 	pub fees_earned: AssetsMap<Amount>,
 }
 
-#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
-pub struct PoolOrders {
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct PoolOrders<T: Config> {
 	/// Limit orders are groups by which asset they are selling.
-	pub limit_orders: AskBidMap<Vec<LimitOrder>>,
+	pub limit_orders: AskBidMap<Vec<LimitOrder<T>>>,
 	/// Range orders can be both buy and/or sell therefore they not split. The current range order
 	/// price determines if they are buy and/or sell.
-	pub range_orders: Vec<RangeOrder>,
+	pub range_orders: Vec<RangeOrder<T>>,
+}
+
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Deserialize, Serialize)]
+pub struct LimitOrderLiquidity {
+	tick: Tick,
+	amount: Amount,
+}
+
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RangeOrderLiquidity {
+	tick: Tick,
+	liquidity: Amount, /* TODO: Change (Using Amount as it is U256 so we get the right
+	                    * serialization) */
 }
 
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Deserialize, Serialize)]
@@ -1190,12 +1208,12 @@ pub struct PoolLiquidity {
 	/// An ordered lists of the amount of assets available at each tick, if a tick contains zero
 	/// liquidity it will not be included in the list. Note limit order liquidity is split by which
 	/// asset the liquidity is "selling".
-	pub limit_orders: AskBidMap<Vec<(Tick, Amount)>>,
+	pub limit_orders: AskBidMap<Vec<LimitOrderLiquidity>>,
 	/// An ordered list of the amount of range order liquidity available from a tick until the next
 	/// tick in the list. Note range orders can be both buy and/or sell therefore they not split by
 	/// sold asset. The current range order price determines if the liquidity can be used for
 	/// buying and/or selling,
-	pub range_orders: Vec<(Tick, Liquidity)>,
+	pub range_orders: Vec<RangeOrderLiquidity>,
 }
 
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Deserialize, Serialize)]
@@ -1214,13 +1232,13 @@ pub struct UnidirectionalPoolDepth {
 	pub range_orders: UnidirectionalSubPoolDepth,
 }
 
-#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolOrder {
 	pub amount: Amount,
 	pub sqrt_price: SqrtPriceQ64F96,
 }
 
-#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PoolOrderbook {
 	pub bids: Vec<PoolOrder>,
 	pub asks: Vec<PoolOrder>,
@@ -1770,16 +1788,28 @@ impl<T: Config> Pallet<T> {
 		let pool = Pools::<T>::get(AssetPair::try_new::<T>(base_asset, quote_asset)?)
 			.ok_or(Error::<T>::PoolDoesNotExist)?;
 		Ok(PoolLiquidity {
-			limit_orders: AskBidMap::from_fn(|order| pool.pool_state.limit_order_liquidity(order)),
-			range_orders: pool.pool_state.range_order_liquidity(),
+			limit_orders: AskBidMap::from_fn(|order| {
+				pool.pool_state
+					.limit_order_liquidity(order)
+					.into_iter()
+					.map(|(tick, amount)| LimitOrderLiquidity { tick, amount })
+					.collect()
+			}),
+			range_orders: pool
+				.pool_state
+				.range_order_liquidity()
+				.into_iter()
+				.map(|(tick, liquidity)| RangeOrderLiquidity { tick, liquidity: liquidity.into() })
+				.collect(),
 		})
 	}
 
+	/// Returns the limit and range orders for a given Liquidity Provider within the given pool.
 	pub fn pool_orders(
 		base_asset: any::Asset,
 		quote_asset: any::Asset,
 		lp: &T::AccountId,
-	) -> Result<PoolOrders, DispatchError> {
+	) -> Result<PoolOrders<T>, DispatchError> {
 		let pool = Pools::<T>::get(AssetPair::try_new::<T>(base_asset, quote_asset)?)
 			.ok_or(Error::<T>::PoolDoesNotExist)?;
 		Ok(PoolOrders {
@@ -1795,6 +1825,7 @@ impl<T: Config> Pallet<T> {
 									.limit_order(&(lp.clone(), *id), asset.sell_order(), *tick)
 									.unwrap();
 								LimitOrder {
+									lp: lp.clone(),
 									id: *id,
 									tick: *tick,
 									sell_amount: position_info.amount,
@@ -1817,12 +1848,76 @@ impl<T: Config> Pallet<T> {
 							.range_order(&(lp.clone(), *id), tick_range.clone())
 							.unwrap();
 						RangeOrder {
+							lp: lp.clone(),
 							id: *id,
 							range: tick_range.clone(),
 							liquidity: position_info.liquidity,
 							fees_earned: collected.accumulative_fees.into(),
 						}
 					})
+				})
+				.collect(),
+		})
+	}
+
+	/// Returns All limit and range orders within the given pool.
+	pub fn all_pool_orders(
+		base_asset: any::Asset,
+		pair_asset: any::Asset,
+	) -> Result<PoolOrders<T>, DispatchError> {
+		let asset_pair = AssetPair::try_new::<T>(base_asset, pair_asset)?;
+		let pool = Pools::<T>::get(asset_pair).ok_or(Error::<T>::PoolDoesNotExist)?;
+		Ok(PoolOrders {
+			limit_orders: AskBidMap::from_sell_map(
+				pool.limit_orders_cache.as_ref().map_with_asset(|asset, limit_order_cache| {
+					limit_order_cache
+						.iter()
+						.flat_map(|(lp, orders)| {
+							orders
+								.iter()
+								.map(|(order_id, tick)| {
+									let (collected, position_info) = pool
+										.pool_state
+										.limit_order(
+											&(lp.clone(), *order_id),
+											asset.sell_order(),
+											*tick,
+										)
+										.unwrap();
+									LimitOrder {
+										lp: lp.clone(),
+										id: *order_id,
+										tick: *tick,
+										sell_amount: position_info.amount,
+										fees_earned: collected.accumulative_fees,
+										original_sell_amount: collected.original_amount,
+									}
+								})
+								.collect::<Vec<_>>()
+						})
+						.collect()
+				}),
+			),
+			range_orders: pool
+				.range_orders_cache
+				.iter()
+				.flat_map(|(lp, range_orders)| {
+					range_orders
+						.iter()
+						.map(|(id, tick_range)| {
+							let (collected, position_info) = pool
+								.pool_state
+								.range_order(&(lp.clone(), *id), tick_range.clone())
+								.unwrap();
+							RangeOrder {
+								lp: lp.clone(),
+								id: *id,
+								range: tick_range.clone(),
+								liquidity: position_info.liquidity,
+								fees_earned: collected.accumulative_fees.into(),
+							}
+						})
+						.collect::<Vec<_>>()
 				})
 				.collect(),
 		})

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -322,7 +322,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 				limit_orders: AskBidMap {
 					asks: vec![LimitOrder {
 						lp: ALICE,
-						id: 0,
+						id: 0.into(),
 						tick: 0,
 						sell_amount: 5000u128.into(),
 						fees_earned: 0.into(),
@@ -330,7 +330,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 					}],
 					bids: vec![LimitOrder {
 						lp: ALICE,
-						id: 1,
+						id: 1.into(),
 						tick: 0,
 						sell_amount: 1000.into(),
 						fees_earned: 0.into(),
@@ -346,7 +346,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 				limit_orders: AskBidMap {
 					asks: vec![LimitOrder {
 						lp: BOB,
-						id: 0,
+						id: 0.into(),
 						tick: 0,
 						sell_amount: 10000u128.into(),
 						fees_earned: 0.into(),
@@ -354,7 +354,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 					}],
 					bids: vec![LimitOrder {
 						lp: BOB,
-						id: 1,
+						id: 1.into(),
 						tick: 0,
 						sell_amount: 10000.into(),
 						fees_earned: 0.into(),
@@ -413,7 +413,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 				limit_orders: AskBidMap {
 					asks: vec![LimitOrder {
 						lp: ALICE,
-						id: 0,
+						id: 0.into(),
 						tick: 0,
 						sell_amount: 3000.into(),
 						fees_earned: 1333.into(),
@@ -421,7 +421,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 					}],
 					bids: vec![LimitOrder {
 						lp: ALICE,
-						id: 1,
+						id: 1.into(),
 						tick: 0,
 						sell_amount: 454.into(),
 						fees_earned: 363.into(),
@@ -437,7 +437,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 				limit_orders: AskBidMap {
 					asks: vec![LimitOrder {
 						lp: BOB,
-						id: 0,
+						id: 0.into(),
 						tick: 0,
 						sell_amount: 6_000u128.into(),
 						fees_earned: 2666.into(),
@@ -445,7 +445,7 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 					}],
 					bids: vec![LimitOrder {
 						lp: BOB,
-						id: 1,
+						id: 1.into(),
 						tick: 0,
 						sell_amount: 4_545.into(),
 						fees_earned: 3636.into(),
@@ -526,7 +526,7 @@ fn pallet_limit_order_is_in_sync_with_pool() {
 				limit_orders: AskBidMap {
 					asks: vec![LimitOrder {
 						lp: ALICE,
-						id: 0,
+						id: 0.into(),
 						tick: 0,
 						sell_amount: 100.into(),
 						fees_earned: 0.into(),
@@ -675,7 +675,7 @@ fn update_pool_liquidity_fee_collects_fees_for_range_order() {
 				limit_orders: AskBidMap { asks: vec![], bids: vec![] },
 				range_orders: vec![RangeOrder {
 					lp: ALICE,
-					id: 0,
+					id: 0.into(),
 					range: range.clone(),
 					liquidity: 1_000_000,
 					fees_earned: AssetsMap { base: 999.into(), quote: 999.into() }
@@ -688,7 +688,7 @@ fn update_pool_liquidity_fee_collects_fees_for_range_order() {
 				limit_orders: AskBidMap { asks: vec![], bids: vec![] },
 				range_orders: vec![RangeOrder {
 					lp: ALICE,
-					id: 0,
+					id: 0.into(),
 					range: range.clone(),
 					liquidity: 1_000_000,
 					fees_earned: AssetsMap { base: 999.into(), quote: 999.into() }
@@ -908,7 +908,7 @@ fn can_get_all_pool_orders() {
 					asks: vec![
 						LimitOrder {
 							lp: ALICE,
-							id: 4,
+							id: 4.into(),
 							tick: 100,
 							sell_amount: 500_000.into(),
 							fees_earned: 0.into(),
@@ -916,7 +916,7 @@ fn can_get_all_pool_orders() {
 						},
 						LimitOrder {
 							lp: ALICE,
-							id: 5,
+							id: 5.into(),
 							tick: 1000,
 							sell_amount: 600_000.into(),
 							fees_earned: 0.into(),
@@ -924,7 +924,7 @@ fn can_get_all_pool_orders() {
 						},
 						LimitOrder {
 							lp: ALICE,
-							id: 6,
+							id: 6.into(),
 							tick: 100,
 							sell_amount: 700_000.into(),
 							fees_earned: 0.into(),
@@ -933,7 +933,7 @@ fn can_get_all_pool_orders() {
 					],
 					bids: vec![LimitOrder {
 						lp: ALICE,
-						id: 7,
+						id: 7.into(),
 						tick: 1000,
 						sell_amount: 800_000.into(),
 						fees_earned: 0.into(),
@@ -943,28 +943,28 @@ fn can_get_all_pool_orders() {
 				range_orders: vec![
 					RangeOrder {
 						lp: ALICE,
-						id: 0,
+						id: 0.into(),
 						range: -100..100,
 						liquidity: 100_000u128,
 						fees_earned: Default::default(),
 					},
 					RangeOrder {
 						lp: ALICE,
-						id: 1,
+						id: 1.into(),
 						range: -234..234,
 						liquidity: 200_000u128,
 						fees_earned: Default::default(),
 					},
 					RangeOrder {
 						lp: BOB,
-						id: 2,
+						id: 2.into(),
 						range: -100..100,
 						liquidity: 300_000u128,
 						fees_earned: Default::default(),
 					},
 					RangeOrder {
 						lp: BOB,
-						id: 3,
+						id: 3.into(),
 						range: -234..234,
 						liquidity: 400_000u128,
 						fees_earned: Default::default(),

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -687,7 +687,7 @@ fn update_pool_liquidity_fee_collects_fees_for_range_order() {
 			Ok(PoolOrders {
 				limit_orders: AskBidMap { asks: vec![], bids: vec![] },
 				range_orders: vec![RangeOrder {
-					lp: ALICE,
+					lp: BOB,
 					id: 0.into(),
 					range: range.clone(),
 					liquidity: 1_000_000,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1086,9 +1086,9 @@ impl_runtime_apis! {
 		fn cf_pool_orders(
 			base_asset: Asset,
 			quote_asset: Asset,
-			maybe_lp: Option<AccountId>,
+			lp: Option<AccountId>,
 		) -> Result<PoolOrders<Runtime>, DispatchError> {
-			match maybe_lp {
+			match lp {
 				Some(lp) => LiquidityPools::pool_orders(base_asset, quote_asset, &lp),
 				None => LiquidityPools::all_pool_orders(base_asset, quote_asset),
 			}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -11,7 +11,9 @@ pub mod test_runner;
 mod weights;
 use crate::{
 	chainflip::{calculate_account_apy, Offence},
-	runtime_apis::{AuctionState, LiquidityProviderInfo, RuntimeApiPenalty},
+	runtime_apis::{
+		AuctionState, DispatchErrorWithMessage, LiquidityProviderInfo, RuntimeApiPenalty,
+	},
 };
 use cf_amm::{
 	common::{Amount, Tick},
@@ -36,7 +38,6 @@ use pallet_cf_reputation::ExclusionList;
 use pallet_cf_swapping::CcmSwapAmounts;
 use pallet_cf_validator::SetSizeMaximisingAuctionResolver;
 use pallet_transaction_payment::{ConstFeeMultiplier, Multiplier};
-use sp_runtime::DispatchError;
 
 use crate::runtime_apis::RuntimeApiAccountInfoV2;
 
@@ -1051,47 +1052,47 @@ impl_runtime_apis! {
 		///
 		/// Note: This function must only be called through RPC, because RPC has its own storage buffer
 		/// layer and would not affect on-chain storage.
-		fn cf_pool_simulate_swap(from: Asset, to:Asset, amount: AssetAmount) -> Result<SwapOutput, DispatchError> {
-			LiquidityPools::swap_with_network_fee(from, to, amount)
+		fn cf_pool_simulate_swap(from: Asset, to:Asset, amount: AssetAmount) -> Result<SwapOutput, DispatchErrorWithMessage> {
+			LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
 		}
 
-		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchError> {
-			LiquidityPools::pool_info(base_asset, quote_asset)
+		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchErrorWithMessage> {
+			LiquidityPools::pool_info(base_asset, quote_asset).map_err(Into::into)
 		}
 
-		fn cf_pool_depth(base_asset: Asset, quote_asset: Asset, tick_range: Range<cf_amm::common::Tick>) -> Result<AskBidMap<UnidirectionalPoolDepth>, DispatchError> {
-			LiquidityPools::pool_depth(base_asset, quote_asset, tick_range)
+		fn cf_pool_depth(base_asset: Asset, quote_asset: Asset, tick_range: Range<cf_amm::common::Tick>) -> Result<AskBidMap<UnidirectionalPoolDepth>, DispatchErrorWithMessage> {
+			LiquidityPools::pool_depth(base_asset, quote_asset, tick_range).map_err(Into::into)
 		}
 
-		fn cf_pool_liquidity(base_asset: Asset, quote_asset: Asset) -> Result<PoolLiquidity, DispatchError> {
-			LiquidityPools::pool_liquidity(base_asset, quote_asset)
+		fn cf_pool_liquidity(base_asset: Asset, quote_asset: Asset) -> Result<PoolLiquidity, DispatchErrorWithMessage> {
+			LiquidityPools::pool_liquidity(base_asset, quote_asset).map_err(Into::into)
 		}
 
 		fn cf_required_asset_ratio_for_range_order(
 			base_asset: Asset,
 			quote_asset: Asset,
 			tick_range: Range<cf_amm::common::Tick>,
-		) -> Result<AssetsMap<Amount>, DispatchError> {
-			LiquidityPools::required_asset_ratio_for_range_order(base_asset, quote_asset, tick_range)
+		) -> Result<AssetsMap<Amount>, DispatchErrorWithMessage> {
+			LiquidityPools::required_asset_ratio_for_range_order(base_asset, quote_asset, tick_range).map_err(Into::into)
 		}
 
 		fn cf_pool_orderbook(
 			base_asset: Asset,
 			quote_asset: Asset,
 			orders: u32,
-		) -> Result<PoolOrderbook, DispatchError> {
-			LiquidityPools::pool_orderbook(base_asset, quote_asset, orders)
+		) -> Result<PoolOrderbook, DispatchErrorWithMessage> {
+			LiquidityPools::pool_orderbook(base_asset, quote_asset, orders).map_err(Into::into)
 		}
 
 		fn cf_pool_orders(
 			base_asset: Asset,
 			quote_asset: Asset,
 			lp: Option<AccountId>,
-		) -> Result<PoolOrders<Runtime>, DispatchError> {
+		) -> Result<PoolOrders<Runtime>, DispatchErrorWithMessage> {
 			match lp {
 				Some(lp) => LiquidityPools::pool_orders(base_asset, quote_asset, &lp),
 				None => LiquidityPools::all_pool_orders(base_asset, quote_asset),
-			}
+			}.map_err(Into::into)
 		}
 
 		fn cf_pool_range_order_liquidity_value(
@@ -1099,8 +1100,8 @@ impl_runtime_apis! {
 			quote_asset: Asset,
 			tick_range: Range<Tick>,
 			liquidity: Liquidity,
-		) -> Result<AssetsMap<Amount>, DispatchError> {
-			LiquidityPools::pool_range_order_liquidity_value(base_asset, quote_asset, tick_range, liquidity)
+		) -> Result<AssetsMap<Amount>, DispatchErrorWithMessage> {
+			LiquidityPools::pool_range_order_liquidity_value(base_asset, quote_asset, tick_range, liquidity).map_err(Into::into)
 		}
 
 		fn cf_network_environment() -> NetworkEnvironment {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1086,9 +1086,12 @@ impl_runtime_apis! {
 		fn cf_pool_orders(
 			base_asset: Asset,
 			quote_asset: Asset,
-			lp: AccountId,
-		) -> Result<PoolOrders, DispatchError> {
-			LiquidityPools::pool_orders(base_asset, quote_asset, &lp)
+			maybe_lp: Option<AccountId>,
+		) -> Result<PoolOrders<Runtime>, DispatchError> {
+			match maybe_lp {
+				Some(lp) => LiquidityPools::pool_orders(base_asset, quote_asset, &lp),
+				None => LiquidityPools::all_pool_orders(base_asset, quote_asset),
+			}
 		}
 
 		fn cf_pool_range_order_liquidity_value(

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -135,7 +135,7 @@ decl_runtime_apis!(
 		fn cf_pool_orders(
 			base_asset: Asset,
 			quote_asset: Asset,
-			maybe_lp: Option<AccountId32>,
+			lp: Option<AccountId32>,
 		) -> Result<PoolOrders<crate::Runtime>, DispatchError>;
 		fn cf_pool_range_order_liquidity_value(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -76,6 +76,21 @@ pub struct LiquidityProviderInfo {
 	pub balances: Vec<(Asset, AssetAmount)>,
 }
 
+#[derive(Debug, Decode, Encode, TypeInfo)]
+pub enum DispatchErrorWithMessage {
+	Module(Vec<u8>),
+	Other(DispatchError),
+}
+impl From<DispatchError> for DispatchErrorWithMessage {
+	fn from(value: DispatchError) -> Self {
+		match value {
+			DispatchError::Module(sp_runtime::ModuleError { message: Some(message), .. }) =>
+				DispatchErrorWithMessage::Module(message.as_bytes().to_vec()),
+			value => DispatchErrorWithMessage::Other(value),
+		}
+	}
+}
+
 decl_runtime_apis!(
 	/// Definition for all runtime API interfaces.
 	pub trait CustomRuntimeApi {
@@ -111,38 +126,41 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-		) -> Result<SwapOutput, DispatchError>;
-		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchError>;
+		) -> Result<SwapOutput, DispatchErrorWithMessage>;
+		fn cf_pool_info(
+			base_asset: Asset,
+			quote_asset: Asset,
+		) -> Result<PoolInfo, DispatchErrorWithMessage>;
 		fn cf_pool_depth(
 			base_asset: Asset,
 			quote_asset: Asset,
 			tick_range: Range<cf_amm::common::Tick>,
-		) -> Result<AskBidMap<UnidirectionalPoolDepth>, DispatchError>;
+		) -> Result<AskBidMap<UnidirectionalPoolDepth>, DispatchErrorWithMessage>;
 		fn cf_pool_liquidity(
 			base_asset: Asset,
 			quote_asset: Asset,
-		) -> Result<PoolLiquidity, DispatchError>;
+		) -> Result<PoolLiquidity, DispatchErrorWithMessage>;
 		fn cf_required_asset_ratio_for_range_order(
 			base_asset: Asset,
 			quote_asset: Asset,
 			tick_range: Range<cf_amm::common::Tick>,
-		) -> Result<AssetsMap<Amount>, DispatchError>;
+		) -> Result<AssetsMap<Amount>, DispatchErrorWithMessage>;
 		fn cf_pool_orderbook(
 			base_asset: Asset,
 			quote_asset: Asset,
 			orders: u32,
-		) -> Result<PoolOrderbook, DispatchError>;
+		) -> Result<PoolOrderbook, DispatchErrorWithMessage>;
 		fn cf_pool_orders(
 			base_asset: Asset,
 			quote_asset: Asset,
 			lp: Option<AccountId32>,
-		) -> Result<PoolOrders<crate::Runtime>, DispatchError>;
+		) -> Result<PoolOrders<crate::Runtime>, DispatchErrorWithMessage>;
 		fn cf_pool_range_order_liquidity_value(
 			base_asset: Asset,
 			quote_asset: Asset,
 			tick_range: Range<Tick>,
 			liquidity: Liquidity,
-		) -> Result<AssetsMap<Amount>, DispatchError>;
+		) -> Result<AssetsMap<Amount>, DispatchErrorWithMessage>;
 		fn cf_min_swap_amount(asset: Asset) -> AssetAmount;
 		fn cf_max_swap_amount(asset: Asset) -> Option<AssetAmount>;
 		fn cf_min_deposit_amount(asset: Asset) -> AssetAmount;

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -133,10 +133,10 @@ decl_runtime_apis!(
 			orders: u32,
 		) -> Result<PoolOrderbook, DispatchError>;
 		fn cf_pool_orders(
-			base: Asset,
-			pair: Asset,
-			lp: AccountId32,
-		) -> Result<PoolOrders, DispatchError>;
+			base_asset: Asset,
+			quote_asset: Asset,
+			maybe_lp: Option<AccountId32>,
+		) -> Result<PoolOrders<crate::Runtime>, DispatchError>;
 		fn cf_pool_range_order_liquidity_value(
 			base_asset: Asset,
 			quote_asset: Asset,


### PR DESCRIPTION

# Pull Request

Closes: PRO-974

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Modified existing `cf_pool_orders` RPC call to take in optional LP.
If no LP is supplied, all pool orders are returned.
