### PR TITLE
Feat: expose ingress and egress fees on events

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -196,6 +196,7 @@ pub mod pallet {
 		Swap { swap_id: SwapId },
 		LiquidityProvision { lp_account: AccountId },
 		CcmTransfer { principal_swap_id: Option<SwapId>, gas_swap_id: Option<SwapId> },
+		NoAction,
 	}
 
 	#[derive(
@@ -1068,7 +1069,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					channel_metadata,
 					..
 				} => {
-					let (principal_swap_id, gas_swap_id) = T::CcmHandler::on_ccm_deposit(
+					if let Ok((principal_swap_id, gas_swap_id)) = T::CcmHandler::on_ccm_deposit(
 						asset.into(),
 						amount_after_fees.into(),
 						destination_asset,
@@ -1085,8 +1086,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 							channel_id,
 							deposit_block_height: block_height.into(),
 						},
-					);
-					DepositAction::CcmTransfer { principal_swap_id, gas_swap_id }
+					) {
+						DepositAction::CcmTransfer { principal_swap_id, gas_swap_id }
+					} else {
+						DepositAction::NoAction
+					}
 				},
 			};
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -29,8 +29,9 @@ use cf_primitives::{
 };
 use cf_traits::{
 	liquidity::{LpBalanceApi, LpDepositHandler},
-	AssetConverter, Broadcaster, CcmHandler, Chainflip, DepositApi, DepositHandler, EgressApi,
-	EpochInfo, GetBlockHeight, GetTrackedData, NetworkEnvironmentProvider, SwapDepositHandler,
+	AssetConverter, Broadcaster, CcmHandler, CcmSwapIds, Chainflip, DepositApi, DepositHandler,
+	EgressApi, EpochInfo, GetBlockHeight, GetTrackedData, NetworkEnvironmentProvider,
+	SwapDepositHandler,
 };
 use frame_support::{
 	pallet_prelude::*,
@@ -1069,24 +1070,25 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					channel_metadata,
 					..
 				} => {
-					if let Ok((principal_swap_id, gas_swap_id)) = T::CcmHandler::on_ccm_deposit(
-						asset.into(),
-						amount_after_fees.into(),
-						destination_asset,
-						destination_address,
-						CcmDepositMetadata {
-							source_chain: asset.into(),
-							source_address: None,
-							channel_metadata,
-						},
-						SwapOrigin::DepositChannel {
-							deposit_address: T::AddressConverter::to_encoded_address(
-								deposit_address.clone().into(),
-							),
-							channel_id,
-							deposit_block_height: block_height.into(),
-						},
-					) {
+					if let Ok(CcmSwapIds { principal_swap_id, gas_swap_id }) =
+						T::CcmHandler::on_ccm_deposit(
+							asset.into(),
+							amount_after_fees.into(),
+							destination_asset,
+							destination_address,
+							CcmDepositMetadata {
+								source_chain: asset.into(),
+								source_address: None,
+								channel_metadata,
+							},
+							SwapOrigin::DepositChannel {
+								deposit_address: T::AddressConverter::to_encoded_address(
+									deposit_address.clone().into(),
+								),
+								channel_id,
+								deposit_block_height: block_height.into(),
+							},
+						) {
 						DepositAction::CcmTransfer { principal_swap_id, gas_swap_id }
 					} else {
 						DepositAction::NoAction

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -415,6 +415,8 @@ pub mod pallet {
 			asset: TargetChainAsset<T, I>,
 			amount: TargetChainAmount<T, I>,
 			deposit_details: <T::TargetChain as Chain>::DepositDetails,
+			// Ingress fee in the deposit asset. i.e. *NOT* the gas asset, if the deposit asset is
+			// a non-gas asset.
 			ingress_fee: TargetChainAmount<T, I>,
 			action: DepositAction<T::AccountId>,
 		},
@@ -425,6 +427,7 @@ pub mod pallet {
 		EgressScheduled {
 			id: EgressId,
 			asset: TargetChainAsset<T, I>,
+			// This amount includes the egress fee.
 			amount: AssetAmount,
 			destination_address: TargetChainAccount<T, I>,
 			egress_fee: TargetChainAmount<T, I>,
@@ -1035,11 +1038,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		} else {
 			let deposit_action = match deposit_channel_details.action {
 				ChannelAction::LiquidityProvision { lp_account, .. } => {
-					T::LpBalance::add_deposit(
-						&lp_account,
-						asset.into(),
-						amount_after_fees.into(),
-					)?;
+					T::LpBalance::add_deposit(&lp_account, asset.into(), amount_after_fees.into())?;
 
 					DepositAction::LiquidityProvision { lp_account }
 				},

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -25,7 +25,7 @@ use cf_chains::{
 };
 use cf_primitives::{
 	Asset, AssetAmount, BasisPoints, BroadcastId, ChannelId, EgressCounter, EgressId, EpochIndex,
-	ForeignChain, ThresholdSignatureRequestId,
+	ForeignChain, SwapId, ThresholdSignatureRequestId,
 };
 use cf_traits::{
 	liquidity::{LpBalanceApi, LpDepositHandler},
@@ -193,10 +193,9 @@ pub mod pallet {
 	/// particular deposit.
 	#[derive(Clone, RuntimeDebug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 	pub enum DepositAction<AccountId> {
-		// TODO: use a SwapId alias
-		Swap { swap_id: u64 },
+		Swap { swap_id: SwapId },
 		LiquidityProvision { lp_account: AccountId },
-		CcmTransfer { principal_swap_id: Option<u64>, gas_swap_id: Option<u64> },
+		CcmTransfer { principal_swap_id: Option<SwapId>, gas_swap_id: Option<SwapId> },
 	}
 
 	#[derive(

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1054,7 +1054,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						destination_address,
 						broker_id,
 						broker_commission_bps,
-						ingress_fee.into(),
 						channel_id,
 					),
 				},

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1150,7 +1150,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Withholds the fee for a given amount.
 	///
-	/// Returns the remaining amount after the fee has been withheld, and the fee itself
+	/// Returns the remaining amount after the fee has been withheld, and the fee itself as
+	/// asset's amount
 	fn withhold_transaction_fee(
 		ingress_or_egress: IngressOrEgress,
 		asset: TargetChainAsset<T, I>,
@@ -1182,7 +1183,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			fees.saturating_accrue(fee_estimate);
 		});
 
-		(remaining_amount, fee_estimate)
+		(remaining_amount, available_amount.saturating_sub(remaining_amount))
 	}
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1027,7 +1027,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_channel_details.deposit_channel,
 		);
 		DepositBalances::<T, I>::mutate(asset, |deposits| {
-			deposits.register_deposit(deposit_amount)
+			deposits.register_deposit(amount_after_fees)
 		});
 
 		if amount_after_fees.is_zero() {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -429,6 +429,8 @@ pub mod pallet {
 			// This amount includes the egress fee.
 			amount: AssetAmount,
 			destination_address: TargetChainAccount<T, I>,
+			// In the case of CCM this egress fee is already reserved as the "gas budget" so it's
+			// not taken from the principal amount.
 			egress_fee: TargetChainAmount<T, I>,
 		},
 		CcmBroadcastRequested {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1039,7 +1039,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						&lp_account,
 						asset.into(),
 						amount_after_fees.into(),
-						ingress_fee.into(),
 					)?;
 
 					DepositAction::LiquidityProvision { lp_account }

--- a/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
@@ -6,11 +6,11 @@ pub use cf_chains::{
 	btc::api::BitcoinApi,
 	CcmDepositMetadata, Chain, ChainEnvironment, DepositChannel,
 };
-use cf_primitives::ChannelId;
 pub use cf_primitives::{
 	chains::{assets, Bitcoin},
 	Asset, AssetAmount,
 };
+use cf_primitives::{ChannelId, SwapId};
 use cf_test_utilities::impl_test_helpers;
 use cf_traits::{
 	impl_mock_callback, impl_mock_chainflip,
@@ -84,7 +84,8 @@ impl SwapDepositHandler for MockSwapDepositHandlerBtc {
 		_broker_id: Self::AccountId,
 		_broker_commission_bps: cf_primitives::BasisPoints,
 		_channel_id: ChannelId,
-	) {
+	) -> SwapId {
+		unimplemented!()
 	}
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -515,13 +515,14 @@ fn can_egress_ccm() {
 	new_test_ext().execute_with(|| {
 		let destination_address: H160 = [0x01; 20].into();
 		let destination_asset = eth::Asset::Eth;
-		let gas_budget = 1_000u128;
+		
+		const GAS_BUDGET: u128 = 1_000;
 		let ccm = CcmDepositMetadata {
 			source_chain: ForeignChain::Ethereum,
 			source_address: Some(ForeignChainAddress::Eth([0xcf; 20].into())),
 			channel_metadata: CcmChannelMetadata {
 				message: vec![0x00, 0x01, 0x02].try_into().unwrap(),
-				gas_budget,
+				gas_budget: GAS_BUDGET,
 				cf_parameters: vec![].try_into().unwrap(),
 			}
 		};
@@ -530,7 +531,7 @@ fn can_egress_ccm() {
 			destination_asset,
 			amount,
 			destination_address,
-			Some((ccm.clone(), gas_budget))
+			Some((ccm.clone(), GAS_BUDGET))
 		);
 
 		assert!(ScheduledEgressFetchOrTransfer::<Test>::get().is_empty());
@@ -544,7 +545,7 @@ fn can_egress_ccm() {
 				cf_parameters: vec![].try_into().unwrap(),
 				source_chain: ForeignChain::Ethereum,
 				source_address: Some(ForeignChainAddress::Eth([0xcf; 20].into())),
-				gas_budget,
+				gas_budget: GAS_BUDGET,
 			}
 		]);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
@@ -553,7 +554,7 @@ fn can_egress_ccm() {
 				asset: destination_asset,
 				amount,
 				destination_address,
-    			egress_fee: 1000,
+    			egress_fee: GAS_BUDGET,
 			}
 		));
 
@@ -569,7 +570,7 @@ fn can_egress_ccm() {
 			},
 			ccm.source_chain,
 			ccm.source_address,
-			gas_budget,
+			GAS_BUDGET,
 			ccm.channel_metadata.message.to_vec(),
 		).unwrap()]);
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -957,6 +957,8 @@ fn deposits_ingress_fee_exceeding_deposit_amount_rejected() {
 				asset: ASSET,
 				amount: DEPOSIT_AMOUNT,
 				deposit_details: (),
+				ingress_fee: 0,
+				action: DepositAction::LiquidityProvision { lp_account: ALICE },
 			},
 		));
 	});

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -156,6 +156,7 @@ fn can_schedule_swap_egress_to_batch() {
 			asset: ETH_ETH,
 			amount: 2_000,
 			destination_address: ALICE_ETH_ADDRESS,
+			egress_fee: 0,
 		}));
 
 		IngressEgress::schedule_egress(ETH_FLIP, 3_000, BOB_ETH_ADDRESS, None);
