### PR TITLE
chore: remove cp dylibs from post check

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -92,8 +92,6 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
-          sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
-          sudo cp ./old-engine-dylib/libchainflip_engine_v*.so /usr/lib/
           touch ./localnet/.setup_complete
           ./localnet/manage.sh
 

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -222,6 +222,7 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
+          # TODO: Should be able to remove this cp line after 1.5 is released.
           sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
           touch ./localnet/.setup_complete
           ./localnet/manage.sh


### PR DESCRIPTION
# Pull Request

Closes: PRO-1480

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

1.4 doesn't have the extra dylib pathfinding metadata in the runner binary so still requires the dylib to be copied to a default search path in the upgrade-test. However, we can remove these from post-check which is running the current version.