### PR TITLE
feat: Authorities should be sorted pseudo-randomly

### DIFF
--- a/state-chain/cf-integration-tests/src/authorities.rs
+++ b/state-chain/cf-integration-tests/src/authorities.rs
@@ -19,11 +19,11 @@ use state_chain_runtime::{
 // Helper function that creates a network, funds backup nodes, and have them join the auction.
 pub fn fund_authorities_and_join_auction(
 	num_backups: AuthorityCount,
-) -> (network::Network, BTreeSet<NodeId>, BTreeSet<NodeId>) {
+) -> (network::Network, Vec<NodeId>, Vec<NodeId>) {
 	// Create MAX_AUTHORITIES backup nodes and fund them above our genesis
 	// authorities The result will be our newly created nodes will be authorities
 	// and the genesis authorities will become backup nodes
-	let genesis_authorities: BTreeSet<AccountId32> = Validator::current_authorities();
+	let genesis_authorities: Vec<AccountId32> = Validator::current_authorities();
 	let (mut testnet, init_backup_nodes) =
 		network::Network::create(num_backups as u8, &genesis_authorities);
 
@@ -217,7 +217,8 @@ fn genesis_nodes_rotated_out_accumulate_rewards_correctly() {
 			let current_authorities = Validator::current_authorities();
 
 			assert_eq!(
-				init_backup_nodes, current_authorities,
+				init_backup_nodes.into_iter().collect::<BTreeSet<AccountId32>>(),
+				current_authorities.clone().into_iter().collect::<BTreeSet<AccountId32>>(),
 				"our new initial backup nodes should be the new authorities"
 			);
 
@@ -234,7 +235,8 @@ fn genesis_nodes_rotated_out_accumulate_rewards_correctly() {
 				Validator::highest_funded_qualified_backup_nodes_lookup();
 
 			assert_eq!(
-				genesis_authorities, highest_funded_backup_nodes,
+				genesis_authorities.into_iter().collect::<BTreeSet<AccountId32>>(),
+				highest_funded_backup_nodes,
 				"the genesis authorities should now be the backup nodes"
 			);
 

--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -270,7 +270,7 @@ fn apy_can_be_above_100_percent() {
 				MAX_AUTHORITIES as u128;
 			let apy_basis_point =
 				FixedU64::from_rational(reward, total).checked_mul_int(10_000u32).unwrap();
-			assert_eq!(apy_basis_point, 241_377_727u32);
+			assert_eq!(apy_basis_point, 243615296); //241_377_727u32);
 			assert_eq!(calculate_account_apy(&validator), Some(apy_basis_point));
 		});
 }

--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -270,7 +270,7 @@ fn apy_can_be_above_100_percent() {
 				MAX_AUTHORITIES as u128;
 			let apy_basis_point =
 				FixedU64::from_rational(reward, total).checked_mul_int(10_000u32).unwrap();
-			assert_eq!(apy_basis_point, 243615296); //241_377_727u32);
+			assert_eq!(apy_basis_point, 241_377_727u32);
 			assert_eq!(calculate_account_apy(&validator), Some(apy_basis_point));
 		});
 }

