### PR TITLE
fix: upgrade test permissions

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Permissions for latest binaries 🛡️
         run: |
           chmod +x ./upgrade-to-bins/chainflip-*
+          chmod +x ./upgrade-to-bins/engine-runner
 
       - name: Get version of latest main ✍️
         run: |


### PR DESCRIPTION
Should fix the permission issue we see on upgrade-test atm: https://github.com/chainflip-io/chainflip-backend/actions/runs/8971952228/job/24639118948