### PR TITLE
chore: increase backspin btc block time

### DIFF
--- a/ci/docker/development/bitcoin/start.sh
+++ b/ci/docker/development/bitcoin/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 btc_version=$(bitcoind --version)
-btc_block_time=15
+btc_block_time=5
 
 PRUNE=$1
 
@@ -16,6 +16,8 @@ else
   done
 
   electrs --conf electrs.conf &
+
+  btc_block_time=15
 fi
 
 echo "Bitcoin version: $btc_version"

--- a/ci/docker/development/bitcoin/start.sh
+++ b/ci/docker/development/bitcoin/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 btc_version=$(bitcoind --version)
-btc_block_time=5
+btc_block_time=15
 
 PRUNE=$1
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

In order to be able to thoroughly test our swapping app transitions, we need to increase the block producing time.


#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.