### PR TITLE
feat(custom-rpc): swap rate with limit orders [WEB-1059][WEB-1062]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -775,7 +775,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -833,7 +833,7 @@ checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -967,7 +967,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.2.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9897ef0f1bd2362169de6d7e436ea2237dc1085d7d1e4db75f4be34d86f309d1"
+checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -1192,15 +1192,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.2.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b41ff04256c5c8330f3dfdaaae2a5cc976a8e75088bafa4625b0d0208de8c"
+checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
 dependencies = [
  "once_cell",
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
  "syn_derive",
 ]
 
@@ -2099,7 +2099,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2682,7 +2682,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2756,7 +2756,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2773,7 +2773,7 @@ checksum = "8908e380a8efd42150c017b0cfa31509fc49b6d47f7cb6b33e93ffb8f4e3661e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2798,12 +2798,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
 ]
 
 [[package]]
@@ -2836,16 +2836,16 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2872,13 +2872,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.5",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3111,7 +3111,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3169,7 +3169,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.55",
+ "syn 2.0.61",
  "termcolor",
  "toml 0.8.10",
  "walkdir",
@@ -3334,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -3394,7 +3394,7 @@ dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3662,7 +3662,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.55",
+ "syn 2.0.61",
  "toml 0.8.10",
  "walkdir",
 ]
@@ -3680,7 +3680,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3706,7 +3706,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.25.0",
- "syn 2.0.55",
+ "syn 2.0.61",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3901,7 +3901,7 @@ dependencies = [
  "fs-err",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4292,7 +4292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing 9.0.0",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4304,7 +4304,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4314,7 +4314,7 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -4499,7 +4499,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -5315,16 +5315,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.36.1"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "serde",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -6493,7 +6492,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -6507,7 +6506,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -6518,7 +6517,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -6529,7 +6528,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -7156,7 +7155,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -7228,7 +7227,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -7333,7 +7332,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8191,7 +8190,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8255,7 +8254,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8293,7 +8292,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8371,7 +8370,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8381,7 +8380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8522,7 +8521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -8599,14 +8598,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -8645,7 +8644,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -9056,7 +9055,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -9602,7 +9601,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -10415,7 +10414,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -10582,9 +10581,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788745a868b0e751750388f4e6546eb921ef714a4317fa6954f7cde114eb2eb7"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10596,9 +10595,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc2f4e8bc344b9fc3d5f74f72c2e55bfc38d28dc2ebc69c194a3df424e4d9ac"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
@@ -10895,9 +10894,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -10913,20 +10912,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -10980,10 +10979,10 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -11385,7 +11384,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -11700,7 +11699,7 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "quote",
  "sp-core-hashing 9.0.0",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -11740,7 +11739,7 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -11751,7 +11750,7 @@ checksum = "50535e1a5708d3ba5c1195b59ebefac61cc8679c2c24716b87a86e8b7ed2e4a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -11761,7 +11760,7 @@ source = "git+https://github.com/paritytech/polkadot-sdk#2556e33fb4c52ea8192de68
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12093,7 +12092,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12106,7 +12105,7 @@ dependencies = [
  "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12119,7 +12118,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12422,7 +12421,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12721,7 +12720,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12872,7 +12871,7 @@ dependencies = [
  "quote",
  "scale-info",
  "subxt-metadata",
- "syn 2.0.55",
+ "syn 2.0.61",
  "thiserror",
  "tokio",
 ]
@@ -12900,11 +12899,11 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5086ce2a90e723083ff19b77f06805d00e732eac3e19c86f6cd643d4255d334"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.5",
  "parity-scale-codec",
  "proc-macro-error",
  "subxt-codegen",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -12953,9 +12952,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12971,7 +12970,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -13081,22 +13080,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -13235,7 +13234,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -13447,7 +13446,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -14060,7 +14059,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -14094,7 +14093,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -14925,7 +14924,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -14945,7 +14944,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -560,7 +560,8 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		additional_limit_orders: Option<Vec<(Tick, U256)>>,
+		first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+		second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1085,7 +1086,8 @@ where
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		additional_limit_orders: Option<Vec<(Tick, U256)>>,
+		first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+		second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput> {
 		self.client
@@ -1104,7 +1106,8 @@ where
 						}
 					})
 					.map_err(|str| anyhow::anyhow!(str))?,
-				additional_limit_orders,
+				first_leg_additional_limit_orders.unwrap_or_default(),
+				second_leg_additional_limit_orders.unwrap_or_default(),
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1106,8 +1106,8 @@ where
 						}
 					})
 					.map_err(|str| anyhow::anyhow!(str))?,
-				first_leg_additional_limit_orders.unwrap_or_default(),
-				second_leg_additional_limit_orders.unwrap_or_default(),
+				first_leg_additional_limit_orders,
+				second_leg_additional_limit_orders,
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -217,9 +217,9 @@ pub struct RpcAuctionState {
 }
 
 #[derive(Serialize, Deserialize)]
