### PR TITLE
chore: add docker tag prefix to `chainflip-ingress-egress-tacker` 🏷️

### DIFF
--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -117,7 +117,7 @@ jobs:
             type=ref,event=tag,prefix=${{ inputs.network }}-
               type=raw,value=${{ needs.get-version-from-branch-name.outputs.version }},prefix=${{ inputs.network }}-,enable=${{ needs.get-version-from-branch-name.outputs.version != '0.0.0' }}
               type=ref,event=pr
-              type=raw,value=${{ github.sha }},prefix=iet-,enable=${{ matrix.target == 'chainflip-ingress-egress-tracker' && github.ref == 'main' }}
+              type=raw,value=${{ github.sha }},prefix=iet-,enable=${{ matrix.target == 'chainflip-ingress-egress-tracker' && github.ref_name == 'main' }}
 
       - name: Login to Github Container Registry 🔑
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d


### PR DESCRIPTION
This is a temporary fix to handle k8s image syncing