### PR TITLE
feat: spec_version of PR is greater than spec version of current release

### DIFF
--- a/bouncer/commands/read_workspace_tomls.ts
+++ b/bouncer/commands/read_workspace_tomls.ts
@@ -61,7 +61,8 @@ if (
 }
 
 const releaseSpecVersion = Number(
-  (await jsonRpc('state_getRuntimeVersion', [], 'perseverance.chainflip.xyz', 443)).specVersion,
+  (await jsonRpc('state_getRuntimeVersion', [], 'https://perseverance.chainflip.xyz:443'))
+    .specVersion,
 );
 console.log(`Release spec version: ${releaseSpecVersion}`);
 

--- a/bouncer/shared/json_rpc.ts
+++ b/bouncer/shared/json_rpc.ts
@@ -3,7 +3,8 @@ export async function jsonRpc(
   method: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any[],
-  port: number,
+  host?: string,
+  port?: number,
 ): Promise<JSON> {
   console.log('Sending json RPC', method);
 
@@ -14,7 +15,10 @@ export async function jsonRpc(
     params,
     id,
   });
-  const response = await fetch(`http://127.0.0.1:${port}`, {
+
+  const fetchHost = host ?? 'localhost';
+  const fetchPort = port ?? 9944;
+  const response = await fetch(`https://${fetchHost}:${fetchPort}`, {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/bouncer/shared/json_rpc.ts
+++ b/bouncer/shared/json_rpc.ts
@@ -3,8 +3,7 @@ export async function jsonRpc(
   method: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any[],
-  host?: string,
-  port?: number,
+  endpoint?: string,
 ): Promise<JSON> {
   console.log('Sending json RPC', method);
 
@@ -16,9 +15,8 @@ export async function jsonRpc(
     id,
   });
 
-  const fetchHost = host ?? 'localhost';
-  const fetchPort = port ?? 9944;
-  const response = await fetch(`https://${fetchHost}:${fetchPort}`, {
+  const fetchEndpoint = endpoint ?? 'http://localhost:9944';
+  const response = await fetch(`${fetchEndpoint}`, {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -32,8 +32,7 @@ const testAddress = '0x1594300cbd587694affd70c933b9ee9155b186d9';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function lpApiRpc(method: string, params: any[]): Promise<any> {
   // The port for the lp api is defined in `start_lp_api.sh`
-  const port = 10589;
-  return jsonRpc(method, params, undefined, port);
+  return jsonRpc(method, params, 'http://127.0.0.1:10589');
 }
 
 async function provideLiquidityAndTestAssetBalances() {

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -33,7 +33,7 @@ const testAddress = '0x1594300cbd587694affd70c933b9ee9155b186d9';
 async function lpApiRpc(method: string, params: any[]): Promise<any> {
   // The port for the lp api is defined in `start_lp_api.sh`
   const port = 10589;
-  return jsonRpc(method, params, port);
+  return jsonRpc(method, params, undefined, port);
 }
 
 async function provideLiquidityAndTestAssetBalances() {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -159,7 +159,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 110,
+	spec_version: 112,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 12,


### PR DESCRIPTION
# Pull Request

Carrying on from #4351 , this one checks spec_version is bumped, which is required to push the runtime version update.

Also closes: PRO-919

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