@@ -165,6 +166,7 @@ fn can_schedule_swap_egress_to_batch() {
 			asset: ETH_FLIP,
 			amount: 4_000,
 			destination_address: BOB_ETH_ADDRESS,
+			egress_fee: 0,
 		}));
 
 		assert_eq!(
@@ -551,6 +553,7 @@ fn can_egress_ccm() {
 				asset: destination_asset,
 				amount,
 				destination_address,
+    			egress_fee: 1000,
 			}
 		));
 
@@ -888,6 +891,7 @@ fn deposits_below_minimum_are_rejected() {
 				asset: flip,
 				amount: default_deposit_amount,
 				deposit_details: Default::default(),
+				ingress_fee: 0,
 			},
 		));
 	});

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
 	mock_eth::*, Call as PalletCall, ChannelAction, ChannelIdCounter, CrossChainMessage,
-	DepositChannelLookup, DepositChannelPool, DepositIgnoredReason, DepositWitness,
+	DepositAction, DepositChannelLookup, DepositChannelPool, DepositIgnoredReason, DepositWitness,
 	DisabledEgressAssets, Event as PalletEvent, FailedForeignChainCall, FailedForeignChainCalls,
 	FetchOrTransfer, MinimumDeposit, Pallet, ScheduledEgressCcm, ScheduledEgressFetchOrTransfer,
 	TargetChainAccount,
