### PR TITLE
feat: add broker api connection limit option

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -142,6 +142,12 @@ pub struct BrokerOptions {
 	)]
 	pub port: u16,
 	#[clap(
+		long = "max_connections",
+		default_value = "100",
+		help = "The maximum number of conncurrent websocket connections to accept."
+	)]
+	pub max_connections: u32,
+	#[clap(
 		long = "state_chain.ws_endpoint",
 		default_value = "ws://localhost:9944",
 		help = "The state chain node's RPC endpoint."
@@ -166,7 +172,10 @@ async fn main() -> anyhow::Result<()> {
 
 	task_scope(|scope| {
 		async move {
-			let server = ServerBuilder::default().build(format!("0.0.0.0:{}", opts.port)).await?;
+			let server = ServerBuilder::default()
+				.max_connections(opts.max_connections)
+				.build(format!("0.0.0.0:{}", opts.port))
+				.await?;
 			let server_addr = server.local_addr()?;
 			let server = server.start(RpcServerImpl::new(scope, opts).await?.into_rpc())?;
 


### PR DESCRIPTION
Adds the possibility to change the broker api connection limit from its  current default of 100.