### PR TITLE
chore: remove deprecated events

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -804,7 +804,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				payload: broadcast_data.transaction_payload.clone(),
 			});
 
-			// TODO: consider removing this
 			Self::deposit_event(Event::<T, I>::TransactionBroadcastRequest {
 				broadcast_id,
 				nominee: nominated_signer,

--- a/state-chain/pallets/cf-threshold-signature/src/key_rotator.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/key_rotator.rs
@@ -37,7 +37,6 @@ impl<T: Config<I>, I: 'static> KeyRotator for Pallet<T, I> {
 			participants: candidates.clone(),
 		});
 
-		// TODO: consider deleting this
 		Pallet::<T, I>::deposit_event(Event::KeygenRequest {
 			ceremony_id,
 			participants: candidates,
@@ -90,7 +89,6 @@ impl<T: Config<I>, I: 'static> KeyRotator for Pallet<T, I> {
 							new_key: new_public_key,
 						});
 
-						// TODO: consider removing this
 						Self::deposit_event(Event::KeyHandoverRequest {
 							ceremony_id,
 							// The key we want to share is the key from the *previous/current*

--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -1283,7 +1283,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					payload: payload.clone(),
 				});
 
-				// TODO: consider removing this
 				Event::<T, I>::ThresholdSignatureRequest {
 					request_id,
 					ceremony_id,

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -316,11 +316,6 @@ pub mod pallet {
 			old_version: Version,
 			new_version: Version,
 		},
-		/// An authority has register her current PeerId \[account_id, public_key, port,
-		/// ip_address\]
-		PeerIdRegistered(T::AccountId, Ed25519PublicKey, Port, Ipv6Addr),
-		/// A authority has unregistered her current PeerId \[account_id, public_key\]
-		PeerIdUnregistered(T::AccountId, Ed25519PublicKey),
 		/// An auction has a set of winners \[winners, bond\]
 		AuctionCompleted(Vec<ValidatorIdOf<T>>, T::Amount),
 		/// Some pallet configuration has been updated.
@@ -614,10 +609,6 @@ pub mod pallet {
 		///
 		/// The dispatch origin of this function must be signed.
 		///
-		/// ## Events
-		///
-		/// - [PeerIdRegistered](Event::PeerIdRegistered)
-		///
 		/// ## Errors
 		///
 		/// - [BadOrigin](frame_system::error::BadOrigin)
@@ -691,8 +682,6 @@ pub mod pallet {
 				ip_address,
 			);
 
-			// TODO: Consider removing this
-			Self::deposit_event(Event::PeerIdRegistered(account_id, peer_id, port, ip_address));
 			Ok(().into())
 		}
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -5,7 +5,11 @@ use core::ops::Range;
 use crate::{mock::*, Error, *};
 use cf_test_utilities::{assert_event_sequence, last_event};
 use cf_traits::{
-	mocks::{cfe_interface_mock::{MockCfeEvent, MockCfeInterface}, key_rotator::MockKeyRotatorA, reputation_resetter::MockReputationResetter},
+	mocks::{
+		cfe_interface_mock::{MockCfeEvent, MockCfeInterface},
+		key_rotator::MockKeyRotatorA,
+		reputation_resetter::MockReputationResetter,
+	},
 	AccountRoleRegistry, SafeMode, SetSafeMode,
 };
 use cf_utilities::success_threshold_from_share_count;
@@ -372,7 +376,6 @@ fn register_peer_id() {
 			}],
 			"should emit event on register peer id"
 		);
-		
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 11)));
 
@@ -411,7 +414,6 @@ fn register_peer_id() {
 			}],
 			"should emit event on register peer id"
 		);
-			
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 11)));
 
@@ -423,7 +425,6 @@ fn register_peer_id() {
 			12,
 			bob_peer_keypair.sign(&BOB.encode()[..]),
 		));
-			
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 12)));
 	});

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use crate::{mock::*, Error, *};
 use cf_test_utilities::{assert_event_sequence, last_event};
 use cf_traits::{
-	mocks::{key_rotator::MockKeyRotatorA, reputation_resetter::MockReputationResetter},
+	mocks::{cfe_interface_mock::{MockCfeEvent, MockCfeInterface}, key_rotator::MockKeyRotatorA, reputation_resetter::MockReputationResetter},
 	AccountRoleRegistry, SafeMode, SetSafeMode,
 };
 use cf_utilities::success_threshold_from_share_count;
@@ -323,14 +323,16 @@ fn register_peer_id() {
 			10,
 			alice_peer_keypair.sign(&ALICE.encode()[..]),
 		));
