### PR TITLE
feat (bouncer): add swapContext to contract swaps

### DIFF
--- a/bouncer/shared/contract_swap.ts
+++ b/bouncer/shared/contract_swap.ts
@@ -153,12 +153,12 @@ export async function performSwapViaContract(
 
     const ccmEventEmitted = messageMetadata
       ? observeCcmReceived(
-        sourceAsset,
-        destAsset,
-        destAddress,
-        messageMetadata,
-        wallet.address.toLowerCase(),
-      )
+          sourceAsset,
+          destAsset,
+          destAddress,
+          messageMetadata,
+          wallet.address.toLowerCase(),
+        )
       : Promise.resolve();
 
     const [newBalance] = await Promise.all([

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -138,6 +138,8 @@ export async function doPerformSwap(
 
   await swapScheduledHandle;
 
+  swapContext?.updateStatus(tag, SwapStatus.SwapScheduled);
+
   if (log) console.log(`${tag} Waiting for balance to update`);
 
   try {

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -45,7 +45,7 @@ function newAbiEncodedMessage(types?: SolidityType[]): string {
     for (let i = 0; i < numElements; i++) {
       typesArray.push(
         Object.values(SolidityType)[
-        Math.floor(Math.random() * (Object.keys(SolidityType).length / 2))
+          Math.floor(Math.random() * (Object.keys(SolidityType).length / 2))
         ],
       );
     }
@@ -89,7 +89,7 @@ export function newCcmMetadata(
 
   const gasBudget = Math.floor(
     Number(amountToFineAmount(defaultAssetAmounts(sourceAsset), assetDecimals(sourceAsset))) /
-    gasDiv,
+      gasDiv,
   );
 
   return {
@@ -179,7 +179,14 @@ export async function testSwapViaContract(
   );
 
   swapContext?.updateStatus(tag, SwapStatus.Initiated);
-  return performSwapViaContract(sourceAsset, destAsset, destAddress, tag, messageMetadata, swapContext);
+  return performSwapViaContract(
+    sourceAsset,
+    destAsset,
+    destAddress,
+    tag,
+    messageMetadata,
+    swapContext,
+  );
 }
 
 export class SwapContext {
@@ -221,7 +228,10 @@ export class SwapContext {
         break;
       }
       case SwapStatus.Success: {
-        assert(currentStatus === SwapStatus.SwapScheduled, `Unexpected status transition for ${tag}`);
+        assert(
+          currentStatus === SwapStatus.SwapScheduled,
+          `Unexpected status transition for ${tag}`,
+        );
         break;
       }
       default:


### PR DESCRIPTION
We added it for channel swaps but not contract swaps, and contract swaps have been getting stuck occasionally, so this should help see where they get stuck.