### PR TITLE
fix: ingress-egress pallet migration co-dependency

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/migrations/add_refund_params.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/add_refund_params.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use frame_support::traits::OnRuntimeUpgrade;
 
-mod old {
+pub(super) mod old {
 
 	use super::*;
 


### PR DESCRIPTION
This (hopefully) fixes a migration issue that was occurring on CI. 

The problem was the two ingress/egress migrations were updating the same storage and we were ending up with corrupted/unmigrated values.