+
 		assert_eq!(
-			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PeerIdRegistered(
-				ALICE,
-				alice_peer_public_key,
-				40044,
-				10
-			)),
+			MockCfeInterface::take_events(),
+			vec![
+			MockCfeEvent::PeerIdRegistered {
+				account_id: ALICE,
+				pubkey: alice_peer_public_key,
+				port: 40044,
+				ip: 10
+			}],
 			"should emit event on register peer id"
 		);
 		assert_eq!(ValidatorPallet::mapped_peer(&alice_peer_public_key), Some(()));
@@ -358,16 +360,19 @@ fn register_peer_id() {
 			11,
 			bob_peer_keypair.sign(&BOB.encode()[..]),
 		),);
+
 		assert_eq!(
-			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PeerIdRegistered(
-				BOB,
-				bob_peer_public_key,
-				40043,
-				11
-			)),
+			MockCfeInterface::take_events(),
+			vec![
+			MockCfeEvent::PeerIdRegistered {
+				account_id: BOB,
+				pubkey: bob_peer_public_key,
+				port: 40043,
+				ip: 11
+			}],
 			"should emit event on register peer id"
 		);
+		
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 11)));
 
@@ -394,16 +399,19 @@ fn register_peer_id() {
 			11,
 			bob_peer_keypair.sign(&BOB.encode()[..]),
 		));
+
 		assert_eq!(
-			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PeerIdRegistered(
-				BOB,
-				bob_peer_public_key,
-				40043,
-				11
-			)),
+			MockCfeInterface::take_events(),
+			vec![
+			MockCfeEvent::PeerIdRegistered {
+				account_id: BOB,
+				pubkey: bob_peer_public_key,
+				port: 40043,
+				ip: 11
+			}],
 			"should emit event on register peer id"
 		);
+			
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 11)));
 
@@ -415,16 +423,7 @@ fn register_peer_id() {
 			12,
 			bob_peer_keypair.sign(&BOB.encode()[..]),
 		));
-		assert_eq!(
-			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PeerIdRegistered(
-				BOB,
-				bob_peer_public_key,
-				40043,
-				12
-			)),
-			"should emit event on register peer id"
-		);
+			
 		assert_eq!(ValidatorPallet::mapped_peer(&bob_peer_public_key), Some(()));
 		assert_eq!(ValidatorPallet::node_peer_id(&BOB), Some((bob_peer_public_key, 40043, 12)));
 	});

--- a/state-chain/traits/src/mocks/cfe_interface_mock.rs
+++ b/state-chain/traits/src/mocks/cfe_interface_mock.rs
@@ -15,6 +15,16 @@ pub enum MockCfeEvent<ValidatorId> {
 	EvmKeygenRequest(cfe_events::KeygenRequest<ValidatorId>),
 	// Note: we don't normally do handover for eth, but this works for tests
 	EthKeyHandoverRequest(cfe_events::KeyHandoverRequest<ValidatorId, MockEthereumChainCrypto>),
+	PeerIdRegistered {
+		account_id: ValidatorId,
+		pubkey: cf_primitives::Ed25519PublicKey,
+		port: u16,
+		ip: cf_primitives::Ipv6Addr,
+	},
+	PeerIdDeregistered {
+		account_id: ValidatorId,
+		pubkey: cf_primitives::Ed25519PublicKey,
+	},
 }
 
 const STORAGE_KEY: &[u8] = b"MockCfeInterface::Events";
@@ -45,19 +55,19 @@ impl<T: Chainflip> CfeBroadcastRequest<T, MockEthereum> for MockCfeInterface {
 
 impl<T: Chainflip> CfePeerRegistration<T> for MockCfeInterface {
 	fn peer_registered(
-		_account_id: <T as Chainflip>::ValidatorId,
-		_pubkey: cf_primitives::Ed25519PublicKey,
-		_port: u16,
-		_ip: cf_primitives::Ipv6Addr,
+		account_id: <T as Chainflip>::ValidatorId,
+		pubkey: cf_primitives::Ed25519PublicKey,
+		port: u16,
+		ip: cf_primitives::Ipv6Addr,
 	) {
-		// TODO: implement when needed for any test
+		Self::append_event(MockCfeEvent::PeerIdRegistered { account_id, pubkey, port, ip });
 	}
 
 	fn peer_deregistered(
-		_account_id: <T as Chainflip>::ValidatorId,
-		_pubkey: cf_primitives::Ed25519PublicKey,
+		account_id: <T as Chainflip>::ValidatorId,
+		pubkey: cf_primitives::Ed25519PublicKey,
 	) {
-		// TODO: implement when needed for any test
+		Self::append_event(MockCfeEvent::PeerIdDeregistered { account_id, pubkey });
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1434

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Removes deprecated events, and removes comment for events that we do want to leave, since they are used externally - and we don't want external APIs depending on CFE Events pallet events.