### PR TITLE
chore: log chainflip header in runner rather than in dylib

### DIFF
--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -31,6 +31,17 @@ mod new {
 // 4. If this new version completes, then we're done. The engine should be upgraded before this is
 //    the case.
 fn main() -> anyhow::Result<()> {
+	println!(
+		"
+		 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗██╗     ██╗██████╗
+		██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██║     ██║██╔══██╗
+		██║     ███████║███████║██║██╔██╗ ██║█████╗  ██║     ██║██████╔╝
+		██║     ██╔══██║██╔══██║██║██║╚██╗██║██╔══╝  ██║     ██║██╔═══╝
+		╚██████╗██║  ██║██║  ██║██║██║ ╚████║██║     ███████╗██║██║
+		 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚═╝     ╚══════╝╚═╝╚═╝
+		"
+	);
+
 	let env_args = std::env::args().collect::<Vec<String>>();
 
 	let c_str_array = CStrArray::from_rust_strings(&env_args)?;

--- a/utilities/src/with_std/logging.rs
+++ b/utilities/src/with_std/logging.rs
@@ -32,16 +32,6 @@ macro_rules! print_start_and_end {
 				env!("CARGO_PKG_VERSION"),
 				$crate::internal_lazy_format!(if let Some(repository_link) = $crate::repository_link() => ("CI Build: \"{}\"", repository_link) else => ("Non-CI Build"))
 			);
-			println!(
-				"
-				 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗██╗     ██╗██████╗
-				██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██║     ██║██╔══██╗
-				██║     ███████║███████║██║██╔██╗ ██║█████╗  ██║     ██║██████╔╝
-				██║     ██╔══██║██╔══██║██║██║╚██╗██║██╔══╝  ██║     ██║██╔═══╝
-				╚██████╗██║  ██║██║  ██║██║██║ ╚████║██║     ███████╗██║██║
-				 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚═╝     ╚══════╝╚═╝╚═╝
-				"
-			);
 
 			match $e {
 				Ok(result) => match result {


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This would log inside the dylib, which is strange when an upgrade occurs and it's handed over to the new dylib, as this would print again. This PR just prints it on binary startup, rather than dylib startup.