### PR TITLE
fix: upgrade test same version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "chainflip-api",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-broadcast 0.5.1",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-ingress-egress-tracker"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3389,7 +3389,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "cf-engine-dylib",
@@ -12552,7 +12552,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "cf-amm",
  "cf-chains",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = '2021'
 build = 'build.rs'
 name = "chainflip-cli"
-version = "1.4.0"
+version = "1.4.1"
 
 [lints]
 workspace = true

--- a/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
+++ b/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-ingress-egress-tracker"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 
 [lints]

--- a/bouncer/shared/polkadot_runtime_update.ts
+++ b/bouncer/shared/polkadot_runtime_update.ts
@@ -171,7 +171,7 @@ export async function bumpAndBuildPolkadotRuntime(): Promise<[string, number]> {
   console.log('Updating polkadot source');
   execSync(`git pull`, { cwd: workspacePath });
 
-  await specVersion(`${workspacePath}/runtime/polkadot/src/lib.rs`, 'write', nextSpecVersion);
+  specVersion(`${workspacePath}/runtime/polkadot/src/lib.rs`, 'write', nextSpecVersion);
 
   // Compile polkadot runtime
   console.log('Compiling polkadot...');

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -321,7 +321,9 @@ export async function upgradeNetworkPrebuilt(
   }
 
   if (cleanOldVersion === nodeVersion) {
-    throw Error('The versions are the same. No need to upgrade. Please provide a different version.');
+    throw Error(
+      'The versions are the same. No need to upgrade. Please provide a different version.',
+    );
   } else if (isCompatibleWith(cleanOldVersion, nodeVersion)) {
     console.log('The versions are compatible.');
     await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -58,7 +58,8 @@ async function incompatibleUpgradeNoBuild(
 
   // We need to kill the engine process before starting the new engine (engine-runner)
   // Since the new engine contains the old one.
-  execSync(`kill $(ps aux | grep chainflip-engine | grep -v grep | awk '{print $2}')`);
+  console.log('Killing the old engines');
+  execSync(`kill $(ps aux | grep engine-runner | grep -v grep | awk '{print $2}')`);
 
   console.log('Starting all the engines');
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "cf-engine-dylib"
-version = "1.4.0"
+version = "1.4.1"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_4_0"
+name = "chainflip_engine_v1_4_1"
 path = 'src/lib.rs'
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.4.0"
+version = "1.4.1"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
@@ -24,8 +24,8 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_4_0.so",
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_4_0.so",
+        "target/release/libchainflip_engine_v1_4_1.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_4_1.so",
         "755",
     ],
     # The old version gets put into target/release by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -12,7 +12,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.4.0")]
+	#[engine_proc_macros::link_engine_library_version("1.4.1")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -11,7 +11,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.3.5";
-pub const NEW_VERSION: &str = "1.4.0";
+pub const NEW_VERSION: &str = "1.4.1";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "chainflip-engine"
-version = "1.4.0"
+version = "1.4.1"
 
 [lib]
 crate-type = ["lib"]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = '<TODO>'
 name = 'chainflip-node'
 publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
-version = "1.4.0"
+version = "1.4.1"
 
 [[bin]]
 name = 'chainflip-node'

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'state-chain-runtime'
-version = '1.4.0'
+version = '1.4.1'
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
 edition = '2021'
 homepage = 'https://chainflip.io'


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

A few fixes:
- Now 1.4 is on sisy, any incompatible upgrades now need to kill the `engine-runner` not the `chainflip-engine` as before.
- Bumps the versions to match the 141 spec version, ensuring we do actually do the upgrade-test correctly.
- Removes an unnecessary await that was on a sync function