### PR TITLE
fix: disable try-state checks

### DIFF
--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -13,6 +13,7 @@ function tryRuntimeCommand(runtimePath: string, blockParam: string, networkUrl: 
   const stderrFile = path.join(os.tmpdir(), `cmd-stderr-${Date.now()}`);
   try {
     execSync(
+      // TODO: Replace pre-and-post with all after the SDK issue paritytech/polkadot-sdk#2560 is merged.
       `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --checks pre-and-post ${blockParam} --uri ${networkUrl} 2> ${stderrFile}`,
       { env: { ...process.env, RUST_LOG: 'runtime::executive=debug' } },
     );

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -13,7 +13,7 @@ function tryRuntimeCommand(runtimePath: string, blockParam: string, networkUrl: 
   const stderrFile = path.join(os.tmpdir(), `cmd-stderr-${Date.now()}`);
   try {
     execSync(
-      `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --checks all ${blockParam} --uri ${networkUrl} 2> ${stderrFile}`,
+      `try-runtime --runtime ${runtimePath} on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --checks pre-and-post ${blockParam} --uri ${networkUrl} 2> ${stderrFile}`,
       { env: { ...process.env, RUST_LOG: 'runtime::executive=debug' } },
     );
     console.log(`try-runtime success for blockParam ${blockParam}`);


### PR DESCRIPTION

Disabling these checks since they throw a lot of false positives. 

We can re-enable when the below issue is resolved:

https://github.com/paritytech/polkadot-sdk/issues/2560
