### PR TITLE
fix: extend upgrade timeout

### DIFF
--- a/bouncer/commands/upgrade_network.ts
+++ b/bouncer/commands/upgrade_network.ts
@@ -120,7 +120,8 @@ async function main(): Promise<void> {
   process.exit(0);
 }
 
-runWithTimeout(main(), 15 * 60 * 1000).catch((error) => {
+// Quite a long timeout, as the sequence of try-runtime runs takes some time.
+runWithTimeout(main(), 30 * 60 * 1000).catch((error) => {
   console.error('upgrade_network exiting due to error: ', error);
   if (process.exitCode === 0) {
     process.exitCode = -1;


### PR DESCRIPTION
Fixes this, which shows up occassionally:

```
upgrade_network exiting due to error:  Error: Timed out after 900000 ms.
    at <anonymous> (/opt/actions-runner/_work/chainflip-backend/chainflip-backend/bouncer/shared/utils.ts:264:13)
    at runWithTimeout (/opt/actions-runner/_work/chainflip-backend/chainflip-backend/bouncer/shared/utils.ts:261:18)
```