### PR TITLE
chore: remove request origin restriction from `geth` container 🆓

### DIFF
--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -20,10 +20,10 @@ services:
     container_name: geth
     platform: linux/amd64
     ports:
-      - "127.0.0.1:8545:8545"
-      - "127.0.0.1:8551:8551"
-      - "127.0.0.1:8546:8546"
-      - "127.0.0.1:30303:30303"
+      - "8545:8545"
+      - "8551:8551"
+      - "8546:8546"
+      - "30303:30303"
     volumes:
       - "/tmp/chainflip/data/l1data:/datadir"
       - "/tmp/chainflip/data/l1keystore:/keystore"


### PR DESCRIPTION
Closes: PLA-1092

As part of the Swapping App e2e tests, the swapping backend needs to communicate with the private ethereum rpc. This was failing due to restricting the request origin to `127.0.0.1`, where the swapping backend will be requesting it from inside another docker container. 