### PR TITLE
chore: SetAggKeyWithAggKey should not error to indicate that a transaction is not needed

### DIFF
--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -31,11 +31,11 @@ where
 	fn new_unsigned(
 		_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
 		new_key: <EvmCrypto as ChainCrypto>::AggKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError> {
-		Ok(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
+		Ok(Some(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(
 			E::replay_protection(E::key_manager_address()),
 			set_agg_key_with_agg_key::SetAggKeyWithAggKey::new(new_key),
-		)))
+		))))
 	}
 }
 

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -111,11 +111,11 @@ where
 	fn new_unsigned(
 		_maybe_old_key: Option<<BitcoinCrypto as ChainCrypto>::AggKey>,
 		_new_key: <BitcoinCrypto as ChainCrypto>::AggKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError> {
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
 		// Utxo transfer into the new vault now happens gradually over the new epoch as part of
 		// consolidation. This prevents sending too many utxos within the same transaction
 		// which may cause threshold signing to fail.
-		Err(SetAggKeyWithAggKeyError::NotRequired)
+		Ok(None)
 	}
 }
 

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -97,16 +97,16 @@ where
 	fn new_unsigned(
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError> {
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
 		let vault = E::try_vault_account().ok_or(SetAggKeyWithAggKeyError::Failed)?;
 
-		Ok(Self::RotateVaultProxy(rotate_vault_proxy::extrinsic_builder(
+		Ok(Some(Self::RotateVaultProxy(rotate_vault_proxy::extrinsic_builder(
 			// we reset the proxy account nonce on a rotation tx
 			E::replay_protection(true),
 			maybe_old_key,
 			new_key,
 			vault,
-		)))
+		))))
 	}
 }
 

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -120,11 +120,11 @@ where
 	fn new_unsigned(
 		_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
 		new_key: <EvmCrypto as ChainCrypto>::AggKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError> {
-		Ok(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
+		Ok(Some(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(
 			E::replay_protection(E::key_manager_address()),
 			set_agg_key_with_agg_key::SetAggKeyWithAggKey::new(new_key),
-		)))
+		))))
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -313,7 +313,6 @@ pub trait ChainEnvironment<
 
 pub enum SetAggKeyWithAggKeyError {
 	Failed,
-	NotRequired,
 }
 
 /// Constructs the `SetAggKeyWithAggKey` api call.
@@ -321,7 +320,7 @@ pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 	fn new_unsigned(
 		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
 		new_key: <C as ChainCrypto>::AggKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError>;
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError>;
 }
 
 #[allow(clippy::result_unit_err)]

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -84,12 +84,12 @@ impl SetAggKeyWithAggKey<MockEthereumChainCrypto> for MockSetAggKeyWithAggKey {
 	fn new_unsigned(
 		old_key: Option<<<MockEthereum as Chain>::ChainCrypto as ChainCrypto>::AggKey>,
 		new_key: <<MockEthereum as Chain>::ChainCrypto as ChainCrypto>::AggKey,
-	) -> Result<Self, SetAggKeyWithAggKeyError> {
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
 		if !SET_AGG_KEY_WITH_AGG_KEY_REQUIRED.with(|cell| *cell.borrow()) {
-			return Err(SetAggKeyWithAggKeyError::NotRequired)
+			return Ok(None)
 		}
 
-		Ok(Self { old_key: old_key.ok_or(SetAggKeyWithAggKeyError::Failed)?, new_key })
+		Ok(Some(Self { old_key: old_key.ok_or(SetAggKeyWithAggKeyError::Failed)?, new_key }))
 	}
 }
 

--- a/state-chain/pallets/cf-vaults/src/vault_activator.rs
+++ b/state-chain/pallets/cf-vaults/src/vault_activator.rs
@@ -33,7 +33,7 @@ impl<T: Config<I>, I: 'static> VaultActivator<<T::Chain as Chain>::ChainCrypto> 
 				maybe_old_public_key,
 				new_public_key,
 			) {
-				Ok(activation_call) => {
+				Ok(Some(activation_call)) => {
 					// we need to sign and submit the rotation call
 					// reporting back the request_id of the tss such that we can complete the
 					// rotation when that request is completed
@@ -46,7 +46,7 @@ impl<T: Config<I>, I: 'static> VaultActivator<<T::Chain as Chain>::ChainCrypto> 
 					);
 					vec![StartKeyActivationResult::Normal(tss_request_id)]
 				},
-				Err(SetAggKeyWithAggKeyError::NotRequired) => {
+				Ok(None) => {
 					// This can happen if, for example, on a utxo chain there are no funds that
 					// need to be swept.
 					Self::activate_new_key_for_chain(T::ChainTracking::get_block_height());


### PR DESCRIPTION
# Pull Request

Closes: PRO-1278

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This is a minor thing, but we used an error to signal when AggKey rotation broadcast is not required. This change uses an Option to indicate whether a transaction needs to be submitted or not and only errors on real errors.
