### PR TITLE
chore: differentiate chain explorer name b/w upgrade test and bouncer

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -343,7 +343,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:
-          name: chain-explorer
+          name: chain-explorer-upgrade-test
           path: /tmp/chainflip/explorer.txt
 
       - name: Upload Snapshots 💾


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

In the merge queue, they will both try to write to the same place, so this just differentiates them so one is not overwritten.