### PR TITLE
fix: allow test coverage to run

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -485,6 +485,25 @@ type GrandpaOffenceReporter<T> = pallet_cf_reputation::ChainflipOffenceReporting
 	<T as pallet_session::historical::Config>::FullIdentification,
 >;
 
+// The coverage build can't resolve the Historical KeyOwnerProof type: Returns "error[E0275]:
+// overflow evaluating the requirement `<Runtime as pallet_grandpa::Config>::KeyOwnerProof ==
+// _`".
+// TODO: periodically check this with new rust toolchains by running coverage with `cargo
+// llvm-cov --no-cfg-coverage`.
+#[cfg(coverage)]
+impl pallet_grandpa::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type MaxAuthorities = ConstU32<MAX_AUTHORITIES>;
+	// Note: We don't use nomination.
+	type MaxNominators = ConstU32<0>;
+
+	type MaxSetIdSessionEntries = ConstU64<8>;
+	type KeyOwnerProof = sp_core::Void;
+	type EquivocationReportSystem = ();
+}
+
+#[cfg(not(coverage))]
 impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -485,12 +485,6 @@ type GrandpaOffenceReporter<T> = pallet_cf_reputation::ChainflipOffenceReporting
 	<T as pallet_session::historical::Config>::FullIdentification,
 >;
 
-// The coverage build can't resolve the Historical KeyOwnerProof type: Returns "error[E0275]:
-// overflow evaluating the requirement `<Runtime as pallet_grandpa::Config>::KeyOwnerProof ==
-// _`".
-// TODO: periodically check this with new rust toolchains by running coverage with `cargo
-// llvm-cov --no-cfg-coverage`.
-#[cfg(coverage)]
 impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
@@ -499,20 +493,7 @@ impl pallet_grandpa::Config for Runtime {
 	type MaxNominators = ConstU32<0>;
 
 	type MaxSetIdSessionEntries = ConstU64<8>;
-	type KeyOwnerProof = sp_core::Void;
-	type EquivocationReportSystem = ();
-}
-
-#[cfg(not(coverage))]
-impl pallet_grandpa::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = ();
-	type MaxAuthorities = ConstU32<MAX_AUTHORITIES>;
-	// Note: We don't use nomination.
-	type MaxNominators = ConstU32<0>;
-
-	type MaxSetIdSessionEntries = ConstU64<8>;
-	type KeyOwnerProof = <Historical as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
+	type KeyOwnerProof = sp_session::MembershipProof;
 	type EquivocationReportSystem = pallet_grandpa::EquivocationReportSystem<
 		Self,
 		GrandpaOffenceReporter<Self>,


### PR DESCRIPTION
# Pull Request

This commit prevents a compiler issue with the code coverage test runner. The issue was a compiler overflow when evaluating some trait bounds related to the Grandpa pallet.

~~I wasn't able to solve the underlying problem - presumably it's something related to the internals of llvm-cov, and presumably it will be fixed in due course.~~

~~For now I have avoided the issue by using llvm-cov's cfg(coverage) compiler flag. I used this to conditionally compiler a more 'friendly' version of the offending trait, which is irrelevant to our code coverage. The 'normal' version of this remains active for all other tests and CI checks.~~

Turns out there's a much simpler solution. Thanks @AlastairHolmes 
