### PR TITLE
bouncer test: broker fee collection

### DIFF
--- a/bouncer/full_bouncer.sh
+++ b/bouncer/full_bouncer.sh
@@ -8,6 +8,7 @@ echo "Running nightly tests 🧪"
 ./tests/all_concurrent_tests.ts $1
 ./tests/rotates_through_btc_swap.ts
 ./tests/btc_utxo_consolidation.ts
+./tests/broker_fee_collection_test.ts
 
 if [[ $LOCALNET == false ]]; then
   echo "🤫 Skipping tests that require localnet"

--- a/bouncer/run.sh
+++ b/bouncer/run.sh
@@ -2,3 +2,4 @@ set -e
 ./commands/observe_block.ts 5
 ./setup_for_test.sh
 ./tests/all_concurrent_tests.ts $1
+./tests/broker_fee_collection_test.ts

--- a/bouncer/shared/new_swap.ts
+++ b/bouncer/shared/new_swap.ts
@@ -14,7 +14,7 @@ export async function newSwap(
   destAsset: Asset,
   destAddress: string,
   messageMetadata?: CcmDepositMetadata,
-  commissionBps = defaultCommissionBps,
+  brokerCommissionBps = defaultCommissionBps,
 ): Promise<void> {
   const destinationAddress =
     destAsset === 'DOT' ? decodeDotAddressForContract(destAddress) : destAddress;
@@ -33,7 +33,7 @@ export async function newSwap(
     },
     {
       url: brokerUrl,
-      commissionBps,
+      commissionBps: brokerCommissionBps,
     },
   );
 }

--- a/bouncer/shared/new_swap.ts
+++ b/bouncer/shared/new_swap.ts
@@ -1,6 +1,8 @@
 import { Asset, broker } from '@chainflip-io/cli';
 import { decodeDotAddressForContract, chainFromAsset } from './utils';
 
+const defaultCommissionBps = 100; // 1%
+
 export interface CcmDepositMetadata {
   message: string;
   gasBudget: number;
@@ -12,6 +14,7 @@ export async function newSwap(
   destAsset: Asset,
   destAddress: string,
   messageMetadata?: CcmDepositMetadata,
+  commissionBps = defaultCommissionBps,
 ): Promise<void> {
   const destinationAddress =
     destAsset === 'DOT' ? decodeDotAddressForContract(destAddress) : destAddress;
@@ -30,7 +33,7 @@ export async function newSwap(
     },
     {
       url: brokerUrl,
-      commissionBps: 0,
+      commissionBps,
     },
   );
 }

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -39,6 +39,7 @@ export async function requestNewSwap(
   destAddress: string,
   tag = '',
   messageMetadata?: CcmDepositMetadata,
+  commissionBps?: number,
   log = true,
 ): Promise<SwapParams> {
   const chainflipApi = await getChainflipApi();
@@ -72,7 +73,7 @@ export async function requestNewSwap(
       return destAddressMatches && destAssetMatches && sourceAssetMatches && ccmMetadataMatches;
     },
   );
-  await newSwap(sourceAsset, destAsset, destAddress, messageMetadata);
+  await newSwap(sourceAsset, destAsset, destAddress, messageMetadata, commissionBps);
 
   const res = (await addressPromise).data;
 
