### PR TITLE
fix(chainflip-broker-api): replace u128 with U256 (#4656)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "hex",
  "jsonrpsee 0.16.3",
  "serde",
+ "sp-core 21.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.6+1)",
  "sp-rpc",
  "substrate-build-script-utils",
  "tokio",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -32,6 +32,7 @@ futures = "0.3"
 hex = "0.4.3"
 jsonrpsee = { version = "0.16.2", features = ["full"] }
 serde = { version = '1.0', features = ['derive'] }
+sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-rpc = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 tokio = "1.20.1"
 tracing = "0.1.34"

--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -17,6 +17,7 @@ use jsonrpsee::{
 	server::ServerBuilder,
 };
 use serde::{Deserialize, Serialize};
+use sp_core::U256;
 use std::path::PathBuf;
 use tracing::log;
 
@@ -29,7 +30,7 @@ pub struct BrokerSwapDepositAddress {
 	pub issued_block: BlockNumber,
 	pub channel_id: ChannelId,
 	pub source_chain_expiry_block: NumberOrHex,
-	pub channel_opening_fee: u128,
+	pub channel_opening_fee: U256,
 }
 
 impl From<chainflip_api::SwapDepositAddress> for BrokerSwapDepositAddress {
@@ -39,7 +40,7 @@ impl From<chainflip_api::SwapDepositAddress> for BrokerSwapDepositAddress {
 			issued_block: value.issued_block,
 			channel_id: value.channel_id,
 			source_chain_expiry_block: NumberOrHex::from(value.source_chain_expiry_block),
-			channel_opening_fee: value.channel_opening_fee,
+			channel_opening_fee: U256::from(value.channel_opening_fee),
 		}
 	}
 }


### PR DESCRIPTION
Cherry picks #4656 onto release/1.3