### PR TITLE
ci: fix wrong debug file name 🐛 (#4682)

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -69,9 +69,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install pnpm
-        run: npm install -g pnpm
-
       - name: Configure NodeJS
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Fixes `release-upgrade` test.

@kylezs I am not sure how to overcome [this check failing](https://github.com/chainflip-io/chainflip-backend/actions/runs/8399942758/job/23006658483?pr=4689#step:9:22). Should we pump the version?