### PR TITLE
fix: add missing debug.log on recreate in localnet/manage.sh

### DIFF
--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -136,6 +136,9 @@ build-localnet() {
     fi
   done
 
+  mkdir -p /tmp/chainflip/
+  touch /tmp/chainflip/debug.log
+
   echo "🪢 Pulling Docker Images"
   docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" pull --quiet >>$DEBUG_OUTPUT_DESTINATION 2>&1
   echo "🔮 Initializing Network"

--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -137,7 +137,7 @@ build-localnet() {
   done
 
   mkdir -p /tmp/chainflip/
-  touch /tmp/chainflip/debug.log
+  touch $DEBUG_OUTPUT_DESTINATION
 
   echo "🪢 Pulling Docker Images"
   docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" pull --quiet >>$DEBUG_OUTPUT_DESTINATION 2>&1

--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -136,7 +136,7 @@ build-localnet() {
     fi
   done
 
-  mkdir -p /tmp/chainflip/
+  mkdir -p $CHAINFLIP_BASE_PATH
   touch $DEBUG_OUTPUT_DESTINATION
 
   echo "🪢 Pulling Docker Images"


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

I noticed that "recreate" option stopped working on localnets, and realised that the fix I've merged in the past for this (https://github.com/chainflip-io/chainflip-backend/pull/4487) got reverted in https://github.com/chainflip-io/chainflip-backend/pull/4796. I'm assuming this wasn't intentional, but let me know if it was @albert-llimos.