### PR TITLE
fix: use existing script for upgrade job

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -134,7 +134,7 @@ jobs:
         id: post-upgrade-bouncer
         working-directory: bouncer
         run: |
-          ./run-no-setup.sh
+          ./tests/all_concurrent_tests.ts
 
       - name: Print chainflip-engine logs
         if: failure()

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -183,4 +183,3 @@ jobs:
           args: |
             ❗️❗️❗️❗️ Sorry **${{ github.actor }}**, The Upgrade Test has not passed ❗️❗️❗️❗️
             👾 Link to job: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            #️⃣ Tagging: <@&939151218708709416>


### PR DESCRIPTION
Missed this in #4400 
