### PR TITLE
fix: engine-runner permissions +x

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Permissions for latest binaries 🛡️
         run: |
           chmod +x ./latest-release-bins/chainflip-*
+          chmod +x ./latest-release-bins/engine-runner
 
       - name: Get version of the latest release ✍️
         run: |


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Now that we are upgrading *from* a version that uses the engine-runner, we need to set the permissions for it in the *from* side of the test.