### PR TITLE
fix: initialise ingress egress pallet values for arbitrum

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -205,6 +205,7 @@ jobs:
           git rev-parse HEAD
           cd bouncer
           pnpm install
+          ./commands/setup_swaps.ts
           ./tests/all_concurrent_tests.ts
 
       - name: Print chainflip-engine logs 🚗

--- a/bouncer/commands/get_arbeth_balance.ts
+++ b/bouncer/commands/get_arbeth_balance.ts
@@ -2,9 +2,9 @@
 // INSTRUCTIONS
 //
 // This command takes one argument.
-// It will print the Arb balance of the address provided as the first argument.
+// It will print the ArbEth balance of the address provided as the first argument.
 //
-// For example: ./commands/get_arb_balance.ts 0xcf1dc766fc2c62bef0b67a8de666c8e67acf35f6
+// For example: ./commands/get_arbeth_balance.ts 0xcf1dc766fc2c62bef0b67a8de666c8e67acf35f6
 // might print: 1.2
 
 import { runWithTimeout } from '../shared/utils';

--- a/bouncer/commands/send_arbeth.ts
+++ b/bouncer/commands/send_arbeth.ts
@@ -5,7 +5,7 @@
 // It will fund the arbitrum address provided as the first argument with the amount
 // provided in the second argument. The asset amount is interpreted in Arb
 //
-// For example: ./commands/send_arb.ts 0xcf1dc766fc2c62bef0b67a8de666c8e67acf35f6 1.2
+// For example: ./commands/send_arbeth.ts 0xcf1dc766fc2c62bef0b67a8de666c8e67acf35f6 1.2
 // will send 1.2 Arb to account 0xcf1dc766fc2c62bef0b67a8de666c8e67acf35f6
 
 import { runWithTimeout } from '../shared/utils';

--- a/localnet/init/scripts/start-node.sh
+++ b/localnet/init/scripts/start-node.sh
@@ -18,7 +18,7 @@ export ETH_INIT_AGG_KEY=$(jq -r '.eth_agg_key' $LOCALNET_INIT_DIR/keyshare/$NODE
 export DOT_INIT_AGG_KEY=$(jq -r '.dot_agg_key' $LOCALNET_INIT_DIR/keyshare/$NODE_COUNT/agg_keys.json)
 $BINARY_ROOT_PATH/chainflip-node key insert --chain=$CHAIN --base-path=/tmp/chainflip/$NODE_NAME/chaindata --suri=0x$(cat $KEYS_DIR/$NODE_NAME/signing_key_file) --key-type=aura --scheme=sr25519
 $BINARY_ROOT_PATH/chainflip-node key insert --chain=$CHAIN --base-path=/tmp/chainflip/$NODE_NAME/chaindata --suri=0x$(cat $KEYS_DIR/$NODE_NAME/signing_key_file) --key-type=gran --scheme=ed25519
-$BINARY_ROOT_PATH/chainflip-node --chain=$CHAIN \
+RUST_LOG=runtime=debug $BINARY_ROOT_PATH/chainflip-node --chain=$CHAIN \
   --base-path=/tmp/chainflip/$NODE_NAME/chaindata \
   --node-key-file=$KEYS_DIR/$NODE_NAME/node_key_file \
   --validator \

--- a/state-chain/runtime/src/migrations/arbitrum_integration.rs
+++ b/state-chain/runtime/src/migrations/arbitrum_integration.rs
@@ -92,7 +92,8 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 			chain_id,
 			usdc_address,
 			start_block_number,
-		): (Address, Address, Address, u64, Address, u64) =
+			deposit_channel_lifetime,
+		): (Address, Address, Address, u64, Address, u64, u64) =
 			match cf_runtime_upgrade_utilities::genesis_hashes::genesis_hash::<Runtime>() {
 				cf_runtime_upgrade_utilities::genesis_hashes::BERGHAIN => {
 					log::warn!("Need to set up arbitrum integration for Berghain");
@@ -103,6 +104,8 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						arb::CHAIN_ID_MAINNET,
 						[0u8; 20].into(),
 						0,
+						// state-chain/node/src/chain_spec/berghain.rs
+						24 * 3600 * 4,
 					)
 				},
 				cf_runtime_upgrade_utilities::genesis_hashes::PERSEVERANCE => {
@@ -114,6 +117,8 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 						[1u8; 20].into(),
 						0,
+						// state-chain/node/src/chain_spec/perseverance.rs
+						2 * 60 * 60 * 4,
 					)
 				},
 				cf_runtime_upgrade_utilities::genesis_hashes::SISYPHOS => {
@@ -125,6 +130,8 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 						[2u8; 20].into(),
 						0,
+						// state-chain/node/src/chain_spec/sisyphos.rs
+						2 * 60 * 60 * 4,
 					)
 				},
 				_ => {
@@ -136,6 +143,8 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						412346,
 						hex_literal::hex!("1D55838a9EC169488D360783D65e6CD985007b72").into(),
 						0,
+						// state-chain/node/src/chain_spec/testnet.rs
+						2 * 60 * 60 * 4,
 					)
 				},
 			};
@@ -151,6 +160,10 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 			block_height: start_block_number,
 			tracked_data: ArbitrumTrackedData { base_fee: 0 },
 		});
+		pallet_cf_ingress_egress::DepositChannelLifetime::<Runtime, ArbitrumInstance>::put(
+			deposit_channel_lifetime,
+		);
+		pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, ArbitrumInstance>::put(1);
 
 		Weight::zero()
 	}


### PR DESCRIPTION
Also add liquidity after the upgrade, so in the case of new chains, there's liquidity there to swap into.