### PR TITLE
fix: mac rpath search should use executable's directory

### DIFF
--- a/engine-runner-bin/build.rs
+++ b/engine-runner-bin/build.rs
@@ -37,6 +37,7 @@ fn main() {
 		println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../../old-engine-dylib");
 		// Tests run the binary from target/<profile>/deps, rather than just target/<profile>.
 		println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../../../old-engine-dylib");
+		println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
 	} else {
 		// TODO: Use $ORIGIN for linux. I tried, but it doesn't seem to work like `@executable_path`
 		// does for mac.


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The new dylib is located in the directory of the executable. This was missed in #4939 