### PR TITLE
fix: use rpath in engine dylib

### DIFF
--- a/engine-runner-bin/README.md
+++ b/engine-runner-bin/README.md
@@ -33,3 +33,10 @@ All the versions that are required to be bumped are checked in the `build.rs` fi
 ### Developer Notes
 
 - The `cfe_entrypoint`, which is the C FFI entrypoint of the dylib that the runner can call, has its version defined by the version specified in the `engine-proc-macros` crate, and NOT the version of the dylib crate itself. This is perhaps a little counterintuitive, but it's just how Rust environment variables and proc-macros work at the moment. This is why the proc-macros crate checks it's version against the `NEW_VERSION` and `OLD_VERSION` consts in it's [build.rs](./../engine-proc-macros/build.rs) file.
+
+## Resources
+
+Some useful resources on dylib file resolution:
+
+- A forum post on [dylib identification](https://forums.developer.apple.com/forums/thread/736719).
+- The man pages for `ld`, `otool` and `install_name_tool`.


### PR DESCRIPTION
This fixes an issue with the engine dylib file that was preventing it from running on mac localnets. 

The dylib install path was previously set to a local path on my machine.
Now it's correctly set to a relative path. 

The engine lib build script already do this correctly on main, but that change hasn't been ported to the release branch. Hence the release version 1.4.5 libs were compiled with absolute paths instead of relative paths. 


Before:

```bash
otool -L old-engine-dylib/libchainflip_engine_v1_4_5.dylib | head -2
old-engine-dylib/libchainflip_engine_v1_4_5.dylib:
        /Users/dan/[...]/old-engine-dylib/libchainflip_engine_v1_4_5.dylib (compatibility version 0.0.0, current version 0.0.0)
```

After:

```bash
otool -L old-engine-dylib/libchainflip_engine_v1_4_5.dylib | head -2
old-engine-dylib/libchainflip_engine_v1_4_5.dylib:
        @rpath/old-engine-dylib/libchainflip_engine_v1_4_5.dylib (compatibility version 0.0.0, current version 0.0.0)
```