### PR TITLE
refactor: remove old observeEvent and observeBadEvent

### DIFF
--- a/bouncer/.eslintrc.json
+++ b/bouncer/.eslintrc.json
@@ -50,6 +50,7 @@
     "import/extensions": "off",
     "import/prefer-default-export": "off",
     "import/no-unresolved": "off",
+    "import/named": "error",
     "no-await-in-loop": "off",
     "no-console": "off",
     "no-plusplus": "off",

--- a/bouncer/commands/check_witnesses.ts
+++ b/bouncer/commands/check_witnesses.ts
@@ -16,7 +16,7 @@
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
 import type { SubmittableResult } from '@polkadot/api';
 import { blake2AsHex } from '../polkadot/util-crypto';
-import { runWithTimeout, sleep, getChainflipApi } from '../shared/utils';
+import { getChainflipApi, runWithTimeout, sleep } from '../shared/utils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const witnessHash = new Set<any>();

--- a/bouncer/commands/go_bananas.ts
+++ b/bouncer/commands/go_bananas.ts
@@ -7,13 +7,13 @@ import * as ecc from 'tiny-secp256k1';
 import { blake2AsHex } from '../polkadot/util-crypto';
 import {
   asciiStringToBytesArray,
-  getChainflipApi,
   hexStringToBytesArray,
   sleep,
   fineAmountToAmount,
   assetDecimals,
   chainFromAsset,
   stateChainAssetFromAsset,
+  getChainflipApi,
 } from '../shared/utils';
 import { requestNewSwap } from '../shared/perform_swap';
 import { testSwap } from '../shared/swapping';

--- a/bouncer/commands/observe_block.ts
+++ b/bouncer/commands/observe_block.ts
@@ -8,7 +8,8 @@
 // For example: ./commands/observe_block.ts 3
 // will wait until block number 3 has appeared on the state chain
 
