### PR TITLE
feat: emit event to help diagnose failed witnessing reports

### DIFF
--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -909,7 +909,7 @@ fn can_handle_failed_vault_transfer() {
 				},
 			));
 
-			System::assert_last_event(RuntimeEvent::EthereumIngressEgress(
+			System::assert_has_event(RuntimeEvent::EthereumIngressEgress(
 				pallet_cf_ingress_egress::Event::<Runtime, Instance1>::TransferFallbackRequested {
 					asset,
 					amount,

--- a/state-chain/pallets/cf-witnesser/Cargo.toml
+++ b/state-chain/pallets/cf-witnesser/Cargo.toml
@@ -40,7 +40,6 @@ frame-benchmarking = { git = "https://github.com/chainflip-io/polkadot-sdk.git",
 frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 frame-system = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-std = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
-sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities' }
@@ -62,7 +61,6 @@ std = [
   'hex/std',
   'scale-info/std',
   'sp-std/std',
-  'sp-runtime/std',
 ]
 runtime-benchmarks = [
   'cf-primitives/runtime-benchmarks',

--- a/state-chain/pallets/cf-witnesser/Cargo.toml
+++ b/state-chain/pallets/cf-witnesser/Cargo.toml
@@ -40,6 +40,7 @@ frame-benchmarking = { git = "https://github.com/chainflip-io/polkadot-sdk.git",
 frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 frame-system = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-std = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 
 [dev-dependencies]
 cf-test-utilities = { path = '../../test-utilities' }
@@ -61,6 +62,7 @@ std = [
   'hex/std',
   'scale-info/std',
   'sp-std/std',
+  'sp-runtime/std',
 ]
 runtime-benchmarks = [
   'cf-primitives/runtime-benchmarks',

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -30,7 +30,6 @@ use frame_support::{
 	Hashable,
 };
 use scale_info::TypeInfo;
-use sp_runtime::Saturating;
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, PartialEq, Eq, RuntimeDebug)]
@@ -309,8 +308,9 @@ pub mod pallet {
 						);
 						Self::deposit_event(Event::<T>::ReportedWitnessingFailures {
 							call_hash,
-							block_number: frame_system::Pallet::<T>::block_number()
-								.saturating_sub(T::LateWitnessGracePeriod::get()),
+							// Safe because n is always inserted using current +
+							// T::LateWitnessGracePeriod::get()
+							block_number: n - T::LateWitnessGracePeriod::get(),
 							accounts: failed_witnessers,
 						});
 					}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1287

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Emit an event when a witnessed call is deposited, and when nodes are being punished for failing to witness a call.
This will help operators to connect what call they were being punished for (when they failed to witness in time).
