### PR TITLE
fix: use custom subxt config + nextAccountIndex

### DIFF
--- a/engine/src/state_chain_observer/client/mod.rs
+++ b/engine/src/state_chain_observer/client/mod.rs
@@ -797,7 +797,7 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 							DefaultExtrinsicParamsBuilder::new()
 								.mortal_unchecked(
 									block_number.into(),
-									block_hash.into(),
+									block_hash,
 									SIGNED_EXTRINSIC_LIFETIME.into(),
 								)
 								.build(),

--- a/engine/src/state_chain_observer/client/mod.rs
+++ b/engine/src/state_chain_observer/client/mod.rs
@@ -730,7 +730,7 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 
 					fn sign(&self, bytes: &[u8]) -> <StateChainConfig as subxt::Config>::Signature {
 						use sp_core::Pair;
-						subxt::utils::MultiSignature::Sr25519(self.1.sign(bytes).0)
+						state_chain_runtime::Signature::Sr25519(self.1.sign(bytes))
 					}
 				}
 				SubxtSignerInterface(subxt::utils::AccountId32(*signer.account_id.as_ref()), pair)

--- a/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
+++ b/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
@@ -1,0 +1,24 @@
+use subxt::{config::signed_extensions, Config};
+
+pub enum StateChainConfig {}
+
+impl Config for StateChainConfig {
+	type Hash = <state_chain_runtime::Runtime as frame_system::Config>::Hash;
+	type AccountId = subxt::utils::AccountId32;
+	type Address = subxt::utils::MultiAddress<Self::AccountId, ()>;
+	type Signature = subxt::utils::MultiSignature;
+	type Hasher = subxt::ext::sp_runtime::traits::BlakeTwo256;
+	type Header = subxt::ext::sp_runtime::generic::Header<u32, Self::Hasher>;
+	type ExtrinsicParams = signed_extensions::AnyOf<
+		Self,
+		(
+			signed_extensions::CheckSpecVersion,
+			signed_extensions::CheckTxVersion,
+			signed_extensions::CheckNonce,
+			signed_extensions::CheckGenesis<Self>,
+			signed_extensions::CheckMortality<Self>,
+			signed_extensions::ChargeAssetTxPayment,
+			signed_extensions::ChargeTransactionPayment,
+		),
+	>;
+}

--- a/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
+++ b/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
@@ -3,12 +3,13 @@ use subxt::{config::signed_extensions, Config};
 pub enum StateChainConfig {}
 
 impl Config for StateChainConfig {
+	// We cannot use our own Runtime's types for every associated type here, see comments below.
 	type Hash = <state_chain_runtime::Runtime as frame_system::Config>::Hash;
-	type AccountId = subxt::utils::AccountId32;
-	type Address = subxt::utils::MultiAddress<Self::AccountId, ()>;
-	type Signature = subxt::utils::MultiSignature;
-	type Hasher = subxt::ext::sp_runtime::traits::BlakeTwo256;
-	type Header = subxt::ext::sp_runtime::generic::Header<u32, Self::Hasher>;
+	type AccountId = subxt::utils::AccountId32; // Requires EncodeAsType trait (which our AccountId doesn't)
+	type Address = subxt::utils::MultiAddress<Self::AccountId, ()>; // Must be convertible from Self::AccountId
+	type Signature = state_chain_runtime::Signature;
+	type Hasher = subxt::ext::sp_runtime::traits::BlakeTwo256; // Requires subxt's custom Hash trait
+	type Header = subxt::ext::sp_runtime::generic::Header<u32, Self::Hasher>; // Requires subxt's custom Header trait
 	type ExtrinsicParams = signed_extensions::AnyOf<
 		Self,
 		(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1126
Closes: PRO-1130

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Uses a custom config for our subxt client used with the SC. This allows us to successfully submit extrinsics to our chain with subxt - in particular the `cfe_version` extrinsic, which is the only one we use subxt for.

v0.32.1 uses the finalised nonce where it previously used the unfinalised nonce. Here we use the system_accountNextIndex call to also account for any mempool txs, ensuring we get the correct nonce.
