### PR TITLE
feat: require upgrade-check pass on merge queue

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -56,6 +56,11 @@ jobs:
     secrets: inherit
     with:
       full_bouncer: false
+  upgrade-check:
+    runs-on: ubuntu-22.04
+    if: false
+    steps:
+      - run: echo "Upgrade check is disabled. This is a placeholder to hack around the fact we just want to run this in the merge queue. But for it to still be required"
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Hacks around the branch protection. We can now protect the branch by requiring "upgrade-check" to be run, but it will be skipped (which is a pass). Then on the merge queue, it will actually run, such that if it fails, it'll fail the PR, since upgrade-check is a branch protection rule