### PR TITLE
feat: storage migrations for signing refactor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12349,6 +12349,7 @@ dependencies = [
  "cf-amm",
  "cf-chains",
  "cf-primitives",
+ "cf-runtime-upgrade-utilities",
  "cf-runtime-utilities",
  "cf-session-benchmarking",
  "cf-test-utilities",

--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -156,7 +156,7 @@ pub enum KeyRotationStatus<T: Config<I>, I: 'static = ()> {
 	},
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(4);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(5);
 
 const THRESHOLD_SIGNATURE_RESPONSE_TIMEOUT_DEFAULT: u32 = 10;
 const KEYGEN_CEREMONY_RESPONSE_TIMEOUT_BLOCKS_DEFAULT: u32 = 90;

--- a/state-chain/pallets/cf-threshold-signature/src/migrations.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/migrations.rs
@@ -1,5 +1,9 @@
 use crate::Pallet;
+use cf_runtime_upgrade_utilities::{migration_template, VersionedMigration};
 
-use cf_runtime_upgrade_utilities::{migration_template::Migration, VersionedMigration};
+mod v4;
 
-pub type PalletMigration<T> = VersionedMigration<Pallet<T>, Migration<T>, 3, 4>;
+pub type PalletMigration<T, I> = (
+	VersionedMigration<Pallet<T, I>, v4::Migration<T, I>, 4, 5>,
+	VersionedMigration<Pallet<T, I>, migration_template::Migration<T>, 5, 6>,
+);

--- a/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
@@ -1,0 +1,99 @@
+use cf_traits::{Chainflip, EpochInfo};
+use frame_support::traits::OnRuntimeUpgrade;
+use sp_std::{marker::PhantomData, prelude::*};
+
+#[cfg(feature = "try-runtime")]
+mod try_runtime_includes {
+	pub use codec::{Decode, DecodeLength, Encode};
+	pub use frame_support::{
+		ensure, pallet_prelude::DispatchError, storage, traits::PalletInfoAccess,
+	};
+}
+#[cfg(feature = "try-runtime")]
+use try_runtime_includes::*;
+
+use crate::{CurrentKeyEpoch, KeyRotationStatus, PendingKeyRotation};
+
+mod old {
+	use cf_primitives::EpochIndex;
+	use frame_support::{storage_alias, Blake2_128Concat};
+
+	use crate::{AggKeyFor, Config, Pallet};
+
+	#[storage_alias]
+	pub type Vaults<T: Config<I>, I: 'static> =
+		StorageMap<Pallet<T, I>, Blake2_128Concat, EpochIndex, AggKeyFor<T, I>>;
+}
+
+/// The V4 migration is partly implemented in the runtime/lib.rs
+/// `ThresholdSignatureRefactorMigration` struct.
+pub struct Migration<T, I>(PhantomData<(T, I)>);
+
+impl<T: crate::Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		log::info!("Running V4 threshold migration");
+		// rename_pallet_storage::<crate::Pallet<T, I>>(b"Vaults", b"Keys");
+		for (k, v) in old::Vaults::<T, I>::drain() {
+			crate::Keys::<T, I>::insert(k, v);
+		}
+		CurrentKeyEpoch::<T, I>::put(<T as Chainflip>::EpochInfo::epoch_index());
+		// Assume we don't migrate during a rotation.
+		PendingKeyRotation::<T, I>::put(KeyRotationStatus::Complete);
+		Default::default()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		// The old vault should have been moved here from the vaults pallet.
+		ensure!(old::Vaults::<T, I>::iter().count() > 0, "Vaults should exist!");
+		ensure!(
+			old::Vaults::<T, I>::contains_key(<T as Chainflip>::EpochInfo::epoch_index()),
+			"Current Epoch Vault should exist!"
+		);
+		Ok(Default::default())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		ensure!(crate::CeremonyIdCounter::<T, I>::exists(), "CeremonyIdCounter was not migrated!");
+		ensure!(
+			crate::KeyHandoverFailureVoters::<T, I>::decode_len().is_none(),
+			"KeyHandoverFailureVoters should be empty!"
+		);
+		ensure!(
+			crate::KeyHandoverSuccessVoters::<T, I>::iter().count() == 0,
+			"KeyHandoverSuccessVoters should be empty!"
+		);
+		ensure!(
+			crate::KeygenFailureVoters::<T, I>::decode_len().is_none(),
+			"KeygenFailureVoters should be empty!"
+		);
+		ensure!(
+			crate::KeygenSuccessVoters::<T, I>::iter().count() == 0,
+			"KeygenSuccessVoters should be empty!"
+		);
+		ensure!(
+			!crate::KeygenResolutionPendingSince::<T, I>::exists(),
+			"KeygenResolutionPendingSince should be empty!"
+		);
+		ensure!(
+			crate::KeygenResponseTimeout::<T, I>::get() > 0u32.into(),
+			"KeygenResponseTimeout should be set!"
+		);
+		ensure!(crate::KeygenSlashAmount::<T, I>::get() > 0, "KeygenSlashAmount should be set!");
+		ensure!(old::Vaults::<T, I>::iter().count() == 0, "Vaults should be deleted!");
+		ensure!(
+			!old::Vaults::<T, I>::contains_key(<T as Chainflip>::EpochInfo::epoch_index()),
+			"Current Epoch Vault should not exist!"
+		);
+		ensure!(
+			CurrentKeyEpoch::<T, I>::get().unwrap() == <T as Chainflip>::EpochInfo::epoch_index(),
+			"CurrentKeyEpoch was not migrated!"
+		);
+		ensure!(
+			crate::Keys::<T, I>::contains_key(<T as Chainflip>::EpochInfo::epoch_index()),
+			"Keys were not migrated!"
+		);
+		Ok(Default::default())
+	}
+}

