### PR TITLE
chore: debug logs to see get_raw_txs query

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/btc_mempool.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/btc_mempool.rs
@@ -101,8 +101,15 @@ async fn update_cache<T: BtcRpcApi>(
 		})
 		.collect();
 
+	tracing::debug!(
+		"Number of unknown mempool transactions: {}",
+		unknown_mempool_transactions.len()
+	);
+
 	let transactions: Vec<Transaction> =
 		btc.get_raw_transactions(unknown_mempool_transactions).await?;
+
+	tracing::debug!("Number of raw transactions returned: {}", transactions.len());
 
 	for tx in transactions {
 		let txid = tx.txid();


### PR DESCRIPTION
Some helpful debug logs for the ingress-egress-tracker
