### PR TITLE
fix: don't have conflicting redis port with localnet

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/README.md
+++ b/api/bin/chainflip-ingress-egress-tracker/README.md
@@ -9,6 +9,8 @@ transactions into Redis.
 
 To start a Redis database locally, run `docker-compose up -d redis`.
 
+This exposes redis at `redis://localhost:6380`.
+
 When working with a "localnet" (e.g. for development purposes), no extra
 configuration is necessary: `./chainflip-ingress-egress-tracker`.
 
@@ -23,7 +25,7 @@ The default configuration can be overwritten with the following env variables:
 - BTC_ENDPOINT: Bitcoin node http endpoint. (Default: http://127.0.0.1:8332)
 - BTC_USERNAME: Bitcoin node username. (Default: flip)
 - BTC_PASSWORD: Bitcoin node password. (Default: flip)
-- REDIS_URL: Redis url. (Default: redis://localhost:6379)
+- REDIS_URL: Redis url. (Default: redis://localhost:6380)
 ```
 
 # Usage

--- a/api/bin/chainflip-ingress-egress-tracker/docker-compose.yaml
+++ b/api/bin/chainflip-ingress-egress-tracker/docker-compose.yaml
@@ -2,4 +2,4 @@ services:
   redis:
     image: 'redislabs/redismod'
     ports:
-      - '6379:6379'
+      - '6380:6379'

--- a/api/bin/chainflip-ingress-egress-tracker/src/settings.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/settings.rs
@@ -67,7 +67,7 @@ impl CfSettings for DepositTrackerSettings {
 			.set_default("btc.http_endpoint", "http://127.0.0.1:8332")?
 			.set_default("btc.basic_auth_user", "flip")?
 			.set_default("btc.basic_auth_password", "flip")?
-			.set_default("redis_url", "http://127.0.0.1:6379")
+			.set_default("redis_url", "http://127.0.0.1:6380")
 	}
 
 	fn validate_settings(


### PR DESCRIPTION
This PR (https://github.com/chainflip-io/chainflip-backend/pull/4399) introduced redis for the ingress egress tracker, however the port used conflicts with localnet. 