### PR TITLE
test: ensure DepositIgnored(NotEnoughToPayFees) event is emitted

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -897,7 +897,7 @@ fn deposits_tx_fee_exceeding_deposit_amount_rejected() {
 	let eth = eth::Asset::Eth;
 
 	// We don't have any minimumDeposit limit set (it is 0), hence the first check
-	// (minimumDepositAmount) is satisfied Since we swap 0 our net_deposit_amount after fees is 0
+	// (minimumDepositAmount) is satisfied. Since we swap 0 our net_deposit_amount after fees is 0
 	// and the process_single_deposit function fails emitting a DepositIgnored(NotEnoughToPayFees)
 	// Event
 	new_test_ext().execute_with(|| {

--- a/state-chain/traits/src/mocks/asset_converter.rs
+++ b/state-chain/traits/src/mocks/asset_converter.rs
@@ -33,6 +33,7 @@ impl AssetConverter for MockAssetConverter {
 	) -> Option<(Amount, Amount)> {
 		let input_asset = input_asset.into();
 		let output_asset = output_asset.into();
+		// the following check is copied from the implementation in the pool pallet
 		if input_asset == output_asset {
 			if desired_output_amount < available_input_amount {
 				return Some((

--- a/state-chain/traits/src/mocks/asset_converter.rs
+++ b/state-chain/traits/src/mocks/asset_converter.rs
@@ -1,6 +1,6 @@
 use cf_primitives::{Asset, AssetAmount};
 use frame_support::sp_runtime::traits::UniqueSaturatedInto;
-use sp_runtime::traits::AtLeast32BitUnsigned;
+use sp_runtime::traits::{AtLeast32BitUnsigned, Zero};
 
 use crate::AssetConverter;
 
@@ -33,6 +33,16 @@ impl AssetConverter for MockAssetConverter {
 	) -> Option<(Amount, Amount)> {
 		let input_asset = input_asset.into();
 		let output_asset = output_asset.into();
+		if input_asset == output_asset {
+			if desired_output_amount < available_input_amount {
+				return Some((
+					available_input_amount.saturating_sub(desired_output_amount),
+					desired_output_amount,
+				))
+			} else {
+				return Some((Zero::zero(), available_input_amount))
+			}
+		}
 		let input = Self::get_price(output_asset, input_asset)
 			.map(|price| price * desired_output_amount.into())?;
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1085

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added test to check the correct Event DepositIgnored(NotEnoughToPayFees) is emitted in case a deposit gets swallowed because fees are higher than the deposited_amount.