### PR TITLE
feat: RPC to return available pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
 name = "cf-traits"
 version = "0.1.0"
 dependencies = [
+ "cf-amm",
  "cf-chains",
  "cf-primitives",
  "cfe-events",

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -304,8 +304,7 @@ pub mod pallet {
 
 			ensure!(
 				T::PoolApi::pools().iter().all(|asset_pair| {
-					T::PoolApi::open_order_count(&account_id, asset_pair.base, asset_pair.quote)
-						.unwrap_or_default() == 0
+					T::PoolApi::open_order_count(&account_id, asset_pair).unwrap_or_default() == 0
 				}),
 				Error::<T>::OpenOrdersRemaining
 			);

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -299,13 +299,12 @@ pub mod pallet {
 		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::deregister_lp_account())]
 		pub fn deregister_lp_account(who: OriginFor<T>) -> DispatchResult {
-			const STABLE_ASSET: Asset = Asset::Usdc;
 			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(who)?;
 			T::PoolApi::sweep(&account_id)?;
 
 			ensure!(
-				Asset::all().filter(|asset| *asset != STABLE_ASSET).all(|asset| {
-					T::PoolApi::open_order_count(&account_id, asset, STABLE_ASSET)
+				T::PoolApi::pools().iter().all(|asset_pair| {
+					T::PoolApi::open_order_count(&account_id, asset_pair.base, asset_pair.quote)
 						.unwrap_or_default() == 0
 				}),
 				Error::<T>::OpenOrdersRemaining

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -987,10 +987,9 @@ impl<T: Config> PoolApi for Pallet<T> {
 
 	fn open_order_count(
 		who: &Self::AccountId,
-		base_asset: Asset,
-		quote_asset: Asset,
+		asset_pair: &PoolPairsMap<Asset>,
 	) -> Result<u32, DispatchError> {
-		let pool_orders = Self::pool_orders(base_asset, quote_asset, Some(who.clone()), true)?;
+		let pool_orders = Self::pool_orders(asset_pair.base, asset_pair.quote, Some(who.clone()), true)?;
 		Ok(pool_orders.limit_orders.asks.len() as u32 +
 			pool_orders.limit_orders.bids.len() as u32 +
 			pool_orders.range_orders.len() as u32)

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1029,6 +1029,10 @@ impl<T: Config> PoolApi for Pallet<T> {
 		}
 		result
 	}
+
+	fn pools() -> Vec<PoolPairsMap<Asset>> {
+		Self::pools()
+	}
 }
 
 #[derive(

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -989,7 +989,8 @@ impl<T: Config> PoolApi for Pallet<T> {
 		who: &Self::AccountId,
 		asset_pair: &PoolPairsMap<Asset>,
 	) -> Result<u32, DispatchError> {
-		let pool_orders = Self::pool_orders(asset_pair.base, asset_pair.quote, Some(who.clone()), true)?;
+		let pool_orders =
+			Self::pool_orders(asset_pair.base, asset_pair.quote, Some(who.clone()), true)?;
 		Ok(pool_orders.limit_orders.asks.len() as u32 +
 			pool_orders.limit_orders.bids.len() as u32 +
 			pool_orders.range_orders.len() as u32)

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1901,6 +1901,10 @@ impl_runtime_apis! {
 		fn cf_safe_mode_statuses() -> RuntimeSafeMode {
 			pallet_cf_environment::RuntimeSafeMode::<Runtime>::get()
 		}
+
+		fn cf_pools() -> Vec<PoolPairsMap<Asset>> {
+			LiquidityPools::pools()
+		}
 	}
 
 	impl monitoring_apis::MonitoringRuntimeApi<Block> for Runtime {

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -274,5 +274,6 @@ decl_runtime_apis!(
 		fn cf_boost_pools_depth() -> Vec<BoostPoolDepth>;
 		fn cf_boost_pool_details(asset: Asset) -> BTreeMap<u16, BoostPoolDetails>;
 		fn cf_safe_mode_statuses() -> RuntimeSafeMode;
+		fn cf_pools() -> Vec<PoolPairsMap<Asset>>;
 	}
 );

--- a/state-chain/traits/Cargo.toml
+++ b/state-chain/traits/Cargo.toml
@@ -15,6 +15,7 @@ log = { version = '0.4.16', default-features = false }
 cf-chains = { path = '../chains', default-features = false }
 cf-primitives = { path = '../primitives', default-features = false }
 cfe-events = { path = '../cfe-events', default-features = false }
+cf-amm = { path = "../amm", default-features = false}
 
 # Parity deps
 codec = { package = 'parity-scale-codec', version = '3.6.1', default-features = false, features = [
@@ -50,6 +51,7 @@ std = [
   'scale-info/std',
   'sp-std/std',
   'serde/std',
+  'cf-amm/std',
 ]
 runtime-benchmarks = [
   'cf-chains/runtime-benchmarks',

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -77,8 +77,7 @@ pub trait PoolApi {
 	/// Returns the number of open orders for the given account and pair.
 	fn open_order_count(
 		who: &Self::AccountId,
-		base_asset: Asset,
-		quote_asset: Asset,
+		asset_pair: &PoolPairsMap<Asset>,
 	) -> Result<u32, DispatchError>;
 
 	fn open_order_balances(who: &Self::AccountId) -> AssetMap<AssetAmount>;
@@ -95,8 +94,7 @@ impl<T: frame_system::Config> PoolApi for T {
 
 	fn open_order_count(
 		_who: &Self::AccountId,
-		_base_asset: Asset,
-		_quote_asset: Asset,
+		_asset_pair: &PoolPairsMap<Asset>,
 	) -> Result<u32, DispatchError> {
 		Ok(0)
 	}

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -1,3 +1,4 @@
+use cf_amm::common::PoolPairsMap;
 use cf_chains::{
 	address::ForeignChainAddress, assets::any::AssetMap, ChannelRefundParameters,
 	SwapRefundParameters,
@@ -7,6 +8,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::{DispatchError, DispatchResult};
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
+use sp_std::{vec, vec::Vec};
 
 pub trait SwapDepositHandler {
 	type AccountId;
@@ -80,6 +82,8 @@ pub trait PoolApi {
 	) -> Result<u32, DispatchError>;
 
 	fn open_order_balances(who: &Self::AccountId) -> AssetMap<AssetAmount>;
+
+	fn pools() -> Vec<PoolPairsMap<Asset>>;
 }
 
 impl<T: frame_system::Config> PoolApi for T {
@@ -98,6 +102,9 @@ impl<T: frame_system::Config> PoolApi for T {
 	}
 	fn open_order_balances(_who: &Self::AccountId) -> AssetMap<AssetAmount> {
 		AssetMap::from_fn(|_| 0)
+	}
+	fn pools() -> Vec<PoolPairsMap<Asset>> {
+		vec![]
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1506

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Added an RPC `cf_available_pools` which rdated the code where we returns the available pools as a Vec<AssetPair>
- Added pools() to PoolApi to access these info internally, updated the code to use this new function instead of looping through all assets but usdc (error prone if we don't create the pool as soon as we release a new chain or if we decide to create pools with quote asset != USDC)


#### Non-Breaking changes