### PR TITLE
chore: remove cf-build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,8 +16,7 @@ cf-test-cfe = "test --package chainflip-engine --package multisig"
 cf-clippy = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings -A deprecated"
 cf-clippy-ci = "clippy --all-targets --features runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests -- -D warnings -A deprecated"
 
-cf-build = "build --features runtime-benchmarks,try-runtime"
-
+cf-build-benchmarks = "build --release --features=runtime-benchmarks"
 cf-build-try-runtime = "build --release --features try-runtime"
 cf-build-release = "build --release"
 cf-build-production = "build --profile=production"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can use either release or debug builds.
 From the repo root, run the following:
 
 ```shell
-cargo cf-build # or cargo cf-build-release
+cargo build
 ./localnet/manage.sh
 ```
 

--- a/state-chain/TROUBLESHOOTING.md
+++ b/state-chain/TROUBLESHOOTING.md
@@ -77,7 +77,7 @@ Make sure to add `my-pallet/try-runtime` in the runtime's Cargo.toml, otherwise 
 ### Compile the node with benchmark features enabled
 
 ```bash
-cargo cf-build-with-benchmarks
+cargo cf-build-benchmarks
 ```
 
 ### Generating weight files

--- a/state-chain/scripts/build-and-benchmark-all.sh
+++ b/state-chain/scripts/build-and-benchmark-all.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 echo "Building the state-chain node with benchmark features enabled..."
-cargo cf-build-with-benchmarks
+cargo build --release --features=runtime-benchmarks
 
 ./state-chain/scripts/benchmark-all.sh


### PR DESCRIPTION
# Pull Request

This command is broken since polkadot-sdk 1.6. 

I decided to remove it pending resolution of the underlying issue. It makes sense (sort of): building with benchmarks enabled is useful for benchmarking only. In 99% of cases we don't want to default to building with benchmarks. 

If you just want to build, you can `cargo build`.
If you want benchmarks, `cargo cf-build-benchmarks`.