### PR TITLE
refactor: minor cleanup of retrier code and vault pallet

### DIFF
--- a/engine/src/btc/retry_rpc.rs
+++ b/engine/src/btc/retry_rpc.rs
@@ -69,11 +69,11 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 	async fn block(&self, block_hash: BlockHash) -> VerboseBlock {
 		self.retry_client
 			.request(
+				RequestLog::new("block".to_string(), Some(format!("{block_hash}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.block(block_hash).await })
 				}),
-				RequestLog::new("block".to_string(), Some(format!("{block_hash}"))),
 			)
 			.await
 	}
@@ -81,28 +81,27 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 	async fn block_hash(&self, block_number: cf_chains::btc::BlockNumber) -> BlockHash {
 		self.retry_client
 			.request(
+				RequestLog::new("block_hash".to_string(), Some(format!("{block_number}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.block_hash(block_number).await })
 				}),
-				RequestLog::new("block_hash".to_string(), Some(format!("{block_number}"))),
 			)
 			.await
 	}
 
 	async fn send_raw_transaction(&self, transaction_bytes: Vec<u8>) -> anyhow::Result<Txid> {
-		let log = RequestLog::new(
-			"send_raw_transaction".to_string(),
-			Some(format!("{transaction_bytes:?}")),
-		);
 		self.retry_client
 			.request_with_limit(
+				RequestLog::new(
+					"send_raw_transaction".to_string(),
+					Some(format!("{transaction_bytes:?}")),
+				),
 				Box::pin(move |client| {
 					let transaction_bytes = transaction_bytes.clone();
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.send_raw_transaction(transaction_bytes).await })
 				}),
-				log,
 				MAX_BROADCAST_RETRIES,
 			)
 			.await
@@ -111,11 +110,11 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 	async fn next_block_fee_rate(&self) -> Option<cf_chains::btc::BtcAmount> {
 		self.retry_client
 			.request(
+				RequestLog::new("next_block_fee_rate".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.next_block_fee_rate().await })
 				}),
-				RequestLog::new("next_block_fee_rate".to_string(), None),
 			)
 			.await
 	}
@@ -123,14 +122,14 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 	async fn average_block_fee_rate(&self, block_hash: BlockHash) -> cf_chains::btc::BtcAmount {
 		self.retry_client
 			.request(
-				Box::pin(move |client| {
-					#[allow(clippy::redundant_async_block)]
-					Box::pin(async move { client.average_block_fee_rate(block_hash).await })
-				}),
 				RequestLog::new(
 					"average_block_fee_rate".to_string(),
 					Some(format!("{block_hash}")),
 				),
+				Box::pin(move |client| {
+					#[allow(clippy::redundant_async_block)]
+					Box::pin(async move { client.average_block_fee_rate(block_hash).await })
+				}),
 			)
 			.await
 	}
@@ -138,6 +137,7 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 	async fn best_block_header(&self) -> BlockHeader {
 		self.retry_client
 			.request(
+				RequestLog::new("best_block_header".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -147,7 +147,6 @@ impl BtcRetryRpcApi for BtcRetryRpcClient {
 						Ok(header)
 					})
 				}),
-				RequestLog::new("best_block_header".to_string(), None),
 			)
 			.await
 	}
@@ -165,6 +164,7 @@ impl ChainClient for BtcRetryRpcClient {
 	) -> Header<Self::Index, Self::Hash, Self::Data> {
 		self.retry_client
 			.request(
+				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -180,7 +180,6 @@ impl ChainClient for BtcRetryRpcClient {
 						})
 					})
 				}),
-				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 			)
 			.await
 	}

--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -115,11 +115,11 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 	async fn block_hash(&self, block_number: PolkadotBlockNumber) -> Option<PolkadotHash> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("block_hash".to_string(), Some(format!("{block_number}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.block_hash(block_number).await })
 				}),
-				RequestLog::new("block_hash".to_string(), Some(format!("{block_number}"))),
 			)
 			.await
 	}