@@ -883,8 +883,9 @@ fn deposits_below_minimum_are_rejected() {
 			},
 		));
 
+		const LP_ACCOUNT: u64 = 0;
 		// Flip deposit should succeed.
-		let (_, deposit_address) = request_address_and_deposit(0, flip);
+		let (_, deposit_address) = request_address_and_deposit(LP_ACCOUNT, flip);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::<Test>::DepositReceived {
 				deposit_address,
@@ -892,6 +893,7 @@ fn deposits_below_minimum_are_rejected() {
 				amount: default_deposit_amount,
 				deposit_details: Default::default(),
 				ingress_fee: 0,
+				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
 			},
 		));
 	});

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -515,7 +515,6 @@ fn can_egress_ccm() {
 	new_test_ext().execute_with(|| {
 		let destination_address: H160 = [0x01; 20].into();
 		let destination_asset = eth::Asset::Eth;
-		
 		const GAS_BUDGET: u128 = 1_000;
 		let ccm = CcmDepositMetadata {
 			source_chain: ForeignChain::Ethereum,
@@ -526,6 +525,8 @@ fn can_egress_ccm() {
 				cf_parameters: vec![].try_into().unwrap(),
 			}
 		};
+
+
 		let amount = 5_000;
 		let egress_id = IngressEgress::schedule_egress(
 			destination_asset,

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -121,7 +121,6 @@ pub mod pallet {
 			account_id: T::AccountId,
 			asset: Asset,
 			amount_credited: AssetAmount,
-			ingress_fee: AssetAmount,
 		},
 	}
 
@@ -279,7 +278,6 @@ impl<T: Config> LpDepositHandler for Pallet<T> {
 		account_id: &Self::AccountId,
 		asset: Asset,
 		amount: AssetAmount,
-		ingress_fee: AssetAmount,
 	) -> frame_support::pallet_prelude::DispatchResult {
 		Self::try_credit_account(account_id, asset, amount)?;
 
@@ -287,7 +285,6 @@ impl<T: Config> LpDepositHandler for Pallet<T> {
 			account_id: account_id.clone(),
 			asset,
 			amount_credited: amount,
-			ingress_fee,
 		});
 
 		Ok(())

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -5,7 +5,7 @@ use cf_chains::{address::AddressConverter, AnyChain, ForeignChainAddress};
 use cf_primitives::{Asset, AssetAmount, ForeignChain};
 use cf_traits::{
 	impl_pallet_safe_mode, liquidity::LpBalanceApi, AccountRoleRegistry, Chainflip, DepositApi,
-	EgressApi, PoolApi,
+	EgressApi, LpDepositHandler, PoolApi,
 };
 
 use frame_support::{pallet_prelude::*, sp_runtime::DispatchResult};
@@ -116,6 +116,12 @@ pub mod pallet {
 			account_id: T::AccountId,
 			chain: ForeignChain,
 			address: ForeignChainAddress,
+		},
+		LiquidityDepositCredited {
+			account_id: T::AccountId,
+			asset: Asset,
+			amount_credited: AssetAmount,
+			ingress_fee: AssetAmount,
 		},
 	}
 
@@ -263,6 +269,28 @@ pub mod pallet {
 			});
 			Ok(())
 		}
+	}
+}
+
+impl<T: Config> LpDepositHandler for Pallet<T> {
+	type AccountId = <T as frame_system::Config>::AccountId;
+
+	fn add_deposit(
+		account_id: &Self::AccountId,
+		asset: Asset,
+		amount: AssetAmount,
+		ingress_fee: AssetAmount,
+	) -> frame_support::pallet_prelude::DispatchResult {
+		Self::try_credit_account(account_id, asset, amount)?;
+
+		Self::deposit_event(Event::LiquidityDepositCredited {
+			account_id: account_id.clone(),
+			asset,
+			amount_credited: amount,
+			ingress_fee,
+		});
+
+		Ok(())
 	}
 }
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -272,7 +272,6 @@ pub mod pallet {
 			origin: SwapOrigin,
 			swap_type: SwapType,
 			broker_commission: Option<AssetAmount>,
-			ingress_fee: Option<AssetAmount>,
 		},
 		/// A swap has been executed.
 		SwapExecuted {
@@ -588,7 +587,6 @@ pub mod pallet {
 				origin: swap_origin,
 				swap_type: SwapType::Swap(destination_address_internal),
 				broker_commission: None,
-				ingress_fee: None,
 			});
 
 			Ok(())
@@ -907,7 +905,6 @@ pub mod pallet {
 			destination_address: ForeignChainAddress,
 			broker_id: Self::AccountId,
 			broker_commission_bps: BasisPoints,
-			ingress_fee: AssetAmount,
 			channel_id: ChannelId,
 		) -> u64 {
 			// Permill maxes out at 100% so this is safe.
@@ -943,7 +940,6 @@ pub mod pallet {
 				origin: swap_origin,
 				swap_type: SwapType::Swap(destination_address),
 				broker_commission: Some(fee),
-				ingress_fee: Some(ingress_fee),
 			});
 
 			swap_id
@@ -1016,7 +1012,6 @@ pub mod pallet {
 						origin: origin.clone(),
 						swap_type: SwapType::CcmPrincipal(ccm_id),
 						broker_commission: None,
-						ingress_fee: None,
 					});
 					Some(swap_id)
 				};
