### PR TITLE
chore: warn on attempt 0 in retrier

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -406,7 +406,7 @@ where
 							let half_max = max_sleep_duration(initial_request_timeout, attempt) / 2;
 							let sleep_duration = half_max + rand::thread_rng().gen_range(Duration::default()..half_max);
 
-							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}", sleep_duration);
+							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {:?}", sleep_duration);
 							if attempt == 0 && !matches!(retry_limit, RetryLimit::Limit(1)) {
 								tracing::warn!(error_message);
 							} else {

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -407,7 +407,7 @@ where
 							let sleep_duration = half_max + rand::thread_rng().gen_range(Duration::default()..half_max);
 
 							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}ms", sleep_duration.as_millis());
-							if attempt == 0 && matches!(retry_limit, RetryLimit::NoLimit) {
+							if attempt == 0 && !matches!(retry_limit, RetryLimit::Limit(1)) {
 								tracing::warn!(error_message);
 							} else {
 								tracing::error!(error_message);

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -406,7 +406,7 @@ where
 							let half_max = max_sleep_duration(initial_request_timeout, attempt) / 2;
 							let sleep_duration = half_max + rand::thread_rng().gen_range(Duration::default()..half_max);
 
-							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}ms", sleep_duration.as_millis());
+							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}", sleep_duration);
 							if attempt == 0 && !matches!(retry_limit, RetryLimit::Limit(1)) {
 								tracing::warn!(error_message);
 							} else {

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -405,7 +405,13 @@ where
 							// We avoid small delays by always having a time of at least half.
 							let half_max = max_sleep_duration(initial_request_timeout, attempt) / 2;
 							let sleep_duration = half_max + rand::thread_rng().gen_range(Duration::default()..half_max);
-							tracing::error!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}ms", sleep_duration.as_millis());
+
+							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}`, attempt `{attempt}`: {e}. Delaying for {}ms", sleep_duration.as_millis());
+							if attempt == 0 && matches!(retry_limit, RetryLimit::NoLimit) {
+								tracing::warn!(error_message);
+							} else {
+								tracing::error!(error_message);
+							}
 
 							// Delay the request before the next retry.
 							retry_delays.push(Box::pin(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1080

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

We want to reduce some noise for monitoring people/systems. Given attempt 0 failures occur occasionally we want to make them warn instead of error - but only for requests that are `RetryLimit::NoLimit` - since requests that do have a limit, we want to know that they fail immediately, as they won't be retried for as long, or perhaps not as long. e.g. in the case of broadcasting, we want to know when we hit a broadcast error, as this could be indicative of lack of ETH in the account for example.