@@ -147,6 +148,7 @@ export async function performSwap(
   messageMetadata?: CcmDepositMetadata,
   senderType = SenderType.Address,
   amount?: string,
+  commissionBps?: number,
   log = true,
 ) {
   const tag = swapTag ?? '';
@@ -164,6 +166,7 @@ export async function performSwap(
     destAddress,
     tag,
     messageMetadata,
+    commissionBps,
     log,
   );
   await doPerformSwap(swapParams, tag, messageMetadata, senderType, amount, log);

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -39,7 +39,7 @@ export async function requestNewSwap(
   destAddress: string,
   tag = '',
   messageMetadata?: CcmDepositMetadata,
-  commissionBps?: number,
+  brokerCommissionBps?: number,
   log = true,
 ): Promise<SwapParams> {
   const chainflipApi = await getChainflipApi();
@@ -73,7 +73,7 @@ export async function requestNewSwap(
       return destAddressMatches && destAssetMatches && sourceAssetMatches && ccmMetadataMatches;
     },
   );
-  await newSwap(sourceAsset, destAsset, destAddress, messageMetadata, commissionBps);
+  await newSwap(sourceAsset, destAsset, destAddress, messageMetadata, brokerCommissionBps);
 
   const res = (await addressPromise).data;
 
@@ -148,7 +148,7 @@ export async function performSwap(
   messageMetadata?: CcmDepositMetadata,
   senderType = SenderType.Address,
   amount?: string,
-  commissionBps?: number,
+  brokerCommissionBps?: number,
   log = true,
 ) {
   const tag = swapTag ?? '';
@@ -166,7 +166,7 @@ export async function performSwap(
     destAddress,
     tag,
     messageMetadata,
-    commissionBps,
+    brokerCommissionBps,
     log,
   );
   await doPerformSwap(swapParams, tag, messageMetadata, senderType, amount, log);

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -143,6 +143,7 @@ export async function testSwap(
     messageMetadata,
     undefined,
     amount,
+    undefined,
     log,
   );
 }

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -385,7 +385,7 @@ export async function newAddress(
     case Assets.FLIP:
     case Assets.ETH:
     case Assets.USDC:
-      rawAddress = newEthAddress(seed).toLowerCase();
+      rawAddress = newEthAddress(seed);
       break;
     case Assets.DOT:
       rawAddress = await newDotAddress(seed);

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -3,7 +3,14 @@ import { setTimeout as sleep } from 'timers/promises';
 import Client from 'bitcoin-core';
 import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
 import { Mutex } from 'async-mutex';
-import { Chain, Asset, assetChains, chainContractIds, assetDecimals } from '@chainflip-io/cli';
+import {
+  Chain,
+  Asset,
+  assetChains,
+  chainContractIds,
+  assetDecimals,
+  Assets,
+} from '@chainflip-io/cli';
 import Web3 from 'web3';
 import { u8aToHex } from '@polkadot/util';
 import { newDotAddress } from './new_dot_address';
@@ -204,7 +211,7 @@ export async function observeEvent(
   return result as Event;
 }
 
-type EgressId = [Chain, number];
+export type EgressId = [Chain, number];
 type BroadcastId = [Chain, number];
 // Observe multiple events related to the same swap that could be emitted in the same block
 export async function observeSwapEvents(
@@ -375,15 +382,15 @@ export async function newAddress(
   let rawAddress;
 
   switch (asset) {
-    case 'FLIP':
-    case 'ETH':
-    case 'USDC':
-      rawAddress = newEthAddress(seed);
+    case Assets.FLIP:
+    case Assets.ETH:
+    case Assets.USDC:
+      rawAddress = newEthAddress(seed).toLowerCase();
       break;
-    case 'DOT':
+    case Assets.DOT:
       rawAddress = await newDotAddress(seed);
       break;
-    case 'BTC':
+    case Assets.BTC:
       rawAddress = await newBtcAddress(seed, type ?? 'P2PKH');
       break;
     default:
@@ -399,6 +406,21 @@ export function chainFromAsset(asset: Asset): Chain {
   }
 
   throw new Error('unexpected asset');
+}
+
+export function chainShortNameFromAsset(asset: Asset): string {
+  switch (asset) {
+    case Assets.FLIP:
+    case Assets.ETH:
+    case Assets.USDC:
+      return 'Eth';
+    case Assets.DOT:
+      return 'Dot';
+    case Assets.BTC:
+      return 'Btc';
+    default:
+      throw new Error('unexpected asset');
+  }
 }
 
 export async function observeBalanceIncrease(

--- a/bouncer/tests/broker_fee_collection_test.ts
+++ b/bouncer/tests/broker_fee_collection_test.ts
@@ -78,7 +78,9 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
   const observeSwapScheduledEvent = observeEvent(
     ':SwapScheduled',
     chainflip,
-    (event) => event.data.destinationAddress[destinationChain] === useableDestinationAddress,
+    (event) =>
+      event.data.destinationAddress[destinationChain]?.toLowerCase() ===
+      useableDestinationAddress.toLowerCase(),
   );
   console.log(`Running swap ${asset} -> ${swapAsset}`);
   await performSwap(
@@ -156,7 +158,9 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
   const observeWithdrawalRequested = observeEvent(
     'swapping:WithdrawalRequested',
     chainflip,
-    (event) => event.data.destinationAddress[chain] === useableWithdrawalAddress,
+    (event) =>
+      event.data.destinationAddress[chain]?.toLowerCase() ===
+      useableWithdrawalAddress.toLowerCase(),
   );
 
   // Only allow one withdrawal at a time to stop nonce issues

--- a/bouncer/tests/broker_fee_collection_test.ts
+++ b/bouncer/tests/broker_fee_collection_test.ts
@@ -1,35 +1,36 @@
 #!/usr/bin/env -S pnpm tsx
 import assert from 'assert';
 import { randomBytes } from 'crypto';
-import { KeyringPair } from '@polkadot/keyring/types';
 import Keyring from '@polkadot/keyring';
 import { Asset, Assets, assetDecimals } from '@chainflip-io/cli';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import {
   EgressId,
   amountToFineAmount,
+  brokerMutex,
   chainShortNameFromAsset,
   decodeDotAddressForContract,
   getChainflipApi,
+  handleSubstrateError,
   newAddress,
   observeBalanceIncrease,
   observeEvent,
   runWithTimeout,
-  sleep,
 } from '../shared/utils';
 import { getBalance } from '../shared/get_balance';
 import { performSwap } from '../shared/perform_swap';
 
-const testSwapAssetAmount = {
+const swapAssetAmount = {
   [Assets.ETH]: 1,
   [Assets.DOT]: 1000,
   [Assets.FLIP]: 1000,
   [Assets.BTC]: 0.1,
   [Assets.USDC]: 1000,
 };
-const testCommissionBps = 1000; // 10%
+const commissionBps = 1000; // 10%
 
-// Maximum expected deposit and withdrawal fees
+// Maximum expected deposit and withdrawal fees.
+// Values obtained from running this test on 1 node localnet.
 const maxDepositFee = {
   [Assets.ETH]: BigInt(350000),
   [Assets.DOT]: BigInt(197300000),
@@ -46,32 +47,34 @@ const maxWithdrawalFee = {
 };
 const chainflip = await getChainflipApi();
 
-let withdrawLockout = false;
-let broker1: KeyringPair | undefined;
-export async function broker1KeyringPair() {
-  if (!broker1) {
-    await cryptoWaitReady();
-    const keyring = new Keyring({ type: 'sr25519' });
-    broker1 = keyring.createFromUri('//BROKER_1');
-  }
-  return broker1;
+const keyring = new Keyring({ type: 'sr25519' });
+const broker1 = keyring.createFromUri('//BROKER_1');
+
+export async function submitBrokerWithdrawal(
+  asset: Asset,
+  addressObject: { [chain: string]: string },
+) {
+  // Only allow one withdrawal at a time to stop nonce issues
+  return brokerMutex.runExclusive(async () =>
+    chainflip.tx.swapping
+      .withdraw(asset, addressObject)
+      .signAndSend(broker1, { nonce: -1 }, handleSubstrateError(chainflip)),
+  );
 }
 
 /// Runs a swap, checks that the broker fees are collected,
 /// then withdraws the broker fees, making sure the balance is correct after the withdrawal.
 async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
-  const broker = await broker1KeyringPair();
-
   // Check the broker fees before the swap
   const earnedBrokerFeesBefore = BigInt(
-    (await chainflip.query.swapping.earnedBrokerFees(broker.address, asset)).toString(),
+    (await chainflip.query.swapping.earnedBrokerFees(broker1.address, asset)).toString(),
   );
   console.log(`${asset} earnedBrokerFeesBefore:`, earnedBrokerFeesBefore);
 
   // Run a swap
   const swapAsset = asset === Assets.USDC ? Assets.FLIP : Assets.USDC;
   const destinationAddress = await newAddress(swapAsset, seed ?? randomBytes(32).toString('hex'));
-  const useableDestinationAddress =
+  const observeDestinationAddress =
     asset === Assets.DOT ? decodeDotAddressForContract(destinationAddress) : destinationAddress;
   const destinationChain = chainShortNameFromAsset(swapAsset); // "ETH" -> "Eth"
   console.log(`${asset} destinationAddress:`, destinationAddress);
@@ -80,7 +83,7 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     chainflip,
     (event) =>
       event.data.destinationAddress[destinationChain]?.toLowerCase() ===
-      useableDestinationAddress.toLowerCase(),
+      observeDestinationAddress.toLowerCase(),
   );
   console.log(`Running swap ${asset} -> ${swapAsset}`);
   await performSwap(
@@ -90,43 +93,35 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     undefined,
     undefined,
     undefined,
-    testSwapAssetAmount[asset].toString(),
-    testCommissionBps,
+    swapAssetAmount[asset].toString(),
+    commissionBps,
     false,
   );
 
-  // Check the broker fees after the swap
-  const earnedBrokerFeesAfter = BigInt(
-    (await chainflip.query.swapping.earnedBrokerFees(broker.address, asset)).toString(),
-  );
-  console.log(`${asset} earnedBrokerFeesAfter:`, earnedBrokerFeesAfter);
-
   // Get values from the swap event
   const swapScheduledEvent = await observeSwapScheduledEvent;
-  const brokerCommission = BigInt(
-    JSON.stringify(swapScheduledEvent.data.brokerCommission)
-      .replaceAll('"', '')
-      .replaceAll(',', ''),
-  );
+  const brokerCommission = BigInt(swapScheduledEvent.data.brokerCommission.replaceAll(',', ''));
   console.log('brokerCommission:', brokerCommission);
 
   // Check that the deposit amount is correct after deducting the deposit fee
-  const depositAmount = BigInt(
-    JSON.stringify(swapScheduledEvent.data.depositAmount).replaceAll('"', '').replaceAll(',', ''),
-  );
+  const depositAmount = BigInt(swapScheduledEvent.data.depositAmount.replaceAll(',', ''));
   const testSwapAmount = BigInt(
-    amountToFineAmount(testSwapAssetAmount[asset].toString(), assetDecimals[asset]),
+    amountToFineAmount(swapAssetAmount[asset].toString(), assetDecimals[asset]),
   );
-  const expectedDepositAmount = testSwapAmount - maxDepositFee[asset];
+  const minExpectedDepositAmount = testSwapAmount - maxDepositFee[asset];
   console.log('depositAmount:', depositAmount);
   assert(
-    depositAmount >= expectedDepositAmount && depositAmount <= testSwapAmount,
-    `Unexpected ${asset} deposit amount ${depositAmount}, expected >=${expectedDepositAmount}, did gas fees change? detectedGasFee: ${
+    depositAmount >= minExpectedDepositAmount && depositAmount <= testSwapAmount,
+    `Unexpected ${asset} deposit amount ${depositAmount}, expected >=${minExpectedDepositAmount}, did gas fees change? detectedGasFee: ${
       testSwapAmount - depositAmount
     }`,
   );
 
-  // Check that the detected increase matches the swap event values and it is equal to the expected amount (after the deposit fee is accounted for)
+  // Check that the detected increase in earned broker fees matches the swap event values and it is equal to the expected amount (after the deposit fee is accounted for)
+  const earnedBrokerFeesAfter = BigInt(
+    (await chainflip.query.swapping.earnedBrokerFees(broker1.address, asset)).toString(),
+  );
+  console.log(`${asset} earnedBrokerFeesAfter:`, earnedBrokerFeesAfter);
   const increase = earnedBrokerFeesAfter - earnedBrokerFeesBefore;
   console.log('increase:', increase);
   assert.strictEqual(
@@ -136,7 +131,7 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
   );
 
   // Calculating the fee. Using some strange math here because the SC rounds down on 0.5 instead of up.
-  const divisor = BigInt(1 / (testCommissionBps / 10000));
+  const divisor = BigInt(10000 / commissionBps);
   const expectedIncrease =
     depositAmount / divisor + (depositAmount % divisor > divisor / 2n ? 1n : 0n);
   assert.strictEqual(
@@ -147,34 +142,26 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
 
   // Withdraw the broker fees
   const withdrawalAddress = await newAddress(asset, seed ?? randomBytes(32).toString('hex'));
-  const useableWithdrawalAddress =
+  const observeWithdrawalAddress =
     asset === Assets.DOT ? decodeDotAddressForContract(withdrawalAddress) : withdrawalAddress;
   const chain = chainShortNameFromAsset(asset);
   console.log(`${chain} withdrawalAddress:`, withdrawalAddress);
   const balanceBeforeWithdrawal = await getBalance(asset, withdrawalAddress);
   console.log(
-    `Withdrawing broker fees to ${useableWithdrawalAddress}, balance before: ${balanceBeforeWithdrawal}`,
+    `Withdrawing broker fees to ${observeWithdrawalAddress}, balance before: ${balanceBeforeWithdrawal}`,
   );
   const observeWithdrawalRequested = observeEvent(
     'swapping:WithdrawalRequested',
     chainflip,
     (event) =>
       event.data.destinationAddress[chain]?.toLowerCase() ===
-      useableWithdrawalAddress.toLowerCase(),
+      observeWithdrawalAddress.toLowerCase(),
   );
 
-  // Only allow one withdrawal at a time to stop nonce issues
-  while (withdrawLockout) {
-    await sleep(100);
-  }
-  withdrawLockout = true;
-  const withdrawal = await chainflip.tx.swapping
-    .withdraw(asset, {
-      [chain]: useableWithdrawalAddress,
-    })
-    .signAndSend(broker);
-
-  console.log('Submitted Withdrawal:', JSON.stringify(withdrawal));
+  await submitBrokerWithdrawal(asset, {
+    [chain]: observeWithdrawalAddress,
+  });
+  console.log(`Submitted withdrawal for ${asset}`);
   const withdrawalRequestedEvent = await observeWithdrawalRequested;
   console.log(`Withdrawal requested, egressId: ${withdrawalRequestedEvent.data.egressId}`);
   const BatchBroadcastRequestedEvent = await observeEvent(
@@ -191,8 +178,6 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     `Batch broadcast requested, broadcastId: ${BatchBroadcastRequestedEvent.data.broadcastId}`,
   );
 
-  withdrawLockout = false;
-
   await observeBalanceIncrease(asset, withdrawalAddress, balanceBeforeWithdrawal);
 
   // Check that the balance after withdrawal is correct after deducting withdrawal fee
@@ -201,35 +186,30 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
   const balanceAfterWithdrawalBigInt = BigInt(
     amountToFineAmount(balanceAfterWithdrawal, assetDecimals[asset]),
   );
-  const expectedBalanceAfterWithdrawal =
-    BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) +
-    earnedBrokerFeesAfter -
-    maxWithdrawalFee[asset];
-  const detectWithdrawalGasFee = -(
-    balanceAfterWithdrawalBigInt -
-    BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) -
-    earnedBrokerFeesAfter
+  const balanceBeforeWithdrawalBigInt = BigInt(
+    amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset]),
   );
-
+  const minExpectedBalanceAfterWithdrawal =
+    balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter - maxWithdrawalFee[asset];
+  const detectWithdrawalGasFee =
+    balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter - balanceAfterWithdrawalBigInt;
   assert(
-    balanceAfterWithdrawalBigInt >= expectedBalanceAfterWithdrawal &&
-      balanceAfterWithdrawalBigInt <=
-        BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) +
-          earnedBrokerFeesAfter,
-    `Unexpected ${asset} balance after withdrawal, amount ${balanceAfterWithdrawalBigInt}, expected >=${expectedBalanceAfterWithdrawal}, did gas fees change? detected gas fee: ${detectWithdrawalGasFee}`,
+    balanceAfterWithdrawalBigInt >= minExpectedBalanceAfterWithdrawal &&
+      balanceAfterWithdrawalBigInt <= balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter,
+    `Unexpected ${asset} balance after withdrawal, amount ${balanceAfterWithdrawalBigInt}, expected >=${minExpectedBalanceAfterWithdrawal}, did gas fees change? detected gas fee: ${detectWithdrawalGasFee}`,
   );
 }
 
 async function main(): Promise<void> {
   console.log('\x1b[36m%s\x1b[0m', '=== Running broker fee collection test ===');
+  await cryptoWaitReady();
 
   // Check account role
-  const brokerAddress = (await broker1KeyringPair()).address;
   const role = JSON.stringify(
-    await chainflip.query.accountRoles.accountRoles(brokerAddress),
+    await chainflip.query.accountRoles.accountRoles(broker1.address),
   ).replaceAll('"', '');
-  console.log('role:', role);
-  console.log('broker1.address:', brokerAddress);
+  console.log('Broker role:', role);
+  console.log('Broker address:', broker1.address);
   assert.strictEqual(role, 'Broker', `Broker has unexpected role: ${role}`);
 
   // Run the test for all assets at the same time (with different seeds so the eth addresses are different)

--- a/bouncer/tests/broker_fee_collection_test.ts
+++ b/bouncer/tests/broker_fee_collection_test.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env -S pnpm tsx
+import assert from 'assert';
+import { randomBytes } from 'crypto';
+import { KeyringPair } from '@polkadot/keyring/types';
+import Keyring from '@polkadot/keyring';
+import { Asset, Assets, assetDecimals } from '@chainflip-io/cli';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import {
+  EgressId,
+  amountToFineAmount,
+  chainShortNameFromAsset,
+  decodeDotAddressForContract,
+  getChainflipApi,
+  newAddress,
+  observeBalanceIncrease,
+  observeEvent,
+  runWithTimeout,
+  sleep,
+} from '../shared/utils';
+import { getBalance } from '../shared/get_balance';
+import { performSwap } from '../shared/perform_swap';
+
+const testSwapAssetAmount = {
+  [Assets.ETH]: 1,
+  [Assets.DOT]: 1000,
+  [Assets.FLIP]: 1000,
+  [Assets.BTC]: 0.1,
+  [Assets.USDC]: 1000,
+};
+const testCommissionBps = 1000; // 10%
+
+// Maximum expected deposit and withdrawal fees
+const maxDepositFee = {
+  [Assets.ETH]: BigInt(350000),
+  [Assets.DOT]: BigInt(197300000),
+  [Assets.FLIP]: BigInt(300000000),
+  [Assets.BTC]: BigInt(190),
+  [Assets.USDC]: BigInt(0), // Fee is too low for localnet, it rounds to 0
+};
+const maxWithdrawalFee = {
+  [Assets.ETH]: BigInt(490000),
+  [Assets.DOT]: BigInt(197450000),
+  [Assets.FLIP]: BigInt(300000000),
+  [Assets.BTC]: BigInt(100),
+  [Assets.USDC]: BigInt(0),
+};
+const chainflip = await getChainflipApi();
+
+let withdrawLockout = false;
+let broker1: KeyringPair | undefined;
+export async function broker1KeyringPair() {
+  if (!broker1) {
+    await cryptoWaitReady();
+    const keyring = new Keyring({ type: 'sr25519' });
+    broker1 = keyring.createFromUri('//BROKER_1');
+  }
+  return broker1;
+}
+
+/// Runs a swap, checks that the broker fees are collected,
+/// then withdraws the broker fees, making sure the balance is correct after the withdrawal.
+async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
+  const broker = await broker1KeyringPair();
+
+  // Check the broker fees before the swap
+  const earnedBrokerFeesBefore = BigInt(
+    (await chainflip.query.swapping.earnedBrokerFees(broker.address, asset)).toString(),
+  );
+  console.log(`${asset} earnedBrokerFeesBefore:`, earnedBrokerFeesBefore);
+
+  // Run a swap
+  const swapAsset = asset === Assets.USDC ? Assets.FLIP : Assets.USDC;
+  const destinationAddress = await newAddress(swapAsset, seed ?? randomBytes(32).toString('hex'));
+  const useableDestinationAddress =
+    asset === Assets.DOT ? decodeDotAddressForContract(destinationAddress) : destinationAddress;
+  const destinationChain = chainShortNameFromAsset(swapAsset); // "ETH" -> "Eth"
+  console.log(`${asset} destinationAddress:`, destinationAddress);
+  const observeSwapScheduledEvent = observeEvent(
+    ':SwapScheduled',
+    chainflip,
+    (event) => event.data.destinationAddress[destinationChain] === useableDestinationAddress,
+  );
+  console.log(`Running swap ${asset} -> ${swapAsset}`);
+  await performSwap(
+    asset,
+    swapAsset,
+    destinationAddress,
+    undefined,
+    undefined,
+    undefined,
+    testSwapAssetAmount[asset].toString(),
+    testCommissionBps,
+    false,
+  );
+
+  // Check the broker fees after the swap
+  const earnedBrokerFeesAfter = BigInt(
+    (await chainflip.query.swapping.earnedBrokerFees(broker.address, asset)).toString(),
+  );
+  console.log(`${asset} earnedBrokerFeesAfter:`, earnedBrokerFeesAfter);
+
+  // Get values from the swap event
+  const swapScheduledEvent = await observeSwapScheduledEvent;
+  const brokerCommission = BigInt(
+    JSON.stringify(swapScheduledEvent.data.brokerCommission)
+      .replaceAll('"', '')
+      .replaceAll(',', ''),
+  );
+  console.log('brokerCommission:', brokerCommission);
+
+  // Check that the deposit amount is correct after deducting the deposit fee
+  const depositAmount = BigInt(
+    JSON.stringify(swapScheduledEvent.data.depositAmount).replaceAll('"', '').replaceAll(',', ''),
+  );
+  const testSwapAmount = BigInt(
+    amountToFineAmount(testSwapAssetAmount[asset].toString(), assetDecimals[asset]),
+  );
+  const expectedDepositAmount = testSwapAmount - maxDepositFee[asset];
+  console.log('depositAmount:', depositAmount);
+  assert(
+    depositAmount >= expectedDepositAmount && depositAmount <= testSwapAmount,
+    `Unexpected ${asset} deposit amount ${depositAmount}, expected >=${expectedDepositAmount}, did gas fees change? detectedGasFee: ${
+      testSwapAmount - depositAmount
+    }`,
+  );
+
+  // Check that the detected increase matches the swap event values and it is equal to the expected amount (after the deposit fee is accounted for)
+  const increase = earnedBrokerFeesAfter - earnedBrokerFeesBefore;
+  console.log('increase:', increase);
+  assert.strictEqual(
+    increase,
+    brokerCommission,
+    `Mismatch between brokerCommission from the swap event and the detected increase. Did some other ${asset} swap happen at the same time as this test?`,
+  );
+
+  // Calculating the fee. Using some strange math here because the SC rounds down on 0.5 instead of up.
+  const divisor = BigInt(1 / (testCommissionBps / 10000));
+  const expectedIncrease =
+    depositAmount / divisor + (depositAmount % divisor > divisor / 2n ? 1n : 0n);
+  assert.strictEqual(
+    increase,
+    expectedIncrease,
+    `Unexpected increase in the ${asset} earned broker fees. Did the broker commission change?`,
+  );
+
+  // Withdraw the broker fees
+  const withdrawalAddress = await newAddress(asset, seed ?? randomBytes(32).toString('hex'));
+  const useableWithdrawalAddress =
+    asset === Assets.DOT ? decodeDotAddressForContract(withdrawalAddress) : withdrawalAddress;
+  const chain = chainShortNameFromAsset(asset);
+  console.log(`${chain} withdrawalAddress:`, withdrawalAddress);
+  const balanceBeforeWithdrawal = await getBalance(asset, withdrawalAddress);
+  console.log(
+    `Withdrawing broker fees to ${useableWithdrawalAddress}, balance before: ${balanceBeforeWithdrawal}`,
+  );
+  const observeWithdrawalRequested = observeEvent(
+    'swapping:WithdrawalRequested',
+    chainflip,
+    (event) => event.data.destinationAddress[chain] === useableWithdrawalAddress,
+  );
+
+  // Only allow one withdrawal at a time to stop nonce issues
+  while (withdrawLockout) {
+    await sleep(100);
+  }
+  withdrawLockout = true;
+  const withdrawal = await chainflip.tx.swapping
+    .withdraw(asset, {
+      [chain]: useableWithdrawalAddress,
+    })
+    .signAndSend(broker);
+
+  console.log('Submitted Withdrawal:', JSON.stringify(withdrawal));
+  const withdrawalRequestedEvent = await observeWithdrawalRequested;
+  console.log(`Withdrawal requested, egressId: ${withdrawalRequestedEvent.data.egressId}`);
+  const BatchBroadcastRequestedEvent = await observeEvent(
+    ':BatchBroadcastRequested',
+    chainflip,
+    (event) =>
+      event.data.egressIds.some(
+        (egressId: EgressId) =>
+          egressId[0] === withdrawalRequestedEvent.data.egressId[0] &&
+          egressId[1] === withdrawalRequestedEvent.data.egressId[1],
+      ),
+  );
+  console.log(
+    `Batch broadcast requested, broadcastId: ${BatchBroadcastRequestedEvent.data.broadcastId}`,
+  );
+
+  withdrawLockout = false;
+
+  await observeBalanceIncrease(asset, withdrawalAddress, balanceBeforeWithdrawal);
+
+  // Check that the balance after withdrawal is correct after deducting withdrawal fee
+  const balanceAfterWithdrawal = await getBalance(asset, withdrawalAddress);
+  console.log(`${asset} Balance after withdrawal:`, balanceAfterWithdrawal);
+  const balanceAfterWithdrawalBigInt = BigInt(
+    amountToFineAmount(balanceAfterWithdrawal, assetDecimals[asset]),
+  );
+  const expectedBalanceAfterWithdrawal =
+    BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) +
+    earnedBrokerFeesAfter -
+    maxWithdrawalFee[asset];
+  const detectWithdrawalGasFee = -(
+    balanceAfterWithdrawalBigInt -
+    BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) -
+    earnedBrokerFeesAfter
+  );
+
+  assert(
+    balanceAfterWithdrawalBigInt >= expectedBalanceAfterWithdrawal &&
+      balanceAfterWithdrawalBigInt <=
+        BigInt(amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset])) +
+          earnedBrokerFeesAfter,
+    `Unexpected ${asset} balance after withdrawal, amount ${balanceAfterWithdrawalBigInt}, expected >=${expectedBalanceAfterWithdrawal}, did gas fees change? detected gas fee: ${detectWithdrawalGasFee}`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log('\x1b[36m%s\x1b[0m', '=== Running broker fee collection test ===');
+
+  // Check account role
+  const brokerAddress = (await broker1KeyringPair()).address;
+  const role = JSON.stringify(
+    await chainflip.query.accountRoles.accountRoles(brokerAddress),
+  ).replaceAll('"', '');
+  console.log('role:', role);
+  console.log('broker1.address:', brokerAddress);
+  assert.strictEqual(role, 'Broker', `Broker has unexpected role: ${role}`);
+
+  // Run the test for all assets at the same time (with different seeds so the eth addresses are different)
+  await Promise.all([
+    testBrokerFees(Assets.FLIP, randomBytes(32).toString('hex')),
+    testBrokerFees(Assets.ETH, randomBytes(32).toString('hex')),
+    testBrokerFees(Assets.DOT, randomBytes(32).toString('hex')),
+    testBrokerFees(Assets.BTC, randomBytes(32).toString('hex')),
+    testBrokerFees(Assets.USDC, randomBytes(32).toString('hex')),
+  ]);
+
+  console.log('\x1b[32m%s\x1b[0m', '=== Broker fee collection test complete ===');
+  process.exit(0);
+}
+
+runWithTimeout(main(), 1200000).catch((error) => {
+  console.error(error);
+  process.exit(-1);
+});


### PR DESCRIPTION
# Pull Request

Closes: PRO-965

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

New bouncer test: Runs a swap, checks that the broker fees are collected, then withdraws the broker fees, making sure the balance is correct after the withdrawal. This is done for all assets at the same time.

- Added an argument to `performSwap` so the test could use a custom `CommissionBps`.
- Set the default broker fee for all bouncer swaps to 1%.

