### PR TITLE
Feat: consistently emit swap scheduled events

### DIFF
--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -63,13 +63,14 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     asset === Assets.Dot ? decodeDotAddressForContract(destinationAddress) : destinationAddress;
   const destinationChain = shortChainFromAsset(swapAsset); // "Eth" -> "Eth"
   console.log(`${asset} destinationAddress:`, destinationAddress);
-  const observeSwapScheduledEvent = observeEvent(':SwapScheduled', chainflip, (event) => {
-    return (
-      event.data.origin != 'Internal' &&
+  const observeSwapScheduledEvent = observeEvent(
+    ':SwapScheduled',
+    chainflip,
+    (event) =>
+      event.data.origin !== 'Internal' &&
       event.data.destinationAddress[destinationChain]?.toLowerCase() ===
-        observeDestinationAddress.toLowerCase()
-    );
-  });
+        observeDestinationAddress.toLowerCase(),
+  );
   console.log(`Running swap ${asset} -> ${swapAsset}`);
 
   const rawDepositForSwapAmount = swapAssetAmount[asset].toString();

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -63,13 +63,13 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
     asset === Assets.Dot ? decodeDotAddressForContract(destinationAddress) : destinationAddress;
   const destinationChain = shortChainFromAsset(swapAsset); // "Eth" -> "Eth"
   console.log(`${asset} destinationAddress:`, destinationAddress);
-  const observeSwapScheduledEvent = observeEvent(
-    ':SwapScheduled',
-    chainflip,
-    (event) =>
+  const observeSwapScheduledEvent = observeEvent(':SwapScheduled', chainflip, (event) => {
+    return (
+      event.data.origin != 'Internal' &&
       event.data.destinationAddress[destinationChain]?.toLowerCase() ===
-      observeDestinationAddress.toLowerCase(),
-  );
+        observeDestinationAddress.toLowerCase()
+    );
+  });
   console.log(`Running swap ${asset} -> ${swapAsset}`);
 
   const rawDepositForSwapAmount = swapAssetAmount[asset].toString();

