### PR TITLE
chore: git fetch --all before checkout in upgrade-test

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -202,6 +202,7 @@ jobs:
       - name: Run bouncer after upgrade 🙅‍♂️
         id: post-upgrade-bouncer
         run: |
+          git fetch --all
           git checkout ${{ env.UPGRADE_TO_COMMIT }}
           git rev-parse HEAD
           cd bouncer

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout chainflip-backend 🛒
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
 
       - name: Get upgrade-to-commit SHA 📜
         uses: ./.github/actions/get-workflow-commit
@@ -161,7 +163,6 @@ jobs:
           BINARY_ROOT_PATH: ./latest-release-bins
           DEBUG_OUTPUT_DESTINATION: /tmp/chainflip/debug.*log
         run: |
-          git fetch --all
           git checkout ${{ steps.get-upgrade-from-commit.outputs.commit-sha }}
           set -x
           mkdir -p /tmp/chainflip/bashful
@@ -175,7 +176,6 @@ jobs:
       - name: Run bouncer on latest release 🙅‍♂️
         id: pre-upgrade-bouncer
         run: |
-          git fetch --all
           git checkout ${{ steps.get-upgrade-from-commit.outputs.commit-sha }}
           git rev-parse HEAD
           cd bouncer
@@ -188,7 +188,6 @@ jobs:
         shell: bash
         id: upgrade-network
         run: |
-          git fetch --all
           git checkout ${{ github.sha }}
           git rev-parse HEAD
           cd bouncer
@@ -202,7 +201,6 @@ jobs:
       - name: Run bouncer after upgrade 🙅‍♂️
         id: post-upgrade-bouncer
         run: |
-          git fetch --all
           git checkout ${{ env.UPGRADE_TO_COMMIT }}
           git rev-parse HEAD
           cd bouncer


### PR DESCRIPTION
Should fix recent issues such as: https://github.com/chainflip-io/chainflip-backend/actions/runs/8803229843