### PR TITLE
feat: added boost_fee param

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -54,6 +54,7 @@ pub trait Rpc {
 		destination_asset: RpcAsset,
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
+		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
 	) -> RpcResult<BrokerSwapDepositAddress>;
 }
@@ -91,6 +92,7 @@ impl RpcServer for RpcServerImpl {
 		destination_asset: RpcAsset,
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
+		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
 	) -> RpcResult<BrokerSwapDepositAddress> {
 		let destination_asset = destination_asset.try_into()?;
@@ -102,6 +104,7 @@ impl RpcServer for RpcServerImpl {
 				destination_asset,
 				clean_foreign_chain_address(destination_asset.into(), &destination_address)?,
 				broker_commission_bps,
+				boost_fee,
 				channel_metadata,
 			)
 			.await

--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -54,8 +54,8 @@ pub trait Rpc {
 		destination_asset: RpcAsset,
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
-		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: Option<BasisPoints>,
 	) -> RpcResult<BrokerSwapDepositAddress>;
 }
 
@@ -92,8 +92,8 @@ impl RpcServer for RpcServerImpl {
 		destination_asset: RpcAsset,
 		destination_address: String,
 		broker_commission_bps: BasisPoints,
-		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: Option<BasisPoints>,
 	) -> RpcResult<BrokerSwapDepositAddress> {
 		let destination_asset = destination_asset.try_into()?;
 		Ok(self
@@ -104,8 +104,8 @@ impl RpcServer for RpcServerImpl {
 				destination_asset,
 				clean_foreign_chain_address(destination_asset.into(), &destination_address)?,
 				broker_commission_bps,
-				boost_fee,
 				channel_metadata,
+				boost_fee,
 			)
 			.await
 			.map(BrokerSwapDepositAddress::from)?)

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -74,18 +74,27 @@ async fn run_cli() -> Result<()> {
 								&params.destination_address,
 							)?,
 							params.broker_commission,
+							params.boost_fee,
 							None,
 						)
 						.await?;
 					println!("Deposit Address: {address}");
 				},
 				LiquidityProvider(
-					LiquidityProviderSubcommands::RequestLiquidityDepositAddress { asset, chain },
+					LiquidityProviderSubcommands::RequestLiquidityDepositAddress {
+						asset,
+						chain,
+						boost_fee,
+					},
 				) => {
 					let asset = RpcAsset::try_from((asset, chain))?;
 					let address = api
 						.lp_api()
-						.request_liquidity_deposit_address(asset.try_into()?, api::WaitFor::InBlock)
+						.request_liquidity_deposit_address(
+							asset.try_into()?,
+							api::WaitFor::InBlock,
+							boost_fee,
+						)
 						.await?
 						.unwrap_details();
 					println!("Deposit Address: {address}");

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -74,8 +74,8 @@ async fn run_cli() -> Result<()> {
 								&params.destination_address,
 							)?,
 							params.broker_commission,
-							params.boost_fee,
 							None,
+							params.boost_fee,
 						)
 						.await?;
 					println!("Deposit Address: {address}");

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -73,6 +73,8 @@ pub struct SwapRequestParams {
 	pub destination_address: String,
 	/// Commission to the broker in basis points
 	pub broker_commission: u16,
+	/// Commission to the booster in basis points
+	pub boost_fee: Option<u16>,
 	/// Chain of the source asset ("Ethereum"|"Polkadot")
 	pub source_chain: Option<ForeignChain>,
 	/// Chain of the destination asset ("Ethereum"|"Polkadot")
@@ -93,6 +95,7 @@ pub enum LiquidityProviderSubcommands {
 		asset: Asset,
 		/// Chain of the deposit asset ("Ethereum"|"Polkadot")
 		chain: Option<ForeignChain>,
+		boost_fee: Option<u16>,
 	},
 	/// Register a Liquidity Refund Address for the given chain. An address must be
 	/// registered to request a deposit address for the given chain.

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -1,4 +1,4 @@
-use cf_primitives::{AccountId, BlockNumber, EgressId};
+use cf_primitives::{AccountId, BasisPoints, BlockNumber, EgressId};
 use cf_utilities::{
 	rpc::NumberOrHex,
 	task_scope::{task_scope, Scope},
@@ -109,6 +109,7 @@ pub trait Rpc {
 		&self,
 		asset: RpcAsset,
 		wait_for: Option<WaitFor>,
+		boost_fee: Option<BasisPoints>,
 	) -> RpcResult<ApiWaitForResult<String>>;
 
 	#[method(name = "register_liquidity_refund_address")]
@@ -252,11 +253,16 @@ impl RpcServer for RpcServerImpl {
 		&self,
 		asset: RpcAsset,
 		wait_for: Option<WaitFor>,
+		boost_fee: Option<BasisPoints>,
 	) -> RpcResult<ApiWaitForResult<String>> {
 		Ok(self
 			.api
 			.lp_api()
-			.request_liquidity_deposit_address(asset.try_into()?, wait_for.unwrap_or_default())
+			.request_liquidity_deposit_address(
+				asset.try_into()?,
+				wait_for.unwrap_or_default(),
+				boost_fee,
+			)
 			.await
 			.map(|result| result.map_details(|address| address.to_string()))?)
 	}

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -313,8 +313,8 @@ pub trait BrokerApi: SignedExtrinsicApi {
 		destination_asset: Asset,
 		destination_address: EncodedAddress,
 		broker_commission_bps: BasisPoints,
-		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: Option<BasisPoints>,
 	) -> Result<SwapDepositAddress> {
 		let (_tx_hash, events, header, ..) = self
 			.submit_signed_extrinsic_with_dry_run(

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -313,6 +313,7 @@ pub trait BrokerApi: SignedExtrinsicApi {
 		destination_asset: Asset,
 		destination_address: EncodedAddress,
 		broker_commission_bps: BasisPoints,
+		boost_fee: Option<BasisPoints>,
 		channel_metadata: Option<CcmChannelMetadata>,
 	) -> Result<SwapDepositAddress> {
 		let (_tx_hash, events, header, ..) = self
@@ -322,6 +323,7 @@ pub trait BrokerApi: SignedExtrinsicApi {
 					destination_asset,
 					destination_address,
 					broker_commission_bps,
+					boost_fee: boost_fee.unwrap_or_default(),
 					channel_metadata,
 				},
 			)

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -323,8 +323,8 @@ pub trait BrokerApi: SignedExtrinsicApi {
 					destination_asset,
 					destination_address,
 					broker_commission_bps,
-					boost_fee: boost_fee.unwrap_or_default(),
 					channel_metadata,
+					boost_fee: boost_fee.unwrap_or_default(),
 				},
 			)
 			.await?

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -5,7 +5,7 @@ pub use cf_amm::{
 	range_orders::Liquidity,
 };
 use cf_chains::address::EncodedAddress;
-use cf_primitives::{Asset, AssetAmount, BlockNumber, EgressId};
+use cf_primitives::{Asset, AssetAmount, BasisPoints, BlockNumber, EgressId};
 use chainflip_engine::state_chain_observer::client::{
 	extrinsic_api::signed::{SignedExtrinsicApi, UntilInBlock, WaitFor, WaitForResult},
 	StateChainClient,
@@ -179,10 +179,14 @@ pub trait LpApi: SignedExtrinsicApi {
 		&self,
 		asset: Asset,
 		wait_for: WaitFor,
+		boost_fee: Option<BasisPoints>,
 	) -> Result<ApiWaitForResult<EncodedAddress>> {
 		let wait_for_result = self
 			.submit_signed_extrinsic_wait_for(
-				pallet_cf_lp::Call::request_liquidity_deposit_address { asset },
+				pallet_cf_lp::Call::request_liquidity_deposit_address {
+					asset,
+					boost_fee: boost_fee.unwrap_or_default(),
+				},
 				wait_for,
 			)
 			.await?;

--- a/bouncer/shared/provide_liquidity.ts
+++ b/bouncer/shared/provide_liquidity.ts
@@ -53,7 +53,7 @@ export async function provideLiquidity(ccy: Asset, amount: number, waitForFinali
   console.log('Requesting ' + ccy + ' deposit address');
   await lpMutex.runExclusive(async () => {
     await chainflip.tx.liquidityProvider
-      .requestLiquidityDepositAddress(ccy.toLowerCase())
+      .requestLiquidityDepositAddress(ccy.toLowerCase(), null)
       .signAndSend(lp, { nonce: -1 }, handleSubstrateError(chainflip));
   });
 

--- a/bouncer/tests/double_deposit.ts
+++ b/bouncer/tests/double_deposit.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
     .registerLiquidityRefundAddress(encodedEthAddr)
     .signAndSend(lp);
 
-  await chainflip.tx.liquidityProvider.requestLiquidityDepositAddress('Eth').signAndSend(lp);
+  await chainflip.tx.liquidityProvider.requestLiquidityDepositAddress('Eth', null).signAndSend(lp);
   const ethIngressKey = (
     await observeEvent(
       'liquidityProvider:LiquidityDepositAddressReady',

--- a/bouncer/tests/eth_witness_test.ts
+++ b/bouncer/tests/eth_witness_test.ts
@@ -10,7 +10,7 @@ async function main(): Promise<void> {
   const lp = keyring.createFromUri(lpUri);
 
   console.log('Requesting ETH deposit address');
-  await chainflip.tx.liquidityProvider.requestLiquidityDepositAddress('Eth').signAndSend(lp);
+  await chainflip.tx.liquidityProvider.requestLiquidityDepositAddress('Eth', null).signAndSend(lp);
   const ethIngressKey = (
     await observeEvent(
       'liquidityProvider:LiquidityDepositAddressReady',

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -241,8 +241,8 @@ fn basic_pool_setup_provision_and_swap() {
 			Asset::Flip,
 			EncodedAddress::Eth([1u8; 20]),
 			0u16,
-			0u16,
 			None,
+			0u16,
 		));
 
 		let deposit_address = <AddressDerivation as AddressDerivationApi<Ethereum>>::generate_address(
@@ -338,8 +338,8 @@ fn can_process_ccm_via_swap_deposit_address() {
 			Asset::Usdc,
 			EncodedAddress::Eth([0x02; 20]),
 			0u16,
-			0u16,
 			Some(message),
+			0u16
 		));
 
 		// Deposit funds for the ccm.

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -241,6 +241,7 @@ fn basic_pool_setup_provision_and_swap() {
 			Asset::Flip,
 			EncodedAddress::Eth([1u8; 20]),
 			0u16,
+			0u16,
 			None,
 		));
 
@@ -336,6 +337,7 @@ fn can_process_ccm_via_swap_deposit_address() {
 			Asset::Flip,
 			Asset::Usdc,
 			EncodedAddress::Eth([0x02; 20]),
+			0u16,
 			0u16,
 			Some(message),
 		));

--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -24,7 +24,7 @@ mod benchmarks {
 		));
 
 		#[extrinsic_call]
-		request_liquidity_deposit_address(RawOrigin::Signed(caller), Asset::Eth);
+		request_liquidity_deposit_address(RawOrigin::Signed(caller), Asset::Eth, 0);
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc = include_str!("../../cf-doc-head.md")]
 
 use cf_chains::{address::AddressConverter, AnyChain, ForeignChainAddress};
-use cf_primitives::{Asset, AssetAmount, ForeignChain};
+use cf_primitives::{Asset, AssetAmount, BasisPoints, ForeignChain};
 use cf_traits::{
 	impl_pallet_safe_mode, liquidity::LpBalanceApi, AccountRoleRegistry, Chainflip, DepositApi,
 	EgressApi, LpDepositHandler, PoolApi,
@@ -105,6 +105,7 @@ pub mod pallet {
 			// account the funds will be credited to upon deposit
 			account_id: T::AccountId,
 			deposit_chain_expiry_block: <AnyChain as Chain>::ChainBlockNumber,
+			boost_fee: BasisPoints,
 		},
 		WithdrawalEgressScheduled {
 			egress_id: EgressId,
@@ -154,6 +155,7 @@ pub mod pallet {
 		pub fn request_liquidity_deposit_address(
 			origin: OriginFor<T>,
 			asset: Asset,
+			boost_fee: BasisPoints,
 		) -> DispatchResult {
 			ensure!(T::SafeMode::get().deposit_enabled, Error::<T>::LiquidityDepositDisabled);
 
@@ -173,6 +175,7 @@ pub mod pallet {
 				deposit_address: T::AddressConverter::to_encoded_address(deposit_address),
 				account_id,
 				deposit_chain_expiry_block: expiry_block,
+				boost_fee,
 			});
 
 			Ok(())

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -76,6 +76,7 @@ fn cannot_deposit_and_withdrawal_during_safe_mode() {
 			LiquidityProvider::request_liquidity_deposit_address(
 				RuntimeOrigin::signed(LP_ACCOUNT.into()),
 				Asset::Eth,
+				0
 			),
 			crate::Error::<Test>::LiquidityDepositDisabled,
 		);
@@ -98,6 +99,7 @@ fn cannot_deposit_and_withdrawal_during_safe_mode() {
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Eth,
+			0
 		));
 
 		assert_ok!(LiquidityProvider::withdraw_asset(
@@ -166,6 +168,7 @@ fn cannot_request_deposit_address_without_registering_liquidity_refund_address()
 		assert_noop!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Eth,
+			0,
 		), crate::Error::<Test>::NoLiquidityRefundAddressRegistered);
 
 		// Register EWA
@@ -178,14 +181,17 @@ fn cannot_request_deposit_address_without_registering_liquidity_refund_address()
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Eth,
+			0,
 		));
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Flip,
+			0,
 		));
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Usdc,
+			0,
 		));
 		assert_events_match!(Test, RuntimeEvent::LiquidityProvider(crate::Event::LiquidityDepositAddressReady {
 			..
@@ -200,10 +206,12 @@ fn cannot_request_deposit_address_without_registering_liquidity_refund_address()
 		assert_noop!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Btc,
+			0,
 		), crate::Error::<Test>::NoLiquidityRefundAddressRegistered);
 		assert_noop!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Dot,
+			0,
 		), crate::Error::<Test>::NoLiquidityRefundAddressRegistered);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -28,6 +28,7 @@ mod benchmarks {
 			destination_asset: Asset::Usdc,
 			destination_address: EncodedAddress::benchmark_value(),
 			broker_commission_bps: 0,
+			boost_fee: 0,
 			channel_metadata: None,
 		};
 		#[block]

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -478,8 +478,8 @@ pub mod pallet {
 			destination_asset: Asset,
 			destination_address: EncodedAddress,
 			broker_commission_bps: BasisPoints,
-			boost_fee: BasisPoints,
 			channel_metadata: Option<CcmChannelMetadata>,
+			boost_fee: BasisPoints,
 		) -> DispatchResult {
 			ensure!(T::SafeMode::get().deposits_enabled, Error::<T>::DepositsDisabled);
 			let broker = T::AccountRoleRegistry::ensure_broker(origin)?;

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -267,6 +267,7 @@ pub mod pallet {
 			broker_commission_rate: BasisPoints,
 			channel_metadata: Option<CcmChannelMetadata>,
 			source_chain_expiry_block: <AnyChain as Chain>::ChainBlockNumber,
+			boost_fee: BasisPoints,
 		},
 		/// A swap deposit has been received.
 		SwapScheduled {
@@ -477,6 +478,7 @@ pub mod pallet {
 			destination_asset: Asset,
 			destination_address: EncodedAddress,
 			broker_commission_bps: BasisPoints,
+			boost_fee: BasisPoints,
 			channel_metadata: Option<CcmChannelMetadata>,
 		) -> DispatchResult {
 			ensure!(T::SafeMode::get().deposits_enabled, Error::<T>::DepositsDisabled);
@@ -513,6 +515,7 @@ pub mod pallet {
 				broker_commission_rate: broker_commission_bps,
 				channel_metadata,
 				source_chain_expiry_block: expiry_height,
+				boost_fee,
 			});
 
 			Ok(())

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -133,6 +133,7 @@ fn request_swap_success_with_valid_parameters() {
 			Asset::Usdc,
 			EncodedAddress::Eth(Default::default()),
 			0,
+			0,
 			None
 		));
 	});