@@ -127,6 +127,7 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 	async fn extrinsics(&self, block_hash: PolkadotHash) -> Vec<Bytes> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("extrinsics".to_string(), Some(format!("{block_hash:?}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -135,7 +136,6 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 					))
 					})
 				}),
-				RequestLog::new("extrinsics".to_string(), Some(format!("{block_hash:?}"))),
 			)
 			.await
 	}
@@ -148,11 +148,11 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 	) -> R::ReturnType<Option<Events<PolkadotConfig>>> {
 		self.rpc_retry_client
 			.request_with_limit(
+				RequestLog::new("events".to_string(), Some(format!("{block_hash:?}"))),
 				Box::pin(move |client: DotHttpRpcClient| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.events(block_hash, parent_hash).await })
 				}),
-				RequestLog::new("events".to_string(), Some(format!("{block_hash:?}"))),
 				retry_limit,
 			)
 			.await
@@ -161,11 +161,11 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 	async fn runtime_version(&self, block_hash: Option<H256>) -> RuntimeVersion {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("runtime_version".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.runtime_version(block_hash).await })
 				}),
-				RequestLog::new("runtime_version".to_string(), None),
 			)
 			.await
 	}
@@ -174,12 +174,12 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 		&self,
 		encoded_bytes: Vec<u8>,
 	) -> anyhow::Result<PolkadotHash> {
-		let log = RequestLog::new(
-			"submit_raw_encoded_extrinsic".to_string(),
-			Some(format!("0x{}", hex::encode(&encoded_bytes[..]))),
-		);
 		self.rpc_retry_client
 			.request_with_limit(
+				RequestLog::new(
+					"submit_raw_encoded_extrinsic".to_string(),
+					Some(format!("0x{}", hex::encode(&encoded_bytes[..]))),
+				),
 				Box::pin(move |client| {
 					let encoded_bytes = encoded_bytes.clone();
 					#[allow(clippy::redundant_async_block)]
@@ -187,7 +187,6 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 						async move { client.submit_raw_encoded_extrinsic(encoded_bytes).await },
 					)
 				}),
-				log,
 				MAX_BROADCAST_RETRIES,
 			)
 			.await
@@ -214,11 +213,11 @@ impl DotRetrySubscribeApi for DotRetryRpcClient {
 	) -> Pin<Box<dyn Stream<Item = anyhow::Result<PolkadotHeader>> + Send>> {
 		self.sub_retry_client
 			.request(
+				RequestLog::new("subscribe_best_heads".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.subscribe_best_heads().await })
 				}),
-				RequestLog::new("subscribe_best_heads".to_string(), None),
 			)
 			.await
 	}
@@ -228,11 +227,11 @@ impl DotRetrySubscribeApi for DotRetryRpcClient {
 	) -> Pin<Box<dyn Stream<Item = anyhow::Result<PolkadotHeader>> + Send>> {
 		self.sub_retry_client
 			.request(
+				RequestLog::new("subscribe_finalized_heads".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.subscribe_finalized_heads().await })
 				}),
-				RequestLog::new("subscribe_finalized_heads".to_string(), None),
 			)
 			.await
 	}
@@ -250,6 +249,7 @@ impl ChainClient for DotRetryRpcClient {
 	) -> Header<Self::Index, Self::Hash, Self::Data> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -279,7 +279,6 @@ impl ChainClient for DotRetryRpcClient {
 						})
 					})
 				}),
-				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 			)
 			.await
 	}

--- a/engine/src/evm/retry_rpc.rs
+++ b/engine/src/evm/retry_rpc.rs
@@ -194,6 +194,10 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn get_logs(&self, block_hash: H256, contract_address: H160) -> Vec<Log> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new(
+					"get_logs".to_string(),
+					Some(format!("{block_hash:?}, {contract_address:?}")),
+				),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -204,10 +208,6 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 							.await
 					})
 				}),
