### PR TITLE
Update Arbitrum migrations and chainspec

### DIFF
--- a/state-chain/node/src/chain_spec/berghain.rs
+++ b/state-chain/node/src/chain_spec/berghain.rs
@@ -27,10 +27,10 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	eth_key_manager_address: hex_literal::hex!("cd351d3626Dc244730796A3168D315168eBf08Be"),
 	eth_vault_address: hex_literal::hex!("F5e10380213880111522dd0efD3dbb45b9f62Bcc"),
 	eth_address_checker_address: hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920"),
-	arb_key_manager_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arb_vault_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
+	arb_key_manager_address: hex_literal::hex!("BFe612c77C2807Ac5a6A41F84436287578000275"),
+	arb_vault_address: hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920"),
 	arbusdc_token_address: hex_literal::hex!("af88d065e77c8cC2239327C5EDb3A432268e5831"),
-	arb_address_checker_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
+	arb_address_checker_address: hex_literal::hex!("c1B12993f760B654897F0257573202fba13D5481"),
 	ethereum_chain_id: cf_chains::eth::CHAIN_ID_MAINNET,
 	arbitrum_chain_id: cf_chains::arb::CHAIN_ID_MAINNET,
 	eth_init_agg_key: hex_literal::hex!(

--- a/state-chain/node/src/chain_spec/berghain.rs
+++ b/state-chain/node/src/chain_spec/berghain.rs
@@ -26,12 +26,12 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	state_chain_gateway_address: hex_literal::hex!("6995Ab7c4D7F4B03f467Cf4c8E920427d9621DBd"),
 	eth_key_manager_address: hex_literal::hex!("cd351d3626Dc244730796A3168D315168eBf08Be"),
 	eth_vault_address: hex_literal::hex!("F5e10380213880111522dd0efD3dbb45b9f62Bcc"),
+	eth_address_checker_address: hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920"),
 	arb_key_manager_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
 	arb_vault_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arbusdc_token_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	eth_address_checker_address: hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920"),
+	arbusdc_token_address: hex_literal::hex!("af88d065e77c8cC2239327C5EDb3A432268e5831"),
 	arb_address_checker_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	ethereum_chain_id: cf_chains::arb::CHAIN_ID_MAINNET,
+	ethereum_chain_id: cf_chains::eth::CHAIN_ID_MAINNET,
 	arbitrum_chain_id: cf_chains::arb::CHAIN_ID_MAINNET,
 	eth_init_agg_key: hex_literal::hex!(
 		"022a1d7efa522ce746bc40a04016178ce38154be1f0537c6957bdeed17057bb955"

--- a/state-chain/node/src/chain_spec/perseverance.rs
+++ b/state-chain/node/src/chain_spec/perseverance.rs
@@ -28,10 +28,10 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	eth_key_manager_address: hex_literal::hex!("4981b1329F29E720642266fc6e172C3f78159dff"),
 	eth_vault_address: hex_literal::hex!("36eaD71325604DC15d35FAE584D7b50646D81753"),
 	eth_address_checker_address: hex_literal::hex!("58eaCD5A40EEbCbBCb660f178F9A46B1Ad63F846"),
-	arb_key_manager_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arb_vault_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arbusdc_token_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arb_address_checker_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
+	arb_key_manager_address: hex_literal::hex!("18195b0E3c33EeF3cA6423b1828E0FE0C03F32Fd"),
+	arb_vault_address: hex_literal::hex!("2bb150e6d4366A1BDBC4275D1F35892CD63F27e3"),
+	arbusdc_token_address: hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"),
+	arb_address_checker_address: hex_literal::hex!("4F358eC5BD58c994f74B317554D7472769a0Ccf8"),
 	ethereum_chain_id: cf_chains::eth::CHAIN_ID_SEPOLIA,
 	arbitrum_chain_id: cf_chains::arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 	eth_init_agg_key: hex_literal::hex!(

--- a/state-chain/node/src/chain_spec/sisyphos.rs
+++ b/state-chain/node/src/chain_spec/sisyphos.rs
@@ -28,10 +28,10 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	eth_key_manager_address: hex_literal::hex!("22f5562e6859924Db082b8B248ea0C974f148a17"),
 	eth_vault_address: hex_literal::hex!("a94d6b1853F3cb611Ed3cCb701b4fdA5a9DACe85"),
 	eth_address_checker_address: hex_literal::hex!("638e16DD15588B81257eBe9676FA1a0175FDB70a"),
-	arb_key_manager_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arb_vault_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arbusdc_token_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
-	arb_address_checker_address: hex_literal::hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), /* put correct values here */
+	arb_key_manager_address: hex_literal::hex!("7EA74208E2954a7294097C731434caD29c5094D8"),
+	arb_vault_address: hex_literal::hex!("8155BdD48CD011e1118b51A1C82be020A3E5c2f2"),
+	arbusdc_token_address: hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"),
+	arb_address_checker_address: hex_literal::hex!("2e78F26e9798EBDe7F2b19736De6Aae4d51d6d34"),
 	ethereum_chain_id: cf_chains::eth::CHAIN_ID_SEPOLIA,
 	arbitrum_chain_id: cf_chains::arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 	eth_init_agg_key: hex_literal::hex!(

--- a/state-chain/runtime/src/migrations/arbitrum_integration.rs
+++ b/state-chain/runtime/src/migrations/arbitrum_integration.rs
@@ -102,12 +102,12 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 				cf_runtime_upgrade_utilities::genesis_hashes::BERGHAIN => {
 					log::warn!("Need to set up arbitrum integration for Berghain");
 					(
-						[0u8; 20].into(),
-						[0u8; 20].into(),
-						[0u8; 20].into(),
+						hex_literal::hex!("BFe612c77C2807Ac5a6A41F84436287578000275").into(),
+						hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920").into(),
+						hex_literal::hex!("c1B12993f760B654897F0257573202fba13D5481").into(),
 						arb::CHAIN_ID_MAINNET,
 						hex_literal::hex!("af88d065e77c8cC2239327C5EDb3A432268e5831").into(),
-						0,
+						208460974,
 						// state-chain/node/src/chain_spec/berghain.rs
 						24 * 3600 * 4,
 					)
@@ -120,7 +120,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						hex_literal::hex!("4F358eC5BD58c994f74B317554D7472769a0Ccf8").into(),
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 						hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d").into(),
-						38766950,
+						38766992,
 						// state-chain/node/src/chain_spec/perseverance.rs
 						2 * 60 * 60 * 4,
 					)
@@ -133,7 +133,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						hex_literal::hex!("2e78F26e9798EBDe7F2b19736De6Aae4d51d6d34").into(),
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
 						hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d").into(),
-						38762559,
+						38762596,
 						// state-chain/node/src/chain_spec/sisyphos.rs
 						2 * 60 * 60 * 4,
 					)

--- a/state-chain/runtime/src/migrations/arbitrum_integration.rs
+++ b/state-chain/runtime/src/migrations/arbitrum_integration.rs
@@ -106,7 +106,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 						[0u8; 20].into(),
 						[0u8; 20].into(),
 						arb::CHAIN_ID_MAINNET,
-						[0u8; 20].into(),
+						hex_literal::hex!("af88d065e77c8cC2239327C5EDb3A432268e5831").into(),
 						0,
 						// state-chain/node/src/chain_spec/berghain.rs
 						24 * 3600 * 4,
@@ -115,12 +115,12 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 				cf_runtime_upgrade_utilities::genesis_hashes::PERSEVERANCE => {
 					log::warn!("Need to set up arbitrum integration for Perseverance");
 					(
-						[1u8; 20].into(),
-						[1u8; 20].into(),
-						[1u8; 20].into(),
+						hex_literal::hex!("18195b0E3c33EeF3cA6423b1828E0FE0C03F32Fd").into(),
+						hex_literal::hex!("2bb150e6d4366A1BDBC4275D1F35892CD63F27e3").into(),
+						hex_literal::hex!("4F358eC5BD58c994f74B317554D7472769a0Ccf8").into(),
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
-						[1u8; 20].into(),
-						0,
+						hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d").into(),
+						38766950,
 						// state-chain/node/src/chain_spec/perseverance.rs
 						2 * 60 * 60 * 4,
 					)
@@ -128,12 +128,12 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 				cf_runtime_upgrade_utilities::genesis_hashes::SISYPHOS => {
 					log::warn!("Need to set up arbitrum integration for Sisyphos");
 					(
-						[2u8; 20].into(),
-						[2u8; 20].into(),
-						[2u8; 20].into(),
+						hex_literal::hex!("7EA74208E2954a7294097C731434caD29c5094D8").into(),
+						hex_literal::hex!("8155BdD48CD011e1118b51A1C82be020A3E5c2f2").into(),
+						hex_literal::hex!("2e78F26e9798EBDe7F2b19736De6Aae4d51d6d34").into(),
 						arb::CHAIN_ID_ARBITRUM_SEPOLIA,
-						[2u8; 20].into(),
-						0,
+						hex_literal::hex!("75faf114eafb1BDbe2F0316DF893fd58CE46AA4d").into(),
+						38762559,
 						// state-chain/node/src/chain_spec/sisyphos.rs
 						2 * 60 * 60 * 4,
 					)


### PR DESCRIPTION
# Pull Request

Closes: PRO-1224

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Update chainspecs and migrations with the correct addresses.

The `eth_address_checker_address` and `arb_vault_address` have the same address, that is not a mistake. It's just that we use the same deployer wallet.