### PR TITLE
fix: broker flakiness on bouncer CI

### DIFF
--- a/bouncer/shared/new_swap.ts
+++ b/bouncer/shared/new_swap.ts
@@ -20,22 +20,35 @@ export async function newSwap(
     destAsset === 'Dot' ? decodeDotAddressForContract(destAddress) : destAddress;
   const brokerUrl = process.env.BROKER_ENDPOINT || 'http://127.0.0.1:10997';
 
-  await broker.requestSwapDepositAddress(
-    {
-      srcAsset: stateChainAssetFromAsset(sourceAsset) as SCAsset,
-      destAsset: stateChainAssetFromAsset(destAsset) as SCAsset,
-      srcChain: chainFromAsset(sourceAsset),
-      destAddress: destinationAddress,
-      destChain: chainFromAsset(destAsset),
-      ccmMetadata: messageMetadata && {
-        message: messageMetadata.message as `0x${string}`,
-        gasBudget: messageMetadata.gasBudget.toString(),
-      },
-    },
-    {
-      url: brokerUrl,
-      commissionBps: brokerCommissionBps,
-    },
-    'backspin',
-  );
+  // If the dry_run of the extrinsic fails on the broker-api then it won't retry. So we retry here to
+  // avoid flakiness on CI.
+  let retryCount = 0;
+  while (retryCount < 20) {
+    try {
+      await broker.requestSwapDepositAddress(
+        {
+          srcAsset: stateChainAssetFromAsset(sourceAsset) as SCAsset,
+          destAsset: stateChainAssetFromAsset(destAsset) as SCAsset,
+          srcChain: chainFromAsset(sourceAsset),
+          destAddress: destinationAddress,
+          destChain: chainFromAsset(destAsset),
+          ccmMetadata: messageMetadata && {
+            message: messageMetadata.message as `0x${string}`,
+            gasBudget: messageMetadata.gasBudget.toString(),
+          },
+        },
+        {
+          url: brokerUrl,
+          commissionBps: brokerCommissionBps,
+        },
+        'backspin',
+      );
+      break; // Exit the loop on success
+    } catch (error) {
+      retryCount++;
+      console.error(
+        `Request swap deposit address for ${sourceAsset} attempt: ${retryCount} failed: ${error}`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
Hide whitespace for an easier review.

# Pull Request

Closes: PRO-1093

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

If the dry_run fails, which it could, for example due to a nonce issue - then the extrinsic isn't retried, and the whole bouncer run fails. Here we just retry until success. 20 retries to be safe, only one retry is likely to ever occur based on the frequency we see this issue occur (not super frequently).