### PR TITLE
fix: print cause of settings error

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -65,7 +65,7 @@ pub fn settings_and_run_main(
 	{
 		Ok(settings) => settings,
 		Err(e) => {
-			eprintln!("Error reading settings: {}", e);
+			eprintln!("{:#}", e);
 			return ExitStatus { status_code: ERROR_READING_SETTINGS, at_block: NO_START_FROM };
 		},
 	};


### PR DESCRIPTION
Previously this just always printed: `Error reading settings: Error reading settings` since using `println!("{}", err)` just prints the context but not the cause. 