-import { runWithTimeout, sleep, getChainflipApi } from '../shared/utils';
+import { runWithTimeout, sleep } from '../shared/utils';
+import { getChainflipApi } from '../shared/utils/substrate';
 
 async function main(): Promise<void> {
   await using api = await getChainflipApi();

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -10,7 +10,6 @@ import { AddressOrPair } from '@polkadot/api/types';
 import Web3 from 'web3';
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
 import {
-  getPolkadotApi,
   getBtcClient,
   handleSubstrateError,
   getEvmEndpoint,
@@ -23,7 +22,7 @@ import {
   initializeArbitrumContracts,
   initializeSolanaPrograms,
 } from '../shared/initialize_new_chains';
-import { observeEvent } from '../shared/utils/substrate';
+import { getPolkadotApi, observeEvent } from '../shared/utils/substrate';
 
 async function main(): Promise<void> {
   const btcClient = getBtcClient();

--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -23,7 +23,8 @@ import {
   tryRuntimeUpgrade,
   tryRuntimeUpgradeWithCompileRuntime,
 } from '../shared/try_runtime_upgrade';
-import { getChainflipApi, runWithTimeout } from '../shared/utils';
+import { runWithTimeout } from '../shared/utils';
+import { getChainflipApi } from '../shared/utils/substrate';
 
 async function main(): Promise<void> {
   const args = await yargs(hideBin(process.argv))

--- a/bouncer/shared/boost.ts
+++ b/bouncer/shared/boost.ts
@@ -3,7 +3,6 @@ import Keyring from '@polkadot/keyring';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 import assert from 'assert';
 import {
-  getChainflipApi,
   lpMutex,
   chainFromAsset,
   shortChainFromAsset,
@@ -20,7 +19,7 @@ import { provideLiquidity } from './provide_liquidity';
 import { requestNewSwap } from './perform_swap';
 import { createBoostPools } from './setup_boost_pools';
 import { jsonRpc } from './json_rpc';
-import { observeEvent, Event } from './utils/substrate';
+import { observeEvent, Event, getChainflipApi } from './utils/substrate';
 
 const keyring = new Keyring({ type: 'sr25519' });
 keyring.setSS58Format(2112);

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -12,13 +12,12 @@ import {
   observeBalanceIncrease,
   shortChainFromAsset,
   hexStringToBytesArray,
-  getChainflipApi,
   calculateFeeWithBps,
   amountToFineAmountBigInt,
 } from '../shared/utils';
 import { getBalance } from '../shared/get_balance';
 import { doPerformSwap } from '../shared/perform_swap';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 const swapAssetAmount = {
   [Assets.Eth]: 1,

--- a/bouncer/shared/cf_governance.ts
+++ b/bouncer/shared/cf_governance.ts
@@ -1,7 +1,8 @@
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
 import type { ApiPromise } from '@polkadot/api';
 import Keyring from '../polkadot/keyring';
-import { getChainflipApi, handleSubstrateError, snowWhiteMutex } from './utils';
+import { handleSubstrateError, snowWhiteMutex } from './utils';
+import { getChainflipApi } from './utils/substrate';
 
 const snowWhiteUri =
   process.env.SNOWWHITE_URI ??

--- a/bouncer/shared/create_lp_pool.ts
+++ b/bouncer/shared/create_lp_pool.ts
@@ -1,6 +1,6 @@
-import { getChainflipApi, assetDecimals, Asset } from '../shared/utils';
+import { assetDecimals, Asset } from '../shared/utils';
 import { submitGovernanceExtrinsic } from './cf_governance';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 export async function createLpPool(ccy: Asset, initialPrice: number) {
   await using chainflip = await getChainflipApi();

--- a/bouncer/shared/fund_flip.ts
+++ b/bouncer/shared/fund_flip.ts
@@ -10,8 +10,9 @@ import {
   getWhaleKey,
   assetDecimals,
 } from './utils';
-import { observeEvent, getChainflipApi, amountToFineAmount } from '../shared/utils';
+import { getChainflipApi, amountToFineAmount } from '../shared/utils';
 import { approveErc20 } from './approve_erc20';
+import { observeEvent } from './utils/substrate';
 
 export async function fundFlip(scAddress: string, flipAmount: string) {
   await using chainflip = await getChainflipApi();
@@ -60,15 +61,16 @@ export async function fundFlip(scAddress: string, flipAmount: string) {
 
   console.log(
     'Transaction complete, tx_hash: ' +
-      receipt2.hash +
-      ' blockNumber: ' +
-      receipt2.blockNumber +
-      ' blockHash: ' +
-      receipt2.blockHash,
+    receipt2.hash +
+    ' blockNumber: ' +
+    receipt2.blockNumber +
+    ' blockHash: ' +
+    receipt2.blockHash,
   );
   await observeEvent(
     'funding:Funded',
-    chainflip,
-    (event) => hexPubkeyToFlipAddress(pubkey) === event.data.accountId,
-  );
+    {
+      test: (event) => hexPubkeyToFlipAddress(pubkey) === event.data.accountId
+    }
+  ).event;
 }

--- a/bouncer/shared/fund_flip.ts
+++ b/bouncer/shared/fund_flip.ts
@@ -10,13 +10,11 @@ import {
   getWhaleKey,
   assetDecimals,
 } from './utils';
-import { getChainflipApi, amountToFineAmount } from '../shared/utils';
+import { amountToFineAmount } from '../shared/utils';
 import { approveErc20 } from './approve_erc20';
 import { observeEvent } from './utils/substrate';
 
 export async function fundFlip(scAddress: string, flipAmount: string) {
-  await using chainflip = await getChainflipApi();
-
   await approveErc20('Flip', getContractAddress('Ethereum', 'GATEWAY'), flipAmount);
 
   const flipperinoAmount = amountToFineAmount(flipAmount, assetDecimals('Flip'));
@@ -61,16 +59,13 @@ export async function fundFlip(scAddress: string, flipAmount: string) {
 
   console.log(
     'Transaction complete, tx_hash: ' +
-    receipt2.hash +
-    ' blockNumber: ' +
-    receipt2.blockNumber +
-    ' blockHash: ' +
-    receipt2.blockHash,
+      receipt2.hash +
+      ' blockNumber: ' +
+      receipt2.blockNumber +
+      ' blockHash: ' +
+      receipt2.blockHash,
   );
-  await observeEvent(
-    'funding:Funded',
-    {
-      test: (event) => hexPubkeyToFlipAddress(pubkey) === event.data.accountId
-    }
-  ).event;
+  await observeEvent('funding:Funded', {
+    test: (event) => hexPubkeyToFlipAddress(pubkey) === event.data.accountId,
+  }).event;
 }

--- a/bouncer/shared/fund_redeem.ts
+++ b/bouncer/shared/fund_redeem.ts
@@ -5,13 +5,13 @@ import {
   fineAmountToAmount,
   newAddress,
   observeBalanceIncrease,
-  getChainflipApi,
   assetDecimals,
 } from '../shared/utils';
 import { getBalance } from '../shared/get_balance';
 import { fundFlip } from '../shared/fund_flip';
 import { redeemFlip, RedeemAmount } from '../shared/redeem_flip';
 import { newStatechainAddress } from '../shared/new_statechain_address';
+import { getChainflipApi } from './utils/substrate';
 
 // Submitting the `redeem` extrinsic will cost a small amount of gas. Any more than this and we should be suspicious.
 const gasErrorMargin = 0.1;

--- a/bouncer/shared/get_dot_balance.ts
+++ b/bouncer/shared/get_dot_balance.ts
@@ -1,4 +1,5 @@
-import { getPolkadotApi, fineAmountToAmount, assetDecimals } from './utils';
+import { fineAmountToAmount, assetDecimals } from './utils';
+import { getPolkadotApi } from './utils/substrate';
 
 export async function getDotBalance(address: string): Promise<string> {
   await using polkadot = await getPolkadotApi(process.env.POLKADOT_ENDPOINT);

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -73,8 +73,8 @@ async function testRegisterLiquidityRefundAddress() {
   const observeRefundAddressRegisteredEvent = observeEvent(
     'liquidityProvider:LiquidityRefundAddressRegistered',
     {
-      test: (event) => event.data.address.Eth === testAddress
-    }
+      test: (event) => event.data.address.Eth === testAddress,
+    },
   );
 
   const registerRefundAddress = await lpApiRpc(`lp_register_liquidity_refund_address`, [
@@ -93,8 +93,8 @@ async function testLiquidityDeposit() {
   const observeLiquidityDepositAddressReadyEvent = observeEvent(
     'liquidityProvider:LiquidityDepositAddressReady',
     {
-      test: (event) => event.data.depositAddress.Eth
-    }
+      test: (event) => event.data.depositAddress.Eth,
+    },
   ).event;
 
   const liquidityDepositAddress = (
@@ -113,18 +113,14 @@ async function testLiquidityDeposit() {
   );
 
   // Send funds to the deposit address and watch for deposit event
-  const observeAccountCreditedEvent = observeEvent(
-    'liquidityProvider:AccountCredited',
-    {
-      test:
-        (event) =>
-          event.data.asset === testAsset &&
-          isWithinOnePercent(
-            BigInt(event.data.amountCredited.replace(/,/g, '')),
-            BigInt(testAssetAmount),
-          )
-    }
-  ).event;
+  const observeAccountCreditedEvent = observeEvent('liquidityProvider:AccountCredited', {
+    test: (event) =>
+      event.data.asset === testAsset &&
+      isWithinOnePercent(
+        BigInt(event.data.amountCredited.replace(/,/g, '')),
+        BigInt(testAssetAmount),
+      ),
+  }).event;
   await sendEvmNative(chainFromAsset(testAsset), liquidityDepositAddress, String(testAmount));
   await observeAccountCreditedEvent;
 }

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -2,7 +2,6 @@ import { InternalAssets as Assets } from '@chainflip/cli';
 import assert from 'assert';
 import Keyring from '../polkadot/keyring';
 import {
-  getChainflipApi,
   isValidHexHash,
   isValidEthAddress,
   amountToFineAmount,
@@ -18,7 +17,7 @@ import { jsonRpc } from './json_rpc';
 import { provideLiquidity } from './provide_liquidity';
 import { sendEvmNative } from './send_evm';
 import { getBalance } from './get_balance';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 type RpcAsset = {
   asset: string;

--- a/bouncer/shared/lp_api_test.ts
+++ b/bouncer/shared/lp_api_test.ts
@@ -3,7 +3,6 @@ import assert from 'assert';
 import Keyring from '../polkadot/keyring';
 import {
   getChainflipApi,
-  observeEvent,
   isValidHexHash,
   isValidEthAddress,
   amountToFineAmount,
@@ -19,6 +18,7 @@ import { jsonRpc } from './json_rpc';
 import { provideLiquidity } from './provide_liquidity';
 import { sendEvmNative } from './send_evm';
 import { getBalance } from './get_balance';
+import { observeEvent } from './utils/substrate';
 
 type RpcAsset = {
   asset: string;
@@ -72,8 +72,9 @@ async function provideLiquidityAndTestAssetBalances() {
 async function testRegisterLiquidityRefundAddress() {
   const observeRefundAddressRegisteredEvent = observeEvent(
     'liquidityProvider:LiquidityRefundAddressRegistered',
-    chainflip,
-    (event) => event.data.address.Eth === testAddress,
+    {
+      test: (event) => event.data.address.Eth === testAddress
+    }
   );
 
   const registerRefundAddress = await lpApiRpc(`lp_register_liquidity_refund_address`, [
@@ -83,7 +84,7 @@ async function testRegisterLiquidityRefundAddress() {
   if (!isValidHexHash(await registerRefundAddress)) {
     throw new Error(`Unexpected lp_register_liquidity_refund_address result`);
   }
-  await observeRefundAddressRegisteredEvent;
+  await observeRefundAddressRegisteredEvent.event;
 
   // TODO: Check that the correct address is now set on the SC
 }
@@ -91,9 +92,10 @@ async function testRegisterLiquidityRefundAddress() {
 async function testLiquidityDeposit() {
   const observeLiquidityDepositAddressReadyEvent = observeEvent(
     'liquidityProvider:LiquidityDepositAddressReady',
-    chainflip,
-    (event) => event.data.depositAddress.Eth,
-  );
+    {
+      test: (event) => event.data.depositAddress.Eth
+    }
+  ).event;
 
   const liquidityDepositAddress = (
     await lpApiRpc(`lp_liquidity_deposit`, [testRpcAsset, 'InBlock'])
@@ -113,14 +115,16 @@ async function testLiquidityDeposit() {
   // Send funds to the deposit address and watch for deposit event
   const observeAccountCreditedEvent = observeEvent(
     'liquidityProvider:AccountCredited',
-    chainflip,
-    (event) =>
-      event.data.asset === testAsset &&
-      isWithinOnePercent(
-        BigInt(event.data.amountCredited.replace(/,/g, '')),
-        BigInt(testAssetAmount),
-      ),
-  );
+    {
+      test:
+        (event) =>
+          event.data.asset === testAsset &&
+          isWithinOnePercent(
+            BigInt(event.data.amountCredited.replace(/,/g, '')),
+            BigInt(testAssetAmount),
+          )
+    }
+  ).event;
   await sendEvmNative(chainFromAsset(testAsset), liquidityDepositAddress, String(testAmount));
   await observeAccountCreditedEvent;
 }

--- a/bouncer/shared/multiple_members_governance.ts
+++ b/bouncer/shared/multiple_members_governance.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import Keyring from '../polkadot/keyring';
-import { getChainflipApi, tryUntilSuccess } from '../shared/utils';
+import { tryUntilSuccess } from '../shared/utils';
 import { snowWhite, submitGovernanceExtrinsic } from '../shared/cf_governance';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 async function getGovernanceMembers(): Promise<string[]> {
   await using chainflip = await getChainflipApi();

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -4,7 +4,6 @@ import { newSwap } from './new_swap';
 import { send, sendViaCfTester } from './send';
 import { getBalance } from './get_balance';
 import {
-  getChainflipApi,
   observeBalanceIncrease,
   observeCcmReceived,
   shortChainFromAsset,
@@ -14,7 +13,7 @@ import {
 } from '../shared/utils';
 import { CcmDepositMetadata } from '../shared/new_swap';
 import { SwapContext, SwapStatus } from './swapping';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 function encodeDestinationAddress(address: string, destAsset: Asset): string {
   let destAddress = address;

--- a/bouncer/shared/polkadot_runtime_update.ts
+++ b/bouncer/shared/polkadot_runtime_update.ts
@@ -5,11 +5,11 @@ import { execSync } from 'child_process';
 
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 import { blake2AsU8a } from '../polkadot/util-crypto';
-import { getPolkadotApi, amountToFineAmount, sleep, assetDecimals } from '../shared/utils';
+import { amountToFineAmount, sleep, assetDecimals } from '../shared/utils';
 import { specVersion, getNetworkRuntimeVersion } from './utils/spec_version';
 import { handleDispatchError, submitAndGetEvent } from '../shared/polkadot_utils';
 import { testSwap } from './swapping';
-import { observeEvent, observeBadEvent } from './utils/substrate';
+import { observeEvent, observeBadEvent, getPolkadotApi } from './utils/substrate';
 
 const POLKADOT_REPO_URL = `https://github.com/chainflip-io/polkadot.git`;
 const PROPOSAL_AMOUNT = '100';

--- a/bouncer/shared/polkadot_utils.ts
+++ b/bouncer/shared/polkadot_utils.ts
@@ -1,6 +1,7 @@
 import { BN } from '@polkadot/util';
 import { aliceKeyringPair } from '../shared/polkadot_keyring';
-import { Event, getPolkadotApi, polkadotSigningMutex, sleep } from '../shared/utils';
+import { Event, polkadotSigningMutex, sleep } from '../shared/utils';
+import { getPolkadotApi } from './utils/substrate';
 
 // TODO: Move getPolkadotApi and other stuff from utils to here
 

--- a/bouncer/shared/provide_liquidity.ts
+++ b/bouncer/shared/provide_liquidity.ts
@@ -2,7 +2,6 @@ import { InternalAsset as Asset } from '@chainflip/cli';
 import { Keyring } from '../polkadot/keyring';
 import {
   newAddress,
-  getChainflipApi,
   decodeDotAddressForContract,
   handleSubstrateError,
   lpMutex,
@@ -15,7 +14,7 @@ import {
   assetDecimals,
 } from '../shared/utils';
 import { send } from '../shared/send';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 export async function provideLiquidity(
   ccy: Asset,

--- a/bouncer/shared/range_order.ts
+++ b/bouncer/shared/range_order.ts
@@ -1,13 +1,7 @@
 import { InternalAsset as Asset } from '@chainflip/cli';
 import { Keyring } from '../polkadot/keyring';
-import {
-  getChainflipApi,
-  handleSubstrateError,
-  amountToFineAmount,
-  lpMutex,
-  assetDecimals,
-} from '../shared/utils';
-import { observeEvent } from './utils/substrate';
+import { handleSubstrateError, amountToFineAmount, lpMutex, assetDecimals } from '../shared/utils';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 export async function rangeOrder(ccy: Asset, amount: number) {
   const fineAmount = amountToFineAmount(String(amount), assetDecimals(ccy));

--- a/bouncer/shared/redeem_flip.ts
+++ b/bouncer/shared/redeem_flip.ts
@@ -9,7 +9,6 @@ import {
   sleep,
   handleSubstrateError,
   getContractAddress,
-  getChainflipApi,
   amountToFineAmount,
   observeEVMEvent,
   chainFromAsset,
@@ -17,7 +16,7 @@ import {
   getWhaleKey,
   assetDecimals,
 } from './utils';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 export type RedeemAmount = 'Max' | { Exact: string };
 

--- a/bouncer/shared/send_dot.ts
+++ b/bouncer/shared/send_dot.ts
@@ -1,11 +1,6 @@
-import {
-  polkadotSigningMutex,
-  sleep,
-  amountToFineAmount,
-  getPolkadotApi,
-  assetDecimals,
-} from './utils';
+import { polkadotSigningMutex, sleep, amountToFineAmount, assetDecimals } from './utils';
 import { aliceKeyringPair } from './polkadot_keyring';
+import { getPolkadotApi } from './utils/substrate';
 
 export async function sendDot(address: string, amount: string) {
   const planckAmount = amountToFineAmount(amount, assetDecimals('Dot'));

--- a/bouncer/shared/setup_boost_pools.ts
+++ b/bouncer/shared/setup_boost_pools.ts
@@ -4,11 +4,10 @@ import {
   chainFromAsset,
   Asset,
   decodeModuleError,
-  getChainflipApi,
   Event,
 } from '../shared/utils';
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 import { addBoostFunds } from './boost';
 import { provideLiquidity } from './provide_liquidity';
 

--- a/bouncer/shared/submit_runtime_upgrade.ts
+++ b/bouncer/shared/submit_runtime_upgrade.ts
@@ -1,9 +1,9 @@
 import { compactAddLength } from '@polkadot/util';
 import { promises as fs } from 'fs';
 import { submitGovernanceExtrinsic } from './cf_governance';
-import { decodeModuleError, getChainflipApi } from '../shared/utils';
+import { decodeModuleError } from '../shared/utils';
 import { tryRuntimeUpgrade } from './try_runtime_upgrade';
-import { observeEvent } from './utils/substrate';
+import { getChainflipApi, observeEvent } from './utils/substrate';
 
 async function readRuntimeWasmFromFile(filePath: string): Promise<Uint8Array> {
   return compactAddLength(new Uint8Array(await fs.readFile(filePath)));

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -373,7 +373,7 @@ export async function observeSwapScheduled(
   swapType?: SwapType,
 ) {
   // need to await this to prevent the chainflip api from being disposed prematurely
-  await observeEvent('swapping:SwapScheduled', {
+  return observeEvent('swapping:SwapScheduled', {
     test: (event) => {
       if ('DepositChannel' in event.data.origin) {
         const channelMatches = Number(event.data.origin.DepositChannel.channelId) === channelId;

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -1,5 +1,79 @@
 import 'disposablestack/auto';
-import { deferredPromise, getChainflipApi, getPolkadotApi } from '../utils';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { deferredPromise } from '../utils';
+
+// @ts-expect-error polyfilling
+Symbol.asyncDispose ??= Symbol('asyncDispose');
+// @ts-expect-error polyfilling
+Symbol.dispose ??= Symbol('dispose');
+
+type DisposableApiPromise = ApiPromise & { [Symbol.asyncDispose](): Promise<void> };
+
+// It is important to cache WS connections because nodes seem to have a
+// limit on how many can be opened at the same time (from the same IP presumably)
+function getCachedSubstrateApi(defaultEndpoint: string) {
+  let api: DisposableApiPromise | undefined;
+  let connections = 0;
+
+  return async (providedEndpoint?: string): Promise<DisposableApiPromise> => {
+    if (!api) {
+      const endpoint = providedEndpoint ?? defaultEndpoint;
+
+      const apiPromise = await ApiPromise.create({
+        provider: new WsProvider(endpoint),
+        noInitWarn: true,
+        types: {
+          EncodedAddress: {
+            _enum: {
+              Eth: '[u8; 20]',
+              Arb: '[u8; 20]',
+              Dot: '[u8; 32]',
+              Btc: 'Vec<u8>',
+            },
+          },
+        },
+      });
+
+      api = new Proxy(apiPromise as unknown as DisposableApiPromise, {
+        get(target, prop, receiver) {
+          if (prop === Symbol.asyncDispose) {
+            return async () => {
+              connections -= 1;
+              if (connections === 0) {
+                setTimeout(() => {
+                  if (connections === 0) {
+                    api = undefined;
+                    Reflect.get(target, 'disconnect', receiver)
+                      .call(target)
+                      .catch(() => null);
+                  }
+                }, 5_000).unref();
+              }
+            };
+          }
+          if (prop === 'disconnect') {
+            return async () => {
+              // noop
+            };
+          }
+
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+    }
+
+    connections += 1;
+
+    return api;
+  };
+}
+
+export const getChainflipApi = getCachedSubstrateApi(
+  process.env.CF_NODE_ENDPOINT ?? 'ws://127.0.0.1:9944',
+);
+export const getPolkadotApi = getCachedSubstrateApi(
+  process.env.POLKADOT_ENDPOINT ?? 'ws://127.0.0.1:9947',
+);
 
 const apiMap = {
   chainflip: getChainflipApi,

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -171,9 +171,8 @@ export function observeEvent<T = any>(
 
   return { stop: () => controller.abort(), event: findEvent() } as AbortableObserver<T>;
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-export function observeBadEvents<T>(
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function observeBadEvent<T = any>(
   eventName: EventName,
   { test, label }: { test?: EventTest<T>; label?: string },
 ): { stop: () => Promise<void> } {

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -20,16 +20,12 @@ async function runAllConcurrentTests() {
   const givenNumberOfNodes = match ? parseInt(match[0]) : null;
   const numberOfNodes = givenNumberOfNodes ?? 1;
 
-  const broadcastAborted = observeBadEvent(
-    ':BroadcastAborted',
-    { label: 'Concurrent broadcast aborted' }
-  );
-  const feeDeficitRefused = observeBadEvent(
-    ':TransactionFeeDeficitRefused',
-    {
-      label: 'Concurrent fee deficit refused',
-    }
-  );
+  const broadcastAborted = observeBadEvent(':BroadcastAborted', {
+    label: 'Concurrent broadcast aborted',
+  });
+  const feeDeficitRefused = observeBadEvent(':TransactionFeeDeficitRefused', {
+    label: 'Concurrent fee deficit refused',
+  });
 
   // Tests that work with any number of nodes and can be run concurrently
   const tests = [

--- a/bouncer/tests/double_deposit.ts
+++ b/bouncer/tests/double_deposit.ts
@@ -1,14 +1,7 @@
 #!/usr/bin/env -S pnpm tsx
 import { Keyring } from '../polkadot/keyring';
-import {
-  runWithTimeout,
-  sleep,
-  hexStringToBytesArray,
-  newAddress,
-  getChainflipApi,
-  lpMutex,
-} from '../shared/utils';
-import { observeEvent } from '../shared/utils/substrate';
+import { runWithTimeout, sleep, hexStringToBytesArray, newAddress, lpMutex } from '../shared/utils';
+import { getChainflipApi, observeEvent } from '../shared/utils/substrate';
 import { sendEvmNative } from '../shared/send_evm';
 
 async function main(): Promise<void> {

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -1,19 +1,18 @@
 #!/usr/bin/env -S pnpm tsx
 import { testGasLimitCcmSwaps } from '../shared/gaslimit_ccm';
-import { runWithTimeout, observeBadEvents } from '../shared/utils';
+import { runWithTimeout } from '../shared/utils';
+import { observeBadEvent } from '../shared/utils/substrate';
 
 // Running this test separately from all the concurrent tests because there will
 // be BroadcastAborted events emited.
 async function testGasLimitCcmTest() {
   console.log('=== Testing GasLimit CCM swaps ===');
 
-  let stopObserving = false;
-  const feeDeficitRefused = observeBadEvents(':TransactionFeeDeficitRefused', () => stopObserving);
+  const feeDeficitRefused = observeBadEvent(':TransactionFeeDeficitRefused', {});
 
   await testGasLimitCcmSwaps();
 
-  stopObserving = true;
-  await feeDeficitRefused;
+  await feeDeficitRefused.stop();
 
   console.log('=== GasLimit CCM test completed ===');
 }

--- a/bouncer/tests/rotates_through_btc_swap.ts
+++ b/bouncer/tests/rotates_through_btc_swap.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S pnpm tsx
 import { requestNewSwap, performSwap, doPerformSwap } from '../shared/perform_swap';
-import { newAddress, getChainflipApi, observeEvent } from '../shared/utils';
+import { newAddress, getChainflipApi } from '../shared/utils';
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
+import { observeEvent } from '../shared/utils/substrate';
 
 async function rotatesThroughBtcSwap() {
   await using chainflip = await getChainflipApi();
@@ -15,7 +16,7 @@ async function rotatesThroughBtcSwap() {
 
   await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
   console.log(`Vault rotation initiated. Awaiting new epoch.`);
-  await observeEvent('validator:NewEpoch', chainflip);
+  await observeEvent('validator:NewEpoch').event;
   console.log('Vault rotated!');
 
   await doPerformSwap(swapParams, tag);

--- a/bouncer/tests/rotates_through_btc_swap.ts
+++ b/bouncer/tests/rotates_through_btc_swap.ts
@@ -1,12 +1,10 @@
 #!/usr/bin/env -S pnpm tsx
 import { requestNewSwap, performSwap, doPerformSwap } from '../shared/perform_swap';
-import { newAddress, getChainflipApi } from '../shared/utils';
+import { newAddress } from '../shared/utils';
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
 import { observeEvent } from '../shared/utils/substrate';
 
 async function rotatesThroughBtcSwap() {
-  await using chainflip = await getChainflipApi();
-
   const tag = `Btc -> Dot (through rotation)`;
   const address = await newAddress('Dot', 'foo');
 

--- a/bouncer/tests/rotation_barrier.ts
+++ b/bouncer/tests/rotation_barrier.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S pnpm tsx
 import { submitGovernanceExtrinsic } from '../shared/cf_governance';
 import { testSwapViaContract } from '../shared/swapping';
-import { observeEvent, observeBadEvents } from '../shared/utils/substrate';
+import { observeEvent, observeBadEvent } from '../shared/utils/substrate';
 
 async function rotateAndSwap() {
   await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
@@ -14,7 +14,7 @@ async function rotateAndSwap() {
   console.log(`Waiting for eth key activation transaction to be sent for signing`);
   await observeEvent('evmThresholdSigner:ThresholdSignatureRequest').event;
 
-  const broadcastAborted = observeBadEvents(':BroadcastAborted', { label: 'Rotate and swap' });
+  const broadcastAborted = observeBadEvent(':BroadcastAborted', { label: 'Rotate and swap' });
 
   // Using Arbitrum as the ingress chain to make the swap as fast as possible
   await testSwapViaContract('ArbEth', 'Eth');


### PR DESCRIPTION
# Pull Request

Part of: PRO-1411

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works. If bouncer works this works :) - I also tested the nightly gaslimit_ccm test locally and that now passes too.
- [x] I have updated documentation where appropriate.

## Summary

Removes the old observeEvent and observeBadEvent. See #4907 .

- Also fixes a bug I introduced yesterday with the gasLimit swaps. 