### PR TITLE
refactor(bouncer): migrate file to new observe event

### DIFF
--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -45,9 +45,9 @@ async function main(): Promise<void> {
   // Step 3
   console.log('Waiting for new keys');
 
-  const dotActivationRequest = observeEvent('polkadotVault:AwaitingGovernanceActivation');
-  const btcActivationRequest = observeEvent('bitcoinVault:AwaitingGovernanceActivation');
-  const arbActivationRequest = observeEvent('arbitrumVault:AwaitingGovernanceActivation');
+  const dotActivationRequest = observeEvent('polkadotVault:AwaitingGovernanceActivation').event;
+  const btcActivationRequest = observeEvent('bitcoinVault:AwaitingGovernanceActivation').event;
+  const arbActivationRequest = observeEvent('arbitrumVault:AwaitingGovernanceActivation').event;
   // const solActivationRequest = observeEvent('solanaVault:AwaitingGovernanceActivation', chainflip);
   const dotKey = (await dotActivationRequest).data.newPublicKey;
   const btcKey = (await btcActivationRequest).data.newPublicKey;
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
   };
   const { vaultAddress, vaultExtrinsicIndex } = await createPolkadotVault();
 
-  const proxyAdded = observeEvent('proxy:ProxyAdded', { chain: 'polkadot' });
+  const proxyAdded = observeEvent('proxy:ProxyAdded', { chain: 'polkadot' }).event;
 
   // Step 5
   console.log('Rotating Proxy and Funding Accounts.');

--- a/bouncer/shared/cf_governance.ts
+++ b/bouncer/shared/cf_governance.ts
@@ -19,9 +19,9 @@ export async function submitGovernanceExtrinsic(
 ) {
   await using chainflip = await getChainflipApi();
   const extrinsic = await cb(chainflip);
-  await snowWhiteMutex.runExclusive(async () =>
-    chainflip.tx.governance
+  await snowWhiteMutex.runExclusive(async () => {
+    await chainflip.tx.governance
       .proposeGovernanceExtrinsic(extrinsic, preAuthorise)
-      .signAndSend(snowWhite, { nonce: -1 }, handleSubstrateError(chainflip)),
-  );
+      .signAndSend(snowWhite, { nonce: -1 }, handleSubstrateError(chainflip));
+  });
 }

--- a/bouncer/shared/create_lp_pool.ts
+++ b/bouncer/shared/create_lp_pool.ts
@@ -20,7 +20,7 @@ export async function createLpPool(ccy: Asset, initialPrice: number) {
     );
     const poolCreatedEvent = observeEvent('liquidityPools:NewPoolCreated', {
       test: (event) => event.data.baseAsset === ccy,
-    });
+    }).event;
     await submitGovernanceExtrinsic((api) => api.tx.liquidityPools.newPool(ccy, 'usdc', 20, price));
     await poolCreatedEvent;
   }

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -15,7 +15,7 @@ import { observeEvent } from './utils/substrate';
 
 export async function initializeArbitrumChain() {
   console.log('Initializing Arbitrum');
-  const arbInitializationRequest = observeEvent('arbitrumVault:ChainInitialized');
+  const arbInitializationRequest = observeEvent('arbitrumVault:ChainInitialized').event;
   await submitGovernanceExtrinsic((chainflip) => chainflip.tx.arbitrumVault.initializeChain());
   await arbInitializationRequest;
 }

--- a/bouncer/shared/provide_liquidity.ts
+++ b/bouncer/shared/provide_liquidity.ts
@@ -13,7 +13,6 @@ import {
   decodeSolAddress,
   chainContractId,
   assetDecimals,
-  Event,
 } from '../shared/utils';
 import { send } from '../shared/send';
 import { observeEvent } from './utils/substrate';
@@ -23,7 +22,7 @@ export async function provideLiquidity(
   amount: number,
   waitForFinalization = false,
   lpKey?: string,
-): Promise<Event> {
+) {
   await using chainflip = await getChainflipApi();
   const chain = shortChainFromAsset(ccy);
 
@@ -55,7 +54,7 @@ export async function provideLiquidity(
 
   let eventHandle = observeEvent('liquidityProvider:LiquidityDepositAddressReady', {
     test: (event) => event.data.asset === ccy && event.data.accountId === lp.address,
-  });
+  }).event;
 
   console.log('Requesting ' + ccy + ' deposit address');
   await lpMutex.runExclusive(async () => {
@@ -76,7 +75,7 @@ export async function provideLiquidity(
         BigInt(amountToFineAmount(String(amount), assetDecimals(ccy))),
       ),
     finalized: waitForFinalization,
-  });
+  }).event;
   await send(ccy, ingressAddress, String(amount));
 
   return eventHandle;

