### PR TITLE
chore: enable all tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,9 +9,9 @@ CF_TEST_CONFIG_ROOT = { value = "engine/config/testing", relative = true }
 # `rustup completions --help` to find out how to set this up.
 
 [alias]
-cf-test = "test --lib --features runtime-benchmarks,try-runtime"
-cf-test-ci = "test --release --lib --features runtime-benchmarks,slow-tests,try-runtime"
-cf-test-cfe = "test --lib --package chainflip-engine --package multisig"
+cf-test = "test --features runtime-benchmarks,try-runtime"
+cf-test-ci = "test --release --features runtime-benchmarks,slow-tests,try-runtime"
+cf-test-cfe = "test --package chainflip-engine --package multisig"
 
 cf-clippy = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings -A deprecated"
 cf-clippy-ci = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings -A deprecated"

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -279,6 +279,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "Requires config file at root"]
 	fn init_default_config() {
 		set_test_env();
 
@@ -294,6 +295,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "Requires config file at default root"]
 	fn test_all_command_line_options() {
 		// Fill the options with test values that will pass the parsing/validation.
 		// The test values need to be different from the default values set during `set_defaults()`

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-2.snap
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-2.snap
@@ -1,5 +1,6 @@
 ---
 source: api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+assertion_line: 487
 expression: "store.storage.get(format!(\"deposit:Polkadot:{}\", format!\n                (\"0x{}\", hex ::\n                encode(polkadot_account_id.aliased_ref()))).as_str()).unwrap()"
 ---
-[{"amount":"0x64","asset":"DOT","deposit_chain_block_height":1}]
+[{"amount":"0x64","asset":{"asset":"DOT","chain":"Polkadot"},"deposit_chain_block_height":1}]

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-3.snap
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-3.snap
@@ -1,5 +1,6 @@
 ---
 source: api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+assertion_line: 497
 expression: "store.storage.get(format!(\"deposit:Ethereum:{}\",\n                eth_address_str2.to_lowercase()).as_str()).unwrap()"
 ---
-[{"amount":"0x64","asset":"ETH","deposit_chain_block_height":1}]
+[{"amount":"0x64","asset":{"asset":"ETH","chain":"Ethereum"},"deposit_chain_block_height":1}]

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-4.snap
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls-4.snap
@@ -1,5 +1,6 @@
 ---
 source: api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+assertion_line: 521
 expression: "store.storage.get(format!(\"deposit:Ethereum:{}\",\n                eth_address_str1.to_lowercase()).as_str()).unwrap()"
 ---
-[{"amount":"0x64","asset":"ETH","deposit_chain_block_height":1},{"amount":"0x1e8480","asset":"ETH","deposit_chain_block_height":1}]
+[{"amount":"0x64","asset":{"asset":"ETH","chain":"Ethereum"},"deposit_chain_block_height":1},{"amount":"0x1e8480","asset":{"asset":"ETH","chain":"Ethereum"},"deposit_chain_block_height":1}]

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls.snap
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/snapshots/chainflip_ingress_egress_tracker__witnessing__state_chain__tests__handle_deposit_calls.snap
@@ -1,5 +1,6 @@
 ---
 source: api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+assertion_line: 483
 expression: "store.storage.get(format!(\"deposit:Ethereum:{}\",\n                eth_address_str1.to_lowercase()).as_str()).unwrap()"
 ---
-[{"amount":"0x64","asset":"ETH","deposit_chain_block_height":1}]
+[{"amount":"0x64","asset":{"asset":"ETH","chain":"Ethereum"},"deposit_chain_block_height":1}]

--- a/state-chain/pallets/cf-governance/README.md
+++ b/state-chain/pallets/cf-governance/README.md
@@ -24,20 +24,20 @@ Every Proposal has an expiry date. If a Proposal is not able to raise enough App
 
 ## Usage
 
-To secure an extrinsic via Governance, implement the following trait.
+To secure an extrinsic via Governance, add the following to your pallet's Config.
 
-```rust
+```rust(ignore)
 type EnsureGovernance: EnsureOrigin<<Self as pallet::Config>::Origin>;
 ```
 
 You must also configure the EnsureGovernance struct for your pallet in the runtime configuration:
 
-```rust
+```rust(ignore)
 type EnsureGovernance = pallet_cf_governance::EnsureGovernance;
 ```
 
 To ensure extrinsics you need to make use of the EnsureGovernance struct. Pass the calling origin like in this example to ensure an extrinsic is only executable via the Governance origin:
 
-```rust
+```rust(ignore)
 T::EnsureGovernance::ensure_origin(origin)?;
 ```

--- a/utilities/src/with_std/task_scope.rs
+++ b/utilities/src/with_std/task_scope.rs
@@ -34,7 +34,7 @@
 //! task_scope system has no method to force spawn_blocking tasks to end/cancel, so they must handle
 //! exiting themselves. For example:
 //!
-//! ```rust
+//! ```rust(ignore)
 //! {
 //!     let (sender, receiver) = std::sync::mpsc::channel(10);
 //!
@@ -68,7 +68,7 @@
 //! If you don't do the above when an error occurs the scope will not ever exit, and will wait for
 //! the spawn_blocking to exit forever i.e. if the spawn_blocking was like this instead:
 //!
-//! ```rust
+//! ```rust(ignore)
 //! {
 //!     scope.spawn_blocking(|| {
 //!         loop {
@@ -309,15 +309,22 @@ pub struct Scope<'env, Error: Debug + Send + 'static> {
 	/// Without invariance, this would compile fine but be unsound:
 	///
 	/// ```compile_fail,E0373
+	/// use utilities::task_scope::task_scope;
+	/// use futures::FutureExt;
+	///
 	/// let mut a = 1;
-	/// task_scope(|scope| {
+	/// task_scope::<(), (), _>(|scope| async move {
 	///     scope.spawn(async {
 	///         a += 1;
+	/// 			Ok(())
 	///     });
 	///     scope.spawn(async {
 	///         a += 1; // might run concurrently to other spawn
+	/// 			Ok(())
 	///     });
-	/// });
+	///
+	/// 		Ok(())
+	/// }.boxed());
 	/// ```
 	_phantom: std::marker::PhantomData<&'env mut &'env ()>,
 }

--- a/utilities/src/with_std/task_scope.rs
+++ b/utilities/src/with_std/task_scope.rs
@@ -316,14 +316,14 @@ pub struct Scope<'env, Error: Debug + Send + 'static> {
 	/// task_scope::<(), (), _>(|scope| async move {
 	///     scope.spawn(async {
 	///         a += 1;
-	/// 			Ok(())
+	///             Ok(())
 	///     });
 	///     scope.spawn(async {
 	///         a += 1; // might run concurrently to other spawn
-	/// 			Ok(())
+	///             Ok(())
 	///     });
 	///
-	/// 		Ok(())
+	///             Ok(())
 	/// }.boxed());
 	/// ```
 	_phantom: std::marker::PhantomData<&'env mut &'env ()>,


### PR DESCRIPTION
The cargo aliases we current use, don't run the tests in the binary code. This enables those tests.

Note this also makes it so that all code snippets are tested.