### PR TITLE
chore: rename boost methods

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -259,7 +259,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn on_lost_deposit(n: Linear<1, 100>) {
+	fn process_deposit_as_lost(n: Linear<1, 100>) {
 		create_boost_pool::<T, I>();
 
 		use strum::IntoEnumIterator;
@@ -294,7 +294,7 @@ mod benchmarks {
 		{
 			BoostPools::<T, I>::mutate(asset, TIER_5_BPS, |pool| {
 				// This depends on the number of boosters who contributed to it:
-				pool.as_mut().unwrap().on_lost_deposit(prewitnessed_deposit_id);
+				pool.as_mut().unwrap().process_deposit_as_lost(prewitnessed_deposit_id);
 			});
 		}
 	}
@@ -520,7 +520,7 @@ mod benchmarks {
 			_add_boost_funds::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
-			_on_lost_deposit::<Test, ()>(100, true);
+			_process_deposit_as_lost::<Test, ()>(100, true);
 		});
 		new_test_ext().execute_with(|| {
 			_stop_boosting::<Test, ()>(true);

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -306,7 +306,7 @@ where
 		Ok(())
 	}
 
-	pub(crate) fn on_finalised_deposit(
+	pub(crate) fn process_deposit_as_finalised(
 		&mut self,
 		prewitnessed_deposit_id: PrewitnessedDepositId,
 	) -> Vec<(AccountId, C::ChainAmount)> {
@@ -339,7 +339,10 @@ where
 	}
 
 	// Returns the number of boosters affected
-	pub fn on_lost_deposit(&mut self, prewitnessed_deposit_id: PrewitnessedDepositId) -> usize {
+	pub fn process_deposit_as_lost(
+		&mut self,
+		prewitnessed_deposit_id: PrewitnessedDepositId,
+	) -> usize {
 		let Some(booster_contributions) = self.pending_boosts.remove(&prewitnessed_deposit_id)
 		else {
 			log_or_panic!(

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -768,10 +768,12 @@ pub mod pallet {
 							BoostPools::<T, I>::mutate(deposit_channel.asset, pool_tier, |pool| {
 								if let Some(pool) = pool {
 									let affected_boosters_count =
-										pool.on_lost_deposit(prewitnessed_deposit_id);
-									used_weight.saturating_accrue(T::WeightInfo::on_lost_deposit(
-										affected_boosters_count as u32,
-									));
+										pool.process_deposit_as_lost(prewitnessed_deposit_id);
+									used_weight.saturating_accrue(
+										T::WeightInfo::process_deposit_as_lost(
+											affected_boosters_count as u32,
+										),
+									);
 								} else {
 									log_or_panic!(
 										"Pool must exist: ({pool_tier:?}, {:?})",
@@ -1661,7 +1663,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				BoostPools::<T, I>::mutate(asset, boost_tier, |maybe_pool| {
 					if let Some(pool) = maybe_pool {
 						for (booster_id, finalised_withdrawn_amount) in
-							pool.on_finalised_deposit(prewitnessed_deposit_id)
+							pool.process_deposit_as_finalised(prewitnessed_deposit_id)
 						{
 							if let Err(err) = T::LpBalance::try_credit_account(
 								&booster_id,

--- a/state-chain/pallets/cf-ingress-egress/src/weights.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/weights.rs
@@ -38,7 +38,7 @@ pub trait WeightInfo {
 	fn vault_transfer_failed() -> Weight;
 	fn ccm_broadcast_failed() -> Weight;
 	fn add_boost_funds() -> Weight;
-	fn on_lost_deposit(n: u32, ) -> Weight;
+	fn process_deposit_as_lost(n: u32, ) -> Weight;
 	fn stop_boosting() -> Weight;
 	fn deposit_boosted() -> Weight;
 	fn boost_finalised() -> Weight;
@@ -183,7 +183,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Storage: `EthereumIngressEgress::BoostPools` (r:1 w:1)
 	/// Proof: `EthereumIngressEgress::BoostPools` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `n` is `[1, 100]`.
-	fn on_lost_deposit(n: u32, ) -> Weight {
+	fn process_deposit_as_lost(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `410 + n * (89 ±0)`
 		//  Estimated: `3874 + n * (89 ±0)`
@@ -431,7 +431,7 @@ impl WeightInfo for () {
 	/// Storage: `EthereumIngressEgress::BoostPools` (r:1 w:1)
 	/// Proof: `EthereumIngressEgress::BoostPools` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `n` is `[1, 100]`.
-	fn on_lost_deposit(n: u32, ) -> Weight {
+	fn process_deposit_as_lost(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `410 + n * (89 ±0)`
 		//  Estimated: `3874 + n * (89 ±0)`


### PR DESCRIPTION
# Pull Request

Closes: PRO-1302

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Wouldn't normally open a PR this small, but wanted to close PRO-1302 (not sure why I didn't bundle this in some other PR).

Although the names are still quite generic, at least they no longer resemble "hooks", and something more specific could be misleading (as they do more than one thing).