### PR TITLE
Revert "fix: Wait for ThresholdSignature success before switching to NewKeysActivated (#4534)"

### DIFF
--- a/state-chain/cf-integration-tests/src/authorities.rs
+++ b/state-chain/cf-integration-tests/src/authorities.rs
@@ -113,9 +113,6 @@ fn authority_rotates_with_correct_sequence() {
 				RotationPhase::ActivatingKeys(..)
 			));
 
-			// Wait for an extra block to allow TSS to complete, we switch to RotationComplete once
-			// that's done
-			testnet.move_forward_blocks(1);
 			assert_eq!(
 				AllVaults::status(),
 				AsyncResult::Ready(KeyRotationStatusOuter::RotationComplete),

--- a/state-chain/cf-integration-tests/src/broadcasting.rs
+++ b/state-chain/cf-integration-tests/src/broadcasting.rs
@@ -42,7 +42,7 @@ fn bitcoin_broadcast_delay_works() {
 			)
 			.unwrap();
 
-			let (broadcast_id, _) =
+			let broadcast_id =
 				<BitcoinBroadcaster as Broadcaster<Bitcoin>>::threshold_sign_and_broadcast(
 					bitcoin_call,
 				);

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -128,7 +128,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn start_next_broadcast_attempt() {
-		let (broadcast_id, _) = Pallet::<T, I>::threshold_sign_and_broadcast(
+		let broadcast_id = Pallet::<T, I>::threshold_sign_and_broadcast(
 			BenchmarkValue::benchmark_value(),
 			None,
 			|_| None,

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -436,7 +436,7 @@ fn threshold_sign_and_broadcast_with_callback() {
 			tx_out_id: MOCK_TRANSACTION_OUT_ID,
 		};
 
-		let (broadcast_id, _) =
+		let broadcast_id =
 			Broadcaster::threshold_sign_and_broadcast(api_call.clone(), Some(MockCallback), |_| {
 				None
 			});
@@ -547,7 +547,7 @@ fn callback_is_called_upon_broadcast_failure() {
 			sig: Default::default(),
 			tx_out_id: MOCK_TRANSACTION_OUT_ID,
 		};
-		let (broadcast_id, _) =
+		let broadcast_id =
 			Broadcaster::threshold_sign_and_broadcast(api_call.clone(), None, |_| {
 				Some(MockCallback)
 			});
@@ -888,7 +888,7 @@ fn initiate_and_sign_broadcast(
 	api_call: &MockApiCall<MockEthereumChainCrypto>,
 	tx_type: TxType,
 ) -> BroadcastId {
-	let (broadcast_id, _) = match tx_type {
+	let broadcast_id = match tx_type {
 		TxType::Normal => <Broadcaster as BroadcasterTrait<
 			<Test as Config<Instance1>>::TargetChain,
 		>>::threshold_sign_and_broadcast((*api_call).clone()),

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -169,11 +169,9 @@ impl Broadcaster<MockEthereum> for MockBroadcast {
 	type ApiCall = MockUpdateFlipSupply;
 	type Callback = MockCallback;
 
-	fn threshold_sign_and_broadcast(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> BroadcastId {
 		Self::call(api_call);
-		(1, 1)
+		1
 	}
 
 	fn threshold_sign_and_broadcast_with_callback(
@@ -184,9 +182,7 @@ impl Broadcaster<MockEthereum> for MockBroadcast {
 		unimplemented!()
 	}
 
-	fn threshold_sign_and_broadcast_rotation_tx(
-		_api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast_rotation_tx(_api_call: Self::ApiCall) -> BroadcastId {
 		unimplemented!()
 	}
 

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -101,9 +101,7 @@ impl Broadcaster<Polkadot> for MockPolkadotBroadcaster {
 	type ApiCall = MockCreatePolkadotVault;
 	type Callback = MockCallback;
 
-	fn threshold_sign_and_broadcast(
-		_api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast(_api_call: Self::ApiCall) -> BroadcastId {
 		unimplemented!()
 	}
 
@@ -115,9 +113,7 @@ impl Broadcaster<Polkadot> for MockPolkadotBroadcaster {
 		unimplemented!()
 	}
 
-	fn threshold_sign_and_broadcast_rotation_tx(
-		_api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast_rotation_tx(_api_call: Self::ApiCall) -> BroadcastId {
 		unimplemented!()
 	}
 

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -483,7 +483,7 @@ pub mod pallet {
 				Self::deposit_event(Event::RedemptionRequested {
 					account_id,
 					amount: redeem_amount,
-					broadcast_id: T::Broadcaster::threshold_sign_and_broadcast(call).0,
+					broadcast_id: T::Broadcaster::threshold_sign_and_broadcast(call),
 					expiry_time: contract_expiry,
 				});
 			} else {

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -156,13 +156,11 @@ impl Broadcaster<Ethereum> for MockBroadcaster {
 	type ApiCall = MockRegisterRedemption;
 	type Callback = MockCallback;
 
-	fn threshold_sign_and_broadcast(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> BroadcastId {
 		REDEMPTION_BROADCAST_REQUESTS.with(|cell| {
 			cell.borrow_mut().push(api_call.amount);
 		});
-		(0, 0)
+		0
 	}
 
 	fn threshold_sign_and_broadcast_with_callback(
@@ -173,9 +171,7 @@ impl Broadcaster<Ethereum> for MockBroadcaster {
 		unimplemented!()
 	}
 
-	fn threshold_sign_and_broadcast_rotation_tx(
-		_api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast_rotation_tx(_api_call: Self::ApiCall) -> BroadcastId {
 		unimplemented!()
 	}
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -659,8 +659,7 @@ pub mod pallet {
 			if let Ok(egress_transaction) =
 				<T::ChainApiCall as ConsolidateCall<T::TargetChain>>::consolidate_utxos()
 			{
-				let (broadcast_id, _) =
-					T::Broadcaster::threshold_sign_and_broadcast(egress_transaction);
+				let broadcast_id = T::Broadcaster::threshold_sign_and_broadcast(egress_transaction);
 				Self::deposit_event(Event::<T, I>::UtxoConsolidation { broadcast_id });
 				Self::deposit_event(Event::<T, I>::BatchBroadcastRequested {
 					broadcast_id,

--- a/state-chain/pallets/cf-threshold-signature/src/key_rotator.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/key_rotator.rs
@@ -147,24 +147,12 @@ impl<T: Config<I>, I: 'static> KeyRotator for Pallet<T, I> {
 						),
 					},
 				KeyRotationStatusVariant::AwaitingActivation => {
-					let (new_public_key, maybe_request_id) = match PendingKeyRotation::<T, I>::get()
-					{
-						Some(KeyRotationStatus::AwaitingActivation {
-							request_id,
+					let new_public_key = match PendingKeyRotation::<T, I>::get() {
+						Some(KeyRotationStatus::AwaitingActivation { new_public_key }) =>
 							new_public_key,
-						}) => (new_public_key, request_id),
 						_ => unreachable!(
 							"Unreachable because we are in the branch for the AwaitingActivation variant."
 						),
-					};
-
-					if let Some(request_id) = maybe_request_id {
-						// After the ceremony completes, it is consumed and Void is left
-						// behind. At this point we are sure the ceremony existed and succeded, we
-						// can activate the key
-						if Signature::<T, I>::get(request_id) == AsyncResult::Void {
-							T::VaultActivator::activate_key();
-						};
 					};
 
 					let status = T::VaultActivator::status()
@@ -200,34 +188,17 @@ impl<T: Config<I>, I: 'static> KeyRotator for Pallet<T, I> {
 			PendingKeyRotation::<T, I>::get()
 		{
 			let maybe_active_epoch_key = Self::active_epoch_key();
-
-			match T::VaultActivator::start_key_activation(
+			T::VaultActivator::activate(
 				new_public_key,
 				maybe_active_epoch_key.map(|EpochKey { key, .. }| key),
-			) {
-				// If a request_id was returned we need to wait for the signing request to complete
-				// before ending the rotation succesfully
-				Some(request_id) => {
-					PendingKeyRotation::<T, I>::put(
-						KeyRotationStatus::<T, I>::AwaitingActivation {
-							request_id: Some(request_id),
-							new_public_key,
-						},
-					);
-				},
-				// if none was returned no ceremony is required and we can already complete the
-				// rotation/wait for governance extrinsic to activate the vault
-				None =>
-					if maybe_active_epoch_key.is_some() {
-						Self::activate_new_key(new_public_key);
-					} else {
-						PendingKeyRotation::<T, I>::put(
-							KeyRotationStatus::<T, I>::AwaitingActivation {
-								request_id: None,
-								new_public_key,
-							},
-						);
-					},
+			);
+
+			if maybe_active_epoch_key.is_some() {
+				Self::activate_new_key(new_public_key);
+			} else {
+				PendingKeyRotation::<T, I>::put(KeyRotationStatus::<T, I>::AwaitingActivation {
+					new_public_key,
+				});
 			}
 		} else {
 			log::error!("Vault activation called during wrong state.");

--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -141,7 +141,6 @@ pub enum KeyRotationStatus<T: Config<I>, I: 'static = ()> {
 	},
 	/// We are waiting for the key to be updated on the contract, and witnessed by the network.
 	AwaitingActivation {
-		request_id: Option<RequestId>,
 		new_public_key: AggKeyFor<T, I>,
 	},
 	/// The key has been successfully updated on the external chain, and/or funds rotated to new

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -8,10 +8,7 @@ use cf_chains::{
 	mocks::{MockAggKey, MockEthereumChainCrypto, MockThresholdSignature},
 	ChainCrypto,
 };
-use cf_primitives::{
-	AuthorityCount, CeremonyId, FlipBalance, ThresholdSignatureRequestId, FLIPPERINOS_PER_FLIP,
-	GENESIS_EPOCH,
-};
+use cf_primitives::{AuthorityCount, CeremonyId, FlipBalance, FLIPPERINOS_PER_FLIP, GENESIS_EPOCH};
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{cfe_interface_mock::MockCfeInterface, signer_nomination::MockNominator},
@@ -191,14 +188,7 @@ impl pallet_cf_threshold_signature::Config<Instance1> for Test {
 pub struct MockVaultActivator;
 impl VaultActivator<MockEthereumChainCrypto> for MockVaultActivator {
 	type ValidatorId = <Test as Chainflip>::ValidatorId;
-	fn start_key_activation(
-		_new_key: MockAggKey,
-		_maybe_old_key: Option<MockAggKey>,
-	) -> Option<ThresholdSignatureRequestId> {
-		VAULT_ACTIVATION_STATUS.with(|value| *(value.borrow_mut()) = AsyncResult::Pending);
-		let ceremony_id = current_ceremony_id();
-		Some(ceremony_id as u32)
-	}
+	fn activate(_new_key: MockAggKey, _maybe_old_key: Option<MockAggKey>) {}
 
 	fn status() -> AsyncResult<()> {
 		VAULT_ACTIVATION_STATUS.with(|value| *value.borrow())
@@ -207,10 +197,6 @@ impl VaultActivator<MockEthereumChainCrypto> for MockVaultActivator {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_status(outcome: AsyncResult<()>) {
 		VAULT_ACTIVATION_STATUS.with(|value| *(value.borrow_mut()) = outcome)
-	}
-
-	fn activate_key() {
-		VAULT_ACTIVATION_STATUS.with(|value| *(value.borrow_mut()) = AsyncResult::Ready(()))
 	}
 }
 

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -138,11 +138,9 @@ impl Broadcaster<MockEthereum> for MockBroadcaster {
 	type ApiCall = MockSetAggKeyWithAggKey;
 	type Callback = MockCallback;
 
-	fn threshold_sign_and_broadcast(
-		_api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast(_api_call: Self::ApiCall) -> BroadcastId {
 		Self::send_broadcast();
-		(1, 1)
+		1
 	}
 
 	fn threshold_sign_and_broadcast_with_callback(
@@ -153,9 +151,7 @@ impl Broadcaster<MockEthereum> for MockBroadcaster {
 		unimplemented!()
 	}
 
-	fn threshold_sign_and_broadcast_rotation_tx(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast_rotation_tx(api_call: Self::ApiCall) -> BroadcastId {
 		Self::threshold_sign_and_broadcast(api_call)
 	}
 

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -42,7 +42,7 @@ fn test_vault_key_rotated_externally_triggers_code_red() {
 #[test]
 fn key_unavailable_on_activate_returns_governance_event() {
 	new_test_ext_no_key().execute_with(|| {
-		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, None);
+		VaultsPallet::activate(NEW_AGG_PUBKEY, None);
 
 		assert_last_event!(crate::Event::AwaitingGovernanceActivation { .. });
 
@@ -57,7 +57,7 @@ fn when_set_agg_key_with_agg_key_not_required_we_skip_to_completion() {
 	new_test_ext().execute_with(|| {
 		MockSetAggKeyWithAggKey::set_required(false);
 
-		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, Some(Default::default()));
+		VaultsPallet::activate(NEW_AGG_PUBKEY, Some(Default::default()));
 
 		assert!(matches!(
 			PendingVaultActivation::<Test, _>::get().unwrap(),
@@ -70,8 +70,8 @@ fn when_set_agg_key_with_agg_key_not_required_we_skip_to_completion() {
 fn vault_start_block_number_is_set_correctly() {
 	new_test_ext_no_key().execute_with(|| {
 		BlockHeightProvider::<MockEthereum>::set_block_height(1000);
-		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, Some(Default::default()));
-		VaultsPallet::activate_key();
+		VaultsPallet::activate(NEW_AGG_PUBKEY, Some(Default::default()));
+
 		assert_eq!(
 			crate::VaultStartBlockNumbers::<Test, _>::get(
 				MockEpochInfo::epoch_index().saturating_add(1)

--- a/state-chain/pallets/cf-vaults/src/vault_activator.rs
+++ b/state-chain/pallets/cf-vaults/src/vault_activator.rs
@@ -1,6 +1,5 @@
 use super::*;
 use cf_chains::SetAggKeyWithAggKeyError;
-use cf_primitives::ThresholdSignatureRequestId;
 use cf_runtime_utilities::{log_or_panic, StorageDecodeVariant};
 use cf_traits::{GetBlockHeight, VaultActivator};
 
@@ -19,44 +18,26 @@ impl<T: Config<I>, I: 'static> VaultActivator<<T::Chain as Chain>::ChainCrypto> 
 		}
 	}
 
-	fn activate_key() {
-		Self::activate_new_key_for_chain(T::ChainTracking::get_block_height());
-	}
-
-	fn start_key_activation(
-		new_public_key: AggKeyFor<T, I>,
-		maybe_old_public_key: Option<AggKeyFor<T, I>>,
-	) -> Option<ThresholdSignatureRequestId> {
+	fn activate(new_public_key: AggKeyFor<T, I>, maybe_old_public_key: Option<AggKeyFor<T, I>>) {
 		if let Some(old_key) = maybe_old_public_key {
 			match <T::SetAggKeyWithAggKey as SetAggKeyWithAggKey<_>>::new_unsigned(
 				Some(old_key),
 				new_public_key,
 			) {
 				Ok(activation_call) => {
-					// we need to sign and submit the rotation call
-					// reporting back the request_id of the tss such that we can complete the
-					// rotation when that request is completed
-					let (_, tss_request_id) =
-						T::Broadcaster::threshold_sign_and_broadcast_rotation_tx(activation_call);
-					// since vaults are activated only when the tss completes we need to initiate
-					// the activation
-					PendingVaultActivation::<T, I>::put(
-						VaultActivationStatus::<T, I>::AwaitingActivation { new_public_key },
-					);
-					Some(tss_request_id)
+					T::Broadcaster::threshold_sign_and_broadcast_rotation_tx(activation_call);
+					Self::activate_new_key_for_chain(T::ChainTracking::get_block_height());
 				},
 				Err(SetAggKeyWithAggKeyError::NotRequired) => {
 					// This can happen if, for example, on a utxo chain there are no funds that
 					// need to be swept.
 					Self::activate_new_key_for_chain(T::ChainTracking::get_block_height());
-					None
 				},
 				Err(SetAggKeyWithAggKeyError::Failed) => {
 					log_or_panic!(
 						"Unexpected failure during {} vault activation.",
 						<T::Chain as cf_chains::Chain>::NAME,
 					);
-					None
 				},
 			}
 		} else {
@@ -65,7 +46,6 @@ impl<T: Config<I>, I: 'static> VaultActivator<<T::Chain as Chain>::ChainCrypto> 
 				VaultActivationStatus::<T, I>::AwaitingActivation { new_public_key },
 			);
 			Self::deposit_event(Event::<T, I>::AwaitingGovernanceActivation { new_public_key });
-			None
 		}
 	}
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -197,15 +197,7 @@ pub trait VaultActivator<C: ChainCrypto> {
 
 	/// Activate key/s on particular chain/s. For example, setting the new key
 	/// on the contract for a smart contract chain.
-	/// Can also complete the activation if we don't require a signing ceremony
-	fn start_key_activation(
-		new_key: C::AggKey,
-		maybe_old_key: Option<C::AggKey>,
-	) -> Option<ThresholdSignatureRequestId>;
-
-	/// Final step of key activation which result in the vault activation (in case we need to wait
-	/// for the signing ceremony to complete)
-	fn activate_key();
+	fn activate(new_key: C::AggKey, maybe_old_key: Option<C::AggKey>);
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_status(_outcome: AsyncResult<()>);
@@ -507,9 +499,7 @@ pub trait Broadcaster<C: Chain> {
 	type Callback: UnfilteredDispatchable;
 
 	/// Request a threshold signature and then build and broadcast the outbound api call.
-	fn threshold_sign_and_broadcast(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId);
+	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> BroadcastId;
 
 	/// Like `threshold_sign_and_broadcast` but also registers a callback to be dispatched when the
 	/// signature accepted event has been witnessed.
@@ -521,9 +511,7 @@ pub trait Broadcaster<C: Chain> {
 
 	/// Request a threshold signature and then build and broadcast the outbound api call
 	/// specifically for a rotation tx..
-	fn threshold_sign_and_broadcast_rotation_tx(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId);
+	fn threshold_sign_and_broadcast_rotation_tx(api_call: Self::ApiCall) -> BroadcastId;
 
 	/// Resign a call, and update the signature data storage, but do not broadcast.
 	fn threshold_resign(broadcast_id: BroadcastId) -> Option<ThresholdSignatureRequestId>;

--- a/state-chain/traits/src/mocks/broadcaster.rs
+++ b/state-chain/traits/src/mocks/broadcaster.rs
@@ -27,22 +27,17 @@ impl<
 	type ApiCall = A;
 	type Callback = C;
 
-	fn threshold_sign_and_broadcast(
-		api_call: Self::ApiCall,
-	) -> (cf_primitives::BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast(api_call: Self::ApiCall) -> cf_primitives::BroadcastId {
 		Self::mutate_value(b"API_CALLS", |api_calls: &mut Option<Vec<A>>| {
 			let api_calls = api_calls.get_or_insert(Default::default());
 			api_calls.push(api_call);
 		});
-		let tss_request_id = Self::next_threshold_id();
-		(
-			<Self as MockPalletStorage>::mutate_value(b"BROADCAST_ID", |v: &mut Option<u32>| {
-				let v = v.get_or_insert(0);
-				*v += 1;
-				*v
-			}),
-			tss_request_id,
-		)
+		let _ = Self::next_threshold_id();
+		<Self as MockPalletStorage>::mutate_value(b"BROADCAST_ID", |v: &mut Option<u32>| {
+			let v = v.get_or_insert(0);
+			*v += 1;
+			*v
+		})
 	}
 
 	fn threshold_sign_and_broadcast_with_callback(
@@ -50,7 +45,7 @@ impl<
 		success_callback: Option<Self::Callback>,
 		failed_callback_generator: impl FnOnce(BroadcastId) -> Option<Self::Callback>,
 	) -> BroadcastId {
-		let (id, _) = <Self as Broadcaster<Api>>::threshold_sign_and_broadcast(api_call);
+		let id = <Self as Broadcaster<Api>>::threshold_sign_and_broadcast(api_call);
 		if let Some(callback) = success_callback {
 			Self::put_storage(b"SUCCESS_CALLBACKS", id, callback);
 		}
@@ -79,9 +74,7 @@ impl<
 	/// Clean up storage data related to a broadcast ID.
 	fn clean_up_broadcast_storage(_broadcast_id: BroadcastId) {}
 
-	fn threshold_sign_and_broadcast_rotation_tx(
-		api_call: Self::ApiCall,
-	) -> (BroadcastId, ThresholdSignatureRequestId) {
+	fn threshold_sign_and_broadcast_rotation_tx(api_call: Self::ApiCall) -> BroadcastId {
 		<Self as Broadcaster<Api>>::threshold_sign_and_broadcast(api_call)
 	}
 }


### PR DESCRIPTION
This reverts commit c1271c094f115f3904cddf2a50953a0951322949.

Fixes rotation edge case of
1. Threshold signature request for the Ethereum new key activation after a rotation
2. Threshold signature request for the Eth egress
3. Ethereum signer succeeded for the key rotation and broadcast is sent
4.  Ethereum signer succeeded for the Eth egress but is not sent for broadcast as it's waiting for the key activation (broadcast barrier)
5. Key activation is succesfully witnessed
6. Broadcast requested for the egress was requested now that the key activation has finished. That fails because it was signed with the old key.