### PR TITLE
Produce an event in case the swap yields a zero egress amount

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -970,9 +970,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Error::<T, I>::AssetMismatch
 		);
 
-		log::warn!("PRO-1075| deposit_amount:      {:?}", deposit_amount);
-		log::warn!("PRO-1075| minimum_deposit:     {:?}", MinimumDeposit::<T, I>::get(asset));
-
 		if deposit_amount < MinimumDeposit::<T, I>::get(asset) {
 			// If the deposit amount is below the minimum allowed, the deposit is ignored.
 			// TODO: track these funds somewhere, for example add them to the withheld fees.
@@ -999,8 +996,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_channel_details.deposit_channel.asset,
 			deposit_amount,
 		);
-
-		log::warn!("PRO-1075| net_deposit_amount: {:?}", net_deposit_amount);
 
 		// Add the deposit to the balance.
 		T::DepositHandler::on_deposit_made(

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -970,6 +970,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Error::<T, I>::AssetMismatch
 		);
 
+		log::warn!("PRO-1075| deposit_amount:      {:?}", deposit_amount);
+		log::warn!("PRO-1075| minimum_deposit:     {:?}", MinimumDeposit::<T, I>::get(asset));
+
 		if deposit_amount < MinimumDeposit::<T, I>::get(asset) {
 			// If the deposit amount is below the minimum allowed, the deposit is ignored.
 			// TODO: track these funds somewhere, for example add them to the withheld fees.
@@ -996,6 +999,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_channel_details.deposit_channel.asset,
 			deposit_amount,
 		);
+
+		log::warn!("PRO-1075| net_deposit_amount: {:?}", net_deposit_amount);
 
 		// Add the deposit to the balance.
 		T::DepositHandler::on_deposit_made(

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -386,9 +386,9 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			// for (asset, min) in &self.minimum_swap_amounts {
-			// 	MinimumSwapAmount::<T>::insert(asset, min);
-			// }
+			for (asset, min) in &self.minimum_swap_amounts {
+				MinimumSwapAmount::<T>::insert(asset, min);
+			}
 		}
 	}
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -347,6 +347,9 @@ pub mod pallet {
 			total_amount: AssetAmount,
 			confiscated_amount: AssetAmount,
 		},
+		EgressAmountZero {
+			swap_id: u64,
+		},
 	}
 	#[pallet::error]
 	pub enum Error<T> {
@@ -383,9 +386,9 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			for (asset, min) in &self.minimum_swap_amounts {
-				MinimumSwapAmount::<T>::insert(asset, min);
-			}
+			// for (asset, min) in &self.minimum_swap_amounts {
+			// 	MinimumSwapAmount::<T>::insert(asset, min);
+			// }
 		}
 	}
 
@@ -451,7 +454,9 @@ pub mod pallet {
 										amount: egress_amount,
 									});
 								} else {
-									log::warn!("EgressSwallowed [id: {:?}; {:?} => {:?}; deposit-amt: {:?}]", swap.swap_id, swap.from, swap.to, swap.amount);
+									Self::deposit_event(Event::<T>::EgressAmountZero {
+										swap_id: swap.swap_id,
+									})
 								},
 							SwapType::CcmPrincipal(ccm_id) => {
 								Self::handle_ccm_swap_result(

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -450,6 +450,8 @@ pub mod pallet {
 										asset: swap.to,
 										amount: egress_amount,
 									});
+								} else {
+									log::warn!("EgressSwallowed [id: {:?}; {:?} => {:?}; deposit-amt: {:?}]", swap.swap_id, swap.from, swap.to, swap.amount);
 								},
 							SwapType::CcmPrincipal(ccm_id) => {
 								Self::handle_ccm_swap_result(

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -347,6 +347,7 @@ pub mod pallet {
 			total_amount: AssetAmount,
 			confiscated_amount: AssetAmount,
 		},
+		/// The swap has been executed, but has led to a zero egress amount.
 		EgressAmountZero {
 			swap_id: u64,
 		},

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1624,12 +1624,14 @@ fn can_handle_swaps_with_zero_outputs() {
 					egress_amount: 0,
 					..
 				}),
+				RuntimeEvent::Swapping(Event::<Test>::EgressAmountZero { swap_id: 1 }),
 				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
 					swap_id: 2,
 					destination_asset: Asset::Eth,
 					egress_amount: 0,
 					..
 				}),
+				RuntimeEvent::Swapping(Event::<Test>::EgressAmountZero { swap_id: 2 }),
 			);
 
 			// Swaps are not egressed when output is 0.


### PR DESCRIPTION
# Pull Request

Closes: PRO-1075

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

### Existing functionality

If the deposited amount is less than `ingress-egress::MinimumDeposit` — an `ingress-egress::DepositIgnored { reason : BelowMinimumDeposit }` will be emitted.

If the (net) swapped amount is less than `swapping::MinimumSwapAmount` — a `swapping::SwapAmountTooLow` will be emitted (apparently, a deprecated scenario: PRO-1101).

### What this PR brings

If for any other reason, the `egress_amount` of a swap appears to be zero — a `swapping::EgressAmountZero` will be emitted.