### PR TITLE
chore: add origin to ccm failed

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -375,6 +375,7 @@ pub mod pallet {
 			reason: CcmFailReason,
 			destination_address: EncodedAddress,
 			deposit_metadata: CcmDepositMetadata,
+			origin: SwapOrigin,
 		},
 		MaximumSwapAmountSet {
 			asset: Asset,
@@ -1133,6 +1134,7 @@ pub mod pallet {
 							reason,
 							destination_address: encoded_destination_address,
 							deposit_metadata,
+							origin: origin.clone(),
 						});
 						return Err(())
 					},

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -101,6 +101,7 @@ fn assert_failed_ccm(
 		reason,
 		destination_address: MockAddressConverter::to_encoded_address(destination_address),
 		deposit_metadata: ccm,
+		origin: SwapOrigin::Vault { tx_hash: Default::default() },
 	}));
 }
 


### PR DESCRIPTION

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Add `origin` to ccmFailed event so it can be associated to a deposit channel.