### PR TITLE
chore: log_or_panic prepends its name

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -779,7 +779,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		PendingBroadcasts::<T, I>::mutate(|pending_broadcasts| {
 			if !pending_broadcasts.remove(broadcast_id) {
 				cf_runtime_utilities::log_or_panic!(
-					"The broadcast_id should exist in the pending broadcasts list since we added it to the list when the broadcast was initated"
+					"The broadcast_id {broadcast_id} should exist in the pending broadcasts list since we added it to the list when the broadcast was initated"
 				);
 			}
 			if let Some(broadcast_barrier_id) = BroadcastBarriers::<T, I>::get().first() {

--- a/state-chain/runtime-utilities/src/lib.rs
+++ b/state-chain/runtime-utilities/src/lib.rs
@@ -63,16 +63,18 @@ where
 /// Logs if running in release, panics if running in test.
 #[macro_export]
 macro_rules! log_or_panic {
-	($($arg:tt)*) => {
-		#[cfg(not(debug_assertions))]
-		{
-			log::error!($($arg)*);
-		}
-		#[cfg(debug_assertions)]
-		{
-			panic!($($arg)*);
-		};
-	};
+    ($($arg:tt)*) => {
+        #[cfg(not(debug_assertions))]
+        {
+			use scale_info::prelude::format;
+            log::error!("{}", format!("log_or_panic: {}", format_args!($($arg)*)));
+        }
+        #[cfg(debug_assertions)]
+        {
+			use scale_info::prelude::format;
+            panic!("log_or_panic: {}", format_args!($($arg)*));
+        };
+    };
 }
 
 #[cfg(test)]

--- a/state-chain/runtime-utilities/src/lib.rs
+++ b/state-chain/runtime-utilities/src/lib.rs
@@ -67,7 +67,7 @@ macro_rules! log_or_panic {
         #[cfg(not(debug_assertions))]
         {
 			use scale_info::prelude::format;
-            log::error!("{}", format!("log_or_panic: {}", format_args!($($arg)*)));
+            log::error!("log_or_panic: {}", format_args!($($arg)*));
         }
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
Related: PRO-1081

It's nice to be able to identify any of these "log_or_panic" messages as more critical than just a simple error message, which is how they appear in the logs - as these should be treated (almost) as if they are an assert.

Also adds broadcast id to one of the messages.