### PR TITLE
fix: eagerly prune ExtraCallData

### DIFF
--- a/state-chain/pallets/cf-witnesser/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock.rs
@@ -97,11 +97,21 @@ impl dummy::Config for Test {
 
 impl WitnessDataExtraction for RuntimeCall {
 	fn extract(&mut self) -> Option<Vec<u8>> {
-		None
+		match self {
+			RuntimeCall::Dummy(dummy::Call::put_value { value }) =>
+				Some(core::mem::take(value).encode()),
+			_ => None,
+		}
 	}
 
-	fn combine_and_inject(&mut self, _data: &mut [Vec<u8>]) {
-		// Do nothing
+	fn combine_and_inject(&mut self, data: &mut [Vec<u8>]) {
+		match self {
+			RuntimeCall::Dummy(dummy::Call::put_value { value }) => {
+				*value =
+					data.into_iter().map(|encoded| u32::decode(&mut &encoded[..]).unwrap()).sum();
+			},
+			_ => (),
+		}
 	}
 }
 

--- a/state-chain/pallets/cf-witnesser/src/mock.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock.rs
@@ -97,20 +97,16 @@ impl dummy::Config for Test {
 
 impl WitnessDataExtraction for RuntimeCall {
 	fn extract(&mut self) -> Option<Vec<u8>> {
-		match self {
-			RuntimeCall::Dummy(dummy::Call::put_value { value }) =>
-				Some(core::mem::take(value).encode()),
-			_ => None,
+		if let RuntimeCall::Dummy(dummy::Call::put_value { value }) = self {
+			Some(core::mem::take(value).encode())
+		} else {
+			None
 		}
 	}
 
 	fn combine_and_inject(&mut self, data: &mut [Vec<u8>]) {
-		match self {
-			RuntimeCall::Dummy(dummy::Call::put_value { value }) => {
-				*value =
-					data.into_iter().map(|encoded| u32::decode(&mut &encoded[..]).unwrap()).sum();
-			},
-			_ => (),
+		if let RuntimeCall::Dummy(dummy::Call::put_value { value }) = self {
+			*value = data.iter_mut().map(|encoded| u32::decode(&mut &encoded[..]).unwrap()).sum();
 		}
 	}
 }

--- a/state-chain/pallets/cf-witnesser/src/mock/dummy.rs
+++ b/state-chain/pallets/cf-witnesser/src/mock/dummy.rs
@@ -65,5 +65,16 @@ pub mod pallet {
 			// Return a successful DispatchResultWithPostInfo
 			Ok(().into())
 		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
+		pub fn put_value(origin: OriginFor<T>, value: u32) -> DispatchResultWithPostInfo {
+			let _who = T::EnsureWitnessed::ensure_origin(origin)?;
+
+			<Something<T>>::put(value);
+
+			// Return a successful DispatchResultWithPostInfo
+			Ok(().into())
+		}
 	}
 }

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -722,7 +722,7 @@ fn test_extra_call_data() {
 		)
 		.is_none(),);
 
-		// Can vote again, but not call data is inserted and result is unaffected.
+		// Can vote again, but call data is not inserted and result is unaffected.
 		assert_ok!(Witnesser::witness_at_epoch(
 			RuntimeOrigin::signed(CHARLEMAGNE),
 			call.clone(),

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -11,7 +11,11 @@ use cf_traits::{
 	mocks::account_role_registry::MockAccountRoleRegistry, AccountRoleRegistry, EpochInfo,
 	EpochTransitionHandler, SafeMode, SetSafeMode,
 };
-use frame_support::{assert_noop, assert_ok, traits::Hooks, weights::Weight};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{Hooks, Len},
+	weights::Weight,
+};
 use sp_std::collections::btree_set::BTreeSet;
 
 #[test]
@@ -675,4 +679,60 @@ fn can_punish_failed_witnesser_in_previous_epochs() {
 			// storage is cleaned up.
 			assert_eq!(WitnessDeadline::<Test>::decode_len(target), None);
 		});
+}
+
+#[test]
+fn test_extra_call_data() {
+	new_test_ext().execute_with(|| {
+		let call = Box::new(RuntimeCall::Dummy(pallet_dummy::Call::<Test>::put_value { value: 1 }));
+		let current_epoch = MockEpochInfo::epoch_index();
+
+		// Witness a call
+		assert_ok!(Witnesser::witness_at_epoch(
+			RuntimeOrigin::signed(ALISSA),
+			call.clone(),
+			current_epoch
+		));
+		// Nothing inserted yet.
+		assert!(pallet_dummy::Something::<Test>::get().is_none());
+		// Extra call data is stored.
+		assert_eq!(
+			ExtraCallData::<Test>::get(
+				current_epoch,
+				Witnesser::split_calldata(&mut call.clone()).1
+			)
+			.len(),
+			1
+		);
+
+		// Vote again, we should reach the threshold and dispatch the call.
+		assert_ok!(Witnesser::witness_at_epoch(
+			RuntimeOrigin::signed(BOBSON),
+			call.clone(),
+			current_epoch
+		));
+
+		// The inserted value should be the sum of the call values.
+		assert_eq!(pallet_dummy::Something::<Test>::get(), Some(2u32));
+
+		// Extra call data is empty.
+		assert!(ExtraCallData::<Test>::get(
+			current_epoch,
+			CallHash(frame_support::Hashable::blake2_256(&*call))
+		)
+		.is_none(),);
+
+		// Can vote again, but not call data is inserted and result is unaffected.
+		assert_ok!(Witnesser::witness_at_epoch(
+			RuntimeOrigin::signed(CHARLEMAGNE),
+			call.clone(),
+			current_epoch
+		));
+		assert_eq!(pallet_dummy::Something::<Test>::get(), Some(2u32));
+		assert!(ExtraCallData::<Test>::get(
+			current_epoch,
+			CallHash(frame_support::Hashable::blake2_256(&*call))
+		)
+		.is_none(),);
+	});
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1391

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

The ExtraCallData storage currently takes up ~300Mb of storage on mainnet. 

This PR makes two changes:

1. remove the ExtraCallData when we recombine it to construct the dispatch calldata.
2. prevent it from being inserted if we have already processed it (ie. if the call has already passed the voting threshold).

This is a non-breaking runtime change. 