### PR TITLE
fix: more try-runtime unwraps.

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/migrations/v3.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/v3.rs
@@ -166,7 +166,8 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 			broadcasts_with_failed_broadcasters,
 			broadcast_retry_queue,
 			timeout_broadcasts,
-		} = MigrationVerification::<T>::decode(&mut &state[..]).unwrap();
+		} = MigrationVerification::<T>::decode(&mut &state[..])
+			.expect("Pre-migration should encode valid MigrationVerification");
 
 		// Ensure all failed broadcasters storage are migrated.
 		broadcasts_with_failed_broadcasters.into_iter().for_each(

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/btc_deposit_channels.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/btc_deposit_channels.rs
@@ -106,7 +106,8 @@ impl<T: Config<Instance3, TargetChain = Bitcoin>> OnRuntimeUpgrade for Migration
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
-		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..]).unwrap();
+		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..])
+			.expect("Pre-migration should insert number of channels in lookup storage.");
 		ensure!(
 			DepositChannelLookup::<T, Instance3>::iter_keys().count() as u32 ==
 				number_of_channels_in_lookup_pre_migration,

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/deposit_channels_with_boost_fee.rs
@@ -53,7 +53,8 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
-		let number_of_channels_in_lookup_pre_migration = <u32>::decode(&mut &state[..]).unwrap();
+		let number_of_channels_in_lookup_pre_migration =
+			<u32>::decode(&mut &state[..]).expect("Pre-migration should encode a u32.");
 		ensure!(
 			DepositChannelLookup::<T, I>::iter_keys().count() as u32 ==
 				number_of_channels_in_lookup_pre_migration,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1833,7 +1833,8 @@ impl_runtime_apis! {
 			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
 			// have a backtrace here. If any of the pre/post migration checks fail, we shall stop
 			// right here and right now.
-			let weight = Executive::try_runtime_upgrade(checks).unwrap();
+			let weight = Executive::try_runtime_upgrade(checks)
+				.inspect_err(|e| log::error!("try_runtime_upgrade failed with: {:?}", e)).unwrap();
 			(weight, BlockWeights::get().max_block)
 		}
 


### PR DESCRIPTION
Changes remaining unwraps (from post-upgrade checks) into expects, and also logs any try-runtime errors before unwrapping the result of the try-runtime call.