### PR TITLE
feat: scheduled swap sub price estimation fallback

### DIFF
--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -351,7 +351,7 @@ pub fn sqrt_price_to_price(sqrt_price: SqrtPriceQ64F96) -> Price {
 /// Converts from a `price` to a `sqrt_price`
 ///
 /// This function never panics.
-pub(super) fn price_to_sqrt_price(price: Price) -> SqrtPriceQ64F96 {
+pub fn price_to_sqrt_price(price: Price) -> SqrtPriceQ64F96 {
 	((U512::from(price) << PRICE_FRACTIONAL_BITS).integer_sqrt() >>
 		(PRICE_FRACTIONAL_BITS - SQRT_PRICE_FRACTIONAL_BITS))
 		.try_into()

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -239,6 +239,7 @@ pub mod pallet {
 		SwapDepositHandler,
 	};
 	use frame_system::WeightInfo as SystemWeightInfo;
+	use sp_runtime::SaturatedConversion;
 
 	use super::*;
 
@@ -951,7 +952,7 @@ pub mod pallet {
 									cf_amm::common::Amount::from(swap.input_amount()),
 									sqrt_price_to_price(pool_sell_price?),
 								)
-								.as_u128(),
+								.saturated_into(),
 							)
 						})?;
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -917,6 +917,7 @@ pub mod pallet {
 		) -> Vec<SwapLegInfo> {
 			let mut swaps: Vec<_> = swaps.into_iter().map(SwapState::new).collect();
 
+			// Can ignore the result here because we use pool price fallback below
 			let _res = Self::swap_into_stable_taking_network_fee(&mut swaps);
 
 			swaps

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -942,32 +942,28 @@ pub mod pallet {
 							(None, None)
 						};
 
-						if swap.stable_amount.is_some() || pool_sell_price.is_some() {
+						let amount = swap.stable_amount.or_else(|| {
 							// If the swap into stable asset failed, fallback to estimating the
 							// amount via pool price.
-							let amount = swap.stable_amount.unwrap_or_else(|| {
+							Some(
 								output_amount_ceil(
 									cf_amm::common::Amount::from(swap.input_amount()),
-									sqrt_price_to_price(
-										pool_sell_price.expect("Safe because of check above"),
-									),
+									sqrt_price_to_price(pool_sell_price?),
 								)
-								.as_u128()
-							});
+								.as_u128(),
+							)
+						})?;
 
-							Some(SwapLegInfo {
-								swap_id: swap.swap_id(),
-								base_asset,
-								// All swaps to `base_asset` have to go through the stable asset:
-								quote_asset: STABLE_ASSET,
-								side: Side::Buy,
-								amount,
-								source_asset,
-								source_amount,
-							})
-						} else {
-							None
-						}
+						Some(SwapLegInfo {
+							swap_id: swap.swap_id(),
+							base_asset,
+							// All swaps to `base_asset` have to go through the stable asset:
+							quote_asset: STABLE_ASSET,
+							side: Side::Buy,
+							amount,
+							source_asset,
+							source_amount,
+						})
 					} else {
 						None
 					}

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -7,6 +7,7 @@ use crate::{
 	EarnedBrokerFees, Error, Event, MaximumSwapAmount, Pallet, PendingCcms, Swap, SwapOrigin,
 	SwapQueue, SwapType,
 };
+use cf_amm::common::{price_to_sqrt_price, PRICE_FRACTIONAL_BITS};
 use cf_chains::{
 	address::{to_encoded_address, AddressConverter, EncodedAddress, ForeignChainAddress},
 	btc::{BitcoinNetwork, ScriptPubkey},
@@ -32,7 +33,7 @@ use frame_support::{
 };
 use itertools::Itertools;
 use sp_arithmetic::Permill;
-use sp_core::H160;
+use sp_core::{H160, U256};
 use sp_runtime::Percent;
 use sp_std::iter;
 
@@ -2280,7 +2281,7 @@ fn test_get_scheduled_swap_legs() {
 		assert_ne!(INIT_AMOUNT, INTERMEDIATE_AMOUNT);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip).unwrap(),
+			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip, None),
 			vec![
 				SwapLegInfo {
 					swap_id: 1,
@@ -2318,6 +2319,53 @@ fn test_get_scheduled_swap_legs() {
 					source_asset: Some(Asset::Eth),
 					source_amount: Some(INIT_AMOUNT),
 				},
+			]
+		);
+	});
+}
+
+#[test]
+fn test_get_scheduled_swap_legs_fallback() {
+	new_test_ext().execute_with(|| {
+		const SWAP_TYPE: SwapType = SwapType::Swap(ForeignChainAddress::Eth(H160::zero()));
+		const INIT_AMOUNT: AssetAmount = 1000000000000000000000;
+		const PRICE: u128 = 2;
+
+		let swaps: Vec<_> = [(1, Asset::Flip, Asset::Eth), (2, Asset::Eth, Asset::Usdc)]
+			.into_iter()
+			.map(|(id, from, to)| Swap::new(id, from, to, INIT_AMOUNT, None, SWAP_TYPE.clone()))
+			.collect();
+
+		// Setting the swap rate to something different from the price so that if the fallback is
+		// not used, it will give a different result, avoiding a false positive.
+		SwapRate::set(PRICE.checked_add(1).unwrap() as f64);
+
+		// The swap simulation must fail for it to use the fallback price estimation
+		MockSwappingApi::set_swaps_should_fail(true);
+
+		let sqrt_price = price_to_sqrt_price((U256::from(PRICE)) << PRICE_FRACTIONAL_BITS);
+
+		assert_eq!(
+			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth, Some(sqrt_price)),
+			vec![
+				SwapLegInfo {
+					swap_id: 1,
+					base_asset: Asset::Eth,
+					quote_asset: Asset::Usdc,
+					side: Side::Buy,
+					amount: INIT_AMOUNT * PRICE,
+					source_asset: Some(Asset::Flip),
+					source_amount: Some(INIT_AMOUNT),
+				},
+				SwapLegInfo {
+					swap_id: 2,
+					base_asset: Asset::Eth,
+					quote_asset: Asset::Usdc,
+					side: Side::Sell,
+					amount: INIT_AMOUNT,
+					source_asset: None,
+					source_amount: None,
+				}
 			]
 		);
 	});


### PR DESCRIPTION
# Pull Request

Closes: PRO-1410, PRO-1437

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

- Changed the `get_scheduled_swap_legs` function to not return a result. In case of swap simulation failure, it will use the given pool_price (of the input asset) to estimate the swap amount (in Usdc) for the second part of the leg.
	- The first leg will now always be returned, even if the swap simulation fails. 
	- The only reason the second leg would not be returned, is if there is no pool_price (no liquidity in the pool at all)
- Added a unit test to cover this new fallback code.