### PR TITLE
chore: update Solana programs to 0.6 and update initialization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 CF_ETH_CONTRACT_ABI_ROOT = { value = "contract-interfaces/eth-contract-abis", relative = true }
 CF_ETH_CONTRACT_ABI_TAG = "v1.1.2"
 CF_SOL_PROGRAM_IDL_ROOT = { value = "contract-interfaces/sol-program-idls", relative = true }
-CF_SOL_PROGRAM_IDL_TAG = "v0.5.0"
+CF_SOL_PROGRAM_IDL_TAG = "v0.6.0"
 CF_ARB_CONTRACT_ABI_ROOT = { value = "contract-interfaces/arb-contract-abis", relative = true }
 CF_TEST_CONFIG_ROOT = { value = "engine/config/testing", relative = true }
 

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   FORCE_COLOR: 1
-  SOLANA_VERSION: v1.18.8
+  SOLANA_VERSION: v1.18.17
 
 permissions:
   packages: read

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -224,6 +224,8 @@ jobs:
           chmod +x ${{ env.BINARY_ROOT_PATH }}/engine-runner
           echo "/usr/lib before copy of .so files"
           ls -l /usr/lib
+          # TODO: Remove this once we have implemented fetching the shared libs in the engine-runner build script
+          curl https://repo.chainflip.io/lib/1_4_6/libchainflip_engine_v1_4_6.so -o /usr/lib/libchainflip_engine_v1_4_6.so
           sudo cp ${{ env.BINARY_ROOT_PATH }}/libchainflip_engine_v*.so /usr/lib/
           sudo cp ./upgrade-to-bins/libchainflip_engine_v*.so /usr/lib/
           echo "/usr/lib after copy of .so files"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "chainflip-api",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-broadcast 0.5.1",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-ingress-egress-tracker"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3380,7 +3380,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -12627,7 +12627,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "cf-amm",
  "cf-chains",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = '2021'
 build = 'build.rs'
 name = "chainflip-cli"
-version = "1.5.0"
+version = "1.6.0"
 
 [lints]
 workspace = true

--- a/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
+++ b/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-ingress-egress-tracker"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [lints]

--- a/bouncer/shared/contract_interfaces.ts
+++ b/bouncer/shared/contract_interfaces.ts
@@ -13,7 +13,7 @@ function loadContractCached(abiPath: string) {
   };
 }
 const CF_ETH_CONTRACT_ABI_TAG = 'v1.1.2';
-const CF_SOL_PROGRAM_IDL_TAG = 'v0.5.0';
+const CF_SOL_PROGRAM_IDL_TAG = 'v0.6.0';
 export const getErc20abi = loadContractCached(
   '../contract-interfaces/eth-contract-abis/IERC20.json',
 );

--- a/bouncer/shared/gaslimit_ccm.ts
+++ b/bouncer/shared/gaslimit_ccm.ts
@@ -288,8 +288,8 @@ async function testGasLimitSwapToSolana(
         transaction = await connection.getTransaction(confirmedSignaturesInfo[0].signature, {
           commitment: 'confirmed',
         });
-        console.log(`${tag} Transaction found: ${transaction}`);
         if (transaction !== null) {
+          console.log(`${tag} Transaction found: ${transaction?.meta}`);
           // This doesn't throw an error, for now it's fine to print it.
           if (transaction?.meta?.err === null) {
             throw new Error('Transaction should have reverted');

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -162,7 +162,7 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
   );
 
   // Set nonce authority to the new AggKey
-  const numberOfNonceAccounts = 8;
+  const numberOfNonceAccounts = 10;
   for (let i = 0; i < numberOfNonceAccounts; i++) {
     // Using the index stringified as the seed ('0', '1', '2' ...)
     const seed = i.toString();

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -160,8 +160,10 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
       programId: solanaVaultProgramId,
     }),
   );
+  await signAndSendTxSol(tx);
 
   // Set nonce authority to the new AggKey
+  tx = new Transaction();
   const numberOfNonceAccounts = 10;
   for (let i = 0; i < numberOfNonceAccounts; i++) {
     // Using the index stringified as the seed ('0', '1', '2' ...)
@@ -183,15 +185,16 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
       }),
     );
   }
