### PR TITLE
feat: Efficient Arbitrum witnessing (PRO-1098)

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/eth.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/eth.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use cf_chains::Ethereum;
+use cf_chains::{Chain, Ethereum};
 use cf_primitives::chains::assets::eth::Asset;
 use std::sync::Arc;
 use utilities::task_scope;
@@ -53,6 +53,7 @@ where
 			"eth_rpc",
 			"eth_subscribe",
 			"Ethereum",
+			Ethereum::WITNESS_PERIOD,
 		)?
 	};
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -38,7 +38,7 @@ use self::{
 	settings::{CommandLineOptions, Settings, DEFAULT_SETTINGS_DIR},
 };
 use anyhow::Context;
-use cf_chains::dot::PolkadotHash;
+use cf_chains::{dot::PolkadotHash, Chain};
 use cf_primitives::AccountRole;
 use chainflip_node::chain_spec::use_chainflip_account_id_encoding;
 use clap::Parser;
@@ -231,6 +231,7 @@ async fn run_main(
 					"eth_rpc",
 					"eth_subscribe",
 					"Ethereum",
+					cf_chains::Ethereum::WITNESS_PERIOD,
 				)?
 			};
 			let arb_client = {
@@ -250,6 +251,7 @@ async fn run_main(
 					"arb_rpc",
 					"arb_subscribe",
 					"Arbitrum",
+					cf_chains::Arbitrum::WITNESS_PERIOD,
 				)?
 			};
 

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -115,7 +115,7 @@ where
 	tracing::info!("Safety margin for Arbitrum is set to {arb_safety_margin} blocks.",);
 
 	let arb_safe_vault_source = arb_source
-		.lag_safety(arb_safety_margin as usize)
+		.lag_safety(arb_safety_margin)
 		.logging("safe block produced")
 		.chunk_by_vault(vaults, scope);
 
@@ -179,6 +179,7 @@ mod tests {
 
 	use std::path::PathBuf;
 
+	use cf_chains::{Arbitrum, Chain};
 	use cf_primitives::AccountRole;
 
 	use crate::{
@@ -250,6 +251,7 @@ mod tests {
 						"arb_rpc",
 						"arb_subscribe",
 						"Arbitrum",
+						Arbitrum::WITNESS_PERIOD,
 					).unwrap()
 				};
 

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -159,7 +159,7 @@ where
 
 	// Full witnessing stream.
 	block_source
-		.lag_safety(btc_safety_margin as usize)
+		.lag_safety(btc_safety_margin)
 		.logging("safe block produced")
 		.chunk_by_vault(vaults, scope)
 		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())

--- a/engine/src/witness/common/chain_source/extension.rs
+++ b/engine/src/witness/common/chain_source/extension.rs
@@ -44,9 +44,12 @@ pub trait ChainSourceExt: ChainSource {
 	/// Apply some safety margin to the chain source, such that the chain source will lag behind by
 	/// a set margin. This is specifically for chains that don't offer deterministic finality, such
 	/// as Ethereum or Bitcoin.
-	fn lag_safety(self, margin: usize) -> LagSafety<Self>
+	fn lag_safety(
+		self,
+		margin: <<Self as ExternalChainSource>::Chain as cf_chains::Chain>::ChainBlockNumber,
+	) -> LagSafety<Self>
 	where
-		Self: Sized,
+		Self: ExternalChainSource + Sized,
 	{
 		LagSafety::new(self, margin)
 	}

--- a/engine/src/witness/common/chain_source/lag_safety.rs
+++ b/engine/src/witness/common/chain_source/lag_safety.rs
@@ -91,6 +91,8 @@ where
 					}
 
 					if let Some(safe_header) = pop_safe_from_cache::<Self>(&mut unsafe_cache, margin) {
+						// Technically this check is unneeded as the witness_period is constant, but if it weren't then a new unsafe block could
+						// cause multiple new blocks to become safe, in which case this would be needed.
 						Some(safe_header)
 					} else {
 						utilities::loop_select!(

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
@@ -75,10 +75,10 @@ where
 				let inprogress_indices = FutureMap::default();
 
 				let unprocessed_indices = {
+					let next_unprocessed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(Step::forward(highest_processed, 1), epoch.info.1));
 					let mut processed_inverse = processed_indices.clone();
 					processed_inverse.invert();
 					processed_inverse.set_range(..epoch.info.1, false);
-					let next_unprocessed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(Step::forward(highest_processed, 1), epoch.info.1));
 					processed_inverse.set_range(next_unprocessed.., false);
 					processed_inverse
 				};
