### PR TITLE
chore: use success runs

### DIFF
--- a/.github/actions/get-workflow-commit/action.yml
+++ b/.github/actions/get-workflow-commit/action.yml
@@ -27,7 +27,7 @@ runs:
             owner,
             repo,
             workflow_id,
-            status: 'completed',
+            status: 'success',
             event: 'push',
           });
           const run = runs.data.workflow_runs[0];

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -51,5 +51,5 @@ jobs:
     uses: ./.github/workflows/upgrade-test.yml
     secrets: inherit
     with:
-      upgrade-from-release: "perseverance"
+      upgrade-from-release: "sisyphos"
       upgrade-to-workflow-name: "ci-main.yml"

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       upgrade-from-release:
-        description: 'The release we want to upgrade *from*: "perseverance" or "berghain"'
+        description: 'The release we want to upgrade *from*: "sisyphos", "perseverance" or "berghain"'
         required: true
         default: 'perseverance'
       upgrade-to-workflow-name:
@@ -29,7 +29,6 @@ on:
         type: string
         description: 'Commit to run the upgrade test against. Leave blank to use latest successful workflow run.'
         required: false
-
 
 env:
   FORCE_COLOR: 1

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -51,6 +51,7 @@ runWithTimeout(runAllConcurrentTests(), 1000000)
     process.exit(0);
   })
   .catch((error) => {
+    console.error!("All concurrent tests timed out. Exiting.")
     console.error(error);
     process.exit(-1);
   });

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -51,7 +51,7 @@ runWithTimeout(runAllConcurrentTests(), 1000000)
     process.exit(0);
   })
   .catch((error) => {
-    console.error!("All concurrent tests timed out. Exiting.")
+    console.error!('All concurrent tests timed out. Exiting.');
     console.error(error);
     process.exit(-1);
   });


### PR DESCRIPTION
- Use the last successful run of each pipeline - meaning we don't have to wait for completion each time (if the last completion doesn't matter)
- Log that it's the concurrent test that times out when it does
- Use sisyphos instead of persa - because currently there's a fix just on the sisy build to make the broker test work (and ultimately doesn't matter too much either way)