### PR TITLE
fix: btc witnesser test failing sometimes

### DIFF
--- a/engine/src/witness/btc/btc_deposits.rs
+++ b/engine/src/witness/btc/btc_deposits.rs
@@ -151,8 +151,8 @@ pub mod tests {
 	use sp_runtime::AccountId32;
 
 	pub fn fake_transaction(tx_outs: Vec<VerboseTxOut>, fee: Option<Amount>) -> VerboseTransaction {
-		let random_number: u8 = rand::thread_rng().gen();
-		let txid = Txid::from_byte_array([random_number; 32]);
+		let random_bytes: [u8; 32] = rand::thread_rng().gen();
+		let txid = Txid::from_byte_array(random_bytes);
 		VerboseTransaction {
 			txid,
 			version: Version::from_consensus(2),


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Was a 1/85 chance of the test failing because 2 of the txid's are the same. Maybe we should make the function take an id argument so the test can guarantee no collisions?
For now i just did the quickest thing and make all the bytes random so the chances and almost 0.