### PR TITLE
feat: add boost fee field to DepositChannelDetails

### DIFF
--- a/engine/src/witness/btc/btc_deposits.rs
+++ b/engine/src/witness/btc/btc_deposits.rs
@@ -182,6 +182,7 @@ pub mod tests {
 			action: ChannelAction::<AccountId32>::LiquidityProvision {
 				lp_account: AccountId32::new([0xab; 32]),
 			},
+			boost_fee: 0,
 		}
 	}
 

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -54,6 +54,7 @@ mod benchmarks {
 				action: ChannelAction::<T::AccountId>::LiquidityProvision {
 					lp_account: account("doogle", 0, 0),
 				},
+				boost_fee: 0,
 			},
 		);
 
@@ -108,6 +109,7 @@ mod benchmarks {
 					action: ChannelAction::<T::AccountId>::LiquidityProvision {
 						lp_account: account("doogle", 0, 0),
 					},
+					boost_fee: 0,
 				};
 			channel.deposit_channel.state.on_fetch_scheduled();
 			DepositChannelLookup::<T, I>::insert(deposit_address.clone(), channel);

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -161,6 +161,8 @@ pub mod pallet {
 
 		/// The action to be taken when the DepositChannel is deposited to.
 		pub action: ChannelAction<T::AccountId>,
+		/// The boost fee, if set to 0 it means no required
+		pub boost_fee: BasisPoints,
 	}
 
 	pub enum IngressOrEgress {
@@ -1142,6 +1144,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn open_channel(
 		source_asset: TargetChainAsset<T, I>,
 		action: ChannelAction<T::AccountId>,
+		boost_fee: BasisPoints
 	) -> Result<(ChannelId, TargetChainAccount<T, I>, TargetChainBlockNumber<T, I>), DispatchError>
 	{
 		let (deposit_channel, channel_id) = if let Some((channel_id, mut deposit_channel)) =
@@ -1183,6 +1186,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				opened_at: current_height,
 				expires_at: expiry_height,
 				action,
+				boost_fee
 			},
 		);
 
@@ -1330,12 +1334,13 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 	fn request_liquidity_deposit_address(
 		lp_account: T::AccountId,
 		source_asset: TargetChainAsset<T, I>,
+		boost_fee: BasisPoints
 	) -> Result<
 		(ChannelId, ForeignChainAddress, <T::TargetChain as Chain>::ChainBlockNumber),
 		DispatchError,
 	> {
 		let (channel_id, deposit_address, expiry_block) =
-			Self::open_channel(source_asset, ChannelAction::LiquidityProvision { lp_account })?;
+			Self::open_channel(source_asset, ChannelAction::LiquidityProvision { lp_account }, boost_fee)?;
 
 		Ok((channel_id, deposit_address.into(), expiry_block))
 	}
@@ -1348,6 +1353,7 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 		broker_commission_bps: BasisPoints,
 		broker_id: T::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: BasisPoints,
 	) -> Result<
 		(ChannelId, ForeignChainAddress, <T::TargetChain as Chain>::ChainBlockNumber),
 		DispatchError,
@@ -1367,6 +1373,7 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 					broker_id,
 				},
 			},
+			boost_fee
 		)?;
 
 		Ok((channel_id, deposit_address.into(), expiry_height))

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -161,7 +161,7 @@ pub mod pallet {
 
 		/// The action to be taken when the DepositChannel is deposited to.
 		pub action: ChannelAction<T::AccountId>,
-		/// The boost fee, if set to 0 it means no required
+		/// The boost fee
 		pub boost_fee: BasisPoints,
 	}
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -100,7 +100,7 @@ impl<C: Chain> CrossChainMessage<C> {
 	}
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(4);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(5);
 
 /// Calls to the external chains that has failed to be broadcast/accepted by the target chain.
 /// User can use information stored here to query for relevant information to broadcast
@@ -1144,7 +1144,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn open_channel(
 		source_asset: TargetChainAsset<T, I>,
 		action: ChannelAction<T::AccountId>,
-		boost_fee: BasisPoints
+		boost_fee: BasisPoints,
 	) -> Result<(ChannelId, TargetChainAccount<T, I>, TargetChainBlockNumber<T, I>), DispatchError>
 	{
 		let (deposit_channel, channel_id) = if let Some((channel_id, mut deposit_channel)) =
@@ -1186,7 +1186,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				opened_at: current_height,
 				expires_at: expiry_height,
 				action,
-				boost_fee
+				boost_fee,
 			},
 		);
 