@@ -1037,7 +1032,6 @@ pub mod pallet {
 					origin,
 					swap_type: SwapType::CcmGas(ccm_id),
 					broker_commission: None,
-					ingress_fee: None,
 				});
 				Some(swap_id)
 			} else {

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -615,7 +615,7 @@ pub mod pallet {
 			let destination_address_internal =
 				Self::validate_destination_address(&destination_address, destination_asset)?;
 
-			Self::on_ccm_deposit(
+			let _ = Self::on_ccm_deposit(
 				source_asset,
 				deposit_amount,
 				destination_asset,
@@ -961,7 +961,7 @@ pub mod pallet {
 			deposit_metadata: CcmDepositMetadata,
 			origin: SwapOrigin,
 			// TODO: Struct?
-		) -> (Option<u64>, Option<u64>) {
+		) -> Result<(Option<u64>, Option<u64>), ()> {
 			let encoded_destination_address =
 				T::AddressConverter::to_encoded_address(destination_address.clone());
 			// Caller should ensure that assets and addresses are compatible.
@@ -986,8 +986,7 @@ pub mod pallet {
 							destination_address: encoded_destination_address,
 							deposit_metadata,
 						});
-						// TODO: Return error here?
-						return (None, None)
+						return Err(())
 					},
 				};
 
@@ -1071,7 +1070,7 @@ pub mod pallet {
 				CcmOutputs::<T>::insert(ccm_id, swap_output);
 			}
 
-			(principal_swap_id, gas_swap_id)
+			Ok((principal_swap_id, gas_swap_id))
 		}
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -4,7 +4,7 @@ use cf_chains::{
 	CcmChannelMetadata, CcmDepositMetadata, SwapOrigin,
 };
 use cf_primitives::{
-	Asset, AssetAmount, ChannelId, ForeignChain, SwapLeg, TransactionHash, STABLE_ASSET,
+	Asset, AssetAmount, ChannelId, ForeignChain, SwapId, SwapLeg, TransactionHash, STABLE_ASSET,
 };
 use cf_traits::{impl_pallet_safe_mode, liquidity::SwappingApi, CcmHandler, DepositApi};
 use frame_support::{
@@ -38,12 +38,12 @@ const BASIS_POINTS_PER_MILLION: u32 = 100;
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub enum SwapType {
 	Swap(ForeignChainAddress),
-	CcmPrincipal(u64),
-	CcmGas(u64),
+	CcmPrincipal(SwapId),
+	CcmGas(SwapId),
 }
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct Swap {
-	pub swap_id: u64,
+	pub swap_id: SwapId,
 	pub from: Asset,
 	pub to: Asset,
 	pub amount: AssetAmount,
@@ -54,7 +54,13 @@ pub struct Swap {
 }
 
 impl Swap {
-	fn new(swap_id: u64, from: Asset, to: Asset, amount: AssetAmount, swap_type: SwapType) -> Self {
+	fn new(
+		swap_id: SwapId,
+		from: Asset,
+		to: Asset,
+		amount: AssetAmount,
+		swap_type: SwapType,
+	) -> Self {
 		Self {
 			swap_id,
 			from,
@@ -149,8 +155,8 @@ pub(crate) struct CcmSwap {
 	destination_asset: Asset,
 	destination_address: ForeignChainAddress,
 	deposit_metadata: CcmDepositMetadata,
-	principal_swap_id: Option<u64>,
-	gas_swap_id: Option<u64>,
+	principal_swap_id: Option<SwapId>,
+	gas_swap_id: Option<SwapId>,
 }
 
 pub struct CcmSwapAmounts {
@@ -174,7 +180,7 @@ impl_pallet_safe_mode! {
 pub mod pallet {
 
 	use cf_chains::{address::EncodedAddress, AnyChain, Chain};
-	use cf_primitives::{Asset, AssetAmount, BasisPoints, EgressId};
+	use cf_primitives::{Asset, AssetAmount, BasisPoints, EgressId, SwapId};
 	use cf_traits::{AccountRoleRegistry, Chainflip, EgressApi, SwapDepositHandler};
 
 	use super::*;
@@ -219,7 +225,7 @@ pub mod pallet {
 
 	/// SwapId Counter
 	#[pallet::storage]
-	pub type SwapIdCounter<T: Config> = StorageValue<_, u64, ValueQuery>;
+	pub type SwapIdCounter<T: Config> = StorageValue<_, SwapId, ValueQuery>;
 
 	/// Earned Fees by Brokers
 	#[pallet::storage]
@@ -264,7 +270,7 @@ pub mod pallet {
 		},
 		/// A swap deposit has been received.
 		SwapScheduled {
-			swap_id: u64,
+			swap_id: SwapId,
 			source_asset: Asset,
 			deposit_amount: AssetAmount,
 			destination_asset: Asset,
@@ -275,7 +281,7 @@ pub mod pallet {
 		},
 		/// A swap has been executed.
 		SwapExecuted {
-			swap_id: u64,
+			swap_id: SwapId,
 			source_asset: Asset,
 			deposit_amount: AssetAmount,
 			destination_asset: Asset,
@@ -284,7 +290,7 @@ pub mod pallet {
 		},
 		/// A swap egress has been scheduled.
 		SwapEgressScheduled {
-			swap_id: u64,
+			swap_id: SwapId,
 			egress_id: EgressId,
 			asset: Asset,
 			amount: AssetAmount,
@@ -308,8 +314,8 @@ pub mod pallet {
 		},
 		CcmDepositReceived {
 			ccm_id: u64,
-			principal_swap_id: Option<u64>,
-			gas_swap_id: Option<u64>,
+			principal_swap_id: Option<SwapId>,
+			gas_swap_id: Option<SwapId>,
 			deposit_amount: AssetAmount,
 			destination_address: EncodedAddress,
 			deposit_metadata: CcmDepositMetadata,
@@ -324,7 +330,7 @@ pub mod pallet {
 			amount: Option<AssetAmount>,
 		},
 		SwapAmountConfiscated {
-			swap_id: u64,
+			swap_id: SwapId,
 			source_asset: Asset,
 			destination_asset: Asset,
 			total_amount: AssetAmount,
@@ -332,7 +338,7 @@ pub mod pallet {
 		},
 		/// The swap has been executed, but has led to a zero egress amount.
 		EgressAmountZero {
-			swap_id: u64,
+			swap_id: SwapId,
 		},
 	}
 	#[pallet::error]
@@ -906,7 +912,7 @@ pub mod pallet {
 			broker_id: Self::AccountId,
 			broker_commission_bps: BasisPoints,
 			channel_id: ChannelId,
-		) -> u64 {
+		) -> SwapId {
 			// Permill maxes out at 100% so this is safe.
 			let fee = Permill::from_parts(broker_commission_bps as u32 * BASIS_POINTS_PER_MILLION) *
 				amount;

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -272,6 +272,7 @@ pub mod pallet {
 			origin: SwapOrigin,
 			swap_type: SwapType,
 			broker_commission: Option<AssetAmount>,
+			ingress_fee: Option<AssetAmount>,
 		},
 		/// A swap has been executed.
 		SwapExecuted {
@@ -587,6 +588,7 @@ pub mod pallet {
 				origin: swap_origin,
 				swap_type: SwapType::Swap(destination_address_internal),
 				broker_commission: None,
+				ingress_fee: None,
 			});
 
 			Ok(())
@@ -905,6 +907,7 @@ pub mod pallet {
 			destination_address: ForeignChainAddress,
 			broker_id: Self::AccountId,
 			broker_commission_bps: BasisPoints,
+			ingress_fee: AssetAmount,
 			channel_id: ChannelId,
 		) {
 			// Permill maxes out at 100% so this is safe.
@@ -940,6 +943,7 @@ pub mod pallet {
 				origin: swap_origin,
 				swap_type: SwapType::Swap(destination_address),
 				broker_commission: Some(fee),
+				ingress_fee: Some(ingress_fee),
 			});
 		}
 	}
@@ -1008,6 +1012,7 @@ pub mod pallet {
 						origin: origin.clone(),
 						swap_type: SwapType::CcmPrincipal(ccm_id),
 						broker_commission: None,
+						ingress_fee: None,
 					});
 					Some(swap_id)
 				};
@@ -1028,6 +1033,7 @@ pub mod pallet {
 					origin,
 					swap_type: SwapType::CcmGas(ccm_id),
 					broker_commission: None,
+					ingress_fee: None,
 				});
 				Some(swap_id)
 			} else {

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -181,7 +181,7 @@ pub mod pallet {
 
 	use cf_chains::{address::EncodedAddress, AnyChain, Chain};
 	use cf_primitives::{Asset, AssetAmount, BasisPoints, EgressId, SwapId};
-	use cf_traits::{AccountRoleRegistry, Chainflip, EgressApi, SwapDepositHandler};
+	use cf_traits::{AccountRoleRegistry, CcmSwapIds, Chainflip, EgressApi, SwapDepositHandler};
 
 	use super::*;
 
@@ -960,8 +960,7 @@ pub mod pallet {
 			destination_address: ForeignChainAddress,
 			deposit_metadata: CcmDepositMetadata,
 			origin: SwapOrigin,
-			// TODO: Struct?
-		) -> Result<(Option<u64>, Option<u64>), ()> {
+		) -> Result<CcmSwapIds, ()> {
 			let encoded_destination_address =
 				T::AddressConverter::to_encoded_address(destination_address.clone());
 			// Caller should ensure that assets and addresses are compatible.
@@ -1070,7 +1069,7 @@ pub mod pallet {
 				CcmOutputs::<T>::insert(ccm_id, swap_output);
 			}
 
-			Ok((principal_swap_id, gas_swap_id))
+			Ok(CcmSwapIds { principal_swap_id, gas_swap_id })
 		}
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -909,7 +909,7 @@ pub mod pallet {
 			broker_commission_bps: BasisPoints,
 			ingress_fee: AssetAmount,
 			channel_id: ChannelId,
-		) {
+		) -> u64 {
 			// Permill maxes out at 100% so this is safe.
 			let fee = Permill::from_parts(broker_commission_bps as u32 * BASIS_POINTS_PER_MILLION) *
 				amount;
@@ -945,6 +945,8 @@ pub mod pallet {
 				broker_commission: Some(fee),
 				ingress_fee: Some(ingress_fee),
 			});
+
+			swap_id
 		}
 	}
 
@@ -956,7 +958,8 @@ pub mod pallet {
 			destination_address: ForeignChainAddress,
 			deposit_metadata: CcmDepositMetadata,
 			origin: SwapOrigin,
-		) {
+			// TODO: Struct?
+		) -> (Option<u64>, Option<u64>) {
 			let encoded_destination_address =
 				T::AddressConverter::to_encoded_address(destination_address.clone());
 			// Caller should ensure that assets and addresses are compatible.
@@ -981,7 +984,8 @@ pub mod pallet {
 							destination_address: encoded_destination_address,
 							deposit_metadata,
 						});
-						return
+						// TODO: Return error here?
+						return (None, None)
 					},
 				};
 
@@ -1066,6 +1070,8 @@ pub mod pallet {
 				PendingCcms::<T>::insert(ccm_id, ccm_swap);
 				CcmOutputs::<T>::insert(ccm_id, swap_output);
 			}
+
+			(principal_swap_id, gas_swap_id)
 		}
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -20,7 +20,7 @@ use cf_traits::{
 	},
 	CcmHandler, SetSafeMode, SwapDepositHandler, SwappingApi,
 };
-use frame_support::{assert_noop, assert_ok, traits::Hooks};
+use frame_support::{assert_err, assert_noop, assert_ok, traits::Hooks};
 use itertools::Itertools;
 use sp_arithmetic::Permill;
 use sp_std::iter;
@@ -73,13 +73,16 @@ fn assert_failed_ccm(
 	ccm: CcmDepositMetadata,
 	reason: CcmFailReason,
 ) {
-	Swapping::on_ccm_deposit(
-		from,
-		amount,
-		output,
-		destination_address.clone(),
-		ccm.clone(),
-		SwapOrigin::Vault { tx_hash: Default::default() },
+	assert_err!(
+		Swapping::on_ccm_deposit(
+			from,
+			amount,
+			output,
+			destination_address.clone(),
+			ccm.clone(),
+			SwapOrigin::Vault { tx_hash: Default::default() },
+		),
+		()
 	);
 	System::assert_last_event(RuntimeEvent::Swapping(Event::CcmFailed {
 		reason,
@@ -482,14 +485,14 @@ fn can_process_ccms_via_swap_deposit_address() {
 			0,
 			Some(request_ccm)
 		));
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			Asset::Dot,
 			deposit_amount,
 			Asset::Eth,
 			ForeignChainAddress::Eth(Default::default()),
 			ccm.clone(),
 			SwapOrigin::Vault { tx_hash: Default::default() },
-		);
+		));
 
 		assert_eq!(
 			PendingCcms::<Test>::get(1),
@@ -937,14 +940,14 @@ fn ccm_without_principal_swaps_are_accepted() {
 		let ccm = generate_ccm_deposit();
 
 		// Ccm with principal asset = 0
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			eth,
 			gas_budget,
 			flip,
 			ForeignChainAddress::Eth(Default::default()),
 			ccm.clone(),
 			SwapOrigin::Vault { tx_hash: Default::default() },
-		);
+		));
 
 		// Verify the CCM is processed successfully
 		assert_event_sequence!(
@@ -968,14 +971,14 @@ fn ccm_without_principal_swaps_are_accepted() {
 
 		// Ccm where principal asset = output asset
 		System::reset_events();
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			eth,
 			gas_budget + principal_amount,
 			eth,
 			ForeignChainAddress::Eth(Default::default()),
 			ccm,
 			SwapOrigin::Vault { tx_hash: Default::default() },
-		);
+		));
 
 		// Verify the CCM is processed successfully
 		assert_event_sequence!(
@@ -1164,14 +1167,14 @@ fn ccm_swaps_emits_events() {
 
 		// Test when both principal and gas need to be swapped.
 		System::reset_events();
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			Asset::Flip,
 			10_000,
 			Asset::Usdc,
 			destination_address.clone(),
 			ccm.clone(),
 			ORIGIN,
-		);
+		));
 		assert_event_sequence!(
 			Test,
 			RuntimeEvent::Swapping(Event::SwapScheduled {
@@ -1205,14 +1208,14 @@ fn ccm_swaps_emits_events() {
 
 		// Test when only principal needs to be swapped.
 		System::reset_events();
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			Asset::Eth,
 			10_000,
 			Asset::Usdc,
 			destination_address.clone(),
 			ccm.clone(),
 			ORIGIN,
-		);
+		));
 		assert_event_sequence!(
 			Test,
 			RuntimeEvent::Swapping(Event::SwapScheduled {
@@ -1236,14 +1239,14 @@ fn ccm_swaps_emits_events() {
 
 		// Test when only gas needs to be swapped.
 		System::reset_events();
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			Asset::Flip,
 			10_000,
 			Asset::Flip,
 			destination_address,
 			ccm,
 			ORIGIN,
-		);
+		));
 		assert_event_sequence!(
 			Test,
 			RuntimeEvent::Swapping(Event::SwapScheduled {
@@ -1274,14 +1277,14 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 			let eth_address = ForeignChainAddress::Eth(Default::default());
 			let ccm = generate_ccm_deposit();
 
-			Swapping::on_ccm_deposit(
+			assert_ok!(Swapping::on_ccm_deposit(
 				Asset::Usdc,
 				100_000,
 				Asset::Eth,
 				eth_address,
 				ccm,
 				SwapOrigin::Vault { tx_hash: Default::default() },
-			);
+			));
 
 			// Change the swap rate so swap output will be 0
 			SwapRate::set(0.0001f64);
@@ -1425,14 +1428,14 @@ fn swap_excess_are_confiscated_ccm_via_deposit() {
 			Some(request_ccm)
 		));
 
-		Swapping::on_ccm_deposit(
+		assert_ok!(Swapping::on_ccm_deposit(
 			from,
 			gas_budget + principal_amount,
 			to,
 			ForeignChainAddress::Eth(Default::default()),
 			ccm.clone(),
 			SwapOrigin::Vault { tx_hash: Default::default() },
-		);
+		));
 
 		// Excess fee is confiscated
 		System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapAmountConfiscated {

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -44,6 +44,8 @@ pub type BasisPoints = u16;
 
 pub type BroadcastId = u32;
 
+pub type SwapId = u64;
+
 /// The type of the Id given to threshold signature requests. Note a single request may
 /// result in multiple ceremonies, but only one ceremony should succeed.
 pub type ThresholdSignatureRequestId = u32;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -21,7 +21,7 @@ use cf_chains::{
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, AuthorityCount, BasisPoints, BroadcastId,
 	CeremonyId, ChannelId, Ed25519PublicKey, EgressId, EpochIndex, FlipBalance, ForeignChain,
-	Ipv6Addr, NetworkEnvironment, SemVer, ThresholdSignatureRequestId,
+	Ipv6Addr, NetworkEnvironment, SemVer, SwapId, ThresholdSignatureRequestId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
@@ -786,8 +786,8 @@ pub trait NetworkEnvironmentProvider {
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
 pub struct CcmSwapIds {
-	pub principal_swap_id: Option<u64>,
-	pub gas_swap_id: Option<u64>,
+	pub principal_swap_id: Option<SwapId>,
+	pub gas_swap_id: Option<SwapId>,
 }
 
 /// Trait for handling cross chain messages.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -787,6 +787,7 @@ pub trait NetworkEnvironmentProvider {
 /// Trait for handling cross chain messages.
 pub trait CcmHandler {
 	/// Triggered when a ccm deposit is made.
+	#[allow(clippy::result_unit_err)]
 	fn on_ccm_deposit(
 		source_asset: Asset,
 		deposit_amount: AssetAmount,
@@ -794,7 +795,7 @@ pub trait CcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	) -> (Option<u64>, Option<u64>);
+	) -> Result<(Option<u64>, Option<u64>), ()>;
 }
 
 impl CcmHandler for () {
@@ -805,8 +806,8 @@ impl CcmHandler for () {
 		_destination_address: ForeignChainAddress,
 		_deposit_metadata: CcmDepositMetadata,
 		_origin: SwapOrigin,
-	) -> (Option<u64>, Option<u64>) {
-		(None, None)
+	) -> Result<(Option<u64>, Option<u64>), ()> {
+		Err(())
 	}
 }
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -784,6 +784,12 @@ pub trait NetworkEnvironmentProvider {
 	fn get_network_environment() -> NetworkEnvironment;
 }
 
+#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+pub struct CcmSwapIds {
+	pub principal_swap_id: Option<u64>,
+	pub gas_swap_id: Option<u64>,
+}
+
 /// Trait for handling cross chain messages.
 pub trait CcmHandler {
 	/// Triggered when a ccm deposit is made.
@@ -795,7 +801,7 @@ pub trait CcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	) -> Result<(Option<u64>, Option<u64>), ()>;
+	) -> Result<CcmSwapIds, ()>;
 }
 
 impl CcmHandler for () {
@@ -806,7 +812,7 @@ impl CcmHandler for () {
 		_destination_address: ForeignChainAddress,
 		_deposit_metadata: CcmDepositMetadata,
 		_origin: SwapOrigin,
-	) -> Result<(Option<u64>, Option<u64>), ()> {
+	) -> Result<CcmSwapIds, ()> {
 		Err(())
 	}
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -794,7 +794,7 @@ pub trait CcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	);
+	) -> (Option<u64>, Option<u64>);
 }
 
 impl CcmHandler for () {
@@ -805,7 +805,8 @@ impl CcmHandler for () {
 		_destination_address: ForeignChainAddress,
 		_deposit_metadata: CcmDepositMetadata,
 		_origin: SwapOrigin,
-	) {
+	) -> (Option<u64>, Option<u64>) {
+		(None, None)
 	}
 }
 

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -15,7 +15,6 @@ pub trait SwapDepositHandler {
 		destination_address: ForeignChainAddress,
 		broker_id: Self::AccountId,
 		broker_commission_bps: BasisPoints,
-		ingress_fee: AssetAmount,
 		channel_id: ChannelId,
 	) -> u64;
 }

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -15,8 +15,22 @@ pub trait SwapDepositHandler {
 		destination_address: ForeignChainAddress,
 		broker_id: Self::AccountId,
 		broker_commission_bps: BasisPoints,
+		ingress_fee: AssetAmount,
 		channel_id: ChannelId,
 	);
+}
+
+pub trait LpDepositHandler {
+	type AccountId;
+
+	/// Attempt to credit the account with the given asset and amount
+	/// as a result of a liquidity deposit.
+	fn add_deposit(
+		who: &Self::AccountId,
+		asset: Asset,
+		amount: AssetAmount,
+		ingress_fee: AssetAmount,
+	) -> DispatchResult;
 }
 
 pub trait LpBalanceApi {

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -17,7 +17,7 @@ pub trait SwapDepositHandler {
 		broker_commission_bps: BasisPoints,
 		ingress_fee: AssetAmount,
 		channel_id: ChannelId,
-	);
+	) -> u64;
 }
 
 pub trait LpDepositHandler {

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -24,12 +24,7 @@ pub trait LpDepositHandler {
 
 	/// Attempt to credit the account with the given asset and amount
 	/// as a result of a liquidity deposit.
-	fn add_deposit(
-		who: &Self::AccountId,
-		asset: Asset,
-		amount: AssetAmount,
-		ingress_fee: AssetAmount,
-	) -> DispatchResult;
+	fn add_deposit(who: &Self::AccountId, asset: Asset, amount: AssetAmount) -> DispatchResult;
 }
 
 pub trait LpBalanceApi {

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -1,5 +1,5 @@
 use cf_chains::address::ForeignChainAddress;
-use cf_primitives::{Asset, AssetAmount, BasisPoints, ChannelId};
+use cf_primitives::{Asset, AssetAmount, BasisPoints, ChannelId, SwapId};
 use frame_support::pallet_prelude::{DispatchError, DispatchResult};
 
 pub trait SwapDepositHandler {
@@ -16,7 +16,7 @@ pub trait SwapDepositHandler {
 		broker_id: Self::AccountId,
 		broker_commission_bps: BasisPoints,
 		channel_id: ChannelId,
-	) -> u64;
+	) -> SwapId;
 }
 
 pub trait LpDepositHandler {

--- a/state-chain/traits/src/mocks/ccm_handler.rs
+++ b/state-chain/traits/src/mocks/ccm_handler.rs
@@ -37,7 +37,7 @@ impl CcmHandler for MockCcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	) {
+	) -> (Option<u64>, Option<u64>) {
 		<Self as MockPalletStorage>::mutate_value(CCM_HANDLER_PREFIX, |ccm_requests| {
 			if ccm_requests.is_none() {
 				*ccm_requests = Some(vec![]);
@@ -53,5 +53,8 @@ impl CcmHandler for MockCcmHandler {
 				});
 			})
 		});
+
+		// TODO: Return real ids
+		(Some(1), Some(2))
 	}
 }

