### PR TITLE
fix: set_range_order now returns an error if no position is created

### DIFF
--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -24,7 +24,7 @@ use cf_traits::HistoricalFeeMigration;
 use cf_traits::LpRegistration;
 use frame_system::pallet_prelude::OriginFor;
 use serde::{Deserialize, Serialize};
-use sp_arithmetic::traits::SaturatedConversion;
+use sp_arithmetic::traits::{SaturatedConversion, Zero};
 use sp_std::{boxed::Box, collections::btree_set::BTreeSet, vec::Vec};
 
 pub use pallet::*;
@@ -215,6 +215,18 @@ pub mod pallet {
 		Liquidity { liquidity: Liquidity },
 	}
 
+	impl RangeOrderSize {
+		/// Returns whether or not the maximum amount of assets contained is 0.
+		pub fn max_is_zero(&self) -> bool {
+			match self {
+				RangeOrderSize::AssetAmounts { maximum: PoolPairsMap { base, quote }, .. } =>
+					*base + *quote,
+				RangeOrderSize::Liquidity { liquidity } => *liquidity,
+			}
+			.is_zero()
+		}
+	}
+
 	/// Indicates the change caused by an operation in the positions size, both in terms of
 	/// liquidity and equivalently in asset amounts
 	#[derive(
@@ -398,6 +410,8 @@ pub mod pallet {
 		UnsupportedCall,
 		/// The update can't be scheduled because it has expired (dispatch_at is in the past).
 		LimitOrderUpdateExpired,
+		/// The range order size is invalid.
+		InvalidSize,
 	}
 
 	#[pallet::event]
@@ -569,7 +583,7 @@ pub mod pallet {
 					(None, Some(tick_range)) | (Some(tick_range), None) => Ok(tick_range),
 					(Some(previous_tick_range), Some(new_tick_range)) => {
 						if previous_tick_range != new_tick_range {
-							let withdrawn_asset_amounts = Self::inner_update_range_order(
+							let (withdrawn_asset_amounts, _) = Self::inner_update_range_order(
 								pool,
 								&lp,
 								asset_pair,
@@ -664,7 +678,7 @@ pub mod pallet {
 						Ok(option_new_tick_range.unwrap_or(previous_tick_range))
 					},
 				}?;
-				Self::inner_update_range_order(
+				let (_, liquidity_change) = Self::inner_update_range_order(
 					pool,
 					&lp,
 					asset_pair,
@@ -681,6 +695,13 @@ pub mod pallet {
 					}),
 					NoOpStatus::Allow,
 				)?;
+
+				// Asset input and resultant liquidity changes should be consistent.
+				ensure!(
+					(size.max_is_zero() && liquidity_change.is_zero()) ||
+						(!size.max_is_zero() && !liquidity_change.is_zero()),
+					Error::<T>::InvalidSize
+				);
 
 				Ok(())
 			})
@@ -1475,7 +1496,7 @@ impl<T: Config> Pallet<T> {
 		tick_range: Range<cf_amm::common::Tick>,
 		size_change: IncreaseOrDecrease<range_orders::Size>,
 		noop_status: NoOpStatus,
-	) -> Result<AssetAmounts, DispatchError> {
+	) -> Result<(AssetAmounts, Liquidity), DispatchError> {
 		let (liquidity_change, position_info, assets_change, collected) = match size_change {
 			IncreaseOrDecrease::Increase(size) => {
 				let (assets_debited, minted_liquidity, collected, position_info) =
@@ -1620,7 +1641,7 @@ impl<T: Config> Pallet<T> {
 			});
 		}
 
-		Ok(assets_change)
+		Ok((assets_change, *liquidity_change.abs()))
 	}
 
 	pub fn try_add_limit_order(

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -678,7 +678,7 @@ pub mod pallet {
 						Ok(option_new_tick_range.unwrap_or(previous_tick_range))
 					},
 				}?;
-				let (_, liquidity_change) = Self::inner_update_range_order(
+				let (_, new_order_liquidity) = Self::inner_update_range_order(
 					pool,
 					&lp,
 					asset_pair,
@@ -697,9 +697,11 @@ pub mod pallet {
 				)?;
 
 				// Asset input and resultant liquidity changes should be consistent.
+				// This condition can be breached in cases where eg. the assets amounts are rounded
+				// to zero liquidity.
 				ensure!(
-					(size.max_is_zero() && liquidity_change.is_zero()) ||
-						(!size.max_is_zero() && !liquidity_change.is_zero()),
+					(size.max_is_zero() && new_order_liquidity.is_zero()) ||
+						(!size.max_is_zero() && !new_order_liquidity.is_zero()),
 					Error::<T>::InvalidSize
 				);
 

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -1238,3 +1238,35 @@ fn test_cancel_orders_batch() {
 		)
 	});
 }
+
+#[test]
+fn handle_zero_liquidity_changes_set_range_order() {
+	new_test_ext().execute_with(|| {
+		const POSITION: core::ops::Range<Tick> = -887272..887272;
+		const FLIP: Asset = Asset::Flip;
+
+		// Create a new pool.
+		assert_ok!(LiquidityPools::new_pool(
+			RuntimeOrigin::root(),
+			FLIP,
+			STABLE_ASSET,
+			Default::default(),
+			price_at_tick(0).unwrap(),
+		));
+
+		assert_noop!(
+			LiquidityPools::set_range_order(
+				RuntimeOrigin::signed(ALICE),
+				FLIP,
+				STABLE_ASSET,
+				0,
+				Some(POSITION),
+				RangeOrderSize::AssetAmounts {
+					maximum: AssetAmounts { base: 1, quote: 0 },
+					minimum: AssetAmounts { base: 0, quote: 0 },
+				}
+			),
+			crate::Error::<Test>::InvalidSize
+		);
+	});
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1063

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

In set_range_order, if the input asset (size) is > 0 but the resultant liquidity change is 0, an error is returned.