### PR TITLE
feat: add fok params to SwapDepositAddressReady

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -295,6 +295,7 @@ pub struct SwapDepositAddress {
 	pub channel_id: ChannelId,
 	pub source_chain_expiry_block: <AnyChain as cf_chains::Chain>::ChainBlockNumber,
 	pub channel_opening_fee: U256,
+	pub refund_parameters: Option<ChannelRefundParameters>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -371,6 +372,7 @@ pub trait BrokerApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 				channel_id,
 				source_chain_expiry_block,
 				channel_opening_fee,
+				refund_parameters,
 				..
 			},
 		)) = events.iter().find(|event| {
@@ -387,6 +389,7 @@ pub trait BrokerApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 				channel_id: *channel_id,
 				source_chain_expiry_block: *source_chain_expiry_block,
 				channel_opening_fee: (*channel_opening_fee).into(),
+				refund_parameters: refund_parameters.clone(),
 			})
 		} else {
 			bail!("No SwapDepositAddressReady event was found");

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -344,6 +344,7 @@ pub mod pallet {
 			boost_fee: BasisPoints,
 			channel_opening_fee: T::Amount,
 			affiliate_fees: Affiliates<T::AccountId>,
+			refund_parameters: Option<ChannelRefundParameters>,
 		},
 		/// A swap is scheduled for the first time
 		SwapScheduled {
@@ -888,7 +889,7 @@ pub mod pallet {
 					broker,
 					channel_metadata.clone(),
 					boost_fee,
-					refund_parameters,
+					refund_parameters.clone(),
 				)?;
 
 			Self::deposit_event(Event::<T>::SwapDepositAddressReady {
@@ -903,6 +904,7 @@ pub mod pallet {
 				boost_fee,
 				channel_opening_fee,
 				affiliate_fees,
+				refund_parameters,
 			});
 
 			Ok(())

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -2235,8 +2235,14 @@ fn swaps_get_retried_after_failure() {
 }
 
 #[test]
-fn deposit_address_ready_event_contain_correct_boost_fee_value() {
+fn deposit_address_ready_event_contains_correct_parameters() {
 	new_test_ext().execute_with(|| {
+		let refund_parameters = ChannelRefundParameters {
+			retry_duration: 10,
+			refund_address: ForeignChainAddress::Eth([10; 20].into()),
+			min_price: 100.into(),
+		};
+
 		const BOOST_FEE: u16 = 100;
 		assert_ok!(Swapping::request_swap_deposit_address_with_affiliates(
 			RuntimeOrigin::signed(ALICE),
@@ -2247,11 +2253,15 @@ fn deposit_address_ready_event_contain_correct_boost_fee_value() {
 			None,
 			BOOST_FEE,
 			Default::default(),
-			None,
+			Some(refund_parameters.clone()),
 		));
 		assert_event_sequence!(
 			Test,
-			RuntimeEvent::Swapping(Event::SwapDepositAddressReady { boost_fee: BOOST_FEE, .. })
+			RuntimeEvent::Swapping(Event::SwapDepositAddressReady {
+				boost_fee: BOOST_FEE,
+				refund_parameters: Some(ref refund_params_in_event),
+				..
+			}) if refund_params_in_event == &refund_parameters
 		);
 	});
 }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

As per @niklasnatter request, adding FoK parameters (`refund_parameters`) to the `SwapDepositAddressReady` event. Updated one of the test to check that it is correctly set. Also added `refund_parameters` to the CLI's `SwapDepositAddress` since its purpose seems to be to observe the event and read its parameters (I'm not sure how this is used exactly, but I'm assuming this is converted to JSON, which means the change is non-breaking).