### PR TITLE
feat: run upgrade-test on push to release branches

### DIFF
--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -65,6 +65,13 @@ jobs:
     secrets: inherit
     with:
       full_bouncer: true
+  upgrade-check:
+    uses: ./.github/workflows/upgrade-test.yml
+    secrets: inherit
+    with:
+      run-job: true
+      upgrade-from-release: "perseverance"
+      upgrade-to-workflow-name: "ci-main.yml"
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml


### PR DESCRIPTION
# Pull Request

Closes: PRO-1380

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Quite simply, run upgrade-test on push to release branches. Given we generally don't expect many pushes to release branches this is fine, and of course, we should be more conservative and run all the CI checks on release, as this is what will go out.