### PR TITLE
feat: debug logs on runtime upgrade test

### DIFF
--- a/bouncer/commands/check_witnesses.ts
+++ b/bouncer/commands/check_witnesses.ts
@@ -16,6 +16,7 @@
 import { blake2AsHex } from '@polkadot/util-crypto';
 import { runWithTimeout, sleep, getChainflipApi } from '../shared/utils';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const witnessHash = new Set<any>();
 function hashCall(extrinsic: SubmittableExtrinsic<'promise', ISubmittableResult>) {
   const blakeHash = blake2AsHex(extrinsic.method.toU8a(), 256);
@@ -48,6 +49,7 @@ async function main(): Promise<void> {
       console.log(currentBlockNumber);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     signedBlock.block.extrinsics.forEach((ex: any, _index: any) => {
       if (ex.toHuman().method.method === 'witnessAtEpoch') {
         const callData = ex.toHuman().method.args.call;

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -14,6 +14,7 @@ function tryRuntimeCommand(runtimePath: string, blockParam: string, networkUrl: 
   try {
     execSync(
       `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --checks all ${blockParam} --uri ${networkUrl} 2> ${stderrFile}`,
+      { env: { ...process.env, RUST_LOG: 'runtime::executive=debug' } }
     );
     console.log(`try-runtime success for blockParam ${blockParam}`);
   } catch (e) {

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -14,7 +14,7 @@ function tryRuntimeCommand(runtimePath: string, blockParam: string, networkUrl: 
   try {
     execSync(
       `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --checks all ${blockParam} --uri ${networkUrl} 2> ${stderrFile}`,
-      { env: { ...process.env, RUST_LOG: 'runtime::executive=debug' } }
+      { env: { ...process.env, RUST_LOG: 'runtime::executive=debug' } },
     );
     console.log(`try-runtime success for blockParam ${blockParam}`);
   } catch (e) {


### PR DESCRIPTION
Adds debug logging to the try-runtime checks so it outputs the *value* it can't deecode and not just the key.