### PR TITLE
chore: fix log message formatting

### DIFF
--- a/engine/src/btc/rpc.rs
+++ b/engine/src/btc/rpc.rs
@@ -86,15 +86,10 @@ impl BtcRpcClient {
 					match get_bitcoin_network(&client, &endpoint).await {
 						Ok(network) if network == expected_btc_network => break,
 						Ok(network) => {
-							error!(
-									"Connected to Bitcoin node but with incorrect network name `{network}`, expected `{expected_btc_network}` on endpoint {}. Please check your CFE
-									configuration file...",
-									endpoint.http_endpoint
-								);
+							error!("Connected to Bitcoin node but with incorrect network name `{network}`, expected `{expected_btc_network}` on endpoint {}. Please check your CFE configuration file...", endpoint.http_endpoint);
 						},
 						Err(e) => error!(
-							"Failure connecting to Bitcoin node at {} with error: {e}. Please check your CFE
-								configuration file. Retrying in {:?}...",
+							"Failure connecting to Bitcoin node at {} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
 							endpoint.http_endpoint,
 							poll_interval.period()
 						),

--- a/engine/src/btc/rpc.rs
+++ b/engine/src/btc/rpc.rs
@@ -86,10 +86,12 @@ impl BtcRpcClient {
 					match get_bitcoin_network(&client, &endpoint).await {
 						Ok(network) if network == expected_btc_network => break,
 						Ok(network) => {
-							error!("Connected to Bitcoin node but with incorrect network name `{network}`, expected `{expected_btc_network}` on endpoint {}. Please check your CFE configuration file...", endpoint.http_endpoint);
+							error!("Connected to Bitcoin node but with incorrect network name `{network}`, expected `{expected_btc_network}` on endpoint {}. \
+							Please check your CFE configuration file...", endpoint.http_endpoint);
 						},
 						Err(e) => error!(
-							"Failure connecting to Bitcoin node at {} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
+							"Failure connecting to Bitcoin node at {} with error: {e}. \
+							Please check your CFE configuration file. Retrying in {:?}...",
 							endpoint.http_endpoint,
 							poll_interval.period()
 						),

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -115,9 +115,10 @@ impl DotHttpRpcClient {
 					},
 					Err(e) => {
 						error!(
-						"Failed to connect to Polkadot node at {url} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
-						poll_interval.period()
-					);
+							"Failed to connect to Polkadot node at {url} with error: {e}. \
+						Please check your CFE configuration file. Retrying in {:?}...",
+							poll_interval.period()
+						);
 					},
 				}
 			};

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -115,8 +115,7 @@ impl DotHttpRpcClient {
 					},
 					Err(e) => {
 						error!(
-						"Failed to connect to Polkadot node at {url} with error: {e}. Please check your CFE
-						configuration file. Retrying in {:?}...",
+						"Failed to connect to Polkadot node at {url} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
 						poll_interval.period()
 					);
 					},

--- a/engine/src/eth/rpc.rs
+++ b/engine/src/eth/rpc.rs
@@ -43,13 +43,15 @@ impl EthRpcClient {
 					Ok(chain_id) if chain_id == expected_chain_id.into() => break client,
 					Ok(chain_id) => {
 						tracing::error!(
-								"Connected to Ethereum node but with incorrect chain_id {chain_id}, expected {expected_chain_id} from {http_endpoint}. Please check your CFE configuration file...",
+								"Connected to Ethereum node but with incorrect chain_id {chain_id}, expected {expected_chain_id} from {http_endpoint}. \
+								Please check your CFE configuration file...",
 							);
 					},
 					Err(e) => tracing::error!(
-							"Cannot connect to an Ethereum node at {http_endpoint} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
-							poll_interval.period()
-						),
+						"Cannot connect to an Ethereum node at {http_endpoint} with error: {e}. \
+							Please check your CFE configuration file. Retrying in {:?}...",
+						poll_interval.period()
+					),
 				}
 			}
 		})

--- a/engine/src/eth/rpc.rs
+++ b/engine/src/eth/rpc.rs
@@ -43,13 +43,11 @@ impl EthRpcClient {
 					Ok(chain_id) if chain_id == expected_chain_id.into() => break client,
 					Ok(chain_id) => {
 						tracing::error!(
-								"Connected to Ethereum node but with incorrect chain_id {chain_id}, expected {expected_chain_id} from {http_endpoint}. Please check your CFE
-								configuration file...",
+								"Connected to Ethereum node but with incorrect chain_id {chain_id}, expected {expected_chain_id} from {http_endpoint}. Please check your CFE configuration file...",
 							);
 					},
 					Err(e) => tracing::error!(
-							"Cannot connect to an Ethereum node at {http_endpoint} with error: {e}. Please check your CFE
-							configuration file. Retrying in {:?}...",
+							"Cannot connect to an Ethereum node at {http_endpoint} with error: {e}. Please check your CFE configuration file. Retrying in {:?}...",
 							poll_interval.period()
 						),
 				}


### PR DESCRIPTION
Annoying seeing the \n\t\t in some log messages like this:

```
{"timestamp":"2024-01-03T10:51:08.061388Z","level":"ERROR","fields":{"message":"Failed to connect to Polkadot node at https://polkadot.api.onfinality.io:443/rpc?apikey=2cc**** with error: Rpc error: RPC error: Networking or low-level protocol error: Server returned an error status code: 504. Please check your CFE\n\t\t\t\t\t\tconfiguration file. Retrying in 10s..."},"target":"chainflip_engine::dot::http_rpc"}
```