@@ -90,8 +90,7 @@ where
 						move |(mut chain_stream, chain_client, mut epoch, mut unprocessed_indices, mut inprogress_indices, mut processed_indices)| async move {
 							let is_epoch_complete = |processed_indices: &RleBitmap<Self::Index>, end: Self::Index| {
 								processed_indices.is_superset(&{
-									<Inner::Chain as Chain>::assert_block_phase(epoch.info.1);
-									<Inner::Chain as Chain>::assert_block_phase(end);
+									assert!(<Inner::Chain as Chain>::is_block_witness_root(end));
 
 									let mut bitmap = RleBitmap::new(true);
 									bitmap.set_range(..epoch.info.1, false);
@@ -100,31 +99,45 @@ where
 								})
 							};
 
-							<Inner::Chain as Chain>::assert_block_phase(epoch.info.1);
+							assert!(<Inner::Chain as Chain>::is_block_witness_root(epoch.info.1));
 
 							loop_select!(
 								let header = chain_stream.next_or_pending() => {
-									<Inner::Chain as Chain>::assert_block_phase(header.index);
-									let next_unprocessed = processed_indices.iter(true).last().map_or(epoch.info.1, |highest_processed| std::cmp::max(Step::forward(highest_processed, 1), epoch.info.1));
-									<Inner::Chain as Chain>::assert_block_phase(next_unprocessed);
-									if next_unprocessed < header.index {
-										for unprocessed_index in (next_unprocessed..header.index).step_by(Into::<u64>::into(<Inner::Chain as Chain>::WITNESS_PERIOD) as usize) {
-											<Inner::Chain as Chain>::assert_block_phase(unprocessed_index);
-											if inprogress_indices.len() < MAXIMUM_CONCURRENT_INPROGRESS {
-												inprogress_indices.insert(unprocessed_index, {
-													let chain_client = chain_client.clone();
-													#[allow(clippy::redundant_async_block)]
-													async move {
-														chain_client.header_at_index(unprocessed_index).await
-													}.boxed()
-												});
+									assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
+
+									for unprocessed_root in itertools::unfold(
+										if processed_indices.is_empty() {
+											Some(epoch.info.1)
+										} else if let Some(next_unprocessed) = <Inner::Chain as Chain>::checked_block_witness_next(processed_indices.iter(true).last().unwrap()) {
+											Some(std::cmp::max(next_unprocessed, epoch.info.1))
+										} else {
+											None
+										},
+										|optional_next_unprocessed_root| {
+											if let Some(next_unprocessed_root) = optional_next_unprocessed_root.as_mut().filter(|next_unprocessed_root| **next_unprocessed_root < header.index) {
+												let next_unprocessed_root = *next_unprocessed_root;
+												*optional_next_unprocessed_root = <Inner::Chain as Chain>::checked_block_witness_next(next_unprocessed_root);
+												Some(next_unprocessed_root)
 											} else {
-												unprocessed_indices.set_range(<Inner::Chain as Chain>::block_period(unprocessed_index), true);
+												None
 											}
+										}
+									) {
+										assert!(<Inner::Chain as Chain>::is_block_witness_root(unprocessed_root));
+										if inprogress_indices.len() < MAXIMUM_CONCURRENT_INPROGRESS {
+											inprogress_indices.insert(unprocessed_root, {
+												let chain_client = chain_client.clone();
+												#[allow(clippy::redundant_async_block)]
+												async move {
+													chain_client.header_at_index(unprocessed_root).await
+												}.boxed()
+											});
+										} else {
+											unprocessed_indices.set_range(<Inner::Chain as Chain>::block_witness_range(unprocessed_root), true);
 										}
 									}
 
-									let processed_index_range = <Inner::Chain as Chain>::block_period(header.index);
+									let processed_index_range = <Inner::Chain as Chain>::block_witness_range(header.index);
 									unprocessed_indices.set_range(processed_index_range.clone(), false);
 									inprogress_indices.remove(header.index);
 									processed_indices.set_range(processed_index_range, true);
@@ -137,16 +150,16 @@ where
 									break None
 								} else disable then if is_epoch_complete(&processed_indices, epoch.historic_signal.get().unwrap().1) => break None,
 								let (_, header) = inprogress_indices.next_or_pending() => {
-									<Inner::Chain as Chain>::assert_block_phase(header.index);
+									assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
-									let processed_index_range = <Inner::Chain as Chain>::block_period(header.index);
+									let processed_index_range = <Inner::Chain as Chain>::block_witness_range(header.index);
 
 									processed_indices.set_range(processed_index_range, true);
 									let _result = self.store.store(epoch.index, &processed_indices);
 
 									let next_unprocessed_indice = unprocessed_indices.iter(true).next();
 									if let Some(unprocessed_index) = next_unprocessed_indice {
-										unprocessed_indices.set_range(<Inner::Chain as Chain>::block_period(unprocessed_index), false);
+										unprocessed_indices.set_range(<Inner::Chain as Chain>::block_witness_range(unprocessed_index), false);
 										inprogress_indices.insert(unprocessed_index, {
 											let chain_client = chain_client.clone();
 											#[allow(clippy::redundant_async_block)]

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/continuous.rs
@@ -105,6 +105,10 @@ where
 								let header = chain_stream.next_or_pending() => {
 									assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
+									// Note if the processed indices loaded from the database are not aligned to the `witness_period`, we will skip blocks.
+									// For example: If the `witness_period` is 5, and the database states 0..3 are witnessed. Then blocks 3..5 will not be
+									// witnessed as we cannot partially witness a `witness_period`, but we will witness 5..10 etc.
+
 									for unprocessed_root in itertools::unfold(
 										if processed_indices.is_empty() {
 											Some(epoch.info.1)

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/deposit_addresses.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/deposit_addresses.rs
@@ -1,4 +1,4 @@
-use cf_chains::instances::ChainInstanceFor;
+use cf_chains::{instances::ChainInstanceFor, Chain};
 use pallet_cf_ingress_egress::DepositChannelDetails;
 use std::sync::Arc;
 use utilities::task_scope::Scope;
@@ -34,7 +34,11 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 		MonitoredSCItems<
 			Inner,
 			Addresses<Inner>,
-			impl Fn(Inner::Index, &Addresses<Inner>) -> Addresses<Inner> + Send + Sync + Clone + 'static,
+			impl Fn(<Inner::Chain as Chain>::ChainBlockNumber, &Addresses<Inner>) -> Addresses<Inner>
+				+ Send
+				+ Sync
+				+ Clone
+				+ 'static,
 		>,
 	>
 	where
@@ -62,9 +66,14 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 					}
 				},
 				|index, addresses: &Addresses<Inner>| {
+					<Inner::Chain as Chain>::assert_block_phase(index);
 					addresses
 						.iter()
-						.filter(|details| details.opened_at <= index && index <= details.expires_at)
+						.filter(|details| {
+							<Inner::Chain as Chain>::assert_block_phase(details.opened_at);
+							<Inner::Chain as Chain>::assert_block_phase(details.expires_at);
+							details.opened_at <= index && index <= details.expires_at
+						})
 						.cloned()
 						.collect()
 				},

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/deposit_addresses.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/deposit_addresses.rs
@@ -66,12 +66,16 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 					}
 				},
 				|index, addresses: &Addresses<Inner>| {
-					<Inner::Chain as Chain>::assert_block_phase(index);
+					assert!(<Inner::Chain as Chain>::is_block_witness_root(index));
 					addresses
 						.iter()
 						.filter(|details| {
-							<Inner::Chain as Chain>::assert_block_phase(details.opened_at);
-							<Inner::Chain as Chain>::assert_block_phase(details.expires_at);
+							assert!(<Inner::Chain as Chain>::is_block_witness_root(
+								details.opened_at
+							));
+							assert!(<Inner::Chain as Chain>::is_block_witness_root(
+								details.expires_at
+							));
 							details.opened_at <= index && index <= details.expires_at
 						})
 						.cloned()

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/egress_items.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/egress_items.rs
@@ -69,11 +69,11 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 					}
 				},
 				|index, tx_out_ids: &TxOutIdsInitiatedAt<Inner>| {
-					<Inner::Chain as Chain>::assert_block_phase(index);
+					assert!(<Inner::Chain as Chain>::is_block_witness_root(index));
 					tx_out_ids
 						.iter()
 						.filter(|(_, initiated_at)| {
-							<Inner::Chain as Chain>::assert_block_phase(*initiated_at);
+							assert!(<Inner::Chain as Chain>::is_block_witness_root(*initiated_at));
 							initiated_at <= &index
 						})
 						.cloned()

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/egress_items.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/egress_items.rs
@@ -69,9 +69,13 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 					}
 				},
 				|index, tx_out_ids: &TxOutIdsInitiatedAt<Inner>| {
+					<Inner::Chain as Chain>::assert_block_phase(index);
 					tx_out_ids
 						.iter()
-						.filter(|(_, initiated_at)| initiated_at <= &index)
+						.filter(|(_, initiated_at)| {
+							<Inner::Chain as Chain>::assert_block_phase(*initiated_at);
+							initiated_at <= &index
+						})
 						.cloned()
 						.collect()
 				},

--- a/engine/src/witness/common/epoch_source.rs
+++ b/engine/src/witness/common/epoch_source.rs
@@ -430,7 +430,7 @@ impl<'a, 'env, StateChainClient: StorageApi + Send + Sync + 'static, Info, Histo
 					.expect(STATE_CHAIN_CONNECTION)
 				{
 					Some(vault_start_block_number) => {
-						TChain::assert_block_phase(vault_start_block_number);
+						assert!(TChain::is_block_witness_root(vault_start_block_number));
 						Some((
 							state_chain_client
 								.storage_map_entry::<pallet_cf_threshold_signature::Keys<

--- a/engine/src/witness/common/epoch_source.rs
+++ b/engine/src/witness/common/epoch_source.rs
@@ -430,16 +430,19 @@ impl<'a, 'env, StateChainClient: StorageApi + Send + Sync + 'static, Info, Histo
 					.expect(STATE_CHAIN_CONNECTION)
 				{
 					Some(vault_start_block_number) => {
+						TChain::assert_block_phase(vault_start_block_number);
 						Some((
-						state_chain_client
-						.storage_map_entry::<pallet_cf_threshold_signature::Keys<
-							state_chain_runtime::Runtime,
-							CryptoInstanceFor<TChain>,
-						>>(block_hash, &epoch)
-						.await
-						.expect(STATE_CHAIN_CONNECTION)
-						.expect("since the block start number for this epoch exists, the vault key for this epoch should also exist. Both the vault key and the vault start block number are set in the same function (activate_keys() in vault_rotator.rs)"),
-						vault_start_block_number, info))
+							state_chain_client
+								.storage_map_entry::<pallet_cf_threshold_signature::Keys<
+									state_chain_runtime::Runtime,
+									CryptoInstanceFor<TChain>,
+								>>(block_hash, &epoch)
+								.await
+								.expect(STATE_CHAIN_CONNECTION)
+								.expect("since the block start number for this epoch exists, the vault key for this epoch should also exist. Both the vault key and the vault start block number are set in the same function (activate_keys() in vault_rotator.rs)"),
+							vault_start_block_number,
+							info
+						))
 					}
 					None => None,
 				}

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -123,7 +123,7 @@ where
 	tracing::info!("Safety margin for Ethereum is set to {eth_safety_margin} blocks.",);
 
 	let eth_safe_vault_source = eth_source
-		.lag_safety(eth_safety_margin as usize)
+		.lag_safety(eth_safety_margin)
 		.logging("safe block produced")
 		.chunk_by_vault(vaults, scope);
 

--- a/engine/src/witness/eth/state_chain_gateway.rs
+++ b/engine/src/witness/eth/state_chain_gateway.rs
@@ -42,7 +42,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 		ProcessingFut: Future<Output = ()> + Send + 'static,
 	{
 		self.then::<Result<Bloom>, _, _>(move |epoch, header| {
-			<Inner::Chain as Chain>::assert_block_phase(header.index);
+			assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();

--- a/engine/src/witness/eth/state_chain_gateway.rs
+++ b/engine/src/witness/eth/state_chain_gateway.rs
@@ -1,4 +1,4 @@
-use cf_chains::Ethereum;
+use cf_chains::{Chain, Ethereum};
 use ethers::{prelude::abigen, types::Bloom};
 use sp_core::{H160, H256};
 use tracing::{info, trace};
@@ -42,10 +42,12 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 		ProcessingFut: Future<Output = ()> + Send + 'static,
 	{
 		self.then::<Result<Bloom>, _, _>(move |epoch, header| {
+			<Inner::Chain as Chain>::assert_block_phase(header.index);
+
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();
 			async move {
-				for event in events_at_block::<StateChainGatewayEvents, _>(
+				for event in events_at_block::<Inner::Chain, StateChainGatewayEvents, _>(
 					header,
 					contract_address,
 					&eth_rpc,

--- a/engine/src/witness/evm/contract_common.rs
+++ b/engine/src/witness/evm/contract_common.rs
@@ -57,7 +57,7 @@ where
 	EventParameters: std::fmt::Debug + ethers::contract::EthLogDecode + Send + Sync + 'static,
 	EvmRpcClient: EvmRetryRpcApi,
 {
-	Chain::assert_block_phase(header.index);
+	assert!(Chain::is_block_witness_root(header.index));
 	if Chain::WITNESS_PERIOD == 1 {
 		let mut contract_bloom = Bloom::default();
 		contract_bloom.accrue(BloomInput::Raw(&contract_address.0));
@@ -71,7 +71,7 @@ where
 		}
 	} else {
 		eth_rpc
-			.get_logs_range(Chain::block_period(header.index), contract_address)
+			.get_logs_range(Chain::block_witness_range(header.index), contract_address)
 			.await
 	}
 	.into_iter()

--- a/engine/src/witness/evm/contract_common.rs
+++ b/engine/src/witness/evm/contract_common.rs
@@ -47,30 +47,36 @@ impl<EventParameters: Debug + ethers::contract::EthLogDecode> Event<EventParamet
 	}
 }
 
-pub async fn events_at_block<EventParameters, EvmRpcClient>(
+pub async fn events_at_block<Chain, EventParameters, EvmRpcClient>(
 	header: Header<u64, H256, Bloom>,
 	contract_address: H160,
 	eth_rpc: &EvmRpcClient,
 ) -> Result<Vec<Event<EventParameters>>>
 where
+	Chain: cf_chains::Chain<ChainBlockNumber = u64>,
 	EventParameters: std::fmt::Debug + ethers::contract::EthLogDecode + Send + Sync + 'static,
 	EvmRpcClient: EvmRetryRpcApi,
 {
-	let mut contract_bloom = Bloom::default();
-	contract_bloom.accrue(BloomInput::Raw(&contract_address.0));
+	Chain::assert_block_phase(header.index);
+	if Chain::WITNESS_PERIOD == 1 {
+		let mut contract_bloom = Bloom::default();
+		contract_bloom.accrue(BloomInput::Raw(&contract_address.0));
 
-	// if we have logs for this block, fetch them.
-	if header.data.contains_bloom(&contract_bloom) {
-		eth_rpc
-			.get_logs(header.hash, contract_address)
-			.await
-			.into_iter()
-			.map(|unparsed_log| -> anyhow::Result<Event<EventParameters>> {
-				Event::<EventParameters>::new_from_unparsed_logs(unparsed_log)
-			})
-			.collect::<anyhow::Result<Vec<_>>>()
+		// if we have logs for this block, fetch them.
+		if header.data.contains_bloom(&contract_bloom) {
+			eth_rpc.get_logs(header.hash, contract_address).await
+		} else {
+			// we know there won't be interesting logs, so don't fetch for events
+			vec![]
+		}
 	} else {
-		// we know there won't be interesting logs, so don't fetch for events
-		anyhow::Result::Ok(vec![])
+		eth_rpc
+			.get_logs_range(Chain::block_period(header.index), contract_address)
+			.await
 	}
+	.into_iter()
+	.map(|unparsed_log| -> anyhow::Result<Event<EventParameters>> {
+		Event::<EventParameters>::new_from_unparsed_logs(unparsed_log)
+	})
+	.collect::<anyhow::Result<Vec<_>>>()
 }

--- a/engine/src/witness/evm/erc20_deposits.rs
+++ b/engine/src/witness/evm/erc20_deposits.rs
@@ -91,7 +91,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 			RuntimeCallHasChain<state_chain_runtime::Runtime, Inner::Chain>,
 	{
 		Ok(self.then(move |epoch, header| {
-			<Inner::Chain as Chain>::assert_block_phase(header.index);
+			assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();

--- a/engine/src/witness/evm/evm_deposits.rs
+++ b/engine/src/witness/evm/evm_deposits.rs
@@ -182,9 +182,7 @@ where
 /// by the Deposit contract upon deployment or after it.
 /// Note that when we have a contract deployed already we substrate the balance at the previous
 /// block, since we will have already witnessed the deposits at the time the deposit was made.
-pub fn eth_ingresses_at_block<
-	Addresses: IntoIterator<Item = (H160, (AddressState, AddressState))>,
->(
+fn eth_ingresses_at_block<Addresses: IntoIterator<Item = (H160, (AddressState, AddressState))>>(
 	addresses: Addresses,
 	native_events: Vec<FetchedNativeFilter>,
 ) -> Result<Vec<(H160, U256)>, anyhow::Error> {

--- a/engine/src/witness/evm/evm_deposits.rs
+++ b/engine/src/witness/evm/evm_deposits.rs
@@ -62,7 +62,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 			RuntimeCallHasChain<state_chain_runtime::Runtime, Inner::Chain>,
 	{
 		self.then(move |epoch, header| {
-			<Inner::Chain as Chain>::assert_block_phase(header.index);
+			assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
 			let eth_rpc = eth_rpc.clone();
 			let process_call = process_call.clone();

--- a/engine/src/witness/evm/key_manager.rs
+++ b/engine/src/witness/evm/key_manager.rs
@@ -77,12 +77,17 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 			RuntimeCallHasChain<state_chain_runtime::Runtime, Inner::Chain>,
 	{
 		self.then::<Result<Bloom>, _, _>(move |epoch, header| {
+			<Inner::Chain as Chain>::assert_block_phase(header.index);
+
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();
 			async move {
-				for event in
-					events_at_block::<KeyManagerEvents, _>(header, contract_address, &eth_rpc)
-						.await?
+				for event in events_at_block::<Inner::Chain, KeyManagerEvents, _>(
+					header,
+					contract_address,
+					&eth_rpc,
+				)
+				.await?
 				{
 					info!("Handling event: {event}");
 					let call: state_chain_runtime::RuntimeCall = match event.event_parameters {
@@ -173,7 +178,7 @@ mod tests {
 
 	use std::{path::PathBuf, str::FromStr};
 
-	use cf_chains::Ethereum;
+	use cf_chains::{Chain, Ethereum};
 	use cf_primitives::AccountRole;
 	use futures_util::FutureExt;
 	use sp_core::{H160, U256};
@@ -206,6 +211,7 @@ mod tests {
 					"eth_rpc",
 					"eth_subscribe",
 					"Ethereum",
+					Ethereum::WITNESS_PERIOD,
 				)
 				.unwrap();
 

--- a/engine/src/witness/evm/key_manager.rs
+++ b/engine/src/witness/evm/key_manager.rs
@@ -77,7 +77,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 			RuntimeCallHasChain<state_chain_runtime::Runtime, Inner::Chain>,
 	{
 		self.then::<Result<Bloom>, _, _>(move |epoch, header| {
-			<Inner::Chain as Chain>::assert_block_phase(header.index);
+			assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();

--- a/engine/src/witness/evm/source.rs
+++ b/engine/src/witness/evm/source.rs
@@ -118,8 +118,6 @@ where
 										};
 										state.evm_header_sequence.clear();
 										return Some((composite_header, state))
-									} else {
-										state.evm_header_sequence.clear();
 									}
 								}
 							}

--- a/engine/src/witness/evm/source.rs
+++ b/engine/src/witness/evm/source.rs
@@ -5,13 +5,17 @@ use futures_util::stream;
 use sp_core::H256;
 
 use crate::{
-	evm::{core_h256, retry_rpc::EvmRetrySubscribeApi, ConscientiousEvmWebsocketBlockHeaderStream},
+	evm::{
+		core_h256,
+		retry_rpc::{EvmRetryRpcApi, EvmRetrySubscribeApi},
+		ConscientiousEvmWebsocketBlockHeaderStream,
+	},
 	witness::common::{
 		chain_source::{BoxChainStream, ChainClient, ChainSource, Header},
 		ExternalChain, ExternalChainSource,
 	},
 };
-use std::time::Duration;
+use std::{collections::VecDeque, time::Duration};
 
 #[derive(Clone)]
 pub struct EvmSource<Client, EvmChain> {
@@ -22,7 +26,10 @@ pub struct EvmSource<Client, EvmChain> {
 impl<C, EvmChain> EvmSource<C, EvmChain>
 where
 	EvmChain: ExternalChain<ChainCrypto = EvmCrypto>,
-	C: EvmRetrySubscribeApi + ChainClient<Index = u64, Hash = H256, Data = Bloom> + Clone,
+	C: EvmRetryRpcApi
+		+ EvmRetrySubscribeApi
+		+ ChainClient<Index = u64, Hash = H256, Data = Bloom>
+		+ Clone,
 {
 	pub fn new(client: C) -> Self {
 		Self { client, _phantom: std::marker::PhantomData }
@@ -38,8 +45,11 @@ const RESTART_STREAM_DELAY: Duration = Duration::from_secs(6);
 #[async_trait::async_trait]
 impl<C, EvmChain> ChainSource for EvmSource<C, EvmChain>
 where
-	EvmChain: ExternalChain<ChainCrypto = EvmCrypto>,
-	C: EvmRetrySubscribeApi + ChainClient<Index = u64, Hash = H256, Data = Bloom> + Clone,
+	EvmChain: ExternalChain<ChainCrypto = EvmCrypto, ChainBlockNumber = u64>,
+	C: EvmRetryRpcApi
+		+ EvmRetrySubscribeApi
+		+ ChainClient<Index = u64, Hash = H256, Data = Bloom>
+		+ Clone,
 {
 	type Index = <C as ChainClient>::Index;
 	type Hash = <C as ChainClient>::Hash;
@@ -52,40 +62,85 @@ where
 		pub struct State<C> {
 			client: C,
 			stream: ConscientiousEvmWebsocketBlockHeaderStream,
+			previous_block_sequence: VecDeque<Header<u64, H256, Bloom>>,
 		}
 
 		let client = self.client.clone();
 		let stream = client.subscribe_blocks().await;
 		(
-			Box::pin(stream::unfold(State { client, stream }, |mut state| async move {
-				loop {
-					while let Ok(Some(header)) =
-						tokio::time::timeout(BLOCK_PULL_TIMEOUT, state.stream.next()).await
-					{
-						if let Ok(header) = header {
-							let (Some(index), Some(hash)) = (header.number, header.hash) else {
-								continue
-							};
+			Box::pin(stream::unfold(
+				State { client, stream, previous_block_sequence: Default::default() },
+				|mut state| async move {
+					loop {
+						while let Ok(Some(header)) =
+							tokio::time::timeout(BLOCK_PULL_TIMEOUT, state.stream.next()).await
+						{
+							if let Ok(header) = header {
+								let (Some(index), Some(hash), parent_hash) = (
+									header.number.map(|number| number.as_u64()),
+									header.hash.map(core_h256),
+									core_h256(header.parent_hash),
+								) else {
+									continue
+								};
 
-							return Some((
-								Header {
-									index: index.as_u64(),
-									hash: core_h256(hash),
-									parent_hash: Some(core_h256(header.parent_hash)),
-									data: header.logs_bloom.0.into(),
-								},
-								state,
-							))
+								let header = Header {
+									index,
+									hash,
+									parent_hash: if index == 0 { None } else { Some(parent_hash) },
+									data: header.logs_bloom,
+								};
+
+								if state.previous_block_sequence.back().map_or(
+									false,
+									|previous_header| {
+										Some(previous_header.hash) != header.parent_hash
+									},
+								) {
+									state.previous_block_sequence.clear();
+								}
+								state.previous_block_sequence.push_back(header);
+								if state.previous_block_sequence.len() >
+									EvmChain::WITNESS_PERIOD as usize
+								{
+									state.previous_block_sequence.pop_front();
+									assert_eq!(
+										state.previous_block_sequence.len(),
+										EvmChain::WITNESS_PERIOD as usize
+									);
+								}
+
+								if state.previous_block_sequence.len() >=
+									EvmChain::WITNESS_PERIOD as usize
+								{
+									if let Some(header) = state
+										.previous_block_sequence
+										.front()
+										.filter(|header| EvmChain::block_phase(header.index) == 0)
+									{
+										return Some((
+											Header {
+												index: header.index,
+												hash: state.previous_block_sequence
+													[EvmChain::WITNESS_PERIOD as usize - 1]
+													.hash,
+												parent_hash: header.parent_hash,
+												data: header.data,
+											},
+											state,
+										))
+									}
+								}
+							}
 						}
-					}
 
-					// We don't want to spam retries if the node returns a stream that's empty
-					// immediately.
-					tokio::time::sleep(RESTART_STREAM_DELAY).await;
-					let stream = state.client.subscribe_blocks().await;
-					state = State { client: state.client, stream };
-				}
-			})),
+						// We don't want to spam retries if the node returns a stream that's empty
+						// immediately.
+						tokio::time::sleep(RESTART_STREAM_DELAY).await;
+						state.stream = state.client.subscribe_blocks().await;
+					}
+				},
+			)),
 			self.client.clone(),
 		)
 	}
@@ -94,7 +149,10 @@ where
 impl<C, EvmChain> ExternalChainSource for EvmSource<C, EvmChain>
 where
 	EvmChain: ExternalChain<ChainBlockNumber = u64, ChainCrypto = EvmCrypto>,
-	C: EvmRetrySubscribeApi + ChainClient<Index = u64, Hash = H256, Data = Bloom> + Clone,
+	C: EvmRetryRpcApi
+		+ EvmRetrySubscribeApi
+		+ ChainClient<Index = u64, Hash = H256, Data = Bloom>
+		+ Clone,
 {
 	type Chain = EvmChain;
 }

--- a/engine/src/witness/evm/source.rs
+++ b/engine/src/witness/evm/source.rs
@@ -17,6 +17,9 @@ use crate::{
 };
 use std::{collections::VecDeque, time::Duration};
 
+/// Note this produces Header's where the hash does not necessarily correspond to real EVM blocks,
+/// if the WITNESS_PERIOD is more than 1. In that case the hash will be the hash of the last block
+/// in the witness range, instead of the hash of the block number equal to the Header's index.
 #[derive(Clone)]
 pub struct EvmSource<Client, EvmChain> {
 	client: Client,
@@ -62,73 +65,61 @@ where
 		pub struct State<C> {
 			client: C,
 			stream: ConscientiousEvmWebsocketBlockHeaderStream,
-			previous_block_sequence: VecDeque<Header<u64, H256, Bloom>>,
+			evm_header_sequence: VecDeque<Header<u64, H256, Bloom>>,
 		}
 
 		let client = self.client.clone();
 		let stream = client.subscribe_blocks().await;
 		(
 			Box::pin(stream::unfold(
-				State { client, stream, previous_block_sequence: Default::default() },
+				State { client, stream, evm_header_sequence: Default::default() },
 				|mut state| async move {
 					loop {
-						while let Ok(Some(header)) =
+						while let Ok(Some(result_raw_evm_header)) =
 							tokio::time::timeout(BLOCK_PULL_TIMEOUT, state.stream.next()).await
 						{
-							if let Ok(header) = header {
-								let (Some(index), Some(hash), parent_hash) = (
-									header.number.map(|number| number.as_u64()),
-									header.hash.map(core_h256),
-									core_h256(header.parent_hash),
-								) else {
-									continue
-								};
-
-								let header = Header {
-									index,
-									hash,
-									parent_hash: if index == 0 { None } else { Some(parent_hash) },
-									data: header.logs_bloom,
-								};
-
-								if state.previous_block_sequence.back().map_or(
+							if let Some(evm_header) =
+								result_raw_evm_header.ok().and_then(|raw_evm_header| {
+									let index =
+										raw_evm_header.number.map(|number| number.as_u64())?;
+									Some(Header {
+										index,
+										hash: raw_evm_header.hash.map(core_h256)?,
+										parent_hash: if index == 0 {
+											None
+										} else {
+											Some(core_h256(raw_evm_header.parent_hash))
+										},
+										data: raw_evm_header.logs_bloom,
+									})
+								}) {
+								if state.evm_header_sequence.back().map_or(
 									false,
-									|previous_header| {
-										Some(previous_header.hash) != header.parent_hash
+									|previous_evm_header| {
+										Some(previous_evm_header.hash) != evm_header.parent_hash
 									},
 								) {
-									state.previous_block_sequence.clear();
+									state.evm_header_sequence.clear();
 								}
-								state.previous_block_sequence.push_back(header);
-								if state.previous_block_sequence.len() >
-									EvmChain::WITNESS_PERIOD as usize
-								{
-									state.previous_block_sequence.pop_front();
-									assert_eq!(
-										state.previous_block_sequence.len(),
-										EvmChain::WITNESS_PERIOD as usize
-									);
-								}
+								state.evm_header_sequence.push_back(evm_header);
 
-								if state.previous_block_sequence.len() >=
-									EvmChain::WITNESS_PERIOD as usize
-								{
-									if let Some(header) = state
-										.previous_block_sequence
-										.front()
-										.filter(|header| EvmChain::block_phase(header.index) == 0)
-									{
-										return Some((
-											Header {
-												index: header.index,
-												hash: state.previous_block_sequence
-													[EvmChain::WITNESS_PERIOD as usize - 1]
-													.hash,
-												parent_hash: header.parent_hash,
-												data: header.data,
-											},
-											state,
-										))
+								let witness_range = EvmChain::block_witness_range(evm_header.index);
+
+								if *witness_range.end() == evm_header.index {
+									if let Some(first_evm_header_in_range) =
+										state.evm_header_sequence.iter().find(|evm_header| {
+											evm_header.index == *witness_range.start()
+										}) {
+										let composite_header = Header {
+											index: EvmChain::block_witness_root(evm_header.index),
+											hash: evm_header.hash,
+											parent_hash: first_evm_header_in_range.parent_hash,
+											data: evm_header.data,
+										};
+										state.evm_header_sequence.clear();
+										return Some((composite_header, state))
+									} else {
+										state.evm_header_sequence.clear();
 									}
 								}
 							}

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -228,7 +228,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 		ProcessingFut: Future<Output = ()> + Send + 'static,
 	{
 		self.then::<Result<Bloom>, _, _>(move |epoch, header| {
-			<Inner::Chain as Chain>::assert_block_phase(header.index);
+			assert!(<Inner::Chain as Chain>::is_block_witness_root(header.index));
 
 			let process_call = process_call.clone();
 			let eth_rpc = eth_rpc.clone();

--- a/state-chain/chains/src/any.rs
+++ b/state-chain/chains/src/any.rs
@@ -12,6 +12,7 @@ use cf_primitives::{
 impl Chain for AnyChain {
 	const NAME: &'static str = "AnyChain";
 	const GAS_ASSET: Self::ChainAsset = assets::any::Asset::Usdc;
+	const WITNESS_PERIOD: u64 = 1;
 
 	type ChainCrypto = NoneChainCrypto;
 	type ChainBlockNumber = u64;

--- a/state-chain/chains/src/arb.rs
+++ b/state-chain/chains/src/arb.rs
@@ -28,6 +28,7 @@ pub const CHAIN_ID_ARBITRUM_SEPOLIA: u64 = 421614;
 impl Chain for Arbitrum {
 	const NAME: &'static str = "Arbitrum";
 	const GAS_ASSET: Self::ChainAsset = assets::arb::Asset::ArbEth;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 24;
 
 	type ChainCrypto = EvmCrypto;
 	type ChainBlockNumber = u64;

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -226,6 +226,7 @@ pub struct EpochStartData {
 impl Chain for Bitcoin {
 	const NAME: &'static str = "Bitcoin";
 	const GAS_ASSET: Self::ChainAsset = assets::btc::Asset::Btc;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
 
 	type ChainCrypto = BitcoinCrypto;
 	type ChainBlockNumber = BlockNumber;

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -325,6 +325,7 @@ pub struct PolkadotTransactionId {
 impl Chain for Polkadot {
 	const NAME: &'static str = "Polkadot";
 	const GAS_ASSET: Self::ChainAsset = assets::dot::Asset::Dot;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
 
 	type ChainCrypto = PolkadotCrypto;
 	type ChainBlockNumber = PolkadotBlockNumber;

--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -33,6 +33,7 @@ pub const CHAIN_ID_KOVAN: u64 = 42;
 impl Chain for Ethereum {
 	const NAME: &'static str = "Ethereum";
 	const GAS_ASSET: Self::ChainAsset = assets::eth::Asset::Eth;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
 
 	type ChainCrypto = evm::EvmCrypto;
 	type ChainBlockNumber = u64;

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -61,6 +61,8 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 
 	const GAS_ASSET: Self::ChainAsset;
 
+	const WITNESS_PERIOD: Self::ChainBlockNumber;
+
 	type ChainCrypto: ChainCrypto;
 
 	type ChainBlockNumber: FullCodec

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -64,6 +64,17 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 		block_number % Self::WITNESS_PERIOD
 	}
 
+	fn assert_block_phase(block_number: Self::ChainBlockNumber) {
+		assert_eq!(Self::block_phase(block_number), Default::default());
+	}
+
+	fn block_period(
+		block_number: Self::ChainBlockNumber,
+	) -> core::ops::Range<Self::ChainBlockNumber> {
+		Self::assert_block_phase(block_number);
+		block_number..block_number + Self::WITNESS_PERIOD
+	}
+
 	type ChainCrypto: ChainCrypto;
 
 	type ChainBlockNumber: FullCodec

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -13,10 +13,7 @@ use cf_primitives::{AssetAmount, BroadcastId, ChannelId, EthAmount, TransactionH
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::{MaybeSerializeDeserialize, Member, RuntimeDebug},
-	sp_runtime::{
-		traits::{AtLeast32BitUnsigned, CheckedSub},
-		BoundedVec, DispatchError,
-	},
+	sp_runtime::{traits::AtLeast32BitUnsigned, BoundedVec, DispatchError},
 	Blake2_256, CloneNoBound, DebugNoBound, EqNoBound, Parameter, PartialEqNoBound, StorageHasher,
 };
 use instances::{ChainCryptoInstanceAlias, ChainInstanceAlias};
@@ -63,6 +60,10 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 
 	const WITNESS_PERIOD: Self::ChainBlockNumber;
 
+	fn block_phase(block_number: Self::ChainBlockNumber) -> Self::ChainBlockNumber {
+		block_number % Self::WITNESS_PERIOD
+	}
+
 	type ChainCrypto: ChainCrypto;
 
 	type ChainBlockNumber: FullCodec
@@ -74,11 +75,9 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 		+ AtLeast32BitUnsigned
 		// this is used primarily for tests. We use u32 because it's the smallest block number we
 		// use (and so we can always .into() into a larger type)
-		+ From<u32>
 		+ Into<u64>
 		+ MaxEncodedLen
 		+ Display
-		+ CheckedSub
 		+ Unpin
 		+ Step
 		+ BenchmarkValue;

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -92,6 +92,7 @@ impl IntoForeignChainAddress<MockEthereum> for u64 {
 impl Chain for MockEthereum {
 	const NAME: &'static str = "MockEthereum";
 	const GAS_ASSET: Self::ChainAsset = assets::eth::Asset::Eth;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
 
 	type ChainCrypto = MockEthereumChainCrypto;
 

--- a/state-chain/chains/src/none.rs
+++ b/state-chain/chains/src/none.rs
@@ -9,6 +9,7 @@ pub enum NoneChain {}
 impl Chain for NoneChain {
 	const NAME: &'static str = "NONE";
 	const GAS_ASSET: Self::ChainAsset = assets::any::Asset::Usdc;
+	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
 	type ChainCrypto = NoneChainCrypto;
 	type ChainBlockNumber = u64;
 	type ChainAmount = u64;

--- a/state-chain/pallets/cf-chain-tracking/src/lib.rs
+++ b/state-chain/pallets/cf-chain-tracking/src/lib.rs
@@ -94,8 +94,9 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> BuildGenesisConfig for GenesisConfig<T, I> {
 		fn build(&self) {
 			CurrentChainState::<T, I>::put(ChainState {
-				block_height: self.init_chain_state.block_height -
-					<T::TargetChain as Chain>::block_phase(self.init_chain_state.block_height),
+				block_height: <T::TargetChain as Chain>::block_witness_root(
+					self.init_chain_state.block_height,
+				),
 				tracked_data: self.init_chain_state.tracked_data.clone(),
 			});
 		}
@@ -132,8 +133,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			T::EnsureWitnessed::ensure_origin(origin)?;
 			ensure!(
-				<T::TargetChain as Chain>::block_phase(new_chain_state.block_height) ==
-					Default::default(),
+				<T::TargetChain as Chain>::is_block_witness_root(new_chain_state.block_height),
 				Error::<T, I>::InvalidBlockHeight
 			);
 			CurrentChainState::<T, I>::try_mutate::<_, Error<T, I>, _>(|previous_chain_state| {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1767,7 +1767,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let recycle_height = <T::TargetChain as Chain>::saturating_block_witness_next(
 			expiry_height.saturating_add(lifetime),
 		);
-		debug_assert_ne!(expiry_height, recycle_height);
+
+		debug_assert!(current_height < expiry_height);
+		debug_assert!(expiry_height < recycle_height);
 
 		(current_height, expiry_height, recycle_height)
 	}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1757,7 +1757,21 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> (TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>)
 	{
 		let current_height = T::ChainTracking::get_block_height();
-		let lifetime = DepositChannelLifetime::<T, I>::get();
+		debug_assert_eq!(
+			<T::TargetChain as Chain>::block_phase(current_height),
+			Default::default()
+		);
+
+		let lifetime = {
+			let lifetime = DepositChannelLifetime::<T, I>::get();
+			let phase = <T::TargetChain as Chain>::block_phase(lifetime);
+			if phase == Default::default() {
+				lifetime
+			} else {
+				lifetime + <T::TargetChain as Chain>::WITNESS_PERIOD - phase
+			}
+		};
+
 		let expiry_height = current_height + lifetime;
 		let recycle_height = expiry_height + lifetime;
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1761,10 +1761,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		let lifetime = DepositChannelLifetime::<T, I>::get();
 
-		let expiry_height =
-			<T::TargetChain as Chain>::block_witness_root(current_height.saturating_add(lifetime));
-		let recycle_height =
-			<T::TargetChain as Chain>::block_witness_root(expiry_height.saturating_add(lifetime));
+		let expiry_height = <T::TargetChain as Chain>::saturating_block_witness_next(
+			current_height.saturating_add(lifetime),
+		);
+		let recycle_height = <T::TargetChain as Chain>::saturating_block_witness_next(
+			expiry_height.saturating_add(lifetime),
+		);
+		debug_assert_ne!(expiry_height, recycle_height);
 
 		(current_height, expiry_height, recycle_height)
 	}

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -9,11 +9,7 @@ use cf_traits::{
 	AsyncResult, Broadcaster, CfeMultisigRequest, Chainflip, CurrentEpochIndex, GetBlockHeight,
 	SafeMode, SetSafeMode, VaultKeyWitnessedHandler,
 };
-use frame_support::{
-	pallet_prelude::*,
-	sp_runtime::traits::{One, Saturating},
-	traits::StorageVersion,
-};
+use frame_support::{pallet_prelude::*, sp_runtime::traits::CheckedAdd, traits::StorageVersion};
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use sp_std::prelude::*;
@@ -217,7 +213,7 @@ pub mod pallet {
 			if let Some(deployment_block) = self.deployment_block {
 				VaultStartBlockNumbers::<T, I>::insert(
 					cf_primitives::GENESIS_EPOCH,
-					deployment_block,
+					deployment_block - <T::Chain as Chain>::block_phase(deployment_block),
 				);
 			} else {
 				log::info!("No genesis vault key configured for {}.", Pallet::<T, I>::name());
@@ -230,10 +226,17 @@ pub mod pallet {
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn activate_new_key_for_chain(block_number: ChainBlockNumberFor<T, I>) {
 		PendingVaultActivation::<T, I>::put(VaultActivationStatus::<T, I>::Complete);
-		VaultStartBlockNumbers::<T, I>::insert(
-			CurrentEpochIndex::<T>::get().saturating_add(1),
-			block_number.saturating_add(One::one()),
-		);
+		VaultStartBlockNumbers::<T, I>::insert(CurrentEpochIndex::<T>::get().saturating_add(1), {
+			let rounded_block_number =
+				block_number - <T::Chain as Chain>::block_phase(block_number);
+			if let Some(next_block_number) =
+				rounded_block_number.checked_add(&<T::Chain as Chain>::WITNESS_PERIOD)
+			{
+				next_block_number
+			} else {
+				rounded_block_number
+			}
+		});
 		Self::deposit_event(Event::VaultActivationCompleted);
 	}
 }

--- a/utilities/src/with_std/rle_bitmap.rs
+++ b/utilities/src/with_std/rle_bitmap.rs
@@ -126,6 +126,10 @@ impl<T: Ord + Copy + Step + Bounded> RleBitmap<T> {
 			.take_while(move |t| if let Some(end) = option_end { *t < end } else { true })
 		})
 	}
+
+	pub fn is_empty(&self) -> bool {
+		self.iter(true).next().is_none()
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Grouping Arbitrum blocks into sets of 24 blocks. Inside the exist architecture the 24 blocks are treated as a single block, with the index of the first in the range, the hash of the last, and the parent_hash of the directly previous block.

There is an issue with bouncer due to recently added call to "setAggKeyWithGovKey", I believe it is just a timing issue, and requires a longer wait after the contract call. Resolved here: https://github.com/chainflip-io/chainflip-backend/pull/4813