### PR TITLE
pick: chore: move lp balance integrity check to unit test (#4852)

### DIFF
--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -189,14 +189,10 @@ async function testTransferAsset() {
     newBalanceDestination > oldBalanceDestination,
     `Failed to observe balance increase after transfer for destination account!`,
   );
+
   assert(
     newBalancesSource < oldBalanceSource,
     `Failed to observe balance decrease after transfer for source account!`,
-  );
-
-  assert(
-    oldBalanceSource + oldBalanceDestination === newBalancesSource + newBalanceDestination,
-    `Balance integrity check failed!`,
   );
 
   console.log('=== testTransferAsset complete ===');

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -63,16 +63,23 @@ fn liquidity_providers_can_withdraw_asset() {
 #[test]
 fn liquidity_providers_can_move_assets_internally() {
 	new_test_ext().execute_with(|| {
-		FreeBalances::<Test>::insert(AccountId::from(LP_ACCOUNT), Asset::Eth, 1_000);
-		// Check if the LP accounts have the correct initial balances.
-		assert_eq!(FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT), Asset::Eth), Some(1_000));
-		assert_eq!(FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT_2), Asset::Eth), None);
+		const BALANCE_LP_1: AssetAmount = 1_000;
+		const TRANSFER_AMOUNT: AssetAmount = 100;
+		FreeBalances::<Test>::insert(AccountId::from(LP_ACCOUNT), Asset::Eth, BALANCE_LP_1);
+
+		let old_balance_origin = FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT), Asset::Eth)
+			.expect("balance exists");
+		let old_balance_dest =
+			FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT_2), Asset::Eth).unwrap_or(0);
+
+		assert_eq!(old_balance_origin, BALANCE_LP_1);
+		assert_eq!(old_balance_dest, 0);
 
 		// Cannot move assets to a non-LP account.
 		assert_noop!(
 			LiquidityProvider::transfer_asset(
 				RuntimeOrigin::signed((LP_ACCOUNT).into()),
-				100,
+				TRANSFER_AMOUNT,
 				Asset::Eth,
 				AccountId::from(NON_LP_ACCOUNT),
 			),
@@ -83,7 +90,7 @@ fn liquidity_providers_can_move_assets_internally() {
 		assert_noop!(
 			LiquidityProvider::transfer_asset(
 				RuntimeOrigin::signed((LP_ACCOUNT).into()),
-				100,
+				TRANSFER_AMOUNT,
 				Asset::Eth,
 				AccountId::from(LP_ACCOUNT),
 			),
@@ -92,7 +99,7 @@ fn liquidity_providers_can_move_assets_internally() {
 
 		assert_ok!(LiquidityProvider::transfer_asset(
 			RuntimeOrigin::signed((LP_ACCOUNT).into()),
-			100,
+			TRANSFER_AMOUNT,
 			Asset::Eth,
 			AccountId::from(LP_ACCOUNT_2),
 		));
@@ -101,12 +108,22 @@ fn liquidity_providers_can_move_assets_internally() {
 				from: AccountId::from(LP_ACCOUNT),
 				to: AccountId::from(LP_ACCOUNT_2),
 				asset: Asset::Eth,
-				amount: 100,
+				amount: TRANSFER_AMOUNT,
 			},
 		));
 		// Expect the balances to be moved between the LP accounts.
 		assert_eq!(FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT), Asset::Eth), Some(900));
 		assert_eq!(FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT_2), Asset::Eth), Some(100));
+
+		let new_balance_origin = FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT), Asset::Eth)
+			.expect("balance exists");
+		let new_balance_dest = FreeBalances::<Test>::get(AccountId::from(LP_ACCOUNT_2), Asset::Eth)
+			.expect("balance exists");
+
+		assert!(
+			old_balance_origin + old_balance_dest == new_balance_origin + new_balance_dest,
+			"Balance integrity check failed!"
+		);
 	});
 }
 


### PR DESCRIPTION
Fixes a flaky bouncer test that has been fixed on main.