### PR TITLE
fix: delay threshold signature retries

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -163,7 +163,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 134,
+	spec_version: 135,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 12,
@@ -898,6 +898,8 @@ impl frame_support::traits::OnRuntimeUpgrade for ResignFailedEthereumBroadcast {
 
 		if let Some(id) = failed_broadcast_id() {
 			resign_eth(id);
+		} else {
+			log::info!("✅ No broadcasts to re-sign.");
 		}
 
 		Default::default()

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -871,14 +871,18 @@ pub struct ResignFailedEthereumBroadcast;
 
 const FAILED_BROADCAST_ID_BERGHAIN: u32 = 3348;
 const FAILED_BROADCAST_ID_PERSEVERANCE: u32 = 113;
+const FAILED_BROADCAST_ID_SISYPHOS: u32 = 93;
 
 pub const BERGHAIN: [u8; 32] =
 	hex_literal::hex!("8b8c140b0af9db70686583e3f6bf2a59052bfe9584b97d20c45068281e976eb9");
 pub const PERSEVERANCE: [u8; 32] =
 	hex_literal::hex!("7a5d4db858ada1d20ed6ded4933c33313fc9673e5fffab560d0ca714782f2080");
+pub const SISYPHOS: [u8; 32] =
+	hex_literal::hex!("7db0684f891ad10fa919c801f9a9f030c0f6831aafa105b1a68e47803f91f2b6");
 
 fn failed_broadcast_id() -> Option<u32> {
 	match frame_system::BlockHash::<Runtime>::get(0).to_fixed_bytes() {
+		SISYPHOS => Some(FAILED_BROADCAST_ID_SISYPHOS),
 		PERSEVERANCE => Some(FAILED_BROADCAST_ID_PERSEVERANCE),
 		BERGHAIN => Some(FAILED_BROADCAST_ID_BERGHAIN),
 		_ => None,
@@ -917,11 +921,7 @@ impl frame_support::traits::OnRuntimeUpgrade for ResignFailedEthereumBroadcast {
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
-		if let Some(id) = match frame_system::BlockHash::<Runtime>::get(0).to_fixed_bytes() {
-			PERSEVERANCE => Some(FAILED_BROADCAST_ID_PERSEVERANCE),
-			BERGHAIN => Some(FAILED_BROADCAST_ID_BERGHAIN),
-			_ => None,
-		} {
+		if let Some(id) = failed_broadcast_id() {
 			frame_support::ensure!(
 				!pallet_cf_broadcast::ThresholdSignatureData::<Runtime, EthereumInstance>::contains_key(id),
 				"Broadcast {id} was not removed.",

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -871,7 +871,6 @@ pub struct ResignFailedEthereumBroadcast;
 
 const FAILED_BROADCAST_ID_BERGHAIN: u32 = 3348;
 const FAILED_BROADCAST_ID_PERSEVERANCE: u32 = 113;
-const FAILED_BROADCAST_ID_SISYPHOS: u32 = 93;
 
 pub const BERGHAIN: [u8; 32] =
 	hex_literal::hex!("8b8c140b0af9db70686583e3f6bf2a59052bfe9584b97d20c45068281e976eb9");
@@ -882,7 +881,7 @@ pub const SISYPHOS: [u8; 32] =
 
 fn failed_broadcast_id() -> Option<u32> {
 	match frame_system::BlockHash::<Runtime>::get(0).to_fixed_bytes() {
-		SISYPHOS => Some(FAILED_BROADCAST_ID_SISYPHOS),
+		SISYPHOS => None,
 		PERSEVERANCE => Some(FAILED_BROADCAST_ID_PERSEVERANCE),
 		BERGHAIN => Some(FAILED_BROADCAST_ID_BERGHAIN),
 		_ => None,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -870,7 +870,7 @@ use frame_support::sp_runtime::DispatchError;
 pub struct ResignFailedEthereumBroadcast;
 
 const FAILED_BROADCAST_ID_BERGHAIN: u32 = 3348;
-const FAILED_BROADCAST_ID_PERSEVERANCE: u32 = 136;
+const FAILED_BROADCAST_ID_PERSEVERANCE: u32 = 113;
 
 pub const BERGHAIN: [u8; 32] =
 	hex_literal::hex!("8b8c140b0af9db70686583e3f6bf2a59052bfe9584b97d20c45068281e976eb9");

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -454,6 +454,14 @@ where
 		request_id
 	}
 
+	/// Temporary workaround to allow scheduling signatures during a runtime upgrade.
+	fn request_signature_with_callback_delayed(
+		payload: C::Payload,
+		callback_generator: impl FnOnce(ThresholdSignatureRequestId) -> Self::Callback,
+	) -> ThresholdSignatureRequestId {
+		Self::request_signature_with_callback(payload, callback_generator)
+	}
+
 	/// Helper function to enable benchmarking of the broadcast pallet
 	#[cfg(feature = "runtime-benchmarks")]
 	fn insert_signature(


### PR DESCRIPTION
Makes the resign-broadcast method use a new temporary method that forces a delayed threshold signature request. 

This is to allow the request to be emitted *after* the runtime upgrade block.

The previous approach didn't work because CfeEvents storage is cleared in the on_initialize hook, which is executed after the runtime upgrade hooks.