### PR TITLE
feat: store boost fees explicitly + rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -339,21 +339,19 @@ mod boost_pool_rpc {
 		pending_withdrawals: Vec<PendingWithdrawal>,
 	}
 
-	fn map_to_vec(map: BTreeMap<AccountId32, AssetAmount>) -> Vec<AccountAndAmount> {
-		map.into_iter()
-			.map(|(account_id, amount)| AccountAndAmount {
-				account_id,
-				amount: NumberOrHex::from(amount),
-			})
-			.collect()
-	}
-
 	impl BoostPoolDetailsRpc {
 		pub fn new(asset: Asset, fee_tier: u16, details: BoostPoolDetails) -> Self {
 			BoostPoolDetailsRpc {
 				asset,
 				fee_tier,
-				available_amounts: map_to_vec(details.available_amounts),
+				available_amounts: details
+					.available_amounts
+					.into_iter()
+					.map(|(account_id, amount)| AccountAndAmount {
+						account_id,
+						amount: NumberOrHex::from(amount),
+					})
+					.collect(),
 				deposits_pending_finalization: details
 					.pending_boosts
 					.into_iter()

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -314,7 +314,7 @@ mod boost_pool_rpc {
 	#[derive(Serialize, Deserialize)]
 	struct AccountAndAmount {
 		account_id: AccountId32,
-		amount: NumberOrHex,
+		amount: U256,
 	}
 
 	#[derive(Serialize, Deserialize)]
@@ -349,7 +349,7 @@ mod boost_pool_rpc {
 					.into_iter()
 					.map(|(account_id, amount)| AccountAndAmount {
 						account_id,
-						amount: NumberOrHex::from(amount),
+						amount: U256::from(amount),
 					})
 					.collect(),
 				deposits_pending_finalization: details
@@ -361,7 +361,7 @@ mod boost_pool_rpc {
 							.into_iter()
 							.map(|(account_id, amount)| AccountAndAmount {
 								account_id,
-								amount: NumberOrHex::from(amount.total),
+								amount: U256::from(amount.total),
 							})
 							.collect(),
 					})
@@ -406,7 +406,7 @@ mod boost_pool_rpc {
 							.into_iter()
 							.map(|(account_id, amount)| AccountAndAmount {
 								account_id,
-								amount: NumberOrHex::from(amount.fee),
+								amount: U256::from(amount.fee),
 							})
 							.collect(),
 					})

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -682,10 +682,17 @@ pub trait CustomApi {
 	) -> RpcResult<Vec<sp_core::Bytes>>;
 
 	#[method(name = "boost_pools_depth")]
-	fn cf_boost_pools_depth(&self) -> RpcResult<BoostPoolDepthResponse>;
+	fn cf_boost_pools_depth(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<BoostPoolDepthResponse>;
 
 	#[method(name = "boost_pool_details")]
-	fn cf_boost_pool_details(&self, asset: Option<Asset>) -> RpcResult<BoostPoolDetailsResponse>;
+	fn cf_boost_pool_details(
+		&self,
+		asset: Option<Asset>,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<BoostPoolDetailsResponse>;
 
 	#[method(name = "boost_pool_pending_fees")]
 	fn cf_boost_pool_pending_fees(
@@ -1100,10 +1107,13 @@ where
 			.and_then(|result| result.map_err(map_dispatch_error))
 	}
 
-	fn cf_boost_pools_depth(&self) -> RpcResult<Vec<BoostPoolDepth>> {
+	fn cf_boost_pools_depth(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<Vec<BoostPoolDepth>> {
 		self.client
 			.runtime_api()
-			.cf_boost_pools_depth(self.client.info().best_hash)
+			.cf_boost_pools_depth(self.unwrap_or_best(at))
 			.map_err(to_rpc_error)
 	}
 
@@ -1512,11 +1522,15 @@ where
 			.collect::<Vec<_>>())
 	}
 
-	fn cf_boost_pool_details(&self, asset: Option<Asset>) -> RpcResult<BoostPoolDetailsResponse> {
+	fn cf_boost_pool_details(
+		&self,
+		asset: Option<Asset>,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<BoostPoolDetailsResponse> {
 		execute_for_all_or_one_asset(asset, |asset| {
 			self.client
 				.runtime_api()
-				.cf_boost_pool_details(self.client.info().best_hash, asset)
+				.cf_boost_pool_details(self.unwrap_or_best(at), asset)
 				.map(|details_for_each_pool| {
 					details_for_each_pool
 						.into_iter()

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_fees_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_fees_serialization.snap
@@ -1,0 +1,35 @@
+---
+source: state-chain/custom-rpc/src/lib.rs
+expression: val
+---
+[
+  {
+    "fee_tier": 10,
+    "chain": "Bitcoin",
+    "asset": "BTC",
+    "pending_fees": [
+      {
+        "deposit_id": 0,
+        "fees": [
+          {
+            "account_id": "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",
+            "amount": "0xa"
+          },
+          {
+            "account_id": "5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt",
+            "amount": "0x64"
+          }
+        ]
+      },
+      {
+        "deposit_id": 1,
+        "fees": [
+          {
+            "account_id": "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",
+            "amount": "0x32"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -76,6 +76,14 @@ impl<C: Chain> ScaledAmount<C> {
 	}
 }
 
+type OwedAmountScaled<C> = OwedAmount<ScaledAmount<C>>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+pub struct OwedAmount<AmountT> {
+	pub total: AmountT,
+	pub fee: AmountT,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct BoostPool<AccountId, C: Chain> {
 	// Fee charged by the pool
@@ -85,7 +93,7 @@ pub struct BoostPool<AccountId, C: Chain> {
 	// Mapping from booster to the available amount they own in `available_amount`
 	amounts: BTreeMap<AccountId, ScaledAmount<C>>,
 	// Boosted deposits awaiting finalisation and how much of them is owed to which booster
-	pending_boosts: BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId, ScaledAmount<C>>>,
+	pending_boosts: BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId, OwedAmountScaled<C>>>,
 	// Stores boosters who have indicated that they want to stop boosting along with
 	// the pending deposits that they have to wait to be finalised
 	pending_withdrawals: BTreeMap<AccountId, BTreeSet<PrewitnessedDepositId>>,
@@ -144,7 +152,7 @@ where
 
 	pub fn get_pending_boosts(
 		&self,
-	) -> BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId, C::ChainAmount>> {
+	) -> BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId, OwedAmount<C::ChainAmount>>> {
 		self.pending_boosts
 			.iter()
 			.map(|(deposit_id, owed_amounts_map)| {
@@ -152,8 +160,14 @@ where
 					*deposit_id,
 					owed_amounts_map
 						.iter()
-						.map(|(account_id, scaled_amount)| {
-							(account_id.clone(), scaled_amount.into_chain_amount())
+						.map(|(account_id, owed_amount)| {
+							(
+								account_id.clone(),
+								OwedAmount {
+									total: owed_amount.total.into_chain_amount(),
+									fee: owed_amount.fee.into_chain_amount(),
+								},
+							)
 						})
 						.collect(),
 				)
@@ -237,7 +251,7 @@ where
 
 				// Same as above, but also includes fees (note, however, that we round down
 				// to ensure that we don't distribute more than we have)
-				let booster_to_receive = multiply_by_rational_with_rounding(
+				let booster_to_receive: ScaledAmount<C> = multiply_by_rational_with_rounding(
 					amount_to_receive.into(),
 					(*amount).into(),
 					current_total_available_amount.into(),
@@ -248,13 +262,18 @@ where
 				.unwrap_or_default()
 				.into();
 
+				let booster_fee = booster_to_receive.saturating_sub(booster_contribution);
+
 				// Amount should always be large enough at this point, but saturating to be safe:
 				amount.saturating_reduce(booster_contribution);
 
 				total_contributed.saturating_accrue(booster_contribution);
 				to_receive_recorded.saturating_accrue(booster_to_receive);
 
-				(booster_id.clone(), booster_to_receive)
+				(
+					booster_id.clone(),
+					OwedAmountScaled { total: booster_to_receive, fee: booster_fee },
+				)
 			})
 			.collect();
 
@@ -273,7 +292,7 @@ where
 			amount.saturating_accrue(excess_contributed);
 
 			if let Some(amount) = boosters_to_receive.get_mut(lucky_id) {
-				amount.saturating_accrue(remaining_to_receive)
+				amount.total.saturating_accrue(remaining_to_receive)
 			}
 		}
 
@@ -309,9 +328,9 @@ where
 					self.pending_withdrawals.remove(&booster_id);
 				}
 
-				unlocked_funds.push((booster_id, amount.into_chain_amount()));
+				unlocked_funds.push((booster_id, amount.total.into_chain_amount()));
 			} else {
-				self.add_funds_inner(booster_id, amount);
+				self.add_funds_inner(booster_id, amount.total);
 			}
 		}
 

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -292,7 +292,8 @@ where
 			amount.saturating_accrue(excess_contributed);
 
 			if let Some(amount) = boosters_to_receive.get_mut(lucky_id) {
-				amount.total.saturating_accrue(remaining_to_receive)
+				amount.total.saturating_accrue(remaining_to_receive);
+				amount.fee.saturating_accrue(remaining_to_receive);
 			}
 		}
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -18,6 +18,7 @@ pub mod weights;
 mod boost_pool;
 
 use boost_pool::BoostPool;
+pub use boost_pool::OwedAmount;
 
 use frame_support::{pallet_prelude::OptionQuery, transactional};
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -39,7 +39,7 @@ use core::ops::Range;
 use frame_support::instances::*;
 pub use frame_system::Call as SystemCall;
 use pallet_cf_governance::GovCallHash;
-use pallet_cf_ingress_egress::{ChannelAction, DepositWitness, TargetChainAsset};
+use pallet_cf_ingress_egress::{ChannelAction, DepositWitness, OwedAmount, TargetChainAsset};
 use pallet_cf_pools::{
 	AskBidMap, AssetPair, PoolLiquidity, PoolOrderbook, PoolPriceV1, PoolPriceV2,
 	UnidirectionalPoolDepth,
@@ -1661,7 +1661,7 @@ impl_runtime_apis! {
 							pending_boosts: pool.get_pending_boosts().into_iter().map(|(deposit_id, owed_amounts)| {
 								(
 									deposit_id,
-									owed_amounts.into_iter().map(|(id, amount)| (id, amount.into())).collect()
+									owed_amounts.into_iter().map(|(id, amount)| (id, OwedAmount {total: amount.total.into(), fee: amount.fee.into()})).collect()
 								)
 							}).collect(),
 							pending_withdrawals: pool.get_pending_withdrawals().clone(),

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -15,6 +15,7 @@ use core::ops::Range;
 use frame_support::sp_runtime::AccountId32;
 use frame_system::EventRecord;
 use pallet_cf_governance::GovCallHash;
+pub use pallet_cf_ingress_egress::OwedAmount;
 use pallet_cf_pools::{
 	AskBidMap, PoolInfo, PoolLiquidity, PoolOrderbook, PoolOrders, PoolPriceV1, PoolPriceV2,
 	UnidirectionalPoolDepth,
@@ -81,10 +82,11 @@ where
 	NumberOrHex::from(*amount).serialize(s)
 }
 
-#[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]
+#[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct BoostPoolDetails {
 	pub available_amounts: BTreeMap<AccountId32, AssetAmount>,
-	pub pending_boosts: BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId32, AssetAmount>>,
+	pub pending_boosts:
+		BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId32, OwedAmount<AssetAmount>>>,
 	pub pending_withdrawals: BTreeMap<AccountId32, BTreeSet<PrewitnessedDepositId>>,
 }
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -78,8 +78,8 @@ fn serialize_as_hex<S>(amount: &AssetAmount, s: S) -> Result<S::Ok, S::Error>
 where
 	S: serde::Serializer,
 {
-	use cf_utilities::rpc::NumberOrHex;
-	NumberOrHex::from(*amount).serialize(s)
+	use sp_core::U256;
+	U256::from(*amount).serialize(s)
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1356

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

I went ahead and implemented this based on the discussion on discord without waiting for PRO-1355 considering we want to merge this for 1.4. Hopefully this is close to what we want.

- Extended boost pool storage to additionally store fees earned by every booster for each pending boost.
- Added `cf_boost_pool_pending_fees` rpc to expose those fees (internally, we still use the same runtime api call, cf_boost_pool_details, which now also returns the fee).
- The rpc works similarly to `cf_boost_pool_details`, in that it takes an optional asset, and returns data for all fee tiers for the asset; when the asset is not specified, data for all assets is returned.
- Added insta test for the new RPC's response.

Example:
```
curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "cf_boost_pool_pending_fees", "params": []}' http://localhost:9944
```
(see the insta file for how the response is formatted)


I also realised (from the discord discussion) that we'd need to query historical data by specifying a block hash. I added an optional block hash parameter to the new RPC for this. Note however, that the existing boost RPC don't let you specify the hash, since we never talked about this. Let me know if we want this parameter in the remaining boost RPCs too @GabrielBuragev. (Update: already did this.)
