### PR TITLE
pick: refactor(bouncer): ensure crypto ready (#4858)

### DIFF
--- a/bouncer/.eslintrc.json
+++ b/bouncer/.eslintrc.json
@@ -44,7 +44,22 @@
     "no-restricted-syntax": "off",
     "prefer-destructuring": "off",
     "prefer-template": "off",
-    "radix": "off"
+    "radix": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["@polkadot/util-crypto"],
+            "message": "Please import this from './polkadot/util-crypto. It has already been initialized"
+          },
+          {
+            "group": ["@polkadot/keyring"],
+            "message": "Please import this from './polkadot/keyring. It has already been initialized"
+          }
+        ]
+      }
+    ]
   },
   "globals": {
     "jest": true

--- a/bouncer/commands/check_witnesses.ts
+++ b/bouncer/commands/check_witnesses.ts
@@ -13,9 +13,9 @@
 // For example: ./commands/check_witnesses.ts ETH
 // will wait for the next chainStateUpdate extrinsic for ethereum and after some blocks (2) it will check how many validator witnessed it
 
-import { blake2AsHex } from '@polkadot/util-crypto';
-import { SubmittableExtrinsic } from '@polkadot/api/types';
-import { SubmittableResult } from '@polkadot/api';
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import type { SubmittableResult } from '@polkadot/api';
+import { blake2AsHex } from '../polkadot/util-crypto';
 import { runWithTimeout, sleep, getChainflipApi } from '../shared/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/bouncer/commands/go_bananas.ts
+++ b/bouncer/commands/go_bananas.ts
@@ -3,8 +3,8 @@ import axios from 'axios';
 import { InternalAsset as Asset, Chain, getInternalAsset } from '@chainflip/cli';
 import bitcoin from 'bitcoinjs-lib';
 import { Tapleaf } from 'bitcoinjs-lib/src/types';
-import { blake2AsHex } from '@polkadot/util-crypto';
 import * as ecc from 'tiny-secp256k1';
+import { blake2AsHex } from '../polkadot/util-crypto';
 import {
   asciiStringToBytesArray,
   getChainflipApi,

--- a/bouncer/polkadot/keyring.ts
+++ b/bouncer/polkadot/keyring.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-restricted-imports */
+import './util-crypto';
+
+// eslint-disable-next-line no-restricted-exports
+export { default } from '@polkadot/keyring';
+export * from '@polkadot/keyring';

--- a/bouncer/polkadot/util-crypto.ts
+++ b/bouncer/polkadot/util-crypto.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-restricted-imports */
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+
+await cryptoWaitReady();
+
+export * from '@polkadot/util-crypto';

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env -S pnpm tsx
 import assert from 'assert';
 import { randomBytes } from 'crypto';
-import Keyring from '@polkadot/keyring';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+import Keyring from '../polkadot/keyring';
 import {
   EgressId,
   brokerMutex,
@@ -215,7 +214,6 @@ async function testBrokerFees(asset: Asset, seed?: string): Promise<void> {
 
 export async function testBrokerFeeCollection(): Promise<void> {
   console.log('\x1b[36m%s\x1b[0m', '=== Running broker fee collection test ===');
-  await cryptoWaitReady();
   await using chainflip = await getChainflipApi();
 
   // Check account role

--- a/bouncer/shared/cf_governance.ts
+++ b/bouncer/shared/cf_governance.ts
@@ -1,14 +1,11 @@
-import { SubmittableExtrinsic } from '@polkadot/api/types';
-import Keyring from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { ApiPromise } from '@polkadot/api';
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+import type { ApiPromise } from '@polkadot/api';
+import Keyring from '../polkadot/keyring';
 import { getChainflipApi, handleSubstrateError, snowWhiteMutex } from './utils';
 
 const snowWhiteUri =
   process.env.SNOWWHITE_URI ??
   'market outdoor rubber basic simple banana resist quarter lab random hurdle cruise';
-
-await cryptoWaitReady();
 
 const keyring = new Keyring({ type: 'sr25519' });
 

--- a/bouncer/shared/fund_flip.ts
+++ b/bouncer/shared/fund_flip.ts
@@ -1,5 +1,4 @@
-import { HexString } from '@polkadot/util/types';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+import type { HexString } from '@polkadot/util/types';
 import { fundStateChainAccount } from '@chainflip/cli';
 import { Wallet, ethers } from 'ethers';
 import { getNextEvmNonce } from './send_evm';
@@ -16,7 +15,6 @@ import { approveErc20 } from './approve_erc20';
 
 export async function fundFlip(scAddress: string, flipAmount: string) {
   await using chainflip = await getChainflipApi();
-  await cryptoWaitReady();
 
   await approveErc20('Flip', getContractAddress('Ethereum', 'GATEWAY'), flipAmount);
 

--- a/bouncer/shared/fund_redeem.ts
+++ b/bouncer/shared/fund_redeem.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { randomBytes } from 'crypto';
-import { HexString } from '@polkadot/util/types';
+import type { HexString } from '@polkadot/util/types';
 import {
   fineAmountToAmount,
   newAddress,

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -1,6 +1,6 @@
 import { InternalAssets as Assets } from '@chainflip/cli';
 import assert from 'assert';
-import Keyring from '@polkadot/keyring';
+import Keyring from '../polkadot/keyring';
 import {
   getChainflipApi,
   observeEvent,

--- a/bouncer/shared/multiple_members_governance.ts
+++ b/bouncer/shared/multiple_members_governance.ts
@@ -1,6 +1,5 @@
-import Keyring from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { assert } from '@polkadot/util';
+import assert from 'assert';
+import Keyring from '../polkadot/keyring';
 import { getChainflipApi, observeEvent } from '../shared/utils';
 import { snowWhite, submitGovernanceExtrinsic } from '../shared/cf_governance';
 
@@ -15,7 +14,6 @@ async function setGovernanceMembers(members: string[]) {
   await submitGovernanceExtrinsic((chainflip) => chainflip.tx.governance.newMembershipSet(members));
 }
 
-await cryptoWaitReady();
 const keyring = new Keyring({ type: 'sr25519' });
 keyring.setSS58Format(2112);
 

--- a/bouncer/shared/new_dot_address.ts
+++ b/bouncer/shared/new_dot_address.ts
@@ -1,8 +1,6 @@
-import Keyring from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+import Keyring from '../polkadot/keyring';
 
 export async function newDotAddress(seed: string): Promise<string> {
-  await cryptoWaitReady();
   const keyring = new Keyring({ type: 'sr25519' });
   const { address } = keyring.createFromUri('//' + seed);
 

--- a/bouncer/shared/new_statechain_address.ts
+++ b/bouncer/shared/new_statechain_address.ts
@@ -1,8 +1,6 @@
-import Keyring from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+import Keyring from '../polkadot/keyring';
 
 export async function newStatechainAddress(seed: string): Promise<string> {
-  await cryptoWaitReady();
   const keyring = new Keyring({ type: 'sr25519' });
   keyring.setSS58Format(2112);
   const { address } = keyring.createFromUri('//' + seed);

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -1,5 +1,5 @@
-import { encodeAddress } from '@polkadot/util-crypto';
 import { InternalAsset as Asset } from '@chainflip/cli';
+import { encodeAddress } from '../polkadot/util-crypto';
 import { newSwap } from './new_swap';
 import { send, sendViaCfTester } from './send';
 import { getBalance } from './get_balance';

--- a/bouncer/shared/polkadot_keyring.ts
+++ b/bouncer/shared/polkadot_keyring.ts
@@ -1,6 +1,6 @@
-import Keyring from '@polkadot/keyring';
-import { KeyringPair } from '@polkadot/keyring/types';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
+// eslint-disable-next-line no-restricted-imports
+import type { KeyringPair } from '@polkadot/keyring/types';
+import Keyring from '../polkadot/keyring';
 
 const aliceUri = process.env.POLKADOT_ALICE_URI || '//Alice';
 
@@ -10,7 +10,6 @@ let alice: KeyringPair | undefined;
 /// Using a singleton instance of the keyring pair to avoid nonce issues.
 export async function aliceKeyringPair() {
   if (!alice) {
-    await cryptoWaitReady();
     const keyring = new Keyring({ type: 'sr25519' });
     alice = keyring.createFromUri(aliceUri);
   }

--- a/bouncer/shared/polkadot_runtime_update.ts
+++ b/bouncer/shared/polkadot_runtime_update.ts
@@ -3,8 +3,8 @@ import path from 'path';
 import assert from 'assert';
 import { execSync } from 'child_process';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
+import { blake2AsU8a } from '../polkadot/util-crypto';
 import {
   getPolkadotApi,
   observeEvent,

--- a/bouncer/shared/provide_liquidity.ts
+++ b/bouncer/shared/provide_liquidity.ts
@@ -1,6 +1,5 @@
-import { Keyring } from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { InternalAsset as Asset } from '@chainflip/cli';
+import { Keyring } from '../polkadot/keyring';
 import {
   newAddress,
   getChainflipApi,
@@ -26,7 +25,6 @@ export async function provideLiquidity(
   lpKey?: string,
 ): Promise<Event> {
   await using chainflip = await getChainflipApi();
-  await cryptoWaitReady();
   const chain = shortChainFromAsset(ccy);
 
   const keyring = new Keyring({ type: 'sr25519' });

--- a/bouncer/shared/range_order.ts
+++ b/bouncer/shared/range_order.ts
@@ -1,6 +1,5 @@
-import { Keyring } from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { InternalAsset as Asset } from '@chainflip/cli';
+import { Keyring } from '../polkadot/keyring';
 import {
   getChainflipApi,
   handleSubstrateError,
@@ -13,7 +12,6 @@ import { observeEvent } from './utils/substrate';
 export async function rangeOrder(ccy: Asset, amount: number) {
   const fineAmount = amountToFineAmount(String(amount), assetDecimals(ccy));
   await using chainflip = await getChainflipApi();
-  await cryptoWaitReady();
 
   const keyring = new Keyring({ type: 'sr25519' });
   keyring.setSS58Format(2112);

--- a/bouncer/shared/redeem_flip.ts
+++ b/bouncer/shared/redeem_flip.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import { InternalAssets as Assets, executeRedemption, getRedemptionDelay } from '@chainflip/cli';
-import { HexString } from '@polkadot/util/types';
+import type { HexString } from '@polkadot/util/types';
 import { Wallet, ethers } from 'ethers';
-import Keyring from '@polkadot/keyring';
+import Keyring from '../polkadot/keyring';
 import { getNextEvmNonce } from './send_evm';
 import { getGatewayAbi } from './contract_interfaces';
 import {

--- a/bouncer/shared/setup_swaps.ts
+++ b/bouncer/shared/setup_swaps.ts
@@ -1,4 +1,3 @@
-import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { createLpPool } from '../shared/create_lp_pool';
 import { provideLiquidity } from '../shared/provide_liquidity';
 import { rangeOrder } from '../shared/range_order';
@@ -32,7 +31,6 @@ const price = new Map<Asset, number>([
 
 export async function setupSwaps(): Promise<void> {
   console.log('=== Setting up for swaps ===');
-  await cryptoWaitReady();
 
   await Promise.all([
     createLpPool('Eth', price.get('Eth')!),

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -1,7 +1,7 @@
-import { randomAsHex, randomAsNumber } from '@polkadot/util-crypto';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 import Web3 from 'web3';
 import assert from 'assert';
+import { randomAsHex, randomAsNumber } from '../polkadot/util-crypto';
 import { performSwap, SwapParams } from '../shared/perform_swap';
 import {
   newAddress,

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -1,7 +1,7 @@
 // This requires the try-runtime cli to be installed globally
 // https://github.com/paritytech/try-runtime-cli
 
-import { ApiPromise } from '@polkadot/api';
+import type { ApiPromise } from '@polkadot/api';
 import path from 'path';
 import { compileBinaries } from './utils/compile_binaries';
 import { createTmpDirIfNotExists, execWithRustLog } from './utils/exec_with_log';

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -14,9 +14,9 @@ import {
 } from '@chainflip/cli';
 import Web3 from 'web3';
 import { Connection, Keypair } from '@solana/web3.js';
-import { base58Decode, base58Encode, cryptoWaitReady } from '@polkadot/util-crypto';
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
+import { base58Decode, base58Encode } from '../polkadot/util-crypto';
 import { newDotAddress } from './new_dot_address';
 import { BtcAddressType, newBtcAddress } from './new_btc_address';
 import { getBalance } from './get_balance';
@@ -250,7 +250,6 @@ function getCachedSubstrateApi(defaultEndpoint: string) {
 
   return async (providedEndpoint?: string): Promise<DisposableApiPromise> => {
     if (!api) {
-      await cryptoWaitReady();
       const endpoint = providedEndpoint ?? defaultEndpoint;
 
       const apiPromise = await ApiPromise.create({

--- a/bouncer/tests/double_deposit.ts
+++ b/bouncer/tests/double_deposit.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S pnpm tsx
-import { Keyring } from '@polkadot/keyring';
-import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { exec } from 'child_process';
+import { Keyring } from '../polkadot/keyring';
 import {
   runWithTimeout,
   sleep,
@@ -13,7 +12,6 @@ import {
 } from '../shared/utils';
 
 async function main(): Promise<void> {
-  await cryptoWaitReady();
   const keyring = new Keyring({ type: 'sr25519' });
   const lpUri = process.env.LP_URI ?? '//LP_1';
   const lp = keyring.createFromUri(lpUri);

--- a/bouncer/tests/eth_witness_test.ts
+++ b/bouncer/tests/eth_witness_test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S pnpm tsx
-import { Keyring } from '@polkadot/keyring';
 import { exec } from 'child_process';
+import { Keyring } from '../polkadot/keyring';
 import { runWithTimeout, observeEvent, getChainflipApi } from '../shared/utils';
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Resolves a source of flakiness that is fixed on main, but this is not on release. Needs to be on release so the upgrade-test can pass on main too.

Example of said flakiness: https://github.com/chainflip-io/chainflip-backend/actions/runs/9283460684/job/25545685114