### PR TITLE
feat: add primary/secondary label to RPC_RETRIER_TOTAL_REQUESTS metric

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -387,7 +387,7 @@ where
 					request_holder.insert(request_id, (response_sender, closure));
 				},
 				let (request_id, request_log, retry_limit, primary_or_secondary, result) = submission_holder.next_or_pending() => {
-					RPC_RETRIER_TOTAL_REQUESTS.inc(&[name, request_log.rpc_method.as_str()]);
+					RPC_RETRIER_TOTAL_REQUESTS.inc(&[name, request_log.rpc_method.as_str(), format!("{:?}", primary_or_secondary).as_str()]);
 					match result {
 						Ok(value) => {
 							if let Some((response_sender, _)) = request_holder.remove(&request_id) {

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -19,8 +19,10 @@ use core::cmp::min;
 use futures::Future;
 use futures_util::stream::FuturesUnordered;
 use rand::Rng;
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::{
+	fmt,
+	fmt::{Display, Formatter},
+};
 use tokio::sync::{mpsc, oneshot};
 use utilities::{
 	metrics::{RPC_RETRIER_REQUESTS, RPC_RETRIER_TOTAL_REQUESTS},
@@ -93,7 +95,7 @@ impl std::ops::Not for PrimaryOrSecondary {
 	}
 }
 
-impl Display for PrimaryOrSecondary{
+impl Display for PrimaryOrSecondary {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		match self {
 			PrimaryOrSecondary::Primary => write!(f, "Primary"),

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -20,6 +20,7 @@ use futures::Future;
 use futures_util::stream::FuturesUnordered;
 use rand::Rng;
 use std::fmt;
+use std::fmt::{Display, Formatter};
 use tokio::sync::{mpsc, oneshot};
 use utilities::{
 	metrics::{RPC_RETRIER_REQUESTS, RPC_RETRIER_TOTAL_REQUESTS},
@@ -88,6 +89,15 @@ impl std::ops::Not for PrimaryOrSecondary {
 		match self {
 			PrimaryOrSecondary::Primary => PrimaryOrSecondary::Secondary,
 			PrimaryOrSecondary::Secondary => PrimaryOrSecondary::Primary,
+		}
+	}
+}
+
+impl Display for PrimaryOrSecondary{
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			PrimaryOrSecondary::Primary => write!(f, "Primary"),
+			PrimaryOrSecondary::Secondary => write!(f, "Secondary"),
 		}
 	}
 }
@@ -387,7 +397,7 @@ where
 					request_holder.insert(request_id, (response_sender, closure));
 				},
 				let (request_id, request_log, retry_limit, primary_or_secondary, result) = submission_holder.next_or_pending() => {
-					RPC_RETRIER_TOTAL_REQUESTS.inc(&[name, request_log.rpc_method.as_str(), format!("{:?}", primary_or_secondary).as_str()]);
+					RPC_RETRIER_TOTAL_REQUESTS.inc(&[name, request_log.rpc_method.as_str(), primary_or_secondary.to_string().as_str()]);
 					match result {
 						Ok(value) => {
 							if let Some((response_sender, _)) = request_holder.remove(&request_id) {

--- a/utilities/src/with_std/metrics.rs
+++ b/utilities/src/with_std/metrics.rs
@@ -432,7 +432,7 @@ build_counter_vec!(
 	RPC_RETRIER_TOTAL_REQUESTS,
 	"cfe_rpc_requests_total",
 	"Count all the rpc calls made by the retrier, it counts every single call even if it is the same made multiple times",
-	["client","rpc_method"]
+	["client", "rpc_method", "endpoint"]
 );
 build_counter_vec!(
 	P2P_MONITOR_EVENT,


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Added a label "endpoint" to RPC_RETRIER_TOTAL_REQUESTS metric such that we know which endpoint (primary or secondary) we are using.
