### PR TITLE
fix: remove old runtime benchmarks

### DIFF
--- a/state-chain/pallets/cf-vaults/src/benchmarking.rs
+++ b/state-chain/pallets/cf-vaults/src/benchmarking.rs
@@ -20,28 +20,6 @@ mod benchmarks {
 	use sp_std::vec;
 
 	#[benchmark]
-	fn vault_key_rotated() {
-		let new_public_key = AggKeyFor::<T, I>::benchmark_value();
-		PendingVaultActivation::<T, I>::put(VaultActivationStatus::<T, I>::AwaitingActivation {
-			new_public_key,
-		});
-		let call = Call::<T, I>::vault_key_rotated {
-			block_number: 5u32.into(),
-			tx_id: Decode::decode(&mut &TX_HASH[..]).unwrap(),
-		};
-		let origin = T::EnsureWitnessedAtCurrentEpoch::try_successful_origin().unwrap();
-
-		#[block]
-		{
-			assert_ok!(call.dispatch_bypass_filter(origin));
-		}
-
-		assert!(VaultStartBlockNumbers::<T, I>::contains_key(
-			T::EpochInfo::epoch_index().saturating_add(1)
-		));
-	}
-
-	#[benchmark]
 	fn vault_key_rotated_externally() {
 		let origin = T::EnsureWitnessedAtCurrentEpoch::try_successful_origin().unwrap();
 		let call = Call::<T, I>::vault_key_rotated_externally {

--- a/state-chain/pallets/cf-vaults/src/benchmarking.rs
+++ b/state-chain/pallets/cf-vaults/src/benchmarking.rs
@@ -44,9 +44,6 @@ mod benchmarks {
 	#[test]
 	fn benchmark_works() {
 		new_test_ext().execute_with(|| {
-			_vault_key_rotated::<Test, ()>(true);
-		});
-		new_test_ext().execute_with(|| {
 			_vault_key_rotated_externally::<Test, ()>(true);
 		});
 	}

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -131,21 +131,6 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
-		/// Deprecated! This extrinsic does nothing
-		#[pallet::call_index(3)]
-		#[pallet::weight(Weight::zero())]
-		pub fn vault_key_rotated(
-			origin: OriginFor<T>,
-			_block_number: ChainBlockNumberFor<T, I>,
-
-			// This field is primarily required to ensure the witness calls are unique per
-			// transaction (on the external chain)
-			_tx_id: TransactionInIdFor<T, I>,
-		) -> DispatchResultWithPostInfo {
-			T::EnsureWitnessedAtCurrentEpoch::ensure_origin(origin)?;
-			Ok(().into())
-		}
-
 		/// The vault's key has been updated externally, outside of the rotation
 		/// cycle. This is an unexpected event as far as our chain is concerned, and
 		/// the only thing we can do is to halt and wait for further governance


### PR DESCRIPTION
This allows the benchmarks ci run to complete. 