### PR TITLE
feat: smart retrier endpoint selection

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -310,17 +310,15 @@ impl<Client: Send + Sync + Clone + 'static> ClientSelector<Client> {
 	}
 
 	pub fn request_failed(&mut self, failed_client: PrimaryOrSecondary) {
-		// If we don't have a second endpoint, then we can only try the primary.
-		if self.secondary_signal.is_none() {
-			return;
+		// If we have a second endpoint, then we should switch to the other one.
+		if self.secondary_signal.is_some() {
+			self.prefer = if failed_client == PrimaryOrSecondary::Primary {
+				self.last_failed_primary = Some(tokio::time::Instant::now());
+				PrimaryOrSecondary::Secondary
+			} else {
+				PrimaryOrSecondary::Primary
+			};
 		}
-
-		self.prefer = if failed_client == PrimaryOrSecondary::Primary {
-			self.last_failed_primary = Some(tokio::time::Instant::now());
-			PrimaryOrSecondary::Secondary
-		} else {
-			PrimaryOrSecondary::Primary
-		};
 	}
 }
 

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -103,13 +103,7 @@ type SubmissionFuture = Pin<Box<dyn Future<Output = SubmissionFutureOutput> + Se
 type SubmissionFutures = FuturesUnordered<SubmissionFuture>;
 
 type RetryDelays = FuturesUnordered<
-	Pin<
-		Box<
-			dyn Future<Output = (RequestId, RequestLog, Attempt, RetryLimit, PrimaryOrSecondary)>
-				+ Send
-				+ 'static,
-		>,
-	>,
+	Pin<Box<dyn Future<Output = (RequestId, RequestLog, Attempt, RetryLimit)> + Send + 'static>>,
 >;
 
 type BoxAny = Box<dyn Any + Send>;
@@ -231,6 +225,8 @@ fn submission_future<Client: Clone + Send + Sync + 'static>(
 	})
 }
 
+const TRY_PRIMARY_AFTER: Duration = Duration::from_secs(120);
+
 // Pass in two clients, a primary and an optional secondary.
 // We can then select the client requested if it's ready, otherwise we return the client that's
 // ready first.
@@ -238,6 +234,11 @@ fn submission_future<Client: Clone + Send + Sync + 'static>(
 struct ClientSelector<Client: Clone + Send + Sync + 'static> {
 	primary_signal: Signal<(Client, PrimaryOrSecondary)>,
 	secondary_signal: Option<Signal<(Client, PrimaryOrSecondary)>>,
+	// The client to favour for the next request or attempt.
+	prefer: PrimaryOrSecondary,
+	// The time we last tried the primary. If we haven't tried the primary in some time, then we
+	// should try it as it could be back online.
+	last_tried_primary: Option<tokio::time::Instant>,
 }
 
 impl<Client: Send + Sync + Clone + 'static> ClientSelector<Client> {
@@ -269,22 +270,32 @@ impl<Client: Send + Sync + Clone + 'static> ClientSelector<Client> {
 			None
 		};
 
-		Self { primary_signal, secondary_signal }
+		Self {
+			primary_signal,
+			secondary_signal,
+			prefer: PrimaryOrSecondary::Primary,
+			last_tried_primary: None,
+		}
 	}
 
 	// Returns a client, and the type of client selected.
