### PR TITLE
improve start up macro

### DIFF
--- a/utilities/src/with_std/logging.rs
+++ b/utilities/src/with_std/logging.rs
@@ -12,46 +12,18 @@ pub struct LoggingSettings {
 #[macro_export]
 macro_rules! print_start_and_end {
 	(async $e:expr) => {
-		println!(
-			"Starting {} v{} ({})",
-			env!("CARGO_PKG_NAME"),
-			env!("CARGO_PKG_VERSION"),
-			utilities::internal_lazy_format!(if let Some(repository_link) = utilities::repository_link() => ("CI Build: \"{}\"", repository_link) else => ("Non-CI Build"))
-		);
-		println!(
-			"
-			 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗██╗     ██╗██████╗
-			██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██║     ██║██╔══██╗
-			██║     ███████║███████║██║██╔██╗ ██║█████╗  ██║     ██║██████╔╝
-			██║     ██╔══██║██╔══██║██║██║╚██╗██║██╔══╝  ██║     ██║██╔═══╝
-			╚██████╗██║  ██║██║  ██║██║██║ ╚████║██║     ███████╗██║██║
-			 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚═╝     ╚══════╝╚═╝╚═╝
-			"
-		);
-
-		match std::panic::AssertUnwindSafe($e).catch_unwind().await {
-			Ok(result) => match result {
-				Ok(_) => {},
-				Err(error) => {
-					println!("Exiting {} due to error: {error:?}", env!("CARGO_PKG_NAME"));
-				},
-			},
-			Err(panic) => {
-				println!(
-					"Exiting {} due to panic: {:#?}",
-					env!("CARGO_PKG_NAME"),
-					panic.downcast_ref::<&str>()
-				);
-			},
-		};
+		$crate::print_start_and_end!(@ ::std::panic::AssertUnwindSafe($e).catch_unwind().await);
 		()
 	};
 	($e:expr) => {
+		$crate::print_start_and_end!(@ ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| $e)));
+	};
+	(@ $e:expr) => {
 		println!(
 			"Starting {} v{} ({})",
 			env!("CARGO_PKG_NAME"),
 			env!("CARGO_PKG_VERSION"),
-			utilities::internal_lazy_format!(if let Some(repository_link) = utilities::repository_link() => ("CI Build: \"{}\"", repository_link) else => ("Non-CI Build"))
+			$crate::internal_lazy_format!(if let Some(repository_link) = $crate::repository_link() => ("CI Build: \"{}\"", repository_link) else => ("Non-CI Build"))
 		);
 		println!(
 			"
@@ -64,7 +36,7 @@ macro_rules! print_start_and_end {
 			"
 		);
 
-		match catch_unwind(AssertUnwindSafe(|| $e)) {
+		match $e {
 			Ok(result) => match result {
 				Ok(_) => {},
 				Err(error) => {
@@ -79,9 +51,8 @@ macro_rules! print_start_and_end {
 					panic.downcast_ref::<&str>()
 				);
 			},
-		};
-
-	}
+		}
+	};
 }
 
 /// Install a tracing subscriber that uses json formatting for the logs. The initial filtering

--- a/utilities/src/with_std/logging.rs
+++ b/utilities/src/with_std/logging.rs
@@ -48,7 +48,7 @@ macro_rules! print_start_and_end {
 				println!(
 					"Exiting {} due to panic: {:#?}",
 					env!("CARGO_PKG_NAME"),
-					panic.downcast_ref::<&str>()
+					panic.downcast_ref::<&str>().map(|str| *str).or_else(|| panic.downcast_ref::<String>().map(String::as_str))
 				);
 			},
 		}


### PR DESCRIPTION
Just two changes:
- Just dedup some code
- Also allow the macro to print panic objects that are `String` instead of just `&str`. `String`s is common in ou code base, as we add a lot of runtime info into the panics.

Note there are two commits one, for each of the above changes, so it is a little easier to review both commits individually.