### PR TITLE
fix: PRO-1330 - Move Location::panic() to inside the function, so it outputs the caller of the fn and not of the async block poll fn.

### DIFF
--- a/utilities/src/with_std/spmc.rs
+++ b/utilities/src/with_std/spmc.rs
@@ -21,13 +21,14 @@ impl<T: Clone> Sender<T> {
 	#[allow(clippy::manual_async_fn)]
 	#[track_caller]
 	pub fn send(&self, msg: T) -> impl futures::Future<Output = bool> + '_ {
+		let caller_location = core::panic::Location::caller();
 		async move {
 			match self.sender.try_broadcast(msg) {
 				Ok(None) => true,
 				Ok(Some(_)) => unreachable!("async_broadcast feature unused"),
 				Err(error) => match error {
 					async_broadcast::TrySendError::Full(msg) => {
-						warn!("Waiting for space in channel which is currently full with a capacity of {} items at {}", self.sender.capacity(), core::panic::Location::caller());
+						warn!("Waiting for space in channel which is currently full with a capacity of {} items at {}", self.sender.capacity(), caller_location);
 						match self.sender.broadcast(msg).await {
 							Ok(None) => true,
 							Ok(Some(_)) => unreachable!("async_broadcast feature unused"),


### PR DESCRIPTION
Have tested it works now, I don't feel there is a reasonable way to unit test, or that it is necessary.