### PR TITLE
fix: increase javascript memory limit for bouncer all_concurrent_tests

### DIFF
--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S NODE_OPTIONS=--max-old-space-size=4096 pnpm tsx
+#!/usr/bin/env -S NODE_OPTIONS=--max-old-space-size=6144 pnpm tsx
 import { SwapContext, testAllSwaps } from '../shared/swapping';
 import { testEvmDeposits } from '../shared/evm_deposits';
 import { runWithTimeout, observeBadEvents } from '../shared/utils';


### PR DESCRIPTION
Hitting memory limit for bouncer in upgrade-test, but it's hitting it on the bouncer run of release, so we need to update it here. 

Ideally we can decrease memory usage, but want to get the upgrade-test blocking check in before looking into that.