### PR TITLE
Fix/workaround metadata bug for pallet config

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -213,26 +213,17 @@ pub enum PalletConfigUpdate<T: Config<I>, I: 'static> {
 	SetMaxSwapRetryDurationBlocks { blocks: BlockNumber },
 }
 
-const fn get_name_for_set_minimum_deposit<T: Config<I>, I: 'static>() -> &'static str {
-	match T::TargetChain::NAME.as_bytes() {
-		b"Ethereum" => "SetMinimumDepositEthereum",
-		b"Polkadot" => "SetMinimumDepositPolkadot",
-		b"Bitcoin" => "SetMinimumDepositBitcoin",
-		b"Arbitrum" => "SetMinimumDepositArbitrum",
-		b"Solana" => "SetMinimumDepositSolana",
-		_ => panic!("Add the new chain to this list!"),
-	}
-}
-
-const fn get_name_for_pallet_config_update<T: Config<I>, I: 'static>() -> &'static str {
-	match T::TargetChain::NAME.as_bytes() {
-		b"Ethereum" => "PalletConfigUpdateEthereum",
-		b"Polkadot" => "PalletConfigUpdatePolkadot",
-		b"Bitcoin" => "PalletConfigUpdateBitcoin",
-		b"Arbitrum" => "PalletConfigUpdateArbitrum",
-		b"Solana" => "PalletConfigUpdateSolana",
-		_ => panic!("Add the new chain to this list!"),
-	}
+macro_rules! append_chain_to_name {
+	($name:ident) => {
+		match T::TargetChain::NAME {
+			"Ethereum" => concat!(stringify!($name), "Ethereum"),
+			"Polkadot" => concat!(stringify!($name), "Polkadot"),
+			"Bitcoin" => concat!(stringify!($name), "Bitcoin"),
+			"Arbitrum" => concat!(stringify!($name), "Arbitrum"),
+			"Solana" => concat!(stringify!($name), "Solana"),
+			_ => concat!(stringify!($name), "Other"),
+		}
+	};
 }
 
 impl<T, I> TypeInfo for PalletConfigUpdate<T, I>
@@ -243,14 +234,14 @@ where
 	type Identity = Self;
 	fn type_info() -> Type {
 		Type::builder()
-			.path(Path::new(get_name_for_pallet_config_update::<T, I>(), module_path!()))
+			.path(Path::new(append_chain_to_name!(PalletConfigUpdate), module_path!()))
 			.variant(
 				Variants::new()
 					.variant("ChannelOpeningFee", |v| {
 						v.index(0)
 							.fields(Fields::named().field(|f| f.ty::<T::Amount>().name("fee")))
 					})
-					.variant(get_name_for_set_minimum_deposit::<T, I>(), |v| {
+					.variant(append_chain_to_name!(SetMinimumDeposit), |v| {
 						v.index(1).fields(
 							Fields::named()
 								.field(|f| f.ty::<TargetChainAsset<T, I>>().name("asset"))


### PR DESCRIPTION
# Pull Request

Closes: PRO-1518

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Defining typeInfos for different enums with the same name causes PolkadotJS some confusion. For example, we have multiple Ingress-Egress pallets, one for each chain. Each of these pallets has an enum defined called "PalletConfigUpdate". Even though their type path and type ID are different, PolkadotJS seems to only look at the enum name when parsing the metadata. This leads to the situation where when trying to set a value for PalletConfigUpdate on Ethereum, the PolkadotJS interface uses the type for Solana (or whatever pallet was constructed last).

The solution is to not derive the typeInfo, but to explicitly construct it and assign different type names for each instance.

The main problem was that the name needs to be a string literal, but we can't construct it via concat!, because that will only work with string literals. Alastair suggested constcat::concat! instead, but that also doesn't work, because Rust doesn't allow to access static elements via generic types (wow).

In the end I just bruteforce write out all the chains. It sucks, but it is better than what we had before.


#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.