--- a/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
@@ -1,6 +1,6 @@
 use cf_traits::{Chainflip, EpochInfo};
 use frame_support::traits::OnRuntimeUpgrade;
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::marker::PhantomData;
 
 #[cfg(feature = "try-runtime")]
 mod try_runtime_includes {
@@ -8,6 +8,7 @@ mod try_runtime_includes {
 	pub use frame_support::{
 		ensure, pallet_prelude::DispatchError, storage, traits::PalletInfoAccess,
 	};
+	pub use sp_std::prelude::*;
 }
 #[cfg(feature = "try-runtime")]
 use try_runtime_includes::*;
@@ -32,7 +33,6 @@ pub struct Migration<T, I>(PhantomData<(T, I)>);
 impl<T: crate::Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		log::info!("Running V4 threshold migration");
-		// rename_pallet_storage::<crate::Pallet<T, I>>(b"Vaults", b"Keys");
 		for (k, v) in old::Vaults::<T, I>::drain() {
 			crate::Keys::<T, I>::insert(k, v);
 		}
@@ -55,6 +55,8 @@ impl<T: crate::Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		// NOTE Most of the below migrations are run by the vaults pallet or in the
+		// ThresholdSignatureRefactorMigration in the runtime.
 		ensure!(crate::CeremonyIdCounter::<T, I>::exists(), "CeremonyIdCounter was not migrated!");
 		ensure!(
 			crate::KeyHandoverFailureVoters::<T, I>::decode_len().is_none(),

--- a/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/migrations/v4.rs
@@ -94,6 +94,6 @@ impl<T: crate::Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 			crate::Keys::<T, I>::contains_key(<T as Chainflip>::EpochInfo::epoch_index()),
 			"Keys were not migrated!"
 		);
-		Ok(Default::default())
+		Ok(())
 	}
 }

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -30,11 +30,6 @@ type Block = frame_system::mocking::MockBlock<Test>;
 
 pub type ValidatorId = u64;
 
