### PR TITLE
fix: patch 1.2 broker test

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -173,9 +173,11 @@ jobs:
 
       - name: Run bouncer on latest release
         id: pre-upgrade-bouncer
+        # TEMP: It should be: # git checkout ${{ steps.get-upgrade-from-commit.outputs.commit-sha }}
+        # But we need the fix for the broker test for 1.2 here for now
         run: |
           git fetch --all
-          git checkout ${{ steps.get-upgrade-from-commit.outputs.commit-sha }}
+          git checkout release-1.2-broker-test-fix
           git rev-parse HEAD
           cd bouncer
           pnpm install

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -106,7 +106,7 @@ async function incompatibleUpgradeNoBuild(
     console.log(e);
   }
 
-  await sleep(7000);
+  await sleep(20000);
 
   const output = execSync("ps aux | grep chainflip-node | grep -v grep | awk '{print $2}'");
   console.log('New node PID: ' + output.toString());
@@ -267,3 +267,5 @@ export async function upgradeNetworkPrebuilt(
 
   console.log('Upgrade complete.');
 }
+
+

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -267,5 +267,3 @@ export async function upgradeNetworkPrebuilt(
 
   console.log('Upgrade complete.');
 }
-
-


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works. https://github.com/chainflip-io/chainflip-backend/actions/runs/8154228772
- [x] I have updated documentation where appropriate.

## Summary

Includes some patches for flakiness for the upgrade-test.

Compare 1.2 to this: https://github.com/chainflip-io/chainflip-backend/tree/release-1.2-broker-test-fix to see changes
