### PR TITLE
fix: add dummy benchmark for account roles pallet

### DIFF
--- a/state-chain/pallets/cf-account-roles/src/benchmarking.rs
+++ b/state-chain/pallets/cf-account-roles/src/benchmarking.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "runtime-benchmarks")]
+
+use crate::{Config, Pallet};
+use frame_benchmarking::v2::*;
+
+// Keep this to avoid CI warnings about no benchmarks in the crate.
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn noop() {
+		#[block]
+		{
+			// Do nothing.
+		}
+	}
+}

--- a/state-chain/pallets/cf-account-roles/src/lib.rs
+++ b/state-chain/pallets/cf-account-roles/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../../cf-doc-head.md")]
 
+mod benchmarking;
 mod mock;
 mod tests;
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1137,6 +1137,7 @@ mod benches {
 		[pallet_cf_broadcast, EthereumBroadcaster]
 		[pallet_cf_chain_tracking, EthereumChainTracking]
 		[pallet_cf_swapping, Swapping]
+		[pallet_cf_account_roles, AccountRoles]
 		[pallet_cf_ingress_egress, EthereumIngressEgress]
 		[pallet_cf_lp, LiquidityProvider]
 		[pallet_cf_pools, LiquidityPools]


### PR DESCRIPTION
This allows CI checks to pass. 