### PR TITLE
fix: use U256 return value for asset volume

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -41,7 +41,7 @@ impl From<chainflip_api::SwapDepositAddress> for BrokerSwapDepositAddress {
 			issued_block: value.issued_block,
 			channel_id: value.channel_id,
 			source_chain_expiry_block: NumberOrHex::from(value.source_chain_expiry_block),
-			channel_opening_fee: U256::from(value.channel_opening_fee),
+			channel_opening_fee: value.channel_opening_fee,
 		}
 	}
 }

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 pub use sp_core::crypto::AccountId32;
-use sp_core::{ed25519::Public as EdPublic, sr25519::Public as SrPublic, Bytes, Pair, H256};
+use sp_core::{ed25519::Public as EdPublic, sr25519::Public as SrPublic, Bytes, Pair, H256, U256};
 pub use state_chain_runtime::chainflip::BlockUpdate;
 use state_chain_runtime::{opaque::SessionKeys, RuntimeCall};
 use zeroize::Zeroize;
@@ -294,15 +294,15 @@ pub struct SwapDepositAddress {
 	pub issued_block: state_chain_runtime::BlockNumber,
 	pub channel_id: ChannelId,
 	pub source_chain_expiry_block: <AnyChain as cf_chains::Chain>::ChainBlockNumber,
-	pub channel_opening_fee: u128,
+	pub channel_opening_fee: U256,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WithdrawFeesDetail {
 	pub tx_hash: H256,
 	pub egress_id: (ForeignChain, u64),
-	pub egress_amount: u128,
-	pub egress_fee: u128,
+	pub egress_amount: U256,
+	pub egress_fee: U256,
 	pub destination_address: String,
 }
 
@@ -384,7 +384,7 @@ pub trait BrokerApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 				issued_block: header.number,
 				channel_id: *channel_id,
 				source_chain_expiry_block: *source_chain_expiry_block,
-				channel_opening_fee: *channel_opening_fee,
+				channel_opening_fee: (*channel_opening_fee).into(),
 			})
 		} else {
 			bail!("No SwapDepositAddressReady event was found");
@@ -423,8 +423,8 @@ pub trait BrokerApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 			Ok(WithdrawFeesDetail {
 				tx_hash,
 				egress_id: *egress_id,
-				egress_amount: *egress_amount,
-				egress_fee: *egress_fee,
+				egress_amount: (*egress_amount).into(),
+				egress_fee: (*egress_fee).into(),
 				destination_address: destination_address.to_string(),
 			})
 		} else {

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -272,8 +272,7 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 			}))
 			.await
 			.until_in_block()
-			.await
-			.context("Unable to transfer asset.")?;
+			.await?;
 		Ok(tx_hash)
 	}
 

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -1,5 +1,5 @@
 use super::SimpleSubmissionApi;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use async_trait::async_trait;
 pub use cf_amm::{
 	common::{Amount, PoolPairsMap, Side, Tick},
@@ -172,8 +172,7 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 			))
 			.await
 			.until_in_block()
-			.await
-			.context("Registration for Liquidity Refund Address failed.")?;
+			.await?;
 		Ok(tx_hash)
 	}
 
@@ -408,12 +407,10 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 	async fn register_account(&self) -> Result<H256> {
 		self.simple_submission_with_dry_run(pallet_cf_lp::Call::register_lp_account {})
 			.await
-			.context("Could not register liquidity provider")
 	}
 
 	async fn deregister_account(&self) -> Result<H256> {
 		self.simple_submission_with_dry_run(pallet_cf_lp::Call::deregister_lp_account {})
 			.await
-			.context("Could not de-register liquidity provider")
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1277

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Ensures we return hex-encoded amounts from broker api. 
Improved error messages. 

Examples:

`broker_withdraw_fees` success:

```json
{
  "jsonrpc": "2.0",
  "result": {
    "tx_hash": "0x3fc8762e54d9eada666adb8adfabe18099611e62544751fff5b5f45a8a8db81d",
    "egress_id": [
      "Ethereum",
      93
    ],
    "egress_amount": "0xa68859da017bcdc",
    "egress_fee": "0x77a10",
    "destination_address": "0xabababababababababababababababababababab"
  },
  "id": 1
}
```


`broker_withdraw_fees` error:

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32000,
    "message": "Module error ‘NoFundsAvailable‘ from pallet ‘Swapping‘: ‘The withdrawal is not possible because not enough funds are available.‘"
  },
  "id": 1
}
```

