### PR TITLE
Bitcoin fee for broadcast was set below minimum resulting in broadcast aborted

### DIFF
--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -53,7 +53,7 @@ fn test_btc_utxo_selection() {
 		add_utxo_amount(dust_amount);
 
 		// select some utxos for a tx
-		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24770;
+		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24680;
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::Some {
 				output_amount: 12000,
@@ -70,7 +70,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121970)
+			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121790)
 		);
 
 		// add some more utxos to the list
@@ -88,7 +88,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000), utxo(15000),], 17950)
+			(vec![utxo(5000), utxo(15000),], 17890)
 		);
 	});
 }
@@ -145,7 +145,7 @@ fn test_btc_utxo_consolidation() {
 		// Should select two UTXOs, with all funds (minus fees) going back to us as change
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectForConsolidation),
-			Some((vec![utxo(10000), utxo(20000)], 27950))
+			Some((vec![utxo(10000), utxo(20000)], 27890))
 		);
 
 		// Any utxo that didn't get consolidated should still be available:

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -53,7 +53,16 @@ fn test_btc_utxo_selection() {
 		add_utxo_amount(dust_amount);
 
 		// select some utxos for a tx
-		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24680;
+
+		// the default fee is 10 satoshi per byte. 
+		// inputs are 78 bytes
+		// outputs are 51 bytes
+		// transactions have a 12 byte base size
+		// the fee for 3 inputs and 2 outputs is thus:
+		// 10*(12 + 3*78 + 2*51) = 3480 satoshi
+		// the expected change is:
+		// 5000 + 10000 + 25000 - 12000 - 3480 = 24520 satoshi
+		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24520;
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::Some {
 				output_amount: 12000,
@@ -70,7 +79,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121790)
+			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121550)
 		);
 
 		// add some more utxos to the list
@@ -88,7 +97,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000), utxo(15000),], 17890)
+			(vec![utxo(5000), utxo(15000),], 17810)
 		);
 	});
 }
@@ -145,7 +154,7 @@ fn test_btc_utxo_consolidation() {
 		// Should select two UTXOs, with all funds (minus fees) going back to us as change
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectForConsolidation),
-			Some((vec![utxo(10000), utxo(20000)], 27890))
+			Some((vec![utxo(10000), utxo(20000)], 27810))
 		);
 
 		// Any utxo that didn't get consolidated should still be available:

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -54,15 +54,15 @@ fn test_btc_utxo_selection() {
 
 		// select some utxos for a tx
 
-		// the default fee is 10 satoshi per byte. 
+		// the default fee is 10 satoshi per byte.
 		// inputs are 78 bytes
 		// outputs are 51 bytes
 		// transactions have a 12 byte base size
 		// the fee for 3 inputs and 2 outputs is thus:
-		// 10*(12 + 3*78 + 2*51) = 3480 satoshi
+		// 10*(16 + 3*78 + 2*51) = 3520 satoshi
 		// the expected change is:
-		// 5000 + 10000 + 25000 - 12000 - 3480 = 24520 satoshi
-		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24520;
+		// 5000 + 10000 + 25000 - 12000 - 3520 = 24480 satoshi
+		const EXPECTED_CHANGE_AMOUNT: crate::BtcAmount = 24480;
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::Some {
 				output_amount: 12000,
@@ -79,7 +79,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121550)
+			(vec![utxo(5000000), utxo(100000), utxo(EXPECTED_CHANGE_AMOUNT),], 5121470)
 		);
 
 		// add some more utxos to the list
@@ -97,7 +97,7 @@ fn test_btc_utxo_selection() {
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectAllForRotation)
 				.unwrap(),
-			(vec![utxo(5000), utxo(15000),], 17810)
+			(vec![utxo(5000), utxo(15000),], 17770)
 		);
 	});
 }
