### PR TITLE
fix: only use cache on PRs to main

### DIFF
--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -63,6 +64,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -52,6 +53,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Setup Rust cache 🦀💰
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
         uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust


### PR DESCRIPTION
# Pull Request

Closes: PRO-1461

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Encountered some issues with the caching, where artifacts from unrelated PRs were polluting each other. This at least protects main and releases by only using the cache on PRs to develop. The issue can still occur, but at least broken code can't make it into main.