@@ -227,6 +228,7 @@ fn expect_swap_id_to_be_emitted() {
 			Asset::Eth,
 			Asset::Usdc,
 			EncodedAddress::Eth(Default::default()),
+			0,
 			0,
 			None
 		));
@@ -408,7 +410,8 @@ fn rejects_invalid_swap_deposit() {
 				Asset::Eth,
 				EncodedAddress::Dot(Default::default()),
 				0,
-				Some(ccm.clone())
+				0,
+				Some(ccm.clone()),
 			),
 			Error::<Test>::IncompatibleAssetAndAddress
 		);
@@ -419,6 +422,7 @@ fn rejects_invalid_swap_deposit() {
 				Asset::Eth,
 				Asset::Dot,
 				EncodedAddress::Dot(Default::default()),
+				0,
 				0,
 				Some(ccm)
 			),
@@ -482,6 +486,7 @@ fn can_process_ccms_via_swap_deposit_address() {
 			Asset::Dot,
 			Asset::Eth,
 			EncodedAddress::Eth(Default::default()),
+			0,
 			0,
 			Some(request_ccm)
 		));
@@ -1425,6 +1430,7 @@ fn swap_excess_are_confiscated_ccm_via_deposit() {
 			to,
 			EncodedAddress::Eth(Default::default()),
 			0,
+			0,
 			Some(request_ccm)
 		));
 