-				RequestLog::new(
-					"get_logs".to_string(),
-					Some(format!("{block_hash:?}, {contract_address:?}")),
-				),
 			)
 			.await
 	}
@@ -215,11 +215,11 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn chain_id(&self) -> U256 {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("chain_id".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.chain_id().await })
 				}),
-				RequestLog::new("chain_id".to_string(), None),
 			)
 			.await
 	}
@@ -227,11 +227,11 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn transaction_receipt(&self, tx_hash: H256) -> TransactionReceipt {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("transaction_receipt".to_string(), Some(format!("{tx_hash:?}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.transaction_receipt(tx_hash).await })
 				}),
-				RequestLog::new("transaction_receipt".to_string(), Some(format!("{tx_hash:?}"))),
 			)
 			.await
 	}
@@ -239,11 +239,11 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn block(&self, block_number: U64) -> Block<H256> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("block".to_string(), Some(format!("{block_number}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.block(block_number).await })
 				}),
-				RequestLog::new("block".to_string(), Some(format!("{block_number}"))),
 			)
 			.await
 	}
@@ -251,11 +251,11 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn block_with_txs(&self, block_number: U64) -> Block<Transaction> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("block_with_txs".to_string(), Some(format!("{block_number}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.block_with_txs(block_number).await })
 				}),
-				RequestLog::new("block_with_txs".to_string(), Some(format!("{block_number}"))),
 			)
 			.await
 	}
@@ -266,12 +266,12 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 		newest_block: BlockNumber,
 		reward_percentiles: Vec<f64>,
 	) -> FeeHistory {
-		let log = RequestLog::new(
-			"fee_history".to_string(),
-			Some(format!("{block_count}, {newest_block}, {reward_percentiles:?}")),
-		);
 		self.rpc_retry_client
 			.request(
+				RequestLog::new(
+					"fee_history".to_string(),
+					Some(format!("{block_count}, {newest_block}, {reward_percentiles:?}")),
+				),
 				Box::pin(move |client| {
 					let reward_percentiles = reward_percentiles.clone();
 					#[allow(clippy::redundant_async_block)]
@@ -279,7 +279,6 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 						client.fee_history(block_count, newest_block, &reward_percentiles).await
 					})
 				}),
-				log,
 			)
 			.await
 	}
@@ -287,11 +286,11 @@ impl<Rpc: EvmRpcApi> EvmRetryRpcApi for EvmRetryRpcClient<Rpc> {
 	async fn get_transaction(&self, tx_hash: H256) -> Transaction {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("get_transaction".to_string(), Some(format!("{tx_hash:?}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.get_transaction(tx_hash).await })
 				}),
-				RequestLog::new("get_transaction".to_string(), Some(format!("{tx_hash:?}"))),
 			)
 			.await
 	}
@@ -304,10 +303,10 @@ impl<Rpc: EvmSigningRpcApi> EvmRetrySigningRpcApi for EvmRetryRpcClient<Rpc> {
 		&self,
 		tx: cf_chains::evm::Transaction,
 	) -> anyhow::Result<TxHash> {
-		let log = RequestLog::new("broadcast_transaction".to_string(), Some(format!("{tx:?}")));
 		let s = self.chain_name.to_owned();
 		self.rpc_retry_client
 			.request_with_limit(
+				RequestLog::new("broadcast_transaction".to_string(), Some(format!("{tx:?}"))),
 				Box::pin(move |client| {
 					let tx = tx.clone();
 					let s = s.clone();
@@ -353,7 +352,6 @@ impl<Rpc: EvmSigningRpcApi> EvmRetrySigningRpcApi for EvmRetryRpcClient<Rpc> {
 							.context(format!("Failed to send {} transaction", s))
 					})
 				}),
-				log,
 				MAX_BROADCAST_RETRIES,
 			)
 			.await
@@ -370,11 +368,11 @@ impl<Rpc: EvmRpcApi> EvmRetrySubscribeApi for EvmRetryRpcClient<Rpc> {
 	async fn subscribe_blocks(&self) -> ConscientiousEvmWebsocketBlockHeaderStream {
 		self.sub_retry_client
 			.request(
+				RequestLog::new("subscribe_blocks".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move { client.subscribe_blocks().await })
 				}),
-				RequestLog::new("subscribe_blocks".to_string(), None),
 			)
 			.await
 	}
