### PR TITLE
doc: fix a typo and minor grammar issue in PRACTICES.md

### DIFF
--- a/PRACTICES.md
+++ b/PRACTICES.md
@@ -13,7 +13,7 @@ Our practices must be:
 - As unambiguous as possible. It should be clear how and when the practice applies. If necessary they should include clarifying examples. Ideally these examples would be from our codebase, and include links to PRs and issues.
 - Well-reasoned. Otherwise we will likely alienate some developers. As such each practice should be justified using logic, principles, ideals, and other practices.
 
-# Maintainance
+# Maintenance
 
 Create an issue on this repository regarding the modification to / problem with the practices, provide a justification for the change, and add the <span style="color:rgb(0,255,0)">practices</span> label. We intentionally chose not to burden ourselves with a formal process to agree on modifications to the practices, but it is expected the whole team be given the opportinity to comment, a majority of the team should agree to a change, and those who disagreed are satisfied with the resolution. Once the modification is agreed on by the team, create a pull request to modify this document. That pull request should contain changes that ensure the codebase matches the new practices if applicable.
 


### PR DESCRIPTION
# Pull Request

Typo and grammar fix for a documentation file.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

I was reading over the practices.md file and noticed a small typo and a grammar issue. Very minor fix.