### PR TITLE
fix: swap subscription amounts as hex

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -9,8 +9,8 @@ use cf_chains::{
 };
 use cf_primitives::{
 	chains::assets::any::{self, OldAsset},
-	AccountRole, Asset, AssetAmount, BroadcastId, ForeignChain, NetworkEnvironment, SemVer,
-	SwapOutput,
+	AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, ForeignChain, NetworkEnvironment,
+	SemVer, SwapId, SwapOutput,
 };
 use cf_utilities::rpc::NumberOrHex;
 use core::ops::Range;
@@ -22,6 +22,7 @@ use jsonrpsee::{
 };
 use pallet_cf_governance::GovCallHash;
 use pallet_cf_pools::{AskBidMap, PoolInfo, PoolLiquidity, PoolPriceV1, UnidirectionalPoolDepth};
+use pallet_cf_swapping::SwapLegInfo;
 use sc_client_api::{BlockchainEvents, HeaderBackend};
 use serde::{Deserialize, Serialize};
 use sp_api::ApiError;
@@ -35,7 +36,7 @@ use state_chain_runtime::{
 	constants::common::TX_FEE_MULTIPLIER,
 	runtime_apis::{
 		BrokerInfo, CustomRuntimeApi, DispatchErrorWithMessage, FailingWitnessValidators,
-		LiquidityProviderInfo, ScheduledSwap, ValidatorInfo,
+		LiquidityProviderInfo, ValidatorInfo,
 	},
 	NetworkFee,
 };
@@ -44,6 +45,38 @@ use std::{
 	marker::PhantomData,
 	sync::Arc,
 };
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledSwap {
+	pub swap_id: SwapId,
+	pub base_asset: Asset,
+	pub quote_asset: Asset,
+	pub side: Side,
+	pub amount: NumberOrHex,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub source_asset: Option<Asset>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub source_amount: Option<NumberOrHex>,
+	pub execute_at: BlockNumber,
+}
+
+impl ScheduledSwap {
+	fn new(
+		SwapLegInfo { swap_id, base_asset, quote_asset, side, amount, source_asset, source_amount}: SwapLegInfo,
+		execute_at: BlockNumber,
+	) -> Self {
+		ScheduledSwap {
+			swap_id,
+			base_asset,
+			quote_asset,
+			side,
+			amount: amount.into(),
+			source_asset,
+			source_amount: source_amount.map(Into::into),
+			execute_at,
+		}
+	}
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetWithAmount {
@@ -1175,7 +1208,11 @@ where
 			sink,
 			move |api, hash| {
 				Ok::<_, ApiError>(SwapResponse {
-					swaps: api.cf_scheduled_swaps(hash, base_asset, quote_asset)?,
+					swaps: api
+						.cf_scheduled_swaps(hash, base_asset, quote_asset)?
+						.into_iter()
+						.map(|(swap, execute_at)| ScheduledSwap::new(swap, execute_at))
+						.collect(),
 				})
 			},
 		)
@@ -1194,10 +1231,14 @@ where
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))?;
 
