### PR TITLE
chore: improve docker images pull time in bouncer 🎚️

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -213,7 +213,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --rmi all --volumes --remove-orphans
+          docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
 
       - name: Notify on failed bouncer 📢
         if: failure() && github.ref_name == 'main' || cancelled() && github.ref_name == 'main' || failure() && contains(github.ref_name, 'release/') || cancelled() && contains(github.ref_name, 'release/')

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -361,7 +361,7 @@ jobs:
         run: |
           ls -alR /tmp/chainflip
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" logs
-          docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --rmi all --volumes --remove-orphans
+          docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
 
       - name: Notify on failed upgrade test 🚨
         if: failure() && github.ref_name == 'main' || cancelled() && github.ref_name == 'main'

--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -35,7 +35,7 @@ set -eo pipefail
 if [[ $CI == true ]]; then
   set -x
   additional_docker_compose_up_args="--quiet-pull"
-  additional_docker_compose_down_args="--volumes --remove-orphans --rmi all"
+  additional_docker_compose_down_args="--volumes --remove-orphans"
 else
   additional_docker_compose_up_args=""
   additional_docker_compose_down_args="--volumes --remove-orphans"


### PR DESCRIPTION
By retaining images between runs, Docker avoids the need to repeatedly download the same images. This results in faster start-up times and reduced network bandwidth usage.