### PR TITLE
fix: missing feature flags

### DIFF
--- a/state-chain/cfe-events/Cargo.toml
+++ b/state-chain/cfe-events/Cargo.toml
@@ -40,3 +40,7 @@ std = [
   'frame-support/std',
   'frame-system/std',
 ]
+runtime-benchmarks = [
+  'frame-system/runtime-benchmarks',
+  'frame-support/runtime-benchmarks',
+]

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -86,4 +86,5 @@ runtime-benchmarks = [
   'cf-primitives/runtime-benchmarks',
   'frame-support/runtime-benchmarks',
 ]
+
 runtime-integration-tests = ['std']

--- a/state-chain/runtime-upgrade-utilities/Cargo.toml
+++ b/state-chain/runtime-upgrade-utilities/Cargo.toml
@@ -32,3 +32,7 @@ std = [
     'sp-io/std',
 ]
 try-runtime = ['frame-support/try-runtime']
+runtime-benchmarks = [
+    'frame-support/runtime-benchmarks',
+    'frame-system/runtime-benchmarks',
+]


### PR DESCRIPTION
Running a test from inside chains crate e.g. `test_eth_eth` in VSCode fails due to some crate with missing runtime-benchmarks - haven't found culprit yet, but found some missing ones