### PR TITLE
feat: upgrade-test can work on releases

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -3,9 +3,8 @@ name: Release Chainflip Development
 on:
   pull_request:
     branches:
-      - nothing
-      # - main
-      # - "release/*"
+      - main
+      - "release/*"
 concurrency:
   group: ${{ github.ref }}-release-development
   cancel-in-progress: true

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -3,8 +3,9 @@ name: Release Chainflip Development
 on:
   pull_request:
     branches:
-      - main
-      - "release/*"
+      - nothing
+      # - main
+      # - "release/*"
 concurrency:
   group: ${{ github.ref }}-release-development
   cancel-in-progress: true

--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'release/[0-9]+.[0-9]+'
+      - feat/upgrade-test-release
 
 concurrency:
   group: ${{ github.ref }}-release-sisyphos
@@ -27,6 +28,15 @@ jobs:
     with:
       profile: "production"
       binary-subdir: "production"
+  # Used to test upgrades to this version from the latest release
+  build-try-runtime:
+    needs: [test]
+    uses: ./.github/workflows/_20_build.yml
+    secrets: inherit
+    with:
+      profile: "try-runtime"
+      upload-name: "chainflip-backend-bin-try-runtime"
+      binary-subdir: release
   docker:
     needs: [build]
     uses: ./.github/workflows/_24_docker.yml

--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'release/[0-9]+.[0-9]+'
-      - feat/upgrade-test-release
 
 concurrency:
   group: ${{ github.ref }}-release-sisyphos

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -3,7 +3,15 @@ name: Test upgrade from latest release to main
 on:
   workflow_dispatch:
     inputs:
-      commit:
+      upgrade-from-release:
+        description: 'This will either by "perseverance" or "berghain"'
+        required: true
+        default: 'perseverance'
+      upgrade-to-workflow-name:
+        description: 'Name of the workflow to pull the upgrade-to artefacts from'
+        required: true
+        default: 'ci-main.yml'
+      upgrade-to-commit:
         description: 'Commit to run the upgrade test against'
         required: false
         default: 'HEAD'
@@ -67,7 +75,7 @@ jobs:
       - name: Download latest release binaries
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: release-perseverance.yml
+          workflow: release-${{ github.event.inputs.upgrade-from-release }}.yml
           name: chainflip-backend-bin-ubuntu-22.04
           github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           path: latest-release-bins
@@ -86,10 +94,10 @@ jobs:
       - name: Download latest main binaries
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: ci-main.yml
+          workflow: ${{ github.event.inputs.upgrade-to-workflow-name }}
           name: chainflip-backend-bin-try-runtime-ubuntu-22.04
           path: upgrade-to-bins
-          commit: ${{ github.event.inputs.commit }}
+          commit: ${{ github.event.inputs.upgrade-to-commit }}
 
       - name: Permissions for latest binaries
         run: |
@@ -98,10 +106,10 @@ jobs:
       - name: Download latest main runtime
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: ci-main.yml
+          workflow: ${{ github.event.inputs.upgrade-to-workflow-name }}
           name: chainflip-node-runtime-try-runtime-ubuntu-22.04
           path: main-runtime
-          commit: ${{ github.event.inputs.commit }}
+          commit: ${{ github.event.inputs.upgrade-to-commit }}
 
       - name: Version of latest main
         run: |

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       upgrade-from-release:
-        description: 'This will either by "perseverance" or "berghain"'
+        description: 'The release we want to upgrade *from*: "perseverance" or "berghain"'
         required: true
         default: 'perseverance'
       upgrade-to-workflow-name:


### PR DESCRIPTION
# Pull Request

Closes: PRO-1149

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Previously you could only run the upgrade-test on main builds. However, because we will often be merging PRs into release branch before releasing - to stabilise the release, we want to be able to test that the upgrade from the sisyphos-release job can be upgrade to from the berghain release version for example.
