### PR TITLE
fix: ensure channel open fee can be paid in benchmarks

### DIFF
--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -2,13 +2,15 @@
 
 use super::*;
 use cf_chains::{address::EncodedAddress, benchmarking_value::BenchmarkValue};
-use cf_primitives::Asset;
-use cf_traits::AccountRoleRegistry;
+use cf_primitives::{Asset, FLIPPERINOS_PER_FLIP};
+use cf_traits::{AccountRoleRegistry, FeePayment};
 use frame_benchmarking::v2::*;
 use frame_support::{assert_ok, traits::OnNewAccount};
 use frame_system::RawOrigin;
 
-#[benchmarks]
+#[benchmarks(
+	where <T::FeePayment as cf_traits::FeePayment>::Amount: From<u128>
+)]
 mod benchmarks {
 	use super::*;
 
@@ -21,6 +23,8 @@ mod benchmarks {
 			RawOrigin::Signed(caller.clone()).into(),
 			EncodedAddress::Eth(Default::default()),
 		));
+		// A non-zero balance is required to pay for the channel opening fee.
+		T::FeePayment::mint_to_account(&caller, (5 * FLIPPERINOS_PER_FLIP).into());
 
 		#[extrinsic_call]
 		request_liquidity_deposit_address(RawOrigin::Signed(caller), Asset::Eth, 0);

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -65,6 +65,12 @@ pub mod pallet {
 
 		/// Benchmark weights
 		type WeightInfo: WeightInfo;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		type FeePayment: cf_traits::FeePayment<
+			Amount = <Self as Chainflip>::Amount,
+			AccountId = <Self as frame_system::Config>::AccountId,
+		>;
 	}
 
 	#[pallet::error]

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -5,6 +5,8 @@ use cf_chains::{
 	AnyChain, Chain, Ethereum,
 };
 use cf_primitives::{chains::assets, AccountId, ChannelId};
+#[cfg(feature = "runtime-benchmarks")]
+use cf_traits::mocks::fee_payment::MockFeePayment;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
@@ -102,6 +104,8 @@ impl crate::Config for Test {
 	type SafeMode = MockRuntimeSafeMode;
 	type WeightInfo = ();
 	type PoolApi = Self;
+	#[cfg(feature = "runtime-benchmarks")]
+	type FeePayment = MockFeePayment<Self>;
 }
 
 pub const LP_ACCOUNT: [u8; 32] = [1u8; 32];

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -3,7 +3,8 @@
 use super::*;
 
 use cf_chains::{address::EncodedAddress, benchmarking_value::BenchmarkValue};
-use cf_traits::AccountRoleRegistry;
+use cf_primitives::FLIPPERINOS_PER_FLIP;
+use cf_traits::{AccountRoleRegistry, FeePayment};
 use frame_benchmarking::v2::*;
 use frame_support::{
 	assert_ok,
@@ -11,7 +12,9 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 
-#[benchmarks]
+#[benchmarks(
+	where <T::FeePayment as cf_traits::FeePayment>::Amount: From<u128>
+)]
 mod benchmarks {
 	use super::*;
 
@@ -20,6 +23,8 @@ mod benchmarks {
 		let caller: T::AccountId = whitelisted_caller();
 		<T as frame_system::Config>::OnNewAccount::on_new_account(&caller);
 		assert_ok!(T::AccountRoleRegistry::register_as_broker(&caller));
+		// A non-zero balance is required to pay for the channel opening fee.
+		T::FeePayment::mint_to_account(&caller, (5 * FLIPPERINOS_PER_FLIP).into());
 
 		let origin = RawOrigin::Signed(caller);
 		let call = Call::<T>::request_swap_deposit_address {

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -226,6 +226,12 @@ pub mod pallet {
 
 		/// The Weight information.
 		type WeightInfo: WeightInfo;
+
+		#[cfg(feature = "runtime-benchmarks")]
+		type FeePayment: cf_traits::FeePayment<
+			Amount = <Self as Chainflip>::Amount,
+			AccountId = <Self as frame_system::Config>::AccountId,
+		>;
 	}
 
 	#[pallet::pallet]

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -3,6 +3,8 @@ use core::cell::Cell;
 use crate::{self as pallet_cf_swapping, PalletSafeMode, WeightInfo};
 use cf_chains::AnyChain;
 use cf_primitives::{Asset, AssetAmount};
+#[cfg(feature = "runtime-benchmarks")]
+use cf_traits::mocks::fee_payment::MockFeePayment;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
@@ -140,6 +142,8 @@ impl pallet_cf_swapping::Config for Test {
 	type SwappingApi = MockSwappingApi;
 	type SafeMode = MockRuntimeSafeMode;
 	type WeightInfo = MockWeightInfo;
+	#[cfg(feature = "runtime-benchmarks")]
+	type FeePayment = MockFeePayment<Self>;
 }
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -235,6 +235,8 @@ impl pallet_cf_swapping::Config for Runtime {
 	type AddressConverter = ChainAddressConverter;
 	type SafeMode = RuntimeSafeMode;
 	type WeightInfo = pallet_cf_swapping::weights::PalletWeight<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type FeePayment = Flip;
 }
 
 impl pallet_cf_vaults::Config<EthereumInstance> for Runtime {
@@ -349,6 +351,8 @@ impl pallet_cf_lp::Config for Runtime {
 	type SafeMode = RuntimeSafeMode;
 	type PoolApi = LiquidityPools;
 	type WeightInfo = pallet_cf_lp::weights::PalletWeight<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type FeePayment = Flip;
 }
 
 impl pallet_cf_account_roles::Config for Runtime {


### PR DESCRIPTION
# Pull Request

As a result of #4512 the benchmarks run broke because the caller did not have enough balance to pay for the channel opening fee. 

This fixes the issue by linking the FeePayment benchmark api.