### PR TITLE
chore: clearer cherry pick title

### DIFF
--- a/.github/workflows/ci-cherry-pick.yml
+++ b/.github/workflows/ci-cherry-pick.yml
@@ -44,8 +44,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
-          commit-message: Cherry-picked from ${{ env.COMMIT_SHA }}
-          title: "Cherry-Pick ${{ env.COMMIT_SHA }} to ${{ env.RELEASE_BRANCH }}"
+          commit-message: "pick: ${{ env.COMMIT_SHA }} to ${{ env.RELEASE_BRANCH }}"
+          title: "${{ github.event.pull_request.title }}"
           body: |
             This is an automated cherry-pick of ${{ env.COMMIT_SHA }} to ${{ env.RELEASE_BRANCH }}.
             Please review and merge if appropriate.


### PR DESCRIPTION
This uses the original PR title as the title for the cherry pick
We already add the label `cherry-pick` to the prs