### PR TITLE
Prevent concurrent tests from exiting :bug: 

### DIFF
--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -244,5 +244,4 @@ export async function testBrokerFeeCollection(): Promise<void> {
   ]);
 
   console.log('\x1b[32m%s\x1b[0m', '=== Broker fee collection test complete ===');
-  process.exit(0);
 }

--- a/bouncer/shared/fund_redeem.ts
+++ b/bouncer/shared/fund_redeem.ts
@@ -42,6 +42,8 @@ async function redeemAndObserve(
 // checking that the balance has increased the expected amount.
 // If no seed is provided, a random one is generated.
 export async function testFundRedeem(providedSeed?: string) {
+  console.log('=== Starting Fund/Redeem test ===');
+
   const chainflip = await getChainflipApi();
   const redemptionTax = await chainflip.query.funding.redemptionTax();
   const redemptionTaxAmount = parseInt(
@@ -88,4 +90,6 @@ export async function testFundRedeem(providedSeed?: string) {
       expectedRedeemAllAmount - expectedRedeemGasFeeFlip * 2
     } - ${expectedRedeemAllAmount}. Did fees change?`,
   );
+
+  console.log('=== Fund/Redeem test complete ===');
 }

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -387,13 +387,13 @@ export async function observeSwapEvents(
             }
             break;
           case swapExecutedEvent:
-            if (Number(expectedEvent.data.swapId) === Number(swapId)) {
+            if (expectedEvent.data.swapId === swapId) {
               expectedMethod = swapEgressScheduled;
               console.log(`${tag} swap executed, with id: ${swapId}`);
             }
             break;
           case swapEgressScheduled:
-            if (Number(expectedEvent.data.swapId) === Number(swapId)) {
+            if (expectedEvent.data.swapId === swapId) {
               expectedMethod = batchBroadcastRequested;
               egressId = expectedEvent.data.egressId as EgressId;
               console.log(`${tag} swap egress scheduled with id: (${egressId[0]}, ${egressId[1]})`);

--- a/bouncer/tests/fund_redeem.ts
+++ b/bouncer/tests/fund_redeem.ts
@@ -3,9 +3,7 @@ import { testFundRedeem } from '../shared/fund_redeem';
 import { runWithTimeout } from '../shared/utils';
 
 async function main(): Promise<void> {
-  console.log('=== Starting Fund/Redeem test ===');
   await testFundRedeem();
-  console.log('=== Fund/Redeem test complete ===');
   process.exit(0);
 }
 


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

In #4622 the broker fee test was moved into all concurrent tests. However, that test exits the process when completed, which meant that all other running tests will exit once that one was completed. That is a problem not only if the other tests were still running but more importantly if they had "hanged" (e.g. waiting for an event) they wouldn't time out, effectively making it impossible to catch it.
Turns out, there was indeed a bug in the existential amount test.