### PR TITLE
fix: remove misleading error

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -656,7 +656,6 @@ pub mod pallet {
 		fn on_finalize(_n: BlockNumberFor<T>) {
 			// Send all fetch/transfer requests as a batch. Revert storage if failed.
 			if let Err(error) = Self::do_egress_scheduled_fetch_transfer() {
-				log::error!("Ingress-Egress failed to send BatchAll. Error: {error:?}");
 				Self::deposit_event(Event::<T, I>::FailedToBuildAllBatchCall { error });
 			}
 


### PR DESCRIPTION
This error is confusing. It's not really an error, can happen quite frequently while we're signing bitcoin transactions. 