### PR TITLE
fix: continuous adapter

### DIFF
--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
@@ -77,8 +77,8 @@ where
 					let mut processed_inverse = processed_indices.clone();
 					processed_inverse.invert();
 					processed_inverse.set_range(..epoch.info.1, false);
-					let highest_processed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(highest_processed, epoch.info.1));
-					processed_inverse.set_range(highest_processed.., false);
+					let next_unprocessed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(Step::forward(highest_processed, 1), epoch.info.1));
+					processed_inverse.set_range(next_unprocessed.., false);
 					processed_inverse
 				};
 

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
@@ -98,9 +98,9 @@ where
 
 							loop_select!(
 								let header = chain_stream.next_or_pending() => {
-									let highest_processed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(highest_processed, epoch.info.1));
-									if highest_processed < header.index {
-										for unprocessed_index in Step::forward(highest_processed, 1)..header.index {
+									let next_unprocessed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(Step::forward(highest_processed, 1), epoch.info.1));
+									if next_unprocessed < header.index {
+										for unprocessed_index in next_unprocessed..header.index {
 											if inprogress_indices.len() < MAXIMUM_CONCURRENT_INPROGRESS {
 												inprogress_indices.insert(unprocessed_index, {
 													let chain_client = chain_client.clone();


### PR DESCRIPTION
Basically, its an off by one error.

If the main stream misses the first block in an epoch, the continuous adapter would not fill the missed witness for that first block.

*Note if the engine was restarted it would fill in the gap.*

Looking at the code we were handling the last_processed_index and the start of the epoch in the same way, but the first is an index we don't want to process, but the second is an index we do want to process.