### PR TITLE
fix: don't ignore arb settings

### DIFF
--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -18,18 +18,9 @@ pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";
 
 // Sometimes we need to remove arguments that are valid for the new version but not for the old
 // version.
-// The args that are required for 1.4 but *not* 1.3 are:
-// #[derive(Parser, Debug, Clone, Default)]
-// pub struct ArbOptions {
-// 	#[clap(long = "arb.rpc.ws_endpoint")]
-// 	pub arb_ws_endpoint: Option<String>,
-// 	#[clap(long = "arb.rpc.http_endpoint")]
-// 	pub arb_http_endpoint: Option<String>,
-// 	#[clap(long = "arb.private_key_file")]
-// 	pub arb_private_key_file: Option<PathBuf>,
-// }
+// There are no settings currently on main branch that are not already in the old version.
 pub fn args_compatible_with_old(args: Vec<String>) -> Vec<String> {
-	args.into_iter().filter(|arg| !arg.starts_with("--arb.")).collect()
+	args
 }
 
 pub use std::ffi::c_char;


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

1.4.3 has arb, so we shouldn't ignore passing them in. I created PRO-1455 to address testing such regressions.