### PR TITLE
feat: protect against pending swaps during upgrade

### DIFF
--- a/state-chain/pallets/cf-governance/src/lib.rs
+++ b/state-chain/pallets/cf-governance/src/lib.rs
@@ -305,9 +305,12 @@ pub mod pallet {
 			// runtime upgrade to go through.
 			cfe_version_restriction: Option<(SemVer, Percent)>,
 			code: Vec<u8>,
+			force: bool,
 		) -> DispatchResultWithPostInfo {
 			T::EnsureGovernance::ensure_origin(origin)?;
-			ensure!(T::UpgradeCondition::is_satisfied(), Error::<T>::UpgradeConditionsNotMet);
+			if !force {
+				ensure!(T::UpgradeCondition::is_satisfied(), Error::<T>::UpgradeConditionsNotMet);
+			}
 
 			if let Some((required_version, percent)) = cfe_version_restriction {
 				ensure!(

--- a/state-chain/pallets/cf-governance/src/tests.rs
+++ b/state-chain/pallets/cf-governance/src/tests.rs
@@ -228,7 +228,8 @@ fn upgrade_runtime_successfully() {
 		assert_ok!(Governance::chainflip_runtime_upgrade(
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 			None,
-			DUMMY_WASM_BLOB
+			DUMMY_WASM_BLOB,
+			false,
 		));
 	});
 }
@@ -241,7 +242,8 @@ fn wrong_upgrade_conditions() {
 			Governance::chainflip_runtime_upgrade(
 				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 				None,
-				DUMMY_WASM_BLOB
+				DUMMY_WASM_BLOB,
+				false,
 			),
 			<Error<Test>>::UpgradeConditionsNotMet
 		);
@@ -259,6 +261,7 @@ fn error_during_runtime_upgrade() {
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 			None,
 			DUMMY_WASM_BLOB,
+			false,
 		);
 		assert!(result.is_err());
 		assert_err!(result, frame_system::Error::<Test>::FailedToExtractRuntimeVersion);
@@ -277,6 +280,7 @@ fn runtime_upgrade_requires_up_to_date_authorities_cfes() {
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 			Some((DESIRED_CFE_VERSION, Percent::from_percent(50))),
 			DUMMY_WASM_BLOB,
+			false,
 		));
 
 		assert_noop!(
@@ -284,6 +288,7 @@ fn runtime_upgrade_requires_up_to_date_authorities_cfes() {
 				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 				Some((DESIRED_CFE_VERSION, Percent::from_percent(51))),
 				DUMMY_WASM_BLOB,
+				false,
 			),
 			crate::Error::<Test>::NotEnoughAuthoritiesCfesAtTargetVersion
 		);
@@ -301,6 +306,7 @@ fn runtime_upgrade_can_have_no_cfes_version_requirement() {
 			pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 			None,
 			DUMMY_WASM_BLOB,
+			false
 		));
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -12,8 +12,8 @@ use cf_primitives::{
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
-	impl_pallet_safe_mode, liquidity::SwappingApi, CcmHandler, DepositApi, IngressEgressFeeApi,
-	NetworkFeeTaken, SwapQueueApi, SwapType,
+	impl_pallet_safe_mode, liquidity::SwappingApi, CcmHandler, DepositApi, ExecutionCondition,
+	IngressEgressFeeApi, NetworkFeeTaken, SwapQueueApi, SwapType,
 };
 use frame_support::{
 	pallet_prelude::*,
@@ -1800,6 +1800,14 @@ impl<T: Config> SwapQueueApi for Pallet<T> {
 impl<T: Config> cf_traits::FlipBurnInfo for Pallet<T> {
 	fn take_flip_to_burn() -> AssetAmount {
 		FlipToBurn::<T>::take()
+	}
+}
+
+pub struct NoPendingSwaps<T: Config>(PhantomData<T>);
+
+impl<T: Config> ExecutionCondition for NoPendingSwaps<T> {
+	fn is_satisfied() -> bool {
+		SwapQueue::<T>::iter().all(|(_, swaps)| swaps.is_empty())
 	}
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -670,7 +670,10 @@ impl pallet_cf_governance::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type TimeSource = Timestamp;
 	type WeightInfo = pallet_cf_governance::weights::PalletWeight<Runtime>;
-	type UpgradeCondition = pallet_cf_validator::NotDuringRotation<Runtime>;
+	type UpgradeCondition = (
+		pallet_cf_validator::NotDuringRotation<Runtime>,
+		pallet_cf_swapping::NoPendingSwaps<Runtime>,
+	);
 	type RuntimeUpgrade = chainflip::RuntimeUpgradeManager;
 	type CompatibleCfeVersions = Environment;
 	type AuthoritiesCfeVersions = Validator;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -618,6 +618,16 @@ pub trait ExecutionCondition {
 	fn is_satisfied() -> bool;
 }
 
+impl<A, B> ExecutionCondition for (A, B)
+where
+	A: ExecutionCondition,
+	B: ExecutionCondition,
+{
+	fn is_satisfied() -> bool {
+		A::is_satisfied() && B::is_satisfied()
+	}
+}
+
 /// Performs a runtime upgrade
 pub trait RuntimeUpgrade {
 	/// Applies the wasm code of a runtime upgrade and returns the


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

TODO: Test

Protects against pending swaps, as the migrations here will be quite difficult to get right, so better to just ensure there are no swaps. 

However, since it's possible we could always have swaps, we allow a force flag for emergency situations. This might also be useful to resolve an issue in a rotation too.