### PR TITLE
feat: Expose tx_hash on BroadcastSuccess event

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -540,7 +540,7 @@ mod tests {
 						max_priority_fee_per_gas: None,
 						contract: H160::from([0; 20]),
 						gas_limit: None,
-						tx_ref: Default::default()
+						tx_ref: Default::default(),
 					},
 				},
 			),

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -540,6 +540,7 @@ mod tests {
 						max_priority_fee_per_gas: None,
 						contract: H160::from([0; 20]),
 						gas_limit: None,
+						tx_ref: Default::default()
 					},
 				},
 			),

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -540,7 +540,7 @@ mod tests {
 						max_priority_fee_per_gas: None,
 						contract: H160::from([0; 20]),
 						gas_limit: None,
-						tx_ref: Default::default(),
+						tx_hash: Default::default(),
 					},
 				},
 			),

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -5,12 +5,14 @@ pub mod btc_source;
 use std::sync::Arc;
 
 use bitcoin::BlockHash;
-use cf_chains::btc::{self, deposit_address::DepositAddress, BlockNumber, CHANGE_ADDRESS_SALT, BitcoinTransactionMetadata};
+use cf_chains::btc::{
+	self, deposit_address::DepositAddress, BitcoinTransactionMetadata, BlockNumber,
+	CHANGE_ADDRESS_SALT,
+};
 use cf_primitives::{EpochIndex, NetworkEnvironment};
 use futures_core::Future;
 use secp256k1::hashes::Hash;
-use utilities::task_scope::Scope;
-use utilities::ArrayCollect;
+use utilities::{task_scope::Scope, ArrayCollect};
 
 use crate::{
 	btc::{
@@ -57,7 +59,9 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 					signer_id: DepositAddress::new(epoch.info.0.current, CHANGE_ADDRESS_SALT)
 						.script_pubkey(),
 					tx_fee: tx.fee.unwrap_or_default().to_sat(),
-					tx_metadata: BitcoinTransactionMetadata { tx_ref: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array() },
+					tx_metadata: BitcoinTransactionMetadata {
+						tx_ref: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array(),
+					},
 				},
 			),
 			epoch.index,

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -12,7 +12,7 @@ use cf_chains::btc::{
 use cf_primitives::{EpochIndex, NetworkEnvironment};
 use futures_core::Future;
 use secp256k1::hashes::Hash;
-use utilities::{task_scope::Scope, ArrayCollect};
+use utilities::task_scope::Scope;
 
 use crate::{
 	btc::{
@@ -59,9 +59,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 					signer_id: DepositAddress::new(epoch.info.0.current, CHANGE_ADDRESS_SALT)
 						.script_pubkey(),
 					tx_fee: tx.fee.unwrap_or_default().to_sat(),
-					tx_metadata: BitcoinTransactionMetadata {
-						tx_hash: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array(),
-					},
+					tx_metadata: BitcoinTransactionMetadata::new(tx_hash),
 				},
 			),
 			epoch.index,

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -5,7 +5,7 @@ pub mod btc_source;
 use std::sync::Arc;
 
 use bitcoin::BlockHash;
-use cf_chains::btc::{self, deposit_address::DepositAddress, BlockNumber, CHANGE_ADDRESS_SALT};
+use cf_chains::btc::{self, deposit_address::DepositAddress, BlockNumber, CHANGE_ADDRESS_SALT, BitcoinTransactionMetadata};
 use cf_primitives::{EpochIndex, NetworkEnvironment};
 use futures_core::Future;
 use secp256k1::hashes::Hash;
@@ -56,7 +56,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 					signer_id: DepositAddress::new(epoch.info.0.current, CHANGE_ADDRESS_SALT)
 						.script_pubkey(),
 					tx_fee: tx.fee.unwrap_or_default().to_sat(),
-					tx_metadata: (),
+					tx_metadata: BitcoinTransactionMetadata::default(),
 				},
 			),
 			epoch.index,

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -10,6 +10,7 @@ use cf_primitives::{EpochIndex, NetworkEnvironment};
 use futures_core::Future;
 use secp256k1::hashes::Hash;
 use utilities::task_scope::Scope;
+use utilities::ArrayCollect;
 
 use crate::{
 	btc::{
@@ -56,7 +57,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 					signer_id: DepositAddress::new(epoch.info.0.current, CHANGE_ADDRESS_SALT)
 						.script_pubkey(),
 					tx_fee: tx.fee.unwrap_or_default().to_sat(),
-					tx_metadata: BitcoinTransactionMetadata::default(),
+					tx_metadata: BitcoinTransactionMetadata { tx_ref: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array() },
 				},
 			),
 			epoch.index,

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -60,7 +60,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 						.script_pubkey(),
 					tx_fee: tx.fee.unwrap_or_default().to_sat(),
 					tx_metadata: BitcoinTransactionMetadata {
-						tx_ref: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array(),
+						tx_hash: tx_hash.iter().rev().map(|elem| elem.to_owned()).collect_array(),
 					},
 				},
 			),

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -4,7 +4,7 @@ mod dot_source;
 
 use cf_chains::dot::{
 	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature,
-	PolkadotTransactionMetadata, PolkadotTransactionSignature, PolkadotUncheckedExtrinsic,
+	PolkadotTransactionId, PolkadotTransactionMetadata, PolkadotUncheckedExtrinsic,
 };
 use cf_primitives::{EpochIndex, PolkadotBlockNumber};
 use futures_core::Future;