-struct SwapFee {
-	amount: U256,
-	asset: Asset,
+pub struct SwapFee {
+	pub amount: U256,
+	pub asset: Asset,
 }
 
 impl SwapFee {

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -249,6 +249,7 @@ impl From<RpcSwapOutputV2> for RpcSwapOutputV1 {
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcFee {
+	#[serde(flatten)]
 	pub asset: Asset,
 	pub amount: Amount,
 }

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -238,15 +238,6 @@ pub struct RpcSwapOutputV1 {
 	pub output: NumberOrHex,
 }
 
-impl From<SwapOutput> for RpcSwapOutputV1 {
-	fn from(swap_output: SwapOutput) -> Self {
-		Self {
-			intermediary: swap_output.intermediary.map(Into::into),
-			output: swap_output.output.into(),
-		}
-	}
-}
-
 impl From<RpcSwapOutputV2> for RpcSwapOutputV1 {
 	fn from(swap_output: RpcSwapOutputV2) -> Self {
 		Self {

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -532,7 +532,7 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		limit_orders: Option<Vec<(i32, NumberOrHex)>>,
+		limit_orders: Option<Vec<(i32, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1057,7 +1057,7 @@ where
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		limit_orders: Option<Vec<(i32, NumberOrHex)>>,
+		limit_orders: Option<Vec<(i32, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput> {
 		self.client
@@ -1076,9 +1076,7 @@ where
 						}
 					})
 					.map_err(|str| anyhow::anyhow!(str))?,
-				limit_orders.map(|orders| {
-					orders.into_iter().map(|(tick, amount)| (tick, amount.into())).collect()
-				}),
+				limit_orders,
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -560,7 +560,7 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		additional_limit_orders: Option<Vec<(i32, U256)>>,
+		additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1085,7 +1085,7 @@ where
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		additional_limit_orders: Option<Vec<(i32, U256)>>,
+		additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput> {
 		self.client

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -2039,9 +2039,9 @@ mod test {
 
 	#[test]
 	fn test_swap_output_serialization() {
-		let swap_output = RpcSwapOutput {
-			output: NumberOrHex::Hex(1_000_000_000_000_000_000u128.into()),
-			intermediary: Some(NumberOrHex::Hex(1_000_000u128.into())),
+		let swap_output = RpcSwapOutputV2 {
+			output: 1_000_000_000_000_000_000u128.into(),
+			intermediate: Some(1_000_000u128.into()),
 			included_fees: vec![SwapFeeKind::Network.into_fee(1_000u128, Asset::Usdc)],
 		};
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -532,6 +532,7 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
+		limit_orders: Option<Vec<(i32, NumberOrHex)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1056,6 +1057,7 @@ where
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
+		limit_orders: Option<Vec<(i32, NumberOrHex)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput> {
 		self.client
@@ -1074,6 +1076,9 @@ where
 						}
 					})
 					.map_err(|str| anyhow::anyhow!(str))?,
+				limit_orders.map(|orders| {
+					orders.into_iter().map(|(tick, amount)| (tick, amount.into())).collect()
+				}),
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1141,9 +1141,12 @@ where
 	) -> RpcResult<RpcSwapOutputV2> {
 		let (first_leg, second_leg) = options
 			.map(|opts| {
-				(opts.first_leg_additional_limit_orders, opts.second_leg_additional_limit_orders)
+				(
+					opts.first_leg_additional_limit_orders.unwrap_or_default(),
+					opts.second_leg_additional_limit_orders.unwrap_or_default(),
+				)
 			})
-			.unwrap_or((None, None));
+			.unwrap_or((vec![], vec![]));
 
 		self.client
 			.runtime_api()

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -560,6 +560,14 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RpcSwapOutput>;
+	#[method(name = "swap_rate_v2")]
+	fn cf_pool_swap_rate_v2(
+		&self,
+		from_asset: Asset,
+		to_asset: Asset,
+		amount: NumberOrHex,
 		first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
@@ -1082,6 +1090,16 @@ where
 	}
 
 	fn cf_pool_swap_rate(
+		&self,
+		from_asset: Asset,
+		to_asset: Asset,
+		amount: NumberOrHex,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RpcSwapOutput> {
+		self.cf_pool_swap_rate_v2(from_asset, to_asset, amount, None, None, at)
+	}
+
+	fn cf_pool_swap_rate_v2(
 		&self,
 		from_asset: Asset,
 		to_asset: Asset,

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -217,11 +217,24 @@ pub struct RpcAuctionState {
 }
 
 #[derive(Serialize, Deserialize)]
+struct SwapFee {
+	amount: U256,
+	asset: Asset,
+}
+
+impl SwapFee {
+	fn new<T: Into<U256>>(amount: T, asset: Asset) -> Self {
+		Self { amount: amount.into(), asset }
+	}
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct RpcSwapOutput {
 	// Intermediary amount, if there's any
 	pub intermediary: Option<NumberOrHex>,
 	// Final output of the swap
 	pub output: NumberOrHex,
+	pub included_fees: Vec<SwapFee>,
 }
 
 impl From<SwapOutput> for RpcSwapOutput {
@@ -229,6 +242,7 @@ impl From<SwapOutput> for RpcSwapOutput {
 		Self {
 			intermediary: swap_output.intermediary.map(Into::into),
 			output: swap_output.output.into(),
+			included_fees: vec![SwapFee::new(swap_output.network_fee, Asset::Usdc)],
 		}
 	}
 }

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -217,7 +217,6 @@ pub struct RpcAuctionState {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SwapFeeKind {
 	Network,
 }

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use sp_api::ApiError;
 use sp_core::U256;
 use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT},
+	traits::{Block as BlockT, Header as HeaderT, UniqueSaturatedInto},
 	Permill,
 };
 use state_chain_runtime::{
@@ -1123,21 +1123,20 @@ where
 						.into_iter()
 						.map(|additional_order| {
 							match additional_order {
-							SwapRateV2AdditionalOrder::LimitOrder {
-								base_asset,
-								quote_asset,
-								side,
-								tick,
-								sell_amount,
-							} =>
-								state_chain_runtime::runtime_apis::SimulateSwapAdditionalOrder::LimitOrder {
+								SwapRateV2AdditionalOrder::LimitOrder {
 									base_asset,
 									quote_asset,
 									side,
 									tick,
-									sell_amount: sell_amount.try_into().unwrap_or(AssetAmount::MAX),
+									sell_amount,
+								} => state_chain_runtime::runtime_apis::SimulateSwapAdditionalOrder::LimitOrder {
+									base_asset,
+									quote_asset,
+									side,
+									tick,
+									sell_amount: sell_amount.unique_saturated_into(),
 								}
-						}
+							}
 						})
 						.collect()
 				}),

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -243,14 +243,14 @@ impl SwapFee {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct RpcSwapOutput {
+pub struct RpcSwapOutputV1 {
 	// Intermediary amount, if there's any
 	pub intermediary: Option<NumberOrHex>,
 	// Final output of the swap
 	pub output: NumberOrHex,
 }
 
-impl From<SwapOutput> for RpcSwapOutput {
+impl From<SwapOutput> for RpcSwapOutputV1 {
 	fn from(swap_output: SwapOutput) -> Self {
 		Self {
 			intermediary: swap_output.intermediary.map(Into::into),
@@ -259,7 +259,7 @@ impl From<SwapOutput> for RpcSwapOutput {
 	}
 }
 
-impl From<RpcSwapOutputV2> for RpcSwapOutput {
+impl From<RpcSwapOutputV2> for RpcSwapOutputV1 {
 	fn from(swap_output: RpcSwapOutputV2) -> Self {
 		Self {
 			intermediary: swap_output.intermediate.map(Into::into),
@@ -593,7 +593,7 @@ pub trait CustomApi {
 		to_asset: Asset,
 		amount: NumberOrHex,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<RpcSwapOutput>;
+	) -> RpcResult<RpcSwapOutputV1>;
 	#[method(name = "swap_rate_v2")]
 	fn cf_pool_swap_rate_v2(
 		&self,
@@ -1126,7 +1126,7 @@ where
 		to_asset: Asset,
 		amount: NumberOrHex,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<RpcSwapOutput> {
+	) -> RpcResult<RpcSwapOutputV1> {
 		self.cf_pool_swap_rate_v2(from_asset, to_asset, amount.into(), None, at)
 			.map(Into::into)
 	}

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -217,20 +217,6 @@ pub struct RpcAuctionState {
 }
 
 #[derive(Serialize, Deserialize)]
-pub enum SwapFeeKind {
-	Network,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct SwapFee {
-	pub amount: U256,
-	#[serde(flatten)]
-	pub asset: Asset,
-	#[serde(rename = "type")]
-	pub kind: SwapFeeKind,
-}
-
-#[derive(Serialize, Deserialize)]
 pub struct RpcSwapOutputV1 {
 	// Intermediary amount, if there's any
 	pub intermediary: Option<NumberOrHex>,
@@ -2059,9 +2045,9 @@ mod test {
 		insta::assert_snapshot!(serde_json::to_value(RpcSwapOutputV2 {
 			output: 1_000_000_000_000_000_000u128.into(),
 			intermediary: Some(1_000_000u128.into()),
-			network_fee: RpcFee {asset: Asset::Usdc, amount: 1_000u128.into()},
-			ingress_fee: RpcFee {asset: Asset::Flip, amount: 500u128.into()},
-			egress_fee: RpcFee {asset: Asset::Eth, amount: 1_000_000u128.into()},
+			network_fee: RpcFee { asset: Asset::Usdc, amount: 1_000u128.into() },
+			ingress_fee: RpcFee { asset: Asset::Flip, amount: 500u128.into() },
+			egress_fee: RpcFee { asset: Asset::Eth, amount: 1_000_000u128.into() },
 		})
 		.unwrap());
 	}

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -217,14 +217,29 @@ pub struct RpcAuctionState {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SwapFeeKind {
+	Network,
+}
+
+impl SwapFeeKind {
+	fn into_fee<T: Into<U256>>(self, amount: T, asset: Asset) -> SwapFee {
+		SwapFee::new(amount, asset, self)
+	}
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct SwapFee {
 	pub amount: U256,
+	#[serde(flatten)]
 	pub asset: Asset,
+	#[serde(rename = "type")]
+	pub kind: SwapFeeKind,
 }
 
 impl SwapFee {
-	fn new<T: Into<U256>>(amount: T, asset: Asset) -> Self {
-		Self { amount: amount.into(), asset }
+	fn new<T: Into<U256>>(amount: T, asset: Asset, kind: SwapFeeKind) -> Self {
+		Self { amount: amount.into(), asset, kind }
 	}
 }
 
@@ -242,7 +257,7 @@ impl From<SwapOutput> for RpcSwapOutput {
 		Self {
 			intermediary: swap_output.intermediary.map(Into::into),
 			output: swap_output.output.into(),
-			included_fees: vec![SwapFee::new(swap_output.network_fee, Asset::Usdc)],
+			included_fees: vec![SwapFeeKind::Network.into_fee(swap_output.network_fee, Asset::Usdc)],
 		}
 	}
 }
@@ -546,7 +561,7 @@ pub trait CustomApi {
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		limit_orders: Option<Vec<(i32, U256)>>,
+		additional_limit_orders: Option<Vec<(i32, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1071,7 +1086,7 @@ where
 		from_asset: Asset,
 		to_asset: Asset,
 		amount: NumberOrHex,
-		limit_orders: Option<Vec<(i32, U256)>>,
+		additional_limit_orders: Option<Vec<(i32, U256)>>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutput> {
 		self.client
@@ -1090,7 +1105,7 @@ where
 						}
 					})
 					.map_err(|str| anyhow::anyhow!(str))?,
-				limit_orders,
+				additional_limit_orders,
 			)
 			.map_err(to_rpc_error)
 			.and_then(|result| result.map_err(map_dispatch_error))
@@ -1973,5 +1988,16 @@ mod test {
 			vec![BoostPoolFeesRpc::new(Asset::Btc, 10, boost_details_1())];
 
 		insta::assert_json_snapshot!(val);
+	}
+
+	#[test]
+	fn test_swap_output_serialization() {
+		let swap_output = RpcSwapOutput {
+			output: NumberOrHex::Hex(1_000_000_000_000_000_000u128.into()),
+			intermediary: Some(NumberOrHex::Hex(1_000_000u128.into())),
+			included_fees: vec![SwapFeeKind::Network.into_fee(1_000u128, Asset::Usdc)],
+		};
+
+		insta::assert_snapshot!(serde_json::to_value(swap_output).unwrap());
 	}
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
@@ -2,4 +2,4 @@
 source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(swap_output).unwrap()"
 ---
-{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"Network"}],"intermediary":"0xf4240","output":"0xde0b6b3a7640000"}
+{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"Network"}],"intermediate":"0xf4240","output":"0xde0b6b3a7640000"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
@@ -2,4 +2,4 @@
 source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(swap_output).unwrap()"
 ---
-{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"NETWORK"}],"intermediary":"0xf4240","output":"0xde0b6b3a7640000"}
+{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"Network"}],"intermediary":"0xf4240","output":"0xde0b6b3a7640000"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
@@ -2,4 +2,4 @@
 source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(swap_output).unwrap()"
 ---
-{"egress_fee":{"amount":"0xf4240","asset":{"asset":"ETH","chain":"Ethereum"}},"ingress_fee":{"amount":"0x1f4","asset":{"asset":"FLIP","chain":"Ethereum"}},"intermediary":"0xf4240","network_fee":{"amount":"0x3e8","asset":{"asset":"USDC","chain":"Ethereum"}},"output":"0xde0b6b3a7640000"}
+{"egress_fee":{"amount":"0xf4240","asset":"ETH","chain":"Ethereum"},"ingress_fee":{"amount":"0x1f4","asset":"FLIP","chain":"Ethereum"},"intermediary":"0xf4240","network_fee":{"amount":"0x3e8","asset":"USDC","chain":"Ethereum"},"output":"0xde0b6b3a7640000"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
@@ -2,4 +2,4 @@
 source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(swap_output).unwrap()"
 ---
-{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"Network"}],"intermediate":"0xf4240","output":"0xde0b6b3a7640000"}
+{"egress_fee":{"amount":"0xf4240","asset":{"asset":"ETH","chain":"Ethereum"}},"ingress_fee":{"amount":"0x1f4","asset":{"asset":"FLIP","chain":"Ethereum"}},"intermediary":"0xf4240","network_fee":{"amount":"0x3e8","asset":{"asset":"USDC","chain":"Ethereum"}},"output":"0xde0b6b3a7640000"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__swap_output_serialization.snap
@@ -1,0 +1,5 @@
+---
+source: state-chain/custom-rpc/src/lib.rs
+expression: "serde_json::to_value(swap_output).unwrap()"
+---
+{"included_fees":[{"amount":"0x3e8","asset":"USDC","chain":"Ethereum","type":"NETWORK"}],"intermediary":"0xf4240","output":"0xde0b6b3a7640000"}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1784,7 +1784,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Returns the remaining amount after the fee has been withheld, and the fee itself, both
 	/// measured in units of the input asset. A swap may be scheduled to convert the fee into the
 	/// gas asset.
-	fn withhold_ingress_or_egress_fee(
+	pub fn withhold_ingress_or_egress_fee(
 		ingress_or_egress: IngressOrEgress,
 		asset: TargetChainAsset<T, I>,
 		available_amount: TargetChainAmount<T, I>,

--- a/state-chain/pallets/cf-pools/Cargo.toml
+++ b/state-chain/pallets/cf-pools/Cargo.toml
@@ -68,6 +68,7 @@ std = [
   'scale-info/std',
   'sp-arithmetic/std',
   'sp-std/std',
+  'sp-core/std',
   'serde/std',
 ]
 runtime-benchmarks = [

--- a/state-chain/pallets/cf-pools/Cargo.toml
+++ b/state-chain/pallets/cf-pools/Cargo.toml
@@ -43,12 +43,12 @@ frame-benchmarking = { git = "https://github.com/chainflip-io/polkadot-sdk.git",
 frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 frame-system = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-arithmetic = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
+sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-std = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 
 [dev-dependencies]
 sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
-sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 cf-test-utilities = { path = '../../test-utilities' }
 
 [features]

--- a/state-chain/pallets/cf-pools/Cargo.toml
+++ b/state-chain/pallets/cf-pools/Cargo.toml
@@ -43,7 +43,7 @@ frame-benchmarking = { git = "https://github.com/chainflip-io/polkadot-sdk.git",
 frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 frame-system = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-arithmetic = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
-sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
+sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-std = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 
 [dev-dependencies]

--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -199,7 +199,7 @@ mod benchmarks {
 			Some(0),
 			10_000,
 		));
-		assert_ok!(Pallet::<T>::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 1_000, None));
+		assert_ok!(Pallet::<T>::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 1_000));
 		let fee = 1_000;
 		let call = Call::<T>::set_pool_fees {
 			base_asset: Asset::Eth,

--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -199,7 +199,7 @@ mod benchmarks {
 			Some(0),
 			10_000,
 		));
-		assert_ok!(Pallet::<T>::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 1_000));
+		assert_ok!(Pallet::<T>::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 1_000, None));
 		let fee = 1_000;
 		let call = Call::<T>::set_pool_fees {
 			base_asset: Asset::Eth,

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1556,7 +1556,7 @@ impl<T: Config> Pallet<T> {
 		sell_amount: Amount,
 	) -> Result<(), DispatchError> {
 		Self::try_mutate_pool(AssetPair::try_new::<T>(base_asset, quote_asset)?, |_, pool| {
-			let _ = Self::collect_and_mint_limit_order_with_dispatch_error(
+			Self::collect_and_mint_limit_order_with_dispatch_error(
 				pool,
 				account_id,
 				side,

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -160,6 +160,8 @@ pub mod pallet {
 
 	pub type AssetAmounts = PoolPairsMap<AssetAmount>;
 
+	pub type TickAndAmount = (Tick, U256);
+
 	/// Represents an amount of liquidity, either as an exact amount, or through maximum and minimum
 	/// amounts of both assets. Internally those max/min are converted into exact liquidity amounts,
 	/// that is if the appropriate asset ratio can be achieved while maintaining the max/min bounds.
@@ -1549,7 +1551,7 @@ impl<T: Config> Pallet<T> {
 		from: any::Asset,
 		to: any::Asset,
 		input_amount: AssetAmount,
-		additional_limit_orders: Option<(T::AccountId, Vec<(Tick, U256)>, Vec<(Tick, U256)>)>,
+		additional_limit_orders: Option<(T::AccountId, Vec<TickAndAmount>, Vec<TickAndAmount>)>,
 	) -> Result<SwapOutput, DispatchError> {
 		match ((from, to), additional_limit_orders) {
 			((_, STABLE_ASSET) | (STABLE_ASSET, _), Some((account_id, limit_orders, _))) => {

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1553,7 +1553,7 @@ impl<T: Config> Pallet<T> {
 		side: Side,
 		id: OrderId,
 		tick: Tick,
-		sell_amount: U256,
+		sell_amount: Amount,
 	) -> Result<(), DispatchError> {
 		Self::try_mutate_pool(AssetPair::try_new::<T>(base_asset, quote_asset)?, |_, pool| {
 			let _ = Self::collect_and_mint_limit_order_with_dispatch_error(

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1542,10 +1542,8 @@ impl<T: Config> Pallet<T> {
 					.map_err(|_| "Failed to set limit order")?;
 			}
 
-			Ok::<_, DispatchError>(())
-		})?;
-
-		Ok(())
+			Ok(())
+		})
 	}
 
 	#[allow(clippy::type_complexity)]

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -2077,12 +2077,7 @@ impl<T: Config> cf_traits::AssetConverter for Pallet<T> {
 
 		let estimation_output = with_transaction_unchecked(|| {
 			TransactionOutcome::Rollback(
-				Self::swap_with_network_fee(
-					input_asset,
-					output_asset,
-					estimation_input,
-				)
-				.ok(),
+				Self::swap_with_network_fee(input_asset, output_asset, estimation_input).ok(),
 			)
 		})?
 		.output;

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -24,7 +24,7 @@ use frame_support::{
 
 use frame_system::pallet_prelude::OriginFor;
 use serde::{Deserialize, Serialize};
-use sp_arithmetic::traits::{AtLeast32BitUnsigned, UniqueSaturatedInto, Zero};
+use sp_arithmetic::traits::{UniqueSaturatedInto, Zero};
 use sp_std::{boxed::Box, collections::btree_set::BTreeSet, vec::Vec};
 
 pub use pallet::*;

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -163,7 +163,7 @@ fn test_sweeping() {
 		assert_eq!(AliceDebitedEth::get(), 0);
 		assert_eq!(AliceDebitedUsdc::get(), POSITION_0_SIZE);
 
-		LiquidityPools::swap_with_network_fee(ETH, STABLE_ASSET, SWAP_AMOUNT).unwrap();
+		LiquidityPools::swap_with_network_fee(ETH, STABLE_ASSET, SWAP_AMOUNT, None).unwrap();
 
 		assert_eq!(AliceCollectedEth::get(), 0);
 		assert_eq!(AliceCollectedUsdc::get(), 0);
@@ -220,8 +220,8 @@ fn test_buy_back_flip() {
 		// Do two swaps of equivalent value.
 		const USDC_SWAP_VALUE: u128 = 100_000;
 		const FLIP_SWAP_VALUE: u128 = USDC_SWAP_VALUE / FLIP_PRICE_IN_USDC;
-		LiquidityPools::swap_with_network_fee(FLIP, STABLE_ASSET, FLIP_SWAP_VALUE).unwrap();
-		LiquidityPools::swap_with_network_fee(STABLE_ASSET, FLIP, USDC_SWAP_VALUE).unwrap();
+		LiquidityPools::swap_with_network_fee(FLIP, STABLE_ASSET, FLIP_SWAP_VALUE, None).unwrap();
+		LiquidityPools::swap_with_network_fee(STABLE_ASSET, FLIP, USDC_SWAP_VALUE, None).unwrap();
 
 		// 2 swaps of 100_000 USDC, 0.2% fee
 		const EXPECTED_COLLECTED_FEES: AssetAmount = 400;
@@ -393,11 +393,11 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 
 		// Do some swaps to collect fees.
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 10_000).unwrap(),
+			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 10_000, None).unwrap(),
 			SwapOutput { intermediary: None, output: 5_987u128, network_fee: 20 }
 		);
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 10_000).unwrap(),
+			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 10_000, None).unwrap(),
 			SwapOutput { intermediary: None, output: 5_987u128, network_fee: 12 }
 		);
 
@@ -582,11 +582,11 @@ fn pallet_limit_order_is_in_sync_with_pool() {
 
 		// Do some swaps to collect fees.
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 202_200).unwrap(),
+			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 202_200, None).unwrap(),
 			SwapOutput { intermediary: None, output: 99_894u128, network_fee: 404 }
 		);
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 18_000).unwrap(),
+			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 18_000, None).unwrap(),
 			SwapOutput { intermediary: None, output: 9_071, network_fee: 18 }
 		);
 
@@ -690,11 +690,11 @@ fn update_pool_liquidity_fee_collects_fees_for_range_order() {
 
 		// Do some swaps to collect fees.
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 5_000).unwrap(),
+			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 5_000, None).unwrap(),
 			SwapOutput { intermediary: None, output: 2_989u128, network_fee: 10 }
 		);
 		assert_eq!(
-			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 5_000).unwrap(),
+			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 5_000, None).unwrap(),
 			SwapOutput { intermediary: None, output: 2_998u128, network_fee: 6 }
 		);
 

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -394,11 +394,11 @@ fn can_update_pool_liquidity_fee_and_collect_for_limit_order() {
 		// Do some swaps to collect fees.
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 10_000).unwrap(),
-			SwapOutput { intermediary: None, output: 5_987u128 }
+			SwapOutput { intermediary: None, output: 5_987u128, network_fee: 20 }
 		);
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 10_000).unwrap(),
-			SwapOutput { intermediary: None, output: 5_987u128 }
+			SwapOutput { intermediary: None, output: 5_987u128, network_fee: 12 }
 		);
 
 		// Updates the fees to the new value and collect any fees on current positions.
@@ -583,11 +583,11 @@ fn pallet_limit_order_is_in_sync_with_pool() {
 		// Do some swaps to collect fees.
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 202_200).unwrap(),
-			SwapOutput { intermediary: None, output: 99_894u128 }
+			SwapOutput { intermediary: None, output: 99_894u128, network_fee: 404 }
 		);
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 18_000).unwrap(),
-			SwapOutput { intermediary: None, output: 9_071 }
+			SwapOutput { intermediary: None, output: 9_071, network_fee: 18 }
 		);
 
 		// Updates the fees to the new value and collect any fees on current positions.
@@ -691,11 +691,11 @@ fn update_pool_liquidity_fee_collects_fees_for_range_order() {
 		// Do some swaps to collect fees.
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(STABLE_ASSET, Asset::Eth, 5_000).unwrap(),
-			SwapOutput { intermediary: None, output: 2_989u128 }
+			SwapOutput { intermediary: None, output: 2_989u128, network_fee: 10 }
 		);
 		assert_eq!(
 			LiquidityPools::swap_with_network_fee(Asset::Eth, STABLE_ASSET, 5_000).unwrap(),
-			SwapOutput { intermediary: None, output: 2_998u128 }
+			SwapOutput { intermediary: None, output: 2_998u128, network_fee: 6 }
 		);
 
 		// Updates the fees to the new value. No fee is collected for range orders.

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -826,7 +826,7 @@ pub mod pallet {
 					"All swaps should have Stable amount set here"
 				);
 				let stable_amount = swap.stable_amount.get_or_insert_with(Default::default);
-				*stable_amount = T::SwappingApi::take_network_fee(*stable_amount);
+				*stable_amount = T::SwappingApi::take_network_fee(*stable_amount).0;
 
 				if swap.to == STABLE_ASSET {
 					swap.final_output = Some(*stable_amount);

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -826,7 +826,7 @@ pub mod pallet {
 					"All swaps should have Stable amount set here"
 				);
 				let stable_amount = swap.stable_amount.get_or_insert_with(Default::default);
-				*stable_amount = T::SwappingApi::take_network_fee(*stable_amount).0;
+				*stable_amount = T::SwappingApi::take_network_fee(*stable_amount).remaining_amount;
 
 				if swap.to == STABLE_ASSET {
 					swap.final_output = Some(*stable_amount);

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -11,7 +11,7 @@ use cf_traits::{
 		address_converter::MockAddressConverter, deposit_handler::MockDepositHandler,
 		egress_handler::MockEgressHandler, ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
-	AccountRoleRegistry, SwappingApi,
+	AccountRoleRegistry, NetworkFeeTaken, SwappingApi,
 };
 use frame_support::{derive_impl, pallet_prelude::DispatchError, parameter_types, weights::Weight};
 use frame_system as system;
@@ -90,9 +90,9 @@ impl MockSwappingApi {
 }
 
 impl SwappingApi for MockSwappingApi {
-	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount) {
+	fn take_network_fee(input_amount: AssetAmount) -> NetworkFeeTaken {
 		let network_fee = NetworkFee::get() * input_amount;
-		(input_amount - network_fee, network_fee)
+		NetworkFeeTaken { remaining_amount: input_amount - network_fee, network_fee }
 	}
 
 	fn swap_single_leg(

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -90,8 +90,9 @@ impl MockSwappingApi {
 }
 
 impl SwappingApi for MockSwappingApi {
-	fn take_network_fee(input_amount: AssetAmount) -> AssetAmount {
-		input_amount - NetworkFee::get() * input_amount
+	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount) {
+		let network_fee = NetworkFee::get() * input_amount;
+		(input_amount - network_fee, network_fee)
 	}
 
 	fn swap_single_leg(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1136,8 +1136,8 @@ fn process_all_into_stable_swaps_first() {
 		assert_swaps_queue_is_empty();
 
 		// Network fee should only be taken once.
-		let NetworkFeeTaken { remaining_amount: total_amount_after_network_fee, .. } =
-			MockSwappingApi::take_network_fee(amount * 4);
+		let total_amount_after_network_fee =
+			MockSwappingApi::take_network_fee(amount * 4).remaining_amount;
 		let output_amount = total_amount_after_network_fee / 4;
 		// Verify swap "from" -> STABLE_ASSET, then "to" -> Output Asset
 		assert_eq!(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1135,7 +1135,7 @@ fn process_all_into_stable_swaps_first() {
 		assert_swaps_queue_is_empty();
 
 		// Network fee should only be taken once.
-		let total_amount_after_network_fee = MockSwappingApi::take_network_fee(amount * 4);
+		let (total_amount_after_network_fee, _) = MockSwappingApi::take_network_fee(amount * 4);
 		let output_amount = total_amount_after_network_fee / 4;
 		// Verify swap "from" -> STABLE_ASSET, then "to" -> Output Asset
 		assert_eq!(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -21,8 +21,7 @@ use cf_traits::{
 		egress_handler::{MockEgressHandler, MockEgressParameter},
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
-	AccountRoleRegistry, CcmHandler, Chainflip, NetworkFeeTaken, SetSafeMode, SwapDepositHandler,
-	SwappingApi,
+	AccountRoleRegistry, CcmHandler, Chainflip, SetSafeMode, SwapDepositHandler, SwappingApi,
 };
 use frame_support::{
 	assert_err, assert_noop, assert_ok,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -21,7 +21,8 @@ use cf_traits::{
 		egress_handler::{MockEgressHandler, MockEgressParameter},
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
-	AccountRoleRegistry, CcmHandler, Chainflip, SetSafeMode, SwapDepositHandler, SwappingApi,
+	AccountRoleRegistry, CcmHandler, Chainflip, NetworkFeeTaken, SetSafeMode, SwapDepositHandler,
+	SwappingApi,
 };
 use frame_support::{
 	assert_err, assert_noop, assert_ok,
@@ -1135,7 +1136,8 @@ fn process_all_into_stable_swaps_first() {
 		assert_swaps_queue_is_empty();
 
 		// Network fee should only be taken once.
-		let (total_amount_after_network_fee, _) = MockSwappingApi::take_network_fee(amount * 4);
+		let NetworkFeeTaken { remaining_amount: total_amount_after_network_fee, .. } =
+			MockSwappingApi::take_network_fee(amount * 4);
 		let output_amount = total_amount_after_network_fee / 4;
 		// Verify swap "from" -> STABLE_ASSET, then "to" -> Output Asset
 		assert_eq!(

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -1,9 +1,12 @@
 use crate::{Config, CurrentAuthorities, HistoricalAuthorities, ValidatorIdOf};
 use core::marker::PhantomData;
-#[cfg(feature = "try-runtime")]
-use frame_support::sp_runtime::DispatchError;
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use sp_std::vec::Vec;
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::sp_runtime::DispatchError;
 
 pub struct Migration<T: Config>(PhantomData<T>);
 

--- a/state-chain/pallets/cf-validator/src/migrations/authorities.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/authorities.rs
@@ -1,5 +1,4 @@
 use crate::{Config, CurrentAuthorities, HistoricalAuthorities, ValidatorIdOf};
-use codec::{Decode, Encode};
 use core::marker::PhantomData;
 #[cfg(feature = "try-runtime")]
 use frame_support::sp_runtime::DispatchError;

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -194,9 +194,7 @@ pub enum AccountRole {
 pub type EgressBatch<Amount, EgressAddress> = Vec<(Amount, EgressAddress)>;
 
 /// Struct that represents the estimated output of a Swap.
-#[derive(
-	PartialEq, Default, Eq, Copy, Clone, Debug, Encode, Decode, TypeInfo, Serialize, Deserialize,
-)]
+#[derive(PartialEq, Default, Eq, Copy, Clone, Debug, Encode, Decode, TypeInfo)]
 pub struct SwapOutput {
 	// Intermediary amount, if there's any
 	pub intermediary: Option<AssetAmount>,

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -202,12 +202,8 @@ pub struct SwapOutput {
 	pub intermediary: Option<AssetAmount>,
 	// Final output of the swap
 	pub output: AssetAmount,
-}
-
-impl From<AssetAmount> for SwapOutput {
-	fn from(value: AssetAmount) -> Self {
-		Self { intermediary: None, output: value }
-	}
+	// the USDC network fee
+	pub network_fee: AssetAmount,
 }
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Encode, Decode, TypeInfo)]

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1278,8 +1278,7 @@ impl_runtime_apis! {
 					let pool = maybe_pool.as_mut().ok_or("Pool not found")?;
 
 					for (id, (tick, amount)) in limit_orders.into_iter().enumerate() {
-						let account_id = AccountId32::new([0; 32]);
-						pool.pool_state.collect_and_mint_limit_order(&(account_id, id as u64), side, tick, amount)
+						pool.pool_state.collect_and_mint_limit_order(&(Default::default(), id as u64), !side, tick, amount)
 							.map_err(|_| "Failed to set limit order")?;
 					}
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1278,7 +1278,7 @@ impl_runtime_apis! {
 
 			let (asset_pair, order) = AssetPair::from_swap(from, to).ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Invalid asset pair")))?;
 
-			let result = pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {
+			pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {
 				let pool = maybe_pool.as_mut().ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Pool not found")))?;
 
 				for (id, (tick, amount)) in limit_orders.into_iter().enumerate() {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -14,7 +14,7 @@ use crate::{
 	runtime_apis::{
 		AuctionState, BoostPoolDepth, BoostPoolDetails, BrokerInfo, DispatchErrorWithMessage,
 		EventFilter, FailingWitnessValidators, LiquidityProviderInfo, RuntimeApiPenalty,
-		SimulateSwapAdditionalOrder, ValidatorInfo,
+		SimulateSwapAdditionalOrder, SimulatedSwapInformation, ValidatorInfo,
 	},
 };
 use cf_amm::{
@@ -39,7 +39,9 @@ use core::ops::Range;
 use frame_support::instances::*;
 pub use frame_system::Call as SystemCall;
 use pallet_cf_governance::GovCallHash;
-use pallet_cf_ingress_egress::{ChannelAction, DepositWitness, OwedAmount, TargetChainAsset};
+use pallet_cf_ingress_egress::{
+	ChannelAction, DepositWitness, IngressOrEgress, OwedAmount, TargetChainAsset,
+};
 use pallet_cf_pools::{
 	AskBidMap, AssetPair, OrderId, PoolLiquidity, PoolOrderbook, PoolPriceV1, PoolPriceV2,
 	UnidirectionalPoolDepth,
@@ -1270,7 +1272,7 @@ impl_runtime_apis! {
 			to: Asset,
 			amount: AssetAmount,
 			additional_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
-		) -> Result<SwapOutput, DispatchErrorWithMessage> {
+		) -> Result<SimulatedSwapInformation, DispatchErrorWithMessage> {
 			if let Some(additional_orders) = additional_orders {
 				for (index, additional_order) in additional_orders.into_iter().enumerate() {
 					match additional_order {
@@ -1295,11 +1297,62 @@ impl_runtime_apis! {
 				}
 			}
 
-			LiquidityPools::swap_with_network_fee(
+			fn remove_fees(ingress_or_egress: IngressOrEgress, asset: Asset, amount: AssetAmount) -> (AssetAmount, AssetAmount) {
+				use pallet_cf_ingress_egress::AmountAndFeesWithheld;
+
+				match asset.into() {
+					ForeignChainAndAsset::Ethereum(asset) => {
+						let AmountAndFeesWithheld {
+							amount_after_fees,
+							fees_withheld,
+						} = pallet_cf_ingress_egress::Pallet::<Runtime, EthereumInstance>::withhold_ingress_or_egress_fee(ingress_or_egress, asset, amount.unique_saturated_into());
+
+						(amount_after_fees, fees_withheld)
+					},
+					ForeignChainAndAsset::Polkadot(asset) => {
+						let AmountAndFeesWithheld {
+							amount_after_fees,
+							fees_withheld,
+						} = pallet_cf_ingress_egress::Pallet::<Runtime, PolkadotInstance>::withhold_ingress_or_egress_fee(ingress_or_egress, asset, amount.unique_saturated_into());
+
+						(amount_after_fees, fees_withheld)
+					},
+					ForeignChainAndAsset::Bitcoin(asset) => {
+						let AmountAndFeesWithheld {
+							amount_after_fees,
+							fees_withheld,
+						} = pallet_cf_ingress_egress::Pallet::<Runtime, BitcoinInstance>::withhold_ingress_or_egress_fee(ingress_or_egress, asset, amount.unique_saturated_into());
+
+						(amount_after_fees.into(), fees_withheld.into())
+					},
+					ForeignChainAndAsset::Arbitrum(asset) => {
+						let AmountAndFeesWithheld {
+							amount_after_fees,
+							fees_withheld,
+						} = pallet_cf_ingress_egress::Pallet::<Runtime, ArbitrumInstance>::withhold_ingress_or_egress_fee(ingress_or_egress, asset, amount.unique_saturated_into());
+
+						(amount_after_fees, fees_withheld)
+					},
+				}
+			}
+
+			let (amount_to_swap, ingress_fee) = remove_fees(IngressOrEgress::Ingress, from, amount);
+
+			let swap_output = LiquidityPools::swap_with_network_fee(
 				from,
 				to,
-				amount
-			).map_err(Into::into)
+				amount_to_swap,
+			)?;
+
+			let (output, egress_fee) = remove_fees(IngressOrEgress::Egress, to, swap_output.output);
+
+			Ok(SimulatedSwapInformation {
+				intermediary: swap_output.intermediary,
+				output,
+				network_fee: swap_output.network_fee,
+				ingress_fee,
+				egress_fee,
+			})
 		}
 
 		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchErrorWithMessage> {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1269,8 +1269,8 @@ impl_runtime_apis! {
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
-			second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage> {
 			LiquidityPools::swap_with_network_fee(
 				from,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1269,8 +1269,8 @@ impl_runtime_apis! {
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
-			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+			second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage> {
 			LiquidityPools::swap_with_network_fee(
 				from,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1269,9 +1269,9 @@ impl_runtime_apis! {
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			limit_orders: Option<Vec<(i32, U256)>>,
+			additional_limit_orders: Option<Vec<(i32, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage> {
-			if let Some(limit_orders) = limit_orders {
+			if let Some(limit_orders) = additional_limit_orders {
 				let (asset_pair, order) = AssetPair::from_swap(from, to).ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Invalid asset pair")))?;
 
 				pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -84,7 +84,7 @@ use sp_runtime::{
 		AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, NumberFor,
 		One, OpaqueKeys, UniqueSaturatedInto, Verify,
 	},
-	BoundedVec, DispatchError,
+	BoundedVec,
 };
 
 use frame_support::genesis_builder_helper::{build_config, create_default_config};
@@ -1269,27 +1269,24 @@ impl_runtime_apis! {
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			additional_limit_orders: Option<Vec<(i32, U256)>>,
+			additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage> {
 			if let Some(limit_orders) = additional_limit_orders {
-				let (asset_pair, order) = AssetPair::from_swap(from, to).ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Invalid asset pair")))?;
+				let (asset_pair, side) = AssetPair::from_swap(from, to).ok_or("Invalid asset pair")?;
 
 				pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {
-					let pool = maybe_pool.as_mut().ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Pool not found")))?;
+					let pool = maybe_pool.as_mut().ok_or("Pool not found")?;
 
 					for (id, (tick, amount)) in limit_orders.into_iter().enumerate() {
 						let account_id = AccountId32::new([0; 32]);
-						pool.pool_state.collect_and_mint_limit_order(&(account_id, id as u64), order, tick, amount)
-							.map_err(|_| DispatchErrorWithMessage::Other(DispatchError::Other("Failed to set limit order")))?;
+						pool.pool_state.collect_and_mint_limit_order(&(account_id, id as u64), side, tick, amount)
+							.map_err(|_| "Failed to set limit order")?;
 					}
 
 					Ok::<_, DispatchErrorWithMessage>(())
 				})?;
-
-				LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
-			} else {
-				LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
 			}
+			LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
 		}
 
 		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchErrorWithMessage> {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1271,26 +1271,25 @@ impl_runtime_apis! {
 			amount: AssetAmount,
 			limit_orders: Option<Vec<(i32, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage> {
-			let limit_orders = match limit_orders {
-				Some(orders) => orders,
-				None => return LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into),
-			};
+			if let Some(limit_orders) = limit_orders {
+				let (asset_pair, order) = AssetPair::from_swap(from, to).ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Invalid asset pair")))?;
 
-			let (asset_pair, order) = AssetPair::from_swap(from, to).ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Invalid asset pair")))?;
+				pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {
+					let pool = maybe_pool.as_mut().ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Pool not found")))?;
 
-			pallet_cf_pools::Pools::<Runtime>::try_mutate(asset_pair, |maybe_pool| {
-				let pool = maybe_pool.as_mut().ok_or(DispatchErrorWithMessage::Other(DispatchError::Other("Pool not found")))?;
+					for (id, (tick, amount)) in limit_orders.into_iter().enumerate() {
+						let account_id = AccountId32::new([0; 32]);
+						pool.pool_state.collect_and_mint_limit_order(&(account_id, id as u64), order, tick, amount)
+							.map_err(|_| DispatchErrorWithMessage::Other(DispatchError::Other("Failed to set limit order")))?;
+					}
 
-				for (id, (tick, amount)) in limit_orders.into_iter().enumerate() {
-					let account_id = AccountId32::new([0; 32]);
-					pool.pool_state.collect_and_mint_limit_order(&(account_id, id as u64), order, tick, amount)
-						.map_err(|_| DispatchErrorWithMessage::Other(DispatchError::Other("Failed to set limit order")))?;
-				}
+					Ok::<_, DispatchErrorWithMessage>(())
+				})?;
 
-				Ok::<_, DispatchErrorWithMessage>(())
-			})?;
-
-			LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
+				LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
+			} else {
+				LiquidityPools::swap_with_network_fee(from, to, amount).map_err(Into::into)
+			}
 		}
 
 		fn cf_pool_info(base_asset: Asset, quote_asset: Asset) -> Result<PoolInfo, DispatchErrorWithMessage> {

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -132,11 +132,6 @@ impl From<DispatchError> for DispatchErrorWithMessage {
 		}
 	}
 }
-impl From<&'static str> for DispatchErrorWithMessage {
-	fn from(message: &'static str) -> Self {
-		DispatchErrorWithMessage::Other(DispatchError::Other(message))
-	}
-}
 
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug)]
 pub struct FailingWitnessValidators {

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -191,7 +191,8 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			additional_limit_orders: Option<Vec<(Tick, U256)>>,
+			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -8,7 +8,7 @@ use cf_chains::{
 };
 use cf_primitives::{
 	AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, EpochIndex, FlipBalance,
-	ForeignChain, NetworkEnvironment, PrewitnessedDepositId, SemVer, SwapOutput,
+	ForeignChain, NetworkEnvironment, PrewitnessedDepositId, SemVer,
 };
 use codec::{Decode, Encode};
 use core::ops::Range;
@@ -129,6 +129,16 @@ pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
 }
 
+/// Struct that represents the estimated output of a Swap.
+#[derive(Encode, Decode, TypeInfo)]
+pub struct SimulatedSwapInformation {
+	pub intermediary: Option<AssetAmount>,
+	pub output: AssetAmount,
+	pub network_fee: AssetAmount,
+	pub ingress_fee: AssetAmount,
+	pub egress_fee: AssetAmount,
+}
+
 #[derive(Debug, Decode, Encode, TypeInfo)]
 pub enum DispatchErrorWithMessage {
 	Module(Vec<u8>),
@@ -197,7 +207,7 @@ decl_runtime_apis!(
 			to: Asset,
 			amount: AssetAmount,
 			additional_limit_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
-		) -> Result<SwapOutput, DispatchErrorWithMessage>;
+		) -> Result<SimulatedSwapInformation, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,
 			quote_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -191,7 +191,7 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			additional_limit_orders: Option<Vec<(i32, U256)>>,
+			additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -185,7 +185,7 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			limit_orders: Option<Vec<(i32, U256)>>,
+			additional_limit_orders: Option<Vec<(i32, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -191,8 +191,8 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
-			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+			second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -74,6 +74,17 @@ pub struct BoostPoolDepth {
 	pub available_amount: AssetAmount,
 }
 
+#[derive(Encode, Decode, TypeInfo)]
+pub enum SimulateSwapAdditionalOrder {
+	LimitOrder {
+		base_asset: Asset,
+		quote_asset: Asset,
+		side: Side,
+		tick: Tick,
+		sell_amount: AssetAmount,
+	},
+}
+
 #[cfg(feature = "std")]
 fn serialize_as_hex<S>(amount: &AssetAmount, s: S) -> Result<S::Ok, S::Error>
 where
@@ -185,8 +196,7 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
-			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			additional_limit_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -25,6 +25,7 @@ use pallet_cf_witnesser::CallHash;
 use scale_info::{prelude::string::String, TypeInfo};
 use serde::{Deserialize, Serialize};
 use sp_api::decl_runtime_apis;
+use sp_core::U256;
 use sp_runtime::DispatchError;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
@@ -184,6 +185,7 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
+			limit_orders: Option<Vec<(i32, U256)>>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -133,6 +133,12 @@ impl From<DispatchError> for DispatchErrorWithMessage {
 		}
 	}
 }
+impl From<&'static str> for DispatchErrorWithMessage {
+	fn from(message: &'static str) -> Self {
+		DispatchErrorWithMessage::Other(DispatchError::Other(message))
+	}
+}
+
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug)]
 pub struct FailingWitnessValidators {
 	pub failing_count: u32,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -190,8 +190,8 @@ decl_runtime_apis!(
 			from: Asset,
 			to: Asset,
 			amount: AssetAmount,
-			first_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
-			second_leg_additional_limit_orders: Option<Vec<(Tick, U256)>>,
+			first_leg_additional_limit_orders: Vec<(Tick, U256)>,
+			second_leg_additional_limit_orders: Vec<(Tick, U256)>,
 		) -> Result<SwapOutput, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -79,7 +79,6 @@ fn serialize_as_hex<S>(amount: &AssetAmount, s: S) -> Result<S::Ok, S::Error>
 where
 	S: serde::Serializer,
 {
-	use sp_core::U256;
 	U256::from(*amount).serialize(s)
 }
 

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -105,20 +105,6 @@ pub trait SwappingApi {
 	) -> Result<AssetAmount, DispatchError>;
 }
 
-impl<T: frame_system::Config> SwappingApi for T {
-	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount) {
-		(input_amount, 0)
-	}
-
-	fn swap_single_leg(
-		_from: Asset,
-		_to: Asset,
-		input_amount: AssetAmount,
-	) -> Result<AssetAmount, DispatchError> {
-		Ok(input_amount)
-	}
-}
-
 pub trait SwapQueueApi {
 	type BlockNumber;
 

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -94,8 +94,8 @@ impl<T: frame_system::Config> PoolApi for T {
 
 pub trait SwappingApi {
 	/// Takes the swap amount in STABLE_ASSET, collect network fee from it
-	/// and return the remaining value
-	fn take_network_fee(input_amount: AssetAmount) -> AssetAmount;
+	/// and return the (remaining value, network fee taken)
+	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount);
 
 	/// Process a single leg of a swap, into or from Stable asset. No network fee is taken.
 	fn swap_single_leg(
@@ -106,8 +106,8 @@ pub trait SwappingApi {
 }
 
 impl<T: frame_system::Config> SwappingApi for T {
-	fn take_network_fee(input_amount: AssetAmount) -> AssetAmount {
-		input_amount
+	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount) {
+		(input_amount, 0)
 	}
 
 	fn swap_single_leg(

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -92,10 +92,14 @@ impl<T: frame_system::Config> PoolApi for T {
 	}
 }
 
+pub struct NetworkFeeTaken {
+	pub remaining_amount: AssetAmount,
+	pub network_fee: AssetAmount,
+}
 pub trait SwappingApi {
 	/// Takes the swap amount in STABLE_ASSET, collect network fee from it
 	/// and return the (remaining value, network fee taken)
-	fn take_network_fee(input_amount: AssetAmount) -> (AssetAmount, AssetAmount);
+	fn take_network_fee(input_amount: AssetAmount) -> NetworkFeeTaken;
 
 	/// Process a single leg of a swap, into or from Stable asset. No network fee is taken.
 	fn swap_single_leg(

--- a/utilities/src/with_std/rpc.rs
+++ b/utilities/src/with_std/rpc.rs
@@ -8,15 +8,6 @@ pub enum NumberOrHex {
 	Hex(U256),
 }
 
-impl From<NumberOrHex> for U256 {
-	fn from(value: NumberOrHex) -> Self {
-		match value {
-			NumberOrHex::Number(n) => n.into(),
-			NumberOrHex::Hex(n) => n,
-		}
-	}
-}
-
 impl Serialize for NumberOrHex {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where

--- a/utilities/src/with_std/rpc.rs
+++ b/utilities/src/with_std/rpc.rs
@@ -8,6 +8,15 @@ pub enum NumberOrHex {
 	Hex(U256),
 }
 
+impl From<NumberOrHex> for U256 {
+	fn from(value: NumberOrHex) -> Self {
+		match value {
+			NumberOrHex::Number(n) => n.into(),
+			NumberOrHex::Hex(n) => n,
+		}
+	}
+}
+
 impl Serialize for NumberOrHex {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where

--- a/utilities/src/with_std/rpc.rs
+++ b/utilities/src/with_std/rpc.rs
@@ -72,6 +72,15 @@ impl TryFrom<NumberOrHex> for u64 {
 	}
 }
 
+impl From<NumberOrHex> for U256 {
+	fn from(value: NumberOrHex) -> Self {
+		match value {
+			NumberOrHex::Number(n) => n.into(),
+			NumberOrHex::Hex(n) => n,
+		}
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;


### PR DESCRIPTION
# Pull Request

Closes: WEB-1059, WEB-1062

## Checklist

Please conduct a thorough self-review before opening the PR.

- [X] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

The current implementation of the quoter uses a version of the AMM wrapped in a rust library that converts it to a native Node.js addon. Then we query the state of the pools via RPC and then add the limit orders we receive from the market makers before we simulate a swap though the pools.

This greatly simplifies the status quo by preventing us from having to monitor changes to the AMM and backporting them into our version of it as well as reducing the number of rpc calls we have to make to just one. 

This is the first in a series of pull requests that will create a more well-rounded swap rate custom RPC that will not only simulate the swap though the pools but also:
- accept additional limit orders to put into the pool before simulating the swap
- return the fees that would be taken after taking them
- include boost related information

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.