### PR TITLE
pick: contract swaps shouldn't wait for SwapScheduled (#4948)

### DIFF
--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -229,7 +229,8 @@ export class SwapContext {
       }
       case SwapStatus.Success: {
         assert(
-          currentStatus === SwapStatus.SwapScheduled,
+          currentStatus === SwapStatus.SwapScheduled ||
+            currentStatus === SwapStatus.ContractExecuted,
           `Unexpected status transition for ${tag}`,
         );
         break;


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works - haven't seen this issue on main since it was merged.
- [x] I have updated documentation where appropriate.

## Summary

Picks across part of #4948 , see there for desc.

To remove flakiness from the upgrade test which needs to run bouncer on 1.4 first.