--- a/bouncer/shared/contract_swap.ts
+++ b/bouncer/shared/contract_swap.ts
@@ -132,7 +132,7 @@ export async function performSwapViaContract(
       messageMetadata,
     );
     await observeEvent('swapping:SwapScheduled', api, (event) => {
-      if ('Vault' in event.data.origin) {
+      if (event.data.origin !== 'Internal' && 'Vault' in event.data.origin) {
         const sourceAssetMatches = sourceAsset === (event.data.sourceAsset as Asset);
         const destAssetMatches = destAsset === (event.data.destinationAsset as Asset);
         const txHashMatches = event.data.origin.Vault.txHash === receipt.hash;

--- a/bouncer/shared/evm_deposits.ts
+++ b/bouncer/shared/evm_deposits.ts
@@ -119,7 +119,7 @@ async function testTxMultipleContractSwaps(sourceAsset: Asset, destAsset: Asset)
     chainflip,
     (event) => {
       if (
-        event.data.origin != 'Internal' &&
+        event.data.origin !== 'Internal' &&
         'Vault' in event.data.origin &&
         event.data.origin.Vault.txHash === receipt.transactionHash
       ) {

--- a/bouncer/shared/evm_deposits.ts
+++ b/bouncer/shared/evm_deposits.ts
@@ -58,7 +58,7 @@ async function testNoDuplicateWitnessing(sourceAsset: Asset, destAsset: Asset) {
     'swapping:SwapScheduled',
     () => stopObserving,
     (event) => {
-      if ('DepositChannel' in event.data.origin) {
+      if (event.data.origin !== 'Internal' && 'DepositChannel' in event.data.origin) {
         const channelMatches =
           Number(event.data.origin.DepositChannel.channelId) === swapParams.channelId;
         const assetMatches = sourceAsset === (event.data.sourceAsset as Asset);
@@ -119,6 +119,7 @@ async function testTxMultipleContractSwaps(sourceAsset: Asset, destAsset: Asset)
     chainflip,
     (event) => {
       if (
+        event.data.origin != 'Internal' &&
         'Vault' in event.data.origin &&
         event.data.origin.Vault.txHash === receipt.transactionHash
       ) {

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -505,11 +505,13 @@ export async function observeSwapScheduled(
 
   // need to await this to prevent the chainflip api from being disposed prematurely
   const result = await observeEvent('swapping:SwapScheduled', chainflipApi, (event) => {
-    if ('DepositChannel' in event.data.origin) {
-      const channelMatches = Number(event.data.origin.DepositChannel.channelId) === channelId;
-      const sourceAssetMatches = sourceAsset === (event.data.sourceAsset as Asset);
-      const destAssetMatches = destAsset === (event.data.destinationAsset as Asset);
-      const swapTypeMatches = swapType ? event.data.swapType[swapType] !== undefined : true;
+    const data = event.data;
+
+    if (data.origin !== 'Internal' && 'DepositChannel' in data.origin) {
+      const channelMatches = Number(data.origin.DepositChannel.channelId) === channelId;
+      const sourceAssetMatches = sourceAsset === (data.sourceAsset as Asset);
+      const destAssetMatches = destAsset === (data.destinationAsset as Asset);
+      const swapTypeMatches = swapType ? data.swapType[swapType] !== undefined : true;
       return channelMatches && sourceAssetMatches && destAssetMatches && swapTypeMatches;
     }
     // Otherwise it was a swap scheduled by interacting with the Eth smart contract

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -434,7 +434,10 @@ export async function observeSwapEvents(
 
         switch (expectedMethod) {
           case swapScheduledEvent:
-            if ('DepositChannel' in expectedEvent.data.origin) {
+            if (
+              expectedEvent.data.origin !== 'Internal' &&
+              'DepositChannel' in expectedEvent.data.origin
+            ) {
               if (
                 Number(expectedEvent.data.origin.DepositChannel.channelId) === channelId &&
                 sourceAsset === (expectedEvent.data.sourceAsset as Asset) &&

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -249,6 +249,7 @@ fn basic_pool_setup_provision_and_swap() {
 
 		let swap_id = assert_events_match!(Runtime, RuntimeEvent::Swapping(pallet_cf_swapping::Event::SwapScheduled {
 			swap_id,
+			swap_input: 50,
 			deposit_amount: 50,
 			origin: SwapOrigin::DepositChannel {
 				deposit_address: events_deposit_address,

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -524,6 +524,8 @@ pub enum SwapOrigin {
 	Vault {
 		tx_hash: TransactionHash,
 	},
+	// Initiated by the protocol rather than externally
+	Internal,
 }
 
 pub const MAX_CCM_MSG_LENGTH: u32 = 10_000;

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1818,6 +1818,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					<T::TargetChain as Chain>::GAS_ASSET.into(),
 					transaction_fee.into(),
 					SwapType::IngressEgressFee,
+					SwapOrigin::Internal,
+					None, /* destination address */
+					None, /* broker fee */
 				);
 			}
 			available_amount.saturating_sub(transaction_fee)

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -7,6 +7,7 @@ use cf_amm::{
 	range_orders::{self, Liquidity},
 	PoolState,
 };
+use cf_chains::SwapOrigin;
 use cf_primitives::{chains::assets::any, Asset, AssetAmount, SwapOutput, STABLE_ASSET};
 use cf_traits::{
 	impl_pallet_safe_mode, Chainflip, LpBalanceApi, PoolApi, SwapQueueApi, SwapType, SwappingApi,
@@ -332,6 +333,9 @@ pub mod pallet {
 							any::Asset::Flip,
 							*collected_fee,
 							SwapType::NetworkFee,
+							SwapOrigin::Internal,
+							None, /* destination address */
+							None, /* broker fee */
 						);
 						collected_fee.set_zero();
 						Ok::<_, DispatchError>(())

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -317,7 +317,9 @@ pub mod pallet {
 		SwapScheduled {
 			swap_id: SwapId,
 			source_asset: Asset,
+			#[deprecated(note = "Use swap_input instead")]
 			deposit_amount: AssetAmount,
+			swap_input: AssetAmount,
 			destination_asset: Asset,
 			destination_address: Option<EncodedAddress>,
 			origin: SwapOrigin,
@@ -1316,7 +1318,8 @@ impl<T: Config> SwapQueueApi for Pallet<T> {
 		Self::deposit_event(Event::<T>::SwapScheduled {
 			swap_id,
 			source_asset: from,
-			deposit_amount: amount.saturating_add(broker_fee.unwrap_or_default()),
+			deposit_amount: swap_amount,
+			swap_input: swap_amount,
 			destination_asset: to,
 			destination_address,
 			origin: swap_origin,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1316,7 +1316,7 @@ impl<T: Config> SwapQueueApi for Pallet<T> {
 		Self::deposit_event(Event::<T>::SwapScheduled {
 			swap_id,
 			source_asset: from,
-			deposit_amount: amount,
+			deposit_amount: amount.saturating_add(broker_fee.unwrap_or_default()),
 			destination_asset: to,
 			destination_address,
 			origin: swap_origin,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -259,6 +259,7 @@ fn cannot_swap_with_incorrect_destination_address_type() {
 	});
 }
 
+#[allow(deprecated)]
 #[test]
 fn expect_swap_id_to_be_emitted() {
 	new_test_ext()
@@ -303,6 +304,7 @@ fn expect_swap_id_to_be_emitted() {
 					swap_id: 1,
 					source_asset: Asset::Eth,
 					deposit_amount: AMOUNT,
+					swap_input: AMOUNT,
 					destination_asset: Asset::Usdc,
 					destination_address: Some(EncodedAddress::Eth(..)),
 					origin: SwapOrigin::DepositChannel {
@@ -380,6 +382,7 @@ fn can_swap_using_witness_origin() {
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
 			source_asset: from,
+			swap_input: amount,
 			deposit_amount: amount,
 			destination_asset: to,
 			destination_address: Some(EncodedAddress::Eth(Default::default())),
@@ -938,6 +941,7 @@ fn swap_by_witnesser_happy_path() {
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
 			source_asset: from,
+			swap_input: amount,
 			deposit_amount: amount,
 			destination_asset: to,
 			destination_address: Some(EncodedAddress::Eth(Default::default())),
@@ -986,6 +990,7 @@ fn swap_by_deposit_happy_path() {
 		);
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
 			swap_id: 1,
+			swap_input: amount,
 			deposit_amount: amount,
 			source_asset: from,
 			destination_asset: to,
@@ -1242,6 +1247,7 @@ fn cannot_withdraw_in_safe_mode() {
 	});
 }
 
+#[allow(deprecated)]
 #[test]
 fn ccm_swaps_emits_events() {
 	new_test_ext().execute_with(|| {
@@ -1266,6 +1272,7 @@ fn ccm_swaps_emits_events() {
 				swap_id: 1,
 				source_asset: Asset::Flip,
 				deposit_amount: 9_000,
+				swap_input: 9_000,
 				destination_asset: Asset::Usdc,
 				destination_address: Some(EncodedAddress::Eth(..)),
 				origin: ORIGIN,
@@ -1277,6 +1284,7 @@ fn ccm_swaps_emits_events() {
 				swap_id: 2,
 				source_asset: Asset::Flip,
 				deposit_amount: 1_000,
+				swap_input: 1_000,
 				destination_asset: Asset::Eth,
 				destination_address: Some(EncodedAddress::Eth(..)),
 				origin: ORIGIN,
@@ -1308,6 +1316,7 @@ fn ccm_swaps_emits_events() {
 				swap_id: 3,
 				source_asset: Asset::Eth,
 				deposit_amount: 9_000,
+				swap_input: 9_000,
 				destination_asset: Asset::Usdc,
 				destination_address: Some(EncodedAddress::Eth(..)),
 				origin: ORIGIN,
@@ -1339,6 +1348,7 @@ fn ccm_swaps_emits_events() {
 				swap_id: 4,
 				source_asset: Asset::Flip,
 				deposit_amount: 1_000,
+				swap_input: 1_000,
 				destination_asset: Asset::Eth,
 				destination_address: Some(EncodedAddress::Eth(..)),
 				origin: ORIGIN,
@@ -1959,6 +1969,7 @@ fn assert_swap_scheduled_event_emitted(
 		swap_id,
 		source_asset,
 		deposit_amount,
+		swap_input: deposit_amount,
 		destination_asset,
 		destination_address: Some(EncodedAddress::Eth([2; 20])),
 		origin: SwapOrigin::DepositChannel {
@@ -1994,7 +2005,7 @@ fn swap_broker_fee_subtracted_from_swap_amount() {
 				assert_swap_scheduled_event_emitted(
 					swap_id,
 					asset,
-					*amount,
+					amount.checked_sub(broker_commission).unwrap(),
 					Asset::Flip,
 					broker_commission,
 					execute_at,

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -1,4 +1,8 @@
-use cf_chains::{address::ForeignChainAddress, assets::any::AssetMap};
+use cf_chains::{
+	address::{EncodedAddress, ForeignChainAddress},
+	assets::any::AssetMap,
+	SwapOrigin,
+};
 use cf_primitives::{Asset, AssetAmount, Beneficiaries, ChannelId, SwapId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::{DispatchError, DispatchResult};
@@ -129,7 +133,10 @@ pub trait SwapQueueApi {
 		to: Asset,
 		amount: AssetAmount,
 		swap_type: SwapType,
-	) -> (u64, Self::BlockNumber);
+		swap_origin: SwapOrigin,
+		destination_address: Option<EncodedAddress>,
+		broker_fee: Option<AssetAmount>,
+	) -> SwapId;
 }
 
 impl<T: frame_system::Config> SwapQueueApi for T {
@@ -140,8 +147,11 @@ impl<T: frame_system::Config> SwapQueueApi for T {
 		_to: Asset,
 		_amount: AssetAmount,
 		_swap_type: SwapType,
-	) -> (u64, Self::BlockNumber) {
-		(0, Self::BlockNumber::default())
+		_swap_origin: SwapOrigin,
+		_destination_address: Option<EncodedAddress>,
+		_broker_fee: Option<AssetAmount>,
+	) -> SwapId {
+		0
 	}
 }
 

--- a/state-chain/traits/src/mocks/swap_queue_api.rs
+++ b/state-chain/traits/src/mocks/swap_queue_api.rs
@@ -1,6 +1,7 @@
 use super::{MockPallet, MockPalletStorage};
 use crate::{SwapQueueApi, SwapType};
-use cf_primitives::{Asset, AssetAmount};
+use cf_chains::{address::EncodedAddress, SwapOrigin};
+use cf_primitives::{Asset, AssetAmount, SwapId};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
@@ -34,10 +35,13 @@ impl SwapQueueApi for MockSwapQueueApi {
 		to: Asset,
 		amount: AssetAmount,
 		swap_type: SwapType,
-	) -> (u64, Self::BlockNumber) {
+		_swap_origin: SwapOrigin,
+		_destination_address: Option<EncodedAddress>,
+		_broker_fee: Option<AssetAmount>,
+	) -> SwapId {
 		Self::mutate_value(SWAP_QUEUE, |queue: &mut Option<Vec<MockSwap>>| {
 			queue.get_or_insert(vec![]).push(MockSwap { from, to, amount, swap_type });
 		});
-		(Self::get_value::<Vec<MockSwap>>(SWAP_QUEUE).unwrap().len() as u64, 0)
+		Self::get_value::<Vec<MockSwap>>(SWAP_QUEUE).unwrap().len() as u64
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1385

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

- `SwapScheduled` is now emitted whenever a swap is scheduled (i.e. inside `schedule_swap`), which ensures that it is always emitted whenever we assign a new swap_id.
- Added `SwapOrigin::Internal` for swaps initiated by the protocol.
- `destination_address` is now optional in `SwapScheduled` so it can be set to None for internal swaps.
- As discussed on discord, depricated `deposit_amount` in `SwapScheduled` in favour of `swap_input` similarly to how it is done in `SwapExecuted`.
- For consistency with `SwapExecuted`, `swap_input` in `SwapScheduled` no longer includes broker fee

Tagging @acdibble 