@@ -1908,6 +1914,7 @@ fn broker_bps_is_limited() {
 				Asset::Usdc,
 				EncodedAddress::Eth(Default::default()),
 				1001,
+				0,
 				None,
 			),
 			Error::<Test>::BrokerCommissionBpsTooHigh

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -133,8 +133,8 @@ fn request_swap_success_with_valid_parameters() {
 			Asset::Usdc,
 			EncodedAddress::Eth(Default::default()),
 			0,
-			0,
-			None
+			None,
+			0
 		));
 	});
 }
@@ -229,8 +229,8 @@ fn expect_swap_id_to_be_emitted() {
 			Asset::Usdc,
 			EncodedAddress::Eth(Default::default()),
 			0,
-			0,
-			None
+			None,
+			0
 		));
 		// 2. Schedule the swap -> SwapScheduled
 		<Pallet<Test> as SwapDepositHandler>::schedule_swap_from_channel(
@@ -410,8 +410,8 @@ fn rejects_invalid_swap_deposit() {
 				Asset::Eth,
 				EncodedAddress::Dot(Default::default()),
 				0,
-				0,
 				Some(ccm.clone()),
+				0
 			),
 			Error::<Test>::IncompatibleAssetAndAddress
 		);
@@ -423,8 +423,8 @@ fn rejects_invalid_swap_deposit() {
 				Asset::Dot,
 				EncodedAddress::Dot(Default::default()),
 				0,
-				0,
-				Some(ccm)
+				Some(ccm),
+				0
 			),
 			Error::<Test>::CcmUnsupportedForTargetChain
 		);
