### PR TITLE
chore: version bump chainflip 1.2.0 -> 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chainflip-api",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-broadcast 0.5.1",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -12344,7 +12344,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "cf-amm",
  "cf-chains",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = '2021'
 build = 'build.rs'
 name = "chainflip-cli"
-version = "1.2.0"
+version = "1.3.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "chainflip-engine"
-version = "1.2.0"
+version = "1.3.0"
 
 [package.metadata.deb]
 depends = "$auto, systemd"

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = '<TODO>'
 name = 'chainflip-node'
 publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
-version = "1.2.0"
+version = "1.3.0"
 
 [[bin]]
 name = 'chainflip-node'

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'state-chain-runtime'
-version = '1.2.0'
+version = '1.3.0'
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
 edition = '2021'
 homepage = 'https://chainflip.io'


### PR DESCRIPTION
Version bump to satisfy the version bump checker. 