### PR TITLE
feat: API Bins check SC compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1428,6 +1428,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac-sha512",
+ "lazy_static",
  "libp2p-identity 0.2.8",
  "libsecp256k1",
  "pallet-cf-account-roles",

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]
@@ -20,6 +20,7 @@ tokio = "1.28"
 tracing = "0.1"
 zeroize = "1.5.4"
 libp2p-identity = { version = "0.2", features = ["ed25519", "peerid"] }
+lazy_static = "1.4"
 
 # Local
 chainflip-engine = { path = "../../engine/" }

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -6,7 +6,7 @@ use cf_chains::{
 	address::EncodedAddress, dot::PolkadotAccountId, evm::to_evm_address, AnyChain,
 	CcmChannelMetadata, ForeignChain,
 };
-use cf_primitives::{AccountRole, Asset, BasisPoints, ChannelId};
+use cf_primitives::{AccountRole, Asset, BasisPoints, ChannelId, SemVer};
 use futures::FutureExt;
 use pallet_cf_governance::ExecutionMode;
 use pallet_cf_validator::MAX_LENGTH_FOR_VANITY_NAME;
@@ -47,6 +47,14 @@ use chainflip_engine::state_chain_observer::client::{
 	StateChainClient,
 };
 use utilities::{clean_hex_address, task_scope::Scope};
+
+lazy_static::lazy_static! {
+	static ref API_VERSION: SemVer = SemVer {
+		major: env!("CARGO_PKG_VERSION_MAJOR").parse::<u8>().unwrap(),
+		minor: env!("CARGO_PKG_VERSION_MINOR").parse::<u8>().unwrap(),
+		patch: env!("CARGO_PKG_VERSION_PATCH").parse::<u8>().unwrap(),
+	};
+}
 
 #[async_trait]
 pub trait AuctionPhaseApi {
@@ -112,7 +120,7 @@ impl StateChainApi {
 			&state_chain_settings.signing_key_file,
 			AccountRole::Unregistered,
 			false,
-			None,
+			Some((*API_VERSION, false)),
 		)
 		.await?;
 

--- a/engine/src/state_chain_observer/client/mod.rs
+++ b/engine/src/state_chain_observer/client/mod.rs
@@ -260,6 +260,7 @@ async fn create_finalized_block_subscription<
 						let base_rpc_client = &base_rpc_client;
 						async move {
 							Ok::<_, anyhow::Error>((
+								block.number,
 								block.hash,
 								base_rpc_client
 									.storage_value::<pallet_cf_environment::CurrentReleaseVersion<
@@ -269,7 +270,7 @@ async fn create_finalized_block_subscription<
 							))
 						}
 					})
-					.try_take_while(|(_block_hash, current_release_version)| {
+					.try_take_while(|(_block_number, _block_hash, current_release_version)| {
 						futures::future::ready({
 							Ok::<_, anyhow::Error>(
 								!required_version.is_compatible_with(*current_release_version),
@@ -278,8 +279,8 @@ async fn create_finalized_block_subscription<
 					})
 					.boxed();
 
-			incompatible_blocks.try_for_each(move |(block_hash, current_release_version)| futures::future::ready({
-			info!("This version '{}' is incompatible with the current release '{}' at block: {}. WAITING for a compatible release version.", required_version, current_release_version, block_hash);
+			incompatible_blocks.try_for_each(move |(block_number, block_hash, current_release_version)| futures::future::ready({
+			info!("This version '{required_version}' is incompatible with the current release '{current_release_version}' at block {block_number}: {block_hash:?}. WAITING for a compatible release version.");
 			Ok::<_, anyhow::Error>(())
 		})).await?;
 		} else {
@@ -290,9 +291,8 @@ async fn create_finalized_block_subscription<
 				.await?;
 			if !required_version.is_compatible_with(current_release_version) {
 				bail!(
-					"This version '{}' is incompatible with the current release '{}' at block: {}.",
-					required_version,
-					current_release_version,
+					"This version '{required_version}' is incompatible with the current release '{current_release_version}' at block {}: {:?}.",
+					latest_block.number,
 					latest_block.hash,
 				);
 			}
@@ -321,9 +321,16 @@ async fn create_finalized_block_subscription<
 					let block = result_block?;
 					latest_block = block;
 					if let Some((required_version, _)) = required_version_and_wait {
-						let current_release_version = base_rpc_client.storage_value::<pallet_cf_environment::CurrentReleaseVersion<state_chain_runtime::Runtime>>(block.hash).await?;
+						let current_release_version = base_rpc_client
+							.storage_value::<pallet_cf_environment::CurrentReleaseVersion<state_chain_runtime::Runtime>>(
+								block.hash,
+							)
+							.await?;
 						if !required_version.is_compatible_with(current_release_version) {
-							break Err(anyhow!("This version '{}' is no longer compatible with the release version '{}' at block: {}", required_version, current_release_version, block.hash))
+							break Err(anyhow!("This version '{required_version}' is no longer compatible with the release version '{current_release_version}' at block {}: {:?}", 
+								block.number, 
+								block.hash
+							))
 						}
 					}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-972

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Added the existing version check to the API lib. This means the Broker, LP API and CLI will all return an error when trying to do a command on the SC using an older version then what's on chain.
- Version check is on all 3 bins, not just the CLI. Let me know if this is a bad idea.
- The check uses the API package version, **NOT** the individual bins version. Is this what we want? I think so.
	- Updated the API version to 1.1.0, like the others. We will need to make sure to update this version when we update the others.
- The error message does **not** let the user know they need to download an update or how to do that. This is because the message general, the CFE uses it.
	- Added block number to the error message.

```sh
Error: This version '0.1.0' is incompatible with the current release '1.1.0' at block 2117: 0xebd4e5c9c477360da764b20bcc4c0e61c723e6641aa422ebce9d0a07120598ae.
```