@@ -487,8 +487,8 @@ fn can_process_ccms_via_swap_deposit_address() {
 			Asset::Eth,
 			EncodedAddress::Eth(Default::default()),
 			0,
-			0,
-			Some(request_ccm)
+			Some(request_ccm),
+			0
 		));
 		assert_ok!(Swapping::on_ccm_deposit(
 			Asset::Dot,
@@ -1430,8 +1430,8 @@ fn swap_excess_are_confiscated_ccm_via_deposit() {
 			to,
 			EncodedAddress::Eth(Default::default()),
 			0,
+			Some(request_ccm),
 			0,
-			Some(request_ccm)
 		));
 
 		assert_ok!(Swapping::on_ccm_deposit(
@@ -1914,8 +1914,8 @@ fn broker_bps_is_limited() {
 				Asset::Usdc,
 				EncodedAddress::Eth(Default::default()),
 				1001,
-				0,
 				None,
+				0,
 			),
 			Error::<Test>::BrokerCommissionBpsTooHigh
 		);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1146
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added boost_fee param to the broker/lp CLI/API when opening a deposit channel 
-it's an optional parameter that defaults to 0 if not provided
-Added boost_fee also to the relevant extrinsics (request_liquidity_deposit_address and request_swap_deposit_address)
Currently the extrinsics use this new parameter only in the events they emit (SwapDepositAddressReady, LiquidityDepositAddressReady) -> This is a breaking change for the CFE.
