### PR TITLE
refactor: improve panic behaviour

### DIFF
--- a/engine/src/state_chain_observer/client/extrinsic_api/unsigned.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/unsigned.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use sp_core::H256;
 use sp_runtime::{traits::Hash, transaction_validity::InvalidTransaction};
 use tokio::sync::{mpsc, oneshot};
-use utilities::task_scope::{Scope, ScopedJoinHandle, OR_CANCEL};
+use utilities::task_scope::{Scope, ScopedJoinHandle, UnwrapOrCancel};
 
 use crate::state_chain_observer::client::extrinsic_api::common::invalid_err_obj;
 
@@ -121,7 +121,7 @@ impl UnsignedExtrinsicApi for UnsignedExtrinsicClient {
 	{
 		send_request(&self.request_sender, |result_sender| (call.into(), result_sender))
 			.await
+			.unwrap_or_cancel()
 			.await
-			.expect(OR_CANCEL)
 	}
 }

--- a/engine/src/witness/common/chain_source/shared.rs
+++ b/engine/src/witness/common/chain_source/shared.rs
@@ -2,7 +2,7 @@ use futures_util::StreamExt;
 use tokio::sync::oneshot;
 use utilities::{
 	loop_select, spmc,
-	task_scope::{Scope, OR_CANCEL},
+	task_scope::{Scope, UnwrapOrCancel},
 };
 
 use crate::witness::common::ExternalChainSource;
@@ -86,7 +86,7 @@ where
 		{
 			let _result = self.request_sender.send(sender).await;
 		}
-		let (stream, client) = receiver.await.expect(OR_CANCEL);
+		let (stream, client) = receiver.unwrap_or_cancel().await;
 		(stream.into_box(), client)
 	}
 }

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/monitored_items.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/monitored_items.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use cf_chains::ChainState;
 use frame_support::CloneNoBound;
