### PR TITLE
fix: old dylib should be pulled from the previous release by tag

### DIFF
--- a/.github/workflows/_25_package.yml
+++ b/.github/workflows/_25_package.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   FORCE_COLOR: 1
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   packages:
@@ -25,6 +26,8 @@ jobs:
     steps:
       - name: Checkout 🛒
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
 
       - name: Download binaries from same run 📥
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -32,10 +35,90 @@ jobs:
           name: chainflip-backend-bin
           path: ./target/release
 
-      - name: Download latest release binaries
+      # Pull requests to release should use the same rules as the release branch itself
+      # For simplicity we use the same rules for branches to main, since it doesn't matter if we use "main" as the branch name.
+      - name: Set branch name
+        id: set-branch-name
+        run: |
+          echo "Working branch name: ${{ env.BRANCH_NAME }}"
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "merge_group" ]; then
+            echo "BRANCH_NAME=${{ github.event.pull_request.base.ref_name }}" >> $GITHUB_ENV
+          fi
+
+      - name: Is the branch a release/x.y branch?
+        run: |
+          BRANCH_NAME=${{ env.BRANCH_NAME }}
+          if [[ "${BRANCH_NAME}" =~ ^release/[0-9]+\.[0-9]+$ ]]; then
+            echo "Branch name ${BRANCH_NAME} does match the required format 'release/x.y'"
+            echo "IS_RELEASE_BRANCH=true" >> $GITHUB_ENV
+          else
+            echo "Branch name ${BRANCH_NAME} does NOT match the required format 'release/x.y."
+            echo "IS_RELEASE_BRANCH=false" >> $GITHUB_ENV
+          fi
+
+      - name: Extract version and compute previous version
+        id: extract_version
+        if: env.IS_RELEASE_BRANCH == 'true'
+        run: |
+          BRANCH_NAME=${{ env.BRANCH_NAME }}
+          VERSION=${BRANCH_NAME#release/}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+
+          # Compute the previous version
+          if [ $MINOR -eq 0 ]; then
+            PREV_MAJOR=$((MAJOR - 1))
+            if [ $PREV_MAJOR -ge 0 ]; then
+              PREV_VERSION="${PREV_MAJOR}"
+            else
+              echo "No previous version available"
+              exit 1
+            fi
+          else
+            PREV_MINOR=$((MINOR - 1))
+            PREV_VERSION="${MAJOR}.${PREV_MINOR}"
+          fi
+
+          echo "Previous version: $PREV_VERSION"
+
+          if [[ "$PREV_VERSION" == *.* ]]; then
+            # Find the highest tag matching the previous minor version prefix
+            HIGHEST_TAG=$(git tag -l "${PREV_VERSION}.*" | sort -V | tail -n 1)
+          else
+            # Find the highest tag for the previous major version
+            HIGHEST_TAG=$(git tag -l "${PREV_VERSION}.*.*" | sort -V | tail -n 1)
+          fi
+
+          if [ -z "$HIGHEST_TAG" ]; then
+            echo "No tags found for previous version $PREV_VERSION"
+            exit 1
+          fi
+
+          echo "HIGHEST_TAG=$HIGHEST_TAG"
+          PREVIOUS_RELEASE_COMMIT=$(git rev-list -n 1 $HIGHEST_TAG)
+          echo "PREVIOUS_RELEASE_COMMIT=$PREVIOUS_RELEASE_COMMIT"
+          echo "PREVIOUS_RELEASE_COMMIT=$PREVIOUS_RELEASE_COMMIT" >> $GITHUB_ENV
+
+      # If we're on a release branch we need to download the previous release binaries
+      - name: Download latest release binaries for release branch.
+        if: env.IS_RELEASE_BRANCH == 'true'
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
         with:
           workflow: release-berghain.yml
+          name: chainflip-backend-bin
+          commit: ${{ env.PREVIOUS_RELEASE_COMMIT }}
+          github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
+          path: latest-release
+
+      # If we're on main then the latest run of the release-sisyphos.yml workflow will have the latest release binaries
+      # Therefore we don't need to provide a commit.
+      - name: Download latest release binaries for main/PR branches.
+        if: env.IS_RELEASE_BRANCH == 'false'
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+          workflow: release-sisyphos.yml
           name: chainflip-backend-bin
           github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           path: latest-release


### PR DESCRIPTION
WIP: Also need to handle PRs to release branches.

# Pull Request

Closes: PRO-1443

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This fixes an issue where, if we had a release branch that had been tagged, causing release-berghain to run, then the next time we released off that branch, the "latest" release would actually be the previous patch release, which is not what we want.

Instead, if we're on release/1.4 we want to get the latest 1.3.x tag and use that.

Will need to cherry-pick this across to release too.