### PR TITLE
fix: don't set code red on "agg-key set by gov-key"

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -169,8 +169,6 @@ pub mod pallet {
 
 			Self::activate_new_key_for_chain(block_number);
 
-			T::SafeMode::set_code_red();
-
 			Pallet::<T, I>::deposit_event(Event::VaultRotatedExternally(new_public_key));
 
 			Ok(().into())

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -4,11 +4,8 @@ use crate::{mock::*, PendingVaultActivation, VaultActivationStatus, VaultStartBl
 use cf_chains::mocks::{MockAggKey, MockEthereum};
 use cf_test_utilities::last_event;
 use cf_traits::{
-	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo, SafeMode,
-	VaultActivator,
+	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo, VaultActivator,
 };
-use frame_support::assert_ok;
-use sp_core::Get;
 
 pub const NEW_AGG_PUBKEY: MockAggKey = MockAggKey(*b"newk");
 
@@ -21,22 +18,6 @@ macro_rules! assert_last_event {
 			event
 		);
 	};
-}
-
-#[test]
-fn test_vault_key_rotated_externally_triggers_code_red() {
-	new_test_ext().execute_with(|| {
-		const TX_HASH: [u8; 4] = [0xab; 4];
-		assert_eq!(<MockRuntimeSafeMode as Get<MockRuntimeSafeMode>>::get(), SafeMode::CODE_GREEN);
-		assert_ok!(VaultsPallet::vault_key_rotated_externally(
-			RuntimeOrigin::root(),
-			NEW_AGG_PUBKEY,
-			1,
-			TX_HASH,
-		));
-		assert_eq!(<MockRuntimeSafeMode as Get<MockRuntimeSafeMode>>::get(), SafeMode::CODE_RED);
-		assert_last_event!(crate::Event::VaultRotatedExternally(..));
-	});
 }
 
 #[test]


### PR DESCRIPTION
As discussed with Dan, we don't want to enable safe mode, when the agg-key is set by governance, as this is a normal situation (on new external chain contract deployment) and governance can independently set safe mode if required.

This also solves a problem were bouncer was intermittently failing, due to code red being set, on initializing Arbitrum. 