@@ -1334,13 +1334,16 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 	fn request_liquidity_deposit_address(
 		lp_account: T::AccountId,
 		source_asset: TargetChainAsset<T, I>,
-		boost_fee: BasisPoints
+		boost_fee: BasisPoints,
 	) -> Result<
 		(ChannelId, ForeignChainAddress, <T::TargetChain as Chain>::ChainBlockNumber),
 		DispatchError,
 	> {
-		let (channel_id, deposit_address, expiry_block) =
-			Self::open_channel(source_asset, ChannelAction::LiquidityProvision { lp_account }, boost_fee)?;
+		let (channel_id, deposit_address, expiry_block) = Self::open_channel(
+			source_asset,
+			ChannelAction::LiquidityProvision { lp_account },
+			boost_fee,
+		)?;
 
 		Ok((channel_id, deposit_address.into(), expiry_block))
 	}
@@ -1373,7 +1376,7 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 					broker_id,
 				},
 			},
-			boost_fee
+			boost_fee,
 		)?;
 
 		Ok((channel_id, deposit_address.into(), expiry_height))

--- a/state-chain/pallets/cf-ingress-egress/src/migrations.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations.rs
@@ -1,4 +1,5 @@
 pub mod btc_deposit_channels;
+pub mod deposit_channels_with_boost_fee;
 pub mod set_dust_limit;
 
 use cf_runtime_upgrade_utilities::VersionedMigration;
@@ -6,4 +7,5 @@ use cf_runtime_upgrade_utilities::VersionedMigration;
 pub type PalletMigration<T, I> = (
 	VersionedMigration<crate::Pallet<T, I>, btc_deposit_channels::Migration<T, I>, 2, 3>,
 	VersionedMigration<crate::Pallet<T, I>, set_dust_limit::Migration<T, I>, 3, 4>,
+	VersionedMigration<crate::Pallet<T, I>, deposit_channels_with_boost_fee::Migration<T, I>, 4, 5>,
 );

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/btc_deposit_channels.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/btc_deposit_channels.rs
@@ -89,6 +89,7 @@ impl<T: Config<Instance3, TargetChain = Bitcoin>> OnRuntimeUpgrade for Migration
 					opened_at: old_channel.opened_at,
 					expires_at: old_channel.expires_at,
 					action: old_channel.action,
+					boost_fee: 0,
 				})
 			},
 		);

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
@@ -203,9 +203,6 @@ mod migration_tests {
 			);
 
 			// Perform runtime migration.