-	pub async fn select_client(
-		&self,
-		primary_or_secondary: PrimaryOrSecondary,
-	) -> (Client, PrimaryOrSecondary) {
+	pub async fn select_client(&mut self) -> (Client, PrimaryOrSecondary) {
 		futures::future::select_all(
 			utilities::conditional::conditional(
 				&self.secondary_signal,
 				|secondary_signal| {
 					// If we have two clients, then we should bias the requested one, but if it's
 					// not ready, request from the other one.
-					match primary_or_secondary {
-						PrimaryOrSecondary::Secondary => [secondary_signal, &self.primary_signal],
+					match self.prefer {
+						PrimaryOrSecondary::Secondary => match self.last_tried_primary {
+							// If we haven't tried the primary in some time, then we should try it
+							// as it could be back online
+							Some(last_tried_primary)
+								if last_tried_primary.elapsed() > TRY_PRIMARY_AFTER =>
+								[&self.primary_signal, secondary_signal],
+
+							_ => [secondary_signal, &self.primary_signal],
+						},
 						PrimaryOrSecondary::Primary => [&self.primary_signal, secondary_signal],
 					}
 					.into_iter()
@@ -296,6 +307,20 @@ impl<Client: Send + Sync + Clone + 'static> ClientSelector<Client> {
 		)
 		.await
 		.0
+	}
+
+	pub fn request_failed(&mut self, failed_client: PrimaryOrSecondary) {
+		// If we don't have a second endpoint, then we can only try the primary.
+		if self.secondary_signal.is_none() {
+			return;
+		}
+
+		self.prefer = if failed_client == PrimaryOrSecondary::Primary {
+			self.last_tried_primary = Some(tokio::time::Instant::now());
+			PrimaryOrSecondary::Secondary
+		} else {
+			PrimaryOrSecondary::Primary
+		};
 	}
 }
 
@@ -370,7 +395,7 @@ where
 		// This holds any submissions that are waiting for a slot to open up.
 		let mut submission_holder = SubmissionHolder::new(maximum_concurrent_submissions);
 
-		let client_selector: ClientSelector<Client> =
+		let mut client_selector: ClientSelector<Client> =
 			ClientSelector::new(scope, primary_client_fut, secondary_client_fut);
 
 		scope.spawn(async move {
@@ -378,7 +403,7 @@ where
 				if let Some((response_sender, request_log, closure, retry_limit)) = request_receiver.recv() => {
 					RPC_RETRIER_REQUESTS.inc(&[name, request_log.rpc_method.as_str()]);
 					let request_id = request_holder.next_request_id();
-					let (client, primary_or_secondary) = client_selector.select_client(PrimaryOrSecondary::Primary).await;
+					let (client, primary_or_secondary) = client_selector.select_client().await;
 
 					tracing::debug!("Retrier {name}: Received request `{request_log}` assigning request_id `{request_id}` and requesting with `{primary_or_secondary:?}`");
 					submission_holder.push(submission_future(client, request_log, retry_limit, &closure, request_id, initial_request_timeout, 0, primary_or_secondary));
@@ -405,18 +430,20 @@ where
 								tracing::error!(error_message);
 							}
 
+							client_selector.request_failed(primary_or_secondary);
+
 							// Delay the request before the next retry.
 							retry_delays.push(Box::pin(
 								async move {
 									tokio::time::sleep(sleep_duration).await;
 									// pass in primary or secondary so we know which client to use.
-									(request_id, request_log, attempt, retry_limit, primary_or_secondary)
+									(request_id, request_log, attempt, retry_limit)
 								}
 							));
 						},
 					}
 				},
-				let (request_id, request_log, attempt, retry_limit, primary_or_secondary) = retry_delays.next_or_pending() => {
+				let (request_id, request_log, attempt, retry_limit) = retry_delays.next_or_pending() => {
 					let next_attempt = attempt.saturating_add(1);
 
 					let (response_sender, closure) = request_holder.get(&request_id).expect("We only remove these on success, and if it's in `retry_delays` then it must still be in `request_holder`");
@@ -431,9 +458,8 @@ where
 								request_holder.remove(&request_id);
 							}
 							_ => {
-								// We want to use a different client than the one we just tried if possible.
 								// This await should always return immediately since we must already have a client if we've already made a request.
-								let (next_client, next_primary_or_secondary) = client_selector.select_client(!primary_or_secondary).await;
+								let (next_client, next_primary_or_secondary) = client_selector.select_client().await;
 								tracing::trace!("Retrier {name}: Retrying request `{request_log}` with id `{request_id}` and client `{next_primary_or_secondary:?}`, attempt `{next_attempt}`");
 								submission_holder.push(submission_future(next_client, request_log, retry_limit, closure, request_id, initial_request_timeout, next_attempt, next_primary_or_secondary));
 							}
@@ -499,6 +525,7 @@ where
 mod tests {
 	use std::any::Any;
 
+	use fmt::Debug;
 	use futures_util::FutureExt;
 	use tokio::time::timeout;
 	use utilities::task_scope::task_scope;
@@ -770,7 +797,7 @@ mod tests {
 		.unwrap();
 	}
 
-	fn specific_fut_err<T: Send + Clone + 'static, Client>(
+	fn specific_fut_err<T: Send + Clone + 'static, Client: Debug>(
 		timeout: Duration,
 	) -> TypedFutureGenerator<T, Client> {
 		Box::pin(move |_client| {
@@ -848,6 +875,145 @@ mod tests {
 							specific_fut_closure(REQUEST_2, INITIAL_TIMEOUT),
 						)
 						.await
+				);
+
+				Ok(())
+			}
+			.boxed()
+		})
+		.await
+		.unwrap();
+	}
+
+	#[tokio::test]
+	async fn backup_used_for_next_request_if_primary_fails() {
+		async fn get_client_primary_or_secondary(
+			primary_or_secondary: PrimaryOrSecondary,
+		) -> PrimaryOrSecondary {
+			primary_or_secondary
+		}
+
+		thread_local! {
+			pub static ATTEMPTED: std::cell::RefCell<u32> = std::cell::RefCell::new(0);
+			pub static TRIED_CLIENTS: std::cell::RefCell<Vec<PrimaryOrSecondary>> = std::cell::RefCell::new(Vec::new());
+		}
+
+		fn specific_fut_closure_err_after_one(
+			timeout: Duration,
+		) -> TypedFutureGenerator<(), PrimaryOrSecondary> {
+			Box::pin(move |client| {
+				Box::pin(async move {
+					// We need to delay in the tests, else we'll resolve immediately, meaning the
+					// channel is sent down, and can theoretically be replaced using the same
+					// request id and the tests will still work despite there potentially being a
+					// bug in the implementation.
+					tokio::time::sleep(timeout).await;
+
+					let attempts = ATTEMPTED.with(|cell| *cell.borrow());
+
+					let return_val = if attempts == 0 || attempts == 6 {
+						Err(anyhow::anyhow!("Sorry, this just doesn't work."))
+					} else {
+						Ok(())
+					};
+
+					// Update attempt after attempted
+					ATTEMPTED.with(|cell| {
+						let mut attempted = cell.borrow_mut();
+						*attempted += 1;
+					});
+
+					TRIED_CLIENTS.with(|cell| {
+						let mut tried_clients = cell.borrow_mut();
+						tried_clients.push(client);
+					});
+
+					return_val
+				})
+			})
+		}
+
+		// === TEST ===
+
+		task_scope(|scope| {
+			async move {
+				const INITIAL_TIMEOUT: Duration = Duration::from_millis(100);
+
+				let retrier_client = RetrierClient::new(
+					scope,
+					"test",
+					get_client_primary_or_secondary(PrimaryOrSecondary::Primary),
+					Some(get_client_primary_or_secondary(PrimaryOrSecondary::Secondary)),
+					INITIAL_TIMEOUT,
+					100,
+				);
+
+				// The first request will fail, and the second request will succeed using the
+				// backup. Then the next two requests will use the backup.
+				for request in 0..=3 {
+					retrier_client
+						.request_with_limit(
+							RequestLog::new(request.to_string(), None),
+							specific_fut_closure_err_after_one(INITIAL_TIMEOUT),
+							5,
+						)
+						.await
+						.unwrap();
+				}
+
+				// We want to advance time so that we can try the primary again.
+				tokio::time::pause();
+				tokio::time::advance(TRY_PRIMARY_AFTER * 2).await;
+				tokio::time::resume();
+
+				for request in 4..6 {
+					retrier_client
+						.request_with_limit(
+							RequestLog::new(request.to_string(), None),
+							specific_fut_closure_err_after_one(INITIAL_TIMEOUT),
+							5,
+						)
+						.await
+						.unwrap();
+				}
+
+				// We want to advance time so that we can try the primary again.
+				tokio::time::pause();
+				tokio::time::advance(TRY_PRIMARY_AFTER * 2).await;
+				tokio::time::resume();
+
+				retrier_client
+					.request_with_limit(
+						RequestLog::new(7.to_string(), None),
+						specific_fut_closure_err_after_one(INITIAL_TIMEOUT),
+						5,
+					)
+					.await
+					.unwrap();
+
+				// Assert the tried clients is what we expect:
+				assert_eq!(
+					TRIED_CLIENTS.with(|cell| cell.borrow().clone()),
+					vec![
+						// first request fails
+						PrimaryOrSecondary::Primary,
+						// first request succeeds on second attempt
+						PrimaryOrSecondary::Secondary,
+						// second succeeds
+						PrimaryOrSecondary::Secondary,
+						// third succeeds
+						PrimaryOrSecondary::Secondary,
+						// fourth succeeds
+						PrimaryOrSecondary::Secondary,
+						// try primary again, and succeeds, so no further items in this list
+						PrimaryOrSecondary::Primary,
+						// primary should still be favoured after it succeeds
+						PrimaryOrSecondary::Primary,
+						// primary fails again, so seocondary is used
+						PrimaryOrSecondary::Secondary,
+						// time elapsed, primary again
+						PrimaryOrSecondary::Primary,
+					]
 				);
 
 				Ok(())

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -329,8 +329,6 @@ impl RetryLimitReturn for NoRetryLimit {
 	}
 }
 
-pub struct SetRetryLimit {}
-
 impl RetryLimitReturn for u32 {
 	type ReturnType<T> = Result<T>;
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1409

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The idea here is that we want to keep trying the secondary endpoint until a specified time (2 minutes) has elapsed. We then try the primary endpoint again to check it's online. If not, we try the backup again. Note that this is global to all requests for the chain - previously every request would start by trying the primary, but not it will try the currently preferred endpoint, and occassionally re-attempt the primary, as we want to bias towards the primary.