@@ -158,8 +158,8 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 								signer_id: epoch.info.0,
 								tx_fee,
 								tx_metadata: PolkadotTransactionMetadata {
-									tx_ref: PolkadotTransactionSignature {
-										block_hash: header.hash,
+									tx_id: PolkadotTransactionId {
+										block_number: header.index,
 										extrinsic_index
 									}
 								},

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -3,8 +3,7 @@ mod dot_deposits;
 mod dot_source;
 
 use cf_chains::dot::{
-	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature,
-	PolkadotUncheckedExtrinsic,
+	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature, PolkadotTransactionMetadata, PolkadotUncheckedExtrinsic
 };
 use cf_primitives::{EpochIndex, PolkadotBlockNumber};
 use futures_core::Future;
@@ -157,7 +156,7 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 								tx_out_id: signature,
 								signer_id: epoch.info.0,
 								tx_fee,
-								tx_metadata: (),
+								tx_metadata: PolkadotTransactionMetadata::default(),
 							}
 							.into(),
 							epoch.index,

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -3,7 +3,7 @@ mod dot_deposits;
 mod dot_source;
 
 use cf_chains::dot::{
-	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature, PolkadotTransactionMetadata, PolkadotUncheckedExtrinsic
+	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature, PolkadotTransactionMetadata, PolkadotUncheckedExtrinsic, PolkadotTransactionSignature,
 };
 use cf_primitives::{EpochIndex, PolkadotBlockNumber};
 use futures_core::Future;
@@ -156,7 +156,12 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 								tx_out_id: signature,
 								signer_id: epoch.info.0,
 								tx_fee,
-								tx_metadata: PolkadotTransactionMetadata::default(),
+								tx_metadata: PolkadotTransactionMetadata {
+									tx_ref: PolkadotTransactionSignature {
+										block_hash: header.hash,
+										extrinsic_index
+									}
+								},
 							}
 							.into(),
 							epoch.index,

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -3,7 +3,8 @@ mod dot_deposits;
 mod dot_source;
 
 use cf_chains::dot::{
-	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature, PolkadotTransactionMetadata, PolkadotUncheckedExtrinsic, PolkadotTransactionSignature,
+	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature,
+	PolkadotTransactionMetadata, PolkadotTransactionSignature, PolkadotUncheckedExtrinsic,
 };
 use cf_primitives::{EpochIndex, PolkadotBlockNumber};
 use futures_core::Future;

--- a/engine/src/witness/eth/key_manager.rs
+++ b/engine/src/witness/eth/key_manager.rs
@@ -130,7 +130,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 								max_fee_per_gas: transaction.max_fee_per_gas,
 								max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 								gas_limit: Some(transaction.gas),
-								tx_ref: transaction.hash,
+								tx_hash: transaction.hash,
 							};
 							pallet_cf_broadcast::Call::<
 								_,

--- a/engine/src/witness/eth/key_manager.rs
+++ b/engine/src/witness/eth/key_manager.rs
@@ -130,7 +130,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 								max_fee_per_gas: transaction.max_fee_per_gas,
 								max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 								gas_limit: Some(transaction.gas),
-								tx_ref: transaction.hash
+								tx_ref: transaction.hash,
 							};
 							pallet_cf_broadcast::Call::<
 								_,

--- a/engine/src/witness/eth/key_manager.rs
+++ b/engine/src/witness/eth/key_manager.rs
@@ -130,7 +130,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 								max_fee_per_gas: transaction.max_fee_per_gas,
 								max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 								gas_limit: Some(transaction.gas),
-								tx_ref: Default::default()
+								tx_ref: transaction.hash
 							};
 							pallet_cf_broadcast::Call::<
 								_,

--- a/engine/src/witness/eth/key_manager.rs
+++ b/engine/src/witness/eth/key_manager.rs
@@ -130,6 +130,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 								max_fee_per_gas: transaction.max_fee_per_gas,
 								max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 								gas_limit: Some(transaction.gas),
+								tx_ref: Default::default()
 							};
 							pallet_cf_broadcast::Call::<
 								_,

