### PR TITLE
Fix/limit sol batches

### DIFF
--- a/foreign-chains/solana/sol-prim/src/consts.rs
+++ b/foreign-chains/solana/sol-prim/src/consts.rs
@@ -38,3 +38,7 @@ pub const MAX_TRANSACTION_LENGTH: usize = 1_232;
 pub const NONCE_ACCOUNT_LENGTH: u64 = 80;
 
 pub const SOL_USDC_DECIMAL: u8 = 6u8;
+
+// Due to transaction size limit in Solana, we have a limit on number of fetches in a solana hetch
+// tx
+pub const MAX_SOL_FETCHES_PER_TX: usize = 10;

--- a/foreign-chains/solana/sol-prim/src/consts.rs
+++ b/foreign-chains/solana/sol-prim/src/consts.rs
@@ -38,7 +38,3 @@ pub const MAX_TRANSACTION_LENGTH: usize = 1_232;
 pub const NONCE_ACCOUNT_LENGTH: u64 = 80;
 
 pub const SOL_USDC_DECIMAL: u8 = 6u8;
-
-// Due to transaction size limit in Solana, we have a limit on number of fetches in a solana hetch
-// tx
-pub const MAX_SOL_FETCHES_PER_TX: usize = 10;

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -29,6 +29,10 @@ pub use sol_tx_core::{
 	Transaction as SolTransaction,
 };
 
