### PR TITLE
fix: broker test upgrade

### DIFF
--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -92,6 +92,12 @@ pub fn extra_accounts() -> Vec<(AccountId, AccountRole, FlipBalance, Option<Vec<
 			100 * FLIPPERINOS_PER_FLIP,
 			Some(b"Chainflip Testnet Broker 2".to_vec()),
 		),
+		(
+			get_account_id_from_seed::<sr25519::Public>("BROKER_FEE_TEST"),
+			AccountRole::Broker,
+			100 * FLIPPERINOS_PER_FLIP,
+			Some(b"Chainflip Testnet Broker for broker_fee_collection_test".to_vec()),
+		),
 	]
 }
 


### PR DESCRIPTION
In order to run the broker_fee_collection_tests.rs on bouncer, we need this account to exist. Because we added this to genesis *after* 1.3, when we do the upgrade, the account doesn't exist, since it's not there at 1.3. So just adding it to genesis on the release branch since it's no impact, and the simplest.