### PR TITLE
fix: debug cli 

### DIFF
--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 #[derive(Parser, Clone, Debug)]
-#[clap(version = env!("SUBSTRATE_CLI_IMPL_VERSION"), version_short = 'v')]
+#[clap(version = env!("SUBSTRATE_CLI_IMPL_VERSION"))]
 pub struct CLICommandLineOptions {
 	#[clap(short = 'c', long = "config-root", env = CONFIG_ROOT, default_value = DEFAULT_CONFIG_ROOT)]
 	pub config_root: String,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1156
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

CLI wasn't working in debug mode, removing the version_short fixed the problem

The version command can now be called with: `--version` or `-V`
If we want `-v` instead I can add 
```
#[cfg(not(debug_assertions))]
#[clap(version = env!("SUBSTRATE_CLI_IMPL_VERSION"), version_short = 'v')]
pub struct CLICommandLineOptions { ... }
```
such that when we compile with --release flag enabled we can use `-v`

#### Non-Breaking changes
