### PR TITLE
BitcoinFeeInfo: store single field, derive the rest

### DIFF
--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -134,6 +134,8 @@ impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
 	}
 }
 
+
+/// A record on the Bitcoin transaction fee.
 #[derive(
 	Copy,
 	Clone,
@@ -152,6 +154,12 @@ pub struct BitcoinFeeInfo {
 }
 
 impl BitcoinFeeInfo {
+	/// Construct an instance of [`BitcoinFeeInfo`].
+	pub fn new(sats_per_kilo_byte: BtcAmount) -> Self {
+		Self { sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE) }
+	}
+
+
 	pub fn sats_per_kilo_byte(&self) -> BtcAmount {
 		self.sats_per_kilo_byte
 	}
@@ -177,14 +185,6 @@ const BYTES_PER_KILOBYTE: BtcAmount = 1024;
 impl Default for BitcoinFeeInfo {
 	fn default() -> Self {
 		Self { sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE }
-	}
-}
-
-impl BitcoinFeeInfo {
-	/// Calculate the fees necessary based on the provided fee rate.
-	/// We ensure that a minimum of 1 sat per vByte is set for each of the fees.
-	pub fn new(sats_per_kilo_byte: BtcAmount) -> Self {
-		Self { sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE) }
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -134,7 +134,6 @@ impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
 	}
 }
 
-
 /// A record on the Bitcoin transaction fee.
 #[derive(
 	Copy,
@@ -153,12 +152,19 @@ pub struct BitcoinFeeInfo {
 	sats_per_kilo_byte: BtcAmount,
 }
 
+const BYTES_PER_KILOBYTE: BtcAmount = 1024;
+
+impl Default for BitcoinFeeInfo {
+	fn default() -> Self {
+		Self { sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE }
+	}
+}
+
 impl BitcoinFeeInfo {
 	/// Construct an instance of [`BitcoinFeeInfo`].
 	pub fn new(sats_per_kilo_byte: BtcAmount) -> Self {
 		Self { sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE) }
 	}
