### PR TITLE
refactor: pass out CFE incompatibility exit information to main

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -123,6 +123,7 @@ impl StateChainApi {
 			false,
 			false,
 			false,
+			None,
 		)
 		.await?;
 

--- a/api/lib/src/queries.rs
+++ b/api/lib/src/queries.rs
@@ -47,6 +47,7 @@ impl QueryApi {
 			false,
 			false,
 			false,
+			None,
 		)
 		.await?;
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -62,6 +62,8 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 					true,
 					true,
 					true,
+					// TODO: Pass this in from the CFE runner: PRO-935
+					None,
 				)
 				.await?;
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,4 +1,4 @@
-use crate::state_chain_observer::client::CreateBlockStreamError;
+use crate::state_chain_observer::client::CreateStateChainClientError;
 use anyhow::Context;
 use cf_chains::dot::PolkadotHash;
 use cf_primitives::AccountRole;
@@ -226,9 +226,9 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 	.await;
 
 	if let Err(e) = &root_result {
-		let sc_error = e.downcast_ref::<CreateBlockStreamError>();
+		let sc_error = e.downcast_ref::<CreateStateChainClientError>();
 		match sc_error {
-			Some(CreateBlockStreamError::NoLongerCompatible {
+			Some(CreateStateChainClientError::NoLongerCompatible {
 				cfe_version,
 				cfe_version_required,
 				first_incompatible_block,
@@ -241,7 +241,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 					first_incompatible_block
 				);
 			},
-			Some(CreateBlockStreamError::NotYetCompatible {
+			Some(CreateStateChainClientError::NotYetCompatible {
 				cfe_version,
 				cfe_version_required,
 			}) => {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -231,14 +231,14 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 			Some(CreateStateChainClientError::NoLongerCompatible {
 				cfe_version,
 				cfe_version_required,
-				first_incompatible_block,
+				at_block,
 			}) => {
 				tracing::info!(
 					"Chainflip Engine is no longer compatible with the current state chain. \
 					Engine version: {}, required version: {}, first incompatible block: {}",
 					cfe_version,
 					cfe_version_required,
-					first_incompatible_block
+					at_block
 				);
 			},
 			Some(CreateStateChainClientError::NotYetCompatible {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -252,9 +252,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 					cfe_version_required
 				);
 			},
-			_ => {
-				tracing::error!("Error in main: {:?}", e);
-			},
+			_ => {},
 		}
 	}
 	root_result

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -225,7 +225,7 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 	})
 	.await;
 
-	if let Err(e) = root_result {
+	if let Err(e) = &root_result {
 		let sc_error = e.downcast_ref::<CreateBlockStreamError>();
 		match sc_error {
 			Some(CreateBlockStreamError::NoLongerCompatible {
@@ -257,5 +257,5 @@ async fn run_main(settings: Settings) -> anyhow::Result<()> {
 			},
 		}
 	}
-	Ok(())
+	root_result
 }

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -590,7 +590,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 						_ => {
 							// No need to fetch any earlier blocks, we just have to move the stream
 							// to the correct starting point.
-							let skip_to = start_from.unwrap_or(finalized_header.number + 1);
+							let skip_to = start_from.unwrap_or(finalized_header.number);
 							for block_number in finalized_block_stream.cache().number + 1..skip_to {
 								assert_eq!(
 									finalized_block_stream.next().await.unwrap()?.number,

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -106,8 +106,6 @@ pub enum CreateStateChainClientError {
 		cfe_version_required: SemVer,
 		first_incompatible_block: state_chain_runtime::BlockNumber,
 	},
-	#[error(transparent)]
-	Other(#[from] anyhow::Error),
 }
 
 pub struct StateChainClient<

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -97,7 +97,7 @@ impl DefaultRpcClient {
 }
 
 #[derive(Error, Debug)]
-pub enum CreateBlockStreamError {
+pub enum CreateStateChainClientError {
 	#[error("The runtime version '{cfe_version}' is not yet compatible with the current release '{cfe_version_required}'")]
 	NotYetCompatible { cfe_version: SemVer, cfe_version_required: SemVer },
 	#[error("The runtime version '{cfe_version}' is no longer compatible with the current release '{cfe_version_required}' at block {first_incompatible_block}")]
@@ -351,7 +351,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 
 			match cfe_compatibility {
 				CfeCompatibility::NoLongerCompatible => {
-					return Err(CreateBlockStreamError::NoLongerCompatible {
+					return Err(CreateStateChainClientError::NoLongerCompatible {
 						cfe_version: *CFE_VERSION,
 						cfe_version_required: latest_version_runtime_requires,
 						first_incompatible_block: first_block.number,
@@ -407,7 +407,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 
 						block_stream
 					} else {
-						return Err(CreateBlockStreamError::NotYetCompatible {
+						return Err(CreateStateChainClientError::NotYetCompatible {
 							cfe_version: *CFE_VERSION,
 							cfe_version_required: latest_version_runtime_requires,
 						}
@@ -448,7 +448,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 							},
 							CfeCompatibility::NoLongerCompatible => {
 								if error_on_incompatible_block {
-									break Err(CreateBlockStreamError::NoLongerCompatible {
+									break Err(CreateStateChainClientError::NoLongerCompatible {
 										cfe_version: *CFE_VERSION,
 										cfe_version_required: version_runtime_requires,
 										first_incompatible_block: block.number,

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -100,11 +100,11 @@ impl DefaultRpcClient {
 pub enum CreateStateChainClientError {
 	#[error("The runtime version '{cfe_version}' is not yet compatible with the current release '{cfe_version_required}'")]
 	NotYetCompatible { cfe_version: SemVer, cfe_version_required: SemVer },
-	#[error("The runtime version '{cfe_version}' is no longer compatible with the current release '{cfe_version_required}' at block {first_incompatible_block}")]
+	#[error("The runtime version '{cfe_version}' is no longer compatible with the current release '{cfe_version_required}' at block {at_block}")]
 	NoLongerCompatible {
 		cfe_version: SemVer,
 		cfe_version_required: SemVer,
-		first_incompatible_block: state_chain_runtime::BlockNumber,
+		at_block: state_chain_runtime::BlockNumber,
 	},
 }
 
@@ -343,7 +343,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 					return Err(CreateStateChainClientError::NoLongerCompatible {
 						cfe_version: *CFE_VERSION,
 						cfe_version_required: latest_version_runtime_requires,
-						first_incompatible_block: first_block.number,
+						at_block: first_block.number,
 					}
 					.into());
 				},
@@ -386,7 +386,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 												CreateStateChainClientError::NoLongerCompatible {
 													cfe_version: *CFE_VERSION,
 													cfe_version_required: version_runtime_requires,
-													first_incompatible_block: block_info.number,
+													at_block: block_info.number,
 												}
 												.into(),
 											),
@@ -450,7 +450,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 									break Err(CreateStateChainClientError::NoLongerCompatible {
 										cfe_version: *CFE_VERSION,
 										cfe_version_required: version_runtime_requires,
-										first_incompatible_block: block.number,
+										at_block: block.number,
 									}.into());
 								}
 							}

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -336,9 +336,9 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 				Box::pin(block_stream.make_try_cached(latest_block))
 			};
 
-			let first_block = *block_stream.cache();
-
 			let mut block_stream = process_stream_fn(block_stream).await?;
+
+			let first_block = *block_stream.cache();
 
 			let block_compatibility =
 				base_rpc_client.check_block_compatibility(first_block).await?;

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -227,7 +227,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 		base_rpc_client: Arc<BaseRpcClient>,
 		wait_for_required_version: bool,
 		error_on_incompatible_block: bool,
-		start_from: Option<u32>,
+		start_from: Option<state_chain_runtime::BlockNumber>,
 		new_stream_fn: NewStreamFn,
 		process_stream_fn: ProcessStreamFn,
 	) -> Result<(
@@ -555,7 +555,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 		base_rpc_client: Arc<BaseRpcClient>,
 		mut signed_extrinsic_client_builder: SignedExtrinsicClientBuilder,
 		wait_for_required_version: bool,
-		start_from: Option<u32>,
+		start_from: Option<state_chain_runtime::BlockNumber>,
 	) -> Result<(impl StreamApi<FINALIZED> + Clone, impl StreamApi<UNFINALIZED> + Clone, Arc<Self>)>
 	{
 		{

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -283,10 +283,8 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 			let mut block_stream =
 				process_stream_fn(Box::pin(block_stream.make_try_cached(latest_block))).await?;
 
-			let first_block = *block_stream.cache();
-
 			let block_compatibility =
-				base_rpc_client.check_block_compatibility(first_block).await?;
+				base_rpc_client.check_block_compatibility(*block_stream.cache()).await?;
 
 			match block_compatibility.compatibility {
 				CfeCompatibility::NoLongerCompatible =>

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -548,7 +548,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 							// we can make this range exclusive because we've saved the cached block
 							// above, which we chain later.
 							let earlier_blocks_to_fetch =
-								start_from..finalized_block_stream.cache().number;
+								start_from..latest_block_from_cache.number;
 
 							let base_rpc_client = base_rpc_client.clone();
 							let mut start_from_headers = Box::pin(

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -584,7 +584,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 						_ => {
 							// No need to fetch any earlier blocks, we just have to move the stream
 							// to the correct starting point.
-							let skip_to = start_from.unwrap_or(finalized_header.number);
+							let skip_to = start_from.unwrap_or(finalized_header.number + 1);
 							for block_number in finalized_block_stream.cache().number + 1..skip_to {
 								assert_eq!(
 									finalized_block_stream.next().await.unwrap()?.number,

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -388,9 +388,16 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 												);
 												true
 											},
-											CfeCompatibility::NoLongerCompatible => {
-												unreachable!("We cannot move from no longer compatible to compatible.")
-											},
+											// Generally we cannot move from no longer compatible to
+											// compatible. We don't expect this to happen.
+											CfeCompatibility::NoLongerCompatible => return Err(
+												CreateStateChainClientError::NoLongerCompatible {
+													cfe_version: *CFE_VERSION,
+													cfe_version_required: version_runtime_requires,
+													first_incompatible_block: block_info.number,
+												}
+												.into(),
+											),
 										}
 									})
 								}
@@ -456,7 +463,12 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 								}
 							}
 							CfeCompatibility::NotYetCompatible => {
-								unreachable!("We've either already returned a NotYetCompatible error, or we've waited until we're compatible.")
+								// We've either already returned a NotYetCompatible error, or we've waited until we're compatible. So we 
+								// don't expect this case to happen.
+								break Err(CreateStateChainClientError::NotYetCompatible {
+									cfe_version: *CFE_VERSION,
+									cfe_version_required: version_runtime_requires,
+								}.into());
 							},
 						}
 					},

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -356,12 +356,10 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 
 		let latest_block = *processed_stream.cache();
 
-		{
-			let block_compatibility =
-				base_rpc_client.check_block_compatibility(latest_block).await?;
-
-			assert_eq!(block_compatibility.compatibility, CfeCompatibility::Compatible);
-		}
+		assert_eq!(
+			base_rpc_client.check_block_compatibility(latest_block).await?.compatibility,
+			CfeCompatibility::Compatible
+		);
 
 		let (latest_block_sender, latest_block_watcher) =
 			tokio::sync::watch::channel::<BlockInfo>(latest_block);

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -355,6 +355,14 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 		let (mut block_sender, block_receiver) = spmc::channel::<BlockInfo>(BLOCK_CAPACITY);
 
 		let latest_block = *processed_stream.cache();
+
+		{
+			let block_compatibility =
+				base_rpc_client.check_block_compatibility(latest_block).await?;
+
+			assert_eq!(block_compatibility.compatibility, CfeCompatibility::Compatible);
+		}
+
 		let (latest_block_sender, latest_block_watcher) =
 			tokio::sync::watch::channel::<BlockInfo>(latest_block);
 

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -308,6 +308,9 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 					.into());
 				},
 				CfeCompatibility::NotYetCompatible => {
+					// TODO: After the whole "single binary CFE upgrade" is complete, we should be
+					// able to remove `wait_for_required_version` as we'll never wait. We'll always
+					// return out the error and let the runner start the other version.
 					if wait_for_required_version {
 						let incompatible_blocks = futures::stream::once(futures::future::ready(
 							Ok::<_, anyhow::Error>(latest_block),

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -284,15 +284,6 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 				}
 			});
 
-		let incompatible_block_message = |block_version: SemVer, block: BlockInfo| {
-			lazy_format::lazy_format!(
-				"This version '{}' is incompatible with the current release '{block_version}' at block {}: {:?}.",
-				*CFE_VERSION,
-				block.number,
-				block.hash,
-			)
-		};
-
 		let mut processed_stream = {
 			let latest_block: BlockInfo = block_stream.next().await.unwrap()?;
 
@@ -379,11 +370,14 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 											CfeCompatibility::NotYetCompatible => {
 												info!(
 													"{} WAITING for a compatible release version.",
-													incompatible_block_message(
-														version_runtime_requires,
-														block_info
+													lazy_format::lazy_format!(
+														"This version '{}' is incompatible with the current release '{version_runtime_requires}' at block {}: {:?}.",
+														*CFE_VERSION,
+														block_info.number,
+														block_info.hash,
 													)
 												);
+
 												true
 											},
 											// Generally we cannot move from no longer compatible to

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -303,13 +303,13 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 									let base_rpc_client = base_rpc_client.clone();
 									let block_info = *block_info;
 									async move {
-										Ok({
+										{
 											let block_compatibility = base_rpc_client
 												.check_block_compatibility(block_info)
 												.await?;
 
 											match block_compatibility.compatibility {
-											CfeCompatibility::Compatible => false,
+											CfeCompatibility::Compatible => Ok(false),
 											// We want the stream to continue as before
 											CfeCompatibility::NotYetCompatible => {
 												info!(
@@ -319,14 +319,14 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 														block_compatibility
 													)
 												);
-												true
+												Ok(true)
 											},
 											// Generally we cannot move from no longer compatible to
 											// compatible. We don't expect this to happen.
 											CfeCompatibility::NoLongerCompatible =>
-												return Err(CreateStateChainClientError::CompatibilityError(block_compatibility).into()),
+												Err(CreateStateChainClientError::CompatibilityError(block_compatibility).into())
 										}
-										})
+										}
 									}
 								})
 								.boxed();

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -641,7 +641,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 			base_rpc_client.clone(),
 			wait_for_required_version,
 			false,
-			start_from,
+			None,
 			|base_rpc_client| base_rpc_client.subscribe_unfinalized_block_headers(),
 			|block_stream| futures::future::ready(Ok(block_stream)),
 		)

--- a/engine/src/state_chain_observer/client/base_rpc_api.rs
+++ b/engine/src/state_chain_observer/client/base_rpc_api.rs
@@ -9,7 +9,6 @@ use sp_core::{
 	storage::{StorageData, StorageKey},
 	Bytes,
 };
-use sp_runtime::traits::BlakeTwo256;
 use sp_version::RuntimeVersion;
 use state_chain_runtime::SignedBlock;
 
@@ -133,11 +132,11 @@ pub trait BaseRpcApi {
 
 	async fn subscribe_finalized_block_headers(
 		&self,
-	) -> RpcResult<Subscription<sp_runtime::generic::Header<u32, BlakeTwo256>>>;
+	) -> RpcResult<Subscription<state_chain_runtime::Header>>;
 
 	async fn subscribe_unfinalized_block_headers(
 		&self,
-	) -> RpcResult<Subscription<sp_runtime::generic::Header<u32, BlakeTwo256>>>;
+	) -> RpcResult<Subscription<state_chain_runtime::Header>>;
 
 	async fn runtime_version(&self) -> RpcResult<RuntimeVersion>;
 
@@ -253,13 +252,13 @@ impl<RawRpcClient: RawRpcApi + Send + Sync> BaseRpcApi for BaseRpcClient<RawRpcC
 
 	async fn subscribe_finalized_block_headers(
 		&self,
-	) -> RpcResult<Subscription<sp_runtime::generic::Header<u32, BlakeTwo256>>> {
+	) -> RpcResult<Subscription<state_chain_runtime::Header>> {
 		self.raw_rpc_client.subscribe_finalized_heads().await
 	}
 
 	async fn subscribe_unfinalized_block_headers(
 		&self,
-	) -> RpcResult<Subscription<sp_runtime::generic::Header<u32, BlakeTwo256>>> {
+	) -> RpcResult<Subscription<state_chain_runtime::Header>> {
 		self.raw_rpc_client.subscribe_new_heads().await
 	}
 

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -22,6 +22,7 @@ use utilities::{
 	task_scope::{self, Scope},
 	UnendingStream,
 };
+use cf_primitives::CfeCompatibility;
 
 use crate::state_chain_observer::client::{
 	base_rpc_api,
@@ -413,7 +414,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 			}
 			self.block_cache.push_back((
 				block_hash,
-				if self.base_rpc_client.check_block_compatibility(block_hash).await?.is_ok() {
+				if self.base_rpc_client.check_block_compatibility(block_hash).await?.0 == CfeCompatibility::Compatible {
 					Some((
 						block.block.header,
 						block.block.extrinsics,

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -29,7 +29,7 @@ use crate::state_chain_observer::client::{
 	error_decoder::{DispatchError, ErrorDecoder},
 	extrinsic_api::common::invalid_err_obj,
 	storage_api::{CheckBlockCompatibility, StorageApi},
-	SUBSTRATE_BEHAVIOUR,
+	BlockInfo, SUBSTRATE_BEHAVIOUR,
 };
 
 use super::signer;
@@ -414,8 +414,15 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 			}
 			self.block_cache.push_back((
 				block_hash,
-				if self.base_rpc_client.check_block_compatibility(block_hash).await?.0 ==
-					CfeCompatibility::Compatible
+				if self
+					.base_rpc_client
+					.check_block_compatibility(BlockInfo {
+						parent_hash: block.block.header.parent_hash,
+						hash: block_hash,
+						number: block.block.header.number,
+					})
+					.await?
+					.compatibility == CfeCompatibility::Compatible
 				{
 					Some((
 						block.block.header,

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use cf_primitives::CfeCompatibility;
 use codec::{Decode, Encode};
 use frame_support::{dispatch::DispatchInfo, pallet_prelude::InvalidTransaction};
 use itertools::Itertools;
@@ -22,7 +23,6 @@ use utilities::{
 	task_scope::{self, Scope},
 	UnendingStream,
 };
-use cf_primitives::CfeCompatibility;
 
 use crate::state_chain_observer::client::{
 	base_rpc_api,
@@ -414,7 +414,9 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 			}
 			self.block_cache.push_back((
 				block_hash,
-				if self.base_rpc_client.check_block_compatibility(block_hash).await?.0 == CfeCompatibility::Compatible {
+				if self.base_rpc_client.check_block_compatibility(block_hash).await?.0 ==
+					CfeCompatibility::Compatible
+				{
 					Some((
 						block.block.header,
 						block.block.extrinsics,

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -29,7 +29,7 @@ use crate::state_chain_observer::client::{
 	error_decoder::{DispatchError, ErrorDecoder},
 	extrinsic_api::common::invalid_err_obj,
 	storage_api::{CheckBlockCompatibility, StorageApi},
-	BlockInfo, SUBSTRATE_BEHAVIOUR,
+	SUBSTRATE_BEHAVIOUR,
 };
 
 use super::signer;
@@ -416,11 +416,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				block_hash,
 				if self
 					.base_rpc_client
-					.check_block_compatibility(BlockInfo {
-						parent_hash: block.block.header.parent_hash,
-						hash: block_hash,
-						number: block.block.header.number,
-					})
+					.check_block_compatibility(block.block.header.clone().into())
 					.await?
 					.compatibility == CfeCompatibility::Compatible
 				{

--- a/engine/src/state_chain_observer/client/storage_api.rs
+++ b/engine/src/state_chain_observer/client/storage_api.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use cf_primitives::SemVer;
+use cf_primitives::{CfeCompatibility, SemVer};
 use codec::{Decode, FullCodec};
 use frame_support::{
 	storage::{
@@ -12,7 +12,6 @@ use frame_support::{
 use jsonrpsee::core::RpcResult;
 use sp_core::storage::StorageKey;
 use utilities::context;
-use cf_primitives::CfeCompatibility;
 
 use super::{CFE_VERSION, SUBSTRATE_BEHAVIOUR};
 
@@ -367,7 +366,10 @@ pub trait CheckBlockCompatibility: StorageApi {
 				block_hash,
 			)
 			.await?;
-		Ok((CFE_VERSION.compatibility_with_runtime(version_runtime_requires), version_runtime_requires))
+		Ok((
+			CFE_VERSION.compatibility_with_runtime(version_runtime_requires),
+			version_runtime_requires,
+		))
 	}
 }
 #[async_trait]

--- a/engine/src/state_chain_observer/client/storage_api.rs
+++ b/engine/src/state_chain_observer/client/storage_api.rs
@@ -12,6 +12,7 @@ use frame_support::{
 use jsonrpsee::core::RpcResult;
 use sp_core::storage::StorageKey;
 use utilities::context;
+use cf_primitives::CfeCompatibility;
 
 use super::{CFE_VERSION, SUBSTRATE_BEHAVIOUR};
 
@@ -360,13 +361,13 @@ pub trait CheckBlockCompatibility: StorageApi {
 	async fn check_block_compatibility(
 		&self,
 		block_hash: state_chain_runtime::Hash,
-	) -> RpcResult<Result<(), SemVer>> {
-		let block_version = self
+	) -> RpcResult<(CfeCompatibility, SemVer)> {
+		let version_runtime_requires = self
 			.storage_value::<pallet_cf_environment::CurrentReleaseVersion<state_chain_runtime::Runtime>>(
 				block_hash,
 			)
 			.await?;
-		Ok(if CFE_VERSION.is_compatible_with(block_version) { Ok(()) } else { Err(block_version) })
+		Ok((CFE_VERSION.compatibility_with_runtime(version_runtime_requires), version_runtime_requires))
 	}
 }
 #[async_trait]

--- a/engine/src/state_chain_observer/sc_observer/tests.rs
+++ b/engine/src/state_chain_observer/sc_observer/tests.rs
@@ -716,6 +716,7 @@ async fn run_the_sc_observer() {
 					false,
 					false,
 					false,
+					None,
 				)
 				.await
 				.unwrap();

--- a/engine/src/witness/eth/key_manager.rs
+++ b/engine/src/witness/eth/key_manager.rs
@@ -213,6 +213,7 @@ mod tests {
 						false,
 						false,
 						false,
+						None,
 					)
 					.await
 					.unwrap();

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -17,7 +17,7 @@ mod rotation_state;
 
 pub use auction_resolver::*;
 use cf_primitives::{
-	AuthorityCount, Ed25519PublicKey, EpochIndex, Ipv6Addr, SemVer,
+	AuthorityCount, CfeCompatibility, Ed25519PublicKey, EpochIndex, Ipv6Addr, SemVer,
 	DEFAULT_MAX_AUTHORITY_SET_CONTRACTION, FLIPPERINOS_PER_FLIP,
 };
 use cf_traits::{
@@ -1419,7 +1419,8 @@ impl<T: Config> AuthoritiesCfeVersions for Pallet<T> {
 			current_authorities
 				.into_iter()
 				.filter(|validator_id| {
-					NodeCFEVersion::<T>::get(validator_id).is_compatible_with(version)
+					NodeCFEVersion::<T>::get(validator_id).compatibility_with_runtime(version) ==
+						CfeCompatibility::Compatible
 				})
 				.count() as u32,
 			authorities_count,

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -253,9 +253,9 @@ impl SemVer {
 		if self.is_compatible_with(version_runtime_requires) {
 			CfeCompatibility::Compatible
 		} else if self < &version_runtime_requires {
-			CfeCompatibility::NotYetCompatible
-		} else {
 			CfeCompatibility::NoLongerCompatible
+		} else {
+			CfeCompatibility::NotYetCompatible
 		}
 	}
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -250,19 +250,15 @@ pub enum CfeCompatibility {
 
 impl SemVer {
 	pub fn compatibility_with_runtime(&self, version_runtime_requires: SemVer) -> CfeCompatibility {
-		if self.is_compatible_with(version_runtime_requires) {
+		if self.major == version_runtime_requires.major &&
+			self.minor == version_runtime_requires.minor
+		{
 			CfeCompatibility::Compatible
 		} else if self < &version_runtime_requires {
 			CfeCompatibility::NoLongerCompatible
 		} else {
 			CfeCompatibility::NotYetCompatible
 		}
-	}
-
-	/// Check if "self" is compatible with the target version.
-	/// This is true if the major and minor versions are the same.
-	pub fn is_compatible_with(&self, target: SemVer) -> bool {
-		self.major == target.major && self.minor == target.minor
 	}
 
 	pub fn is_more_recent_than(&self, other: SemVer) -> bool {

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -243,7 +243,8 @@ pub enum CfeCompatibility {
 	/// The version is not yet compatible with the target. Should wait for the new version.
 	NotYetCompatible,
 
-	/// The version of the engine is no longer compatible with the runtime. Should switch to the new version.
+	/// The version of the engine is no longer compatible with the runtime. Should switch to the
+	/// new version.
 	NoLongerCompatible,
 }
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -234,7 +234,30 @@ pub struct SemVer {
 	pub minor: u8,
 	pub patch: u8,
 }
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum CfeCompatibility {
+	/// The version is currently compatible with the target.
+	Compatible,
+
+	/// The version is not yet compatible with the target. Should wait for the new version.
+	NotYetCompatible,
+
+	/// The version of the engine is no longer compatible with the runtime. Should switch to the new version.
+	NoLongerCompatible,
+}
+
 impl SemVer {
+	pub fn compatibility_with_runtime(&self, version_runtime_requires: SemVer) -> CfeCompatibility {
+		if self.is_compatible_with(version_runtime_requires) {
+			CfeCompatibility::Compatible
+		} else if self < &version_runtime_requires {
+			CfeCompatibility::NotYetCompatible
+		} else {
+			CfeCompatibility::NoLongerCompatible
+		}
+	}
+
 	/// Check if "self" is compatible with the target version.
 	/// This is true if the major and minor versions are the same.
 	pub fn is_compatible_with(&self, target: SemVer) -> bool {


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
 I've tested every case of error returning from the client - and that the downcast works as expected. alles gut.
- [x] I have updated documentation where appropriate.

## Summary

A step towards single-binary CFE upgrades. This will allow the reason for shutting down to bubble up to the runner. 

Also allows for passing a starting block number to the SCC to ensure it won't miss blocks on the handover to the new version in an upcoming PR.

Non breaking but no point including it in the release.