### PR TITLE
feat: optimistic build, streamlined ci-main

### DIFF
--- a/.github/workflows/ci-main-merge-queue.yml
+++ b/.github/workflows/ci-main-merge-queue.yml
@@ -17,14 +17,12 @@ jobs:
       test_features: runtime-benchmarks
     secrets: inherit
   build:
-    needs: [test]
     uses: ./.github/workflows/_20_build.yml
     secrets: inherit
     with:
       profile: "release"
   # Used to test upgrades to this version from the latest release
   build-try-runtime:
-    needs: [test]
     uses: ./.github/workflows/_20_build.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,10 +44,6 @@ jobs:
     with:
       network: "test"
     secrets: inherit
-  post-check:
-    needs: [build]
-    uses: ./.github/workflows/_40_post_check.yml
-    secrets: inherit
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -19,21 +19,18 @@ jobs:
       test_features: runtime-benchmarks
     secrets: inherit
   build:
-    needs: [test]
     uses: ./.github/workflows/_20_build.yml
     secrets: inherit
     with:
       profile: "release"
   # Used to test upgrades to this version from the latest release
   build-try-runtime:
-    needs: [test]
     uses: ./.github/workflows/_20_build.yml
     secrets: inherit
     with:
       profile: "try-runtime"
       upload-name: "chainflip-backend-bin-try-runtime"
       binary-subdir: release
-
   docker:
     needs: [build]
     uses: ./.github/workflows/_24_docker.yml

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -55,10 +55,3 @@ jobs:
       version: ci/${{ github.sha }}/
       environment: "development"
     secrets: inherit
-  upgrade-check:
-    needs: [build-try-runtime]
-    uses: ./.github/workflows/upgrade-test.yml
-    secrets: inherit
-    with:
-      upgrade-from-release: "sisyphos"
-      upgrade-to-workflow-name: "ci-main.yml"


### PR DESCRIPTION
Since merge queues, we can optimistically build in ci-main, speeding it up, because it's *very* unlikely to fail. 
We also already run the post-check and upgrade-check as part of the merge queue, so these don't need to be run again (especially since they are slow). 

Note: We still run bouncer on nightly, as it uses `full_bouncer` which runs some extra, longer tests.