--- a/state-chain/chains/src/any.rs
+++ b/state-chain/chains/src/any.rs
@@ -24,7 +24,7 @@ impl Chain for AnyChain {
 	type TransactionMetadata = ();
 	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
-	type TransactionHashItem = ();
+	type TransactionRef = ();
 }
 
 impl FeeRefundCalculator<AnyChain> for () {

--- a/state-chain/chains/src/any.rs
+++ b/state-chain/chains/src/any.rs
@@ -24,6 +24,7 @@ impl Chain for AnyChain {
 	type TransactionMetadata = ();
 	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
+	type TransactionHashItem = ();
 }
 
 impl FeeRefundCalculator<AnyChain> for () {

--- a/state-chain/chains/src/benchmarking_value.rs
+++ b/state-chain/chains/src/benchmarking_value.rs
@@ -12,11 +12,11 @@ use crate::address::EncodedAddress;
 #[cfg(feature = "runtime-benchmarks")]
 use crate::address::ForeignChainAddress;
 #[cfg(feature = "runtime-benchmarks")]
-use crate::evm::{EvmFetchId, EvmTransactionMetadata};
+use crate::btc::BitcoinTransactionMetadata;
 #[cfg(feature = "runtime-benchmarks")]
 use crate::dot::PolkadotTransactionMetadata;
 #[cfg(feature = "runtime-benchmarks")]
-use crate::btc::BitcoinTransactionMetadata;
+use crate::evm::{EvmFetchId, EvmTransactionMetadata};
 
 /// Ensure type specifies a value to be used for benchmarking purposes.
 pub trait BenchmarkValue {
@@ -136,7 +136,7 @@ impl BenchmarkValue for EvmTransactionMetadata {
 			max_fee_per_gas: Some(U256::zero()),
 			max_priority_fee_per_gas: Some(U256::zero()),
 			gas_limit: None,
-			tx_ref: Default::default()
+			tx_ref: Default::default(),
 		}
 	}
 }
@@ -144,18 +144,14 @@ impl BenchmarkValue for EvmTransactionMetadata {
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for PolkadotTransactionMetadata {
 	fn benchmark_value() -> Self {
-		Self {
-			tx_ref: Default::default()
-		}
+		Self { tx_ref: Default::default() }
 	}
 }
 
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for BitcoinTransactionMetadata {
 	fn benchmark_value() -> Self {
-		Self {
-			tx_ref: Default::default()
-		}
+		Self { tx_ref: Default::default() }
 	}
 }
 

--- a/state-chain/chains/src/benchmarking_value.rs
+++ b/state-chain/chains/src/benchmarking_value.rs
@@ -13,6 +13,10 @@ use crate::address::EncodedAddress;
 use crate::address::ForeignChainAddress;
 #[cfg(feature = "runtime-benchmarks")]
 use crate::evm::{EvmFetchId, EvmTransactionMetadata};
+#[cfg(feature = "runtime-benchmarks")]
+use crate::dot::PolkadotTransactionMetadata;
+#[cfg(feature = "runtime-benchmarks")]
+use crate::btc::BitcoinTransactionMetadata;
 
 /// Ensure type specifies a value to be used for benchmarking purposes.
 pub trait BenchmarkValue {
@@ -132,6 +136,25 @@ impl BenchmarkValue for EvmTransactionMetadata {
 			max_fee_per_gas: Some(U256::zero()),
 			max_priority_fee_per_gas: Some(U256::zero()),
 			gas_limit: None,
+			tx_ref: Default::default()
+		}
+	}
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl BenchmarkValue for PolkadotTransactionMetadata {
+	fn benchmark_value() -> Self {
+		Self {
+			tx_ref: Default::default()
+		}
+	}
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl BenchmarkValue for BitcoinTransactionMetadata {
+	fn benchmark_value() -> Self {
+		Self {
+			tx_ref: Default::default()
 		}
 	}
 }

--- a/state-chain/chains/src/benchmarking_value.rs
+++ b/state-chain/chains/src/benchmarking_value.rs
@@ -136,7 +136,7 @@ impl BenchmarkValue for EvmTransactionMetadata {
 			max_fee_per_gas: Some(U256::zero()),
 			max_priority_fee_per_gas: Some(U256::zero()),
 			gas_limit: None,
-			tx_ref: Default::default(),
+			tx_hash: Default::default(),
 		}
 	}
 }
@@ -144,14 +144,14 @@ impl BenchmarkValue for EvmTransactionMetadata {
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for PolkadotTransactionMetadata {
 	fn benchmark_value() -> Self {
-		Self { tx_ref: Default::default() }
+		Self { tx_id: Default::default() }
 	}
 }
 
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for BitcoinTransactionMetadata {
 	fn benchmark_value() -> Self {
-		Self { tx_ref: Default::default() }
+		Self { tx_hash: Default::default() }
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -243,7 +243,8 @@ pub struct BitcoinTransactionMetadata {
 }
 impl BitcoinTransactionMetadata {
 	/// It creates a tx_hash by reversing the provided hash
-	/// Btc softwares and explorers display blocks/txs hashes as big endian values, we need to convert it to obtain a valid tx hash
+	/// Btc softwares and explorers display blocks/txs hashes as big endian values, we need to
+	/// convert it to obtain a valid tx hash
 	pub fn new(hash: Hash) -> Self {
 		BitcoinTransactionMetadata { tx_hash: hash.iter().rev().copied().collect_array() }
 	}

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use self::deposit_address::DepositAddress;
 use crate::{
 	Chain, ChainCrypto, DepositChannel, FeeEstimationApi, FeeRefundCalculator, RetryPolicy,
-	TransactionMetadata, TransactionMetadataHash,
+	TransactionMetadata,
 };
 use alloc::{collections::VecDeque, string::String};
 use arrayref::array_ref;
@@ -239,23 +239,20 @@ impl ConsolidationParameters {
 	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
 pub struct BitcoinTransactionMetadata {
-	pub tx_ref: Hash,
+	pub tx_hash: Hash,
 }
 
-impl<C: Chain<TransactionHashItem = Hash>> TransactionMetadataHash<C>
-	for BitcoinTransactionMetadata
-{
-	fn get_transaction_hash(&self) -> <C as Chain>::TransactionHashItem {
-		self.tx_ref
-	}
-}
-impl<C: Chain> TransactionMetadata<C> for BitcoinTransactionMetadata {
+impl<C: Chain<TransactionRef = Hash>> TransactionMetadata<C> for BitcoinTransactionMetadata {
 	fn extract_metadata(_transaction: &<C as Chain>::Transaction) -> Self {
 		Default::default()
 	}
 
 	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
 		true
+	}
+
+	fn get_transaction_ref(&self) -> <C as Chain>::TransactionRef {
+		self.tx_hash
 	}
 }
 
@@ -279,7 +276,7 @@ impl Chain for Bitcoin {
 	// There is no need for replay protection on Bitcoin since it is a UTXO chain.
 	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
-	type TransactionHashItem = Hash;
+	type TransactionRef = Hash;
 }
 
 #[derive(Clone, Copy, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq)]

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -4,12 +4,10 @@ pub mod deposit_address;
 pub mod utxo_selection;
 
 extern crate alloc;
-use core::{cmp::max, mem::size_of};
-use crate::TransactionHashTest;
-use crate::TransactionMetadata;
 use self::deposit_address::DepositAddress;
 use crate::{
 	Chain, ChainCrypto, DepositChannel, FeeEstimationApi, FeeRefundCalculator, RetryPolicy,
+	TransactionMetadata, TransactionMetadataHash,
 };
 use alloc::{collections::VecDeque, string::String};
 use arrayref::array_ref;
@@ -22,6 +20,7 @@ use cf_primitives::{
 };
 use cf_utilities::SliceToArray;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::{cmp::max, mem::size_of};
 use frame_support::{
 	pallet_prelude::RuntimeDebug,
 	sp_runtime::{FixedPointNumber, FixedU128},
@@ -243,18 +242,20 @@ pub struct BitcoinTransactionMetadata {
 	pub tx_ref: Hash,
 }
 
-impl <C: Chain<TransactionHashItem = Hash>> TransactionHashTest<C> for BitcoinTransactionMetadata {
+impl<C: Chain<TransactionHashItem = Hash>> TransactionMetadataHash<C>
+	for BitcoinTransactionMetadata
+{
 	fn get_transaction_hash(&self) -> <C as Chain>::TransactionHashItem {
 		self.tx_ref
 	}
 }
-impl<C: Chain>TransactionMetadata<C> for BitcoinTransactionMetadata {
+impl<C: Chain> TransactionMetadata<C> for BitcoinTransactionMetadata {
 	fn extract_metadata(_transaction: &<C as Chain>::Transaction) -> Self {
 		Default::default()
 	}
 
-	fn verify_metadata(&self, expected_metadata: &Self) -> bool {
-		self.tx_ref == expected_metadata.tx_ref
+	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
+		true
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -242,6 +242,8 @@ pub struct BitcoinTransactionMetadata {
 	pub tx_hash: Hash,
 }
 impl BitcoinTransactionMetadata {
+	/// It creates a tx_hash by reversing the provided hash
+	/// Btc softwares and explorers display blocks/txs hashes as big endian values, we need to convert it to obtain a valid tx hash
 	pub fn new(hash: Hash) -> Self {
 		BitcoinTransactionMetadata { tx_hash: hash.iter().rev().copied().collect_array() }
 	}

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -318,17 +318,12 @@ impl FeeEstimationApi<Polkadot> for PolkadotTrackedData {
 	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
 pub struct PolkadotTransactionMetadata {
-	pub tx_ref: PolkadotTransactionSignature,
+	pub tx_id: PolkadotTransactionId,
 }
 
-impl<C: Chain<TransactionHashItem = PolkadotTransactionSignature>> TransactionMetadataHash<C>
+impl<C: Chain<TransactionRef = PolkadotTransactionId>> TransactionMetadata<C>
 	for PolkadotTransactionMetadata
 {
-	fn get_transaction_hash(&self) -> <C as Chain>::TransactionHashItem {
-		self.tx_ref.clone()
-	}
-}
-impl<C: Chain> TransactionMetadata<C> for PolkadotTransactionMetadata {
 	fn extract_metadata(_transaction: &<C as Chain>::Transaction) -> Self {
 		Default::default()
 	}
@@ -336,13 +331,17 @@ impl<C: Chain> TransactionMetadata<C> for PolkadotTransactionMetadata {
 	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
 		true
 	}
+
+	fn get_transaction_ref(&self) -> <C as Chain>::TransactionRef {
+		self.tx_id.clone()
+	}
 }
 
 #[derive(
 	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
-pub struct PolkadotTransactionSignature {
-	pub block_hash: H256,
+pub struct PolkadotTransactionId {
+	pub block_number: PolkadotBlockNumber,
 	pub extrinsic_index: u32,
 }
 
@@ -365,7 +364,7 @@ impl Chain for Polkadot {
 	type TransactionMetadata = PolkadotTransactionMetadata;
 	type ReplayProtectionParams = ResetProxyAccountNonce;
 	type ReplayProtection = PolkadotReplayProtection;
-	type TransactionHashItem = PolkadotTransactionSignature;
+	type TransactionRef = PolkadotTransactionId;
 }
 
 pub type ResetProxyAccountNonce = bool;

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -339,7 +339,7 @@ impl<C: Chain>TransactionMetadata<C> for PolkadotTransactionMetadata {
 #[derive(
 	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
-pub struct PolkadotTransactionSignature { block_hash: sp_core::H160, extrinsic_index: u32, }
+pub struct PolkadotTransactionSignature { pub block_hash: H256, pub extrinsic_index: u32, }
 
 impl Chain for Polkadot {
 	const NAME: &'static str = "Polkadot";

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -321,25 +321,30 @@ pub struct PolkadotTransactionMetadata {
 	pub tx_ref: PolkadotTransactionSignature,
 }
 
-impl <C: Chain<TransactionHashItem = PolkadotTransactionSignature>> TransactionHashTest<C> for PolkadotTransactionMetadata {
+impl<C: Chain<TransactionHashItem = PolkadotTransactionSignature>> TransactionMetadataHash<C>
+	for PolkadotTransactionMetadata
+{
 	fn get_transaction_hash(&self) -> <C as Chain>::TransactionHashItem {
 		self.tx_ref.clone()
 	}
 }
-impl<C: Chain>TransactionMetadata<C> for PolkadotTransactionMetadata {
+impl<C: Chain> TransactionMetadata<C> for PolkadotTransactionMetadata {
 	fn extract_metadata(_transaction: &<C as Chain>::Transaction) -> Self {
 		Default::default()
 	}
 
-	fn verify_metadata(&self, expected_metadata: &Self) -> bool {
-		self.tx_ref == expected_metadata.tx_ref
+	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
+		true
 	}
 }
 
 #[derive(
 	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
-pub struct PolkadotTransactionSignature { pub block_hash: H256, pub extrinsic_index: u32, }
+pub struct PolkadotTransactionSignature {
+	pub block_hash: H256,
+	pub extrinsic_index: u32,
+}
 
 impl Chain for Polkadot {
 	const NAME: &'static str = "Polkadot";

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -314,6 +314,33 @@ impl FeeEstimationApi<Polkadot> for PolkadotTrackedData {
 	}
 }
 
+#[derive(
+	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+pub struct PolkadotTransactionMetadata {
+	pub tx_ref: PolkadotTransactionSignature,
+}
+
+impl <C: Chain<TransactionHashItem = PolkadotTransactionSignature>> TransactionHashTest<C> for PolkadotTransactionMetadata {
+	fn get_transaction_hash(&self) -> <C as Chain>::TransactionHashItem {
+		self.tx_ref.clone()
+	}
+}
+impl<C: Chain>TransactionMetadata<C> for PolkadotTransactionMetadata {
+	fn extract_metadata(_transaction: &<C as Chain>::Transaction) -> Self {
+		Default::default()
+	}
+
+	fn verify_metadata(&self, expected_metadata: &Self) -> bool {
+		self.tx_ref == expected_metadata.tx_ref
+	}
+}
+
+#[derive(
+	Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+pub struct PolkadotTransactionSignature { block_hash: sp_core::H160, extrinsic_index: u32, }
+
 impl Chain for Polkadot {
 	const NAME: &'static str = "Polkadot";
 	const GAS_ASSET: Self::ChainAsset = assets::dot::Asset::Dot;
@@ -330,9 +357,10 @@ impl Chain for Polkadot {
 	type DepositChannelState = PolkadotChannelState;
 	type DepositDetails = ();
 	type Transaction = PolkadotTransactionData;
-	type TransactionMetadata = ();
+	type TransactionMetadata = PolkadotTransactionMetadata;
 	type ReplayProtectionParams = ResetProxyAccountNonce;
 	type ReplayProtection = PolkadotReplayProtection;
+	type TransactionHashItem = PolkadotTransactionSignature;
 }
 
 pub type ResetProxyAccountNonce = bool;

--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -47,7 +47,7 @@ impl Chain for Ethereum {
 	type TransactionMetadata = EvmTransactionMetadata;
 	type ReplayProtectionParams = Self::ChainAccount;
 	type ReplayProtection = EvmReplayProtection;
-	type TransactionHashItem = H256;
+	type TransactionRef = H256;
 }
 #[derive(
 	Copy,

--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -47,6 +47,7 @@ impl Chain for Ethereum {
 	type TransactionMetadata = EvmTransactionMetadata;
 	type ReplayProtectionParams = Self::ChainAccount;
 	type ReplayProtection = EvmReplayProtection;
+	type TransactionHashItem = H256;
 }
 #[derive(
 	Copy,

--- a/state-chain/chains/src/evm.rs
+++ b/state-chain/chains/src/evm.rs
@@ -406,7 +406,7 @@ impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransact
 			check_optional!(gas_limit)
 	}
 }
-impl <C: Chain<TransactionHashItem = H256>> TransactionHashTest<C> for EvmTransactionMetadata {
+impl<C: Chain<TransactionHashItem = H256>> TransactionMetadataHash<C> for EvmTransactionMetadata {
 	fn get_transaction_hash(&self) -> C::TransactionHashItem {
 		self.tx_ref
 	}

--- a/state-chain/chains/src/evm.rs
+++ b/state-chain/chains/src/evm.rs
@@ -379,17 +379,19 @@ pub struct EvmTransactionMetadata {
 	pub max_priority_fee_per_gas: Option<Uint>,
 	pub contract: Address,
 	pub gas_limit: Option<Uint>,
-	pub tx_ref: H256,
+	pub tx_hash: H256,
 }
 
-impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransactionMetadata {
+impl<C: Chain<Transaction = Transaction, TransactionRef = H256>> TransactionMetadata<C>
+	for EvmTransactionMetadata
+{
 	fn extract_metadata(transaction: &<C as Chain>::Transaction) -> Self {
 		Self {
 			contract: transaction.contract,
 			max_fee_per_gas: transaction.max_fee_per_gas,
 			max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 			gas_limit: transaction.gas_limit,
-			tx_ref: Default::default(),
+			tx_hash: Default::default(),
 		}
 	}
 
@@ -405,12 +407,11 @@ impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransact
 			check_optional!(max_priority_fee_per_gas) &&
 			check_optional!(gas_limit)
 	}
-}
-impl<C: Chain<TransactionHashItem = H256>> TransactionMetadataHash<C> for EvmTransactionMetadata {
-	fn get_transaction_hash(&self) -> C::TransactionHashItem {
-		self.tx_ref
+	fn get_transaction_ref(&self) -> C::TransactionRef {
+		self.tx_hash
 	}
 }
+
 impl Transaction {
 	fn check_contract(
 		&self,
@@ -764,7 +765,7 @@ fn metadata_verification() {
 		max_priority_fee_per_gas: Some(U256::one()),
 		contract: Default::default(),
 		gas_limit: None,
-		tx_ref: Default::default(),
+		tx_hash: Default::default(),
 	};
 
 	// Exact match.

--- a/state-chain/chains/src/evm.rs
+++ b/state-chain/chains/src/evm.rs
@@ -379,6 +379,7 @@ pub struct EvmTransactionMetadata {
 	pub max_priority_fee_per_gas: Option<Uint>,
 	pub contract: Address,
 	pub gas_limit: Option<Uint>,
+	pub tx_ref: H256,
 }
 
 impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransactionMetadata {
@@ -388,6 +389,7 @@ impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransact
 			max_fee_per_gas: transaction.max_fee_per_gas,
 			max_priority_fee_per_gas: transaction.max_priority_fee_per_gas,
 			gas_limit: transaction.gas_limit,
+			tx_ref: Default::default(),
 		}
 	}
 
@@ -404,7 +406,11 @@ impl<C: Chain<Transaction = Transaction>> TransactionMetadata<C> for EvmTransact
 			check_optional!(gas_limit)
 	}
 }
-
+impl <C: Chain<TransactionHashItem = H256>> TransactionHashTest<C> for EvmTransactionMetadata {
+	fn get_transaction_hash(&self) -> C::TransactionHashItem {
+		self.tx_ref
+	}
+}
 impl Transaction {
 	fn check_contract(
 		&self,
@@ -758,6 +764,7 @@ fn metadata_verification() {
 		max_priority_fee_per_gas: Some(U256::one()),
 		contract: Default::default(),
 		gas_limit: None,
+		tx_ref: Default::default(),
 	};
 
 	// Exact match.

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -138,10 +138,12 @@ pub trait Chain: Member + Parameter {
 		+ Parameter
 		+ TransactionMetadata<Self>
 		+ BenchmarkValue
-		+ Default;
+		+ Default
+		+ TransactionHashTest<Self>;
 	/// Passed in to construct the replay protection.
 	type ReplayProtectionParams: Member + Parameter;
 	type ReplayProtection: Member + Parameter;
+	type TransactionHashItem: Member + Parameter;
 }
 
 /// Common crypto-related types and operations for some external chain.
@@ -251,6 +253,14 @@ where
 	/// Calculate the Units of gas that is allowed to make this call.
 	fn calculate_gas_limit(_call: &Call) -> Option<U256> {
 		Default::default()
+	}
+}
+
+pub trait TransactionHashTest<C: Chain> {
+	fn get_transaction_hash(&self) -> C::TransactionHashItem;
+}
+impl <C: Chain<TransactionHashItem = ()>> TransactionHashTest<C> for () {
+	fn get_transaction_hash(&self) -> C::TransactionHashItem {
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -139,11 +139,13 @@ pub trait Chain: Member + Parameter {
 		+ TransactionMetadata<Self>
 		+ BenchmarkValue
 		+ Default
-		+ TransactionHashTest<Self>;
+		+ TransactionMetadataHash<Self>;
+
+	type TransactionHashItem: Member + Parameter;
+
 	/// Passed in to construct the replay protection.
 	type ReplayProtectionParams: Member + Parameter;
 	type ReplayProtection: Member + Parameter;
-	type TransactionHashItem: Member + Parameter;
 }
 
 /// Common crypto-related types and operations for some external chain.
@@ -256,12 +258,11 @@ where
 	}
 }
 
-pub trait TransactionHashTest<C: Chain> {
+pub trait TransactionMetadataHash<C: Chain> {
 	fn get_transaction_hash(&self) -> C::TransactionHashItem;
 }
-impl <C: Chain<TransactionHashItem = ()>> TransactionHashTest<C> for () {
-	fn get_transaction_hash(&self) -> C::TransactionHashItem {
-	}
+impl<C: Chain<TransactionHashItem = ()>> TransactionMetadataHash<C> for () {
+	fn get_transaction_hash(&self) -> C::TransactionHashItem {}
 }
 
 pub trait TransactionMetadata<C: Chain> {

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -140,7 +140,7 @@ pub trait Chain: Member + Parameter {
 		+ BenchmarkValue
 		+ Default
 		+ TransactionMetadataHash<Self>;
-
+	/// The type representing the transaction hash for this particular chain
 	type TransactionHashItem: Member + Parameter;
 
 	/// Passed in to construct the replay protection.

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -138,10 +138,10 @@ pub trait Chain: Member + Parameter {
 		+ Parameter
 		+ TransactionMetadata<Self>
 		+ BenchmarkValue
-		+ Default
-		+ TransactionMetadataHash<Self>;
+		+ Default;
+
 	/// The type representing the transaction hash for this particular chain
-	type TransactionHashItem: Member + Parameter;
+	type TransactionRef: Member + Parameter;
 
 	/// Passed in to construct the replay protection.
 	type ReplayProtectionParams: Member + Parameter;
@@ -258,25 +258,20 @@ where
 	}
 }
 
-pub trait TransactionMetadataHash<C: Chain> {
-	fn get_transaction_hash(&self) -> C::TransactionHashItem;
-}
-impl<C: Chain<TransactionHashItem = ()>> TransactionMetadataHash<C> for () {
-	fn get_transaction_hash(&self) -> C::TransactionHashItem {}
-}
-
 pub trait TransactionMetadata<C: Chain> {
 	fn extract_metadata(transaction: &C::Transaction) -> Self;
 	fn verify_metadata(&self, expected_metadata: &Self) -> bool;
+	fn get_transaction_ref(&self) -> C::TransactionRef;
 }
 
-impl<C: Chain> TransactionMetadata<C> for () {
+impl<C: Chain<TransactionRef = ()>> TransactionMetadata<C> for () {
 	fn extract_metadata(_transaction: &C::Transaction) -> Self {
 		Default::default()
 	}
 	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
 		true
 	}
+	fn get_transaction_ref(&self) -> C::TransactionRef {}
 }
 
 /// Contains all the parameters required to fetch incoming transactions on an external chain.

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -66,13 +66,11 @@ impl TransactionMetadata<MockEthereum> for MockEthereumTransactionMetadata {
 	fn verify_metadata(&self, _expected_metadata: &Self) -> bool {
 		MOCK_VALID_METADATA.with(|cell| *cell.borrow())
 	}
-}
-
-impl TransactionMetadataHash<MockEthereum> for MockEthereumTransactionMetadata {
-	fn get_transaction_hash(&self) -> <MockEthereum as Chain>::TransactionHashItem {
+	fn get_transaction_ref(&self) -> <MockEthereum as Chain>::TransactionRef {
 		Default::default()
 	}
 }
+
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for MockEthereumTransactionMetadata {
 	fn benchmark_value() -> Self {
@@ -107,7 +105,7 @@ impl Chain for MockEthereum {
 	type TransactionMetadata = MockEthereumTransactionMetadata;
 	type ReplayProtectionParams = ();
 	type ReplayProtection = EvmReplayProtection;
-	type TransactionHashItem = ();
+	type TransactionRef = ();
 }
 
 impl ToHumanreadableAddress for u64 {

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -68,7 +68,7 @@ impl TransactionMetadata<MockEthereum> for MockEthereumTransactionMetadata {
 	}
 }
 
-impl TransactionHashTest<MockEthereum> for MockEthereumTransactionMetadata {
+impl TransactionMetadataHash<MockEthereum> for MockEthereumTransactionMetadata {
 	fn get_transaction_hash(&self) -> <MockEthereum as Chain>::TransactionHashItem {
 		Default::default()
 	}

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -68,6 +68,11 @@ impl TransactionMetadata<MockEthereum> for MockEthereumTransactionMetadata {
 	}
 }
 
+impl TransactionHashTest<MockEthereum> for MockEthereumTransactionMetadata {
+	fn get_transaction_hash(&self) -> <MockEthereum as Chain>::TransactionHashItem {
+		Default::default()
+	}
+}
 #[cfg(feature = "runtime-benchmarks")]
 impl BenchmarkValue for MockEthereumTransactionMetadata {
 	fn benchmark_value() -> Self {
@@ -102,6 +107,7 @@ impl Chain for MockEthereum {
 	type TransactionMetadata = MockEthereumTransactionMetadata;
 	type ReplayProtectionParams = ();
 	type ReplayProtection = EvmReplayProtection;
+	type TransactionHashItem = ();
 }
 
 impl ToHumanreadableAddress for u64 {

--- a/state-chain/chains/src/none.rs
+++ b/state-chain/chains/src/none.rs
@@ -23,6 +23,7 @@ impl Chain for NoneChain {
 	type TransactionMetadata = ();
 	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
+	type TransactionHashItem = ();
 }
 
 impl FeeRefundCalculator<NoneChain> for () {

--- a/state-chain/chains/src/none.rs
+++ b/state-chain/chains/src/none.rs
@@ -23,7 +23,7 @@ impl Chain for NoneChain {
 	type TransactionMetadata = ();
 	type ReplayProtectionParams = ();
 	type ReplayProtection = ();
-	type TransactionHashItem = ();
+	type TransactionRef = ();
 }
 
 impl FeeRefundCalculator<NoneChain> for () {

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -15,7 +15,7 @@ use cf_primitives::{BroadcastId, ThresholdSignatureRequestId};
 
 use cf_chains::{
 	ApiCall, Chain, ChainCrypto, FeeRefundCalculator, RetryPolicy, TransactionBuilder,
-	TransactionMetadata as _,
+	TransactionMetadata as _, TransactionHashTest,
 };
 use cf_traits::{
 	offence_reporting::OffenceReporter, BroadcastNomination, Broadcaster, CfeBroadcastRequest,
@@ -80,6 +80,9 @@ pub mod pallet {
 
 	pub type TransactionOutIdFor<T, I> =
 		<<<T as Config<I>>::TargetChain as Chain>::ChainCrypto as ChainCrypto>::TransactionOutId;
+	
+	pub type TransactionHashFor<T, I> =
+		<<T as Config<I>>::TargetChain as Chain>::TransactionHashItem;
 
 	/// Type alias for the instance's configured Payload.
 	pub type PayloadFor<T, I> =
@@ -316,6 +319,7 @@ pub mod pallet {
 		BroadcastSuccess {
 			broadcast_id: BroadcastId,
 			transaction_out_id: TransactionOutIdFor<T, I>,
+			transaction_hash: TransactionHashFor<T, I>,
 		},
 		/// A broadcast's threshold signature is invalid, we will attempt to re-sign it.
 		ThresholdSignatureInvalid { broadcast_id: BroadcastId },
@@ -589,6 +593,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T, I>::BroadcastSuccess {
 				broadcast_id,
 				transaction_out_id: tx_out_id,
+				transaction_hash: tx_metadata.get_transaction_hash(),
 			});
 			Ok(().into())
 		}

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -15,7 +15,7 @@ use cf_primitives::{BroadcastId, ThresholdSignatureRequestId};
 
 use cf_chains::{
 	ApiCall, Chain, ChainCrypto, FeeRefundCalculator, RetryPolicy, TransactionBuilder,
-	TransactionMetadata as _, TransactionMetadataHash,
+	TransactionMetadata as _,
 };
 use cf_traits::{
 	offence_reporting::OffenceReporter, BroadcastNomination, Broadcaster, CfeBroadcastRequest,
@@ -81,8 +81,7 @@ pub mod pallet {
 	pub type TransactionOutIdFor<T, I> =
 		<<<T as Config<I>>::TargetChain as Chain>::ChainCrypto as ChainCrypto>::TransactionOutId;
 
-	pub type TransactionHashFor<T, I> =
-		<<T as Config<I>>::TargetChain as Chain>::TransactionHashItem;
+	pub type TransactionRefFor<T, I> = <<T as Config<I>>::TargetChain as Chain>::TransactionRef;
 
 	/// Type alias for the instance's configured Payload.
 	pub type PayloadFor<T, I> =
@@ -319,7 +318,7 @@ pub mod pallet {
 		BroadcastSuccess {
 			broadcast_id: BroadcastId,
 			transaction_out_id: TransactionOutIdFor<T, I>,
-			transaction_hash: TransactionHashFor<T, I>,
+			transaction_ref: TransactionRefFor<T, I>,
 		},
 		/// A broadcast's threshold signature is invalid, we will attempt to re-sign it.
 		ThresholdSignatureInvalid { broadcast_id: BroadcastId },
@@ -593,7 +592,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T, I>::BroadcastSuccess {
 				broadcast_id,
 				transaction_out_id: tx_out_id,
-				transaction_hash: tx_metadata.get_transaction_hash(),
+				transaction_ref: tx_metadata.get_transaction_ref(),
 			});
 			Ok(().into())
 		}

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -15,7 +15,7 @@ use cf_primitives::{BroadcastId, ThresholdSignatureRequestId};
 
 use cf_chains::{
 	ApiCall, Chain, ChainCrypto, FeeRefundCalculator, RetryPolicy, TransactionBuilder,
-	TransactionMetadata as _, TransactionHashTest,
+	TransactionMetadata as _, TransactionMetadataHash,
 };
 use cf_traits::{
 	offence_reporting::OffenceReporter, BroadcastNomination, Broadcaster, CfeBroadcastRequest,
@@ -80,7 +80,7 @@ pub mod pallet {
 
 	pub type TransactionOutIdFor<T, I> =
 		<<<T as Config<I>>::TargetChain as Chain>::ChainCrypto as ChainCrypto>::TransactionOutId;
-	
+
 	pub type TransactionHashFor<T, I> =
 		<<T as Config<I>>::TargetChain as Chain>::TransactionHashItem;
 

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -997,7 +997,7 @@ fn aborted_broadcasts_can_still_succeed() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default()
+					transaction_hash: Default::default(),
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);
@@ -1151,7 +1151,7 @@ fn succeeded_broadcasts_will_not_retry() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default()
+					transaction_hash: Default::default(),
 				},
 			));
 			broadcast_id
@@ -1264,7 +1264,7 @@ fn broadcast_is_retried_without_initial_nominee() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default()
+					transaction_hash: Default::default(),
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -14,7 +14,7 @@ use cf_chains::{
 		MockEthereumChainCrypto, MockEthereumTransactionMetadata, MockThresholdSignature,
 		MockTransactionBuilder, ETH_TX_FEE, MOCK_TRANSACTION_OUT_ID, MOCK_TX_METADATA,
 	},
-	ChainCrypto, FeeRefundCalculator,
+	ChainCrypto, FeeRefundCalculator, TransactionMetadata as _,
 };
 use cf_traits::{
 	mocks::{

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -459,7 +459,8 @@ fn threshold_sign_and_broadcast_with_callback() {
 			events.pop().expect("an event").event,
 			RuntimeEvent::Broadcaster(crate::Event::BroadcastSuccess {
 				broadcast_id,
-				transaction_out_id: api_call.tx_out_id
+				transaction_out_id: api_call.tx_out_id,
+				transaction_hash: Default::default()
 			})
 		);
 		assert_eq!(
@@ -996,6 +997,7 @@ fn aborted_broadcasts_can_still_succeed() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
+					transaction_hash: Default::default()
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);
@@ -1149,6 +1151,7 @@ fn succeeded_broadcasts_will_not_retry() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
+					transaction_hash: Default::default()
 				},
 			));
 			broadcast_id
@@ -1261,6 +1264,7 @@ fn broadcast_is_retried_without_initial_nominee() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
+					transaction_hash: Default::default()
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -460,7 +460,7 @@ fn threshold_sign_and_broadcast_with_callback() {
 			RuntimeEvent::Broadcaster(crate::Event::BroadcastSuccess {
 				broadcast_id,
 				transaction_out_id: api_call.tx_out_id,
-				transaction_hash: Default::default()
+				transaction_ref: MOCK_TX_METADATA.get_transaction_ref(),
 			})
 		);
 		assert_eq!(
@@ -997,7 +997,7 @@ fn aborted_broadcasts_can_still_succeed() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default(),
+					transaction_ref: MOCK_TX_METADATA.get_transaction_ref(),
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);
@@ -1151,7 +1151,7 @@ fn succeeded_broadcasts_will_not_retry() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default(),
+					transaction_ref: MOCK_TX_METADATA.get_transaction_ref(),
 				},
 			));
 			broadcast_id
@@ -1264,7 +1264,7 @@ fn broadcast_is_retried_without_initial_nominee() {
 				crate::Event::<Test, Instance1>::BroadcastSuccess {
 					broadcast_id,
 					transaction_out_id,
-					transaction_hash: Default::default(),
+					transaction_ref: MOCK_TX_METADATA.get_transaction_ref(),
 				},
 			));
 			assert_broadcast_storage_cleaned_up(broadcast_id);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1195

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Updated transaction_succeeded and BroadcastSuccess Event to include the tx_ref which represent the transaction hash (or an equivalent way of identifying a transaction depending on the chain)


#### Breaking changes

This PR is breaking, both an extrinsic used in the engine and an event changed