### PR TITLE
chore: log raw dispatch error

### DIFF
--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -831,6 +831,7 @@ export function handleSubstrateError(api: any) {
       } else {
         error = dispatchError.toString();
       }
+      console.log('Dispatch error:' + error);
       console.log('Extrinsic failed: ' + error);
       process.exit(1);
     }


### PR DESCRIPTION
Getting the Liquidity Deposit safe mode enabled error again :/

Doesn't really make sense, so printing the raw dispatch error for when it happens again, so we can check it's not a bug in the error parsing (which is possible, we've seen quite a few metadata related polkadot-js issues lately).