### PR TITLE
fix: start localnet using correct commit

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -161,7 +161,11 @@ jobs:
         env:
           BINARY_ROOT_PATH: ./latest-release-bins
           DEBUG_OUTPUT_DESTINATION: /tmp/chainflip/debug.log
+        # TEMP: It should be: # git checkout ${{ steps.get-upgrade-from-commit.outputs.commit-sha }}
+        # But we need the fix for the broker test for 1.2 here for now
         run: |
+          git fetch --all
+          git checkout release-1.2-broker-test-fix
           set -x
           mkdir -p /tmp/chainflip/bashful
           mkdir -p /tmp/chainflip/doc


### PR DESCRIPTION
Fixes the fact the localnet configuration might be different between releases - we obviously want to start using the localnet of the same version as the release.