--- a/state-chain/cf-integration-tests/src/network.rs
+++ b/state-chain/cf-integration-tests/src/network.rs
@@ -577,10 +577,7 @@ impl Network {
 
 	// Create a network which includes the authorities in genesis of number of nodes
 	// and return a network and sorted list of nodes within
-	pub fn create(
-		number_of_backup_nodes: u8,
-		existing_nodes: &BTreeSet<NodeId>,
-	) -> (Self, BTreeSet<NodeId>) {
+	pub fn create(number_of_backup_nodes: u8, existing_nodes: &Vec<NodeId>) -> (Self, Vec<NodeId>) {
 		let mut network: Network = Default::default();
 
 		// Include any nodes already *created* to the test network
@@ -591,10 +588,10 @@ impl Network {
 		}
 
 		// Create the backup nodes
-		let mut backup_nodes = BTreeSet::new();
+		let mut backup_nodes = Vec::new();
 		for _ in 0..number_of_backup_nodes {
 			let node_id = network.create_engine();
-			backup_nodes.insert(node_id.clone());
+			backup_nodes.push(node_id.clone());
 		}
 
 		(network, backup_nodes)
@@ -740,11 +737,11 @@ impl Network {
 // Helper function that creates a network, funds backup nodes, and have them join the auction.
 pub fn fund_authorities_and_join_auction(
 	max_authorities: AuthorityCount,
-) -> (network::Network, BTreeSet<NodeId>, BTreeSet<NodeId>) {
+) -> (network::Network, Vec<NodeId>, Vec<NodeId>) {
 	// Create MAX_AUTHORITIES backup nodes and fund them above our genesis
 	// authorities The result will be our newly created nodes will be authorities
 	// and the genesis authorities will become backup nodes
-	let genesis_authorities: BTreeSet<AccountId32> = Validator::current_authorities();
+	let genesis_authorities: Vec<AccountId32> = Validator::current_authorities();
 	let (mut testnet, init_backup_nodes) =
 		network::Network::create(max_authorities as u8, &genesis_authorities);
 

--- a/state-chain/cf-integration-tests/src/new_epoch.rs
+++ b/state-chain/cf-integration-tests/src/new_epoch.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use super::*;
 use crate::genesis::GENESIS_BALANCE;
 use cf_chains::btc::{
@@ -186,8 +188,8 @@ fn epoch_rotates() {
 
 			genesis_nodes.append(&mut backup_nodes);
 			assert_eq!(
-						Validator::current_authorities(),
-						genesis_nodes,
+						Validator::current_authorities().into_iter().collect::<BTreeSet<AccountId32>>(),
+						genesis_nodes.into_iter().collect::<BTreeSet<AccountId32>>(),
 						"the new winners should be those genesis authorities and the backup nodes that have keys set"
 					);
 

--- a/state-chain/cf-integration-tests/src/signer_nomination.rs
+++ b/state-chain/cf-integration-tests/src/signer_nomination.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use cf_traits::{offence_reporting::OffenceReporter, EpochInfo, ThresholdSignerNomination};
 use pallet_cf_threshold_signature::PalletOffence;
 use pallet_cf_validator::{CurrentAuthorities, CurrentEpoch, HistoricalAuthorities};
@@ -30,7 +28,7 @@ fn threshold_signer_nomination_respects_epoch() {
 		CurrentEpoch::<Runtime>::put(next_epoch);
 
 		// double the number of authorities, so we also have a different threshold size
-		let new_authorities: BTreeSet<_> = (0u8..(2 * genesis_authorities.len() as u8))
+		let new_authorities: Vec<_> = (0u8..(2 * genesis_authorities.len() as u8))
 			.map(|i| AccountId32::from([i; 32]))
 			.collect();
 		CurrentAuthorities::<Runtime>::put(&new_authorities);

--- a/state-chain/cf-integration-tests/src/witnessing.rs
+++ b/state-chain/cf-integration-tests/src/witnessing.rs
@@ -96,7 +96,10 @@ fn can_punish_failed_witnesser() {
 			// New epoch uses the new authorities.
 			testnet.move_to_the_next_epoch();
 			assert_eq!(Validator::current_epoch(), epoch + 1);
-			assert_eq!(Validator::current_authorities(), new_authorities);
+			assert_eq!(
+				Validator::current_authorities().into_iter().collect::<BTreeSet<AccountId32>>(),
+				new_authorities
+			);
 
 			// After deadline has passed, the correct set of authority nodes are reported.
 			assert_eq!(

--- a/state-chain/pallets/cf-account-roles/src/migrations.rs
+++ b/state-chain/pallets/cf-account-roles/src/migrations.rs
@@ -5,13 +5,13 @@ mod remove_swapping_enabled;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<Pallet<T>, remove_swapping_enabled::Migration<T>, 0, 1>,
-	// Migration 1 -> 2 is in the runtime/src/lib.rs `VanityNamesMigration`
-	// This ensures the storage version bump.
 	VersionedMigration<
 		Pallet<T>,
 		NoopRuntimeUpgrade,
-		{ vanity_name_migration::APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION - 1 },
-		{ vanity_name_migration::APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION },
+		// Migration 1 -> 2 is in the runtime/src/lib.rs:
+		// - VanityNamesMigration
+		1,
+		2,
 	>,
 );
 

--- a/state-chain/pallets/cf-account-roles/src/migrations.rs
+++ b/state-chain/pallets/cf-account-roles/src/migrations.rs
@@ -1,7 +1,20 @@
-use cf_runtime_upgrade_utilities::VersionedMigration;
+use crate::Pallet;
+use cf_runtime_upgrade_utilities::{NoopRuntimeUpgrade, VersionedMigration};
 
 mod remove_swapping_enabled;
 
-// Migration 1->2 is in the runtime/src/lib.rs `VanityNamesMigration`
-pub type PalletMigration<T> =
-	(VersionedMigration<crate::Pallet<T>, remove_swapping_enabled::Migration<T>, 0, 1>,);
+pub type PalletMigration<T> = (
+	VersionedMigration<Pallet<T>, remove_swapping_enabled::Migration<T>, 0, 1>,
+	// Migration 1 -> 2 is in the runtime/src/lib.rs `VanityNamesMigration`
+	// This ensures the storage version bump.
+	VersionedMigration<
+		Pallet<T>,
+		NoopRuntimeUpgrade,
+		{ vanity_name_migration::APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION - 1 },
+		{ vanity_name_migration::APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION },
+	>,
+);
+
+pub mod vanity_name_migration {
+	pub const APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION: u16 = 2;
+}

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -213,7 +213,8 @@ fn test_abort_after_number_of_attempts_is_equal_to_the_number_of_authorities() {
 fn ready_to_abort_broadcast(broadcast_id: BroadcastId) -> u64 {
 	// Mock when all the possible broadcasts have failed another broadcast, and are
 	// therefore aborted.
-	let mut validators = MockEpochInfo::current_authorities();
+	let mut validators =
+		MockEpochInfo::current_authorities().into_iter().collect::<BTreeSet<u64>>();
 	let nominee = validators.pop_first().unwrap();
 	FailedBroadcasters::<Test, Instance1>::insert(broadcast_id, validators);
 	nominee

--- a/state-chain/pallets/cf-funding/src/migrations.rs
+++ b/state-chain/pallets/cf-funding/src/migrations.rs
@@ -5,8 +5,10 @@ pub type PalletMigration<T> = (
 	VersionedMigration<
 		Pallet<T>,
 		NoopRuntimeUpgrade,
-		{ active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION - 1 },
-		{ active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION },
+		// Migration 3 ->. 4 is in the runtime/src/lib.rs:
+		// - ActiveBiddersMigration
+		3,
+		4,
 	>,
 );
 

--- a/state-chain/pallets/cf-funding/src/migrations.rs
+++ b/state-chain/pallets/cf-funding/src/migrations.rs
@@ -1,7 +1,18 @@
 use crate::Pallet;
-use cf_runtime_upgrade_utilities::PlaceholderMigration;
+use cf_runtime_upgrade_utilities::{NoopRuntimeUpgrade, VersionedMigration};
 
-pub type PalletMigration<T> = PlaceholderMigration<Pallet<T>, 3>;
+pub type PalletMigration<T> = (
+	VersionedMigration<
+		Pallet<T>,
+		NoopRuntimeUpgrade,
+		{ active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION - 1 },
+		{ active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION },
+	>,
+);
+
+pub mod active_bidders_migration {
+	pub const APPLY_AT_FUNDING_STORAGE_VERSION: u16 = 4;
+}
 
 pub mod old {
 	use crate::*;

--- a/state-chain/pallets/cf-reputation/src/benchmarking.rs
+++ b/state-chain/pallets/cf-reputation/src/benchmarking.rs
@@ -83,7 +83,7 @@ mod benchmarks {
 
 		// Generate validators and set as validators
 		let validators =
-			(0..o).map(|v| account("validator", v, v)).collect::<BTreeSet<T::ValidatorId>>();
+			(0..o).map(|v| account("validator", v, v)).collect::<Vec<T::ValidatorId>>();
 		T::EpochInfo::set_authorities(validators);
 
 		let interval = T::HeartbeatBlockInterval::get();

--- a/state-chain/pallets/cf-reputation/src/mock.rs
+++ b/state-chain/pallets/cf-reputation/src/mock.rs
@@ -195,6 +195,6 @@ cf_test_utilities::impl_test_helpers! {
 	||{
 		assert_ok!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&ALICE));
 		assert_ok!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&BOB));
-		<Test as Chainflip>::EpochInfo::next_epoch(BTreeSet::from([ALICE]));
+		<Test as Chainflip>::EpochInfo::next_epoch(Vec::from([ALICE]));
 	}
 }

--- a/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
@@ -26,7 +26,7 @@ where
 	T: frame_system::Config + pallet_cf_validator::Config + pallet_cf_reputation::Config,
 	I: Clone + Iterator<Item = <T as Chainflip>::ValidatorId>,
 {
-	CurrentAuthorities::<T>::put(authorities.clone().collect::<BTreeSet<_>>());
+	CurrentAuthorities::<T>::put(authorities.clone().collect::<Vec<_>>());
 	for validator_id in authorities {
 		let account_id = validator_id.into_ref();
 		<T as frame_system::Config>::OnNewAccount::on_new_account(account_id);
@@ -203,7 +203,7 @@ mod benchmarks {
 		let key = <T::TargetChainCrypto as ChainCrypto>::AggKey::benchmark_value();
 		let current_epoch = CurrentEpochIndex::<T>::get();
 		<Pallet<T, I> as KeyProvider<T::TargetChainCrypto>>::set_key(key, current_epoch);
-		CurrentAuthorities::<T>::put(BTreeSet::<<T as Chainflip>::ValidatorId>::new());
+		CurrentAuthorities::<T>::put(Vec::<<T as Chainflip>::ValidatorId>::new());
 
 		// These attempts will fail because there are no authorities to do the signing.
 		for _ in 0..r {

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -282,7 +282,7 @@ impl TestHelper for TestRunner<()> {
 
 	fn with_authorities(self, validators: impl IntoIterator<Item = u64>) -> Self {
 		self.execute_with(|| {
-			let validators = BTreeSet::from_iter(validators);
+			let validators = Vec::from_iter(validators);
 			for id in &validators {
 				<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(id)
 					.unwrap();
@@ -382,7 +382,7 @@ cf_test_utilities::impl_test_helpers! {
 			_instance: PhantomData,
 	} },
 	|| {
-		let authorities = BTreeSet::from([ALICE, BOB, CHARLIE]);
+		let authorities = Vec::from([ALICE, BOB, CHARLIE]);
 		for id in &authorities {
 			<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(id)
 				.unwrap();

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -167,7 +167,7 @@ mod benchmarks {
 		HistoricalBonds::<T>::insert(OLD_EPOCH, amount);
 		HistoricalBonds::<T>::insert(EPOCH_TO_EXPIRE, amount);
 
-		let authorities: BTreeSet<_> = (0..a).map(|id| account("hello", id, id)).collect();
+		let authorities: Vec<_> = (0..a).map(|id| account("hello", id, id)).collect();
 
 		HistoricalAuthorities::<T>::insert(OLD_EPOCH, authorities.clone());
 		HistoricalAuthorities::<T>::insert(EPOCH_TO_EXPIRE, authorities.clone());

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -28,7 +28,6 @@ use cf_traits::{
 	MissedAuthorshipSlots, OnAccountFunded, QualifyNode, RedemptionCheck, ReputationResetter,
 	SetSafeMode,
 };
-
 use cf_utilities::Port;
 use frame_support::{
 	pallet_prelude::*,
@@ -39,6 +38,7 @@ use frame_support::{
 	traits::{EstimateNextSessionRotation, OnKilledAccount},
 };
 use frame_system::pallet_prelude::*;
+use nanorand::{Rng, WyRand};
 pub use pallet::*;
 use sp_core::ed25519;
 use sp_std::{
@@ -189,8 +189,7 @@ pub mod pallet {
 
 	/// A set of the current authorities.
 	#[pallet::storage]
-	pub type CurrentAuthorities<T: Config> =
-		StorageValue<_, BTreeSet<ValidatorIdOf<T>>, ValueQuery>;
+	pub type CurrentAuthorities<T: Config> = StorageValue<_, Vec<ValidatorIdOf<T>>, ValueQuery>;
 
 	/// The bond of the current epoch.
 	#[pallet::storage]
@@ -227,7 +226,7 @@ pub mod pallet {
 	/// A map between an epoch and the set of authorities (participating in this epoch).
 	#[pallet::storage]
 	pub type HistoricalAuthorities<T: Config> =
-		StorageMap<_, Twox64Concat, EpochIndex, BTreeSet<ValidatorIdOf<T>>, ValueQuery>;
+		StorageMap<_, Twox64Concat, EpochIndex, Vec<ValidatorIdOf<T>>, ValueQuery>;
 
 	/// A map between an epoch and the bonded balance (MAB)
 	#[pallet::storage]
@@ -413,8 +412,6 @@ pub mod pallet {
 					let num_primary_candidates = rotation_state.num_primary_candidates();
 					match T::KeyRotator::status() {
 						AsyncResult::Ready(KeyRotationStatusOuter::KeyHandoverComplete) => {
-							let new_authorities = rotation_state.authority_candidates();
-							HistoricalAuthorities::<T>::insert(rotation_state.new_epoch_index, new_authorities);
 							T::KeyRotator::activate_keys();
 							Self::set_rotation_phase(RotationPhase::ActivatingKeys(rotation_state));
 						},
@@ -886,7 +883,7 @@ pub mod pallet {
 
 			Pallet::<T>::initialise_new_epoch(
 				GENESIS_EPOCH,
-				&self.genesis_authorities,
+				&self.genesis_authorities.iter().cloned().collect(),
 				self.bond,
 				self.genesis_backups.clone(),
 			);
@@ -902,11 +899,11 @@ impl<T: Config> EpochInfo for Pallet<T> {
 		LastExpiredEpoch::<T>::get()
 	}
 
-	fn current_authorities() -> BTreeSet<Self::ValidatorId> {
+	fn current_authorities() -> Vec<Self::ValidatorId> {
 		CurrentAuthorities::<T>::get()
 	}
 
-	fn authorities_at_epoch(epoch: u32) -> BTreeSet<Self::ValidatorId> {
+	fn authorities_at_epoch(epoch: u32) -> Vec<Self::ValidatorId> {
 		HistoricalAuthorities::<T>::get(epoch)
 	}
 
@@ -936,7 +933,7 @@ impl<T: Config> EpochInfo for Pallet<T> {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn add_authority_info_for_epoch(
 		epoch_index: EpochIndex,
-		new_authorities: BTreeSet<Self::ValidatorId>,
+		new_authorities: Vec<Self::ValidatorId>,
 	) {
 		for (i, authority) in new_authorities.iter().enumerate() {
 			AuthorityIndex::<T>::insert(epoch_index, authority, i as AuthorityCount);
@@ -946,7 +943,7 @@ impl<T: Config> EpochInfo for Pallet<T> {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_authorities(authorities: BTreeSet<Self::ValidatorId>) {
+	fn set_authorities(authorities: Vec<Self::ValidatorId>) {
 		CurrentAuthorities::<T>::put(authorities);
 	}
 }
@@ -992,8 +989,17 @@ impl<T: Config> Pallet<T> {
 			old_epoch,
 		);
 
-		let new_authorities = rotation_state.authority_candidates();
+		let mut new_authorities: Vec<<T as Chainflip>::ValidatorId> =
+			rotation_state.authority_candidates().into_iter().collect();
+		let hash = frame_system::Pallet::<T>::block_hash(
+			frame_system::Pallet::<T>::current_block_number(),
+		);
 
+		let mut buf: [u8; 8] = [0; 8];
+		buf.copy_from_slice(&hash.as_ref()[..8]);
+
+		let seed_from_hash: u64 = u64::from_be_bytes(buf);
+		WyRand::new_seed(seed_from_hash).shuffle(&mut new_authorities);
 		Self::initialise_new_epoch(
 			new_epoch,
 			&new_authorities,
@@ -1034,7 +1040,7 @@ impl<T: Config> Pallet<T> {
 	/// expiries etc. that relate to the state of previous epochs.
 	fn initialise_new_epoch(
 		new_epoch: EpochIndex,
-		new_authorities: &BTreeSet<ValidatorIdOf<T>>,
+		new_authorities: &Vec<ValidatorIdOf<T>>,
 		new_bond: T::Amount,
 		backup_map: BackupMap<T>,
 	) {
@@ -1326,7 +1332,7 @@ impl<T: Config> HistoricalEpoch for EpochHistory<T> {
 	type ValidatorId = ValidatorIdOf<T>;
 	type EpochIndex = EpochIndex;
 	type Amount = T::Amount;
-	fn epoch_authorities(epoch: Self::EpochIndex) -> BTreeSet<Self::ValidatorId> {
+	fn epoch_authorities(epoch: Self::EpochIndex) -> Vec<Self::ValidatorId> {
 		HistoricalAuthorities::<T>::get(epoch)
 	}
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -94,8 +94,6 @@ pub enum PalletOffence {
 	MissedAuthorshipSlot,
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(2);
-
 impl_pallet_safe_mode!(PalletSafeMode; authority_rotation_enabled, start_bidding_enabled, stop_bidding_enabled);
 
 #[frame_support::pallet]

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -70,6 +70,8 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(2);
+
 // Might be better to add the enum inside a struct rather than struct inside enum
 #[derive(Clone, PartialEq, Eq, Default, Encode, Decode, TypeInfo, RuntimeDebugNoBound)]
 #[scale_info(skip_type_params(T))]

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -70,7 +70,7 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(2);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(3);
 
 // Might be better to add the enum inside a struct rather than struct inside enum
 #[derive(Clone, PartialEq, Eq, Default, Encode, Decode, TypeInfo, RuntimeDebugNoBound)]

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -13,11 +13,23 @@ pub type PalletMigration<T> = (
 		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION - 1 },
 		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION },
 	>,
+	VersionedMigration<
+		Pallet<T>,
+		NoopRuntimeUpgrade,
+		{ active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION - 1 },
+		{ active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION },
+	>,
 );
 
 pub mod vanity_name_migration {
 	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 2;
 }
+
+pub mod active_bidders_migration {
+	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 3;
+}
+
+
 
 #[cfg(feature = "try-runtime")]
 pub mod old {

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -5,31 +5,21 @@ mod authorities;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<Pallet<T>, authorities::Migration<T>, 0, 1>,
-	// Migration 1 -> 2 is in the runtime/src/lib.rs `VanityNamesMigration`
-	// This ensures the storage version bump.
-	VersionedMigration<
-		Pallet<T>,
-		NoopRuntimeUpgrade,
-		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION - 1 },
-		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION },
-	>,
-	VersionedMigration<
-		Pallet<T>,
-		NoopRuntimeUpgrade,
-		{ active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION - 1 },
-		{ active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION },
-	>,
+	// Migrations 1 -> 3 are in the runtime/src/lib.rs:
+	// - VanityNamesMigration
+	// - ActiveBiddersMigration
+	// This ensures the storage version bumps.
+	VersionedMigration<Pallet<T>, NoopRuntimeUpgrade, 1, 2>,
+	VersionedMigration<Pallet<T>, NoopRuntimeUpgrade, 2, 3>,
 );
 
 pub mod vanity_name_migration {
-	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 2;
+	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 3;
 }
 
 pub mod active_bidders_migration {
 	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 3;
 }
-
-
 
 #[cfg(feature = "try-runtime")]
 pub mod old {

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -3,7 +3,7 @@ use cf_runtime_upgrade_utilities::VersionedMigration;
 mod authorities;
 
 pub type PalletMigration<T> =
-	(VersionedMigration<crate::Pallet<T>, authorities::Migration<T>, 1, 2>,);
+	(VersionedMigration<crate::Pallet<T>, authorities::Migration<T>, 0, 1>,);
 
 #[cfg(feature = "try-runtime")]
 pub mod old {

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -1,3 +1,10 @@
+use cf_runtime_upgrade_utilities::VersionedMigration;
+
+mod authorities;
+
+pub type PalletMigration<T> =
+	(VersionedMigration<crate::Pallet<T>, authorities::Migration<T>, 1, 2>,);
+
 #[cfg(feature = "try-runtime")]
 pub mod old {
 	use crate::*;

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -1,9 +1,23 @@
-use cf_runtime_upgrade_utilities::VersionedMigration;
+use crate::Pallet;
+use cf_runtime_upgrade_utilities::{NoopRuntimeUpgrade, VersionedMigration};
 
 mod authorities;
 
-pub type PalletMigration<T> =
-	(VersionedMigration<crate::Pallet<T>, authorities::Migration<T>, 0, 1>,);
+pub type PalletMigration<T> = (
+	VersionedMigration<Pallet<T>, authorities::Migration<T>, 0, 1>,
+	// Migration 1 -> 2 is in the runtime/src/lib.rs `VanityNamesMigration`
+	// This ensures the storage version bump.
+	VersionedMigration<
+		Pallet<T>,
+		NoopRuntimeUpgrade,
+		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION - 1 },
+		{ vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION },
+	>,
+);
+
+pub mod vanity_name_migration {
+	pub const APPLY_AT_VALIDATOR_STORAGE_VERSION: u16 = 2;
+}
 
 #[cfg(feature = "try-runtime")]
 pub mod old {
@@ -11,7 +25,7 @@ pub mod old {
 	use cf_primitives::AccountId;
 	use frame_support::pallet_prelude::ValueQuery;
 
-	// Migration 0->1 is in the runtime/src/lib.rs `VanityNamesMigration`
+	// Migration 1 -> 2 is in the runtime/src/lib.rs `VanityNamesMigration`
 	#[frame_support::storage_alias]
 	pub type VanityNames<T: Config> =
 		StorageValue<Pallet<T>, BTreeMap<AccountId, Vec<u8>>, ValueQuery>;

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -7,12 +7,10 @@ pub struct Migration<T: Config>(PhantomData<T>);
 
 impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		let result = CurrentAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(|btree| {
-			Some(btree.unwrap().into_iter().collect::<Vec<ValidatorIdOf<T>>>())
-		});
-		if result.is_err() {
-			println!("ERROR DURING MIGRATION");
-		}
+		let _result =
+			CurrentAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(|btree| {
+				Some(btree.unwrap().into_iter().collect::<Vec<ValidatorIdOf<T>>>())
+			});
 
 		HistoricalAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(
 			|_epoch_index, btree| Some(btree.into_iter().collect::<Vec<ValidatorIdOf<T>>>()),

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -1,4 +1,4 @@
-use crate::{Config, CurrentAuthorities, ValidatorIdOf};
+use crate::{Config, CurrentAuthorities, HistoricalAuthorities, ValidatorIdOf};
 use core::marker::PhantomData;
 use frame_support::{sp_runtime::DispatchError, traits::OnRuntimeUpgrade, weights::Weight};
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
@@ -13,6 +13,11 @@ impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 		if result.is_err() {
 			println!("ERROR DURING MIGRATION");
 		}
+
+        HistoricalAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(|_epoch_index, btree| {
+			Some(btree.into_iter().collect::<Vec<ValidatorIdOf<T>>>())
+		});
+
 		Weight::zero()
 	}
 

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -14,9 +14,9 @@ impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 			println!("ERROR DURING MIGRATION");
 		}
 
-        HistoricalAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(|_epoch_index, btree| {
-			Some(btree.into_iter().collect::<Vec<ValidatorIdOf<T>>>())
-		});
+		HistoricalAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(
+			|_epoch_index, btree| Some(btree.into_iter().collect::<Vec<ValidatorIdOf<T>>>()),
+		);
 
 		Weight::zero()
 	}

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -1,0 +1,28 @@
+use crate::{Config, CurrentAuthorities, ValidatorIdOf};
+use core::marker::PhantomData;
+use frame_support::{sp_runtime::DispatchError, traits::OnRuntimeUpgrade, weights::Weight};
+use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+
+pub struct Migration<T: Config>(PhantomData<T>);
+
+impl<T: Config> OnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		let result = CurrentAuthorities::<T>::translate::<BTreeSet<ValidatorIdOf<T>>, _>(|btree| {
+			Some(btree.unwrap().into_iter().collect::<Vec<ValidatorIdOf<T>>>())
+		});
+		if result.is_err() {
+			println!("ERROR DURING MIGRATION");
+		}
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok(Default::default())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -239,8 +239,8 @@ macro_rules! assert_invariants {
 		assert_eq!(
 			<ValidatorPallet as EpochInfo>::current_authorities()
 				.into_iter()
-				.collect::<Vec<_>>(),
-			Session::validators(),
+				.collect::<BTreeSet<_>>(),
+			Session::validators().into_iter().collect::<BTreeSet<_>>(),
 			"Authorities out of sync at block {:?}. RotationPhase: {:?}",
 			System::block_number(),
 			ValidatorPallet::current_rotation_phase(),

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -237,10 +237,8 @@ cf_test_utilities::impl_test_helpers! {
 macro_rules! assert_invariants {
 	() => {
 		assert_eq!(
-			<ValidatorPallet as EpochInfo>::current_authorities()
-				.into_iter()
-				.collect::<BTreeSet<_>>(),
-			Session::validators().into_iter().collect::<BTreeSet<_>>(),
+			<ValidatorPallet as EpochInfo>::current_authorities(),
+			Session::validators(),
 			"Authorities out of sync at block {:?}. RotationPhase: {:?}",
 			System::block_number(),
 			ValidatorPallet::current_rotation_phase(),
@@ -290,6 +288,7 @@ impl<Ctx: Clone> TestHelper for TestRunner<Ctx> {
 	) -> TestRunner<R> {
 		self.then_execute_with(|_| System::current_block_number() + blocks)
 			.then_process_blocks_until(|execution_block| {
+				assert_invariants!();
 				System::current_block_number() == execution_block - 1
 			})
 			.then_execute_at_next_block(|_| {

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -49,7 +49,7 @@ macro_rules! assert_default_rotation_outcome {
 		assert_eq!(Bond::<Test>::get(), EXPECTED_BOND, "bond should be updated");
 		assert_eq!(
 			ValidatorPallet::current_authorities(),
-			BTreeSet::from_iter(WINNING_BIDS.into_iter().map(|bid| bid.bidder_id))
+			WINNING_BIDS.into_iter().map(|bid| bid.bidder_id).collect::<Vec<_>>()
 		);
 	};
 }
@@ -195,7 +195,7 @@ fn auction_winners_should_be_the_new_authorities_on_new_epoch() {
 	new_test_ext()
 		.then_execute_with_checks(|| {
 			assert_eq!(
-				CurrentAuthorities::<Test>::get(),
+				CurrentAuthorities::<Test>::get().into_iter().collect::<BTreeSet<u64>>(),
 				genesis_set,
 				"the current authorities should be the genesis authorities"
 			);
@@ -204,7 +204,7 @@ fn auction_winners_should_be_the_new_authorities_on_new_epoch() {
 		})
 		.then_advance_n_blocks_and_execute_with_checks(EPOCH_DURATION, || {
 			assert_eq!(
-				ValidatorPallet::current_authorities(),
+				ValidatorPallet::current_authorities().into_iter().collect::<BTreeSet<u64>>(),
 				genesis_set,
 				"we should still be validating with the genesis authorities"
 			);
@@ -230,7 +230,7 @@ fn auction_winners_should_be_the_new_authorities_on_new_epoch() {
 fn genesis() {
 	new_test_ext().then_execute_with_checks(|| {
 		assert_eq!(
-			CurrentAuthorities::<Test>::get(),
+			CurrentAuthorities::<Test>::get().into_iter().collect::<BTreeSet<u64>>(),
 			BTreeSet::from(GENESIS_AUTHORITIES),
 			"We should have a set of validators at genesis"
 		);
@@ -513,15 +513,15 @@ fn highest_bond() {
 	new_test_ext().then_execute_with_checks(|| {
 		// Epoch 1
 		EpochHistory::<Test>::activate_epoch(&ALICE, 1);
-		HistoricalAuthorities::<Test>::insert(1, BTreeSet::from([ALICE]));
+		HistoricalAuthorities::<Test>::insert(1, Vec::from([ALICE]));
 		HistoricalBonds::<Test>::insert(1, 10);
 		// Epoch 2
 		EpochHistory::<Test>::activate_epoch(&ALICE, 2);
-		HistoricalAuthorities::<Test>::insert(2, BTreeSet::from([ALICE]));
+		HistoricalAuthorities::<Test>::insert(2, Vec::from([ALICE]));
 		HistoricalBonds::<Test>::insert(2, 30);
 		// Epoch 3
 		EpochHistory::<Test>::activate_epoch(&ALICE, 3);
-		HistoricalAuthorities::<Test>::insert(3, BTreeSet::from([ALICE]));
+		HistoricalAuthorities::<Test>::insert(3, Vec::from([ALICE]));
 		HistoricalBonds::<Test>::insert(3, 20);
 		// Expect the bond of epoch 2
 		assert_eq!(EpochHistory::<Test>::active_bond(&ALICE), 30);
@@ -1074,7 +1074,7 @@ fn can_calculate_percentage_cfe_at_target_version() {
 			let _ = ValidatorPallet::register_as_validator(RuntimeOrigin::signed(*id));
 			assert_ok!(ValidatorPallet::cfe_version(RuntimeOrigin::signed(*id), initial_version,));
 		});
-		CurrentAuthorities::<Test>::set(BTreeSet::from(authorities));
+		CurrentAuthorities::<Test>::set(Vec::from(authorities));
 
 		assert_eq!(
 			ValidatorPallet::percent_authorities_compatible_with_version(initial_version),
@@ -1100,7 +1100,7 @@ fn can_calculate_percentage_cfe_at_target_version() {
 		);
 
 		// Change authorities
-		CurrentAuthorities::<Test>::set(BTreeSet::from(authorities));
+		CurrentAuthorities::<Test>::set(Vec::from(authorities));
 		assert_eq!(
 			ValidatorPallet::percent_authorities_compatible_with_version(initial_version),
 			Percent::from_percent(0)

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -605,10 +605,7 @@ mod bond_expiry {
 		new_test_ext().execute_with(|| {
 			const BOND: u128 = 100;
 			let initial_epoch = ValidatorPallet::current_epoch();
-			ValidatorPallet::transition_to_next_epoch(simple_rotation_state(
-				vec![1, 2],
-				Some(BOND),
-			));
+			ValidatorPallet::transition_to_next_epoch(vec![1, 2], BOND);
 			assert_eq!(ValidatorPallet::bond(), BOND);
 
 			// Ensure the new bond is set for each authority
@@ -617,10 +614,7 @@ mod bond_expiry {
 			});
 
 			const NEXT_BOND: u128 = BOND + 1;
-			ValidatorPallet::transition_to_next_epoch(simple_rotation_state(
-				vec![2, 3],
-				Some(NEXT_BOND),
-			));
+			ValidatorPallet::transition_to_next_epoch(vec![2, 3], NEXT_BOND);
 			assert_eq!(ValidatorPallet::bond(), NEXT_BOND);
 
 			ValidatorPallet::current_authorities().iter().for_each(|account_id| {
@@ -644,20 +638,14 @@ mod bond_expiry {
 		new_test_ext().execute_with(|| {
 			let initial_epoch = ValidatorPallet::current_epoch();
 			const AUTHORITY_IN_BOTH_EPOCHS: u64 = 2;
-			ValidatorPallet::transition_to_next_epoch(simple_rotation_state(
-				vec![1, AUTHORITY_IN_BOTH_EPOCHS],
-				Some(100),
-			));
+			ValidatorPallet::transition_to_next_epoch(vec![1, AUTHORITY_IN_BOTH_EPOCHS], 100);
 			assert_eq!(ValidatorPallet::bond(), 100);
 
 			ValidatorPallet::current_authorities().iter().for_each(|account_id| {
 				assert_eq!(MockBonder::get_bond(account_id), 100);
 			});
 
-			ValidatorPallet::transition_to_next_epoch(simple_rotation_state(
-				vec![AUTHORITY_IN_BOTH_EPOCHS, 3],
-				Some(99),
-			));
+			ValidatorPallet::transition_to_next_epoch(vec![AUTHORITY_IN_BOTH_EPOCHS, 3], 99);
 			assert_eq!(ValidatorPallet::bond(), 99);
 
 			// Keeps the highest bond of all the epochs it's been active in

--- a/state-chain/pallets/cf-witnesser/src/benchmarking.rs
+++ b/state-chain/pallets/cf-witnesser/src/benchmarking.rs
@@ -7,7 +7,7 @@ use cf_traits::AccountRoleRegistry;
 use frame_benchmarking::v2::*;
 use frame_support::{assert_ok, traits::Hooks};
 use frame_system::RawOrigin;
-use sp_std::{boxed::Box, collections::btree_set::BTreeSet};
+use sp_std::boxed::Box;
 
 #[benchmarks]
 mod benchmarks {
@@ -21,7 +21,7 @@ mod benchmarks {
 		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 		let epoch = T::EpochInfo::epoch_index();
 
-		T::EpochInfo::add_authority_info_for_epoch(epoch, BTreeSet::from([validator_id]));
+		T::EpochInfo::add_authority_info_for_epoch(epoch, Vec::from([validator_id]));
 
 		#[extrinsic_call]
 		witness_at_epoch(RawOrigin::Signed(caller.clone()), Box::new(call.clone()), epoch);

--- a/state-chain/pallets/cf-witnesser/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock.rs
@@ -11,7 +11,6 @@ use frame_system as system;
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
-use sp_std::collections::btree_set::BTreeSet;
 
 type AccountId = u64;
 
@@ -116,7 +115,7 @@ cf_test_utilities::impl_test_helpers! {
 	Test,
 	RuntimeGenesisConfig::default(),
 	||{
-		MockEpochInfo::next_epoch(BTreeSet::from(GENESIS_AUTHORITIES));
+		MockEpochInfo::next_epoch(Vec::from(GENESIS_AUTHORITIES));
 		for id in GENESIS_AUTHORITIES.iter().chain(&[DEIRDRE]) {
 			<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(id)
 				.unwrap();

--- a/state-chain/runtime-upgrade-utilities/src/lib.rs
+++ b/state-chain/runtime-upgrade-utilities/src/lib.rs
@@ -78,6 +78,14 @@ where
 	}
 }
 
+pub struct NoopRuntimeUpgrade;
+
+impl OnRuntimeUpgrade for NoopRuntimeUpgrade {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		Default::default()
+	}
+}
+
 /// A helper enum to wrap the pre_upgrade bytes like an Option before passing them to post_upgrade.
 /// This enum is used rather than an Option to make the API clearer to the developer.
 #[derive(Encode, Decode)]

--- a/state-chain/runtime/src/chainflip/decompose_recompose.rs
+++ b/state-chain/runtime/src/chainflip/decompose_recompose.rs
@@ -134,7 +134,7 @@ mod tests {
 	use frame_support::{assert_ok, traits::Get, Hashable};
 	use pallet_cf_chain_tracking::CurrentChainState;
 	use pallet_cf_witnesser::CallHash;
-	use sp_std::{collections::btree_set::BTreeSet, iter};
+	use sp_std::iter;
 
 	const BLOCK_HEIGHT: u64 = 1_000;
 	const BASE_FEE: u128 = 40;
@@ -230,8 +230,7 @@ mod tests {
 
 			let calls = [1u32, 100, 12, 10, 9, 11].map(chain_tracking_call_with_fee::<Ethereum>);
 
-			let authorities =
-				(0..calls.len()).map(|i| [i as u8; 32].into()).collect::<BTreeSet<_>>();
+			let authorities = (0..calls.len()).map(|i| [i as u8; 32].into()).collect::<Vec<_>>();
 			let current_epoch = 1;
 			pallet_cf_validator::CurrentEpoch::<Runtime>::put(current_epoch);
 			pallet_cf_validator::HistoricalAuthorities::<Runtime>::insert(

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1015,7 +1015,7 @@ type PalletMigrations = (
 	pallet_cf_environment::migrations::PalletMigration<Runtime>,
 	pallet_cf_funding::migrations::PalletMigration<Runtime>,
 	pallet_cf_account_roles::migrations::PalletMigration<Runtime>,
-	// pallet_cf_validator::migrations::PalletMigration<Runtime>,
+	pallet_cf_validator::migrations::PalletMigration<Runtime>,
 	pallet_cf_governance::migrations::PalletMigration<Runtime>,
 	pallet_cf_tokenholder_governance::migrations::PalletMigration<Runtime>,
 	pallet_cf_chain_tracking::migrations::PalletMigration<Runtime, EthereumInstance>,
@@ -1055,8 +1055,8 @@ type MigrationsForV1_4 = (
 		9,
 		10,
 	>,
-	migrations::housekeeping::Migration,
-	migrations::reap_old_accounts::Migration,
+	// migrations::housekeeping::Migration,
+	// migrations::reap_old_accounts::Migration,
 	// NOTE: Do not change this validator pallet migration order:
 	// Migrate Validator pallet from version 0 -> 1
 	migrations::vanity_names::Migration,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1055,8 +1055,8 @@ type MigrationsForV1_4 = (
 		9,
 		10,
 	>,
-	// migrations::housekeeping::Migration,
-	// migrations::reap_old_accounts::Migration,
+	migrations::housekeeping::Migration,
+	migrations::reap_old_accounts::Migration,
 	// NOTE: Do not change this validator pallet migration order:
 	// Migrate Validator pallet from version 0 -> 1
 	migrations::vanity_names::Migration,

--- a/state-chain/runtime/src/migrations/active_bidders.rs
+++ b/state-chain/runtime/src/migrations/active_bidders.rs
@@ -1,6 +1,8 @@
 use crate::{AccountId, Runtime};
 use frame_support::traits::{GetStorageVersion, StorageVersion};
 use sp_std::collections::btree_set::BTreeSet;
+use pallet_cf_funding::migrations::active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION;
+use pallet_cf_validator::migrations::active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION;
 
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
@@ -8,10 +10,9 @@ pub struct Migration;
 
 impl frame_support::traits::OnRuntimeUpgrade for Migration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() ==
-			3 &&
+		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == APPLY_AT_VALIDATOR_STORAGE_VERSION &&
 			<pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version(
-			) == 1
+			) == APPLY_AT_FUNDING_STORAGE_VERSION
 		{
 			log::info!("🔨 Applying ActiveBidder migration.");
 
@@ -40,8 +41,8 @@ impl frame_support::traits::OnRuntimeUpgrade for Migration {
 		use codec::Encode;
 		use frame_support::migrations::VersionedPostUpgradeData;
 
-		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() ==
-			3
+		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() <
+			APPLY_AT_FUNDING_STORAGE_VERSION
 		{
 			Ok(VersionedPostUpgradeData::MigrationExecuted(
 				pallet_cf_funding::migrations::old::ActiveBidder::<Runtime>::iter()

--- a/state-chain/runtime/src/migrations/active_bidders.rs
+++ b/state-chain/runtime/src/migrations/active_bidders.rs
@@ -1,5 +1,5 @@
 use crate::{AccountId, Runtime};
-use frame_support::traits::{GetStorageVersion, StorageVersion};
+use frame_support::traits::GetStorageVersion;
 use pallet_cf_funding::migrations::active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION;
 use pallet_cf_validator::migrations::active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION;
 use sp_std::collections::btree_set::BTreeSet;

--- a/state-chain/runtime/src/migrations/active_bidders.rs
+++ b/state-chain/runtime/src/migrations/active_bidders.rs
@@ -1,8 +1,8 @@
 use crate::{AccountId, Runtime};
 use frame_support::traits::{GetStorageVersion, StorageVersion};
-use sp_std::collections::btree_set::BTreeSet;
 use pallet_cf_funding::migrations::active_bidders_migration::APPLY_AT_FUNDING_STORAGE_VERSION;
 use pallet_cf_validator::migrations::active_bidders_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION;
+use sp_std::collections::btree_set::BTreeSet;
 
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
@@ -10,9 +10,10 @@ pub struct Migration;
 
 impl frame_support::traits::OnRuntimeUpgrade for Migration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == APPLY_AT_VALIDATOR_STORAGE_VERSION &&
+		if <pallet_cf_funding::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() ==
+			APPLY_AT_FUNDING_STORAGE_VERSION &&
 			<pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version(
-			) == APPLY_AT_FUNDING_STORAGE_VERSION
+			) == APPLY_AT_VALIDATOR_STORAGE_VERSION
 		{
 			log::info!("🔨 Applying ActiveBidder migration.");
 
@@ -21,11 +22,7 @@ impl frame_support::traits::OnRuntimeUpgrade for Migration {
 					.filter_map(|(validator, is_bidding)| is_bidding.then_some(validator))
 					.collect::<BTreeSet<_>>();
 
-			pallet_cf_validator::ActiveBidder::<Runtime>::set(active_bidders);
-
-			// Bump the version of both pallets
-			StorageVersion::new(4).put::<pallet_cf_funding::Pallet<Runtime>>();
-			StorageVersion::new(2).put::<pallet_cf_validator::Pallet<Runtime>>();
+			pallet_cf_validator::ActiveBidder::<Runtime>::set(active_bidders)
 		} else {
 			log::info!(
 				"⏭ Skipping ActiveBidder migration. Funding version: {:?}, Validator Version: {:?}",

--- a/state-chain/runtime/src/migrations/vanity_names.rs
+++ b/state-chain/runtime/src/migrations/vanity_names.rs
@@ -1,13 +1,15 @@
 use crate::Runtime;
-use frame_support::traits::{GetStorageVersion, StorageVersion};
+use frame_support::traits::GetStorageVersion;
+use pallet_cf_account_roles::migrations::vanity_name_migration::APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION;
+use pallet_cf_validator::migrations::vanity_name_migration::APPLY_AT_VALIDATOR_STORAGE_VERSION;
 
 pub struct Migration;
 
 impl frame_support::traits::OnRuntimeUpgrade for Migration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 1 &&
+		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == APPLY_AT_VALIDATOR_STORAGE_VERSION &&
 			<pallet_cf_account_roles::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version(
-			) == 1
+			) == APPLY_AT_ACCOUNT_ROLES_STORAGE_VERSION
 		{
 			log::info!("⏫ Applying VanityNames migration.");
 			// Moving the VanityNames storage item from the validators pallet to the account roles pallet.
@@ -15,10 +17,6 @@ impl frame_support::traits::OnRuntimeUpgrade for Migration {
 				pallet_cf_validator::Pallet<Runtime>,
 				pallet_cf_account_roles::Pallet<Runtime>,
 			>(b"VanityNames");
-
-			// Bump the version of both pallets
-			StorageVersion::new(2).put::<pallet_cf_validator::Pallet<Runtime>>();
-			StorageVersion::new(2).put::<pallet_cf_account_roles::Pallet<Runtime>>();
 		} else {
 			log::info!(
 				"⏭ Skipping VanityNames migration. Validator version: {:?}, AccountRoles version: {:?}",
@@ -34,8 +32,8 @@ impl frame_support::traits::OnRuntimeUpgrade for Migration {
 		use codec::Encode;
 		use frame_support::migrations::VersionedPostUpgradeData;
 
-		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() ==
-			0
+		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() <
+			APPLY_AT_VALIDATOR_STORAGE_VERSION
 		{
 			// The new VanityNames item should be empty before the upgrade.
 			frame_support::ensure!(

--- a/state-chain/runtime/src/migrations/vanity_names.rs
+++ b/state-chain/runtime/src/migrations/vanity_names.rs
@@ -5,7 +5,7 @@ pub struct Migration;
 
 impl frame_support::traits::OnRuntimeUpgrade for Migration {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
-		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 0 &&
+		if <pallet_cf_validator::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version() == 1 &&
 			<pallet_cf_account_roles::Pallet<Runtime> as GetStorageVersion>::on_chain_storage_version(
 			) == 1
 		{
@@ -17,7 +17,7 @@ impl frame_support::traits::OnRuntimeUpgrade for Migration {
 			>(b"VanityNames");
 
 			// Bump the version of both pallets
-			StorageVersion::new(1).put::<pallet_cf_validator::Pallet<Runtime>>();
+			StorageVersion::new(2).put::<pallet_cf_validator::Pallet<Runtime>>();
 			StorageVersion::new(2).put::<pallet_cf_account_roles::Pallet<Runtime>>();
 		} else {
 			log::info!(

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -96,10 +96,10 @@ pub trait EpochInfo {
 	fn last_expired_epoch() -> EpochIndex;
 
 	/// The current authority set's validator ids
-	fn current_authorities() -> BTreeSet<Self::ValidatorId>;
+	fn current_authorities() -> Vec<Self::ValidatorId>;
 
 	/// The authority set for a given epoch
-	fn authorities_at_epoch(epoch: EpochIndex) -> BTreeSet<Self::ValidatorId>;
+	fn authorities_at_epoch(epoch: EpochIndex) -> Vec<Self::ValidatorId>;
 
 	/// Get the current number of authorities
 	fn current_authority_count() -> AuthorityCount;
@@ -123,11 +123,11 @@ pub trait EpochInfo {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn add_authority_info_for_epoch(
 		epoch_index: EpochIndex,
-		new_authorities: BTreeSet<Self::ValidatorId>,
+		new_authorities: Vec<Self::ValidatorId>,
 	);
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn set_authorities(authorities: BTreeSet<Self::ValidatorId>);
+	fn set_authorities(authorities: Vec<Self::ValidatorId>);
 }
 
 pub struct CurrentEpochIndex<T>(PhantomData<T>);
@@ -623,7 +623,7 @@ pub trait HistoricalEpoch {
 	type EpochIndex;
 	type Amount;
 	/// All validators which were in an epoch's authority set.
-	fn epoch_authorities(epoch: Self::EpochIndex) -> BTreeSet<Self::ValidatorId>;
+	fn epoch_authorities(epoch: Self::EpochIndex) -> Vec<Self::ValidatorId>;
 	/// The bond for an epoch
 	fn epoch_bond(epoch: Self::EpochIndex) -> Self::Amount;
 	/// The unexpired epochs for which a node was in the authority set.

--- a/state-chain/traits/src/mocks/epoch_info.rs
+++ b/state-chain/traits/src/mocks/epoch_info.rs
@@ -5,8 +5,8 @@ macro_rules! impl_mock_epoch_info {
 		pub struct MockEpochInfo;
 
 		thread_local! {
-			pub static CURRENT_AUTHORITIES: std::cell::RefCell<sp_std::collections::btree_set::BTreeSet<$account_id>> = std::cell::RefCell::new(Default::default());
-			pub static PAST_AUTHORITIES: std::cell::RefCell<sp_std::collections::btree_set::BTreeSet<$account_id>> = std::cell::RefCell::new(Default::default());
+			pub static CURRENT_AUTHORITIES: std::cell::RefCell<sp_std::vec::Vec<$account_id>> = std::cell::RefCell::new(Default::default());
+			pub static PAST_AUTHORITIES: std::cell::RefCell<sp_std::vec::Vec<$account_id>> = std::cell::RefCell::new(Default::default());
 			pub static AUTHORITY_INDEX: std::cell::RefCell<std::collections::HashMap<$epoch_index, std::collections::HashMap<$account_id, $authority_count>>> = std::cell::RefCell::new(std::collections::HashMap::new());
 			pub static BOND: std::cell::RefCell<$balance> = std::cell::RefCell::new(0);
 			pub static EPOCH: std::cell::RefCell<$epoch_index> = std::cell::RefCell::new(0);
@@ -17,13 +17,13 @@ macro_rules! impl_mock_epoch_info {
 		impl MockEpochInfo {
 
 			/// Set the current authorities.
-			pub fn set_authorities(authorities: sp_std::collections::btree_set::BTreeSet<$account_id>) {
+			pub fn set_authorities(authorities: sp_std::vec::Vec<$account_id>) {
 				CURRENT_AUTHORITIES.with(|cell| {
 					*cell.borrow_mut() = authorities;
 				})
 			}
 
-			pub fn set_past_authorities(authorities: sp_std::collections::btree_set::BTreeSet<$account_id>) {
+			pub fn set_past_authorities(authorities: sp_std::vec::Vec<$account_id>) {
 				PAST_AUTHORITIES.with(|cell| {
 					*cell.borrow_mut() = authorities;
 				})
@@ -31,7 +31,7 @@ macro_rules! impl_mock_epoch_info {
 
 			/// Add an authority to the current authorities.
 			pub fn add_authorities(account: $account_id) {
-				CURRENT_AUTHORITIES.with(|cell| cell.borrow_mut().insert(account));
+				CURRENT_AUTHORITIES.with(|cell| cell.borrow_mut().push(account));
 			}
 
 			/// Set the bond amount.
@@ -54,7 +54,7 @@ macro_rules! impl_mock_epoch_info {
 				})
 			}
 
-			pub fn set_authority_indices(epoch_index: $epoch_index, account_ids: sp_std::collections::btree_set::BTreeSet<$account_id>) {
+			pub fn set_authority_indices(epoch_index: $epoch_index, account_ids: sp_std::vec::Vec<$account_id>) {
 				AUTHORITY_INDEX.with(|cell| {
 					let mut map = cell.borrow_mut();
 					let authority_index = map.entry(epoch_index).or_insert(std::collections::HashMap::new());
@@ -64,7 +64,7 @@ macro_rules! impl_mock_epoch_info {
 				})
 			}
 
-			pub fn next_epoch(authorities: sp_std::collections::btree_set::BTreeSet<$account_id>) -> $epoch_index {
+			pub fn next_epoch(authorities: sp_std::vec::Vec<$account_id>) -> $epoch_index {
 				let new_epoch_index = EPOCH.with(|cell| *(cell.borrow_mut()) + 1);
 				MockEpochInfo::set_epoch(new_epoch_index);
 				MockEpochInfo::set_authorities(authorities.clone());
@@ -72,7 +72,7 @@ macro_rules! impl_mock_epoch_info {
 				new_epoch_index
 			}
 
-			pub fn inner_add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::collections::btree_set::BTreeSet<$account_id>) {
+			pub fn inner_add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::vec::Vec<$account_id>) {
 				MockEpochInfo::set_epoch_authority_count(epoch_index, new_authorities.len() as $authority_count);
 				MockEpochInfo::set_authority_indices(epoch_index, new_authorities);
 			}
@@ -86,7 +86,7 @@ macro_rules! impl_mock_epoch_info {
 				LAST_EXPIRED_EPOCH.with(|cell| *cell.borrow())
 			}
 
-			fn current_authorities() -> sp_std::collections::btree_set::BTreeSet<Self::ValidatorId> {
+			fn current_authorities() -> sp_std::vec::Vec<Self::ValidatorId> {
 				CURRENT_AUTHORITIES.with(|cell| cell.borrow().clone())
 			}
 
@@ -110,7 +110,7 @@ macro_rules! impl_mock_epoch_info {
 				})
 			}
 
-			fn authorities_at_epoch(epoch: $epoch_index) -> sp_std::collections::btree_set::BTreeSet<Self::ValidatorId> {
+			fn authorities_at_epoch(epoch: $epoch_index) -> sp_std::vec::Vec<Self::ValidatorId> {
 				if epoch == Self::epoch_index() {
 					CURRENT_AUTHORITIES.with(|cell| cell.borrow().clone())
 				} else {
@@ -127,13 +127,13 @@ macro_rules! impl_mock_epoch_info {
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]
-			fn add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::collections::btree_set::BTreeSet<Self::ValidatorId>) {
+			fn add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::vec::Vec<Self::ValidatorId>) {
 				MockEpochInfo::inner_add_authority_info_for_epoch(epoch_index, new_authorities);
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]
 			fn set_authorities(
-				authorities: sp_std::collections::btree_set::BTreeSet<Self::ValidatorId>,
+				authorities: sp_std::vec::Vec<Self::ValidatorId>,
 			) {
 				Self::set_authorities(authorities);
 			}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1201

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Changed Storage Items (currentAuthorities, historicalAuthorities) to use a Vec instead of BTreeSet
- Added randomization when creating the new authority set such that authorities are not sorted based on their ID

