### PR TITLE
chore: remove errors and warnings from runtime upgrade

### DIFF
--- a/state-chain/pallets/cf-environment/src/migrations.rs
+++ b/state-chain/pallets/cf-environment/src/migrations.rs
@@ -32,7 +32,7 @@ impl<T: Config> OnRuntimeUpgrade for VersionUpdate<T> {
 	}
 }
 
-pub type PalletMigration<T> = PlaceholderMigration<Pallet<T>, 9>;
+pub type PalletMigration<T> = PlaceholderMigration<Pallet<T>, 10>;
 
 #[cfg(test)]
 mod tests {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1019,6 +1019,12 @@ type AllMigrations = (
 /// comment out or remove pallet migrations. Prefer to delete the migration at the pallet level and
 /// replace with a dummy migration.
 type PalletMigrations = (
+	VersionedMigration<
+		pallet_cf_environment::Pallet<Runtime>,
+		migrations::arbitrum_integration::ArbitrumIntegration,
+		9,
+		10,
+	>,
 	pallet_cf_environment::migrations::PalletMigration<Runtime>,
 	pallet_cf_funding::migrations::PalletMigration<Runtime>,
 	pallet_cf_account_roles::migrations::PalletMigration<Runtime>,
@@ -1053,15 +1059,9 @@ type PalletMigrations = (
 	pallet_cf_cfe_interface::migrations::PalletMigration<Runtime>,
 );
 
-// TODO: After this  release, remember to un-comment the
+// TODO: After this release, remember to un-comment the
 // Arbitrum-specific pallet migrations.
 type MigrationsForV1_4 = (
-	VersionedMigration<
-		pallet_cf_environment::Pallet<Runtime>,
-		migrations::arbitrum_integration::ArbitrumIntegration,
-		9,
-		10,
-	>,
 	migrations::housekeeping::Migration,
 	migrations::reap_old_accounts::Migration,
 	// NOTE: Do not change this validator pallet migration order:

--- a/state-chain/runtime/src/migrations/arbitrum_integration.rs
+++ b/state-chain/runtime/src/migrations/arbitrum_integration.rs
@@ -112,7 +112,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 		): (Address, Address, Address, u64, Address, u64, u64) =
 			match cf_runtime_upgrade_utilities::genesis_hashes::genesis_hash::<Runtime>() {
 				cf_runtime_upgrade_utilities::genesis_hashes::BERGHAIN => {
-					log::warn!("Need to set up arbitrum integration for Berghain");
+					log::info!("Applying Arbitrum settings for BERGHAIN");
 					(
 						hex_literal::hex!("BFe612c77C2807Ac5a6A41F84436287578000275").into(),
 						hex_literal::hex!("79001a5e762f3bEFC8e5871b42F6734e00498920").into(),
@@ -125,7 +125,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 					)
 				},
 				cf_runtime_upgrade_utilities::genesis_hashes::PERSEVERANCE => {
-					log::warn!("Need to set up arbitrum integration for Perseverance");
+					log::info!("Applying Arbitrum settings for PERSEVERANCE");
 					(
 						hex_literal::hex!("18195b0E3c33EeF3cA6423b1828E0FE0C03F32Fd").into(),
 						hex_literal::hex!("2bb150e6d4366A1BDBC4275D1F35892CD63F27e3").into(),
@@ -138,7 +138,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 					)
 				},
 				cf_runtime_upgrade_utilities::genesis_hashes::SISYPHOS => {
-					log::warn!("Need to set up arbitrum integration for Sisyphos");
+					log::info!("Applying Arbitrum settings for SISYPHOS");
 					(
 						hex_literal::hex!("7EA74208E2954a7294097C731434caD29c5094D8").into(),
 						hex_literal::hex!("8155BdD48CD011e1118b51A1C82be020A3E5c2f2").into(),
@@ -151,6 +151,7 @@ impl OnRuntimeUpgrade for ArbitrumIntegration {
 					)
 				},
 				_ => {
+					log::info!("Applying Arbitrum settings for testnet");
 					// Assume testnet
 					(
 						hex_literal::hex!("5FbDB2315678afecb367f032d93F642f64180aa3").into(),


### PR DESCRIPTION
This removes some spurious warnings from the 1.4 runtime upgrade. Checked against perseverance and berghain.