### PR TITLE
chore: remove insta deprecated warning

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -574,18 +574,18 @@ mod tests {
 
 		assert_eq!(store.storage.len(), 3);
 		println!("{:?}", store.storage);
-		insta::assert_display_snapshot!(store
+		insta::assert_snapshot!(store
 			.storage
 			.get(format!("deposit:Ethereum:{}", eth_address_str1.to_lowercase()).as_str())
 			.unwrap());
-		insta::assert_display_snapshot!(store
+		insta::assert_snapshot!(store
 			.storage
 			.get(
 				format!("deposit:Polkadot:0x{}", hex::encode(polkadot_account_id.aliased_ref()))
 					.as_str()
 			)
 			.unwrap());
-		insta::assert_display_snapshot!(store
+		insta::assert_snapshot!(store
 			.storage
 			.get(format!("deposit:Ethereum:{}", eth_address_str2.to_lowercase()).as_str())
 			.unwrap());
@@ -609,7 +609,7 @@ mod tests {
 		.await
 		.expect("failed to handle call");
 		assert_eq!(store.storage.len(), 3);
-		insta::assert_display_snapshot!(store
+		insta::assert_snapshot!(store
 			.storage
 			.get(format!("deposit:Ethereum:{}", eth_address_str1.to_lowercase()).as_str())
 			.unwrap());
@@ -646,7 +646,7 @@ mod tests {
 		.expect("failed to handle call");
 
 		assert_eq!(store.storage.len(), 1);
-		insta::assert_display_snapshot!(store.storage.get("broadcast:Ethereum:1").unwrap());
+		insta::assert_snapshot!(store.storage.get("broadcast:Ethereum:1").unwrap());
 	}
 
 	#[test]

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1476,14 +1476,12 @@ mod test {
 
 	#[test]
 	fn test_no_account_serialization() {
-		insta::assert_display_snapshot!(
-			serde_json::to_value(RpcAccountInfo::unregistered(0)).unwrap()
-		);
+		insta::assert_snapshot!(serde_json::to_value(RpcAccountInfo::unregistered(0)).unwrap());
 	}
 
 	#[test]
 	fn test_broker_serialization() {
-		insta::assert_display_snapshot!(serde_json::to_value(RpcAccountInfo::broker(
+		insta::assert_snapshot!(serde_json::to_value(RpcAccountInfo::broker(
 			0,
 			BrokerInfo {
 				earned_fees: vec![
@@ -1546,7 +1544,7 @@ mod test {
 			0,
 		);
 
-		insta::assert_display_snapshot!(serde_json::to_value(lp).unwrap());
+		insta::assert_snapshot!(serde_json::to_value(lp).unwrap());
 	}
 
 	#[test]
@@ -1570,7 +1568,7 @@ mod test {
 			)]),
 		});
 
-		insta::assert_display_snapshot!(serde_json::to_value(validator).unwrap());
+		insta::assert_snapshot!(serde_json::to_value(validator).unwrap());
 	}
 
 	#[test]
@@ -1678,6 +1676,6 @@ mod test {
 			},
 		};
 
-		insta::assert_display_snapshot!(serde_json::to_value(env).unwrap());
+		insta::assert_snapshot!(serde_json::to_value(env).unwrap());
 	}
 }


### PR DESCRIPTION
Was a compiler warning that the old method was deprecated, so just moving to the new one.