### PR TITLE
fix: recreate debug.log in build-localnet

### DIFF
--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -100,6 +100,9 @@ build-localnet() {
   echo "🪄 Generating docker-compose.yml"
   envsubst < ./localnet/docker-compose.template.yml > ./localnet/docker-compose.yml
 
+  mkdir -p /tmp/chainflip/
+  touch /tmp/chainflip/debug.log
+
   echo "🔮 Initializing Network"
   docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" up $INITIAL_CONTAINERS -d $additional_docker_compose_up_args >>$DEBUG_OUTPUT_DESTINATION 2>&1
   echo "🦺 Updating init state files permissions ..."


### PR DESCRIPTION
# Pull Request


## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Noticed that the recently added `debug.log` does not exist when "re-creating" localnet, resulting in errors that abort the script. I put the creation of this file in `build-localnet()` as well to ensure it always exists. (Seems like creating it at the beginning of the file is still necessary.)