### PR TITLE
fix: grep correct spec_version

### DIFF
--- a/ci/scripts/check_runtime_spec_version.sh
+++ b/ci/scripts/check_runtime_spec_version.sh
@@ -5,7 +5,7 @@ network=$1
 runtime_spec_version_file="state-chain/runtime/src/lib.rs"
 
 # Extract the spec_version from the Rust file
-spec_version=$(grep '#[sp_version::runtime_version]' -A 10 $runtime_spec_version_file | grep 'spec_version' | awk '{print $2}' | tr -d ',')
+spec_version=$(grep -F '#[sp_version::runtime_version]' -A 10 $runtime_spec_version_file | grep 'spec_version' | awk '{print $2}' | tr -d ',')
 
 if [ -z $network ]; then
     echo "Network not specified"

--- a/ci/scripts/check_runtime_spec_version.sh
+++ b/ci/scripts/check_runtime_spec_version.sh
@@ -5,7 +5,7 @@ network=$1
 runtime_spec_version_file="state-chain/runtime/src/lib.rs"
 
 # Extract the spec_version from the Rust file
-spec_version=$(grep 'spec_version:' $runtime_spec_version_file | awk '{print $2}' | tr -d ',')
+spec_version=$(grep '#[sp_version::runtime_version]' -A 10 $runtime_spec_version_file | grep 'spec_version' | awk '{print $2}' | tr -d ',')
 
 if [ -z $network ]; then
     echo "Network not specified"


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

It was grepping two `spec_version` s from the file.