### PR TITLE
fix: remove old failed ccms

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/migrations.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations.rs
@@ -1,5 +1,6 @@
 pub mod btc_deposit_channels;
 pub mod deposit_channels_with_boost_fee;
+pub mod remove_old_storage;
 pub mod set_dust_limit;
 
 use cf_runtime_upgrade_utilities::VersionedMigration;
@@ -8,4 +9,5 @@ pub type PalletMigration<T, I> = (
 	VersionedMigration<crate::Pallet<T, I>, btc_deposit_channels::Migration<T, I>, 2, 3>,
 	VersionedMigration<crate::Pallet<T, I>, set_dust_limit::Migration<T, I>, 3, 4>,
 	VersionedMigration<crate::Pallet<T, I>, deposit_channels_with_boost_fee::Migration<T, I>, 4, 5>,
+	VersionedMigration<crate::Pallet<T, I>, remove_old_storage::Migration<T, I>, 5, 6>,
 );

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/remove_old_storage.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/remove_old_storage.rs
@@ -1,0 +1,48 @@
+use crate::{Config, FailedForeignChainCalls};
+use frame_support::traits::OnRuntimeUpgrade;
+use sp_std::{marker::PhantomData, prelude::*};
+
+pub struct Migration<T: Config<I>, I: 'static>(PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		for (i, v) in FailedForeignChainCalls::<T, I>::drain()
+			.filter(|(_, v)| !v.is_empty())
+			.collect::<Vec<_>>()
+		{
+			FailedForeignChainCalls::<T, I>::insert(i, v);
+		}
+
+		Default::default()
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::{
+		mock_eth::{new_test_ext, Test},
+		FailedForeignChainCall,
+	};
+
+	#[test]
+	fn test_migration() {
+		let call = |i| FailedForeignChainCall { broadcast_id: i, original_epoch: i };
+		new_test_ext().execute_with(|| {
+			FailedForeignChainCalls::<Test, _>::set(1, vec![call(1)]);
+			FailedForeignChainCalls::<Test, _>::set(2, vec![]);
+			FailedForeignChainCalls::<Test, _>::set(3, vec![call(2), call(3)]);
+			FailedForeignChainCalls::<Test, _>::set(4, vec![]);
+
+			assert!(FailedForeignChainCalls::<Test, _>::contains_key(2));
+			assert!(FailedForeignChainCalls::<Test, _>::contains_key(4));
+
+			Migration::<Test, _>::on_runtime_upgrade();
+
+			assert_eq!(FailedForeignChainCalls::<Test, _>::get(1), vec![call(1)]);
+			assert!(!FailedForeignChainCalls::<Test, _>::contains_key(2));
+			assert_eq!(FailedForeignChainCalls::<Test, _>::get(3), vec![call(2), call(3)]);
+			assert!(!FailedForeignChainCalls::<Test, _>::contains_key(4));
+		});
+	}
+}

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1455,9 +1455,9 @@ fn on_finalize_handles_failed_calls() {
 		));
 
 		// All calls are culled from storage.
-		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch), vec![]);
-		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch + 1), vec![]);
-		assert_eq!(FailedForeignChainCalls::<Test>::get(epoch + 2), vec![]);
+		assert!(!FailedForeignChainCalls::<Test>::contains_key(epoch));
+		assert!(!FailedForeignChainCalls::<Test>::contains_key(epoch + 1));
+		assert!(!FailedForeignChainCalls::<Test>::contains_key(epoch + 2));
 	});
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1193

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

i noticed we were leaving some old storage lingering in the ingress egress pallet. This is a fix, and a storage migration to delete the old values. 