--- a/state-chain/traits/src/mocks/ccm_handler.rs
+++ b/state-chain/traits/src/mocks/ccm_handler.rs
@@ -37,7 +37,7 @@ impl CcmHandler for MockCcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	) -> (Option<u64>, Option<u64>) {
+	) -> Result<(Option<u64>, Option<u64>), ()> {
 		<Self as MockPalletStorage>::mutate_value(CCM_HANDLER_PREFIX, |ccm_requests| {
 			if ccm_requests.is_none() {
 				*ccm_requests = Some(vec![]);
@@ -55,6 +55,6 @@ impl CcmHandler for MockCcmHandler {
 		});
 
 		// TODO: Return real ids
-		(Some(1), Some(2))
+		Ok((Some(1), Some(2)))
 	}
 }

--- a/state-chain/traits/src/mocks/ccm_handler.rs
+++ b/state-chain/traits/src/mocks/ccm_handler.rs
@@ -1,4 +1,4 @@
-use crate::CcmHandler;
+use crate::{CcmHandler, CcmSwapIds};
 use cf_chains::{address::ForeignChainAddress, CcmDepositMetadata, SwapOrigin};
 
 use cf_primitives::{Asset, AssetAmount};
@@ -37,7 +37,7 @@ impl CcmHandler for MockCcmHandler {
 		destination_address: ForeignChainAddress,
 		deposit_metadata: CcmDepositMetadata,
 		origin: SwapOrigin,
-	) -> Result<(Option<u64>, Option<u64>), ()> {
+	) -> Result<CcmSwapIds, ()> {
 		<Self as MockPalletStorage>::mutate_value(CCM_HANDLER_PREFIX, |ccm_requests| {
 			if ccm_requests.is_none() {
 				*ccm_requests = Some(vec![]);
@@ -55,6 +55,6 @@ impl CcmHandler for MockCcmHandler {
 		});
 
 		// TODO: Return real ids
-		Ok((Some(1), Some(2)))
+		Ok(CcmSwapIds { principal_swap_id: Some(1), gas_swap_id: Some(2) })
 	}
 }

--- a/state-chain/traits/src/mocks/lp_balance.rs
+++ b/state-chain/traits/src/mocks/lp_balance.rs
@@ -1,4 +1,4 @@
-use crate::LpBalanceApi;
+use crate::{LpBalanceApi, LpDepositHandler};
 use cf_chains::assets::any::Asset;
 use cf_primitives::AssetAmount;
 use sp_runtime::DispatchResult;
@@ -7,6 +7,20 @@ use sp_runtime::DispatchResult;
 use cf_chains::ForeignChainAddress;
 
 pub struct MockBalance;
+
+impl LpDepositHandler for MockBalance {
+	type AccountId = u64;
+
+	fn add_deposit(
+		who: &Self::AccountId,
+		asset: Asset,
+		amount: AssetAmount,
+		_ingress_fee: AssetAmount,
+	) -> frame_support::pallet_prelude::DispatchResult {
+		Self::try_credit_account(who, asset, amount)
+	}
+}
+
 impl LpBalanceApi for MockBalance {
 	type AccountId = u64;
 

--- a/state-chain/traits/src/mocks/lp_balance.rs
+++ b/state-chain/traits/src/mocks/lp_balance.rs
@@ -15,7 +15,6 @@ impl LpDepositHandler for MockBalance {
 		who: &Self::AccountId,
 		asset: Asset,
 		amount: AssetAmount,
-		_ingress_fee: AssetAmount,
 	) -> frame_support::pallet_prelude::DispatchResult {
 		Self::try_credit_account(who, asset, amount)
 	}

--- a/state-chain/traits/src/mocks/swap_deposit_handler.rs
+++ b/state-chain/traits/src/mocks/swap_deposit_handler.rs
@@ -20,6 +20,7 @@ where
 		destination_address: cf_chains::ForeignChainAddress,
 		_broker_id: Self::AccountId,
 		_broker_commission_bps: cf_primitives::BasisPoints,
+		_ingress_fee: cf_primitives::AssetAmount,
 		_channel_id: cf_primitives::ChannelId,
 	) {
 		E::schedule_egress(

--- a/state-chain/traits/src/mocks/swap_deposit_handler.rs
+++ b/state-chain/traits/src/mocks/swap_deposit_handler.rs
@@ -22,12 +22,14 @@ where
 		_broker_commission_bps: cf_primitives::BasisPoints,
 		_ingress_fee: cf_primitives::AssetAmount,
 		_channel_id: cf_primitives::ChannelId,
-	) {
+	) -> u64 {
 		E::schedule_egress(
 			to.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			amount.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			destination_address.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			None,
 		);
+		// TODO: Returna  real id
+		1
 	}
 }

--- a/state-chain/traits/src/mocks/swap_deposit_handler.rs
+++ b/state-chain/traits/src/mocks/swap_deposit_handler.rs
@@ -1,4 +1,5 @@
 use cf_chains::Chain;
+use cf_primitives::SwapId;
 
 use crate::{EgressApi, SwapDepositHandler};
 
@@ -21,14 +22,13 @@ where
 		_broker_id: Self::AccountId,
 		_broker_commission_bps: cf_primitives::BasisPoints,
 		_channel_id: cf_primitives::ChannelId,
-	) -> u64 {
+	) -> SwapId {
 		E::schedule_egress(
 			to.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			amount.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			destination_address.try_into().unwrap_or_else(|_| panic!("Unable to convert")),
 			None,
 		);
-		// TODO: Returna  real id
 		1
 	}
 }

