### PR TITLE
chore: remove backcompat asset encoding from rpcs (and make them line up with newer Asset encoding)

### DIFF
--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -11,7 +11,7 @@ use chainflip_api::{
 		ApiWaitForResult, LpApi, PoolPairsMap, Side, Tick,
 	},
 	primitives::{
-		chains::{assets::any::OldAsset, Bitcoin, Ethereum, Polkadot},
+		chains::{Bitcoin, Ethereum, Polkadot},
 		AccountRole, Asset, ForeignChain, Hash, RedemptionAmount,
 	},
 	settings::StateChain,
@@ -94,7 +94,7 @@ pub mod rpc_types {
 
 	#[derive(Serialize, Deserialize, Clone)]
 	pub struct AssetBalance {
-		pub asset: OldAsset,
+		pub asset: Asset,
 		pub balance: NumberOrHex,
 	}
 }
@@ -223,8 +223,8 @@ pub struct OrderFills {
 pub enum OrderFilled {
 	LimitOrder {
 		lp: AccountId,
-		base_asset: OldAsset,
-		quote_asset: OldAsset,
+		base_asset: Asset,
+		quote_asset: Asset,
 		side: Side,
 		id: U256,
 		tick: Tick,
@@ -235,8 +235,8 @@ pub enum OrderFilled {
 	},
 	RangeOrder {
 		lp: AccountId,
-		base_asset: OldAsset,
-		quote_asset: OldAsset,
+		base_asset: Asset,
+		quote_asset: Asset,
 		id: U256,
 		range: Range<Tick>,
 		fees: PoolPairsMap<U256>,
@@ -311,7 +311,7 @@ impl RpcServer for RpcServerImpl {
 			lp_asset_balances
 				.entry(asset.into())
 				.or_default()
-				.push(AssetBalance { asset: asset.into(), balance: amount.into() });
+				.push(AssetBalance { asset, balance: amount.into() });
 		}
 		Ok(lp_asset_balances)
 	}
@@ -599,8 +599,8 @@ where
 									} else {
 										Some(OrderFilled::LimitOrder {
 											lp,
-											base_asset: asset_pair.assets().base.into(),
-											quote_asset: asset_pair.assets().quote.into(),
+											base_asset: asset_pair.assets().base,
+											quote_asset: asset_pair.assets().quote,
 											side,
 											id: id.into(),
 											tick,
@@ -645,8 +645,8 @@ where
 								} else {
 									Some(OrderFilled::RangeOrder {
 										lp: lp.clone(),
-										base_asset: asset_pair.assets().base.into(),
-										quote_asset: asset_pair.assets().quote.into(),
+										base_asset: asset_pair.assets().base,
+										quote_asset: asset_pair.assets().quote,
 										id: id.into(),
 										range: range.clone(),
 										fees: fees.map(|fees| fees),

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -44,12 +44,11 @@ impl<T> ApiWaitForResult<T> {
 
 pub mod types {
 	use super::*;
-	use cf_chains::assets::any::OldAsset;
 
 	#[derive(Serialize, Deserialize, Clone)]
 	pub struct RangeOrder {
-		pub base_asset: OldAsset,
-		pub quote_asset: OldAsset,
+		pub base_asset: Asset,
+		pub quote_asset: Asset,
 		pub id: U256,
 		pub tick_range: Range<Tick>,
 		pub liquidity_total: U256,
@@ -65,8 +64,8 @@ pub mod types {
 
 	#[derive(Serialize, Deserialize, Clone)]
 	pub struct LimitOrder {
-		pub base_asset: OldAsset,
-		pub quote_asset: OldAsset,
+		pub base_asset: Asset,
+		pub quote_asset: Asset,
 		pub side: Side,
 		pub id: U256,
 		pub tick: Tick,
@@ -95,8 +94,8 @@ fn collect_range_order_returns(
 					..
 				},
 			) => Some(types::RangeOrder {
-				base_asset: base_asset.into(),
-				quote_asset: quote_asset.into(),
+				base_asset,
+				quote_asset,
 				id: id.into(),
 				size_change: size_change.map(|increase_or_decrese| {
 					increase_or_decrese.map(|range_order_change| types::RangeOrderChange {
@@ -133,8 +132,8 @@ fn collect_limit_order_returns(
 					..
 				},
 			) => Some(types::LimitOrder {
-				base_asset: base_asset.into(),
-				quote_asset: quote_asset.into(),
+				base_asset,
+				quote_asset,
 				side,
 				id: id.into(),
 				tick,

--- a/api/lib/src/queries.rs
+++ b/api/lib/src/queries.rs
@@ -18,8 +18,8 @@ use utilities::task_scope;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SwapChannelInfo<C: Chain> {
 	deposit_address: <C::ChainAccount as ToHumanreadableAddress>::Humanreadable,
-	source_asset: any::OldAsset,
-	destination_asset: any::OldAsset,
+	source_asset: any::Asset,
+	destination_asset: any::Asset,
 }
 
 pub struct PreUpdateStatus {
@@ -88,8 +88,8 @@ impl QueryApi {
 					destination_asset, ..
 				} => Some(SwapChannelInfo {
 					deposit_address: deposit_channel.address.to_humanreadable(network_environment),
-					source_asset: Into::<Asset>::into(deposit_channel.asset).into(),
-					destination_asset: (*destination_asset).into(),
+					source_asset: deposit_channel.asset.into(),
+					destination_asset: *destination_asset,
 				}),
 				_ => None,
 			})

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -54,9 +54,7 @@ async function provideLiquidityAndTestAssetBalances() {
   let ethBalance = 0;
   do {
     const balances = await lpApiRpc(`lp_asset_balances`, []);
-    ethBalance = parseInt(
-      balances.Ethereum.filter((el) => el.asset === 'Eth').map((el) => el.balance)[0],
-    );
+    ethBalance = parseInt(balances.Ethereum.Eth);
     retryCount++;
     if (retryCount > 14) {
       throw new Error(

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -8,9 +8,8 @@ use cf_chains::{
 	Chain,
 };
 use cf_primitives::{
-	chains::assets::any::{self, OldAsset},
-	AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, ForeignChain, NetworkEnvironment,
-	SemVer, SwapId, SwapOutput,
+	chains::assets::any, AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, ForeignChain,
+	NetworkEnvironment, SemVer, SwapId, SwapOutput,
 };
 use cf_utilities::rpc::NumberOrHex;
 use codec::Encode;
@@ -281,16 +280,16 @@ pub struct RpcEnvironment {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct PoolPriceV2 {
-	pub base_asset: OldAsset,
-	pub quote_asset: OldAsset,
+	pub base_asset: Asset,
+	pub quote_asset: Asset,
 	#[serde(flatten)]
 	pub price: pallet_cf_pools::PoolPriceV2,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct RpcPrewitnessedSwap {
-	pub base_asset: OldAsset,
-	pub quote_asset: OldAsset,
+	pub base_asset: Asset,
+	pub quote_asset: Asset,
 	pub side: Side,
 	pub amounts: Vec<U256>,
 }
@@ -528,7 +527,7 @@ pub trait CustomApi {
 	) -> RpcResult<RpcPrewitnessedSwap>;
 
 	#[method(name = "supported_assets")]
-	fn cf_supported_assets(&self) -> RpcResult<HashMap<ForeignChain, Vec<OldAsset>>>;
+	fn cf_supported_assets(&self) -> RpcResult<HashMap<ForeignChain, Vec<Asset>>>;
 
 	#[method(name = "failed_call_ethereum")]
 	fn cf_failed_call_ethereum(
@@ -900,8 +899,8 @@ where
 	) -> RpcResult<PoolPriceV2> {
 		let hash = self.unwrap_or_best(at);
 		Ok(PoolPriceV2 {
-			base_asset: base_asset.into(),
-			quote_asset: quote_asset.into(),
+			base_asset,
+			quote_asset,
 			price: self
 				.client
 				.runtime_api()
@@ -1196,11 +1195,7 @@ where
 				api.cf_pool_price_v2(hash, base_asset, quote_asset)
 					.map_err(to_rpc_error)
 					.and_then(|result| result.map_err(map_dispatch_error))
-					.map(|price| PoolPriceV2 {
-						base_asset: base_asset.into(),
-						quote_asset: quote_asset.into(),
-						price,
-					})
+					.map(|price| PoolPriceV2 { base_asset, quote_asset, price })
 			},
 		)
 	}
@@ -1272,8 +1267,8 @@ where
 			sink,
 			move |api, hash| {
 				Ok::<RpcPrewitnessedSwap, jsonrpsee::core::Error>(RpcPrewitnessedSwap {
-					base_asset: base_asset.into(),
-					quote_asset: quote_asset.into(),
+					base_asset,
+					quote_asset,
 					side,
 					amounts: api
 						.cf_prewitness_swaps(hash, base_asset, quote_asset, side)
@@ -1294,8 +1289,8 @@ where
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcPrewitnessedSwap> {
 		Ok(RpcPrewitnessedSwap {
-			base_asset: base_asset.into(),
-			quote_asset: quote_asset.into(),
+			base_asset,
+			quote_asset,
 			side,
 			amounts: self
 				.client
@@ -1308,10 +1303,10 @@ where
 		})
 	}
 
-	fn cf_supported_assets(&self) -> RpcResult<HashMap<ForeignChain, Vec<OldAsset>>> {
-		let mut chain_to_asset: HashMap<ForeignChain, Vec<OldAsset>> = HashMap::new();
+	fn cf_supported_assets(&self) -> RpcResult<HashMap<ForeignChain, Vec<Asset>>> {
+		let mut chain_to_asset: HashMap<ForeignChain, Vec<Asset>> = HashMap::new();
 		Asset::all().for_each(|asset| {
-			chain_to_asset.entry((asset).into()).or_default().push(asset.into());
+			chain_to_asset.entry((asset).into()).or_default().push(asset);
 		});
 		Ok(chain_to_asset)
 	}

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -14,7 +14,6 @@ use cf_chains::assets::any::AssetMap;
 use frame_support::{pallet_prelude::*, sp_runtime::DispatchResult};
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
-use sp_std::vec::Vec;
 
 mod benchmarking;
 
@@ -427,14 +426,8 @@ impl<T: Config> LpBalanceApi for Pallet<T> {
 		});
 	}
 
-	fn asset_balances(
-		who: &Self::AccountId,
-	) -> Result<Vec<(cf_primitives::Asset, u128)>, DispatchError> {
-		let mut balances: Vec<(Asset, AssetAmount)> = vec![];
+	fn asset_balances(who: &Self::AccountId) -> Result<AssetMap<AssetAmount>, DispatchError> {
 		T::PoolApi::sweep(who)?;
-		for asset in Asset::all() {
-			balances.push((asset, FreeBalances::<T>::get(who, asset).unwrap_or_default()));
-		}
-		Ok(balances)
+		Ok(AssetMap::from_fn(|asset| FreeBalances::<T>::get(who, asset).unwrap_or_default()))
 	}
 }

--- a/state-chain/pallets/cf-pools/src/mock.rs
+++ b/state-chain/pallets/cf-pools/src/mock.rs
@@ -1,4 +1,5 @@
 use crate::{self as pallet_cf_pools, PalletSafeMode};
+use cf_chains::assets::any::AssetMap;
 use cf_primitives::{Asset, AssetAmount};
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode, AccountRoleRegistry, LpBalanceApi, SwapType,
@@ -132,7 +133,7 @@ impl LpBalanceApi for MockBalance {
 
 	fn asset_balances(
 		_who: &Self::AccountId,
-	) -> Result<std::vec::Vec<(cf_primitives::Asset, u128)>, sp_runtime::DispatchError> {
+	) -> Result<AssetMap<AssetAmount>, sp_runtime::DispatchError> {
 		unreachable!()
 	}
 }

--- a/state-chain/primitives/src/chains/assets.rs
+++ b/state-chain/primitives/src/chains/assets.rs
@@ -345,6 +345,12 @@ macro_rules! assets {
 						iter.clone().find(|(asset, _t)| *asset == required_asset).ok_or(()).map(|x| x.1)
 					}).ok()
 				}
+
+				pub fn iter(&self) -> impl Iterator<Item = (Asset, &T)> {
+					Asset::all().map(|asset| {
+						(asset, &self[asset])
+					})
+				}
 			}
 
 			impl<T> IndexMut<Asset> for AssetMap<T> {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -22,7 +22,7 @@ use cf_amm::{
 };
 use cf_chains::{
 	arb::api::ArbitrumApi,
-	assets::any::ForeignChainAndAsset,
+	assets::any::{AssetMap, ForeignChainAndAsset},
 	btc::{BitcoinCrypto, BitcoinRetryPolicy},
 	dot::{self, PolkadotCrypto},
 	eth::{self, api::EthereumApi, Address as EthereumAddress, Ethereum},
@@ -1206,7 +1206,7 @@ impl_runtime_apis! {
 				})
 				.collect()
 		}
-		fn cf_asset_balances(account_id: AccountId) -> Result<Vec<(Asset, u128)>, DispatchErrorWithMessage> {
+		fn cf_asset_balances(account_id: AccountId) -> Result<AssetMap<AssetAmount>, DispatchErrorWithMessage> {
 			LiquidityProvider::asset_balances(&account_id).map_err(Into::into)
 		}
 		fn cf_account_flip_balance(account_id: &AccountId) -> u128 {

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -206,7 +206,7 @@ decl_runtime_apis!(
 		fn cf_account_role(account_id: AccountId32) -> Option<AccountRole>;
 		fn cf_asset_balances(
 			account_id: AccountId32,
-		) -> Result<Vec<(Asset, u128)>, DispatchErrorWithMessage>;
+		) -> Result<AssetMap<AssetAmount>, DispatchErrorWithMessage>;
 		fn cf_redemption_tax() -> AssetAmount;
 		fn cf_network_environment() -> NetworkEnvironment;
 		fn cf_failed_call_ethereum(

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -1,10 +1,9 @@
-use cf_chains::address::ForeignChainAddress;
+use cf_chains::{address::ForeignChainAddress, assets::any::AssetMap};
 use cf_primitives::{Asset, AssetAmount, BasisPoints, ChannelId, SwapId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::{DispatchError, DispatchResult};
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
-use sp_std::vec::Vec;
 
 pub trait SwapDepositHandler {
 	type AccountId;
@@ -61,7 +60,7 @@ pub trait LpBalanceApi {
 	fn record_fees(who: &Self::AccountId, amount: AssetAmount, asset: Asset);
 
 	/// Returns the asset balances of the given account.
-	fn asset_balances(who: &Self::AccountId) -> Result<Vec<(Asset, AssetAmount)>, DispatchError>;
+	fn asset_balances(who: &Self::AccountId) -> Result<AssetMap<AssetAmount>, DispatchError>;
 }
 
 pub trait PoolApi {

--- a/state-chain/traits/src/mocks/lp_balance.rs
+++ b/state-chain/traits/src/mocks/lp_balance.rs
@@ -1,5 +1,5 @@
 use crate::{LpBalanceApi, LpDepositHandler};
-use cf_chains::assets::any::Asset;
+use cf_chains::assets::any::{Asset, AssetMap};
 use cf_primitives::AssetAmount;
 use sp_runtime::DispatchResult;
 
@@ -53,7 +53,7 @@ impl LpBalanceApi for MockBalance {
 	fn record_fees(_who: &Self::AccountId, _amount: AssetAmount, _asset: Asset) {}
 	fn asset_balances(
 		_who: &Self::AccountId,
-	) -> Result<Vec<(cf_primitives::Asset, u128)>, sp_runtime::DispatchError> {
+	) -> Result<AssetMap<AssetAmount>, sp_runtime::DispatchError> {
 		unreachable!()
 	}
 }


### PR DESCRIPTION
Affects the responses of these rpcs:

lp-api rpcs
- lp_subscribe_order_fills
- lp_order_fills
- lp_get_open_swap_channels
- lp_asset_balances

node rpcs
- cf_pool_price_v2
- cf_subscribe_pool_price_v2
- cf_subscribe_prewitness_swaps
- cf_prewitness_swaps
- cf_supported_assets
- cf_asset_balances

I'll make a doc PR later today.
