### PR TITLE
fix: utxo consolidation works without prev key

### DIFF
--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -529,7 +529,7 @@ impl<T: Config> Pallet<T> {
 						}
 
 						let selected_utxo = select_utxos_for_consolidation(
-							current_key,
+							previous,
 							available_utxos,
 							&bitcoin_fee_info,
 							Self::consolidation_parameters(),

--- a/state-chain/traits/src/mocks/key_provider.rs
+++ b/state-chain/traits/src/mocks/key_provider.rs
@@ -14,7 +14,7 @@ impl<C: ChainCrypto> MockPallet for MockKeyProvider<C> {
 const EPOCH_KEY: &[u8] = b"EPOCH_KEY";
 
 impl<C: ChainCrypto> MockKeyProvider<C> {
-	pub fn add_key(key: C::AggKey) {
+	pub fn set_key(key: C::AggKey) {
 		Self::put_value(EPOCH_KEY, EpochKey { key, epoch_index: Default::default() });
 	}
 }


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

@j4m1ef0rd noticed that consolidation test didn't work on localnet, so I had a look (it is part of full bouncer, but not run by default in PRs). Looks like at some point the code was changed resulting in consolidation being skipped if the previous key isn't available (which it is not the case unless you've rotated multiple times on localnet).
Arguably, we don't care about this edge case, but it is still techincally a bug and it is annoying that the test stopped working on localnet (it wasn't a problem in full bouncer because we rotate more than once there), so I fix it here.

**Update**: This turned out to be more work than I originally thought, but I decided that I might as well finish what I started. Specifically, some changes were required in unit tests, which I found a bit messy. Some of them expliclty asserted that consolidation shouldn't happen if no previous key is set, which was simply "how thing worked" rather than "how things should work". "Consolidation" of old utxos still only happens when previous key is provided. (I really wish we didn't merge the two mechanisms into the same function.)

I also noticed that "consolidation" of old utxos worked even for "stale" utxos (corresponding to the key older than previous). We should only "consolidate" old uxtos that belong to the previous key because we shouldn't assume that we can sign anything older than that (and we already discard such utxos in practice). I changed the code to only "consolidate" old utxos from previous key (in addition to normal consolidation of current key utxos).

This fix probably doesn't matter in practice since old utxos would be discarded elsewhere, but the original behaviour made it more difficult to reason about tests, where we expect "stale" utxos to be discarded rather than "consolidated" (the original tests were hiding this due to the consolidation function not always being called), and the code is now more consistent with "telling the story" about how stale utxos are handled.