### PR TITLE
feat: better diagnostics for bouncer swaps

### DIFF
--- a/bouncer/commands/go_bananas.ts
+++ b/bouncer/commands/go_bananas.ts
@@ -250,7 +250,7 @@ async function playSwapper() {
     const dest = assets
       .filter((x) => x !== src)
       .at(Math.floor(Math.random() * (assets.length - 1)))!;
-    testSwap(src, dest, undefined, undefined, undefined, swapAmount.get(src));
+    testSwap(src, dest, undefined, undefined, undefined, undefined, swapAmount.get(src));
     await sleep(5000);
   }
 }

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -111,7 +111,7 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
       depositAddress,
       channelId,
     },
-    undefined,
+    `${asset}->${swapAsset} BrokerFee`,
     undefined,
     undefined,
     rawDepositForSwapAmount,

--- a/bouncer/shared/evm_deposits.ts
+++ b/bouncer/shared/evm_deposits.ts
@@ -31,6 +31,7 @@ async function testSuccessiveDepositEvm(sourceAsset: Asset, destAsset: Asset) {
     destAsset,
     undefined,
     undefined,
+    undefined,
     ' EvmDepositTestFirstDeposit',
   );
 
@@ -46,6 +47,7 @@ async function testNoDuplicateWitnessing(sourceAsset: Asset, destAsset: Asset) {
   const swapParams = await testSwap(
     sourceAsset,
     destAsset,
+    undefined,
     undefined,
     undefined,
     ' NoDuplicateWitnessingTest',

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -14,6 +14,7 @@ import {
   observeBroadcastSuccess,
 } from '../shared/utils';
 import { CcmDepositMetadata } from '../shared/new_swap';
+import { SwapContext, SwapStatus } from './swapping';
 
 function encodeDestinationAddress(address: string, destAsset: Asset): string {
   let destAddress = address;
@@ -107,6 +108,7 @@ export async function doPerformSwap(
   senderType = SenderType.Address,
   amount?: string,
   log = true,
+  swapContext?: SwapContext,
 ) {
   const oldBalance = await getBalance(destAsset, destAddress);
 
@@ -124,6 +126,8 @@ export async function doPerformSwap(
 
   if (log) console.log(`${tag} Funded the address`);
 
+  swapContext?.updateStatus(tag, SwapStatus.Funded);
+
   await swapScheduledHandle;
 
   if (log) console.log(`${tag} Waiting for balance to update`);
@@ -135,7 +139,9 @@ export async function doPerformSwap(
     ]);
 
     if (log) console.log(`${tag} Swap success! New balance: ${newBalance}!`);
+    swapContext?.updateStatus(tag, SwapStatus.Success);
   } catch (err) {
+    swapContext?.updateStatus(tag, SwapStatus.Failure);
     throw new Error(`${tag} ${err}`);
   }
 }
@@ -150,6 +156,7 @@ export async function performSwap(
   amount?: string,
   brokerCommissionBps?: number,
   log = true,
+  swapContext?: SwapContext,
 ) {
   const tag = swapTag ?? '';
 
@@ -173,7 +180,8 @@ export async function performSwap(
     brokerCommissionBps,
     log,
   );
-  await doPerformSwap(swapParams, tag, messageMetadata, senderType, amount, log);
+
+  await doPerformSwap(swapParams, tag, messageMetadata, senderType, amount, log, swapContext);
 
   return swapParams;
 }

--- a/bouncer/shared/polkadot_runtime_update.ts
+++ b/bouncer/shared/polkadot_runtime_update.ts
@@ -206,7 +206,16 @@ async function randomPolkadotSwap(): Promise<void> {
     destAsset = Assets.Dot;
   }
 
-  await testSwap(sourceAsset, destAsset, undefined, undefined, undefined, undefined, false);
+  await testSwap(
+    sourceAsset,
+    destAsset,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    false,
+  );
   swapsComplete++;
   console.log(`Swap complete: (${swapsComplete}/${swapsStarted})`);
 }

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -1,6 +1,7 @@
 import { randomAsHex, randomAsNumber } from '@polkadot/util-crypto';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 import Web3 from 'web3';
+import assert from 'assert';
 import { performSwap, SwapParams } from '../shared/perform_swap';
 import {
   newAddress,
@@ -20,6 +21,13 @@ enum SolidityType {
   String = 'string',
   Bytes = 'bytes',
   Address = 'address',
+}
+
+export enum SwapStatus {
+  Initiated,
+  Funded,
+  Success,
+  Failure,
 }
 
 let swapCount = 1;
@@ -121,6 +129,7 @@ export async function testSwap(
   destAsset: Asset,
   addressType?: BtcAddressType,
   messageMetadata?: CcmDepositMetadata,
+  swapContext?: SwapContext,
   tagSuffix?: string,
   amount?: string,
   log = true,
@@ -133,6 +142,9 @@ export async function testSwap(
     tagSuffix,
     log,
   );
+
+  swapContext?.updateStatus(tag, SwapStatus.Initiated);
+
   return performSwap(
     sourceAsset,
     destAsset,
@@ -143,6 +155,7 @@ export async function testSwap(
     amount,
     undefined,
     log,
+    swapContext,
   );
 }
 export async function testSwapViaContract(
@@ -150,6 +163,7 @@ export async function testSwapViaContract(
   destAsset: Asset,
   addressType?: BtcAddressType,
   messageMetadata?: CcmDepositMetadata,
+  swapContext?: SwapContext,
   tagSuffix?: string,
 ) {
   const { destAddress, tag } = await prepareSwap(
@@ -159,10 +173,62 @@ export async function testSwapViaContract(
     messageMetadata,
     (tagSuffix ?? '') + ' Contract',
   );
+
+  swapContext?.updateStatus(tag, SwapStatus.Initiated);
   return performSwapViaContract(sourceAsset, destAsset, destAddress, tag, messageMetadata);
 }
 
-export async function testAllSwaps() {
+export class SwapContext {
+  allSwaps: Map<string, SwapStatus>;
+
+  constructor() {
+    this.allSwaps = new Map();
+  }
+
+  updateStatus(tag: string, status: SwapStatus) {
+    const currentStatus = this.allSwaps.get(tag);
+
+    // Sanity checks:
+    switch (status) {
+      case SwapStatus.Initiated: {
+        assert(currentStatus === undefined, `Unexpected status transition for ${tag}`);
+        break;
+      }
+      case SwapStatus.Funded: {
+        assert(currentStatus === SwapStatus.Initiated, `Unexpected status transition for ${tag}`);
+        break;
+      }
+      case SwapStatus.Success: {
+        assert(currentStatus === SwapStatus.Funded, `Unexpected status transition for ${tag}`);
+        break;
+      }
+      default:
+        // nothing to do
+        break;
+    }
+
+    this.allSwaps.set(tag, status);
+  }
+
+  print_report() {
+    const unsuccessfulSwapsEntries: string[] = [];
+    this.allSwaps.forEach((status, tag) => {
+      if (status !== SwapStatus.Success) {
+        unsuccessfulSwapsEntries.push(`${tag}: ${SwapStatus[status]}`);
+      }
+    });
+
+    if (unsuccessfulSwapsEntries.length === 0) {
+      console.log('All swaps are successful!');
+    } else {
+      let report = `Unsuccessful swaps:\n`;
+      report += unsuccessfulSwapsEntries.join('\n');
+      console.error(report);
+    }
+  }
+}
+
+export async function testAllSwaps(swapContext: SwapContext) {
   const allSwaps: Promise<SwapParams | ContractSwapParams>[] = [];
 
   function appendSwap(
@@ -173,10 +239,12 @@ export async function testAllSwaps() {
   ) {
     if (destAsset === 'Btc') {
       Object.values(btcAddressTypes).forEach((btcAddrType) => {
-        allSwaps.push(functionCall(sourceAsset, destAsset, btcAddrType, messageMetadata));
+        allSwaps.push(
+          functionCall(sourceAsset, destAsset, btcAddrType, messageMetadata, swapContext),
+        );
       });
     } else {
-      allSwaps.push(functionCall(sourceAsset, destAsset, undefined, messageMetadata));
+      allSwaps.push(functionCall(sourceAsset, destAsset, undefined, messageMetadata, swapContext));
     }
   }
 

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S pnpm tsx
-import { testAllSwaps } from '../shared/swapping';
+import { SwapContext, testAllSwaps } from '../shared/swapping';
 import { testEvmDeposits } from '../shared/evm_deposits';
 import { runWithTimeout, observeBadEvents } from '../shared/utils';
 import { testFundRedeem } from '../shared/fund_redeem';
@@ -8,6 +8,8 @@ import { testLpApi } from '../shared/lp_api_test';
 import { swapLessThanED } from '../shared/swap_less_than_existential_deposit_dot';
 import { testPolkadotRuntimeUpdate } from '../shared/polkadot_runtime_update';
 import { testBrokerFeeCollection } from '../shared/broker_fee_collection';
+
+const swapContext = new SwapContext();
 
 async function runAllConcurrentTests() {
   // Specify the number of nodes via providing an argument to this script.
@@ -23,7 +25,7 @@ async function runAllConcurrentTests() {
   // Tests that work with any number of nodes
   const tests = [
     swapLessThanED(),
-    testAllSwaps(),
+    testAllSwaps(swapContext),
     testEvmDeposits(),
     testFundRedeem('redeem'),
     testMultipleMembersGovernance(),
@@ -52,6 +54,7 @@ runWithTimeout(runAllConcurrentTests(), 2000000)
   })
   .catch((error) => {
     console.error!('All concurrent tests timed out. Exiting.');
+    swapContext.print_report();
     console.error(error);
     process.exit(-1);
   });

--- a/bouncer/tests/swapping.ts
+++ b/bouncer/tests/swapping.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env -S pnpm tsx
-import { testAllSwaps } from '../shared/swapping';
+import { SwapContext, testAllSwaps } from '../shared/swapping';
 import { runWithTimeout } from '../shared/utils';
 
+const swapContext = new SwapContext();
+
 async function main(): Promise<void> {
-  await testAllSwaps();
+  await testAllSwaps(swapContext);
+  swapContext.print_report();
   process.exit(0);
 }
 
@@ -14,5 +17,6 @@ runWithTimeout(main(), 1800000)
   })
   .catch((error) => {
     console.error(error);
+    swapContext.print_report();
     process.exit(-1);
   });


### PR DESCRIPTION
# Pull Request

In support of PRO-1342

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

I found it quite tedious finding out which swaps didn't finish from what's currently avalable in the logs.

Now record and update their status in a `SwapContext` object, which is shared between all concurrent swaps. When the test times out, we now print a report containing the unsuccessful swaps along with their status (the stage at which they got stuck).  
