### PR TITLE
feat: run upgrade-test on commit of trigger

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -48,6 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Get upgrade-to-commit SHA 📜
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         uses: ./.github/actions/get-workflow-commit
         id: get-upgrade-to-commit
         with:
@@ -57,7 +58,11 @@ jobs:
       - name: Set upgrade-to-commit 📲
         run: |
           if [ -z "${{ inputs.upgrade-to-commit }}" ]; then
+          if [[ "${{ github.event_name }}" == "workflow_call" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "UPGRADE_TO_COMMIT=${{ steps.get-upgrade-to-commit.outputs.commit-sha }}" >> $GITHUB_ENV
+          else
+            echo "UPGRADE_TO_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+          fi
           else
             echo "UPGRADE_TO_COMMIT=${{ inputs.upgrade-to-commit }}" >> $GITHUB_ENV
           fi
@@ -131,7 +136,15 @@ jobs:
           echo $RELEASE_VERSION
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
-      - name: Download latest main binaries 📥
+      - name: Download upgrade-to binaries for push or pull request📥
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/download-artifact@v3
+        with:
+          name: chainflip-backend-bin-try-runtime
+          path: upgrade-to-bins
+
+      - name: Download upgrade-to binaries for workflow call 📥
+        if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch'
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ inputs.upgrade-to-workflow-name }}
@@ -139,7 +152,15 @@ jobs:
           path: upgrade-to-bins
           commit: ${{ env.UPGRADE_TO_COMMIT }}
 
-      - name: Download latest main runtime 📥
+      - name: Download upgrade-to runtime for push or pull request 📥
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/download-artifact@v3
+        with:
+          name: chainflip-node-runtime-try-runtime
+          path: main-runtime
+
+      - name: Download upgrade-to runtime for workflow call 📥
+        if: github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch'
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ inputs.upgrade-to-workflow-name }}


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works - runs correctly: https://github.com/chainflip-io/chainflip-backend/actions/runs/9188540682/job/25268902240?pr=4881 this job was triggered on a push (I added the upgrade-check job to ci-development to test it)
I also manually ran a workflow to ensure that also still works: https://github.com/chainflip-io/chainflip-backend/actions/runs/9188546171
- [x] I have updated documentation where appropriate.

## Summary

Previously the upgrade test was pulling the last successful commit from the main workflow. However, what we want to do is use the artefacts that are built as part of the commit that triggers the workflow. Though, I also maintained the behaviour of allowing a manually triggered workflow and selecting the commit as before.

There are effectively 3 cases:
1. Workflow call/dispatch with provided commit to upgrade to
2. Workflow call/dispatch without provided commit
3. Push/pull request (in which case, use the commit of the push/pr)