@@ -154,7 +154,7 @@ fn test_btc_utxo_consolidation() {
 		// Should select two UTXOs, with all funds (minus fees) going back to us as change
 		assert_eq!(
 			Environment::select_and_take_bitcoin_utxos(UtxoSelectionType::SelectForConsolidation),
-			Some((vec![utxo(10000), utxo(20000)], 27810))
+			Some((vec![utxo(10000), utxo(20000)], 27770))
 		);
 
 		// Any utxo that didn't get consolidated should still be available:

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -57,10 +57,43 @@ pub const FLIPPERINOS_PER_FLIP: FlipBalance = 10u128.pow(FLIP_DECIMALS);
 // tracking.
 pub const DEFAULT_FEE_SATS_PER_KILO_BYTE: u64 = 102400;
 
-// Approximate values calculated
+// To spend one of our deposit UTXOs, we need:
+// 32 bytes for the TX ID
+// 4 bytes for the output index
+// 1 byte to indicate that this is a segwit input (i.e. unlock script length = 0)
+// 4 bytes for the sequence number
+// In addition to that we need the witness data, which is:
+// 1 byte for the number of witness elements
+// 65 bytes for the signature
+// 1 length byte for the unlock script
+// up to 9 bytes for the salt
+// 1 byte to drop the salt
+// 33 bytes for the pubkey
+// 1 bytes to check the signature
+// 34 bytes for the internal pubkey
+// In Bitcoin, each byte of witness data is counted as only 1/4 of a byte towards
+// the size of the transaction, so assuming the largest possible salt value, we have:
+// utxo size = 41 + (145 / 4) = 77.25 bytes
+// since we may add multiple utxos together, the fractional parts could add up to another byte,
+// so we are rounding up to be on the safe side and set the UTXO size to 78 bytes
 pub const INPUT_UTXO_SIZE_IN_BYTES: u64 = 78;
-pub const OUTPUT_UTXO_SIZE_IN_BYTES: u64 = 43;
-pub const MINIMUM_BTC_TX_SIZE_IN_BYTES: u64 = 12;
+
+// An output contains:
+// 8 bytes for the amount
+// between 1 and 9 bytes for the length of the scriptPubKey
+// x bytes for the scriptPubKey
+// Since we only support certain types of destination addresses, we know that the
+// largest supported scriptPubKey is for segwit version 1 and above, which is 42 bytes long
+// so that the maximum output size is 8 + 1 + 42 = 51 bytes
+pub const OUTPUT_UTXO_SIZE_IN_BYTES: u64 = 51;
+
+// Any transaction contains:
+// a 4 byte version number
+// 2 bytes of flags to indicate a segwit transaction
+// between 1 and 9 bytes to count the number of inputs (we assume up to 3 bytes)
+// between 1 and 9 bytes to count the number of outputs (we assume up to 3 bytes)
+// 4 bytes for the locktime
+pub const MINIMUM_BTC_TX_SIZE_IN_BYTES: u64 = 16;
 
 /// This determines the average expected block time that we are targeting.
 /// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -58,7 +58,7 @@ pub const FLIPPERINOS_PER_FLIP: FlipBalance = 10u128.pow(FLIP_DECIMALS);
 pub const DEFAULT_FEE_SATS_PER_KILO_BYTE: u64 = 102400;
 
 // Approximate values calculated
-pub const INPUT_UTXO_SIZE_IN_BYTES: u64 = 75;
+pub const INPUT_UTXO_SIZE_IN_BYTES: u64 = 78;
 pub const OUTPUT_UTXO_SIZE_IN_BYTES: u64 = 43;
 pub const MINIMUM_BTC_TX_SIZE_IN_BYTES: u64 = 12;
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1082

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

To spend one of our deposit UTXOs, we need:
32 bytes for the TX ID
4 bytes for the output index
1 byte to indicate that this is a segwit input
4 bytes for the sequence number
= 41 bytes
in addition to that we need the witness data, which is:
1 byte for the element counter
65 bytes for the signature
1 length byte for the unlock script
x bytes for the salt
1 byte to drop the salt
33 bytes for the pubkey
1 bytes to check the signature
34 bytes for the internal pubkey
= 136 bytes + x

Initially, we assumed that the salt would be 1 byte long, but since it is varint encoded, it can grow up to 9 bytes.
In Bitcoin, each byte of witness data is counted as only 1/4 of a byte towards the size of the transaction, so assuming the largest possible salt value, we have:
utxo size = 41 + (136 + 9) / 4 = 77.25 bytes
since we may add multiple utxos together, the fractional parts may add up to another byte, so we are rounding up to be on the safe side and set the UTXO size to 78 bytes