+// Due to transaction size limit in Solana, we have a limit on number of fetches in a solana fetch
+// tx
+pub const MAX_SOL_FETCHES_PER_TX: usize = 10;
+
 impl Chain for Solana {
 	const NAME: &'static str = "Solana";
 	const GAS_ASSET: Self::ChainAsset = assets::sol::Asset::Sol;

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -693,6 +693,10 @@ impl<T: Config> Pallet<T> {
 		nonce_accounts.extend(&mut SolanaUnAvailableNonceAccounts::<T>::iter());
 		nonce_accounts
 	}
+
+	pub fn get_number_of_available_sol_nonce_accounts() -> usize {
+		SolanaAvailableNonceAccounts::<T>::decode_len().unwrap_or(0)
+	}
 }
 
 impl<T: Config> CompatibleCfeVersions for Pallet<T> {

--- a/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
@@ -125,6 +125,7 @@ impl pallet_cf_ingress_egress::Config for Test {
 	type AssetConverter = MockAssetConverter;
 	type FeePayment = MockFeePayment<Self>;
 	type SwapQueueApi = MockSwapQueueApi;
+	type TransfersLimitProvider = cf_traits::NoTransfersLimit;
 	type SafeMode = MockRuntimeSafeMode;
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_btc.rs
@@ -125,7 +125,7 @@ impl pallet_cf_ingress_egress::Config for Test {
 	type AssetConverter = MockAssetConverter;
 	type FeePayment = MockFeePayment<Self>;
 	type SwapQueueApi = MockSwapQueueApi;
-	type TransfersLimitProvider = cf_traits::NoTransfersLimit;
+	type FetchesTransfersLimitProvider = cf_traits::NoLimit;
 	type SafeMode = MockRuntimeSafeMode;
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
@@ -130,7 +130,7 @@ impl crate::Config for Test {
 	type AssetConverter = MockAssetConverter;
 	type FeePayment = MockFeePayment<Self>;
 	type SwapQueueApi = MockSwapQueueApi;
-	type TransfersLimitProvider = cf_traits::NoTransfersLimit;
+	type FetchesTransfersLimitProvider = cf_traits::NoLimit;
 	type SafeMode = MockRuntimeSafeMode;
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mock_eth.rs
@@ -130,6 +130,7 @@ impl crate::Config for Test {
 	type AssetConverter = MockAssetConverter;
 	type FeePayment = MockFeePayment<Self>;
 	type SwapQueueApi = MockSwapQueueApi;
+	type TransfersLimitProvider = cf_traits::NoTransfersLimit;
 	type SafeMode = MockRuntimeSafeMode;
 }
 

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -59,9 +59,9 @@ use cf_primitives::{chains::assets, AccountRole, Asset, BasisPoints, Beneficiari
 use cf_traits::{
 	AccountInfo, AccountRoleRegistry, BackupRewardsNotifier, BlockEmissions,
 	BroadcastAnyChainGovKey, Broadcaster, Chainflip, CommKeyBroadcaster, DepositApi, EgressApi,
-	EpochInfo, Heartbeat, IngressEgressFeeApi, Issuance, KeyProvider, OnBroadcastReady, OnDeposit,
-	QualifyNode, RewardsDistribution, RuntimeUpgrade, ScheduledEgressDetails,
-	TransfersLimitProvider,
+	EpochInfo, FetchesTransfersLimitProvider, Heartbeat, IngressEgressFeeApi, Issuance,
+	KeyProvider, OnBroadcastReady, OnDeposit, QualifyNode, RewardsDistribution, RuntimeUpgrade,
+	ScheduledEgressDetails,
 };
 use codec::{Decode, Encode};
 use eth::Address as EvmAddress;
@@ -79,6 +79,7 @@ pub use offences::*;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 pub use signer_nomination::RandomSignerNomination;
+use sol_prim::consts::MAX_SOL_FETCHES_PER_TX;
 use sp_core::U256;
 use sp_std::prelude::*;
 
@@ -868,9 +869,13 @@ impl_ingress_egress_fee_api_for_anychain!(
 	(Solana, SolanaIngressEgress)
 );
 
-pub struct SolanaTransfersLimit;
-impl TransfersLimitProvider for SolanaTransfersLimit {
+pub struct SolanaLimit;
+impl FetchesTransfersLimitProvider for SolanaLimit {
 	fn maybe_transfers_limit() -> Option<usize> {
 		Some(Environment::get_number_of_available_sol_nonce_accounts().saturating_sub(1))
+	}
+
+	fn maybe_fetches_limit() -> Option<usize> {
+		Some(MAX_SOL_FETCHES_PER_TX)
 	}
 }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -61,6 +61,7 @@ use cf_traits::{
 	BroadcastAnyChainGovKey, Broadcaster, Chainflip, CommKeyBroadcaster, DepositApi, EgressApi,
 	EpochInfo, Heartbeat, IngressEgressFeeApi, Issuance, KeyProvider, OnBroadcastReady, OnDeposit,
 	QualifyNode, RewardsDistribution, RuntimeUpgrade, ScheduledEgressDetails,
+	TransfersLimitProvider,
 };
 use codec::{Decode, Encode};
 use eth::Address as EvmAddress;
@@ -866,3 +867,10 @@ impl_ingress_egress_fee_api_for_anychain!(
 	(Arbitrum, ArbitrumIngressEgress),
 	(Solana, SolanaIngressEgress)
 );
+
+pub struct SolanaTransfersLimit;
+impl TransfersLimitProvider for SolanaTransfersLimit {
+	fn maybe_transfers_limit() -> Option<usize> {
+		Some(Environment::get_number_of_available_sol_nonce_accounts().saturating_sub(1))
+	}
+}

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -871,10 +871,18 @@ impl_ingress_egress_fee_api_for_anychain!(
 pub struct SolanaLimit;
 impl FetchesTransfersLimitProvider for SolanaLimit {
 	fn maybe_transfers_limit() -> Option<usize> {
-		Some(Environment::get_number_of_available_sol_nonce_accounts().saturating_sub(1))
+		// we need to leave one nonce for the fetch tx and one nonce reserved for rotation tx since
+		// rotation tx can fail to build if all nonce accounts are occupied
+		Some(Environment::get_number_of_available_sol_nonce_accounts().saturating_sub(2))
 	}
 
 	fn maybe_fetches_limit() -> Option<usize> {
-		Some(cf_chains::sol::MAX_SOL_FETCHES_PER_TX)
+		// only fetch if we have more than once nonce account available since one nonce nonce is
+		// reserved for rotations. See above
+		Some(if Environment::get_number_of_available_sol_nonce_accounts() > 1 {
+			cf_chains::sol::MAX_SOL_FETCHES_PER_TX
+		} else {
+			0
+		})
 	}
 }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -79,7 +79,6 @@ pub use offences::*;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 pub use signer_nomination::RandomSignerNomination;
-use sol_prim::consts::MAX_SOL_FETCHES_PER_TX;
 use sp_core::U256;
 use sp_std::prelude::*;
 
@@ -876,6 +875,6 @@ impl FetchesTransfersLimitProvider for SolanaLimit {
 	}
 
 	fn maybe_fetches_limit() -> Option<usize> {
-		Some(MAX_SOL_FETCHES_PER_TX)
+		Some(cf_chains::sol::MAX_SOL_FETCHES_PER_TX)
 	}
 }

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -45,7 +45,7 @@ use cf_chains::{
 	TransactionBuilder,
 };
 use cf_primitives::{BroadcastId, EpochIndex, NetworkEnvironment, STABLE_ASSET};
-use cf_traits::{AdjustedFeeEstimationApi, AssetConverter, LpBalanceApi};
+use cf_traits::{AdjustedFeeEstimationApi, AssetConverter, LpBalanceApi, NoTransfersLimit};
 use codec::{alloc::string::ToString, Encode};
 use core::ops::Range;
 use frame_support::instances::*;
@@ -125,7 +125,8 @@ pub use pallet_cf_validator::SetSizeParameters;
 use chainflip::{
 	epoch_transition::ChainflipEpochTransitions, evm_vault_activator::EvmVaultActivator,
 	BroadcastReadyProvider, BtcEnvironment, ChainAddressConverter, ChainflipHeartbeat,
-	DotEnvironment, EvmEnvironment, SolEnvironment, TokenholderGovernanceBroadcaster,
+	DotEnvironment, EvmEnvironment, SolEnvironment, SolanaTransfersLimit,
+	TokenholderGovernanceBroadcaster,
 };
 use safe_mode::{RuntimeSafeMode, WitnesserCallPermission};
 
@@ -340,6 +341,7 @@ impl pallet_cf_ingress_egress::Config<Instance1> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type TransfersLimitProvider = NoTransfersLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -361,6 +363,7 @@ impl pallet_cf_ingress_egress::Config<Instance2> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type TransfersLimitProvider = NoTransfersLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -382,6 +385,7 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type TransfersLimitProvider = NoTransfersLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -403,6 +407,7 @@ impl pallet_cf_ingress_egress::Config<Instance4> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type TransfersLimitProvider = NoTransfersLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -424,6 +429,7 @@ impl pallet_cf_ingress_egress::Config<Instance5> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
+	type TransfersLimitProvider = SolanaTransfersLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -45,7 +45,7 @@ use cf_chains::{
 	TransactionBuilder,
 };
 use cf_primitives::{BroadcastId, EpochIndex, NetworkEnvironment, STABLE_ASSET};
-use cf_traits::{AdjustedFeeEstimationApi, AssetConverter, LpBalanceApi, NoTransfersLimit};
+use cf_traits::{AdjustedFeeEstimationApi, AssetConverter, LpBalanceApi, NoLimit};
 use codec::{alloc::string::ToString, Encode};
 use core::ops::Range;
 use frame_support::instances::*;
@@ -125,8 +125,7 @@ pub use pallet_cf_validator::SetSizeParameters;
 use chainflip::{
 	epoch_transition::ChainflipEpochTransitions, evm_vault_activator::EvmVaultActivator,
 	BroadcastReadyProvider, BtcEnvironment, ChainAddressConverter, ChainflipHeartbeat,
-	DotEnvironment, EvmEnvironment, SolEnvironment, SolanaTransfersLimit,
-	TokenholderGovernanceBroadcaster,
+	DotEnvironment, EvmEnvironment, SolEnvironment, SolanaLimit, TokenholderGovernanceBroadcaster,
 };
 use safe_mode::{RuntimeSafeMode, WitnesserCallPermission};
 
@@ -341,7 +340,7 @@ impl pallet_cf_ingress_egress::Config<Instance1> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
-	type TransfersLimitProvider = NoTransfersLimit;
+	type FetchesTransfersLimitProvider = NoLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -363,7 +362,7 @@ impl pallet_cf_ingress_egress::Config<Instance2> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
-	type TransfersLimitProvider = NoTransfersLimit;
+	type FetchesTransfersLimitProvider = NoLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -385,7 +384,7 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
-	type TransfersLimitProvider = NoTransfersLimit;
+	type FetchesTransfersLimitProvider = NoLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -407,7 +406,7 @@ impl pallet_cf_ingress_egress::Config<Instance4> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
-	type TransfersLimitProvider = NoTransfersLimit;
+	type FetchesTransfersLimitProvider = NoLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 
@@ -429,7 +428,7 @@ impl pallet_cf_ingress_egress::Config<Instance5> for Runtime {
 	type AssetConverter = LiquidityPools;
 	type FeePayment = Flip;
 	type SwapQueueApi = Swapping;
-	type TransfersLimitProvider = SolanaTransfersLimit;
+	type FetchesTransfersLimitProvider = SolanaLimit;
 	type SafeMode = RuntimeSafeMode;
 }
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -949,3 +949,12 @@ pub trait AssetConverter {
 pub trait IngressEgressFeeApi<C: Chain> {
 	fn accrue_withheld_fee(asset: C::ChainAsset, amount: C::ChainAmount);
 }
+
+pub trait TransfersLimitProvider {
+	fn maybe_transfers_limit() -> Option<usize> {
+		None
+	}
+}
+
+pub struct NoTransfersLimit;
+impl TransfersLimitProvider for NoTransfersLimit {}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -950,11 +950,14 @@ pub trait IngressEgressFeeApi<C: Chain> {
 	fn accrue_withheld_fee(asset: C::ChainAsset, amount: C::ChainAmount);
 }
 
-pub trait TransfersLimitProvider {
+pub trait FetchesTransfersLimitProvider {
 	fn maybe_transfers_limit() -> Option<usize> {
+		None
+	}
+	fn maybe_fetches_limit() -> Option<usize> {
 		None
 	}
 }
 
-pub struct NoTransfersLimit;
-impl TransfersLimitProvider for NoTransfersLimit {}
+pub struct NoLimit;
+impl FetchesTransfersLimitProvider for NoLimit {}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1401

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

This introduces a general functionality of limiting the number of fetches and transfers while creating the allbatch call. It also implements the limits for the case of solana. For solana, we want the limit on transfers to be 1 less than the available nonces. The remaining nonce is reserved for fetch tx. We put a limit on fetches so that there is only one fetch tx.


#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.