### PR TITLE
feat: added safe mode for ingress egress pallet

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -468,37 +468,37 @@ mod benchmarks {
 	#[test]
 	fn benchmark_works() {
 		new_test_ext().execute_with(|| {
-			_ccm_broadcast_failed::<Test, Instance1>(true);
+			_ccm_broadcast_failed::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_vault_transfer_failed::<Test, Instance1>(true);
+			_vault_transfer_failed::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_finalise_ingress::<Test, Instance1>(100, true);
+			_finalise_ingress::<Test, ()>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_process_single_deposit::<Test, Instance1>(true);
+			_process_single_deposit::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_disable_asset_egress::<Test, Instance1>(true);
+			_disable_asset_egress::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_clear_prewitnessed_deposits::<Test, Instance1>(100, true);
+			_clear_prewitnessed_deposits::<Test, ()>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_add_boost_funds::<Test, Instance1>(true);
+			_add_boost_funds::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_on_lost_deposit::<Test, Instance1>(100, true);
+			_on_lost_deposit::<Test, ()>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_stop_boosting::<Test, Instance1>(true);
+			_stop_boosting::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_deposit_boosted::<Test, Instance1>(true);
+			_deposit_boosted::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_boost_finalised::<Test, Instance1>(true);
+			_boost_finalised::<Test, ()>(true);
 		});
 	}
 }

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -468,37 +468,37 @@ mod benchmarks {
 	#[test]
 	fn benchmark_works() {
 		new_test_ext().execute_with(|| {
-			_ccm_broadcast_failed::<Test, ()>(true);
+			_ccm_broadcast_failed::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_vault_transfer_failed::<Test, ()>(true);
+			_vault_transfer_failed::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_finalise_ingress::<Test, ()>(100, true);
+			_finalise_ingress::<Test, Instance1>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_process_single_deposit::<Test, ()>(true);
+			_process_single_deposit::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_disable_asset_egress::<Test, ()>(true);
+			_disable_asset_egress::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_clear_prewitnessed_deposits::<Test, ()>(100, true);
+			_clear_prewitnessed_deposits::<Test, Instance1>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_add_boost_funds::<Test, ()>(true);
+			_add_boost_funds::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_on_lost_deposit::<Test, ()>(100, true);
+			_on_lost_deposit::<Test, Instance1>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_stop_boosting::<Test, ()>(true);
+			_stop_boosting::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_deposit_boosted::<Test, ()>(true);
+			_deposit_boosted::<Test, Instance1>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_boost_finalised::<Test, ()>(true);
+			_boost_finalised::<Test, Instance1>(true);
 		});
 	}
 }

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -38,7 +38,7 @@ use cf_traits::{
 	liquidity::{LpBalanceApi, LpDepositHandler},
 	AccountRoleRegistry, AdjustedFeeEstimationApi, AssetConverter, Broadcaster, CcmHandler,
 	CcmSwapIds, Chainflip, DepositApi, EgressApi, EpochInfo, FeePayment, GetBlockHeight,
-	IngressEgressFeeApi, NetworkEnvironmentProvider, OnDeposit, ScheduledEgressDetails,
+	IngressEgressFeeApi, NetworkEnvironmentProvider, OnDeposit, SafeMode, ScheduledEgressDetails,
 	SwapDepositHandler, SwapQueueApi, SwapType,
 };
 use frame_support::{
@@ -50,6 +50,7 @@ pub use pallet::*;
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	marker::PhantomData,
 	vec,
 	vec::Vec,
 };
@@ -153,6 +154,32 @@ impl<C: Chain> CrossChainMessage<C> {
 }
 
 pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
+
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, PartialEq, Eq, RuntimeDebug)]
+#[scale_info(skip_type_params(I))]
+pub struct PalletSafeMode<I: 'static> {
+	pub boost_swaps_enabled: bool,
+	pub add_boost_funds_enabled: bool,
+	pub stop_boosting_enabled: bool,
+	#[doc(hidden)]
+	#[codec(skip)]
+	_phantom: PhantomData<I>,
+}
+
+impl<I: 'static> SafeMode for PalletSafeMode<I> {
+	const CODE_RED: Self = PalletSafeMode {
+		boost_swaps_enabled: false,
+		add_boost_funds_enabled: false,
+		stop_boosting_enabled: false,
+		_phantom: PhantomData,
+	};
+	const CODE_GREEN: Self = PalletSafeMode {
+		boost_swaps_enabled: true,
+		add_boost_funds_enabled: true,
+		stop_boosting_enabled: true,
+		_phantom: PhantomData,
+	};
+}
 
 /// Calls to the external chains that has failed to be broadcast/accepted by the target chain.
 /// User can use information stored here to query for relevant information to broadcast
@@ -431,6 +458,9 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		type SwapQueueApi: SwapQueueApi;
+
+		/// Safe Mode access.
+		type SafeMode: Get<PalletSafeMode<I>>;
 	}
 
 	/// Lookup table for addresses to corresponding deposit channels.
@@ -695,6 +725,10 @@ pub mod pallet {
 		BitcoinChannelIdTooLarge,
 		/// The amount is below the minimum egress amount.
 		BelowEgressDustLimit,
+		/// Adding boost funds is disabled due to safe mode.
+		AddBoostFundsDisabled,
+		/// Retrieving boost funds disabled due to safe mode.
+		StopBoostingDisabled,
 	}
 
 	#[pallet::hooks]