--- a/state-chain/traits/src/mocks/swap_deposit_handler.rs
+++ b/state-chain/traits/src/mocks/swap_deposit_handler.rs
@@ -20,7 +20,6 @@ where
 		destination_address: cf_chains::ForeignChainAddress,
 		_broker_id: Self::AccountId,
 		_broker_commission_bps: cf_primitives::BasisPoints,
-		_ingress_fee: cf_primitives::AssetAmount,
 		_channel_id: cf_primitives::ChannelId,
 	) -> u64 {
 		E::schedule_egress(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1119, PRO-1119

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- `withhold_transaction_fee` now also returns the deducted fee.
- Added `ingress_fee` to the `DepositReceived` event.
- Added `action` field to the `DepositReceived` event. This allows the frontend to explicitly associate an action with a deposit.
- Added `egress_fee` to the `EgressScheduled` event, which we either get from `withhold_transaction_fee` (for regular swaps) or set to `gas_budget` (for CCM swaps).
- As discussed, I moved `DepositBalances` to `schedule_egress`, which is now called on CCM swaps too.

Technically this needs a migration, since the meaning of "amount" in ScheduledEgressFetchOrTransfer has now changed to mean "after fee deducted", but because these items are cleared after a block is finalised (unless we disable egress), it shouldn't be necessary in practice. If we want, I could write a migration that would deduct egress fees from pending transfers in case they haven't been cleared for some reason.