-		self.client
+		Ok(self
+			.client
 			.runtime_api()
 			.cf_scheduled_swaps(self.unwrap_or_best(at), base_asset, quote_asset)
-			.map_err(to_rpc_error)
+			.map_err(to_rpc_error)?
+			.into_iter()
+			.map(|(swap, execute_at)| ScheduledSwap::new(swap, execute_at))
+			.collect())
 	}
 
 	fn cf_subscribe_prewitness_swaps(

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -59,16 +59,13 @@ pub struct Swap {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapLegInfo {
 	pub swap_id: SwapId,
 	pub base_asset: Asset,
 	pub quote_asset: Asset,
 	pub side: Side,
 	pub amount: AssetAmount,
-	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
 	pub source_asset: Option<Asset>,
-	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
 	pub source_amount: Option<AssetAmount>,
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -13,7 +13,7 @@ use crate::{
 	chainflip::{calculate_account_apy, Offence},
 	runtime_apis::{
 		AuctionState, BrokerInfo, DispatchErrorWithMessage, FailingWitnessValidators,
-		LiquidityProviderInfo, RuntimeApiPenalty, ScheduledSwap, ValidatorInfo,
+		LiquidityProviderInfo, RuntimeApiPenalty, ValidatorInfo,
 	},
 };
 use cf_amm::{
@@ -39,7 +39,7 @@ use pallet_cf_pools::{
 	UnidirectionalPoolDepth,
 };
 use pallet_cf_reputation::ExclusionList;
-use pallet_cf_swapping::CcmSwapAmounts;
+use pallet_cf_swapping::{CcmSwapAmounts, SwapLegInfo};
 use pallet_cf_validator::SetSizeMaximisingAuctionResolver;
 use pallet_transaction_payment::{ConstFeeMultiplier, Multiplier};
 use scale_info::prelude::string::String;
@@ -1437,7 +1437,7 @@ impl_runtime_apis! {
 			all_prewitnessed_swaps
 		}
 
-		fn cf_scheduled_swaps(base_asset: Asset, _quote_asset: Asset) -> Vec<ScheduledSwap> {
+		fn cf_scheduled_swaps(base_asset: Asset, _quote_asset: Asset) -> Vec<(SwapLegInfo, BlockNumber)> {
 
 			let current_block = System::block_number();
 
@@ -1447,7 +1447,7 @@ impl_runtime_apis! {
 				let execute_at = core::cmp::max(block, current_block.saturating_add(1));
 
 				let swaps: Vec<_> = swaps_for_block.iter().filter(|swap| swap.from == base_asset || swap.to == base_asset).cloned().collect();
-				Swapping::get_scheduled_swap_legs(swaps, base_asset).unwrap().into_iter().map(move |swap| ScheduledSwap {swap, execute_at })
+				Swapping::get_scheduled_swap_legs(swaps, base_asset).unwrap().into_iter().map(move |swap| (swap, execute_at))
 			}).collect()
 	}
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -106,14 +106,6 @@ pub struct FailingWitnessValidators {
 	pub validators: Vec<(cf_primitives::AccountId, String, bool)>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
-pub struct ScheduledSwap {
-	#[cfg_attr(feature = "std", serde(flatten))]
-	pub swap: SwapLegInfo,
-	pub execute_at: BlockNumber,
-}
-
 decl_runtime_apis!(
 	/// Definition for all runtime API interfaces.
 	pub trait CustomRuntimeApi {
@@ -197,7 +189,10 @@ decl_runtime_apis!(
 			quote_asset: Asset,
 			side: Side,
 		) -> Vec<AssetAmount>;
-		fn cf_scheduled_swaps(base_asset: Asset, quote_asset: Asset) -> Vec<ScheduledSwap>;
+		fn cf_scheduled_swaps(
+			base_asset: Asset,
+			quote_asset: Asset,
+		) -> Vec<(SwapLegInfo, BlockNumber)>;
 		fn cf_liquidity_provider_info(account_id: AccountId32) -> LiquidityProviderInfo;
 		fn cf_broker_info(account_id: AccountId32) -> BrokerInfo;
 		fn cf_account_role(account_id: AccountId32) -> Option<AccountRole>;


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Upading amounts to be in hex as discussed in https://github.com/chainflip-io/chainflip-docs/pull/203#discussion_r1507172631. I chose to remove nesting from `ScheduledSwap` and move it out of runtime (`NumberOrHex` seems like an RPC-only concept). Tested on localnet, this is what the output looks like now:

```
{"jsonrpc":"2.0","method":"cf_subscribe_scheduled_swaps","params":{"subscription":"XSY3MSys5BEB6nOx","result":{"block_hash":"0x27c3e08998aeda7b41071d90d2d9162a48d543c109223df66a7c6b0854c04714","block_number":242,"swaps":[{"swap_id":2,"base_asset":{"chain":"Ethereum","asset":"FLIP"},"quote_asset":{"chain":"Ethereum","asset":"USDC"},"side":"sell","amount":"0x1ad54e6809d4cf6e69","execute_at":243}]}}}
```