### PR TITLE
Fix failing gas ccm tests

### DIFF
--- a/bouncer/run.sh
+++ b/bouncer/run.sh
@@ -3,5 +3,6 @@ set -e
 if lsof -Pi :8899 -sTCP:LISTEN -t >/dev/null ; then
     ./commands/send_sol.ts 7QQGNm3ptwinipDCyaCF7jY5katgmFUu1ieP2f7nwLpE 1.2
 fi
+./tests/gaslimit_ccm.ts
 ./setup_for_test.sh
 ./tests/all_concurrent_tests.ts $1

--- a/bouncer/run.sh
+++ b/bouncer/run.sh
@@ -4,5 +4,4 @@ if lsof -Pi :8899 -sTCP:LISTEN -t >/dev/null ; then
     ./commands/send_sol.ts 7QQGNm3ptwinipDCyaCF7jY5katgmFUu1ieP2f7nwLpE 1.2
 fi
 ./setup_for_test.sh
-./tests/gaslimit_ccm.ts
 ./tests/all_concurrent_tests.ts $1

--- a/bouncer/run.sh
+++ b/bouncer/run.sh
@@ -3,6 +3,6 @@ set -e
 if lsof -Pi :8899 -sTCP:LISTEN -t >/dev/null ; then
     ./commands/send_sol.ts 7QQGNm3ptwinipDCyaCF7jY5katgmFUu1ieP2f7nwLpE 1.2
 fi
-./tests/gaslimit_ccm.ts
 ./setup_for_test.sh
+./tests/gaslimit_ccm.ts
 ./tests/all_concurrent_tests.ts $1

--- a/bouncer/shared/gaslimit_ccm.ts
+++ b/bouncer/shared/gaslimit_ccm.ts
@@ -44,8 +44,6 @@ const CCM_CHAINS_NATIVE_ASSETS: Record<string, Asset> = {
   // Solana: 'Sol',
 };
 
-let stopObservingCcmReceived = false;
-
 function gasTestCcmMetadata(sourceAsset: Asset, gasToConsume: number, gasBudgetFraction?: number) {
   const web3 = new Web3();
 
@@ -215,6 +213,8 @@ async function testGasLimitSwap(
     gasConsumption + MIN_BASE_GAS_OVERHEAD[destChain] + byteLength * GAS_PER_BYTE;
   // This is a very rough approximation for the gas limit required. A buffer is added to account for that.
   if (minGasLimitRequired + BASE_GAS_OVERHEAD_BUFFER[destChain] >= gasLimitBudget) {
+    let stopObservingCcmReceived = false;
+
     observeCcmReceived(
       sourceAsset,
       destAsset,

--- a/bouncer/shared/gaslimit_ccm.ts
+++ b/bouncer/shared/gaslimit_ccm.ts
@@ -390,12 +390,12 @@ export async function testGasLimitCcmSwaps() {
     testGasLimitSwap('Eth', 'Usdt', ' insufBudget', undefined, 10 ** 5),
     testGasLimitSwap('Flip', 'Eth', ' insufBudget', undefined, 10 ** 5),
     testGasLimitSwap('Btc', 'Eth', ' insufBudget', undefined, 10 ** 4),
-    testGasLimitSwap('Dot', 'ArbEth', ' insufBudget', undefined, 10 ** 3),
+    testGasLimitSwap('Dot', 'ArbEth', ' insufBudget', undefined, 10 ** 4),
     testGasLimitSwap('Eth', 'ArbEth', ' insufBudget', undefined, 10 ** 4),
     testGasLimitSwap('Flip', 'ArbUsdc', ' insufBudget', undefined, 10 ** 4),
-    testGasLimitSwap('Btc', 'ArbUsdc', ' insufBudget', undefined, 10 ** 3),
-    testGasLimitSwap('ArbEth', 'Eth', ' insufBudget', undefined, 10 ** 4),
-    testGasLimitSwap('ArbUsdc', 'Flip', ' insufBudget', undefined, 10 ** 3),
+    testGasLimitSwap('Btc', 'ArbUsdc', ' insufBudget', undefined, 10 ** 4),
+    testGasLimitSwap('ArbEth', 'Eth', ' insufBudget', undefined, 10 ** 5),
+    testGasLimitSwap('ArbUsdc', 'Flip', ' insufBudget', undefined, 10 ** 4),
   ];
 
   // This amount of gasLimitBudget will be swapped into very little gasLimitBudget. Not into zero as that will cause a debug_assert to


### PR DESCRIPTION
# Pull Request

Closes: PRO-1095

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Tweak gas parameters. It was consistently failing before.
- Some rare flakyness is almost impossible to avoid in this test. However, as explained in PRO-1095 it was sometimes failing and sometimes hanging. `stopObservingCcmReceived` being a global variable instead of a local variable. There was a race condition causing that an unexpected broadcasted CCM swap would sometimes not be caught as an error and the test would hang. After this change, if the protocol works well, we should see it either pass or fail due to a need to tweak the gas, but never hang.