### PR TITLE
chore: increase limit on max number of bitcoin payloads in a ceremony to theoretical maximum

### DIFF
--- a/engine/multisig/src/crypto/bitcoin.rs
+++ b/engine/multisig/src/crypto/bitcoin.rs
@@ -70,7 +70,7 @@ impl ChainSigning for BtcSigning {
 
 	/// The window is smaller for bitcoin because its block time is a lot longer and it supports
 	/// multiple signing payloads
-	const CEREMONY_ID_WINDOW: u64 = 1500;
+	const CEREMONY_ID_WINDOW: u64 = 50;
 }
 
 impl CryptoScheme for BtcCryptoScheme {

--- a/engine/multisig/src/lib.rs
+++ b/engine/multisig/src/lib.rs
@@ -14,12 +14,9 @@ pub mod client;
 mod crypto;
 
 /// Maximum number of payloads in a single bitcoin signing ceremony
-// We choose 5000 because the maximum size of a Bitcoin block is 1MB.
-// The average size of a transaction is around 500 bytes, however, historically
-// this was 250 bytes. See this thread: https://bitcoin.stackexchange.com/q/31974/109777.
-// Given we only accept a single UTXO in each of these transactions, the maximum number of signing
-// payloads we'd ever have to do in a single block is approximately 4000.
-pub const MAX_BTC_SIGNING_PAYLOADS: usize = 4000;
+// We choose 20,000 because this is approaching the theoretical maximum number of UTXOs in a single
+// Bitcoin block.
+pub const MAX_BTC_SIGNING_PAYLOADS: usize = 20_000;
 
 pub mod p2p {
 	use cf_primitives::AccountId;

--- a/engine/multisig/src/lib.rs
+++ b/engine/multisig/src/lib.rs
@@ -14,7 +14,12 @@ pub mod client;
 mod crypto;
 
 /// Maximum number of payloads in a single bitcoin signing ceremony
-pub const MAX_BTC_SIGNING_PAYLOADS: usize = 1000;
+// We choose 5000 because the maximum size of a Bitcoin block is 1MB.
+// The average size of a transaction is around 500 bytes, however, historically
+// this was 250 bytes. See this thread: https://bitcoin.stackexchange.com/q/31974/109777.
+// Given we only accept a single UTXO in each of these transactions, the maximum number of signing
+// payloads we'd ever have to do in a single block is approximately 4000.
+pub const MAX_BTC_SIGNING_PAYLOADS: usize = 4000;
 
 pub mod p2p {
 	use cf_primitives::AccountId;


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

I've increased the limit to the theoretical maximum number of signing payloads we could receive, rather than removing the limit. This is to protect against potential spam attacks. Created this PRO-992.