### PR TITLE
Chore/benchmarking improvements

### DIFF
--- a/state-chain/pallets/cf-broadcast/Cargo.toml
+++ b/state-chain/pallets/cf-broadcast/Cargo.toml
@@ -43,7 +43,7 @@ sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chain
 cf-test-utilities = { path = '../../test-utilities' }
 
 [features]
-default = ['std']
+default = ['std', 'runtime-benchmarks']
 std = [
   'cf-chains/std',
   'cfe-events/std',

--- a/state-chain/pallets/cf-broadcast/Cargo.toml
+++ b/state-chain/pallets/cf-broadcast/Cargo.toml
@@ -43,7 +43,7 @@ sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chain
 cf-test-utilities = { path = '../../test-utilities' }
 
 [features]
-default = ['std', 'runtime-benchmarks']
+default = ['std']
 std = [
   'cf-chains/std',
   'cfe-events/std',

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -173,12 +173,12 @@ mod benchmarks {
 			));
 		}
 
-		// We expect the unwrap to error if the extrinsic didn't fire an event - if an event has
-		// been emitted we reached the end of the extrinsic
-		let _ = frame_system::Pallet::<T>::events()
-			.pop()
-			.expect("No event has been emitted from the transaction_succeeded extrinsic")
-			.event;
+		// Storage is cleaned up upon successful broadcast
+		assert!(TransactionOutIdToBroadcastId::<T, I>::get(
+			TransactionOutIdFor::<T, I>::benchmark_value()
+		)
+		.is_none());
+		assert!(TransactionMetadata::<T, I>::get(broadcast_id).is_none());
 	}
 
 	#[cfg(test)]

--- a/state-chain/pallets/cf-governance/src/benchmarking.rs
+++ b/state-chain/pallets/cf-governance/src/benchmarking.rs
@@ -74,8 +74,8 @@ mod benchmarks {
 	}
 
 	#[benchmark]