@@ -1039,6 +1073,10 @@ pub mod pallet {
 			pool_tier: BoostPoolTier,
 		) -> DispatchResult {
 			let booster_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+			ensure!(
+				T::SafeMode::get().add_boost_funds_enabled,
+				Error::<T, I>::AddBoostFundsDisabled
+			);
 
 			T::LpBalance::try_debit_account(&booster_id, asset.into(), amount.into())?;
 
@@ -1067,6 +1105,7 @@ pub mod pallet {
 			pool_tier: BoostPoolTier,
 		) -> DispatchResult {
 			let booster = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+			ensure!(T::SafeMode::get().stop_boosting_enabled, Error::<T, I>::StopBoostingDisabled);
 
 			let (unlocked_amount, pending_boosts) =
 				BoostPools::<T, I>::mutate(asset, pool_tier, |pool| {
@@ -1381,7 +1420,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			);
 
 			// Only boost on non-zero fee and if the channel isn't already boosted:
-			if boost_fee > 0 && !matches!(boost_status, BoostStatus::Boosted { .. }) {
+			if T::SafeMode::get().boost_swaps_enabled &&
+				boost_fee > 0 && !matches!(boost_status, BoostStatus::Boosted { .. })
+			{
 				match Self::try_boosting(asset, amount, boost_fee, prewitnessed_deposit_id) {
 					Ok(BoostOutput { used_pools, total_fee: boost_fee_amount }) => {
 						DepositChannelLookup::<T, I>::mutate(&deposit_address, |details| {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -158,7 +158,7 @@ pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Copy, Clone, PartialEq, Eq, RuntimeDebug)]
 #[scale_info(skip_type_params(I))]
 pub struct PalletSafeMode<I: 'static> {
-	pub boost_swaps_enabled: bool,
+	pub boost_deposits_enabled: bool,
 	pub add_boost_funds_enabled: bool,
 	pub stop_boosting_enabled: bool,
 	#[doc(hidden)]
@@ -168,13 +168,13 @@ pub struct PalletSafeMode<I: 'static> {
 
 impl<I: 'static> SafeMode for PalletSafeMode<I> {
 	const CODE_RED: Self = PalletSafeMode {
-		boost_swaps_enabled: false,
+		boost_deposits_enabled: false,
 		add_boost_funds_enabled: false,
 		stop_boosting_enabled: false,
 		_phantom: PhantomData,
 	};
 	const CODE_GREEN: Self = PalletSafeMode {
-		boost_swaps_enabled: true,
+		boost_deposits_enabled: true,
 		add_boost_funds_enabled: true,
 		stop_boosting_enabled: true,
 		_phantom: PhantomData,
@@ -1420,7 +1420,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			);
 
 			// Only boost on non-zero fee and if the channel isn't already boosted:
-			if T::SafeMode::get().boost_swaps_enabled &&
+			if T::SafeMode::get().boost_deposits_enabled &&
 				boost_fee > 0 && !matches!(boost_status, BoostStatus::Boosted { .. })
 			{
 				match Self::try_boosting(asset, amount, boost_fee, prewitnessed_deposit_id) {

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/add_boost_pools.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/add_boost_pools.rs
@@ -121,13 +121,13 @@ mod migration_tests {
 
 			// Verify data is correctly migrated into new storage.
 			for address in [address1, address2] {
-				let channel = DepositChannelLookup::<Test, Instance3>::get(address);
+				let channel = DepositChannelLookup::<Test, ()>::get(address);
 				assert!(channel.is_some());
 				assert_eq!(channel.unwrap().boost_status, BoostStatus::NotBoosted);
 			}
 		});
 
-		fn mock_deposit_channel_details() -> old::DepositChannelDetails<Test, Instance3> {
+		fn mock_deposit_channel_details() -> old::DepositChannelDetails<Test, ()> {
 			old::DepositChannelDetails::<Test, _> {
 				deposit_channel: DepositChannel {
 					channel_id: 123,

--- a/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
@@ -1,16 +1,13 @@
-pub use crate::{self as pallet_cf_ingress_egress, Instance3};
+pub use crate::{self as pallet_cf_ingress_egress};
 
 use crate::PalletSafeMode;
 use cf_chains::btc::{deposit_address::DepositAddress, BitcoinTrackedData};
 pub use cf_chains::{
-	address::{AddressDerivationApi, AddressDerivationError, ForeignChainAddress},
+	address::{AddressDerivationApi, AddressDerivationError},
 	Chain,
 };
-pub use cf_primitives::{
-	chains::{assets, Bitcoin},
-	Asset, AssetAmount,
-};
-use cf_primitives::{ChannelId, SwapId};
+pub use cf_primitives::chains::{assets, Bitcoin};
+use cf_primitives::ChannelId;
 use cf_test_utilities::impl_test_helpers;
 use cf_traits::{
 	impl_mock_callback, impl_mock_chainflip, impl_mock_runtime_safe_mode,
@@ -26,7 +23,7 @@ use cf_traits::{
 		swap_deposit_handler::MockSwapDepositHandler,
 		swap_queue_api::MockSwapQueueApi,
 	},
-	NetworkEnvironmentProvider, OnDeposit, SwapDepositHandler,
+	NetworkEnvironmentProvider, OnDeposit,
 };
 use frame_support::{derive_impl, traits::UnfilteredDispatchable};
 use sp_core::H256;
@@ -38,7 +35,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 frame_support::construct_runtime!(
 	pub enum Test {
 		System: frame_system,
-		IngressEgress: pallet_cf_ingress_egress::<Instance3>,
+		IngressEgress: pallet_cf_ingress_egress,
 	}
 );
 
@@ -75,25 +72,6 @@ impl_mock_callback!(RuntimeOrigin);
 pub struct MockDepositHandler;
 impl OnDeposit<Bitcoin> for MockDepositHandler {}
 
-pub struct MockSwapDepositHandlerBtc;
-impl SwapDepositHandler for MockSwapDepositHandlerBtc {
-	type AccountId = AccountId;
-
-	fn schedule_swap_from_channel(
-		_deposit_address: ForeignChainAddress,
-		_deposit_block_height: u64,
-		_from: Asset,
-		_to: Asset,
-		_amount: AssetAmount,
-		_destination_address: ForeignChainAddress,
-		_broker_id: Self::AccountId,
-		_broker_commission_bps: cf_primitives::BasisPoints,
-		_channel_id: ChannelId,
-	) -> SwapId {
-		unimplemented!()
-	}
-}
-
 pub type MockEgressBroadcaster =
 	MockBroadcaster<(MockBitcoinApiCall<MockBtcEnvironment>, RuntimeCall)>;
 
@@ -126,9 +104,9 @@ impl NetworkEnvironmentProvider for MockNetworkEnvironmentProvider {
 	}
 }
 
-impl_mock_runtime_safe_mode! { ingress_egress_bitcoin: PalletSafeMode<Instance3> }
+impl_mock_runtime_safe_mode! { ingress_egress_bitcoin: PalletSafeMode<()> }
 
-impl pallet_cf_ingress_egress::Config<Instance3> for Test {
+impl pallet_cf_ingress_egress::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type TargetChain = Bitcoin;
@@ -136,7 +114,7 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Test {
 	type AddressConverter = MockAddressConverter;
 	type LpBalance = MockBalance;
 	type SwapDepositHandler =
-		MockSwapDepositHandler<(Bitcoin, pallet_cf_ingress_egress::Pallet<Self, Instance3>)>;
+		MockSwapDepositHandler<(Bitcoin, pallet_cf_ingress_egress::Pallet<Self>)>;
 	type ChainApiCall = MockBitcoinApiCall<MockBtcEnvironment>;
 	type Broadcaster = MockEgressBroadcaster;
 	type DepositHandler = MockDepositHandler;

--- a/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
@@ -1,5 +1,6 @@
 pub use crate::{self as pallet_cf_ingress_egress, Instance3};
 
+use crate::PalletSafeMode;
 use cf_chains::btc::{deposit_address::DepositAddress, BitcoinTrackedData};
 pub use cf_chains::{
 	address::{AddressDerivationApi, AddressDerivationError, ForeignChainAddress},
@@ -12,7 +13,7 @@ pub use cf_primitives::{
 use cf_primitives::{ChannelId, SwapId};
 use cf_test_utilities::impl_test_helpers;
 use cf_traits::{
-	impl_mock_callback, impl_mock_chainflip,
+	impl_mock_callback, impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
 		address_converter::MockAddressConverter,
 		api_call::{MockBitcoinApiCall, MockBtcEnvironment},
@@ -22,6 +23,7 @@ use cf_traits::{
 		chain_tracking::ChainTracker,
 		fee_payment::MockFeePayment,
 		lp_balance::MockBalance,
+		swap_deposit_handler::MockSwapDepositHandler,
 		swap_queue_api::MockSwapQueueApi,
 	},
 	NetworkEnvironmentProvider, OnDeposit, SwapDepositHandler,
@@ -124,6 +126,8 @@ impl NetworkEnvironmentProvider for MockNetworkEnvironmentProvider {
 	}
 }
 
+impl_mock_runtime_safe_mode! { ingress_egress_bitcoin: PalletSafeMode<Instance3> }
+
 impl pallet_cf_ingress_egress::Config<Instance3> for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
@@ -131,7 +135,8 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Test {
 	type AddressDerivation = MockAddressDerivation;
 	type AddressConverter = MockAddressConverter;
 	type LpBalance = MockBalance;
-	type SwapDepositHandler = MockSwapDepositHandlerBtc;
+	type SwapDepositHandler =
+		MockSwapDepositHandler<(Bitcoin, pallet_cf_ingress_egress::Pallet<Self, Instance3>)>;
 	type ChainApiCall = MockBitcoinApiCall<MockBtcEnvironment>;
 	type Broadcaster = MockEgressBroadcaster;
 	type DepositHandler = MockDepositHandler;
@@ -142,6 +147,7 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Test {
 	type AssetConverter = MockAssetConverter;
 	type FeePayment = MockFeePayment<Self>;
 	type SwapQueueApi = MockSwapQueueApi;
+	type SafeMode = MockRuntimeSafeMode;
 }
 
 impl_test_helpers! {

--- a/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
@@ -1,5 +1,5 @@
 pub use crate::{self as pallet_cf_ingress_egress};
-use crate::{DepositBalances, DepositWitness, Instance1, PalletSafeMode};
+use crate::{DepositBalances, DepositWitness, PalletSafeMode};
 
 use cf_chains::eth::EthereumTrackedData;
 pub use cf_chains::{
@@ -40,7 +40,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 frame_support::construct_runtime!(
 	pub enum Test {
 		System: frame_system,
-		IngressEgress: pallet_cf_ingress_egress::<Instance1>,
+		IngressEgress: pallet_cf_ingress_egress,
 	}
 );
 
@@ -109,9 +109,9 @@ impl NetworkEnvironmentProvider for MockNetworkEnvironmentProvider {
 	}
 }
 
-impl_mock_runtime_safe_mode! { ingress_egress_ethereum: PalletSafeMode<Instance1> }
+impl_mock_runtime_safe_mode! { ingress_egress_ethereum: PalletSafeMode<()> }
 
-impl crate::Config<Instance1> for Test {
+impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type TargetChain = Ethereum;
@@ -119,7 +119,7 @@ impl crate::Config<Instance1> for Test {
 	type AddressConverter = MockAddressConverter;
 	type LpBalance = MockBalance;
 	type SwapDepositHandler =
-		MockSwapDepositHandler<(Ethereum, pallet_cf_ingress_egress::Pallet<Self, Instance1>)>;
+		MockSwapDepositHandler<(Ethereum, pallet_cf_ingress_egress::Pallet<Self>)>;
 	type ChainApiCall = MockEthereumApiCall<MockEvmEnvironment>;
 	type Broadcaster = MockEgressBroadcaster;
 	type DepositHandler = MockDepositHandler;
@@ -152,9 +152,9 @@ impl_test_helpers! {
 	}
 }
 
-type TestChainAccount = <<Test as crate::Config<Instance1>>::TargetChain as Chain>::ChainAccount;
-type TestChainAmount = <<Test as crate::Config<Instance1>>::TargetChain as Chain>::ChainAmount;
-type TestChainAsset = <<Test as crate::Config<Instance1>>::TargetChain as Chain>::ChainAsset;
+type TestChainAccount = <<Test as crate::Config>::TargetChain as Chain>::ChainAccount;
+type TestChainAmount = <<Test as crate::Config>::TargetChain as Chain>::ChainAmount;
+type TestChainAsset = <<Test as crate::Config>::TargetChain as Chain>::ChainAsset;
 
 pub trait RequestAddressAndDeposit {
 	fn request_address_and_deposit(

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -34,7 +34,6 @@ use cf_traits::{
 };
 use frame_support::{
 	assert_err, assert_ok,
-	instances::Instance1,
 	traits::{Hooks, OriginTrait},
 	weights::Weight,
 };
@@ -49,7 +48,7 @@ const DEFAULT_DEPOSIT_AMOUNT: u128 = 1_000;
 #[track_caller]
 fn expect_size_of_address_pool(size: usize) {
 	assert_eq!(
-		DepositChannelPool::<Test, Instance1>::iter_keys().count(),
+		DepositChannelPool::<Test, ()>::iter_keys().count(),
 		size,
 		"Address pool size is incorrect!"
 	);
@@ -61,9 +60,9 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 		let asset = ETH_ETH;
 
 		// Cannot egress assets that are blacklisted.
-		assert!(DisabledEgressAssets::<Test, Instance1>::get(asset).is_none());
+		assert!(DisabledEgressAssets::<Test, ()>::get(asset).is_none());
 		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, true));
-		assert!(DisabledEgressAssets::<Test, Instance1>::get(asset).is_some());
+		assert!(DisabledEgressAssets::<Test, ()>::get(asset).is_some());
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::AssetEgressStatusChanged { asset, disabled: true },
 		));
@@ -76,7 +75,7 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 
 		// The egress has not been sent
 		assert_eq!(
-			ScheduledEgressFetchOrTransfer::<Test, Instance1>::get(),
+			ScheduledEgressFetchOrTransfer::<Test, ()>::get(),
 			vec![FetchOrTransfer::<Ethereum>::Transfer {
 				asset,
 				amount: 1_000,
@@ -87,7 +86,7 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 
 		// re-enable the asset for Egress
 		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, false));
-		assert!(DisabledEgressAssets::<Test, Instance1>::get(asset).is_none());
+		assert!(DisabledEgressAssets::<Test, ()>::get(asset).is_none());
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::AssetEgressStatusChanged { asset, disabled: false },
 		));
@@ -95,7 +94,7 @@ fn blacklisted_asset_will_not_egress_via_batch_all() {
 		IngressEgress::on_finalize(1);
 
 		// The egress should be sent now
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty());
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty());
 	});
 }
 
@@ -114,7 +113,7 @@ fn blacklisted_asset_will_not_egress_via_ccm() {
 			},
 		};
 
-		assert!(DisabledEgressAssets::<Test, Instance1>::get(asset).is_none());
+		assert!(DisabledEgressAssets::<Test, ()>::get(asset).is_none());
 		assert_ok!(IngressEgress::enable_or_disable_egress(RuntimeOrigin::root(), asset, true));
 
 		// Eth should be blocked while Flip can be sent
@@ -135,7 +134,7 @@ fn blacklisted_asset_will_not_egress_via_ccm() {
 
 		// The egress has not been sent
 		assert_eq!(
-			ScheduledEgressCcm::<Test, Instance1>::get(),
+			ScheduledEgressCcm::<Test, ()>::get(),
 			vec![CrossChainMessage {
 				egress_id: (ForeignChain::Ethereum, 1),
 				asset,
@@ -155,7 +154,7 @@ fn blacklisted_asset_will_not_egress_via_ccm() {
 		IngressEgress::on_finalize(2);
 
 		// The egress should be sent now
-		assert!(ScheduledEgressCcm::<Test, Instance1>::get().is_empty());
+		assert!(ScheduledEgressCcm::<Test, ()>::get().is_empty());
 	});
 }
 
@@ -165,14 +164,14 @@ fn egress_below_minimum_deposit_ignored() {
 		const MIN_EGRESS: u128 = 1_000;
 		const AMOUNT: u128 = MIN_EGRESS - 1;
 
-		EgressDustLimit::<Test, Instance1>::set(ETH_ETH, MIN_EGRESS);
+		EgressDustLimit::<Test, ()>::set(ETH_ETH, MIN_EGRESS);
 
 		assert_err!(
 			IngressEgress::schedule_egress(ETH_ETH, AMOUNT, ALICE_ETH_ADDRESS, None),
 			crate::Error::<Test, _>::BelowEgressDustLimit
 		);
 
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty());
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty());
 	});
 }
 
@@ -185,7 +184,7 @@ fn can_schedule_swap_egress_to_batch() {
 		assert_ok!(IngressEgress::schedule_egress(ETH_FLIP, 4_000, BOB_ETH_ADDRESS, None));
 
 		assert_eq!(
-			ScheduledEgressFetchOrTransfer::<Test, Instance1>::get(),
+			ScheduledEgressFetchOrTransfer::<Test, ()>::get(),
 			vec![
 				FetchOrTransfer::<Ethereum>::Transfer {
 					asset: ETH_ETH,
@@ -236,14 +235,14 @@ fn request_address_and_deposit(
 #[test]
 fn can_schedule_deposit_fetch() {
 	new_test_ext().execute_with(|| {
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty());
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty());
 
 		request_address_and_deposit(1u64, eth::Asset::Eth);
 		request_address_and_deposit(2u64, eth::Asset::Eth);
 		request_address_and_deposit(3u64, eth::Asset::Flip);
 
 		assert!(matches!(
-			&ScheduledEgressFetchOrTransfer::<Test, Instance1>::get()[..],
+			&ScheduledEgressFetchOrTransfer::<Test, ()>::get()[..],
 			&[
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
@@ -258,7 +257,7 @@ fn can_schedule_deposit_fetch() {
 		request_address_and_deposit(4u64, eth::Asset::Eth);
 
 		assert!(matches!(
-			&ScheduledEgressFetchOrTransfer::<Test, Instance1>::get()[..],
+			&ScheduledEgressFetchOrTransfer::<Test, ()>::get()[..],
 			&[
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
@@ -306,7 +305,7 @@ fn on_finalize_can_send_batch_all() {
 			},
 		));
 
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty());
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty());
 	});
 }
 
@@ -331,13 +330,13 @@ fn all_batch_apicall_creation_failure_should_rollback_storage() {
 		MockEthAllBatch::<MockEvmEnvironment>::set_success(false);
 		request_address_and_deposit(4u64, eth::Asset::Usdc);
 
-		let scheduled_requests = ScheduledEgressFetchOrTransfer::<Test, Instance1>::get();
+		let scheduled_requests = ScheduledEgressFetchOrTransfer::<Test, ()>::get();
 
 		// Try to send the scheduled egresses via Allbatch apicall. Will fail and so should rollback
 		// the ScheduledEgressFetchOrTransfer
 		IngressEgress::on_finalize(1);
 
-		assert_eq!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get(), scheduled_requests);
+		assert_eq!(ScheduledEgressFetchOrTransfer::<Test, ()>::get(), scheduled_requests);
 	});
 }
 
@@ -433,11 +432,11 @@ fn create_new_address_while_pool_is_empty() {
 		BlockHeightProvider::<MockEthereum>::set_block_height(recycle_block);
 		IngressEgress::on_idle(1, Weight::MAX);
 
-		assert_eq!(ChannelIdCounter::<Test, Instance1>::get(), 2);
+		assert_eq!(ChannelIdCounter::<Test, ()>::get(), 2);
 		request_address_and_deposit(3u64, eth::Asset::Eth);
-		assert_eq!(ChannelIdCounter::<Test, Instance1>::get(), 2);
+		assert_eq!(ChannelIdCounter::<Test, ()>::get(), 2);
 		IngressEgress::on_finalize(1);
-		assert_eq!(ChannelIdCounter::<Test, Instance1>::get(), 2);
+		assert_eq!(ChannelIdCounter::<Test, ()>::get(), 2);
 	});
 }
 
@@ -446,7 +445,7 @@ fn reused_address_channel_id_matches() {
 	new_test_ext().execute_with(|| {
 		const CHANNEL_ID: ChannelId = 0;
 		let new_channel = DepositChannel::<Ethereum>::generate_new::<
-			<Test as crate::Config<Instance1>>::AddressDerivation,
+			<Test as crate::Config>::AddressDerivation,
 		>(CHANNEL_ID, eth::Asset::Eth)
 		.unwrap();
 		DepositChannelPool::<Test, _>::insert(CHANNEL_ID, new_channel.clone());
@@ -497,7 +496,7 @@ fn can_process_ccm_deposit() {
 		let deposit_address: TargetChainAccount<Test, _> = deposit_address.try_into().unwrap();
 
 		assert_eq!(
-			DepositChannelLookup::<Test, Instance1>::get(deposit_address).unwrap().opened_at,
+			DepositChannelLookup::<Test, ()>::get(deposit_address).unwrap().opened_at,
 			BlockHeightProvider::<MockEthereum>::get_block_height()
 		);
 
@@ -556,8 +555,8 @@ fn can_egress_ccm() {
 			Some((ccm.clone(), GAS_BUDGET))
 		).expect("Egress should succeed");
 
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty());
-		assert_eq!(ScheduledEgressCcm::<Test, Instance1>::get(), vec![
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty());
+		assert_eq!(ScheduledEgressCcm::<Test, ()>::get(), vec![
 			CrossChainMessage {
 				egress_id,
 				asset: destination_asset,
@@ -588,7 +587,7 @@ fn can_egress_ccm() {
 		).unwrap()]);
 
 		// Storage should be cleared
-		assert_eq!(ScheduledEgressCcm::<Test, Instance1>::decode_len(), Some(0));
+		assert_eq!(ScheduledEgressCcm::<Test, ()>::decode_len(), Some(0));
 	});
 }
 
@@ -747,13 +746,13 @@ fn multi_use_deposit_same_block() {
 					DepositWitness {
 						deposit_address,
 						asset,
-						amount: MinimumDeposit::<Test, Instance1>::get(asset) + DEPOSIT_AMOUNT,
+						amount: MinimumDeposit::<Test, ()>::get(asset) + DEPOSIT_AMOUNT,
 						deposit_details: Default::default(),
 					},
 					DepositWitness {
 						deposit_address,
 						asset,
-						amount: MinimumDeposit::<Test, Instance1>::get(asset) + DEPOSIT_AMOUNT,
+						amount: MinimumDeposit::<Test, ()>::get(asset) + DEPOSIT_AMOUNT,
 						deposit_details: Default::default(),
 					},
 				],
@@ -846,7 +845,7 @@ fn can_set_minimum_deposit() {
 	new_test_ext().execute_with(|| {
 		let asset = eth::Asset::Eth;
 		let minimum_deposit = 1_500u128;
-		assert_eq!(MinimumDeposit::<Test, Instance1>::get(asset), 0);
+		assert_eq!(MinimumDeposit::<Test, ()>::get(asset), 0);
 		// Set the new minimum deposits
 		assert_ok!(IngressEgress::update_pallet_config(
 			RuntimeOrigin::root(),
@@ -855,10 +854,10 @@ fn can_set_minimum_deposit() {
 				.unwrap()
 		));
 
-		assert_eq!(MinimumDeposit::<Test, Instance1>::get(asset), minimum_deposit);
+		assert_eq!(MinimumDeposit::<Test, ()>::get(asset), minimum_deposit);
 
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::MinimumDepositSet { asset, minimum_deposit },
+			crate::Event::<Test, ()>::MinimumDepositSet { asset, minimum_deposit },
 		));
 	});
 }
@@ -890,7 +889,7 @@ fn deposits_below_minimum_are_rejected() {
 		// Observe that eth deposit gets rejected.
 		let (_, deposit_address) = request_address_and_deposit(0, eth);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::DepositIgnored {
+			crate::Event::<Test, ()>::DepositIgnored {
 				deposit_address,
 				asset: eth,
 				amount: default_deposit_amount,
@@ -903,7 +902,7 @@ fn deposits_below_minimum_are_rejected() {
 		// Flip deposit should succeed.
 		let (channel_id, deposit_address) = request_address_and_deposit(LP_ACCOUNT, flip);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::DepositFinalised {
+			crate::Event::<Test, ()>::DepositFinalised {
 				deposit_address,
 				asset: flip,
 				amount: default_deposit_amount,
@@ -946,7 +945,7 @@ fn deposits_ingress_fee_exceeding_deposit_amount_rejected() {
 		assert!(
 			matches!(
 				cf_test_utilities::last_event::<Test>(),
-				RuntimeEvent::IngressEgress(crate::Event::<Test, Instance1>::DepositIgnored {
+				RuntimeEvent::IngressEgress(crate::Event::<Test, ()>::DepositIgnored {
 					asset: ASSET,
 					amount: DEPOSIT_AMOUNT,
 					deposit_details: (),
@@ -969,7 +968,7 @@ fn deposits_ingress_fee_exceeding_deposit_amount_rejected() {
 		assert!(
 			matches!(
 				cf_test_utilities::last_event::<Test>(),
-				RuntimeEvent::IngressEgress(crate::Event::<Test, Instance1>::DepositFinalised {
+				RuntimeEvent::IngressEgress(crate::Event::<Test, ()>::DepositFinalised {
 					asset: ASSET,
 					amount: DEPOSIT_AMOUNT,
 					deposit_details: (),
@@ -1109,7 +1108,7 @@ fn channel_reuse_with_different_assets() {
 fn ingress_finalisation_succeeds_after_channel_expired_but_not_recycled() {
 	new_test_ext().execute_with(|| {
 		assert!(
-			ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty(),
+			ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty(),
 			"Is empty after genesis"
 		);
 
@@ -1123,7 +1122,7 @@ fn ingress_finalisation_succeeds_after_channel_expired_but_not_recycled() {
 
 		IngressEgress::on_finalize(1);
 
-		assert!(ScheduledEgressFetchOrTransfer::<Test, Instance1>::get().is_empty(),);
+		assert!(ScheduledEgressFetchOrTransfer::<Test, ()>::get().is_empty(),);
 	});
 }
 
@@ -1152,7 +1151,7 @@ fn can_store_failed_vault_transfers() {
 			},
 		));
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![FailedForeignChainCall { broadcast_id, original_epoch: epoch }]
 		);
 	});
@@ -1337,16 +1336,16 @@ fn failed_ccm_is_stored() {
 	new_test_ext().execute_with(|| {
 		let epoch = MockEpochInfo::epoch_index();
 		let broadcast_id = 1;
-		assert_eq!(FailedForeignChainCalls::<Test, Instance1>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test, ()>::get(epoch), vec![]);
 
 		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), broadcast_id,));
 
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![FailedForeignChainCall { broadcast_id, original_epoch: epoch }]
 		);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::CcmBroadcastFailed { broadcast_id },
+			crate::Event::<Test, ()>::CcmBroadcastFailed { broadcast_id },
 		));
 	});
 }
@@ -1358,7 +1357,7 @@ fn on_finalize_handles_failed_calls() {
 		let epoch = 1u32;
 		MockEpochInfo::set_epoch(epoch);
 		let destination_address = [0xcf; 20].into();
-		assert_eq!(FailedForeignChainCalls::<Test, Instance1>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test, ()>::get(epoch), vec![]);
 
 		assert_ok!(IngressEgress::vault_transfer_failed(
 			RuntimeOrigin::root(),
@@ -1370,7 +1369,7 @@ fn on_finalize_handles_failed_calls() {
 		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), 13,));
 
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![
 				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
@@ -1382,7 +1381,7 @@ fn on_finalize_handles_failed_calls() {
 		IngressEgress::on_finalize(0);
 
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![
 				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
@@ -1396,39 +1395,39 @@ fn on_finalize_handles_failed_calls() {
 		// Resign 1 call per block
 		IngressEgress::on_finalize(1);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallResigned {
+			crate::Event::<Test, ()>::FailedForeignChainCallResigned {
 				broadcast_id: 13,
 				threshold_signature_id: 2,
 			},
 		));
 		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(13u32));
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![
 				FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
 			]
 		);
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch + 1),
+			FailedForeignChainCalls::<Test, ()>::get(epoch + 1),
 			vec![FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }]
 		);
 
 		// Resign the 2nd call
 		IngressEgress::on_finalize(2);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallResigned {
+			crate::Event::<Test, ()>::FailedForeignChainCallResigned {
 				broadcast_id: 12,
 				threshold_signature_id: 3,
 			},
 		));
 		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(12u32));
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch),
+			FailedForeignChainCalls::<Test, ()>::get(epoch),
 			vec![FailedForeignChainCall { broadcast_id: 1, original_epoch: epoch }]
 		);
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch + 1),
+			FailedForeignChainCalls::<Test, ()>::get(epoch + 1),
 			vec![
 				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch }
@@ -1437,15 +1436,15 @@ fn on_finalize_handles_failed_calls() {
 		// Resign the last call
 		IngressEgress::on_finalize(3);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallResigned {
+			crate::Event::<Test, ()>::FailedForeignChainCallResigned {
 				broadcast_id: 1,
 				threshold_signature_id: 4,
 			},
 		));
 		assert_eq!(MockEgressBroadcaster::resigned_call(), Some(1u32));
-		assert_eq!(FailedForeignChainCalls::<Test, Instance1>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test, ()>::get(epoch), vec![]);
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch + 1),
+			FailedForeignChainCalls::<Test, ()>::get(epoch + 1),
 			vec![
 				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch },
@@ -1457,11 +1456,11 @@ fn on_finalize_handles_failed_calls() {
 		MockEpochInfo::set_epoch(epoch + 2);
 		IngressEgress::on_finalize(4);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallExpired { broadcast_id: 1 },
+			crate::Event::<Test, ()>::FailedForeignChainCallExpired { broadcast_id: 1 },
 		));
-		assert_eq!(FailedForeignChainCalls::<Test, Instance1>::get(epoch), vec![]);
+		assert_eq!(FailedForeignChainCalls::<Test, ()>::get(epoch), vec![]);
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch + 1),
+			FailedForeignChainCalls::<Test, ()>::get(epoch + 1),
 			vec![
 				FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch },
 				FailedForeignChainCall { broadcast_id: 12, original_epoch: epoch }
@@ -1470,22 +1469,22 @@ fn on_finalize_handles_failed_calls() {
 
 		IngressEgress::on_finalize(5);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallExpired { broadcast_id: 12 },
+			crate::Event::<Test, ()>::FailedForeignChainCallExpired { broadcast_id: 12 },
 		));
 		assert_eq!(
-			FailedForeignChainCalls::<Test, Instance1>::get(epoch + 1),
+			FailedForeignChainCalls::<Test, ()>::get(epoch + 1),
 			vec![FailedForeignChainCall { broadcast_id: 13, original_epoch: epoch }]
 		);
 
 		IngressEgress::on_finalize(6);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
-			crate::Event::<Test, Instance1>::FailedForeignChainCallExpired { broadcast_id: 13 },
+			crate::Event::<Test, ()>::FailedForeignChainCallExpired { broadcast_id: 13 },
 		));
 
 		// All calls are culled from storage.
-		assert!(!FailedForeignChainCalls::<Test, Instance1>::contains_key(epoch));
-		assert!(!FailedForeignChainCalls::<Test, Instance1>::contains_key(epoch + 1));
-		assert!(!FailedForeignChainCalls::<Test, Instance1>::contains_key(epoch + 2));
+		assert!(!FailedForeignChainCalls::<Test, ()>::contains_key(epoch));
+		assert!(!FailedForeignChainCalls::<Test, ()>::contains_key(epoch + 1));
+		assert!(!FailedForeignChainCalls::<Test, ()>::contains_key(epoch + 2));
 	});
 }
 
@@ -1507,20 +1506,20 @@ fn consolidation_tx_gets_broadcasted_on_finalize() {
 fn all_batch_errors_are_logged_as_event() {
 	new_test_ext()
 		.execute_with(|| {
-			ScheduledEgressFetchOrTransfer::<Test, Instance1>::set(vec![FetchOrTransfer::<
-				Ethereum,
-			>::Transfer {
-				asset: ETH_ETH,
-				amount: 1_000,
-				destination_address: ALICE_ETH_ADDRESS,
-				egress_id: (ForeignChain::Ethereum, 1),
-			}]);
+			ScheduledEgressFetchOrTransfer::<Test, ()>::set(vec![
+				FetchOrTransfer::<Ethereum>::Transfer {
+					asset: ETH_ETH,
+					amount: 1_000,
+					destination_address: ALICE_ETH_ADDRESS,
+					egress_id: (ForeignChain::Ethereum, 1),
+				},
+			]);
 			MockEthAllBatch::set_success(false);
 		})
 		.then_execute_at_next_block(|_| {})
 		.then_execute_with(|_| {
 			System::assert_last_event(RuntimeEvent::IngressEgress(
-				crate::Event::<Test, Instance1>::FailedToBuildAllBatchCall {
+				crate::Event::<Test, ()>::FailedToBuildAllBatchCall {
 					error: cf_chains::AllBatchError::UnsupportedToken,
 				},
 			));
@@ -1618,10 +1617,10 @@ fn should_cleanup_prewitnessed_deposits_when_channel_is_recycled() {
 		));
 
 		// Check that the deposit is stored in the storage
-		let prewitnessed_deposit_id = PrewitnessedDepositIdCounter::<Test, Instance1>::get();
-		let channel_id = ChannelIdCounter::<Test, Instance1>::get();
+		let prewitnessed_deposit_id = PrewitnessedDepositIdCounter::<Test, ()>::get();
+		let channel_id = ChannelIdCounter::<Test, ()>::get();
 		assert_eq!(
-			PrewitnessedDeposits::<Test, Instance1>::get(channel_id, prewitnessed_deposit_id),
+			PrewitnessedDeposits::<Test, ()>::get(channel_id, prewitnessed_deposit_id),
 			Some(PrewitnessedDeposit {
 				asset: ASSET,
 				amount: DEPOSIT_AMOUNT,
@@ -1640,7 +1639,7 @@ fn should_cleanup_prewitnessed_deposits_when_channel_is_recycled() {
 
 		// Check that the prewitnessed deposit is removed from the storage
 		assert_eq!(
-			PrewitnessedDeposits::<Test, Instance1>::get(channel_id, prewitnessed_deposit_id),
+			PrewitnessedDeposits::<Test, ()>::get(channel_id, prewitnessed_deposit_id),
 			None
 		);
 	});
@@ -1692,11 +1691,8 @@ fn should_remove_prewitnessed_deposit_when_witnessed() {
 		));
 
 		// Check that the deposits are in storage
-		let channel_id = ChannelIdCounter::<Test, Instance1>::get();
-		assert_eq!(
-			PrewitnessedDeposits::<Test, Instance1>::iter_prefix_values(channel_id).count(),
-			3
-		);
+		let channel_id = ChannelIdCounter::<Test, ()>::get();
+		assert_eq!(PrewitnessedDeposits::<Test, ()>::iter_prefix_values(channel_id).count(), 3);
 
 		// Witness one of the deposits
 		assert_ok!(Pallet::<Test, _>::process_deposit_witnesses(
@@ -1706,13 +1702,10 @@ fn should_remove_prewitnessed_deposit_when_witnessed() {
 
 		// Check that one of the deposits was removed and the other 2 remain.
 		// we don't care which one of the two with the same amount was removed.
+		assert_eq!(PrewitnessedDeposits::<Test, ()>::iter_prefix_values(channel_id).count(), 2);
+		let prewitnessed_deposit_id = PrewitnessedDepositIdCounter::<Test, ()>::get();
 		assert_eq!(
-			PrewitnessedDeposits::<Test, Instance1>::iter_prefix_values(channel_id).count(),
-			2
-		);
-		let prewitnessed_deposit_id = PrewitnessedDepositIdCounter::<Test, Instance1>::get();
-		assert_eq!(
-			PrewitnessedDeposits::<Test, Instance1>::get(channel_id, prewitnessed_deposit_id),
+			PrewitnessedDeposits::<Test, ()>::get(channel_id, prewitnessed_deposit_id),
 			Some(PrewitnessedDeposit {
 				asset: ASSET,
 				amount: DEPOSIT_AMOUNT_2,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -822,7 +822,7 @@ fn turn_safe_mode_off() {
 }
 
 #[test]
-fn boosting_swaps_is_disabled_by_safe_mode() {
+fn boosting_deposits_is_disabled_by_safe_mode() {
 	new_test_ext().execute_with(|| {
 		const DEPOSIT_AMOUNT: AssetAmount = 250_000_000;
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -796,6 +796,11 @@ fn test_add_boost_funds() {
 
 #[track_caller]
 fn turn_safe_mode_on() {
+	assert!(
+		<MockRuntimeSafeMode as sp_core::Get<PalletSafeMode<()>>>::get() ==
+			PalletSafeMode::CODE_GREEN,
+		"Safe mode was already on"
+	);
 	<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_red();
 	assert!(
 		<MockRuntimeSafeMode as sp_core::Get<PalletSafeMode<()>>>::get() ==
@@ -805,6 +810,11 @@ fn turn_safe_mode_on() {
 
 #[track_caller]
 fn turn_safe_mode_off() {
+	assert!(
+		<MockRuntimeSafeMode as sp_core::Get<PalletSafeMode<()>>>::get() ==
+			PalletSafeMode::CODE_RED,
+		"Safe mode was already off"
+	);
 	<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_green();
 	assert!(
 		<MockRuntimeSafeMode as sp_core::Get<PalletSafeMode<()>>>::get() ==

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -313,6 +313,7 @@ impl pallet_cf_ingress_egress::Config<Instance1> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type SafeMode = RuntimeSafeMode;
 }
 
 impl pallet_cf_ingress_egress::Config<Instance2> for Runtime {
@@ -333,6 +334,7 @@ impl pallet_cf_ingress_egress::Config<Instance2> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type SafeMode = RuntimeSafeMode;
 }
 
 impl pallet_cf_ingress_egress::Config<Instance3> for Runtime {
@@ -353,6 +355,7 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type SafeMode = RuntimeSafeMode;
 }
 
 impl pallet_cf_ingress_egress::Config<Instance4> for Runtime {
@@ -373,6 +376,7 @@ impl pallet_cf_ingress_egress::Config<Instance4> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type SafeMode = RuntimeSafeMode;
 }
 
 parameter_types! {

--- a/state-chain/runtime/src/migrations/arbitrum_integration.rs
+++ b/state-chain/runtime/src/migrations/arbitrum_integration.rs
@@ -2,6 +2,7 @@ use crate::{safe_mode, Runtime};
 use cf_chains::{
 	arb::{self, ArbitrumTrackedData},
 	eth::Address,
+	instances::{BitcoinInstance, EthereumInstance, PolkadotInstance},
 	ChainState,
 };
 use cf_traits::SafeMode;
@@ -76,9 +77,12 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 							broadcast_ethereum: old.broadcast_ethereum,
 							broadcast_bitcoin: old.broadcast_bitcoin,
 							broadcast_polkadot: old.broadcast_polkadot,
-							broadcast_arbitrum: <pallet_cf_broadcast::PalletSafeMode<
-								ArbitrumInstance,
-							> as SafeMode>::CODE_GREEN,
+							broadcast_arbitrum: <pallet_cf_broadcast::PalletSafeMode<ArbitrumInstance> as SafeMode>::CODE_GREEN,
+							// Set safe mode on for ingress-egress to disable boost features.
+							ingress_egress_ethereum: <pallet_cf_ingress_egress::PalletSafeMode<EthereumInstance> as SafeMode>::CODE_RED,
+							ingress_egress_bitcoin: <pallet_cf_ingress_egress::PalletSafeMode<BitcoinInstance> as SafeMode>::CODE_RED,
+							ingress_egress_polkadot: <pallet_cf_ingress_egress::PalletSafeMode<PolkadotInstance> as SafeMode>::CODE_RED,
+							ingress_egress_arbitrum: <pallet_cf_ingress_egress::PalletSafeMode<ArbitrumInstance> as SafeMode>::CODE_RED,
 							witnesser: old.witnesser,
 						}
 				})

--- a/state-chain/runtime/src/safe_mode.rs
+++ b/state-chain/runtime/src/safe_mode.rs
@@ -24,6 +24,10 @@ impl_runtime_safe_mode! {
 	broadcast_polkadot: pallet_cf_broadcast::PalletSafeMode<Instance2>,
 	broadcast_arbitrum: pallet_cf_broadcast::PalletSafeMode<Instance4>,
 	witnesser: pallet_cf_witnesser::PalletSafeMode<WitnesserCallPermission>,
+	ingress_egress_ethereum: pallet_cf_ingress_egress::PalletSafeMode<Instance1>,
+	ingress_egress_bitcoin: pallet_cf_ingress_egress::PalletSafeMode<Instance3>,
+	ingress_egress_polkadot: pallet_cf_ingress_egress::PalletSafeMode<Instance2>,
+	ingress_egress_arbitrum: pallet_cf_ingress_egress::PalletSafeMode<Instance4>,
 }
 
 /// Contains permissions for different Runtime calls.


### PR DESCRIPTION
# Pull Request

Closes: PRO-1300

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

- Added 3 safe mode enable flags for the boost features (add, stop, boost). These are implemented for each chain.
- Changed the eth and btc mocks to work with the chain instance's as it was now needed.
- Added unit tests for the 3 flags.
- Added the new safe mode settings to the 1.4 arbitrum migration and set them to CODE_RED by default, so for testnet/mainnet we can turn the boost features on when we are ready.
	- For localnets, the boost features will be defaultly enabled at genesis.
