### PR TITLE
chore: remove ` too_many_arguments` warning supression

### DIFF
--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -330,7 +330,6 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 		))
 	}
 
-	#[allow(clippy::too_many_arguments)]
 	async fn update_limit_order(
 		&self,
 		base_asset: Asset,
@@ -357,7 +356,6 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 		.await
 	}
 
-	#[allow(clippy::too_many_arguments)]
 	async fn set_limit_order(
 		&self,
 		base_asset: Asset,

--- a/state-chain/chains/src/eth/api/register_redemption.rs
+++ b/state-chain/chains/src/eth/api/register_redemption.rs
@@ -52,7 +52,6 @@ impl Tokenizable for RedemptionExecutor {
 }
 
 impl RegisterRedemption {
-	#[allow(clippy::too_many_arguments)]
 	pub fn new<Amount: Into<Uint> + Clone>(
 		node_id: &[u8; 32],
 		amount: Amount,

--- a/state-chain/chains/src/evm/api/execute_x_swap_and_call.rs
+++ b/state-chain/chains/src/evm/api/execute_x_swap_and_call.rs
@@ -24,7 +24,6 @@ pub struct ExecutexSwapAndCall {
 }
 
 impl ExecutexSwapAndCall {
-	#[allow(clippy::too_many_arguments)]
 	pub(crate) fn new(
 		transfer_param: EncodableTransferAssetParams,
 		source_chain: ForeignChain,

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -443,7 +443,6 @@ network_spec!(berghain);
 
 /// Configure initial storage state for FRAME modules.
 /// 150 authority limit
-#[allow(clippy::too_many_arguments)]
 fn testnet_genesis(
 	initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>, // initial validators
 	extra_accounts: Vec<(AccountId, AccountRole, u128, Option<Vec<u8>>)>,

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -367,7 +367,6 @@ pub mod pallet {
 		/// ## Errors
 		///
 		/// - [BadOrigin](frame_support::error::BadOrigin)
-		#[allow(clippy::too_many_arguments)]
 		#[pallet::call_index(5)]
 		// This weight is not strictly correct but since it's a governance call, weight is
 		// irrelevant.

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1278,7 +1278,6 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	#[allow(clippy::too_many_arguments)]
 	fn inner_update_limit_order(
 		pool: &mut Pool<T>,
 		lp: &T::AccountId,
@@ -1368,7 +1367,6 @@ impl<T: Config> Pallet<T> {
 		Ok(*sold_amount_change.abs())
 	}
 
-	#[allow(clippy::too_many_arguments)]
 	fn inner_update_range_order(
 		pool: &mut Pool<T>,
 		lp: &T::AccountId,
@@ -1899,7 +1897,6 @@ impl<T: Config> Pallet<T> {
 	/// - Payout collected `fee` and `bought_amount`
 	/// - Update cache storage for Pool
 	/// - Deposit the correct event.
-	#[allow(clippy::too_many_arguments)]
 	fn process_limit_order_update(
 		pool: &mut Pool<T>,
 		asset_pair: &AssetPair,

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -8,7 +8,6 @@ use scale_info::TypeInfo;
 pub trait SwapDepositHandler {
 	type AccountId;
 
-	#[allow(clippy::too_many_arguments)]
 	fn schedule_swap_from_channel(
 		deposit_address: ForeignChainAddress,
 		deposit_block_height: u64,


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

# Summary
we no longer need the allow(too_many_arguments) since the threshold is now set to 100