+	// Benchmarks the weight of Partitioning expired proposal.
 	fn on_initialize(b: Linear<1, 100>) {
-		// TODO: mock the time to end in the expire proposals case which is more expensive
 		for _n in 1..b {
 			let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
 			Pallet::<T>::push_proposal(call, ExecutionMode::Automatic);

--- a/state-chain/pallets/cf-reputation/src/benchmarking.rs
+++ b/state-chain/pallets/cf-reputation/src/benchmarking.rs
@@ -91,7 +91,7 @@ mod benchmarks {
 		let interval = T::HeartbeatBlockInterval::get();
 
 		// Without heartbeat, all nodes are automatically disqualified.
-		let _ = LastHeartbeat::<T>::clear(u32::MAX, None);
+		let _old_heartbeat = LastHeartbeat::<T>::clear(u32::MAX, None);
 
 		#[block]
 		{

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -140,9 +140,11 @@ pub mod pallet {
 				current_block % T::HeartbeatBlockInterval::get() == Zero::zero()
 			{
 				// Reputation depends on heartbeats
-				Self::penalise_offline_authorities(Self::current_network_state().offline);
+				let offline_authorities = Self::current_network_state().offline;
+				let num_offline_authorities = offline_authorities.len() as u32;
+				Self::penalise_offline_authorities(offline_authorities);
 				T::Heartbeat::on_heartbeat_interval();
-				return T::WeightInfo::submit_network_state()
+				return T::WeightInfo::submit_network_state(num_offline_authorities)
 			}
 			T::WeightInfo::on_initialize_no_action()
 		}

--- a/state-chain/pallets/cf-reputation/src/weights.rs
+++ b/state-chain/pallets/cf-reputation/src/weights.rs
@@ -36,7 +36,7 @@ pub trait WeightInfo {
 	fn set_penalty() -> Weight;
 	fn update_missed_heartbeat_penalty() -> Weight;
 	fn heartbeat() -> Weight;
-	fn submit_network_state() -> Weight;
+	fn submit_network_state(o: u32) -> Weight;
 	fn on_initialize_no_action() -> Weight;
 }
 
@@ -113,7 +113,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `Emissions::CurrentAuthorityEmissionPerBlock` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
 	/// Storage: `Emissions::BackupNodeEmissionPerBlock` (r:0 w:1)
 	/// Proof: `Emissions::BackupNodeEmissionPerBlock` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	fn submit_network_state() -> Weight {
+	fn submit_network_state(_o: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1291`
 		//  Estimated: `4756`
@@ -206,7 +206,7 @@ impl WeightInfo for () {
 	/// Proof: `Emissions::CurrentAuthorityEmissionPerBlock` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
 	/// Storage: `Emissions::BackupNodeEmissionPerBlock` (r:0 w:1)
 	/// Proof: `Emissions::BackupNodeEmissionPerBlock` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	fn submit_network_state() -> Weight {
+	fn submit_network_state(_o: u32) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1291`
 		//  Estimated: `4756`

--- a/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
@@ -74,7 +74,7 @@ mod benchmarks {
 
 		add_authorities::<T, _>(all_accounts);
 
-		let _ = <Pallet<T, I> as ThresholdSigner<_>>::request_signature(
+		let _request_id = <Pallet<T, I> as ThresholdSigner<_>>::request_signature(
 			PayloadFor::<T, I>::benchmark_value(),
 		);
 		let ceremony_id = 1;

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -894,6 +894,11 @@ impl<T: Config> EpochInfo for Pallet<T> {
 		}
 		HistoricalAuthorities::<T>::insert(epoch_index, new_authorities);
 	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_authorities(authorities: BTreeSet<Self::ValidatorId>) {
+		CurrentAuthorities::<T>::put(authorities);
+	}
 }
 
 /// Indicates to the session module if the session should be rotated.

--- a/state-chain/pallets/cf-witnesser/src/benchmarking.rs
+++ b/state-chain/pallets/cf-witnesser/src/benchmarking.rs
@@ -24,10 +24,6 @@ mod benchmarks {
 
 		T::EpochInfo::add_authority_info_for_epoch(epoch, BTreeSet::from([validator_id]));
 
-		// TODO: currently we don't measure the actual execution path
-		// we need to set the threshold to 1 to do this.
-		// Unfortunately, this is blocked by the fact that we can't pass
-		// a witness call here - for now.
 		#[extrinsic_call]
 		witness_at_epoch(RawOrigin::Signed(caller.clone()), Box::new(call.clone()), epoch);
 
@@ -46,7 +42,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			let _ = Votes::<T>::clear_prefix(0, u32::MAX, None);
+			let _old_votes = Votes::<T>::clear_prefix(0, u32::MAX, None);
 		}
 	}
 
@@ -56,7 +52,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			let _ = crate::Pallet::<T>::on_idle(Default::default(), Default::default());
+			let _weight = crate::Pallet::<T>::on_idle(Default::default(), Default::default());
 		}
 	}
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -122,6 +122,9 @@ pub trait EpochInfo {
 		epoch_index: EpochIndex,
 		new_authorities: BTreeSet<Self::ValidatorId>,
 	);
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_authorities(authorities: BTreeSet<Self::ValidatorId>);
 }
 
 pub struct CurrentEpochIndex<T>(PhantomData<T>);

--- a/state-chain/traits/src/mocks/epoch_info.rs
+++ b/state-chain/traits/src/mocks/epoch_info.rs
@@ -2,7 +2,6 @@
 macro_rules! impl_mock_epoch_info {
 	($account_id:ty, $balance:ty, $epoch_index:ty, $authority_count:ty $(,)? ) => {
 		use $crate::EpochInfo;
-
 		pub struct MockEpochInfo;
 
 		thread_local! {
@@ -124,6 +123,13 @@ macro_rules! impl_mock_epoch_info {
 			#[cfg(feature = "runtime-benchmarks")]
 			fn add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::collections::btree_set::BTreeSet<Self::ValidatorId>) {
 				MockEpochInfo::inner_add_authority_info_for_epoch(epoch_index, new_authorities);
+			}
+
+			#[cfg(feature = "runtime-benchmarks")]
+			fn set_authorities(
+				authorities: sp_std::collections::btree_set::BTreeSet<Self::ValidatorId>,
+			) {
+				Self::set_authorities(authorities);
 			}
 		}
 	};


### PR DESCRIPTION
# Pull Request

Closes: PRO-1151

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Fixed an incomplete benchmarking.
Remove  `let _ = `s in benchmarking code to ensure the intended data is returned
Removed 2 TODOs after investigation:
1. Governance::on_initialize(): This benchmarks the partitioning of expired proposals. Partition splits the vec into 2 separate vecs, whether the item is added to the left or right does not matter. We also do not want to add expired proposals as the handling of expired proposals is benchmarked separately. Having any proposal expire during this call will double count the weight.

2. Witnesser:: witness_at_epoch(): The correct code path is used here. We do not want to trigger the actual proposed call during benchmarking, as the weight of the call itself is added separately. Benchmarking is now done with 3 node chain spec so during actual Runtime benchmarking the proposed call should not be dispatched. This is working as intended.




