### PR TITLE
test: snapshot testing for new rpcs

### DIFF
--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_depth_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_depth_serialization.snap
@@ -1,0 +1,22 @@
+---
+source: state-chain/custom-rpc/src/lib.rs
+expression: val
+---
+[
+  {
+    "asset": {
+      "chain": "Ethereum",
+      "asset": "FLIP"
+    },
+    "tier": 10,
+    "available_amount": 1000000000000000000000000000000000000
+  },
+  {
+    "asset": {
+      "chain": "Ethereum",
+      "asset": "FLIP"
+    },
+    "tier": 30,
+    "available_amount": 0
+  }
+]

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
@@ -1,0 +1,40 @@
+---
+source: state-chain/custom-rpc/src/lib.rs
+expression: val
+---
+{
+  "10": {
+    "available_amount": 10000,
+    "amounts": {
+      "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT": 10000
+    },
+    "pending_boosts": {
+      "0": {
+        "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT": 200,
+        "5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt": 2000
+      },
+      "1": {
+        "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT": 1000
+      }
+    },
+    "pending_withdrawals": {}
+  },
+  "30": {
+    "available_amount": 0,
+    "amounts": {},
+    "pending_boosts": {
+      "0": {
+        "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT": 1000,
+        "5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt": 2000
+      }
+    },
+    "pending_withdrawals": {
+      "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT": [
+        0
+      ],
+      "5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt": [
+        0
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1336

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added snapshot tests for the boost RPCs.

I also used `assert_json_snapshot`, which seems to work better than `assert_snapshot` with converting to JSON manually used for other RPCs (it also pretty-prints, which means on conflict you will see its precise location because serialization is no longer a single line).

Note that this is on top of the other open PR (if both are approved at the same time, it might be easier to merge this one first).