### PR TITLE
fix: remove bounded balance check

### DIFF
--- a/bouncer/tests/broker_fee_collection_test.ts
+++ b/bouncer/tests/broker_fee_collection_test.ts
@@ -36,14 +36,7 @@ const maxDepositFee = {
   [Assets.DOT]: BigInt(197300000),
   [Assets.FLIP]: BigInt('20000000000000000'),
   [Assets.BTC]: BigInt(190),
-  [Assets.USDC]: BigInt(0), // Fee is too low for localnet, it rounds to 0
-};
-const maxWithdrawalFee = {
-  [Assets.ETH]: BigInt(490000),
-  [Assets.DOT]: BigInt(197450000),
-  [Assets.FLIP]: BigInt(300000000),
-  [Assets.BTC]: BigInt(100),
-  [Assets.USDC]: BigInt(0),
+  [Assets.USDC]: BigInt(400000), // Fee is too low for localnet, it rounds to 0
 };
 const chainflip = await getChainflipApi();
 
@@ -189,8 +182,6 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
   const balanceBeforeWithdrawalBigInt = BigInt(
     amountToFineAmount(balanceBeforeWithdrawal, assetDecimals[asset]),
   );
-  const detectWithdrawalGasFee =
-    balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter - balanceAfterWithdrawalBigInt;
   // Log the chain state for Ethereum assets to help debugging.
   if (['FLIP', 'ETH', 'USDC'].includes(asset.toString())) {
     const chainState = JSON.stringify(
@@ -199,9 +190,8 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     console.log('Ethereum chain tracking state:', chainState);
   }
   assert(
-    detectWithdrawalGasFee <= maxWithdrawalFee[asset] &&
-      balanceAfterWithdrawalBigInt <= balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter,
-    `Unexpected ${asset} balance after withdrawal, amount ${balanceAfterWithdrawalBigInt}, did gas fees change? Max expected gas fee is ${maxWithdrawalFee[asset]}, detected gas fee: ${detectWithdrawalGasFee}`,
+    balanceAfterWithdrawalBigInt <= balanceBeforeWithdrawalBigInt + earnedBrokerFeesAfter,
+    `Unexpected ${asset} balance after withdrawal, amount ${balanceAfterWithdrawalBigInt}, did gas fees change?`,
   );
 }
 


### PR DESCRIPTION
The bounds are too tight, and we can't exactly predict the fees - this code is unit tested anyway. This test is more for testing the e2e flow a broker might take, rather than specific tight balances.