### PR TITLE
fix: dry run gets fresh runtime version (PRO-1249)

### DIFF
--- a/engine/src/state_chain_observer/client/base_rpc_api.rs
+++ b/engine/src/state_chain_observer/client/base_rpc_api.rs
@@ -138,12 +138,15 @@ pub trait BaseRpcApi {
 		&self,
 	) -> RpcResult<Subscription<state_chain_runtime::Header>>;
 
-	async fn runtime_version(&self) -> RpcResult<RuntimeVersion>;
+	async fn runtime_version(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RuntimeVersion>;
 
 	async fn dry_run(
 		&self,
 		extrinsic: Bytes,
-		at: Option<state_chain_runtime::Hash>,
+		block_hash: state_chain_runtime::Hash,
 	) -> RpcResult<Bytes>;
 
 	async fn request_raw(
@@ -262,16 +265,19 @@ impl<RawRpcClient: RawRpcApi + Send + Sync> BaseRpcApi for BaseRpcClient<RawRpcC
 		self.raw_rpc_client.subscribe_new_heads().await
 	}
 
-	async fn runtime_version(&self) -> RpcResult<RuntimeVersion> {
-		self.raw_rpc_client.runtime_version(None).await
+	async fn runtime_version(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RuntimeVersion> {
+		self.raw_rpc_client.runtime_version(at).await
 	}
 
 	async fn dry_run(
 		&self,
 		extrinsic: Bytes,
-		at: Option<state_chain_runtime::Hash>,
+		block_hash: state_chain_runtime::Hash,
 	) -> RpcResult<Bytes> {
-		self.raw_rpc_client.dry_run(extrinsic, at).await
+		self.raw_rpc_client.dry_run(extrinsic, Some(block_hash)).await
 	}
 
 	async fn request_raw(

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed.rs
@@ -200,7 +200,7 @@ impl SignedExtrinsicClient {
 							account_nonce,
 							state_chain_stream.cache().hash,
 							state_chain_stream.cache().number,
-							base_rpc_client.runtime_version().await?,
+							base_rpc_client.runtime_version(None).await?,
 							genesis_hash,
 							SIGNED_EXTRINSIC_LIFETIME,
 							base_rpc_client.clone(),

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher/tests.rs
@@ -30,7 +30,7 @@ async fn should_update_version_on_bad_proof() {
 				)))
 			});
 
-			mock_rpc_api.expect_runtime_version().times(1).returning(move || {
+			mock_rpc_api.expect_runtime_version().times(1).returning(move |_| {
 				let new_runtime_version = sp_version::RuntimeVersion {
 					spec_name: "test".into(),
 					impl_name: "test".into(),


### PR DESCRIPTION
We had the problem where dry-run wouldn't re-obtain the runtime version when it is out of date, so here I changed the dry-run to always re-obtain the runtime version.