-pub const ETH_DUMMY_SIG: SchnorrVerificationComponents =
-	SchnorrVerificationComponents { s: [0xcf; 32], k_times_g_address: [0xcf; 20] };
-
-pub const BTC_DUMMY_SIG: btc::Signature = [0xcf; 64];
-
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
 	pub enum Test {

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -5,8 +5,6 @@ use crate::{
 	EnsureThresholdSigned, Origin, Pallet, PalletOffence, PendingCeremonies, RequestId,
 };
 use cf_chains::{
-	btc,
-	evm::SchnorrVerificationComponents,
 	mocks::{MockAggKey, MockEthereumChainCrypto, MockThresholdSignature},
 	ChainCrypto,
 };

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -19,6 +19,7 @@ pub use pallet::*;
 use sp_std::prelude::*;
 
 mod benchmarking;
+pub mod migrations;
 
 mod vault_activator;
 
@@ -27,7 +28,7 @@ pub use weights::WeightInfo;
 mod mock;
 mod tests;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(3);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(4);
 
 pub type PayloadFor<T, I = ()> = <<T as Config<I>>::Chain as ChainCrypto>::Payload;
 

--- a/state-chain/pallets/cf-vaults/src/migrations.rs
+++ b/state-chain/pallets/cf-vaults/src/migrations.rs
@@ -1,5 +1,9 @@
 use crate::Pallet;
+use cf_runtime_upgrade_utilities::{migration_template, VersionedMigration};
 
-use cf_runtime_upgrade_utilities::{migration_template::Migration, VersionedMigration};
+mod v3;
 
-pub type PalletMigration<T> = VersionedMigration<Pallet<T>, Migration<T>, 2, 3>;
+pub type PalletMigration<T, I> = (
+	VersionedMigration<Pallet<T, I>, v3::Migration<T, I>, 3, 4>,
+	VersionedMigration<Pallet<T, I>, migration_template::Migration<T>, 4, 5>,
+);

--- a/state-chain/pallets/cf-vaults/src/migrations/v3.rs
+++ b/state-chain/pallets/cf-vaults/src/migrations/v3.rs
@@ -1,0 +1,82 @@
+use frame_support::traits::OnRuntimeUpgrade;
+use sp_std::{marker::PhantomData, prelude::*};
+
+#[cfg(feature = "try-runtime")]
+mod try_runtime_includes {
+	pub use codec::{Decode, DecodeLength, Encode};
+	pub use frame_support::{ensure, pallet_prelude::DispatchError};
+}
+#[cfg(feature = "try-runtime")]
+use try_runtime_includes::*;
+
+use crate::{PendingVaultActivation, VaultActivationStatus, VaultStartBlockNumbers};
+
+mod old {
+	use cf_chains::{Chain, ChainCrypto};
+	use cf_primitives::EpochIndex;
+	use codec::{Decode, Encode};
+	use frame_support::{storage_alias, Blake2_128Concat};
+
+	use crate::{Config, Pallet};
+
+	/// A single vault.
+	#[derive(Default, PartialEq, Eq, Clone, Encode, Decode)]
+	pub struct Vault<T: Chain> {
+		/// The vault's public key.
+		pub public_key: <<T as Chain>::ChainCrypto as ChainCrypto>::AggKey,
+		/// The first active block for this vault
+		pub active_from_block: T::ChainBlockNumber,
+	}
+
+	#[storage_alias]
+	pub type Vaults<T: Config<I>, I: 'static> =
+		StorageMap<Pallet<T, I>, Blake2_128Concat, EpochIndex, Vault<<T as Config<I>>::Chain>>;
+}
+
+mod new {
+	use cf_chains::{Chain, ChainCrypto};
+	use cf_primitives::EpochIndex;
+	use frame_support::{storage_alias, Blake2_128Concat};
+
+	use crate::{Config, Pallet};
+
+	// Temporary - should be erased after the threshols signature part of the migration.
+	#[storage_alias]
+	pub type Vaults<T: Config<I>, I: 'static> = StorageMap<
+		Pallet<T, I>,
+		Blake2_128Concat,
+		EpochIndex,
+		<<<T as Config<I>>::Chain as Chain>::ChainCrypto as ChainCrypto>::AggKey,
+	>;
+}
+
+/// The V3 migration is partly implemented in the runtime/lib.rs
+/// `ThresholdSignatureRefactorMigration` struct.
+pub struct Migration<T, I>(PhantomData<(T, I)>);
+
+impl<T: crate::Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		PendingVaultActivation::<T, I>::put(VaultActivationStatus::Complete);
+		// We don't drain the old storage, it's required for the other part of the migration
+		// (threhsold signer pallet).
+
+		for (epoch_index, old::Vault { active_from_block, .. }) in old::Vaults::<T, I>::iter() {
+			VaultStartBlockNumbers::<T, I>::insert(epoch_index, active_from_block);
+		}
+		new::Vaults::<T, I>::translate::<old::Vault<T::Chain>, _>(|_, old_vault| {
+			Some(old_vault.public_key)
+		});
+
+		Default::default()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok(Default::default())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-vaults/src/migrations/v3.rs
+++ b/state-chain/pallets/cf-vaults/src/migrations/v3.rs
@@ -1,10 +1,11 @@
 use frame_support::traits::OnRuntimeUpgrade;
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::marker::PhantomData;
 
 #[cfg(feature = "try-runtime")]
 mod try_runtime_includes {
 	pub use codec::{Decode, DecodeLength, Encode};
 	pub use frame_support::{ensure, pallet_prelude::DispatchError};
+	pub use sp_std::prelude::*;
 }
 #[cfg(feature = "try-runtime")]
 use try_runtime_includes::*;

--- a/state-chain/runtime-upgrade-utilities/src/helper_functions.rs
+++ b/state-chain/runtime-upgrade-utilities/src/helper_functions.rs
@@ -1,18 +1,12 @@
-use frame_support::storage::{storage_prefix, unhashed};
+use frame_support::{migration::move_storage_from_pallet, traits::PalletInfoAccess};
 
-/// Not to be confused with [move_prefix]. This function move the storage identified by the given
-/// pallet and storage names.
-pub fn move_storage(
-	old_pallet_name: &[u8],
-	old_storage_name: &[u8],
-	new_pallet_name: &[u8],
-	new_storage_name: &[u8],
-) {
-	let new_prefix = storage_prefix(new_pallet_name, new_storage_name);
-	let old_prefix = storage_prefix(old_pallet_name, old_storage_name);
-
-	if let Some(value) = unhashed::get_raw(&old_prefix) {
-		unhashed::put_raw(&new_prefix, &value);
-		unhashed::kill(&old_prefix);
-	}
+/// Move storage between pallets.
+pub fn move_pallet_storage<From: PalletInfoAccess, To: PalletInfoAccess>(storage_name: &[u8]) {
+	log::info!(
+		"⏫ Moving storage {} from {} to {}.",
+		sp_std::str::from_utf8(storage_name).expect("storage names are all valid utf8"),
+		From::name(),
+		To::name(),
+	);
+	move_storage_from_pallet(storage_name, From::name().as_bytes(), To::name().as_bytes());
 }

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -29,6 +29,7 @@ cf-chains = { path = '../chains', default-features = false }
 cf-primitives = { path = '../primitives', default-features = false }
 cf-session-benchmarking = { path = '../cf-session-benchmarking', optional = true, default-features = false }
 cf-runtime-utilities = { path = '../runtime-utilities', default-features = false }
+cf-runtime-upgrade-utilities = { path = '../runtime-upgrade-utilities', default-features = false }
 cf-traits = { path = '../traits', default-features = false }
 cf-utilities = { package = 'utilities', path = '../../utilities', default-features = false }
 
@@ -141,6 +142,7 @@ std = [
   'cf-chains/std',
   'cf-primitives/std',
   'cf-runtime-utilities/std',
+  'cf-runtime-upgrade-utilities/std',
   'cf-traits/std',
   'cf-utilities/std',
   'codec/std',
@@ -199,6 +201,7 @@ std = [
   'dep:cf-test-utilities',
 ]
 try-runtime = [
+  'cf-runtime-upgrade-utilities/try-runtime',
   'frame-executive/try-runtime',
   'frame-try-runtime/try-runtime',
   'frame-system/try-runtime',

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -929,8 +929,6 @@ mod threshold_signature_refactor_migration {
 					"CeremonyIdCounter",
 					"KeygenSlashAmount",
 					"Vaults",
-					"VaultsByEpoch",
-					"VaultsByEpochAndKey",
 				] {
 					move_pallet_storage::<
 						pallet_cf_vaults::Pallet<Runtime, I>,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 120,
+	spec_version: 130,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 12,
@@ -888,12 +888,14 @@ type PalletMigrations = (
 	pallet_cf_chain_tracking::migrations::PalletMigration<Runtime, Instance1>,
 	pallet_cf_chain_tracking::migrations::PalletMigration<Runtime, Instance2>,
 	pallet_cf_chain_tracking::migrations::PalletMigration<Runtime, Instance3>,
-	// pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance1>,
-	// pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance2>,
-	// pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance3>,
-	// pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance1>,
-	// pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance2>,
-	// pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance3>,
+	pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance1>,
+	pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance2>,
+	pallet_cf_vaults::migrations::PalletMigration<Runtime, Instance3>,
+	// TODO: Remove this after version 1.3 release.
+	ThresholdSignatureRefactorMigration,
+	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance1>,
+	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance2>,
+	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, Instance3>,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, Instance1>,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, Instance2>,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, Instance3>,
@@ -904,6 +906,53 @@ type PalletMigrations = (
 	pallet_cf_ingress_egress::migrations::PalletMigration<Runtime, Instance3>,
 	// pallet_cf_pools::migrations::PalletMigration<Runtime>,
 );
+
+pub struct ThresholdSignatureRefactorMigration;
+
+mod threshold_signature_refactor_migration {
+	use super::Runtime;
+	use cf_runtime_upgrade_utilities::move_pallet_storage;
+	use frame_support::traits::GetStorageVersion;
+
+	pub fn migrate_instance<I: 'static>()
+	where
+		Runtime: pallet_cf_threshold_signature::Config<I>,
+		Runtime: pallet_cf_vaults::Config<I>,
+	{
+		// The migration needs to be run *after* the vaults pallet migration (3 -> 4) and *before*
+		// the threshold signer pallet migration (4 -> 5).
+		if <pallet_cf_threshold_signature::Pallet::<Runtime, I> as GetStorageVersion>::on_chain_storage_version() == 4 &&
+			<pallet_cf_vaults::Pallet::<Runtime, I> as GetStorageVersion>::on_chain_storage_version() == 4 {
+
+				log::info!("✅ Applying threshold signature refactor storage migration.");
+				for storage_name in [
+					"CeremonyIdCounter",
+					"KeygenSlashAmount",
+					"Vaults",
+					"VaultsByEpoch",
+					"VaultsByEpochAndKey",
+				] {
+					move_pallet_storage::<
+						pallet_cf_vaults::Pallet<Runtime, I>,
+						pallet_cf_threshold_signature::Pallet<Runtime, I>,
+					>(storage_name.as_bytes());
+				}
+			} else {
+				log::info!("⏭ Skipping threshold signature refactor migration.");
+			}
+	}
+}
+
+impl frame_support::traits::OnRuntimeUpgrade for ThresholdSignatureRefactorMigration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		log::info!("⏫ Applying threshold signature refactor storage migration.");
+		threshold_signature_refactor_migration::migrate_instance::<EthereumInstance>();
+		threshold_signature_refactor_migration::migrate_instance::<BitcoinInstance>();
+		threshold_signature_refactor_migration::migrate_instance::<PolkadotInstance>();
+
+		Default::default()
+	}
+}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1178

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Adds migrations for the threshols signer refactor. 

The migration happens in three steps:
1. Vaults pallet migration v3: migrates/intializes storage in the vault pallet
2. custom runtime migration `ThresholdSignatureRefactorMigration`: moves storage from vaults to threshold signer pallets.
3. Threshold Signer pallet migration: Renames Vaults -> Keys and initialises CurrentKeyEpoch and PendingKeyRotation. 

The migration only works if we upgrade outside of a rotation. 

I used this output from subxt diff as a basis:

```
~ BitcoinThresholdSigner
        Storage Entries:
            + CeremonyIdCounter <- init from vault pallet
            + CurrentKeyEpoch <- init with current epoch
            + KeyHandoverFailureVoters <- empty
            + KeyHandoverResolutionPendingSince <- empty
            + KeyHandoverSuccessVoters <- empty
            + KeygenFailureVoters <- empty
            + KeygenResolutionPendingSince <- empty
            + KeygenResponseTimeout <- init with default value (already done)
            + KeygenSlashAmount <- copy from vault pallet
            + KeygenSuccessVoters <- empty
            + Keys <- copy from vaults pallet
            + PendingKeyRotation <- init with default value (Complete?)
            ~ RequestCallback (Changed: )
    ~ BitcoinVault
        Storage Entries:
            - CeremonyIdCounter <- move this to thresholdSigner pallet
            - CurrentVaultEpoch <- delete this
            - KeyHandoverFailureVoters <- delete this
            - KeyHandoverResolutionPendingSince <- delete this
            - KeyHandoverSuccessVoters <- delete this
            - KeygenFailureVoters <- delete this
            - KeygenResolutionPendingSince <- delete this
            - KeygenResponseTimeout <- delete this
            - KeygenSlashAmount <- delete this
            - KeygenSuccessVoters <- delete this
            + PendingVaultActivation <- needs migration to default value
            - PendingVaultRotation <- delete this
            + VaultStartBlockNumbers <- needs initialization from Vaults
            - Vaults <- migrated to thresholdSigner.Keys
```