@@ -394,6 +392,7 @@ impl<Rpc: EvmRpcApi> ChainClient for EvmRetryRpcClient<Rpc> {
 	) -> Header<Self::Index, Self::Hash, Self::Data> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
 					Box::pin(async move {
@@ -415,7 +414,6 @@ impl<Rpc: EvmRpcApi> ChainClient for EvmRetryRpcClient<Rpc> {
 						})
 					})
 				}),
-				RequestLog::new("header_at_index".to_string(), Some(format!("{index}"))),
 			)
 			.await
 	}

--- a/engine/src/evm/retry_rpc/address_checker.rs
+++ b/engine/src/evm/retry_rpc/address_checker.rs
@@ -36,6 +36,10 @@ impl<Rpc: EvmRpcApi + AddressCheckerRpcApi> AddressCheckerRetryRpcApi for EvmRet
 	) -> Vec<AddressState> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new(
+					"address_states".to_string(),
+					Some(format!("{block_hash:?}, {contract_address:?}")),
+				),
 				Box::pin(move |client| {
 					let addresses = addresses.clone();
 					#[allow(clippy::redundant_async_block)]
@@ -43,10 +47,6 @@ impl<Rpc: EvmRpcApi + AddressCheckerRpcApi> AddressCheckerRetryRpcApi for EvmRet
 						client.address_states(block_hash, contract_address, addresses).await
 					})
 				}),
-				RequestLog::new(
-					"address_states".to_string(),
-					Some(format!("{block_hash:?}, {contract_address:?}")),
-				),
 			)
 			.await
 	}
@@ -59,6 +59,10 @@ impl<Rpc: EvmRpcApi + AddressCheckerRpcApi> AddressCheckerRetryRpcApi for EvmRet
 	) -> Vec<U256> {
 		self.rpc_retry_client
 			.request(
+				RequestLog::new(
+					"balances".to_string(),
+					Some(format!("{block_hash:?}, {contract_address:?}")),
+				),
 				Box::pin(move |client| {
 					let addresses = addresses.clone();
 					#[allow(clippy::redundant_async_block)]
@@ -66,10 +70,6 @@ impl<Rpc: EvmRpcApi + AddressCheckerRpcApi> AddressCheckerRetryRpcApi for EvmRet
 						client.balances(block_hash, contract_address, addresses).await
 					})
 				}),
-				RequestLog::new(
-					"balances".to_string(),
-					Some(format!("{block_hash:?}, {contract_address:?}")),
-				),
 			)
 			.await
 	}

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -473,10 +473,10 @@ where
 	/// Sets retry limit of no limit, since we expect most requests not to fail.
 	pub async fn request<T: Send + 'static>(
 		&self,
-		specific_closure: TypedFutureGenerator<T, Client>,
 		request_log: RequestLog,
+		specific_closure: TypedFutureGenerator<T, Client>,
 	) -> T {
-		self.request_with_limit::<T, NoRetryLimit>(specific_closure, request_log, NoRetryLimit)
+		self.request_with_limit::<T, NoRetryLimit>(request_log, specific_closure, NoRetryLimit)
 			.await
 	}
 
@@ -484,8 +484,8 @@ where
 	/// Returns an error if the retry limit is reached.
 	pub async fn request_with_limit<T: Send + 'static, R: RetryLimitReturn>(
 		&self,
-		specific_closure: TypedFutureGenerator<T, Client>,
 		request_log: RequestLog,
