### PR TITLE
chore: rename DerivedAta to PdaAndBump

### DIFF
--- a/foreign-chains/solana/sol-prim/src/lib.rs
+++ b/foreign-chains/solana/sol-prim/src/lib.rs
@@ -27,7 +27,7 @@ define_binary!(signature, Signature, crate::consts::SOLANA_SIGNATURE_LEN, "S");
 
 /// Represents a derived Associated Token Account to be used as deposit channels.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-pub struct DerivedAta {
+pub struct PdaAndBump {
 	pub address: Address,
 	pub bump: AccountBump,
 }

--- a/foreign-chains/solana/sol-prim/src/pda.rs
+++ b/foreign-chains/solana/sol-prim/src/pda.rs
@@ -3,7 +3,7 @@ use digest::Digest;
 use scale_info::TypeInfo;
 use sha2::Sha256;
 
-use crate::{address::Address, consts, AccountBump, DerivedAta};
+use crate::{address::Address, consts, AccountBump, PdaAndBump};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -62,7 +62,7 @@ impl Pda {
 		Ok(self)
 	}
 
-	pub fn finish(self) -> Result<DerivedAta, PdaError> {
+	pub fn finish(self) -> Result<PdaAndBump, PdaError> {
 		for bump in (0..=AccountBump::MAX).rev() {
 			let digest = self
 				.hasher
@@ -73,7 +73,7 @@ impl Pda {
 				.finalize();
 			if !bytes_are_curve_point(digest) {
 				let address = Address(digest.into());
-				let pda = DerivedAta { address, bump };
+				let pda = PdaAndBump { address, bump };
 				return Ok(pda)
 			}
 		}

--- a/foreign-chains/solana/sol-prim/src/tests/pda.rs
+++ b/foreign-chains/solana/sol-prim/src/tests/pda.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 mod failures {
-	use crate::{consts, DerivedAta};
+	use crate::{consts, PdaAndBump};
 
 	use super::*;
 
@@ -46,7 +46,7 @@ mod failures {
 	fn initial_address_should_be_a_valid_point() {
 		let public_key: Address =
 			"J4mK4RXAuizk5aMZw8Vz8W3y7mrCy6dcgniZ4qwZimZE".parse().expect("public key");
-		let DerivedAta { address, .. } =
+		let PdaAndBump { address, .. } =
 			Pda::from_address(public_key).expect("derive").finish().expect("finish");
 		assert!(matches!(
 			Pda::from_address(address).expect_err("PDA can't be a valid point on a curve"),
@@ -56,13 +56,13 @@ mod failures {
 }
 
 mod happy {
-	use crate::DerivedAta;
+	use crate::PdaAndBump;
 
 	use super::*;
 	fn run_single(public_key: &str, seeds: &[&str], expected_pda: &str) {
 		let public_key: Address = public_key.parse().expect("public-key");
 		let expected_pda: Address = expected_pda.parse().expect("expected-pda");
-		let DerivedAta { address: actual_pda, .. } = seeds
+		let PdaAndBump { address: actual_pda, .. } = seeds
 			.iter()
 			.try_fold(Pda::from_address(public_key).expect("derive"), Pda::chain_seed)
 			.expect("chain-seed")

--- a/state-chain/chains/src/sol/instruction_builder.rs
+++ b/state-chain/chains/src/sol/instruction_builder.rs
@@ -397,7 +397,7 @@ mod test {
 
 	use sol_prim::{
 		consts::{MAX_TRANSACTION_LENGTH, SOL_USDC_DECIMAL},
-		DerivedAta,
+		PdaAndBump,
 	};
 
 	// Arbitrary number used for testing
@@ -408,7 +408,7 @@ mod test {
 		asset: SolAsset,
 	) -> crate::FetchAssetParams<Solana> {
 		let channel_id = channel_id.unwrap_or(923_601_931u64);
-		let DerivedAta { address, bump } =
+		let PdaAndBump { address, bump } =
 			derive_deposit_address(channel_id, api_env().vault_program).unwrap();
 
 		crate::FetchAssetParams {

--- a/state-chain/chains/src/sol/sol_tx_core.rs
+++ b/state-chain/chains/src/sol/sol_tx_core.rs
@@ -982,7 +982,7 @@ mod tests {
 			MAX_TRANSACTION_LENGTH, SOL_USDC_DECIMAL, SYSTEM_PROGRAM_ID, SYS_VAR_INSTRUCTIONS,
 			TOKEN_PROGRAM_ID,
 		},
-		DerivedAta,
+		PdaAndBump,
 	};
 
 	#[derive(BorshSerialize, BorshDeserialize)]
@@ -1194,7 +1194,7 @@ mod tests {
 		// Deposit channel derived from the Vault address from the seed and the bump
 		assert_eq!(
 			deposit_channel,
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("JDtAzKWKzQJCiHCfK4PU7qYuE4wChxuqfDqQhRbv6kwX")
 					.unwrap(),
 				bump: 254u8
@@ -1202,7 +1202,7 @@ mod tests {
 		);
 		assert_eq!(
 			deposit_channel_ata,
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("7QWupKVHBPUnJpuvdt7uJxXaNWKYpEUAHPG9Rb28aEXS")
 					.unwrap(),
 				bump: 254u8
@@ -1211,7 +1211,7 @@ mod tests {
 		// Historical fetch account derived from the Vault address using the ATA as the seed
 		assert_eq!(
 			deposit_channel_historical_fetch,
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("FuNSXye89kBJQXp3rqkcz7oCUd5C5rVUDo7o5CRQ6T2o")
 					.unwrap(),
 				bump: 252u8

--- a/state-chain/chains/src/sol/sol_tx_core/address_derivation.rs
+++ b/state-chain/chains/src/sol/sol_tx_core/address_derivation.rs
@@ -2,7 +2,7 @@
 //! as well as deriving ATA for token operations (such as fetch or transfer).
 
 use cf_primitives::ChannelId;
-use sol_prim::DerivedAta;
+use sol_prim::PdaAndBump;
 
 use crate::sol::{AddressDerivationError, DerivedAddressBuilder, SolAddress};
 use sol_prim::consts::{ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID};
@@ -11,7 +11,7 @@ use sol_prim::consts::{ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID};
 pub fn derive_deposit_address(
 	channel_id: ChannelId,
 	vault_program: SolAddress,
-) -> Result<DerivedAta, AddressDerivationError> {
+) -> Result<PdaAndBump, AddressDerivationError> {
 	let seed = channel_id.to_le_bytes();
 	derive_address(seed, vault_program)
 }
@@ -20,7 +20,7 @@ pub fn derive_deposit_address(
 pub fn derive_associated_token_account(
 	target: SolAddress,
 	mint_pubkey: SolAddress,
-) -> Result<DerivedAta, AddressDerivationError> {
+) -> Result<PdaAndBump, AddressDerivationError> {
 	DerivedAddressBuilder::from_address(ASSOCIATED_TOKEN_PROGRAM_ID)?
 		.chain_seed(target)?
 		.chain_seed(TOKEN_PROGRAM_ID)?
@@ -32,7 +32,7 @@ pub fn derive_associated_token_account(
 pub fn derive_fetch_account(
 	deposit_channel_address: SolAddress,
 	vault_program: SolAddress,
-) -> Result<DerivedAta, AddressDerivationError> {
+) -> Result<PdaAndBump, AddressDerivationError> {
 	derive_address(deposit_channel_address, vault_program)
 }
 
@@ -40,7 +40,7 @@ pub fn derive_fetch_account(
 fn derive_address(
 	seed: impl AsRef<[u8]>,
 	vault_program: SolAddress,
-) -> Result<DerivedAta, AddressDerivationError> {
+) -> Result<PdaAndBump, AddressDerivationError> {
 	DerivedAddressBuilder::from_address(vault_program)?.chain_seed(seed)?.finish()
 }
 
@@ -58,7 +58,7 @@ mod tests {
 
 		assert_eq!(
 			derive_associated_token_account(wallet_address, mint_pubkey).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("BeRexE9vZSdQMNg65PAnhy3rRPUxF6oWsxyNegYxySZD")
 					.unwrap(),
 				bump: 253u8
@@ -74,7 +74,7 @@ mod tests {
 
 		assert_eq!(
 			derive_associated_token_account(pda_address, mint_pubkey).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("DUjCLckPi4g7QAwBEwuFL1whpgY6L9fxwXnqbWvS2pcW")
 					.unwrap(),
 				bump: 251u8
@@ -91,7 +91,7 @@ mod tests {
 
 		assert_eq!(
 			derive_address(channel_0_seed, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("JDtAzKWKzQJCiHCfK4PU7qYuE4wChxuqfDqQhRbv6kwX")
 					.unwrap(),
 				bump: 254u8
@@ -99,7 +99,7 @@ mod tests {
 		);
 		assert_eq!(
 			derive_address(channel_1_seed, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("32qRitYeor2v7Rb3M2iL8PHkoyqhcoCCqYuWCNKqstN7")
 					.unwrap(),
 				bump: 255u8
@@ -108,7 +108,7 @@ mod tests {
 
 		assert_eq!(
 			derive_address([11u8, 12u8, 13u8, 55u8], vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("XFmi41e1L9t732KoZdmzMSVige3SjjzsLzk1rW4rhwP")
 					.unwrap(),
 				bump: 255u8
@@ -117,7 +117,7 @@ mod tests {
 
 		assert_eq!(
 			derive_address([1], vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("5N72J9YQKpky5yFnrWWpFcBQsWpFMK4rW6b2Ue3YmYcu")
 					.unwrap(),
 				bump: 255u8
@@ -126,7 +126,7 @@ mod tests {
 
 		assert_eq!(
 			derive_address([1, 2], vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("6PkQHEp18NgEDS5ydkgivU4pzTV6sYmoEaHvbbv4un73")
 					.unwrap(),
 				bump: 255u8
@@ -139,7 +139,7 @@ mod tests {
 		let vault_program = sol_test_values::VAULT_PROGRAM;
 		assert_eq!(
 			derive_deposit_address(0u64, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("JDtAzKWKzQJCiHCfK4PU7qYuE4wChxuqfDqQhRbv6kwX")
 					.unwrap(),
 				bump: 254u8
@@ -148,7 +148,7 @@ mod tests {
 
 		assert_eq!(
 			derive_deposit_address(1u64, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("32qRitYeor2v7Rb3M2iL8PHkoyqhcoCCqYuWCNKqstN7")
 					.unwrap(),
 				bump: 255u8
@@ -162,7 +162,7 @@ mod tests {
 		let derived_account_0 = derive_deposit_address(0u64, vault_program).unwrap();
 		assert_eq!(
 			derive_associated_token_account(derived_account_0.address, token_mint_pubkey).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("7QWupKVHBPUnJpuvdt7uJxXaNWKYpEUAHPG9Rb28aEXS")
 					.unwrap(),
 				bump: 254u8
@@ -172,7 +172,7 @@ mod tests {
 		let derived_account_1 = derive_deposit_address(1u64, vault_program).unwrap();
 		assert_eq!(
 			derive_associated_token_account(derived_account_1.address, token_mint_pubkey).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("9roLwm8U86pj24Hwwzx71AF8axYnSc6U542Bdx5w7FUZ")
 					.unwrap(),
 				bump: 255u8
@@ -200,7 +200,7 @@ mod tests {
 		let deposit_channel = derive_deposit_address(0u64, vault_program).unwrap().address;
 		assert_eq!(
 			derive_fetch_account(deposit_channel, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("AS1fDXUeL6dYHKxvyMGyFoqrsN5zPcUsanPDqmvVvFUA")
 					.unwrap(),
 				bump: 255u8
@@ -219,7 +219,7 @@ mod tests {
 
 		assert_eq!(
 			derive_fetch_account(deposit_channel_ata, vault_program).unwrap(),
-			DerivedAta {
+			PdaAndBump {
 				address: SolAddress::from_str("FuNSXye89kBJQXp3rqkcz7oCUd5C5rVUDo7o5CRQ6T2o")
 					.unwrap(),
 				bump: 252u8


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Renaming `DerivedAta` because it was wrong. That was a Program derived address (PDA) but not an ATA (Associated token account).