### PR TITLE
Fix: CFE Witnessing, use parent block metadata when decoding events

### DIFF
--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -129,10 +129,10 @@ impl DotRpcApi for DotRpcClient {
 
 	/// Returns the events for a particular block hash.
 	/// If the block for the given block hash does not exist, then this returns `Ok(None)`.
-	/// The parent hash is used to determine the runtime version to decode the events.
 	async fn events(
 		&self,
 		block_hash: PolkadotHash,
+		// The parent hash is used to determine the runtime version to decode the events.
 		parent_hash: PolkadotHash,
 	) -> Result<Option<Events<PolkadotConfig>>> {
 		self.http_client.events(block_hash, parent_hash).await

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -151,16 +151,16 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 							"Witnessing transaction_succeeded. signature: {signature:?}"
 						);
 						process_call(
-						pallet_cf_broadcast::Call::<_, PolkadotInstance>::transaction_succeeded {
-							tx_out_id: signature,
-							signer_id: epoch.info.1,
-							tx_fee,
-							tx_metadata: (),
-						}
-						.into(),
-						epoch.index,
-					)
-					.await;
+							pallet_cf_broadcast::Call::<_, PolkadotInstance>::transaction_succeeded {
+								tx_out_id: signature,
+								signer_id: epoch.info.1,
+								tx_fee,
+								tx_metadata: (),
+							}
+							.into(),
+							epoch.index,
+						)
+						.await;
 					}
 				},
 			Err(error) => {

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -143,12 +143,14 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 		);
 		let mut xt_bytes = xt.0.as_slice();
 
-		let unchecked = PolkadotUncheckedExtrinsic::decode(&mut xt_bytes);
-		if let Ok(unchecked) = unchecked {
-			if let Some(signature) = unchecked.signature() {
-				if monitored_egress_ids.contains(&signature) {
-					tracing::info!("Witnessing transaction_succeeded. signature: {signature:?}");
-					process_call(
+		match PolkadotUncheckedExtrinsic::decode(&mut xt_bytes) {
+			Ok(unchecked) =>
+				if let Some(signature) = unchecked.signature() {
+					if monitored_egress_ids.contains(&signature) {
+						tracing::info!(
+							"Witnessing transaction_succeeded. signature: {signature:?}"
+						);
+						process_call(
 						pallet_cf_broadcast::Call::<_, PolkadotInstance>::transaction_succeeded {
 							tx_out_id: signature,
 							signer_id: epoch.info.1,
@@ -159,13 +161,14 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 						epoch.index,
 					)
 					.await;
-				}
-			}
-		} else {
-			// We expect this to occur when attempting to decode
-			// a transaction that was not sent by us.
-			// We can safely ignore it, but we log it in case.
-			tracing::debug!("Failed to decode UncheckedExtrinsic {unchecked:?}");
+					}
+				},
+			Err(error) => {
+				// We expect this to occur when attempting to decode
+				// a transaction that was not sent by us.
+				// We can safely ignore it, but we log it in case.
+				tracing::debug!("Failed to decode UncheckedExtrinsic {error}");
+			},
 		}
 	}
 }
@@ -237,9 +240,7 @@ where
 	DotFinalisedSource::new(dot_client.clone())
 		.strictly_monotonic()
 		.logging("finalised block produced")
-		.then(|header| async move {
-			header.data.iter().filter_map(filter_map_events).collect::<Vec<_>>()
-		})
+		.then(|header| async move { header.data.iter().filter_map(filter_map_events).collect() })
 		.chunk_by_vault(vaults, scope)
 		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
 		.await

--- a/engine/src/witness/dot/dot_source.rs
+++ b/engine/src/witness/dot/dot_source.rs
@@ -40,7 +40,10 @@ macro_rules! polkadot_source {
 					{
 						if let Ok(header) = header {
 							let Some(events) = unwrap_events(
-								state.client.events(header.hash(), $retry_limit).await,
+								state
+									.client
+									.events(header.hash(), header.parent_hash, $retry_limit)
+									.await,
 							) else {
 								continue
 							};
@@ -104,7 +107,7 @@ where
 		&self,
 	) -> (BoxChainStream<'_, Self::Index, Self::Hash, Self::Data>, Self::Client) {
 		// For the unfinalised source we limit to two retries, so we try the primary and backup. We
-		// stop here becauase for unfinalised it's possible the block simple doesn't exist, due to a
+		// stop here because for unfinalised it's possible the block simple doesn't exist, due to a
 		// reorg.
 		polkadot_source!(self, subscribe_best_heads, 2, |raw_events: Result<
 			Option<Events<PolkadotConfig>>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1017

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The issue is caused by the `state_getRuntimeVersion` rpc returning the new runtime version when called at the given block, but the events in that block at encoded with the old runtime.
- Use parent block hash when getting polkadot runtime version & metadata
- Added a test that gets the events from the block on polkadot mainnet that had the runtime update in it and caused the error that we seen in the logs. Then parses the events and checks for any failure to decode. This test is set to ignore because it uses an external public endpoint.
- A few other small changes cleaning up code here and there.