### PR TITLE
[cherry-pick 🍒] chore: clear CDN cache after releasing new apt packages 🪄 (#4325)

### DIFF
--- a/.github/workflows/_70_post_release.yml
+++ b/.github/workflows/_70_post_release.yml
@@ -1,0 +1,35 @@
+on:
+  workflow_call:
+    inputs:
+      network:
+        description: Network being released
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  invalidate-apt-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials using OIDC 🪪
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-central-1
+          role-to-assume: arn:aws:iam::962042992619:role/chainflip-github-bot
+
+      - name: Invalidate CloudFront Cache - Sisyphos 🔥
+        if: ${{ inputs.network == 'sisyphos' }}
+        run: >
+          aws cloudfront create-invalidation
+          --distribution-id E3LRLBQETRDJF3
+          --paths '/*'
+
+      - name: Invalidate CloudFront Cache - Perseverance 🔥
+        if: ${{ inputs.network == 'perseverance' }}
+        run: >
+          aws cloudfront create-invalidation
+          --distribution-id E15DU9IPLRYY7S
+          --paths '/*'

--- a/.github/workflows/release-perseverance.yml
+++ b/.github/workflows/release-perseverance.yml
@@ -41,3 +41,8 @@ jobs:
     secrets: inherit
     with:
       network: "perseverance"
+  invalidate-apt-cache:
+    needs: [publish]
+    uses: ./.github/workflows/_70_post_release.yml
+    with:
+      network: "perseverance"

--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -51,3 +51,8 @@ jobs:
       version: "sisyphos/"
       environment: "development"
     secrets: inherit
+  invalidate-apt-cache:
+    needs: [publish]
+    uses: ./.github/workflows/_70_post_release.yml
+    with:
+      network: "sisyphos"


### PR DESCRIPTION
This is a cherry-pick from main to allow automatic AWS CloudFront cache invalidation which is necessary to make sure that new package are available immediately after publishing. 