### PR TITLE
feat: try-runtime build step on dev ci

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -29,6 +29,14 @@ jobs:
     secrets: inherit
     with:
       profile: "release"
+  # Used to test upgrades to this version from the latest release
+  build-try-runtime:
+    uses: ./.github/workflows/_20_build.yml
+    secrets: inherit
+    with:
+      profile: "try-runtime"
+      upload-name: "chainflip-backend-bin-try-runtime"
+      binary-subdir: release
   docker:
     needs: [build]
     uses: ./.github/workflows/_24_docker.yml


### PR DESCRIPTION
Build with try-runtime so the upgrade test can be run on branches in development

I think this should close: PRO-1258