### PR TITLE
Feat: solana engine broadcast retries

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,6 +1,14 @@
 # This CI runs a lot of the jobs in parallel to speed up development time. We also run a simpler suite of bouncer tests.
 name: Release Chainflip Development
-on: push
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/*"
+      - "wip/*"
+concurrency:
+  group: ${{ github.ref }}-release-development
+  cancel-in-progress: true
 
 jobs:
   pre-check:

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,14 +1,6 @@
 # This CI runs a lot of the jobs in parallel to speed up development time. We also run a simpler suite of bouncer tests.
 name: Release Chainflip Development
-on:
-  pull_request:
-    branches:
-      - main
-      - "release/*"
-      - "wip/*"
-concurrency:
-  group: ${{ github.ref }}-release-development
-  cancel-in-progress: true
+on: push
 
 jobs:
   pre-check:

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -216,7 +216,7 @@ impl SolRetryRpcApi for SolRetryRpcClient {
 						for status_retry in 0..GET_STATUS_BROADCAST_RETRIES {
 							let signature_statuses =
 								client.get_signature_statuses(&[tx_signature], true).await?;
-							match signature_statuses.value.iter().next() {
+							match signature_statuses.value.first() {
 								Some(_) => return Ok(tx_signature),
 								None => {
 									// Ignore sleep at last step

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -225,13 +225,11 @@ impl SolRetryRpcApi for SolRetryRpcClient {
 								None => {
 									// Ignore sleep at last step
 									if status_retry < GET_STATUS_BROADCAST_RETRIES {
-										// Retry twice a second
 										tokio::time::sleep(Duration::from_millis(
 											GET_STATUS_BROADCAST_DELAY,
 										))
 										.await;
 									}
-									continue;
 								},
 							}
 						}
@@ -328,6 +326,7 @@ mod tests {
 	use super::*;
 
 	#[tokio::test]
+	#[ignore]
 	async fn test_sol_retry_rpc() {
 		task_scope(|scope| {
 			async move {
@@ -375,6 +374,7 @@ mod tests {
 	}
 
 	#[tokio::test]
+	#[ignore]
 	async fn test_sol_get_transaction() {
 		task_scope(|scope| {
 			async move {

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -217,8 +217,7 @@ impl SolRetryRpcApi for SolRetryRpcClient {
 							client.get_signature_statuses(&[tx_signature], true).await?;
 						match signature_statuses.value.first().and_then(|status| status.as_ref()) {
 							Some(_) => Ok(tx_signature),
-							None =>
-								Err(anyhow!("Expected a Tx Status to be Some")),
+							None => Err(anyhow!("Expected a Tx Status to be Some")),
 						}
 					})
 				}),

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -216,10 +216,7 @@ impl SolRetryRpcApi for SolRetryRpcClient {
 						for status_retry in 0..GET_STATUS_BROADCAST_RETRIES {
 							let signature_statuses =
 								client.get_signature_statuses(&[tx_signature], true).await?;
-							match signature_statuses
-								.value
-								.first()
-								.and_then(|status| status.as_ref())
+match signature_statuses.value.iter().next()
 							{
 								Some(_) => return Ok(tx_signature),
 								None => {

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -216,8 +216,7 @@ impl SolRetryRpcApi for SolRetryRpcClient {
 						for status_retry in 0..GET_STATUS_BROADCAST_RETRIES {
 							let signature_statuses =
 								client.get_signature_statuses(&[tx_signature], true).await?;
-match signature_statuses.value.iter().next()
-							{
+							match signature_statuses.value.iter().next() {
 								Some(_) => return Ok(tx_signature),
 								None => {
 									// Ignore sleep at last step

--- a/engine/src/sol/rpc.rs
+++ b/engine/src/sol/rpc.rs
@@ -273,8 +273,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_sol_devnet() {
-		// init_test_logger();
-
 		let sol_rpc_client = SolRpcClient::new(
 			SecretUrl::from("https://api.devnet.solana.com".to_string()),
 			Some(SolHash::from_str("EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG").unwrap()),

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -247,6 +247,7 @@ mod tests {
 	use super::*;
 
 	#[tokio::test]
+	#[ignore]
 	async fn test_success_witnesses() {
 		task_scope::task_scope(|scope| {
 			async {


### PR DESCRIPTION
# Pull Request

Closes: PRO-1499

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Add a check that the transactions is processed after it's send (with a delay). If not, it errors so it gets retried again by the retrier rpc. See an example of this in the Rust SDK client:
https://docs.rs/solana-rpc-client/2.0.2/src/solana_rpc_client/nonblocking/rpc_client.rs.html#592
This is because the `send_transaction` won't ensure that the transaction hasn't been dropped and in case of congestion there is no other mechanism than just manually checking if the transaction has landed and resending it otherwise.