+		specific_closure: TypedFutureGenerator<T, Client>,
 		retry_limit: R,
 	) -> R::ReturnType<T> {
 		let retry_limit = R::into_retry_limit(retry_limit);
@@ -635,8 +635,8 @@ mod tests {
 					REQUEST_1,
 					retrier_client
 						.request(
-							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 							RequestLog::new("request 1".to_string(), None),
+							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 						)
 						.await
 				);
@@ -646,8 +646,8 @@ mod tests {
 					REQUEST_2,
 					retrier_client
 						.request(
-							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 							RequestLog::new("request 2".to_string(), None),
+							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 						)
 						.await
 				);
@@ -674,8 +674,8 @@ mod tests {
 					REQUEST_1,
 					retrier_client
 						.request_with_limit(
-							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 							RequestLog::new("request 1".to_string(), None),
+							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 							5
 						)
 						.await
@@ -687,8 +687,8 @@ mod tests {
 					REQUEST_2,
 					retrier_client
 						.request_with_limit(
-							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 							RequestLog::new("request 2".to_string(), None),
+							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 							5
 						)
 						.await
@@ -740,8 +740,8 @@ mod tests {
 				timeout(
 					Duration::from_millis(100),
 					retrier_client.request(
-						specific_fut_closure(REQUEST_3, Duration::default()),
 						RequestLog::new("request 3".to_string(), None),
+						specific_fut_closure(REQUEST_3, Duration::default()),
 					),
 				)
 				.await
@@ -752,8 +752,8 @@ mod tests {
 					timeout(
 						Duration::from_millis(600),
 						retrier_client.request(
-							specific_fut_closure(REQUEST_3, Duration::default()),
 							RequestLog::new("request 3".to_string(), None),
+							specific_fut_closure(REQUEST_3, Duration::default()),
 						),
 					)
 					.await
@@ -794,8 +794,8 @@ mod tests {
 
 				retrier_client
 					.request_with_limit(
-						specific_fut_err::<(), _>(INITIAL_TIMEOUT),
 						RequestLog::new("request".to_string(), None),
+						specific_fut_err::<(), _>(INITIAL_TIMEOUT),
 						5,
 					)
 					.await
@@ -835,8 +835,8 @@ mod tests {
 					REQUEST_1,
 					retrier_client
 						.request(
-							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 							RequestLog::new("request 1".to_string(), None),
+							specific_fut_closure(REQUEST_1, INITIAL_TIMEOUT),
 						)
 						.await
 				);
@@ -846,8 +846,8 @@ mod tests {
 					REQUEST_2,
 					retrier_client
 						.request(
-							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 							RequestLog::new("request 2".to_string(), None),
+							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 						)
 						.await
 				);
@@ -872,8 +872,8 @@ mod tests {
 
 				retrier_client
 					.request(
-						specific_fut_err::<(), _>(INITIAL_TIMEOUT),
 						RequestLog::new("request".to_string(), None),
+						specific_fut_err::<(), _>(INITIAL_TIMEOUT),
 					)
 					.await;
 

--- a/state-chain/pallets/cf-vaults/src/vault_activator.rs
+++ b/state-chain/pallets/cf-vaults/src/vault_activator.rs
@@ -49,7 +49,7 @@ impl<T: Config<I>, I: 'static> VaultActivator<<T::Chain as Chain>::ChainCrypto> 
 				Ok(None) => {
 					// This can happen if, for example, on a utxo chain there are no funds that
 					// need to be swept.
-					Self::activate_new_key_for_chain(T::ChainTracking::get_block_height());
+					Self::activate_key();
 					vec![StartKeyActivationResult::ActivationTxNotRequired]
 				},
 				Err(SetAggKeyWithAggKeyError::Failed) => {


### PR DESCRIPTION
Having the log parameter after the async-closure parameter creates a common lifetime issue that we need to move the parameters into the async-closure, but we also need those parameter to create the text for the log message. Meaning you need to uninline the log parameter and create it before creating the async-closure, or clone the parameter. This makes the code more difficult to read. By moving the log message parameter first you avoid that.

Also I noted that the activate_key function exists, but wasn't always being in this particular case for no reason.