### PR TITLE
fix: cp .so files to /usr/lib

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -92,9 +92,13 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
+          echo "Check for libchainflip_engine_v*.so"
+          ls -l /usr/lib/
           # TODO: These shouldn't be required: PRO-1510
           sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
           sudo cp ./old-engine-dylib/libchainflip_engine_v*.so /usr/lib/
+          echo "Check /usr/lib after copy"
+          ls -l /usr/lib/
           touch ./localnet/.setup_complete
           ./localnet/manage.sh
 

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -92,6 +92,9 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
+          # TODO: These shouldn't be required: PRO-1510
+          sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
+          sudo cp ./old-engine-dylib/libchainflip_engine_v*.so /usr/lib/
           touch ./localnet/.setup_complete
           ./localnet/manage.sh
 

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -222,8 +222,14 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
-          # TODO: Should be able to remove this cp line after 1.5 is released.
+          echo "/usr/lib before copy of .so"
+          ls -l /usr/lib
           sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
+          echo "/usr/lib after binary root path copy of .so"
+          ls -l /usr/lib
+          sudo cp ./upgrade-to-bins/libchainflip_engine_v*.so /usr/lib/
+          echo "/usr/lib after upgrade-to-bins copy of .so"
+          ls -l /usr/lib
           touch ./localnet/.setup_complete
           ./localnet/manage.sh
 

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -222,13 +222,11 @@ jobs:
           touch /tmp/chainflip/debug.log
           chmod +x ${{ env.BINARY_ROOT_PATH }}/chainflip-*
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
-          echo "/usr/lib before copy of .so"
+          echo "/usr/lib before copy of .so files"
           ls -l /usr/lib
           sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
-          echo "/usr/lib after binary root path copy of .so"
-          ls -l /usr/lib
           sudo cp ./upgrade-to-bins/libchainflip_engine_v*.so /usr/lib/
-          echo "/usr/lib after upgrade-to-bins copy of .so"
+          echo "/usr/lib after copy of .so files"
           ls -l /usr/lib
           touch ./localnet/.setup_complete
           ./localnet/manage.sh


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

It turns out that the change here: https://github.com/chainflip-io/chainflip-backend/pull/5044/files was actually wrong. The reason it worked before is because the runs were using *old* dylibs, i.e. one that had already been moved into /usr/lib because at that time `/usr/lib` was not being cleaned up on the runner. 
Now that `/usr/lib` is cleaned up, it's clear that the relative linking is not working as expected. We should find out why: PRO-1510 . But getting this in now because it's blocking.