### PR TITLE
fix: restart node on compatible upgrade

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -236,6 +236,8 @@ jobs:
 
       - name: Print new pre-upgrade chainflip-engine logs 🚗
         if: always()
+        # In the case of a compatible upgrade, we don't expect any logs here
+        continue-on-error: true
         run: |
           cat /tmp/chainflip/*/start-all-engines-pre-upgrade.*log
 

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -201,7 +201,7 @@ jobs:
           git rev-parse HEAD
           cd bouncer
           pnpm install --frozen-lockfile
-          ./run.sh
+          ./setup_for_test.sh
 
       # we need to be sure that when this fails, we catch the error, any panics etc. that occur
       # TODO: Run swaps simultaneously to the upgrade - we could do that inside the `upgrade_network` command itself.

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -201,7 +201,7 @@ jobs:
           git rev-parse HEAD
           cd bouncer
           pnpm install --frozen-lockfile
-          ./setup_for_test.sh
+          ./run.sh
 
       # we need to be sure that when this fails, we catch the error, any panics etc. that occur
       # TODO: Run swaps simultaneously to the upgrade - we could do that inside the `upgrade_network` command itself.

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -237,12 +237,12 @@ jobs:
       - name: Print new pre-upgrade chainflip-engine logs 🚗
         if: always()
         run: |
-          cat /tmp/chainflip/*/chainflip-engine-pre-upgrade.*log
+          cat /tmp/chainflip/*/start-all-engines-pre-upgrade.*log
 
       - name: Print new post-upgrade chainflip-engine logs 🚗
         if: always()
         run: |
-          cat /tmp/chainflip/*/chainflip-engine-post-upgrade.*log
+          cat /tmp/chainflip/*/start-all-engines-post-upgrade.*log
 
       - name: Print chainflip-node logs 📡
         if: always()

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -162,7 +162,7 @@ async function incompatibleUpgradeNoBuild(
 
   console.log('Engines started');
 
-  await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, false);
+  await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);
 
   console.log(
     'Check that the old engine has now shut down, and that the new engine is now running.',
@@ -316,11 +316,7 @@ export async function upgradeNetworkGit(
     console.log('Upgrade complete.');
   } else if (!isCompatible) {
     console.log('The versions are incompatible.');
-    await incompatibleUpgrade(
-      localnetInitPath,
-      nextVersionWorkspacePath,
-      numberOfNodes,
-    );
+    await incompatibleUpgrade(localnetInitPath, nextVersionWorkspacePath, numberOfNodes);
   }
 
   console.log('Cleaning up...');
@@ -369,20 +365,10 @@ export async function upgradeNetworkPrebuilt(
     );
   } else if (isCompatibleWith(cleanOldVersion, nodeVersion)) {
     console.log('The versions are compatible.');
-    await compatibleUpgrade(
-      localnetInitPath,
-      binariesPath,
-      runtimePath,
-      numberOfNodes,
-    );
+    await compatibleUpgrade(localnetInitPath, binariesPath, runtimePath, numberOfNodes);
   } else {
     console.log('The versions are incompatible.');
-    await incompatibleUpgradeNoBuild(
-      localnetInitPath,
-      binariesPath,
-      runtimePath,
-      numberOfNodes,
-    );
+    await incompatibleUpgradeNoBuild(localnetInitPath, binariesPath, runtimePath, numberOfNodes);
   }
 
   console.log('Upgrade complete.');

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -65,11 +65,11 @@ async function startBrokerAndLpApi(localnetInitPath: string, binaryPath: string,
   console.log('Starting new broker and lp-api.');
 
   execWithLog(`${localnetInitPath}/scripts/start-broker-api.sh ${binaryPath}`, 'start-broker-api', {
-    keysDir,
+    KEYS_DIR: keysDir,
   });
 
   execWithLog(`${localnetInitPath}/scripts/start-lp-api.sh ${binaryPath}`, 'start-lp-api', {
-    keysDir,
+    KEYS_DIR: keysDir,
   });
 
   await sleep(10000);

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -68,7 +68,6 @@ async function compatibleUpgrade(
   binaryPath: string,
   runtimePath: string,
   numberOfNodes: 1 | 3,
-  newVersion: string,
 ) {
   await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);
 
@@ -105,7 +104,6 @@ async function compatibleUpgrade(
       BINARY_ROOT_PATH: binaryPath,
     },
   );
-
 }
 
 async function incompatibleUpgradeNoBuild(
@@ -318,13 +316,9 @@ export async function upgradeNetworkGit(
   const localnetInitPath = `${currentVersionWorkspacePath}/localnet/init`;
   if (isCompatible) {
     console.log('The versions are compatible.');
-    await compatibleUpgrade(
-      localnetInitPath,
-      `${nextVersionWorkspacePath}/target/release`,
-      `${nextVersionWorkspacePath}/target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm`,
-      numberOfNodes,
-      toTomlVersion,
-    );
+    await simpleRuntimeUpgrade(nextVersionWorkspacePath, true);
+
+    // TODO: Add restart nodes support, as in the prebuilt case.
 
     console.log('Upgrade complete.');
   } else if (!isCompatible) {

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -114,7 +114,7 @@ async function compatibleUpgrade(
   });
 
   // wait for nodes to be ready
-  await sleep(10000);
+  await sleep(20000);
 
   // engines crashed when node shutdown, so restart them.
   execWithLog(
@@ -162,7 +162,7 @@ async function incompatibleUpgradeNoBuild(
 
   console.log('Engines started');
 
-  await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, true);
+  await submitRuntimeUpgradeWithRestrictions(runtimePath, undefined, undefined, false);
 
   console.log(
     'Check that the old engine has now shut down, and that the new engine is now running.',

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -9,9 +9,7 @@ import { bumpSpecVersionAgainstNetwork } from './utils/spec_version';
 import { compileBinaries } from './utils/compile_binaries';
 import { submitRuntimeUpgradeWithRestrictions } from './submit_runtime_upgrade';
 import { execWithLog } from './utils/exec_with_log';
-import { setupArbVault } from './setup_arb_vault';
 import { submitGovernanceExtrinsic } from './cf_governance';
-import { setupSwaps } from './setup_swaps';
 
 async function readPackageTomlVersion(projectRoot: string): Promise<string> {
   const data = await fs.readFile(path.join(projectRoot, '/state-chain/runtime/Cargo.toml'), 'utf8');
@@ -132,7 +130,7 @@ async function compatibleUpgrade(
     },
   );
 
-  startBrokerAndLpApi(localnetInitPath, binaryPath, KEYS_DIR);
+  await startBrokerAndLpApi(localnetInitPath, binaryPath, KEYS_DIR);
 }
 
 async function incompatibleUpgradeNoBuild(
@@ -140,7 +138,6 @@ async function incompatibleUpgradeNoBuild(
   binaryPath: string,
   runtimePath: string,
   numberOfNodes: 1 | 3,
-  newVersion: string,
 ) {
   const SELECTED_NODES = numberOfNodes === 1 ? 'bashful' : 'bashful doc dopey';
 
@@ -239,15 +236,7 @@ async function incompatibleUpgradeNoBuild(
 
   await sleep(4000);
 
-  if (newVersion.includes('1.4')) {
-    await setupArbVault();
-  }
-
-  startBrokerAndLpApi(localnetInitPath, binaryPath, KEYS_DIR);
-
-  if (newVersion.includes('1.4')) {
-    await setupSwaps();
-  }
+  await startBrokerAndLpApi(localnetInitPath, binaryPath, KEYS_DIR);
 
   console.log('Started new broker and lp-api.');
 }
@@ -257,7 +246,6 @@ async function incompatibleUpgrade(
   localnetInitPath: string,
   nextVersionWorkspacePath: string,
   numberOfNodes: 1 | 3,
-  newVersion: string,
 ) {
   await bumpSpecVersionAgainstNetwork(
     `${nextVersionWorkspacePath}/state-chain/runtime/src/lib.rs`,
@@ -271,7 +259,6 @@ async function incompatibleUpgrade(
     `${nextVersionWorkspacePath}/target/release`,
     `${nextVersionWorkspacePath}/target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm`,
     numberOfNodes,
-    newVersion,
   );
 }
 
@@ -333,7 +320,6 @@ export async function upgradeNetworkGit(
       localnetInitPath,
       nextVersionWorkspacePath,
       numberOfNodes,
-      toTomlVersion,
     );
   }
 
@@ -388,7 +374,6 @@ export async function upgradeNetworkPrebuilt(
       binariesPath,
       runtimePath,
       numberOfNodes,
-      nodeVersion,
     );
   } else {
     console.log('The versions are incompatible.');
@@ -397,7 +382,6 @@ export async function upgradeNetworkPrebuilt(
       binariesPath,
       runtimePath,
       numberOfNodes,
-      nodeVersion,
     );
   }
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

When the versions are "compatible" it doesn't mean the RPCs will be unbroken. So we have to start the node with the new version to ensure the RPC updates are reflected on the node.
e.g. see this failure: https://github.com/chainflip-io/chainflip-backend/actions/runs/9191091275/job/25277048379

Upgrade tests should pass now: https://github.com/chainflip-io/chainflip-backend/actions/runs/9208000827 