--- a/bouncer/shared/range_order.ts
+++ b/bouncer/shared/range_order.ts
@@ -28,7 +28,7 @@ export async function rangeOrder(ccy: Asset, amount: number) {
   const orderCreatedEvent = observeEvent('liquidityPools:RangeOrderUpdated', {
     test: (event) =>
       event.data.lp === lp.address && event.data.baseAsset === ccy && event.data.id === String(0),
-  });
+  }).event;
   await lpMutex.runExclusive(async () => {
     await chainflip.tx.liquidityPools
       .setRangeOrder(ccy.toLowerCase(), 'usdc', 0, [-887272, 887272], {

--- a/bouncer/shared/setup_arb_vault.ts
+++ b/bouncer/shared/setup_arb_vault.ts
@@ -17,7 +17,7 @@ export async function setupArbVault(): Promise<void> {
   await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
 
   // Step 3
-  const arbActivationRequest = observeEvent('arbitrumVault:AwaitingGovernanceActivation');
+  const arbActivationRequest = observeEvent('arbitrumVault:AwaitingGovernanceActivation').event;
 
   const arbKey = (await arbActivationRequest).data.newPublicKey;
 

--- a/bouncer/shared/setup_boost_pools.ts
+++ b/bouncer/shared/setup_boost_pools.ts
@@ -47,8 +47,8 @@ export async function createBoostPools(newPools: BoostPoolId[]): Promise<void> {
           event.data.boostPool.asset === pool.asset &&
           Number(event.data.boostPool.tier) === pool.tier,
       },
-    );
-    const observeGovernanceFailedExecution = observeEvent(`governance:FailedExecution`);
+    ).event;
+    const observeGovernanceFailedExecution = observeEvent(`governance:FailedExecution`).event;
 
     observeBoostPoolEvents.push(
       Promise.race([observeBoostPoolCreated, observeGovernanceFailedExecution]),

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -1,8 +1,9 @@
 import { compactAddLength } from '@polkadot/util';
 import { promises as fs } from 'fs';
 import { submitGovernanceExtrinsic } from './cf_governance';
-import { decodeModuleError, getChainflipApi, observeEvent } from '../shared/utils';
+import { decodeModuleError, getChainflipApi } from '../shared/utils';
 import { tryRuntimeUpgrade } from './try_runtime_upgrade';
+import { observeEvent } from './utils/substrate';
 
 async function readRuntimeWasmFromFile(filePath: string): Promise<Uint8Array> {
   return compactAddLength(new Uint8Array(await fs.readFile(filePath)));
@@ -42,8 +43,8 @@ export async function submitRuntimeUpgradeWithRestrictions(
   console.log('Submitted runtime upgrade. Waiting for the runtime upgrade to complete.');
 
   const event = await Promise.race([
-    observeEvent('system:CodeUpdated', chainflip),
-    observeEvent('governance:FailedExecution', chainflip),
+    observeEvent('system:CodeUpdated').event,
+    observeEvent('governance:FailedExecution').event,
   ]);
 
   if (event.name.method === 'FailedExecution') {

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -338,6 +338,7 @@ export function getBtcClient(): Client {
 type EventQuery = (data: any) => boolean;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Event = { name: any; data: any; block: number; event_index: number };
+/** @deprecated there is a new one in the substrate utils */
 export async function observeEvent(
   eventName: string,
   api: ApiPromise,

--- a/bouncer/tests/rotation_barrier.ts
+++ b/bouncer/tests/rotation_barrier.ts
@@ -1,34 +1,25 @@
 #!/usr/bin/env -S pnpm tsx
-import { getChainflipApi, observeBadEvents, observeEvent } from '../shared/utils';
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
 import { testSwapViaContract } from '../shared/swapping';
+import { observeEvent, observeBadEvents } from '../shared/utils/substrate';
 
 async function rotateAndSwap() {
-  await using chainflip = await getChainflipApi();
-
   await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
 
   // Wait for the activation key to be created and the activation key to be sent for signing
   console.log(`Vault rotation initiated`);
-  await observeEvent('evmThresholdSigner:KeygenSuccess', chainflip);
+  await observeEvent('evmThresholdSigner:KeygenSuccess').event;
   console.log(`Waiting for the bitcoin key handover`);
-  await observeEvent('bitcoinThresholdSigner:KeyHandoverSuccessReported', chainflip);
+  await observeEvent('bitcoinThresholdSigner:KeyHandoverSuccessReported').event;
   console.log(`Waiting for eth key activation transaction to be sent for signing`);
-  await observeEvent('evmThresholdSigner:ThresholdSignatureRequest', chainflip);
+  await observeEvent('evmThresholdSigner:ThresholdSignatureRequest').event;
 
-  let stopObserving = false;
-  const broadcastAborted = observeBadEvents(
-    ':BroadcastAborted',
-    () => stopObserving,
-    undefined,
-    'Rotate and swap',
-  );
+  const broadcastAborted = observeBadEvents(':BroadcastAborted', { label: 'Rotate and swap' });
 
   // Using Arbitrum as the ingress chain to make the swap as fast as possible
   await testSwapViaContract('ArbEth', 'Eth');
 
-  stopObserving = true;
-  await broadcastAborted;
+  await broadcastAborted.stop();
 }
 
 try {

--- a/bouncer/tsconfig.json
+++ b/bouncer/tsconfig.json
@@ -29,7 +29,7 @@
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "Bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Intention is to use this new observeEvents to memoize the subscription instead of creating a new subscription for each event listener.

Part of: PRO-1411