### PR TITLE
Ability to specify output for the subcommands, other than `/dev/null`

### DIFF
--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -10,6 +10,8 @@ CORE_CONTAINERS="bitcoin geth polkadot redis"
 ARB_CONTAINERS="sequencer staker-unsafe poster"
 export NODE_COUNT=1-node
 
+DEBUG_OUTPUT=${DEBUG_OUTPUT:-'/dev/null'}
+
 source ./localnet/helper.sh
 
 set -eo pipefail
@@ -28,13 +30,13 @@ setup() {
   echo "👽 We need to do some quick set up to get you ready!"
   sleep 3
 
-  if ! which op >/dev/null 2>&1; then
+  if ! which op >$DEBUG_OUTPUT 2>&1; then
     echo "❌  OnePassword CLI not installed."
     echo "https://developer.1password.com/docs/cli/get-started/#install"
     exit 1
   fi
 
-  if ! which docker >/dev/null 2>&1; then
+  if ! which docker >$DEBUG_OUTPUT 2>&1; then
     echo "❌  docker CLI not installed."
     echo "https://docs.docker.com/get-docker/"
     exit 1
@@ -90,23 +92,23 @@ build-localnet() {
   done
 
   echo "🔮 Initializing Network"
-  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $INITIAL_CONTAINERS -d $additional_docker_compose_up_args > /dev/null 2>&1
+  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $INITIAL_CONTAINERS -d $additional_docker_compose_up_args >$DEBUG_OUTPUT 2>&1
 
   echo "🏗 Building network"
-  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $CORE_CONTAINERS -d $additional_docker_compose_up_args > /dev/null 2>&1
+  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $CORE_CONTAINERS -d $additional_docker_compose_up_args >$DEBUG_OUTPUT 2>&1
 
   echo "🪙 Waiting for Bitcoin node to start"
-  check_endpoint_health -s --user flip:flip -H 'Content-Type: text/plain;' --data '{"jsonrpc":"1.0", "id": "1", "method": "getblockchaininfo", "params" : []}' http://localhost:8332 > /dev/null
+  check_endpoint_health -s --user flip:flip -H 'Content-Type: text/plain;' --data '{"jsonrpc":"1.0", "id": "1", "method": "getblockchaininfo", "params" : []}' http://localhost:8332 >$DEBUG_OUTPUT
 
   echo "💎 Waiting for ETH node to start"
-  check_endpoint_health -s -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' http://localhost:8545 > /dev/null
-  wscat -c ws://127.0.0.1:8546 -x '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' > /dev/null
+  check_endpoint_health -s -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' http://localhost:8545 >$DEBUG_OUTPUT
+  wscat -c ws://127.0.0.1:8546 -x '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' >$DEBUG_OUTPUT
 
   echo "🚦 Waiting for polkadot node to start"
   REPLY=$(check_endpoint_health -H "Content-Type: application/json" -s -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlockHash", "params":[0]}' 'http://localhost:9947') || [ -z $(echo $REPLY | grep -o '\"result\":\"0x[^"]*' | grep -o '0x.*') ]
 
   echo "🦑 Starting Arbitrum ..."
-  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $ARB_CONTAINERS -d $additional_docker_compose_up_args > /dev/null 2>&1
+  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $ARB_CONTAINERS -d $additional_docker_compose_up_args >$DEBUG_OUTPUT 2>&1
 
   DOT_GENESIS_HASH=$(echo $REPLY | grep -o '\"result\":\"0x[^"]*' | grep -o '0x.*')
 
@@ -123,7 +125,7 @@ build-localnet() {
 
   RPC_PORT=$INIT_RPC_PORT
   for NODE in "${SELECTED_NODES[@]}"; do
-    check_endpoint_health -s -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock"}' "http://localhost:$RPC_PORT" > /dev/null
+    check_endpoint_health -s -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "chain_getBlock"}' "http://localhost:$RPC_PORT" >$DEBUG_OUTPUT
     echo "💚 $NODE's chainflip-node is running!"
     ((RPC_PORT++))
   done
@@ -164,7 +166,7 @@ build-localnet() {
 
 destroy() {
   echo -n "💣 Destroying network..."
-  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down $additional_docker_compose_down_args > /dev/null 2>&1
+  docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down $additional_docker_compose_down_args >$DEBUG_OUTPUT 2>&1
   for pid in $(ps -ef | grep chainflip | grep -v grep | awk '{print $2}'); do kill -9 $pid; done
   rm -rf /tmp/chainflip
   echo "done"
@@ -256,13 +258,13 @@ logs() {
 bouncer() {
   (
     cd ./bouncer
-    pnpm install > /dev/null 2>&1
+    pnpm install >$DEBUG_OUTPUT 2>&1
     ./run.sh $NODE_COUNT
   )
 }
 
 main() {
-    if ! which wscat > /dev/null; then
+    if ! which wscat >$DEBUG_OUTPUT; then
         echo "wscat is not installed. Installing now..."
         npm install -g wscat
     fi


### PR DESCRIPTION
# Pull Request

This PR has no Linear ticket associated with it.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

When the docker is not launched, or some auth-token is stale, or something else prevents the script from normal execution, it can be fruitful to have a possibility to hear out the underlying commands' complaints:

```sh
DEBUG_OUTPUT=/dev/fd/1 /bin/bash -x ./localnet/manage.sh
```
