### PR TITLE
feat: CFE interface version check

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -339,6 +339,11 @@ mod tests {
 				block_hash: state_chain_runtime::Hash,
 			) -> RpcResult<<StorageValue::QueryKind as QueryKindTrait<StorageValue::Value, StorageValue::OnEmpty>>::Query>;
 
+			async fn storage_value_raw<StorageValue: storage_api::StorageValueAssociatedTypes + 'static>(
+				&self,
+				block_hash: state_chain_runtime::Hash,
+			) -> RpcResult<Option<Vec<u8>>>;
+
 			async fn storage_map_entry<StorageMap: storage_api::StorageMapAssociatedTypes + 'static>(
 				&self,
 				block_hash: state_chain_runtime::Hash,

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -111,7 +111,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 			// Use the ceremony id counters from before the initial block so the SCO can process the
 			// events from the initial block.
 			let ceremony_id_counters = state_chain_observer::get_ceremony_id_counters_before_block(
-				state_chain_stream.cache().hash,
+				*state_chain_stream.cache(),
 				state_chain_client.clone(),
 			)
 			.await?;

--- a/engine/src/p2p.rs
+++ b/engine/src/p2p.rs
@@ -231,6 +231,7 @@ async fn monitor_p2p_registration_events<StateChainClient, BlockStream: StreamAp
 ) where
 	StateChainClient: StorageApi + 'static + Send + Sync,
 {
+	use crate::state_chain_observer::get_cfe_events;
 	use state_chain_runtime::Runtime;
 	type CfeEvent = pallet_cf_cfe_interface::CfeEvent<Runtime>;
 
@@ -238,11 +239,7 @@ async fn monitor_p2p_registration_events<StateChainClient, BlockStream: StreamAp
 	loop {
 		match sc_block_stream.next().await {
 			Some(current_block) => {
-				if let Ok(events) = state_chain_client
-					.storage_value::<pallet_cf_cfe_interface::CfeEvents<Runtime>>(
-						current_block.hash,
-					)
-					.await
+				if let Ok(events) = get_cfe_events(state_chain_client.clone(), current_block).await
 				{
 					for event in events {
 						match event {

--- a/engine/src/state_chain_observer/client/mod.rs
+++ b/engine/src/state_chain_observer/client/mod.rs
@@ -1082,6 +1082,11 @@ pub mod mocks {
 				block_hash: state_chain_runtime::Hash,
 			) -> RpcResult<<StorageValue::QueryKind as QueryKindTrait<StorageValue::Value, StorageValue::OnEmpty>>::Query>;
 
+			async fn storage_value_raw<StorageValue: storage_api::StorageValueAssociatedTypes + 'static>(
+				&self,
+				block_hash: state_chain_runtime::Hash,
+			) -> RpcResult<Option<Vec<u8>>>;
+
 			async fn storage_map_entry<StorageMap: storage_api::StorageMapAssociatedTypes + 'static>(
 				&self,
 				block_hash: state_chain_runtime::Hash,

--- a/engine/src/state_chain_observer/mod.rs
+++ b/engine/src/state_chain_observer/mod.rs
@@ -5,4 +5,4 @@ mod sc_observer;
 #[cfg(test)]
 mod test_helpers;
 
-pub use sc_observer::{get_ceremony_id_counters_before_block, start};
+pub use sc_observer::{get_ceremony_id_counters_before_block, get_cfe_events, start};

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -233,6 +233,7 @@ impl ExtBuilder {
 			bitcoin_ingress_egress: Default::default(),
 			polkadot_ingress_egress: Default::default(),
 			ethereum_ingress_egress: Default::default(),
+			cfe_interface: Default::default(),
 		})
 	}
 }

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -680,6 +680,7 @@ fn testnet_genesis(
 			deposit_channel_lifetime: polkadot_deposit_channel_lifetime,
 			witness_safety_margin: None,
 		},
+		cfe_interface: Default::default(),
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1128

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Added a storage value for a CFE Events version number.
	- Added it to the genesis config so we will not read 0 on block 0 with localnets.
- Changed the SCO to read this new version number each block so it can decode the events using the correct struct.
- Added a function to the storage api that reads a storage value without decoding it.