-use futures::{Future, FutureExt};
+use futures::Future;
 use futures_util::{stream, StreamExt};
 use state_chain_runtime::PalletInstanceAlias;
 use tokio::sync::watch;
 use utilities::{
 	loop_select,
-	task_scope::{Scope, OR_CANCEL},
+	task_scope::{Scope, UnwrapOrCancel},
 };
 
 use crate::{
@@ -231,7 +231,7 @@ where
 								if let Some(header) = chain_stream.next() => {
 									state.add_headers(std::iter::once(header));
 								} else disable then if state.pending_headers.is_empty() => break None,
-								let _ = state.receiver.changed().map(|result| result.expect(OR_CANCEL)) => {
+								let _ = state.receiver.changed().unwrap_or_cancel() => {
 									// Headers we weren't yet ready to process might be ready now if the chain tracking has progressed.
 									let pending_headers = std::mem::take(&mut state.pending_headers);
 									state.add_headers(pending_headers);
@@ -298,8 +298,8 @@ where
 		let addresses = {
 			let chain_state_and_addresses = receiver
 				.wait_for(|(chain_state, _addresses)| is_header_ready::<Inner>(index, chain_state))
-				.await
-				.expect(OR_CANCEL);
+				.unwrap_or_cancel()
+				.await;
 			let (_option_chain_state, addresses) = &*chain_state_and_addresses;
 
 			(self.filter_fn)(index, addresses)

--- a/utilities/src/with_std.rs
+++ b/utilities/src/with_std.rs
@@ -76,8 +76,9 @@ macro_rules! assert_panics {
 #[macro_export]
 macro_rules! assert_future_panics {
 	($future:expr) => {
-		use futures::future::FutureExt;
-		match ::std::panic::AssertUnwindSafe($future).catch_unwind().await {
+		match ::futures::future::FutureExt::catch_unwind(::std::panic::AssertUnwindSafe($future))
+			.await
+		{
 			Ok(_result) => panic!("future didn't panic '{}'", stringify!($future),),
 			Err(panic) => panic,
 		}

--- a/utilities/src/with_std/task_scope.rs
+++ b/utilities/src/with_std/task_scope.rs
@@ -99,9 +99,73 @@ use futures::{
 };
 use tokio::sync::oneshot;
 
-/// This expresses the idea that another task's failure means this task cannot proceed reasonably
-/// and so we must fail too
-pub const OR_CANCEL: &str = "An error has occurred in another task";
+pub trait Unwrappable {
+	type Item;
+
+	fn __internal_to_option(x: Self) -> Option<Self::Item>;
+}
+impl<T> Unwrappable for Option<T> {
+	type Item = T;
+
+	fn __internal_to_option(x: Self) -> Option<Self::Item> {
+		x
+	}
+}
+impl<T, E> Unwrappable for Result<T, E> {
+	type Item = T;
+
+	fn __internal_to_option(x: Self) -> Option<Self::Item> {
+		x.ok()
+	}
+}
+
+const UNWRAP_OR_CANCEL_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500u64);
+
+#[pin_project::pin_project]
+pub struct UnwrapOrCancelFuture<F> {
+	#[pin]
+	f: Option<F>,
+	#[pin]
+	timeout: Option<tokio::time::Sleep>,
+}
+impl<T> Future for UnwrapOrCancelFuture<T>
+where
+	T: Future,
+	T::Output: Unwrappable,
+{
+	type Output = <T::Output as Unwrappable>::Item;
+
+	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		let mut this = self.project();
+		if let Some(f) = this.f.as_mut().as_pin_mut() {
+			if let Some(output) = Unwrappable::__internal_to_option(ready!(f.poll(cx))) {
+				return Poll::Ready(output)
+			} else {
+				this.f.set(None);
+			}
+		}
+
+		if this.timeout.is_none() {
+			this.timeout.set(Some(tokio::time::sleep(UNWRAP_OR_CANCEL_TIMEOUT)));
+		}
+		ready!(this.timeout.as_pin_mut().unwrap().poll(cx));
+		panic!("Expected task to be cancelled due to another task's failure, but it was not cancelled within {UNWRAP_OR_CANCEL_TIMEOUT:?}");
+	}
+}
+
+pub trait UnwrapOrCancel {
+	/// This expresses the idea that this unwrap can only fail if another task has failed (errored
+	/// or panicked) thereby causing the task scope to be cancelled, and so we expect this task to
+	/// be cancelled very shortly if this unwrap fails.
+	fn unwrap_or_cancel(self) -> UnwrapOrCancelFuture<Self>
+	where
+		Self: Future + Sized,
+		Self::Output: Unwrappable,
+	{
+		UnwrapOrCancelFuture { f: Some(self), timeout: None }
+	}
+}
+impl<T: ?Sized> UnwrapOrCancel for T where T: Future {}
 
 /// This function allows a top level task to spawn tasks such that if any tasks panic or error,
 /// all other tasks will be cancelled, and the panic or error will be propagated by this function.
@@ -143,7 +207,8 @@ pub fn task_scope<
 							if let Ok(panic) = error.try_into_panic() {
 								std::panic::resume_unwind(panic);
 							} /* else: Can only occur if tokio's runtime is dropped during task
-							  * scope's lifetime, in this we are about to be cancelled ourselves */
+							  * scope's lifetime, in this case we are about to be cancelled
+							  * ourselves */
 						},
 						Ok(future_result) => future_result?,
 					}
@@ -722,5 +787,53 @@ mod tests {
 		})
 		.await
 		.unwrap();
+	}
+
+	#[tokio::test]
+	async fn test_unwrap_or_cancel() {
+		crate::assert_future_panics!(async { Option::<()>::None }.unwrap_or_cancel());
+		crate::assert_future_panics!(async { Result::<(), ()>::Err(()) }.unwrap_or_cancel());
+
+		let shorter_than_timeout: std::time::Duration = UNWRAP_OR_CANCEL_TIMEOUT.mul_f64(0.5f64);
+
+		crate::assert_err!(
+			tokio::time::timeout(
+				shorter_than_timeout,
+				async { Option::<()>::None }.unwrap_or_cancel()
+			)
+			.await
+		);
+		crate::assert_err!(
+			tokio::time::timeout(
+				shorter_than_timeout,
+				async { Result::<(), ()>::Err(()) }.unwrap_or_cancel()
+			)
+			.await
+		);
+
+		let longer_than_timeout: std::time::Duration = UNWRAP_OR_CANCEL_TIMEOUT.mul_f64(2.0f64);
+
+		crate::assert_future_panics!(tokio::time::timeout(
+			longer_than_timeout,
+			async { Option::<()>::None }.unwrap_or_cancel()
+		));
+		crate::assert_future_panics!(tokio::time::timeout(
+			longer_than_timeout,
+			async { Result::<(), ()>::Err(()) }.unwrap_or_cancel()
+		));
+
+		async { Some(()) }.unwrap_or_cancel().await;
+		async { Result::<(), ()>::Ok(()) }.unwrap_or_cancel().await;
+
+		crate::assert_ok!(
+			tokio::time::timeout(shorter_than_timeout, async { Some(()) }.unwrap_or_cancel()).await
+		);
+		crate::assert_ok!(
+			tokio::time::timeout(
+				shorter_than_timeout,
+				async { Result::<(), ()>::Ok(()) }.unwrap_or_cancel()
+			)
+			.await
+		);
 	}
 }


### PR DESCRIPTION
Ensures tasks that are likely to be cancelled do not panic, making it simpler to find the true cause of a failure when reading the logs.