### PR TITLE
fix: correct cfe-events pallet version

### DIFF
--- a/state-chain/pallets/cf-cfe-interface/src/lib.rs
+++ b/state-chain/pallets/cf-cfe-interface/src/lib.rs
@@ -21,7 +21,7 @@ use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use sp_std::vec::Vec;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(2);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
 
 pub type EventId = u64;
 

--- a/state-chain/pallets/cf-cfe-interface/src/migrations.rs
+++ b/state-chain/pallets/cf-cfe-interface/src/migrations.rs
@@ -3,4 +3,4 @@ pub mod add_arb_to_cfe_events;
 use cf_runtime_upgrade_utilities::VersionedMigration;
 
 pub type PalletMigration<T> =
-	(VersionedMigration<crate::Pallet<T>, add_arb_to_cfe_events::Migration<T>, 1, 2>,);
+	(VersionedMigration<crate::Pallet<T>, add_arb_to_cfe_events::Migration<T>, 0, 1>,);


### PR DESCRIPTION
I think this might finally fix the failing nightly try-runtime check. 