### PR TITLE
refactor: use yargs for all try_runtime_command options

### DIFF
--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -26,42 +26,46 @@ import {
 import { getChainflipApi, runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-  const argv = yargs(hideBin(process.argv))
+  const args = await yargs(hideBin(process.argv))
+    .option('block', {
+      describe:
+        'The block number to try the runtime upgrade at. `<number>` runs at that block number. `latest` runs it on the latest block. `all` runs it on all blocks. `last-n` runs it on the last N blocks.',
+      type: 'string',
+      demandOption: true,
+      requiresArg: true,
+    })
     .boolean('compile')
     .default('compile', false)
     .option('runtime', {
       describe: 'path to the runtime wasm file. Required when compile is not set.',
       type: 'string',
+      default: './target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm',
+      demandOption: false,
+      requiresArg: true,
+    })
+    .option('last-n', {
+      describe: 'If block is lastN, this is the number of blocks to run the migration on.',
+      type: 'number',
+      default: 50,
       demandOption: false,
       requiresArg: true,
     }).argv;
 
-  const block = argv.block;
-
-  if (block === undefined) {
-    console.error(
-      'Must provide a block number to try the upgrade at. The options are to use a block number, or `latest` of `last-n <number>` to use the latest block number on the network.',
-    );
-    process.exit(-1);
-  }
-
   const endpoint = process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944';
   const chainflipApi = await getChainflipApi();
 
-  const lastN = argv.lastN ?? 100;
-
-  if (argv.compile) {
+  if (args.compile) {
     console.log('Try runtime after compiling.');
     await tryRuntimeUpgradeWithCompileRuntime(
-      block,
+      args.block,
       chainflipApi,
       path.dirname(process.cwd()),
       endpoint,
-      lastN,
+      args.lastN,
     );
   } else {
-    console.log('Try runtime using runtime at ' + argv.runtime);
-    await tryRuntimeUpgrade(block, chainflipApi, endpoint, argv.runtime, lastN);
+    console.log('Try runtime using runtime at ' + args.runtime);
+    await tryRuntimeUpgrade(args.block, chainflipApi, endpoint, args.runtime, args.lastN);
   }
 
   process.exit(0);

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -39,7 +39,8 @@ async function main(): Promise<void> {
     .option('runtime', {
       describe: 'path to the runtime wasm file. Required when compile is not set.',
       type: 'string',
-      default: './target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm',
+      default:
+        './target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm',
       demandOption: false,
       requiresArg: true,
     })


### PR DESCRIPTION
# Pull Request

Closes: PRO-1023

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Simplifies, using yargs for everything in the command.
- Adds default value for the runtime