### PR TITLE
fix: bump subxt version to 0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
  "custom-rpc",
  "futures",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "serde",
  "sp-rpc",
  "substrate-build-script-utils 3.0.0 (git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+3)",
@@ -1530,7 +1530,7 @@ dependencies = [
  "hex",
  "httparse",
  "itertools 0.11.0",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "lazy_static",
  "mockall",
  "multisig",
@@ -1603,7 +1603,7 @@ dependencies = [
  "config",
  "futures",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "pallet-cf-broadcast",
  "pallet-cf-environment",
  "pallet-cf-ingress-egress",
@@ -1632,7 +1632,7 @@ dependencies = [
  "frame-system",
  "futures",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "pallet-cf-pools",
  "serde",
  "serde_json",
@@ -1659,7 +1659,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
@@ -2417,7 +2417,7 @@ dependencies = [
  "futures",
  "hex",
  "insta",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "pallet-cf-governance",
  "pallet-cf-pools",
  "sc-client-api",
@@ -3920,7 +3920,7 @@ dependencies = [
  "async-recursion",
  "futures",
  "indicatif",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "serde",
@@ -5156,15 +5156,27 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
 dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
+ "jsonrpsee-client-transport 0.16.3",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-http-client 0.16.3",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.16.3",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
+dependencies = [
+ "jsonrpsee-client-transport 0.20.3",
+ "jsonrpsee-core 0.20.3",
+ "jsonrpsee-http-client 0.20.3",
+ "jsonrpsee-types 0.20.3",
 ]
 
 [[package]]
@@ -5179,8 +5191,8 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -5190,6 +5202,26 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots 0.25.2",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
+dependencies = [
+ "futures-util",
+ "http",
+ "jsonrpsee-core 0.20.3",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5208,7 +5240,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.16.3",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -5222,6 +5254,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
+dependencies = [
+ "anyhow",
+ "async-lock 2.8.0",
+ "async-trait",
+ "beef",
+ "futures-timer",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types 0.20.3",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-http-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,14 +5284,34 @@ dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls",
+ "jsonrpsee-core 0.20.3",
+ "jsonrpsee-types 0.20.3",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5263,8 +5337,8 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "serde",
  "serde_json",
  "soketto",
@@ -5290,14 +5364,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e5df77c8f625d36e4cfb583c5a674eccebe32403fcfe42f7ceff7fac9324dd"
 dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-client-transport 0.16.3",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
 ]
 
 [[package]]
@@ -5307,9 +5395,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
 dependencies = [
  "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-client-transport 0.16.3",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
 ]
 
 [[package]]
@@ -7531,7 +7619,7 @@ name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+5#7ed06344974340d3057663575503cb9aeab4a041"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "sp-api",
@@ -9396,7 +9484,7 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "finality-grandpa",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -9731,7 +9819,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+5#7ed06344974340d3057663575503cb9aeab4a041"
 dependencies = [
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9761,7 +9849,7 @@ name = "sc-rpc-api"
 version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+5#7ed06344974340d3057663575503cb9aeab4a041"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-transaction-pool-api",
@@ -9781,7 +9869,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+5#7ed06344974340d3057663575503cb9aeab4a041"
 dependencies = [
  "http",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
@@ -9799,7 +9887,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -9826,7 +9914,7 @@ dependencies = [
  "exit-future",
  "futures",
  "futures-timer",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -12069,7 +12157,7 @@ source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthl
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "parity-scale-codec",
  "sc-rpc-api",
@@ -12099,7 +12187,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/chainflip-io/substrate.git?tag=chainflip-monthly-2023-08+5#7ed06344974340d3057663575503cb9aeab4a041"
 dependencies = [
  "async-trait",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "sc-rpc-api",
  "serde",
@@ -12147,10 +12235,11 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d140449e7d967b21b0ae386cdc6bd5933ade38613866bb40bb2c6df79638a4"
+checksum = "588b8ce92699eeb06290f4fb02dad4f7e426c4e6db4d53889c6bcbc808cf24ac"
 dependencies = [
+ "async-trait",
  "base58",
  "blake2",
  "derivative",
@@ -12159,7 +12248,7 @@ dependencies = [
  "futures",
  "hex",
  "impl-serde",
- "jsonrpsee",
+ "jsonrpsee 0.20.3",
  "parity-scale-codec",
  "primitive-types",
  "scale-bits",
@@ -12181,14 +12270,14 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af52575d54de7b9528601788f2876b41965e3e473d137c9c61c1ac35aeeaa3b"
+checksum = "98f5a534c8d475919e9c845d51fc2316da4fcadd04fe17552d932d2106de930e"
 dependencies = [
  "frame-metadata 16.0.0",
  "heck",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.20.3",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
@@ -12201,9 +12290,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa72c1cb7e06772efa1476949c3f0e83718c79c1b2615eb510c076b012e9c84"
+checksum = "10fd0ac9b091211f962b6ae19e26cd08e0b86efa064dfb7fac69c8f79f122329"
 dependencies = [
  "futures",
  "futures-util",
@@ -12218,9 +12307,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe9f7e2994a20ab9748a9a040a3fe96054faa219a60ed21af51b9ab9e5f7da6"
+checksum = "12e8be9ab6fe88b8c13edbe15911e148482cfb905a8b8d5b8d766a64c54be0bd"
 dependencies = [
  "darling 0.20.3",
  "proc-macro-error",
@@ -12230,9 +12319,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880017c466f66af10e1c9b28cfa4cb2e4f59ab1bfe0b0f7250f7aca6e9d593b0"
+checksum = "b6898275765d36a37e5ef564358e0341cf41b5f3a91683d7d8b859381b65ac8a"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -12699,6 +12788,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite 0.2.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13215,7 +13308,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.11.0",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "lazy_format",
  "lazy_static",
  "mockall",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -69,7 +69,7 @@ secp256k1 = "0.27"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.10"
-subxt = { version = "0.31.0", features = ["substrate-compat"] }
+subxt = { version = "0.32.1", features = ["substrate-compat"] }
 thiserror = "1.0.26"
 tokio = { version = "1.22", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use cf_chains::dot::{PolkadotHash, RuntimeVersion};
 use cf_primitives::PolkadotBlockNumber;
 use futures_core::Future;
@@ -11,13 +9,16 @@ use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use serde_json::value::RawValue;
 use sp_core::H256;
 use subxt::{
+	backend::{
+		legacy::{
+			rpc_methods::{BlockDetails, Bytes},
+			LegacyRpcMethods,
+		},
+		rpc::{RawRpcFuture, RawRpcSubscription, RpcClient, RpcClientT},
+	},
 	error::{BlockError, RpcError},
 	events::{Events, EventsClient},
-	rpc::{
-		types::{Bytes, ChainBlockExtrinsic, ChainBlockResponse},
-		RpcClientT, RpcFuture, RpcSubscription,
-	},
-	rpc_params, OnlineClient, PolkadotConfig,
+	OnlineClient, PolkadotConfig,
 };
 
 use anyhow::Result;
@@ -56,7 +57,7 @@ impl RpcClientT for PolkadotHttpClient {
 		&'a self,
 		method: &'a str,
 		params: Option<Box<RawValue>>,
-	) -> RpcFuture<'a, Box<RawValue>> {
+	) -> RawRpcFuture<'a, Box<RawValue>> {
 		Box::pin(async move {
 			let res = self
 				.0
@@ -72,7 +73,7 @@ impl RpcClientT for PolkadotHttpClient {
 		_sub: &'a str,
 		_params: Option<Box<RawValue>>,
 		_unsub: &'a str,
-	) -> RpcFuture<'a, RpcSubscription> {
+	) -> RawRpcFuture<'a, RawRpcSubscription> {
 		unimplemented!("HTTP Client does not support subscription");
 	}
 }
@@ -80,6 +81,7 @@ impl RpcClientT for PolkadotHttpClient {
 #[derive(Clone)]
 pub struct DotHttpRpcClient {
 	online_client: OnlineClient<PolkadotConfig>,
+	rpc_methods: LegacyRpcMethods<PolkadotConfig>,
 }
 
 impl DotHttpRpcClient {
@@ -87,7 +89,7 @@ impl DotHttpRpcClient {
 		url: SecretUrl,
 		expected_genesis_hash: Option<PolkadotHash>,
 	) -> Result<impl Future<Output = Self>> {
-		let polkadot_http_client = Arc::new(PolkadotHttpClient::new(&url)?);
+		let rpc_client = RpcClient::new(PolkadotHttpClient::new(&url)?);
 
 		Ok(async move {
 			// We don't want to return an error here. Returning an error means that we'll exit the
@@ -97,9 +99,7 @@ impl DotHttpRpcClient {
 			let online_client = loop {
 				poll_interval.tick().await;
 
-				match OnlineClient::<PolkadotConfig>::from_rpc_client(polkadot_http_client.clone())
-					.await
-				{
+				match OnlineClient::<PolkadotConfig>::from_rpc_client(rpc_client.clone()).await {
 					Ok(online_client) => {
 						if let Some(expected_genesis_hash) = expected_genesis_hash {
 							let genesis_hash = online_client.genesis_hash();
@@ -124,32 +124,29 @@ impl DotHttpRpcClient {
 					},
 				}
 			};
-			Self { online_client }
+			Self { online_client, rpc_methods: LegacyRpcMethods::new(rpc_client) }
 		})
 	}
 
 	pub async fn metadata(&self, block_hash: H256) -> Result<subxt::Metadata> {
-		Ok(self.online_client.rpc().metadata_legacy(Some(block_hash)).await?)
+		Ok(self.rpc_methods.state_get_metadata(Some(block_hash)).await?)
 	}
 }
 
 #[async_trait::async_trait]
 impl DotRpcApi for DotHttpRpcClient {
 	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Result<Option<PolkadotHash>> {
-		Ok(self.online_client.rpc().block_hash(Some(block_number.into())).await?)
+		Ok(self.rpc_methods.chain_get_block_hash(Some(block_number.into())).await?)
 	}
 
 	async fn block(
 		&self,
 		block_hash: PolkadotHash,
-	) -> Result<Option<ChainBlockResponse<PolkadotConfig>>> {
-		Ok(self.online_client.rpc().block(Some(block_hash)).await?)
+	) -> Result<Option<BlockDetails<PolkadotConfig>>> {
+		Ok(self.rpc_methods.chain_get_block(Some(block_hash)).await?)
 	}
 
-	async fn extrinsics(
-		&self,
-		block_hash: PolkadotHash,
-	) -> Result<Option<Vec<ChainBlockExtrinsic>>> {
+	async fn extrinsics(&self, block_hash: PolkadotHash) -> Result<Option<Vec<Bytes>>> {
 		Ok(self.block(block_hash).await?.map(|block| block.block.extrinsics))
 	}
 
@@ -169,7 +166,7 @@ impl DotRpcApi for DotHttpRpcClient {
 		// RPC returning the value of the runtime at the end of the block, not the beginning.
 		let chain_runtime_version = self.runtime_version(Some(parent_hash)).await?;
 
-		let client_runtime_version = self.online_client.runtime_version();
+		let client_runtime_version = self.rpc_methods.state_get_runtime_version(None).await?;
 
 		// We set the metadata and runtime version we need to decode this block's events.
 		// The metadata from the OnlineClient is used within the EventsClient to decode the
@@ -180,10 +177,9 @@ impl DotRpcApi for DotHttpRpcClient {
 		{
 			let new_metadata = self.metadata(parent_hash).await?;
 
-			self.online_client.set_runtime_version(subxt::rpc::types::RuntimeVersion {
+			self.online_client.set_runtime_version(subxt::backend::RuntimeVersion {
 				spec_version: chain_runtime_version.spec_version,
 				transaction_version: chain_runtime_version.transaction_version,
-				other: Default::default(),
 			});
 			self.online_client.set_metadata(new_metadata);
 		}
@@ -200,24 +196,16 @@ impl DotRpcApi for DotHttpRpcClient {
 	}
 
 	async fn runtime_version(&self, block_hash: Option<H256>) -> Result<RuntimeVersion> {
-		Ok(self
-			.online_client
-			.rpc()
-			.runtime_version(block_hash)
-			.await
-			.map(|v| RuntimeVersion {
+		Ok(self.rpc_methods.state_get_runtime_version(block_hash).await.map(|v| {
+			RuntimeVersion {
 				spec_version: v.spec_version,
 				transaction_version: v.transaction_version,
-			})?)
+			}
+		})?)
 	}
 
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash> {
-		let encoded_bytes: Bytes = encoded_bytes.into();
-		Ok(self
-			.online_client
-			.rpc()
-			.request("author_submitExtrinsic", rpc_params![encoded_bytes.clone()])
-			.await?)
+		Ok(self.rpc_methods.author_submit_extrinsic(&encoded_bytes).await?)
 	}
 }
 

--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -14,7 +14,8 @@ use futures_core::Stream;
 use sp_core::H256;
 use std::pin::Pin;
 use subxt::{
-	config::Header as SubxtHeader, events::Events, rpc::types::ChainBlockExtrinsic, PolkadotConfig,
+	backend::legacy::rpc_methods::Bytes, config::Header as SubxtHeader, events::Events,
+	PolkadotConfig,
 };
 use utilities::task_scope::Scope;
 
@@ -92,7 +93,7 @@ impl DotRetryRpcClient {
 pub trait DotRetryRpcApi: Clone {
 	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Option<PolkadotHash>;
 
-	async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<ChainBlockExtrinsic>;
+	async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<Bytes>;
 
 	async fn events<R: RetryLimitReturn>(
 		&self,
@@ -123,7 +124,7 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 			.await
 	}
 
-	async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<ChainBlockExtrinsic> {
+	async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<Bytes> {
 		self.rpc_retry_client
 			.request(
 				Box::pin(move |client| {
@@ -300,7 +301,7 @@ pub mod mocks {
 		impl DotRetryRpcApi for DotHttpRpcClient {
 			async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Option<PolkadotHash>;
 
-			async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<ChainBlockExtrinsic>;
+			async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<Bytes>;
 
 			async fn events<R: RetryLimitReturn>(&self, block_hash: PolkadotHash, parent_hash: PolkadotHash, retry_limit: R) -> R::ReturnType<Option<Events<PolkadotConfig>>>;
 

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -7,8 +7,8 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use sp_core::H256;
 use std::sync::Arc;
 use subxt::{
+	backend::legacy::rpc_methods::{BlockDetails, Bytes},
 	events::Events,
-	rpc::types::{ChainBlockExtrinsic, ChainBlockResponse},
 	Config, OnlineClient, PolkadotConfig,
 };
 use tokio::sync::RwLock;
@@ -81,15 +81,10 @@ pub trait DotSubscribeApi: Send + Sync {
 pub trait DotRpcApi: Send + Sync {
 	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Result<Option<PolkadotHash>>;
 
-	async fn block(
-		&self,
-		block_hash: PolkadotHash,
-	) -> Result<Option<ChainBlockResponse<PolkadotConfig>>>;
+	async fn block(&self, block_hash: PolkadotHash)
+		-> Result<Option<BlockDetails<PolkadotConfig>>>;
 
-	async fn extrinsics(
-		&self,
-		block_hash: PolkadotHash,
-	) -> Result<Option<Vec<ChainBlockExtrinsic>>>;
+	async fn extrinsics(&self, block_hash: PolkadotHash) -> Result<Option<Vec<Bytes>>>;
 
 	async fn events(
 		&self,
@@ -112,7 +107,7 @@ impl DotRpcApi for DotRpcClient {
 	async fn block(
 		&self,
 		block_hash: PolkadotHash,
-	) -> Result<Option<ChainBlockResponse<PolkadotConfig>>> {
+	) -> Result<Option<BlockDetails<PolkadotConfig>>> {
 		self.http_client.block(block_hash).await
 	}
 
@@ -120,10 +115,7 @@ impl DotRpcApi for DotRpcClient {
 		self.http_client.runtime_version(at).await
 	}
 
-	async fn extrinsics(
-		&self,
-		block_hash: PolkadotHash,
-	) -> Result<Option<Vec<ChainBlockExtrinsic>>> {
+	async fn extrinsics(&self, block_hash: PolkadotHash) -> Result<Option<Vec<Bytes>>> {
 		self.http_client.extrinsics(block_hash).await
 	}
 

--- a/engine/src/state_chain_observer/client/base_rpc_api.rs
+++ b/engine/src/state_chain_observer/client/base_rpc_api.rs
@@ -25,6 +25,7 @@ use sc_rpc_api::{
 use futures::future::BoxFuture;
 use serde_json::value::RawValue;
 use std::sync::Arc;
+use subxt::backend::rpc::RawRpcSubscription;
 
 #[cfg(test)]
 use mockall::automock;
@@ -302,7 +303,9 @@ impl jsonrpsee::core::traits::ToRpcParams for Params {
 
 pub struct SubxtInterface<T>(pub T);
 
-impl<T: BaseRpcApi + Send + Sync + 'static> subxt::rpc::RpcClientT for SubxtInterface<Arc<T>> {
+impl<T: BaseRpcApi + Send + Sync + 'static> subxt::backend::rpc::RpcClientT
+	for SubxtInterface<Arc<T>>
+{
 	fn request_raw<'a>(
 		&'a self,
 		method: &'a str,
@@ -321,7 +324,7 @@ impl<T: BaseRpcApi + Send + Sync + 'static> subxt::rpc::RpcClientT for SubxtInte
 		sub: &'a str,
 		params: Option<Box<RawValue>>,
 		unsub: &'a str,
-	) -> BoxFuture<'a, Result<subxt::rpc::RpcSubscription, subxt::error::RpcError>> {
+	) -> BoxFuture<'a, Result<RawRpcSubscription, subxt::error::RpcError>> {
 		Box::pin(async move {
 			let stream = self
 				.0
@@ -340,7 +343,7 @@ impl<T: BaseRpcApi + Send + Sync + 'static> subxt::rpc::RpcClientT for SubxtInte
 
 			let stream =
 				stream.map_err(|e| subxt::error::RpcError::ClientError(Box::new(e))).boxed();
-			Ok(subxt::rpc::RpcSubscription { stream, id })
+			Ok(RawRpcSubscription { stream, id })
 		})
 	}
 }

--- a/engine/src/state_chain_observer/client/mod.rs
+++ b/engine/src/state_chain_observer/client/mod.rs
@@ -17,6 +17,7 @@ use jsonrpsee::core::RpcResult;
 use sp_core::{Pair, H256};
 use state_chain_runtime::AccountId;
 use std::{sync::Arc, time::Duration};
+use subxt::backend::rpc::RpcClient;
 use tokio::sync::watch;
 use tracing::{info, warn};
 
@@ -25,6 +26,8 @@ use utilities::{
 	task_scope::{Scope, OR_CANCEL},
 	CachedStream, MakeCachedStream, MakeTryCachedStream, TryCachedStream,
 };
+
+use crate::state_chain_observer::client::base_rpc_api::SubxtInterface;
 
 use self::{
 	base_rpc_api::BaseRpcClient,
@@ -704,11 +707,10 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 		};
 
 		if let Some(this_version) = self.update_cfe_version {
-			use crate::state_chain_observer::client::base_rpc_api::SubxtInterface;
 			use subxt::{tx::Signer, PolkadotConfig};
 
 			let subxt_client = subxt::client::OnlineClient::<PolkadotConfig>::from_rpc_client(
-				Arc::new(SubxtInterface(base_rpc_client.clone())),
+				RpcClient::new(SubxtInterface(base_rpc_client.clone())),
 			)
 			.await?;
 			let subxt_signer = {

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -10,6 +10,7 @@ use cf_primitives::{EpochIndex, PolkadotBlockNumber};
 use futures_core::Future;
 use state_chain_runtime::PolkadotInstance;
 use subxt::{
+	backend::legacy::rpc_methods::Bytes,
 	config::PolkadotConfig,
 	events::{EventDetails, Phase, StaticEvent},
 	utils::AccountId32,
@@ -133,8 +134,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 	// To guarantee witnessing egress, we are interested in all extrinsics that were successful
 	extrinsic_indices.extend(extrinsic_success_indices(&events));
 
-	let extrinsics: Vec<subxt::rpc::types::ChainBlockExtrinsic> =
-		dot_client.extrinsics(header.hash).await;
+	let extrinsics: Vec<Bytes> = dot_client.extrinsics(header.hash).await;
 
 	for (extrinsic_index, tx_fee) in transaction_fee_paids(&extrinsic_indices, &events) {
 		let xt = extrinsics.get(extrinsic_index as usize).expect(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1000

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

On bad blocks, which we did receive from getblock.io at some point - as in the issue, subxt would previously panic. Now, instead, they throw an error in 0.32.0+ version. So here I'm bumping the version to 0.32.1, since upgrading to 0.33.0 (latest at time of writing) requires a compiler version bump, which isn't necessary right now. 