-  // Set Vault's upgrade authority to upgradeSignerPDa
-  tx.add(
+  await signAndSendTxSol(tx);
+
+  // Set Vault's upgrade authority to upgradeSignerPDa and enable token support
+  tx = new Transaction().add(
     createUpgradeAuthorityInstruction(
       solanaVaultProgramId,
       whaleKeypair.publicKey,
       upgradeSignerPda,
     ),
   );
-  await signAndSendTxSol(tx);
 
   // Add token support
   const enableTokenSupportDiscriminatorString = vaultIdl.instructions.find(
@@ -208,7 +211,7 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
     solanaVaultProgramId,
   );
 
-  tx = new Transaction().add(
+  tx.add(
     new TransactionInstruction({
       data: Buffer.concat([
         Buffer.from(enableTokenSupportDiscriminator.buffer),

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -5,6 +5,7 @@ import {
   SystemProgram,
   Transaction,
   TransactionInstruction,
+  LAMPORTS_PER_SOL,
 } from '@solana/web3.js';
 import { getContractAddress, getSolWhaleKeyPair, encodeSolAddress } from '../shared/utils';
 import { sendSol, signAndSendTxSol } from '../shared/send_sol';
@@ -45,6 +46,24 @@ export async function initializeArbitrumContracts(
     })
     .encodeABI();
   await signAndSendTxEvm('Arbitrum', keyManagerAddress, '0', txData);
+}
+
+function numberToBuffer(bytes: number, number: number): Buffer {
+  const buf = Buffer.alloc(bytes);
+  if (bytes === 2) {
+    buf.writeUInt16LE(number, 0);
+  } else if (bytes === 4) {
+    buf.writeUInt32LE(number, 0);
+  } else {
+    throw new Error('Unsupported byte length');
+  }
+  return buf;
+}
+
+function bigNumberToU64Buffer(number: bigint): Buffer {
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64LE(number, 0);
+  return buf;
 }
 
 export async function initializeSolanaPrograms(solClient: Connection, solKey: string) {
@@ -99,10 +118,10 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const vaultIdl: any = await getSolanaVaultIdl();
 
-  const discriminatorString = vaultIdl.instructions.find(
+  const initializeDiscriminatorString = vaultIdl.instructions.find(
     (instruction: { name: string }) => instruction.name === 'initialize',
   ).discriminator;
-  const discriminator = new Uint8Array(discriminatorString.map(Number));
+  const initializeDiscriminator = new Uint8Array(initializeDiscriminatorString.map(Number));
 
   const solKeyBuffer = Buffer.from(solKey.slice(2), 'hex');
   const newAggKey = new PublicKey(encodeSolAddress(solKey));
@@ -114,16 +133,24 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
   await sendSol(solKey, '100');
 
   // Initialize Vault program
-  const tx = new Transaction().add(
+  let tx = new Transaction().add(
     new TransactionInstruction({
       data: Buffer.concat([
-        Buffer.from(discriminator.buffer),
+        Buffer.from(initializeDiscriminator.buffer),
         solKeyBuffer,
-        solKeyBuffer,
+        whaleKeypair.publicKey.toBuffer(), // govkey
         tokenVaultPda.toBuffer(),
         Buffer.from([253]), // tokenVaultPda bump
         upgradeSignerPda.toBuffer(),
         Buffer.from([255]), // upgradeSignerPda bump
+        Buffer.from([0]), // suspendedVault (false)
+        Buffer.from([1]), // suspendedLegacySwaps (true)
+        Buffer.from([0]), // suspendedEventSwaps (false)
+        bigNumberToU64Buffer(5n * (BigInt(LAMPORTS_PER_SOL) / 10n)), // minNativeSwapAmount
+        numberToBuffer(2, 64), // maxDstAddressLen
+        numberToBuffer(4, 10000), // maxCcmMessageLen
+        numberToBuffer(4, 1000), // maxCfParametersLen
+        numberToBuffer(4, 500), // max_event_accounts
       ]),
       keys: [
         { pubkey: dataAccount, isSigner: false, isWritable: true },
@@ -163,6 +190,39 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
       whaleKeypair.publicKey,
       upgradeSignerPda,
     ),
+  );
+  await signAndSendTxSol(tx);
+
+  // Add token support
+  const enableTokenSupportDiscriminatorString = vaultIdl.instructions.find(
+    (instruction: { name: string }) => instruction.name === 'enable_token_support',
+  ).discriminator;
+  const enableTokenSupportDiscriminator = new Uint8Array(
+    enableTokenSupportDiscriminatorString.map(Number),
+  );
+
+  const solUsdcMintPubkey = new PublicKey(getContractAddress('Solana', 'SolUsdc'));
+
+  const [tokenSupportedAccount] = PublicKey.findProgramAddressSync(
+    [solUsdcMintPubkey.toBuffer()],
+    solanaVaultProgramId,
+  );
+
+  tx = new Transaction().add(
+    new TransactionInstruction({
+      data: Buffer.concat([
+        Buffer.from(enableTokenSupportDiscriminator.buffer),
+        bigNumberToU64Buffer(5n * 10n ** 6n), // minTokenSwapAmount
+      ]),
+      keys: [
+        { pubkey: dataAccount, isSigner: false, isWritable: true },
+        { pubkey: whaleKeypair.publicKey, isSigner: true, isWritable: false },
+        { pubkey: tokenSupportedAccount, isSigner: false, isWritable: true },
+        { pubkey: solUsdcMintPubkey, isSigner: false, isWritable: false },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      ],
+      programId: solanaVaultProgramId,
+    }),
   );
   await signAndSendTxSol(tx);
 }

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -164,7 +164,7 @@ export async function initializeSolanaPrograms(solClient: Connection, solKey: st
 
   // Set nonce authority to the new AggKey
   tx = new Transaction();
-  const numberOfNonceAccounts = 10;
+  const numberOfNonceAccounts = 8;
   for (let i = 0; i < numberOfNonceAccounts; i++) {
     // Using the index stringified as the seed ('0', '1', '2' ...)
     const seed = i.toString();

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -104,7 +104,7 @@ function newSolanaCfParameters() {
   // therefore also depends on the message length. With the limited message < 100 bytes
   // we can ensure we fit 10 accounts but we can fit almost double for native asset.
   const remainingAccounts = [];
-  const numRemainingAccounts = Math.floor(Math.random() * 10) + 1;
+  const numRemainingAccounts = Math.floor(Math.random() * 10);
 
   for (let i = 0; i < numRemainingAccounts; i++) {
     remainingAccounts.push(

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -98,6 +98,8 @@ export function getContractAddress(chain: Chain, contract: string): string {
           return process.env.ARB_USDC_ADDRESS ?? '24PNhTaNtomHhoy3fTRaMhAFCRj4uHqhZEEoWrKDbR5p';
         case 'CFTESTER':
           return '8pBPaVfTAcjLeNfC187Fkvi9b1XEFhRNJ95BQXXVksmH';
+        case 'SWAP_ENDPOINT':
+          return '35uYgHdfZQT4kHkaaXQ6ZdCkK5LFrsk43btTLbGCRCNT';
         default:
           throw new Error(`Unsupported contract: ${contract}`);
       }

--- a/contract-interfaces/sol-program-idls/v0.6.0/cf_tester.json
+++ b/contract-interfaces/sol-program-idls/v0.6.0/cf_tester.json
@@ -223,6 +223,9 @@
           "writable": true
         },
         {
+          "name": "token_supported_account"
+        },
+        {
           "name": "token_program",
           "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
@@ -375,6 +378,19 @@
         18,
         233
       ]
+    },
+    {
+      "name": "SupportedToken",
+      "discriminator": [
+        56,
+        162,
+        96,
+        99,
+        193,
+        245,
+        204,
+        108
+      ]
     }
   ],
   "events": [
@@ -441,6 +457,34 @@
           {
             "name": "suspended",
             "type": "bool"
+          },
+          {
+            "name": "suspended_ix_swaps",
+            "type": "bool"
+          },
+          {
+            "name": "suspended_event_swaps",
+            "type": "bool"
+          },
+          {
+            "name": "min_native_swap_amount",
+            "type": "u64"
+          },
+          {
+            "name": "max_dst_address_len",
+            "type": "u16"
+          },
+          {
+            "name": "max_ccm_message_len",
+            "type": "u32"
+          },
+          {
+            "name": "max_cf_parameters_len",
+            "type": "u32"
+          },
+          {
+            "name": "max_event_accounts",
+            "type": "u32"
           }
         ]
       }
@@ -483,6 +527,22 @@
             "type": {
               "vec": "bool"
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SupportedToken",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "min_swap_amount",
+            "type": "u64"
           }
         ]
       }

--- a/contract-interfaces/sol-program-idls/v0.6.0/vault.json
+++ b/contract-interfaces/sol-program-idls/v0.6.0/vault.json
@@ -8,6 +8,88 @@
   },
   "instructions": [
     {
+      "name": "disable_token_support",
+      "discriminator": [
+        72,
+        4,
+        35,
+        144,
+        194,
+        49,
+        71,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "data_account",
+          "writable": true
+        },
+        {
+          "name": "gov_key",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_supported_account",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "enable_token_support",
+      "discriminator": [
+        125,
+        160,
+        180,
+        50,
+        26,
+        27,
+        112,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "data_account",
+          "writable": true
+        },
+        {
+          "name": "gov_key",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_supported_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "min_swap_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
       "name": "execute_ccm_native_call",
       "discriminator": [
         125,
@@ -92,7 +174,7 @@
         {
           "name": "cf_receiver",
           "docs": [
-            "the aggregate key signature."
+            "without passing the aggregate key signature."
           ]
         },
         {
@@ -221,11 +303,184 @@
         },
         {
           "name": "deposit_channel_associated_token_account",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "deposit_channel_pda"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "token_vault_associated_token_account",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "data_account.token_vault_pda",
+                "account": "DataAccount"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "mint"
@@ -347,6 +602,38 @@
         {
           "name": "expected_upgrade_signer_pda_bump",
           "type": "u8"
+        },
+        {
+          "name": "suspended_vault",
+          "type": "bool"
+        },
+        {
+          "name": "suspended_legacy_swaps",
+          "type": "bool"
+        },
+        {
+          "name": "suspended_event_swaps",
+          "type": "bool"
+        },
+        {
+          "name": "min_native_swap_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_dst_address_len",
+          "type": "u16"
+        },
+        {
+          "name": "max_ccm_message_len",
+          "type": "u32"
+        },
+        {
+          "name": "max_cf_parameters_len",
+          "type": "u32"
+        },
+        {
+          "name": "max_event_accounts",
+          "type": "u32"
         }
       ]
     },
@@ -447,6 +734,51 @@
       ]
     },
     {
+      "name": "set_program_swaps_parameters",
+      "discriminator": [
+        129,
+        254,
+        31,
+        151,
+        111,
+        149,
+        135,
+        77
+      ],
+      "accounts": [
+        {
+          "name": "data_account",
+          "writable": true
+        },
+        {
+          "name": "gov_key",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "min_native_swap_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_dst_address_len",
+          "type": "u16"
+        },
+        {
+          "name": "max_ccm_message_len",
+          "type": "u32"
+        },
+        {
+          "name": "max_cf_parameters_len",
+          "type": "u32"
+        },
+        {
+          "name": "max_event_accounts",
+          "type": "u32"
+        }
+      ]
+    },
+    {
       "name": "set_suspended_state",
       "discriminator": [
         145,
@@ -471,6 +803,14 @@
       "args": [
         {
           "name": "suspend",
+          "type": "bool"
+        },
+        {
+          "name": "suspend_legacy_swaps",
+          "type": "bool"
+        },
+        {
+          "name": "suspend_event_swaps",
           "type": "bool"
         }
       ]
@@ -500,7 +840,94 @@
         },
         {
           "name": "token_vault_associated_token_account",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "data_account.token_vault_pda",
+                "account": "DataAccount"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "to_token_account",
@@ -595,19 +1022,19 @@
       "args": []
     },
     {
-      "name": "upgrade_vault_program",
+      "name": "upgrade_program",
       "docs": [
         "* ****************************************************************************\n     * *************************** IMPORTANT NOTE *********************************\n     * ****************************************************************************\n     * The signer_pda is the upgrade authority for the vault program. Changing this\n     * logic should be done with caution and understanding the consequences.\n     *\n     *        DO NOT MODIFY THIS WITHOUT UNDERSTANDING THE CONSEQUENCES!\n     * ****************************************************************************\n     * ****************************************************************************"
       ],
       "discriminator": [
-        72,
-        211,
-        76,
-        189,
-        84,
-        176,
-        62,
-        101
+        223,
+        236,
+        39,
+        89,
+        111,
+        204,
+        114,
+        37
       ],
       "accounts": [
         {
@@ -681,16 +1108,16 @@
       "args": []
     },
     {
-      "name": "x_swap_native",
+      "name": "x_swap_native_legacy",
       "discriminator": [
-        163,
-        38,
-        92,
-        226,
-        243,
-        105,
-        141,
-        196
+        97,
+        21,
+        117,
+        255,
+        21,
+        6,
+        232,
+        176
       ],
       "accounts": [
         {
@@ -776,16 +1203,16 @@
       ]
     },
     {
-      "name": "x_swap_token",
+      "name": "x_swap_token_legacy",
       "discriminator": [
-        69,
-        50,
-        252,
-        99,
-        229,
-        83,
-        119,
-        235
+        248,
+        32,
+        195,
+        34,
+        38,
+        180,
+        117,
+        127
       ],
       "accounts": [
         {
@@ -793,7 +1220,94 @@
         },
         {
           "name": "token_vault_associated_token_account",
-          "writable": true
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "data_account.token_vault_pda",
+                "account": "DataAccount"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
           "name": "from",
@@ -802,6 +1316,9 @@
         {
           "name": "from_token_account",
           "writable": true
+        },
+        {
+          "name": "token_supported_account"
         },
         {
           "name": "token_program",
@@ -907,6 +1424,19 @@
         81,
         100
       ]
+    },
+    {
+      "name": "SupportedToken",
+      "discriminator": [
+        56,
+        162,
+        96,
+        99,
+        193,
+        245,
+        204,
+        108
+      ]
     }
   ],
   "events": [
@@ -963,6 +1493,19 @@
       ]
     },
     {
+      "name": "ProgramSwapsParametersSet",
+      "discriminator": [
+        173,
+        82,
+        238,
+        223,
+        74,
+        121,
+        243,
+        142
+      ]
+    },
+    {
       "name": "Suspended",
       "discriminator": [
         220,
@@ -976,29 +1519,42 @@
       ]
     },
     {
-      "name": "SwapNative",
+      "name": "SwapEvent",
       "discriminator": [
-        155,
-        153,
-        130,
-        43,
-        124,
-        36,
-        21,
-        166
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
       ]
     },
     {
-      "name": "SwapToken",
+      "name": "TokenSupportDisabled",
       "discriminator": [
-        251,
-        44,
-        110,
-        28,
-        74,
+        35,
+        252,
+        131,
         176,
+        50,
+        103,
+        135,
+        13
+      ]
+    },
+    {
+      "name": "TokenSupportEnabled",
+      "discriminator": [
+        11,
+        203,
+        178,
+        141,
+        170,
         213,
-        137
+        67,
+        234
       ]
     }
   ],
@@ -1047,6 +1603,41 @@
       "code": 6008,
       "name": "InvalidUpgradeSignerPdaBump",
       "msg": "Invalid upgrade signer bump"
+    },
+    {
+      "code": 6009,
+      "name": "SuspendedIxSwaps",
+      "msg": "Instruction swaps are suspended"
+    },
+    {
+      "code": 6010,
+      "name": "SuspendedEventSwaps",
+      "msg": "Event swaps are suspended"
+    },
+    {
+      "code": 6011,
+      "name": "NativeAmountBelowMinimumSwapAmount",
+      "msg": "Native amount below minimum swap amount"
+    },
+    {
+      "code": 6012,
+      "name": "TokenAmountBelowMinimumSwapAmount",
+      "msg": "Token amount below minimum swap amount"
+    },
+    {
+      "code": 6013,
+      "name": "DestinationAddressExceedsMaxLength",
+      "msg": "Destination address exceeds max length"
+    },
+    {
+      "code": 6014,
+      "name": "CfParametersExceedsMaxLength",
+      "msg": "Cf Parameters exceeds max length"
+    },
+    {
+      "code": 6015,
+      "name": "CcmMessageExceedsMaxLength",
+      "msg": "Ccm message exceeds max length"
     }
   ],
   "types": [
@@ -1117,6 +1708,34 @@
           {
             "name": "suspended",
             "type": "bool"
+          },
+          {
+            "name": "suspended_legacy_swaps",
+            "type": "bool"
+          },
+          {
+            "name": "suspended_event_swaps",
+            "type": "bool"
+          },
+          {
+            "name": "min_native_swap_amount",
+            "type": "u64"
+          },
+          {
+            "name": "max_dst_address_len",
+            "type": "u16"
+          },
+          {
+            "name": "max_ccm_message_len",
+            "type": "u32"
+          },
+          {
+            "name": "max_cf_parameters_len",
+            "type": "u32"
+          },
+          {
+            "name": "max_event_accounts",
+            "type": "u32"
           }
         ]
       }
@@ -1182,6 +1801,70 @@
       }
     },
     {
+      "name": "ProgramSwapsParametersSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_min_swap_amount",
+            "type": "u64"
+          },
+          {
+            "name": "old_max_dst_address_len",
+            "type": "u16"
+          },
+          {
+            "name": "old_max_ccm_message_len",
+            "type": "u32"
+          },
+          {
+            "name": "old_max_cf_parameters_len",
+            "type": "u32"
+          },
+          {
+            "name": "old_max_event_accounts",
+            "type": "u32"
+          },
+          {
+            "name": "new_min_swap_amount",
+            "type": "u64"
+          },
+          {
+            "name": "new_max_dst_address_len",
+            "type": "u16"
+          },
+          {
+            "name": "new_max_ccm_message_len",
+            "type": "u32"
+          },
+          {
+            "name": "new_max_cf_parameters_len",
+            "type": "u32"
+          },
+          {
+            "name": "new_max_event_accounts",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SupportedToken",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "min_swap_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "Suspended",
       "type": {
         "kind": "struct",
@@ -1189,54 +1872,20 @@
           {
             "name": "suspended",
             "type": "bool"
+          },
+          {
+            "name": "suspended_legacy_swaps",
+            "type": "bool"
+          },
+          {
+            "name": "suspended_event_swaps",
+            "type": "bool"
           }
         ]
       }
     },
     {
-      "name": "SwapNative",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "dst_chain",
-            "type": "u32"
-          },
-          {
-            "name": "dst_address",
-            "type": "bytes"
-          },
-          {
-            "name": "dst_token",
-            "type": "u32"
-          },
-          {
-            "name": "amount",
-            "type": "u64"
-          },
-          {
-            "name": "sender",
-            "type": "pubkey"
-          },
-          {
-            "name": "ccm_parameters",
-            "type": {
-              "option": {
-                "defined": {
-                  "name": "CcmParams"
-                }
-              }
-            }
-          },
-          {
-            "name": "cf_parameters",
-            "type": "bytes"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SwapToken",
+      "name": "SwapEvent",
       "type": {
         "kind": "struct",
         "fields": [
@@ -1254,7 +1903,9 @@
           },
           {
             "name": "src_token",
-            "type": "pubkey"
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
             "name": "amount",
@@ -1277,6 +1928,46 @@
           {
             "name": "cf_parameters",
             "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupportDisabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_token_supported",
+            "type": {
+              "defined": {
+                "name": "SupportedToken"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupportEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_token_supported",
+            "type": {
+              "defined": {
+                "name": "SupportedToken"
+              }
+            }
+          },
+          {
+            "name": "new_token_supported",
+            "type": {
+              "defined": {
+                "name": "SupportedToken"
+              }
+            }
           }
         ]
       }

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "cf-engine-dylib"
-version = "1.5.0"
+version = "1.6.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_5_0"
+name = "chainflip_engine_v1_6_0"
 path = 'src/lib.rs'
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.5.0"
+version = "1.6.0"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
@@ -24,19 +24,19 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_5_0.so",
+        "target/release/libchainflip_engine_v1_6_0.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_5_0.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_0.so",
         "755",
     ],
     # The old version gets put into target/release by the package github actions workflow.
     # It downloads the correct version from the releases page.
     [
-        "target/release/libchainflip_engine_v1_4_5.so",
+        "target/release/libchainflip_engine_v1_5_0.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_4_5.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_5_0.so",
         "755",
     ],
 ]

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -2,7 +2,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.4.5")]
+	#[engine_proc_macros::link_engine_library_version("1.5.0")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,
@@ -12,7 +12,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.5.0")]
+	#[engine_proc_macros::link_engine_library_version("1.6.0")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -10,8 +10,8 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.4.5";
-pub const NEW_VERSION: &str = "1.5.0";
+pub const OLD_VERSION: &str = "1.5.0";
+pub const NEW_VERSION: &str = "1.6.0";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "chainflip-engine"
-version = "1.5.0"
+version = "1.6.0"
 
 [lib]
 crate-type = ["lib"]

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: /bin/sh -c "cp -R /initial-state/* /localnet-initial-state"
 
   solana-init:
-    image: ghcr.io/chainflip-io/solana-localnet-ledger:v0.5.0
+    image: ghcr.io/chainflip-io/solana-localnet-ledger:v0.6.0
     pull_policy: if_not_present
     container_name: init-solana
     platform: linux/amd64

--- a/localnet/helper.sh
+++ b/localnet/helper.sh
@@ -26,6 +26,7 @@ function print_success() {
 💚 Head to https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer to access PolkadotJS of Chainflip Network
 🧡 Head to https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9947#/explorer to access PolkadotJS of the Private Polkadot Network
 💜 Head to http://localhost:3002 to access the local Bitcoin explorer (credentials: flip / flip)
+💙 Head to https://explorer.solana.com/?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899 to access SolExplorer for the Solana local Network
 👮‍ To run the bouncer: ./localnet/manage.sh -> (6)
 EOM
 )

--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -142,14 +142,9 @@ build-localnet() {
   rm $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
   ln -s $SOLANA_BASE_PATH/test-ledger/accounts/snapshot/100 $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
 
-  if which solana-test-validator >>$DEBUG_OUTPUT_DESTINATION 2>&1; then
-    echo "☀️ Waiting for Solana node to start"
-    ./localnet/init/scripts/start-solana.sh
-    check_endpoint_health -s http://localhost:8899 >> $DEBUG_OUTPUT_DESTINATION 2>&1
-  else
-    echo "☀️ Solana not installed, skipping..."
-  fi
-
+  echo "☀️ Waiting for Solana node to start"
+  ./localnet/init/scripts/start-solana.sh
+  check_endpoint_health -s http://localhost:8899 >> $DEBUG_OUTPUT_DESTINATION 2>&1
 
   echo "🦑 Waiting for Arbitrum nodes to start"
   $DOCKER_COMPOSE_CMD -f localnet/docker-compose.yml -p "chainflip-localnet" up $ARB_CONTAINERS $additional_docker_compose_up_args -d >>$DEBUG_OUTPUT_DESTINATION 2>&1

--- a/localnet/manage.sh
+++ b/localnet/manage.sh
@@ -142,9 +142,15 @@ build-localnet() {
   rm $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
   ln -s $SOLANA_BASE_PATH/test-ledger/accounts/snapshot/100 $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
 
-  echo "☀️ Waiting for Solana node to start"
-  ./localnet/init/scripts/start-solana.sh
-  check_endpoint_health -s http://localhost:8899 >> $DEBUG_OUTPUT_DESTINATION 2>&1
+  if which solana-test-validator >>$DEBUG_OUTPUT_DESTINATION 2>&1; then
+    echo "☀️ Waiting for Solana node to start"
+    ./localnet/init/scripts/start-solana.sh
+    check_endpoint_health -s http://localhost:8899 >> $DEBUG_OUTPUT_DESTINATION 2>&1
+  else
+    echo "❌  Solana is not installed, please see https://solana.com/developers/guides/getstarted/setup-local-development#3-install-the-solana-cli"
+    exit 1
+  fi
+
 
   echo "🦑 Waiting for Arbitrum nodes to start"
   $DOCKER_COMPOSE_CMD -f localnet/docker-compose.yml -p "chainflip-localnet" up $ARB_CONTAINERS $additional_docker_compose_up_args -d >>$DEBUG_OUTPUT_DESTINATION 2>&1

--- a/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
+++ b/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
@@ -589,6 +589,8 @@ solana_program!(
 		set_suspended_state => SetSuspendedState {
 			args: [
 				suspend: bool,
+				suspend_legacy_swaps: bool,
+				suspend_event_swaps: bool,
 			],
 			account_metas: [
 				data_account: { signer: false, writable: true },
@@ -596,20 +598,7 @@ solana_program!(
 			]
 		},
 
-		transfer_vault_upgrade_authority => TransferVaultUpgradeAuthority {
-			args: [],
-			account_metas: [
-				data_account: { signer: false, writable: false },
-				agg_key: { signer: true, writable: false },
-				program_data_address: { signer: false, writable: true },
-				program_address: { signer: false, writable: false },
-				new_authority: { signer: false, writable: false },
-				signer_pda: { signer: false, writable: false },
-				bpf_loader_upgradeable: { signer: false, writable: false },
-			]
-		},
-
-		upgrade_vault_program => UpgradeVaultProgram {
+		upgrade_program => UpgradeVaultProgram {
 			args: [],
 			account_metas: [
 				data_account: { signer: false, writable: false },

--- a/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
+++ b/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
@@ -598,6 +598,19 @@ solana_program!(
 			]
 		},
 
+		transfer_vault_upgrade_authority => TransferVaultUpgradeAuthority {
+			args: [],
+			account_metas: [
+				data_account: { signer: false, writable: false },
+				agg_key: { signer: true, writable: false },
+				program_data_address: { signer: false, writable: true },
+				program_address: { signer: false, writable: false },
+				new_authority: { signer: false, writable: false },
+				signer_pda: { signer: false, writable: false },
+				bpf_loader_upgradeable: { signer: false, writable: false },
+			]
+		},
+
 		upgrade_program => UpgradeVaultProgram {
 			args: [],
 			account_metas: [

--- a/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
+++ b/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
@@ -652,6 +652,7 @@ mod idl {
 	pub enum IdlType {
 		Bytes,
 		U8,
+		U16,
 		U64,
 		U32,
 		Bool,
@@ -665,6 +666,7 @@ mod idl {
 			match self {
 				IdlType::Bytes => write!(f, "Vec<u8>"),
 				IdlType::U8 => write!(f, "u8"),
+				IdlType::U16 => write!(f, "u16"),
 				IdlType::U64 => write!(f, "u64"),
 				IdlType::U32 => write!(f, "u32"),
 				IdlType::Bool => write!(f, "bool"),

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = '<TODO>'
 name = 'chainflip-node'
 publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
-version = "1.5.0"
+version = "1.6.0"
 
 [[bin]]
 name = 'chainflip-node'

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -101,7 +101,7 @@ pub struct StateChainEnvironment {
 	sol_usdc_token_mint_pubkey: SolAddress,
 	sol_token_vault_pda_account: SolAddress,
 	sol_usdc_token_vault_ata: SolAddress,
-	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 8], /* we inject 8 nonce accounts
+	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 10], /* we inject 10 nonce accounts
 	                                                               * at genesis */
 }
 

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -101,8 +101,9 @@ pub struct StateChainEnvironment {
 	sol_usdc_token_mint_pubkey: SolAddress,
 	sol_token_vault_pda_account: SolAddress,
 	sol_usdc_token_vault_ata: SolAddress,
-	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 10], /* we inject 10 nonce accounts
-	                                                               * at genesis */
+	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 10], /* we inject 10 nonce
+	                                                                * accounts
+	                                                                * at genesis */
 }
 
 /// Get the values from the State Chain's environment variables. Else set them via the defaults

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -101,9 +101,8 @@ pub struct StateChainEnvironment {
 	sol_usdc_token_mint_pubkey: SolAddress,
 	sol_token_vault_pda_account: SolAddress,
 	sol_usdc_token_vault_ata: SolAddress,
-	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 10], /* we inject 10 nonce
-	                                                                * accounts
-	                                                                * at genesis */
+	sol_durable_nonces_and_accounts: [DurableNonceAndAccount; 8], /* we inject 8 nonce accounts
+	                                                               * at genesis */
 }
 
 /// Get the values from the State Chain's environment variables. Else set them via the defaults

--- a/state-chain/node/src/chain_spec/berghain.rs
+++ b/state-chain/node/src/chain_spec/berghain.rs
@@ -93,14 +93,6 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/berghain.rs
+++ b/state-chain/node/src/chain_spec/berghain.rs
@@ -93,6 +93,14 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/perseverance.rs
+++ b/state-chain/node/src/chain_spec/perseverance.rs
@@ -93,14 +93,6 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/perseverance.rs
+++ b/state-chain/node/src/chain_spec/perseverance.rs
@@ -93,6 +93,14 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/sisyphos.rs
+++ b/state-chain/node/src/chain_spec/sisyphos.rs
@@ -94,14 +94,6 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
-		(
-			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
-			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
-		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/sisyphos.rs
+++ b/state-chain/node/src/chain_spec/sisyphos.rs
@@ -94,6 +94,14 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
 			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
 		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
+		(
+			const_address("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"),
+			const_hash("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG"),
+		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -93,6 +93,14 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
 			const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 		),
+		(
+			const_address("GUMpVpQFNYJvSbyTtUarZVL7UDUgErKzDTSVJhekUX55"),
+			const_hash("HgZQKdVeArjJmetoAw4SpYKyzKJh3txaqb7VQe4kJ7tV"),
+		),
+		(
+			const_address("AUiHYbzH7qLZSkb3u7nAqtvqC7e41sEzgWjBEvXrpfGv"),
+			const_hash("ZW7wrDEXQe94VrsoG5A6b5iQMEdUPGkc16Vk5rt7pgR"),
+		),
 	],
 };
 

--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -63,35 +63,35 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 	sol_durable_nonces_and_accounts: [
 		(
 			const_address("2cNMwUCF51djw2xAiiU54wz1WrU8uG4Q8Kp8nfEuwghw"),
-			const_hash("Cq9Wwnn5prHaLe4kJsv8gwfevG78FbbqrwuXJeoCcy3F"),
+			const_hash("BcuQnUuMLi7dDGTcW13fPmkf26gZp6cmMycwuzXAPUWq"),
 		),
 		(
 			const_address("HVG21SovGzMBJDB9AQNuWb6XYq4dDZ6yUwCbRUuFnYDo"),
-			const_hash("78jKw9x4KNWDuyc8cNrSeQrcMF9qno4KBTwL4mANUCPS"),
+			const_hash("CCFc5QptF1HogqCZHCD1HaEzZRunGJvpqJJEnELsoqrH"),
 		),
 		(
 			const_address("HDYArziNzyuNMrK89igisLrXFe78ti8cvkcxfx4qdU2p"),
-			const_hash("8tqDp26Tc6bbuKbNYnPXaoHievTbSPQjDmM9TVnYCJXf"),
+			const_hash("CjPEYgDoX2PD5sQKg9pJyBzVFPEy6BYHCZtYpE7LKEPu"),
 		),
 		(
 			const_address("HLPsNyxBqfq2tLE31v6RiViLp2dTXtJRgHgsWgNDRPs2"),
-			const_hash("GvVRkjsMnRMeHFrpx5wq4GEGZH3eJW9PbLfVqFjajZ47"),
+			const_hash("HKx2FNX7rsfzat1Nsr83Xq82LZSBnEB3LyzBmEtFGpAy"),
 		),
 		(
 			const_address("GKMP63TqzbueWTrFYjRwMNkAyTHpQ54notRbAbMDmePM"),
-			const_hash("7qzLYSLTigv4MmQRJJCij7La9ZFaxRe7Ai7xx6i8n5mD"),
+			const_hash("92ijUn6xBxFExuazPhspSSzhZXjQqbXmYre4ztNGWLJ9"),
 		),
 		(
 			const_address("EpmHm2aSPsB5ZZcDjqDhQ86h1BV32GFCbGSMuC58Y2tn"),
-			const_hash("61BZ5VDjGw4SJgfommyZHVBaGKxUwaDUc13VnnuX6L8s"),
+			const_hash("BiHQhh7xY1ZFuEuC2vj9rFsZSXvhWA6FcdNDfBsfENbh"),
 		),
 		(
 			const_address("9yBZNMrLrtspj4M7bEf2X6tqbqHxD2vNETw8qSdvJHMa"),
-			const_hash("F3te41Tm3t9iRR8pZ4a4nrZQxJyB312AKXLB31co8wq4"),
+			const_hash("AtxE1WFQGV1hbxmNmAcN7azMRLjaEyp6wk8Y62swxQEz"),
 		),
 		(
 			const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
-			const_hash("HKVCQ7mdp6nt4veHEvrUcYBgiWaydEx8cxU9t2p17Rbf"),
+			const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 		),
 	],
 };

--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -93,14 +93,6 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 			const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
 			const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 		),
-		(
-			const_address("GUMpVpQFNYJvSbyTtUarZVL7UDUgErKzDTSVJhekUX55"),
-			const_hash("HgZQKdVeArjJmetoAw4SpYKyzKJh3txaqb7VQe4kJ7tV"),
-		),
-		(
-			const_address("AUiHYbzH7qLZSkb3u7nAqtvqC7e41sEzgWjBEvXrpfGv"),
-			const_hash("ZW7wrDEXQe94VrsoG5A6b5iQMEdUPGkc16Vk5rt7pgR"),
-		),
 	],
 };
 

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'state-chain-runtime'
-version = '1.5.0'
+version = '1.6.0'
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
 edition = '2021'
 homepage = 'https://chainflip.io'

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -185,7 +185,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 150,
+	spec_version: 160,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 12,

--- a/state-chain/runtime/src/migrations/solana_integration.rs
+++ b/state-chain/runtime/src/migrations/solana_integration.rs
@@ -223,14 +223,6 @@ impl OnRuntimeUpgrade for SolanaIntegration {
 							const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
 							const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 						),
-						(
-							const_address("GUMpVpQFNYJvSbyTtUarZVL7UDUgErKzDTSVJhekUX55"),
-							const_hash("HgZQKdVeArjJmetoAw4SpYKyzKJh3txaqb7VQe4kJ7tV"),
-						),
-						(
-							const_address("AUiHYbzH7qLZSkb3u7nAqtvqC7e41sEzgWjBEvXrpfGv"),
-							const_hash("ZW7wrDEXQe94VrsoG5A6b5iQMEdUPGkc16Vk5rt7pgR"),
-						),
 					],
 				),
 			};

--- a/state-chain/runtime/src/migrations/solana_integration.rs
+++ b/state-chain/runtime/src/migrations/solana_integration.rs
@@ -193,35 +193,35 @@ impl OnRuntimeUpgrade for SolanaIntegration {
 					vec![
 						(
 							const_address("2cNMwUCF51djw2xAiiU54wz1WrU8uG4Q8Kp8nfEuwghw"),
-							const_hash("Cq9Wwnn5prHaLe4kJsv8gwfevG78FbbqrwuXJeoCcy3F"),
+							const_hash("BcuQnUuMLi7dDGTcW13fPmkf26gZp6cmMycwuzXAPUWq"),
 						),
 						(
 							const_address("HVG21SovGzMBJDB9AQNuWb6XYq4dDZ6yUwCbRUuFnYDo"),
-							const_hash("78jKw9x4KNWDuyc8cNrSeQrcMF9qno4KBTwL4mANUCPS"),
+							const_hash("CCFc5QptF1HogqCZHCD1HaEzZRunGJvpqJJEnELsoqrH"),
 						),
 						(
 							const_address("HDYArziNzyuNMrK89igisLrXFe78ti8cvkcxfx4qdU2p"),
-							const_hash("8tqDp26Tc6bbuKbNYnPXaoHievTbSPQjDmM9TVnYCJXf"),
+							const_hash("CjPEYgDoX2PD5sQKg9pJyBzVFPEy6BYHCZtYpE7LKEPu"),
 						),
 						(
 							const_address("HLPsNyxBqfq2tLE31v6RiViLp2dTXtJRgHgsWgNDRPs2"),
-							const_hash("GvVRkjsMnRMeHFrpx5wq4GEGZH3eJW9PbLfVqFjajZ47"),
+							const_hash("HKx2FNX7rsfzat1Nsr83Xq82LZSBnEB3LyzBmEtFGpAy"),
 						),
 						(
 							const_address("GKMP63TqzbueWTrFYjRwMNkAyTHpQ54notRbAbMDmePM"),
-							const_hash("7qzLYSLTigv4MmQRJJCij7La9ZFaxRe7Ai7xx6i8n5mD"),
+							const_hash("92ijUn6xBxFExuazPhspSSzhZXjQqbXmYre4ztNGWLJ9"),
 						),
 						(
 							const_address("EpmHm2aSPsB5ZZcDjqDhQ86h1BV32GFCbGSMuC58Y2tn"),
-							const_hash("61BZ5VDjGw4SJgfommyZHVBaGKxUwaDUc13VnnuX6L8s"),
+							const_hash("BiHQhh7xY1ZFuEuC2vj9rFsZSXvhWA6FcdNDfBsfENbh"),
 						),
 						(
 							const_address("9yBZNMrLrtspj4M7bEf2X6tqbqHxD2vNETw8qSdvJHMa"),
-							const_hash("F3te41Tm3t9iRR8pZ4a4nrZQxJyB312AKXLB31co8wq4"),
+							const_hash("AtxE1WFQGV1hbxmNmAcN7azMRLjaEyp6wk8Y62swxQEz"),
 						),
 						(
 							const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
-							const_hash("HKVCQ7mdp6nt4veHEvrUcYBgiWaydEx8cxU9t2p17Rbf"),
+							const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 						),
 					],
 				),

--- a/state-chain/runtime/src/migrations/solana_integration.rs
+++ b/state-chain/runtime/src/migrations/solana_integration.rs
@@ -223,6 +223,14 @@ impl OnRuntimeUpgrade for SolanaIntegration {
 							const_address("J9dT7asYJFGS68NdgDCYjzU2Wi8uBoBusSHN1Z6JLWna"),
 							const_hash("Ub9SGgi88Pyrd2ZPRLj6QzsMDf4VCM4U2EBz37f3QWP"),
 						),
+						(
+							const_address("GUMpVpQFNYJvSbyTtUarZVL7UDUgErKzDTSVJhekUX55"),
+							const_hash("HgZQKdVeArjJmetoAw4SpYKyzKJh3txaqb7VQe4kJ7tV"),
+						),
+						(
+							const_address("AUiHYbzH7qLZSkb3u7nAqtvqC7e41sEzgWjBEvXrpfGv"),
+							const_hash("ZW7wrDEXQe94VrsoG5A6b5iQMEdUPGkc16Vk5rt7pgR"),
+						),
 					],
 				),
 			};


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Update to the latest Solana programs with multiple updates including, among others, support for program swaps.
- Update bouncer initialization process to match the new programs.
- Update to Solana Client 1.18.17
- Makes Solana mandatory to have installed locally to run the bouncer.
- Update the durable nonces value as it changes everytime there is a new image, as it's not deterministic.