-
 
 	pub fn sats_per_kilo_byte(&self) -> BtcAmount {
 		self.sats_per_kilo_byte
@@ -177,14 +183,6 @@ impl BitcoinFeeInfo {
 	pub fn min_fee_required_per_tx(&self) -> BtcAmount {
 		// Minimum size of tx that does not scale with input and output utxos is 12 bytes
 		self.sats_per_kilo_byte.saturating_mul(MINIMUM_BTC_TX_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE
-	}
-}
-
-const BYTES_PER_KILOBYTE: BtcAmount = 1024;
-
-impl Default for BitcoinFeeInfo {
-	fn default() -> Self {
-		Self { sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE }
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -152,18 +152,20 @@ pub struct BitcoinFeeInfo {
 }
 
 impl BitcoinFeeInfo {
-	pub fn sats_per_kilo_byte(&self) -> BtcAmount { self.sats_per_kilo_byte }
-
-	pub fn fee_per_input_utxo(&self) -> BtcAmount { 
-		// Our input utxos are approximately 178 bytes each in the Btc transaction
-		self.sats_per_kilo_byte.saturating_mul(INPUT_UTXO_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE 
+	pub fn sats_per_kilo_byte(&self) -> BtcAmount {
+		self.sats_per_kilo_byte
 	}
-	
+
+	pub fn fee_per_input_utxo(&self) -> BtcAmount {
+		// Our input utxos are approximately 178 bytes each in the Btc transaction
+		self.sats_per_kilo_byte.saturating_mul(INPUT_UTXO_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE
+	}
+
 	pub fn fee_per_output_utxo(&self) -> BtcAmount {
 		// Our output utxos are approximately 34 bytes each in the Btc transaction
-		self.sats_per_kilo_byte.saturating_mul(OUTPUT_UTXO_SIZE_IN_BYTES) /BYTES_PER_KILOBYTE
+		self.sats_per_kilo_byte.saturating_mul(OUTPUT_UTXO_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE
 	}
-	
+
 	pub fn min_fee_required_per_tx(&self) -> BtcAmount {
 		// Minimum size of tx that does not scale with input and output utxos is 12 bytes
 		self.sats_per_kilo_byte.saturating_mul(MINIMUM_BTC_TX_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE
@@ -174,9 +176,7 @@ const BYTES_PER_KILOBYTE: BtcAmount = 1024;
 
 impl Default for BitcoinFeeInfo {
 	fn default() -> Self {
-		Self {
-			sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE,
-		}
+		Self { sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE }
 	}
 }
 
@@ -184,9 +184,7 @@ impl BitcoinFeeInfo {
 	/// Calculate the fees necessary based on the provided fee rate.
 	/// We ensure that a minimum of 1 sat per vByte is set for each of the fees.
 	pub fn new(sats_per_kilo_byte: BtcAmount) -> Self {
-		Self {
-			sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE),
-		}
+		Self { sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE) }
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -122,7 +122,7 @@ impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
 		_asset: <Bitcoin as Chain>::ChainAsset,
 	) -> <Bitcoin as Chain>::ChainAmount {
 		// Include the min fee so we over-estimate the cost.
-		self.btc_fee_info.min_fee_required_per_tx + self.btc_fee_info.fee_per_input_utxo
+		self.btc_fee_info.min_fee_required_per_tx() + self.btc_fee_info.fee_per_input_utxo()
 	}
 
 	fn estimate_egress_fee(
@@ -130,7 +130,7 @@ impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
 		_asset: <Bitcoin as Chain>::ChainAsset,
 	) -> <Bitcoin as Chain>::ChainAmount {
 		// Include the min fee so we over-estimate the cost.
-		self.btc_fee_info.min_fee_required_per_tx + self.btc_fee_info.fee_per_output_utxo
+		self.btc_fee_info.min_fee_required_per_tx() + self.btc_fee_info.fee_per_output_utxo()
 	}
 }
 
@@ -148,9 +148,26 @@ impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
 	Deserialize,
 )]
 pub struct BitcoinFeeInfo {
-	pub fee_per_input_utxo: BtcAmount,
-	pub fee_per_output_utxo: BtcAmount,
-	pub min_fee_required_per_tx: BtcAmount,
+	sats_per_kilo_byte: BtcAmount,
+}
+
+impl BitcoinFeeInfo {
+	pub fn sats_per_kilo_byte(&self) -> BtcAmount { self.sats_per_kilo_byte }
+
+	pub fn fee_per_input_utxo(&self) -> BtcAmount { 
+		// Our input utxos are approximately 178 bytes each in the Btc transaction
+		self.sats_per_kilo_byte.saturating_mul(INPUT_UTXO_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE 
+	}
+	
+	pub fn fee_per_output_utxo(&self) -> BtcAmount {
+		// Our output utxos are approximately 34 bytes each in the Btc transaction
+		self.sats_per_kilo_byte.saturating_mul(OUTPUT_UTXO_SIZE_IN_BYTES) /BYTES_PER_KILOBYTE
+	}
+	
+	pub fn min_fee_required_per_tx(&self) -> BtcAmount {
+		// Minimum size of tx that does not scale with input and output utxos is 12 bytes
+		self.sats_per_kilo_byte.saturating_mul(MINIMUM_BTC_TX_SIZE_IN_BYTES) / BYTES_PER_KILOBYTE
+	}
 }
 
 const BYTES_PER_KILOBYTE: BtcAmount = 1024;
@@ -158,12 +175,7 @@ const BYTES_PER_KILOBYTE: BtcAmount = 1024;
 impl Default for BitcoinFeeInfo {
 	fn default() -> Self {
 		Self {
-			fee_per_input_utxo: DEFAULT_FEE_SATS_PER_KILO_BYTE * INPUT_UTXO_SIZE_IN_BYTES /
-				BYTES_PER_KILOBYTE,
-			fee_per_output_utxo: DEFAULT_FEE_SATS_PER_KILO_BYTE * OUTPUT_UTXO_SIZE_IN_BYTES /
-				BYTES_PER_KILOBYTE,
-			min_fee_required_per_tx: DEFAULT_FEE_SATS_PER_KILO_BYTE * MINIMUM_BTC_TX_SIZE_IN_BYTES /
-				BYTES_PER_KILOBYTE,
+			sats_per_kilo_byte: DEFAULT_FEE_SATS_PER_KILO_BYTE,
 		}
 	}
 }
@@ -173,18 +185,7 @@ impl BitcoinFeeInfo {
 	/// We ensure that a minimum of 1 sat per vByte is set for each of the fees.
 	pub fn new(sats_per_kilo_byte: BtcAmount) -> Self {
 		Self {
-			// Our input utxos are approximately 178 bytes each in the Btc transaction
-			fee_per_input_utxo: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE)
-				.saturating_mul(INPUT_UTXO_SIZE_IN_BYTES) /
-				BYTES_PER_KILOBYTE,
-			// Our output utxos are approximately 34 bytes each in the Btc transaction
-			fee_per_output_utxo: max(BYTES_PER_KILOBYTE, sats_per_kilo_byte)
-				.saturating_mul(OUTPUT_UTXO_SIZE_IN_BYTES) /
-				BYTES_PER_KILOBYTE,
-			// Minimum size of tx that does not scale with input and output utxos is 12 bytes
-			min_fee_required_per_tx: max(BYTES_PER_KILOBYTE, sats_per_kilo_byte)
-				.saturating_mul(MINIMUM_BTC_TX_SIZE_IN_BYTES) /
-				BYTES_PER_KILOBYTE,
+			sats_per_kilo_byte: max(sats_per_kilo_byte, BYTES_PER_KILOBYTE),
 		}
 	}
 }

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -404,7 +404,7 @@ impl<T: Config> Pallet<T> {
 		let fee_per_input_utxo = bitcoin_fee_info.fee_per_input_utxo();
 		let min_fee_required_per_tx = bitcoin_fee_info.min_fee_required_per_tx();
 		let fee_per_output_utxo = bitcoin_fee_info.fee_per_output_utxo();
-		
+
 		match utxo_selection_type {
 			UtxoSelectionType::SelectAllForRotation => {
 				let spendable_utxos: Vec<_> = BitcoinAvailableUtxos::<T>::take()

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -7,7 +7,7 @@ use cf_chains::{
 		api::{SelectedUtxosAndChangeAmount, UtxoSelectionType},
 		deposit_address::DepositAddress,
 		utxo_selection::{select_utxos_for_consolidation, select_utxos_from_pool},
-		Bitcoin, BitcoinFeeInfo, BtcAmount, Utxo, UtxoId, CHANGE_ADDRESS_SALT,
+		Bitcoin, BtcAmount, Utxo, UtxoId, CHANGE_ADDRESS_SALT,
 	},
 	dot::{Polkadot, PolkadotAccountId, PolkadotHash, PolkadotIndex},
 	eth::Address as EthereumAddress,
@@ -400,8 +400,11 @@ impl<T: Config> Pallet<T> {
 	pub fn select_and_take_bitcoin_utxos(
 		utxo_selection_type: UtxoSelectionType,
 	) -> Option<SelectedUtxosAndChangeAmount> {
-		let BitcoinFeeInfo { fee_per_input_utxo, fee_per_output_utxo, min_fee_required_per_tx } =
-			T::BitcoinFeeInfo::bitcoin_fee_info();
+		let bitcoin_fee_info = T::BitcoinFeeInfo::bitcoin_fee_info();
+		let fee_per_input_utxo = bitcoin_fee_info.fee_per_input_utxo();
+		let min_fee_required_per_tx = bitcoin_fee_info.min_fee_required_per_tx();
+		let fee_per_output_utxo = bitcoin_fee_info.fee_per_output_utxo();
+		
 		match utxo_selection_type {
 			UtxoSelectionType::SelectAllForRotation => {
 				let spendable_utxos: Vec<_> = BitcoinAvailableUtxos::<T>::take()

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -6,9 +6,7 @@ use cf_chains::{
 	dot::{api::CreatePolkadotVault, PolkadotCrypto},
 	eth, ApiCall, Bitcoin, Chain, ChainCrypto, Polkadot,
 };
-use cf_primitives::{
-	BroadcastId, SemVer, ThresholdSignatureRequestId,
-};
+use cf_primitives::{BroadcastId, SemVer, ThresholdSignatureRequestId};
 use cf_traits::{
 	impl_mock_callback, impl_mock_chainflip, impl_mock_runtime_safe_mode, impl_pallet_safe_mode,
 	Broadcaster, GetBitcoinFeeInfo, VaultKeyWitnessedHandler,

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -7,8 +7,7 @@ use cf_chains::{
 	eth, ApiCall, Bitcoin, Chain, ChainCrypto, Polkadot,
 };
 use cf_primitives::{
-	BroadcastId, SemVer, ThresholdSignatureRequestId, INPUT_UTXO_SIZE_IN_BYTES,
-	MINIMUM_BTC_TX_SIZE_IN_BYTES, OUTPUT_UTXO_SIZE_IN_BYTES,
+	BroadcastId, SemVer, ThresholdSignatureRequestId,
 };
 use cf_traits::{
 	impl_mock_callback, impl_mock_chainflip, impl_mock_runtime_safe_mode, impl_pallet_safe_mode,
@@ -160,11 +159,7 @@ parameter_types! {
 pub struct MockBitcoinFeeInfo;
 impl GetBitcoinFeeInfo for MockBitcoinFeeInfo {
 	fn bitcoin_fee_info() -> BitcoinFeeInfo {
-		BitcoinFeeInfo {
-			fee_per_input_utxo: 10 * INPUT_UTXO_SIZE_IN_BYTES,
-			fee_per_output_utxo: 10 * OUTPUT_UTXO_SIZE_IN_BYTES,
-			min_fee_required_per_tx: 10 * MINIMUM_BTC_TX_SIZE_IN_BYTES,
-		}
+		BitcoinFeeInfo::new(10 * 1024)
 	}
 }
 

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -48,7 +48,7 @@ fn test_btc_utxo_selection() {
 		// dust amount should be ignored in all cases
 		let dust_amount = {
 			use cf_traits::GetBitcoinFeeInfo;
-			<Test as crate::Config>::BitcoinFeeInfo::bitcoin_fee_info().fee_per_input_utxo
+			<Test as crate::Config>::BitcoinFeeInfo::bitcoin_fee_info().fee_per_input_utxo()
 		};
 		add_utxo_amount(dust_amount);
 
@@ -117,7 +117,7 @@ fn test_btc_utxo_consolidation() {
 
 		let dust_amount = {
 			use cf_traits::GetBitcoinFeeInfo;
-			<Test as crate::Config>::BitcoinFeeInfo::bitcoin_fee_info().fee_per_input_utxo
+			<Test as crate::Config>::BitcoinFeeInfo::bitcoin_fee_info().fee_per_input_utxo()
 		};
 
 		add_utxo_amount(10000);

--- a/state-chain/runtime/src/chainflip/decompose_recompose.rs
+++ b/state-chain/runtime/src/chainflip/decompose_recompose.rs
@@ -25,11 +25,7 @@ fn decode_many<T: Encode + Decode>(data: &mut [Vec<u8>]) -> Vec<T> {
 }
 
 fn select_median_btc_info(data: Vec<BitcoinFeeInfo>) -> Option<BitcoinFeeInfo> {
-	select_median(
-		data.iter()
-			.map(BitcoinFeeInfo::sats_per_kilo_byte)
-			.collect()
-		)
+	select_median(data.iter().map(BitcoinFeeInfo::sats_per_kilo_byte).collect())
 		.map(BitcoinFeeInfo::new)
 }
 

--- a/state-chain/runtime/src/chainflip/decompose_recompose.rs
+++ b/state-chain/runtime/src/chainflip/decompose_recompose.rs
@@ -6,12 +6,8 @@ use pallet_cf_witnesser::WitnessDataExtraction;
 use sp_std::{mem, prelude::*};
 
 fn select_median<T: Ord + Copy>(mut data: Vec<T>) -> Option<T> {
-	if data.is_empty() {
-		return None
-	}
-
-	let len = data.len();
-	let median_index = (len - 1) / 2;
+	let len_sub_one = data.len().checked_sub(1)?;
+	let median_index = len_sub_one / 2;
 	let (_, median_value, _) = data.select_nth_unstable(median_index);
 
 	Some(*median_value)


### PR DESCRIPTION
# Pull Request

Closes: PRO-1073

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

As the value of `BitcoinFeeInfo` is stored, it is better to reduce its size.

As all the estimations are basically the function of `sats_per_kilo_byte` — only `sats_per_kilo_byte` is to be kept in this record.

As the estimations linearly depend on `sats_per_kilo_byte`, sorting by `sats_per_kilo_byte` instead of the estimations's values will not change the order (the median-value calculation in `decompose_recompose.rs` will not be affected).