### PR TITLE
chore: don't panic in scheduled swaps

### DIFF
--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -334,7 +334,7 @@ pub const PRICE_FRACTIONAL_BITS: u32 = 128;
 /// Converts from a [SqrtPriceQ64F96] to a [Price].
 ///
 /// Will panic for `sqrt_price`'s outside `MIN_SQRT_PRICE..=MAX_SQRT_PRICE`
-pub(super) fn sqrt_price_to_price(sqrt_price: SqrtPriceQ64F96) -> Price {
+pub fn sqrt_price_to_price(sqrt_price: SqrtPriceQ64F96) -> Price {
 	assert!(is_sqrt_price_valid(sqrt_price));
 
 	// Note the value here cannot ever be zero as MIN_SQRT_PRICE has its 33th bit set, so sqrt_price
@@ -347,10 +347,18 @@ pub(super) fn sqrt_price_to_price(sqrt_price: SqrtPriceQ64F96) -> Price {
 	)
 }
 
+// TODO JAMIE: remove this duplicate from max's PR
+pub fn output_amount_floor(input: Amount, price: Price) -> Amount {
+	mul_div_floor(input, price, U256::one() << PRICE_FRACTIONAL_BITS)
+}
+pub fn output_amount_ceil(input: Amount, price: Price) -> Amount {
+	mul_div_ceil(input, price, U256::one() << PRICE_FRACTIONAL_BITS)
+}
+
 /// Converts from a `price` to a `sqrt_price`
 ///
 /// This function never panics.
-pub(super) fn price_to_sqrt_price(price: Price) -> SqrtPriceQ64F96 {
+pub fn price_to_sqrt_price(price: Price) -> SqrtPriceQ64F96 {
 	((U512::from(price) << PRICE_FRACTIONAL_BITS).integer_sqrt() >>
 		(PRICE_FRACTIONAL_BITS - SQRT_PRICE_FRACTIONAL_BITS))
 		.try_into()

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -194,6 +194,7 @@ impl_pallet_safe_mode! {
 
 #[frame_support::pallet]
 pub mod pallet {
+	use cf_amm::common::{output_amount_ceil, sqrt_price_to_price, SqrtPriceQ64F96};
 	use cf_chains::{address::EncodedAddress, AnyChain, Chain};
 	use cf_primitives::{Asset, AssetAmount, BasisPoints, EgressId, SwapId};
 	use cf_traits::{
@@ -765,11 +766,11 @@ pub mod pallet {
 		pub fn get_scheduled_swap_legs(
 			mut swaps: Vec<Swap>,
 			base_asset: Asset,
-		) -> Result<Vec<SwapLegInfo>, ()> {
-			Self::swap_into_stable_taking_network_fee(&mut swaps)
-				.map_err(|_| log::error!("Failed to simulate swaps"))?;
+			pool_sell_price: Option<SqrtPriceQ64F96>,
+		) -> Vec<SwapLegInfo> {
+			let _res = Self::swap_into_stable_taking_network_fee(&mut swaps);
 
-			Ok(swaps
+			swaps
 				.into_iter()
 				.filter_map(|swap| {
 					if swap.from == base_asset {
@@ -792,23 +793,35 @@ pub mod pallet {
 							(None, None)
 						};
 
-						Some(SwapLegInfo {
-							swap_id: swap.swap_id,
-							base_asset,
-							// All swaps to `base_asset` have to go through the stable asset:
-							quote_asset: STABLE_ASSET,
-							side: Side::Buy,
-							// Safe to unwrap as we have swapped everything into the stable asset at
-							// this point
-							amount: swap.stable_amount.unwrap(),
-							source_asset,
-							source_amount,
-						})
+						if swap.stable_amount.is_some() || pool_sell_price.is_some() {
+							// If the swap into stable asset failed, fallback to estimating the
+							// amount via pool price.
+							let amount = swap.stable_amount.unwrap_or_else(|| {
+								output_amount_ceil(
+									cf_amm::common::Amount::from(swap.input_amount),
+									sqrt_price_to_price(pool_sell_price.unwrap()),
+								)
+								.as_u128()
+							});
+
+							Some(SwapLegInfo {
+								swap_id: swap.swap_id,
+								base_asset,
+								// All swaps to `base_asset` have to go through the stable asset:
+								quote_asset: STABLE_ASSET,
+								side: Side::Buy,
+								amount,
+								source_asset,
+								source_amount,
+							})
+						} else {
+							None
+						}
 					} else {
 						None
 					}
 				})
-				.collect())
+				.collect()
 		}
 
 		fn swap_into_stable_taking_network_fee(

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1745,7 +1745,8 @@ impl_runtime_apis! {
 				let execute_at = core::cmp::max(block, current_block.saturating_add(1));
 
 				let swaps: Vec<_> = swaps_for_block.iter().filter(|swap| swap.from == base_asset || swap.to == base_asset).cloned().collect();
-				Swapping::get_scheduled_swap_legs(swaps, base_asset).unwrap().into_iter().map(move |swap| (swap, execute_at))
+				// TODO: Use the FoK logic when this fails instead of unwrap_or_default.
+				Swapping::get_scheduled_swap_legs(swaps, base_asset).unwrap_or_default().into_iter().map(move |swap| (swap, execute_at))
 			}).collect()
 		}
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -44,7 +44,7 @@ use cf_chains::{
 	Arbitrum, Bitcoin, CcmChannelMetadata, DefaultRetryPolicy, ForeignChain, Polkadot, Solana,
 	TransactionBuilder,
 };
-use cf_primitives::{BroadcastId, EpochIndex, NetworkEnvironment};
+use cf_primitives::{BroadcastId, EpochIndex, NetworkEnvironment, STABLE_ASSET};
 use cf_traits::{AdjustedFeeEstimationApi, AssetConverter, LpBalanceApi};
 use codec::{alloc::string::ToString, Encode};
 use core::ops::Range;
@@ -1735,7 +1735,8 @@ impl_runtime_apis! {
 			all_prewitnessed_swaps
 		}
 
-		fn cf_scheduled_swaps(base_asset: Asset, _quote_asset: Asset) -> Vec<(SwapLegInfo, BlockNumber)> {
+		fn cf_scheduled_swaps(base_asset: Asset, quote_asset: Asset) -> Vec<(SwapLegInfo, BlockNumber)> {
+			assert_eq!(quote_asset, STABLE_ASSET, "Only USDC is supported as quote asset");
 
 			let current_block = System::block_number();
 
@@ -1745,8 +1746,9 @@ impl_runtime_apis! {
 				let execute_at = core::cmp::max(block, current_block.saturating_add(1));
 
 				let swaps: Vec<_> = swaps_for_block.iter().filter(|swap| swap.from == base_asset || swap.to == base_asset).cloned().collect();
-				// TODO: Use the FoK logic when this fails instead of unwrap_or_default.
-				Swapping::get_scheduled_swap_legs(swaps, base_asset).unwrap_or_default().into_iter().map(move |swap| (swap, execute_at))
+
+				let pool_sell_price = LiquidityPools::pool_price(base_asset, quote_asset).expect("Pool should exist").sell;
+				Swapping::get_scheduled_swap_legs(swaps, base_asset, pool_sell_price).into_iter().map(move |swap| (swap, execute_at))
 			}).collect()
 		}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1410

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Changed the unwrap to an `unwrap_or_default` if the `get_scheduled_swap_legs` returns error. This is fine for now, but when the more complex FoK logic is in, it will not mirror the same behaviour as the actual `process_swaps_for_block` function and may miss swaps.