### PR TITLE
chore: Solana engine not require tx history

### DIFF
--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -384,7 +384,7 @@ mod tests {
 				let signature_status = retry_client
 				.get_signature_statuses(
 					&[signature],
-					true
+					false
 				).await;
 
 				let confirmation_status = signature_status.value.first().and_then(Option::as_ref).and_then(|ts| ts.confirmation_status.as_ref()).expect("Expected confirmation_status to be Some");

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -86,7 +86,7 @@ where
 	let mut finalized_transactions = Vec::new();
 
 	let signature_statuses = sol_client
-		.get_signature_statuses(monitored_tx_signatures.as_slice(), true)
+		.get_signature_statuses(monitored_tx_signatures.as_slice(), false)
 		.await
 		.value;
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

By default the nodes store a few days worth of data which should be plenty for our purpose. Setting the flag to true makes the node look into months worth of data (terabytes) making the query a lot more computationally heavy.