### PR TITLE
fix: allow validators to deregister once they no longer have relevant key material

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -749,7 +749,7 @@ pub mod pallet {
 			>>::from_ref(&account_id);
 
 			ensure!(
-				(LastExpiredEpoch::<T>::get()..=CurrentEpoch::<T>::get())
+				(LastExpiredEpoch::<T>::get() + 1..=CurrentEpoch::<T>::get())
 					.all(|epoch| !HistoricalAuthorities::<T>::get(epoch).contains(validator_id)),
 				Error::<T>::StillKeyHolder
 			);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1503

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

https://github.com/chainflip-io/chainflip-backend/blob/main/state-chain/pallets/cf-validator/src/lib.rs#L752
The corresponding code checks the range last_expired..=current but should check last_expired+1..=current