-			// crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance1>::on_runtime_upgrade();
-			// Perform runtime migration.
-			// crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance2>::on_runtime_upgrade();
 			crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance3>::on_runtime_upgrade();
 
 			// Verify data is correctly migrated into new storage.

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
@@ -84,9 +84,14 @@ mod migration_tests {
 			// Insert mock data into old storage
 			old::DepositChannelLookup::insert(address1.clone(), mock_deposit_channel_details());
 			old::DepositChannelLookup::insert(address2.clone(), mock_deposit_channel_details());
+            #[cfg(feature = "try-runtime")]
+            let state: Vec<u8> = crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, _>::pre_upgrade().unwrap();
 
 			// Perform runtime migration.
 			crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, _>::on_runtime_upgrade();
+
+            #[cfg(feature = "try-runtime")]
+            crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, _>::post_upgrade(state).unwrap();
 
 			// Verify data is correctly migrated into new storage.
 			let channel = DepositChannelLookup::<Test, Instance3>::get(address1);

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
@@ -1,0 +1,220 @@
+use crate::{Instance1, Instance2, Instance3, *};
+use cf_chains::{
+	btc::ScriptPubkey, dot::PolkadotAccountId, Bitcoin, DepositChannel, Ethereum, Polkadot,
+};
+use frame_support::traits::OnRuntimeUpgrade;
+pub struct Migration<T: Config<I>, I: 'static>(PhantomData<(T, I)>);
+
+mod old {
+	use super::*;
+
+	#[derive(
+		CloneNoBound, RuntimeDebug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen,
+	)]
+	#[scale_info(skip_type_params(T, I))]
+	pub struct DepositChannelDetails<T: Config<I>, I: 'static> {
+		pub deposit_channel: DepositChannel<T::TargetChain>,
+		pub opened_at: TargetChainBlockNumber<T, I>,
+		pub expires_at: TargetChainBlockNumber<T, I>,
+		pub action: ChannelAction<T::AccountId>,
+	}
+
+	#[frame_support::storage_alias]
+	pub type DepositChannelLookup<T: Config<I>, I: 'static> = StorageMap<
+		Pallet<T, I>,
+		Twox64Concat,
+		TargetChainAccount<T, I>,
+		old::DepositChannelDetails<T, I>,
+		OptionQuery,
+	>;
+}
+
+impl<T: Config<Instance1, TargetChain = Ethereum>> OnRuntimeUpgrade for Migration<T, Instance1> {
+	fn on_runtime_upgrade() -> Weight {
+		DepositChannelLookup::<T, Instance1>::translate(
+			|_address: <cf_chains::Ethereum as cf_chains::Chain>::ChainAccount,
+			 old_channel: old::DepositChannelDetails<T, Instance1>| {
+				Some(DepositChannelDetails::<T, Instance1> {
+					deposit_channel: old_channel.deposit_channel,
+					opened_at: old_channel.opened_at,
+					expires_at: old_channel.expires_at,
+					action: old_channel.action,
+					boost_fee: 0,
+				})
+			},
+		);
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let number_of_channels_in_lookup =
+			old::DepositChannelLookup::<T, Instance1>::iter_keys().count() as u32;
+
+		Ok(number_of_channels_in_lookup.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..]).unwrap();
+		ensure!(
+			DepositChannelLookup::<T, Instance1>::iter_keys().count() as u32 ==
+				number_of_channels_in_lookup_pre_migration,
+			"DepositChannelLookup migration failed."
+		);
+		Ok(())
+	}
+}
+
+impl<T: Config<Instance2, TargetChain = Polkadot>> OnRuntimeUpgrade for Migration<T, Instance2> {
+	fn on_runtime_upgrade() -> Weight {
+		DepositChannelLookup::<T, Instance2>::translate(
+			|_address: PolkadotAccountId, old_channel: old::DepositChannelDetails<T, Instance2>| {
+				Some(DepositChannelDetails::<T, Instance2> {
+					deposit_channel: old_channel.deposit_channel,
+					opened_at: old_channel.opened_at,
+					expires_at: old_channel.expires_at,
+					action: old_channel.action,
+					boost_fee: 0,
+				})
+			},
+		);
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let number_of_channels_in_lookup =
+			old::DepositChannelLookup::<T, Instance2>::iter_keys().count() as u32;
+
+		Ok(number_of_channels_in_lookup.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..]).unwrap();
+		ensure!(
+			DepositChannelLookup::<T, Instance2>::iter_keys().count() as u32 ==
+				number_of_channels_in_lookup_pre_migration,
+			"DepositChannelLookup migration failed."
+		);
+		Ok(())
+	}
+}
+
+impl<T: Config<Instance3, TargetChain = Bitcoin>> OnRuntimeUpgrade for Migration<T, Instance3> {
+	fn on_runtime_upgrade() -> Weight {
+		DepositChannelLookup::<T, Instance3>::translate(
+			|_address: ScriptPubkey, old_channel: old::DepositChannelDetails<T, Instance3>| {
+				Some(DepositChannelDetails::<T, Instance3> {
+					deposit_channel: old_channel.deposit_channel,
+					opened_at: old_channel.opened_at,
+					expires_at: old_channel.expires_at,
+					action: old_channel.action,
+					boost_fee: 0,
+				})
+			},
+		);
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let number_of_channels_in_lookup =
+			old::DepositChannelLookup::<T, Instance3>::iter_keys().count() as u32;
+
+		Ok(number_of_channels_in_lookup.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..]).unwrap();
+		ensure!(
+			DepositChannelLookup::<T, Instance3>::iter_keys().count() as u32 ==
+				number_of_channels_in_lookup_pre_migration,
+			"DepositChannelLookup migration failed."
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod migration_tests {
+	use cf_chains::btc::{
+		deposit_address::{DepositAddress, TapscriptPath},
+		BitcoinScript, ScriptPubkey,
+	};
+
+	use self::mock_btc::new_test_ext;
+
+	use super::*;
+	use crate::mock_btc::*;
+
+	#[test]
+	fn test_migration() {
+		new_test_ext().execute_with(|| {
+			let address1 = ScriptPubkey::Taproot([0u8; 32]);
+			let address2 = ScriptPubkey::Taproot([1u8; 32]);
+
+			// Insert mock data into old storage
+			old::DepositChannelLookup::insert(
+				address1.clone(),
+				old::DepositChannelDetails::<Test, _> {
+					deposit_channel: DepositChannel {
+						channel_id: 123,
+						address: address2.clone(),
+						asset: <Bitcoin as Chain>::ChainAsset::Btc,
+						state: DepositAddress {
+							pubkey_x: [1u8; 32],
+							script_path: Some(TapscriptPath {
+                                salt: 123,
+								tweaked_pubkey_bytes: [2u8; 33],
+								tapleaf_hash: [3u8; 32],
+								unlock_script: BitcoinScript::new(Default::default()),
+                            }),
+						},
+					},
+					opened_at: Default::default(),
+					expires_at: Default::default(),
+					action: ChannelAction::LiquidityProvision { lp_account: Default::default() },
+				},
+			);
+			old::DepositChannelLookup::insert(
+				address2.clone(),
+				old::DepositChannelDetails::<Test, _> {
+					deposit_channel: DepositChannel {
+						channel_id: 123,
+						address: address2.clone(),
+						asset: <Bitcoin as Chain>::ChainAsset::Btc,
+						state: DepositAddress {
+							pubkey_x: [1u8; 32],
+							script_path: Some(TapscriptPath {
+                                salt: 123,
+								tweaked_pubkey_bytes: [2u8; 33],
+								tapleaf_hash: [3u8; 32],
+								unlock_script: BitcoinScript::new(Default::default()),
+                            }),
+						},
+					},
+					opened_at: Default::default(),
+					expires_at: Default::default(),
+					action: ChannelAction::LiquidityProvision { lp_account: Default::default() },
+				},
+			);
+
+			// Perform runtime migration.
+			// crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance1>::on_runtime_upgrade();
+			// Perform runtime migration.
+			// crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance2>::on_runtime_upgrade();
+			crate::migrations::deposit_channels_with_boost_fee::Migration::<Test, Instance3>::on_runtime_upgrade();
+
+			// Verify data is correctly migrated into new storage.
+			let channel = DepositChannelLookup::<Test, Instance3>::get(address1);
+			assert!(channel.is_some());
+			assert_eq!(channel.unwrap().boost_fee, 0);
+			let channel = DepositChannelLookup::<Test, Instance3>::get(address2);
+            assert!(channel.is_some());
+            assert_eq!(channel.unwrap().boost_fee, 0);
+		});
+	}
+}

--- a/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
@@ -230,7 +230,7 @@ impl<Ctx: Clone> RequestAddress for TestExternalities<Test, Ctx> {
 				.cloned()
 				.map(|request| match request {
 					DepositRequest::Liquidity { lp_account, asset } =>
-						IngressEgress::request_liquidity_deposit_address(lp_account, asset)
+						IngressEgress::request_liquidity_deposit_address(lp_account, asset, 0)
 							.map(|(id, addr, ..)| {
 								(request, id, TestChainAccount::try_from(addr).unwrap())
 							})
@@ -246,6 +246,7 @@ impl<Ctx: Clone> RequestAddress for TestExternalities<Test, Ctx> {
 						Default::default(),
 						BROKER,
 						None,
+						0,
 					)
 					.map(|(channel_id, deposit_address, ..)| {
 						(request, channel_id, TestChainAccount::try_from(deposit_address).unwrap())

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -207,7 +207,8 @@ fn request_address_and_deposit(
 	who: ChannelId,
 	asset: eth::Asset,
 ) -> (ChannelId, <Ethereum as Chain>::ChainAccount) {
-	let (id, address, ..) = IngressEgress::request_liquidity_deposit_address(who, asset).unwrap();
+	let (id, address, ..) =
+		IngressEgress::request_liquidity_deposit_address(who, asset, 0).unwrap();
 	let address: <Ethereum as Chain>::ChainAccount = address.try_into().unwrap();
 	assert_ok!(IngressEgress::process_single_deposit(
 		address,
@@ -439,6 +440,7 @@ fn reused_address_channel_id_matches() {
 		let (reused_channel_id, reused_address, ..) = IngressEgress::open_channel(
 			eth::Asset::Eth,
 			ChannelAction::LiquidityProvision { lp_account: 0 },
+			0,
 		)
 		.unwrap();
 		// The reused details should be the same as before.
@@ -474,6 +476,7 @@ fn can_process_ccm_deposit() {
 			0,
 			1,
 			Some(channel_metadata),
+			0,
 		)
 		.unwrap();
 
@@ -578,7 +581,7 @@ fn multi_deposit_includes_deposit_beyond_recycle_height() {
 	new_test_ext()
 		.then_execute_at_next_block(|_| {
 			let (_, address, ..) =
-				IngressEgress::request_liquidity_deposit_address(ALICE, ETH).unwrap();
+				IngressEgress::request_liquidity_deposit_address(ALICE, ETH, 0).unwrap();
 			let address: <Ethereum as Chain>::ChainAccount = address.try_into().unwrap();
 			let recycles_at = IngressEgress::expiry_and_recycle_block_height().2;
 			(address, recycles_at)
@@ -589,7 +592,7 @@ fn multi_deposit_includes_deposit_beyond_recycle_height() {
 		})
 		.then_execute_at_next_block(|address| {
 			let (_, address2, ..) =
-				IngressEgress::request_liquidity_deposit_address(ALICE, ETH).unwrap();
+				IngressEgress::request_liquidity_deposit_address(ALICE, ETH, 0).unwrap();
 			let address2: <Ethereum as Chain>::ChainAccount = address2.try_into().unwrap();
 			(address, address2)
 		})
@@ -906,7 +909,7 @@ fn deposits_ingress_fee_exceeding_deposit_amount_rejected() {
 		});
 
 		let (_id, address, ..) =
-			IngressEgress::request_liquidity_deposit_address(ALICE, ASSET).unwrap();
+			IngressEgress::request_liquidity_deposit_address(ALICE, ASSET, 0).unwrap();
 		let deposit_address = address.try_into().unwrap();
 
 		// Swap a low enough amount such that it gets swallowed by fees

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -171,7 +171,7 @@ pub mod pallet {
 			);
 
 			let (channel_id, deposit_address, expiry_block) =
-				T::DepositHandler::request_liquidity_deposit_address(account_id.clone(), asset)?;
+				T::DepositHandler::request_liquidity_deposit_address(account_id.clone(), asset, boost_fee)?;
 
 			Self::deposit_event(Event::LiquidityDepositAddressReady {
 				channel_id,

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -171,7 +171,11 @@ pub mod pallet {
 			);
 
 			let (channel_id, deposit_address, expiry_block) =
-				T::DepositHandler::request_liquidity_deposit_address(account_id.clone(), asset, boost_fee)?;
+				T::DepositHandler::request_liquidity_deposit_address(
+					account_id.clone(),
+					asset,
+					boost_fee,
+				)?;
 
 			Self::deposit_event(Event::LiquidityDepositAddressReady {
 				channel_id,

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -219,39 +219,40 @@ fn cannot_request_deposit_address_without_registering_liquidity_refund_address()
 #[test]
 fn deposit_address_ready_event_contain_correct_boost_fee_value() {
 	new_test_ext().execute_with(|| {
+		const BOOST_FEE1: u16 = 0;
+		const BOOST_FEE2: u16 = 50;
+		const BOOST_FEE3: u16 = 100;
 
-		// Register EWA
 		assert_ok!(LiquidityProvider::register_liquidity_refund_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			EncodedAddress::Eth([0x01; 20])
 		));
 
-		// Now the LPer should be able to request deposit channel for assets of the Ethereum chain.
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Eth,
-			0,
+			BOOST_FEE1,
 		));
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Flip,
-			100,
+			BOOST_FEE2,
 		));
 		assert_ok!(LiquidityProvider::request_liquidity_deposit_address(
 			RuntimeOrigin::signed(LP_ACCOUNT.into()),
 			Asset::Usdc,
-			50,
+			BOOST_FEE3,
 		));
 		assert_events_match!(Test, RuntimeEvent::LiquidityProvider(crate::Event::LiquidityDepositAddressReady {
-			boost_fee: 0,
+			boost_fee: BOOST_FEE1,
 			..
 		}) => (),
 		RuntimeEvent::LiquidityProvider(crate::Event::LiquidityDepositAddressReady {
-			boost_fee: 100,
+			boost_fee: BOOST_FEE2,
 			..
 		}) => (),
 		RuntimeEvent::LiquidityProvider(crate::Event::LiquidityDepositAddressReady {
-			boost_fee: 50,
+			boost_fee: BOOST_FEE3,
 			..
 		}) => ());
 	});

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -524,6 +524,7 @@ pub mod pallet {
 					broker_commission_bps,
 					broker,
 					channel_metadata.clone(),
+					boost_fee,
 				)?;
 
 			Self::deposit_event(Event::<T>::SwapDepositAddressReady {

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1938,6 +1938,7 @@ fn broker_bps_is_limited() {
 #[test]
 fn deposit_address_ready_event_contain_correct_boost_fee_value() {
 	new_test_ext().execute_with(|| {
+		const BOOST_FEE: u16 = 100;
 		assert_ok!(Swapping::request_swap_deposit_address(
 			RuntimeOrigin::signed(ALICE),
 			Asset::Eth,
@@ -1945,18 +1946,11 @@ fn deposit_address_ready_event_contain_correct_boost_fee_value() {
 			EncodedAddress::Eth(Default::default()),
 			0,
 			None,
-			100
+			BOOST_FEE
 		));
 		assert_event_sequence!(
 			Test,
-			RuntimeEvent::Swapping(Event::SwapDepositAddressReady {
-				deposit_address: EncodedAddress::Eth(..),
-				destination_address: EncodedAddress::Eth(..),
-				source_asset: Asset::Eth,
-				destination_asset: Asset::Usdc,
-				channel_id: 0,
-				..
-			})
+			RuntimeEvent::Swapping(Event::SwapDepositAddressReady { boost_fee: BOOST_FEE, .. })
 		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1934,3 +1934,29 @@ fn broker_bps_is_limited() {
 		);
 	});
 }
+
+#[test]
+fn deposit_address_ready_event_contain_correct_boost_fee_value() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(Swapping::request_swap_deposit_address(
+			RuntimeOrigin::signed(ALICE),
+			Asset::Eth,
+			Asset::Usdc,
+			EncodedAddress::Eth(Default::default()),
+			0,
+			None,
+			100
+		));
+		assert_event_sequence!(
+			Test,
+			RuntimeEvent::Swapping(Event::SwapDepositAddressReady {
+				deposit_address: EncodedAddress::Eth(..),
+				destination_address: EncodedAddress::Eth(..),
+				source_asset: Asset::Eth,
+				destination_asset: Asset::Usdc,
+				channel_id: 0,
+				..
+			})
+		);
+	});
+}

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -437,6 +437,7 @@ macro_rules! impl_deposit_api_for_anychain {
 			fn request_liquidity_deposit_address(
 				lp_account: Self::AccountId,
 				source_asset: Asset,
+				boost_fee: BasisPoints
 			) -> Result<(ChannelId, ForeignChainAddress, <AnyChain as cf_chains::Chain>::ChainBlockNumber), DispatchError> {
 				match source_asset.into() {
 					$(
@@ -444,6 +445,7 @@ macro_rules! impl_deposit_api_for_anychain {
 							$pallet::request_liquidity_deposit_address(
 								lp_account,
 								source_asset.try_into().unwrap(),
+								boost_fee
 							).map(|(channel, address, block_number)| (channel, address, block_number.into())),
 					)+
 				}
@@ -456,6 +458,7 @@ macro_rules! impl_deposit_api_for_anychain {
 				broker_commission_bps: BasisPoints,
 				broker_id: Self::AccountId,
 				channel_metadata: Option<CcmChannelMetadata>,
+				boost_fee: BasisPoints
 			) -> Result<(ChannelId, ForeignChainAddress, <AnyChain as cf_chains::Chain>::ChainBlockNumber), DispatchError> {
 				match source_asset.into() {
 					$(
@@ -466,6 +469,7 @@ macro_rules! impl_deposit_api_for_anychain {
 							broker_commission_bps,
 							broker_id,
 							channel_metadata,
+							boost_fee
 						).map(|(channel, address, block_number)| (channel, address, block_number.into())),
 					)+
 				}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -668,6 +668,7 @@ pub trait DepositApi<C: Chain> {
 	fn request_liquidity_deposit_address(
 		lp_account: Self::AccountId,
 		source_asset: C::ChainAsset,
+		boost_fee: BasisPoints
 	) -> Result<(ChannelId, ForeignChainAddress, C::ChainBlockNumber), DispatchError>;
 
 	/// Issues a channel id and deposit address for a new swap.
@@ -678,6 +679,7 @@ pub trait DepositApi<C: Chain> {
 		broker_commission_bps: BasisPoints,
 		broker_id: Self::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: BasisPoints,
 	) -> Result<(ChannelId, ForeignChainAddress, C::ChainBlockNumber), DispatchError>;
 }
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -668,7 +668,7 @@ pub trait DepositApi<C: Chain> {
 	fn request_liquidity_deposit_address(
 		lp_account: Self::AccountId,
 		source_asset: C::ChainAsset,
-		boost_fee: BasisPoints
+		boost_fee: BasisPoints,
 	) -> Result<(ChannelId, ForeignChainAddress, C::ChainBlockNumber), DispatchError>;
 
 	/// Issues a channel id and deposit address for a new swap.

--- a/state-chain/traits/src/mocks/deposit_handler.rs
+++ b/state-chain/traits/src/mocks/deposit_handler.rs
@@ -29,6 +29,7 @@ pub struct SwapChannel<C: Chain, T: Chainflip> {
 	pub broker_commission_bps: BasisPoints,
 	pub broker_id: <T as frame_system::Config>::AccountId,
 	pub channel_metadata: Option<CcmChannelMetadata>,
+	pub boost_fee: BasisPoints,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
@@ -36,6 +37,7 @@ pub struct LpChannel<C: Chain, T: Chainflip> {
 	pub deposit_address: ForeignChainAddress,
 	pub source_asset: <C as Chain>::ChainAsset,
 	pub lp_account: <T as frame_system::Config>::AccountId,
+	pub boost_fee: BasisPoints,
 }
 
 impl<C: Chain, T: Chainflip> MockDepositHandler<C, T> {
@@ -81,6 +83,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 	fn request_liquidity_deposit_address(
 		lp_account: Self::AccountId,
 		source_asset: <C as cf_chains::Chain>::ChainAsset,
+		boost_fee: BasisPoints
 	) -> Result<
 		(cf_primitives::ChannelId, ForeignChainAddress, <C as cf_chains::Chain>::ChainBlockNumber),
 		sp_runtime::DispatchError,
@@ -96,6 +99,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 					deposit_address: deposit_address.clone(),
 					source_asset,
 					lp_account,
+					boost_fee
 				});
 			}
 		});
@@ -109,6 +113,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 		broker_commission_bps: BasisPoints,
 		broker_id: Self::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
+		boost_fee: BasisPoints,
 	) -> Result<
 		(cf_primitives::ChannelId, ForeignChainAddress, C::ChainBlockNumber),
 		sp_runtime::DispatchError,
@@ -128,6 +133,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 					broker_commission_bps,
 					broker_id,
 					channel_metadata,
+					boost_fee,
 				});
 			};
 		});

--- a/state-chain/traits/src/mocks/deposit_handler.rs
+++ b/state-chain/traits/src/mocks/deposit_handler.rs
@@ -83,7 +83,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 	fn request_liquidity_deposit_address(
 		lp_account: Self::AccountId,
 		source_asset: <C as cf_chains::Chain>::ChainAsset,
-		boost_fee: BasisPoints
+		boost_fee: BasisPoints,
 	) -> Result<
 		(cf_primitives::ChannelId, ForeignChainAddress, <C as cf_chains::Chain>::ChainBlockNumber),
 		sp_runtime::DispatchError,
@@ -99,7 +99,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 					deposit_address: deposit_address.clone(),
 					source_asset,
 					lp_account,
-					boost_fee
+					boost_fee,
 				});
 			}
 		});


### PR DESCRIPTION
# Pull Request

Closes: PRO-1170

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Use the boost_fee parameter passed in open_swap_channel/open_liquidity_channel extrinsic and add it to the DepositChannelDetails
- Migrate old channelDetails to include this new field, set to 0 for "old" channels
