### PR TITLE
refactor: bouncer cmd for FoK swap

### DIFF
--- a/bouncer/commands/new_swap.ts
+++ b/bouncer/commands/new_swap.ts
@@ -1,35 +1,97 @@
 #!/usr/bin/env -S pnpm tsx
 // INSTRUCTIONS
 //
-// This command takes four arguments.
-// It will request a new swap with the provided parameters
-// Argument 1 is the source currency ("Btc", "Eth", "Dot" or "Usdc")
-// Argument 2 is the destination currency ("Btc", "Eth", "Dot" or "Usdc")
-// Argument 3 is the destination address
-// Argument 4 (optional) is the max boost fee bps (default: 0 (no boosting))
-// For example: ./commands/new_swap.ts Dot Btc n1ocq2FF95qopwbEsjUTy3ZrawwXDJ6UsX
+// Request a new swap with the provided parameters:
+// <sourceAsset> <destAsset> <destAddress> [maxBoostFeeBps] [refundAddress] [minPrice] [refundDuration]
+// Use `-h` for help.
+// If the refundAddress is provided, the minPrice must also be provided. The refundDuration will default to 0 if not provided.
+// Example: ./commands/new_swap.ts Dot Btc n1ocq2FF95qopwbEsjUTy3ZrawwXDJ6UsX --refundAddress "0xa0b52be60216f8e0f2eb5bd17fa3c66908cc1652f3080a90d3ab20b2d352b610" --minPrice 100000000000000000
 
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import { InternalAsset } from '@chainflip/cli';
 import { parseAssetString, executeWithTimeout } from '../shared/utils';
 import { requestNewSwap } from '../shared/perform_swap';
+import { RefundParameters } from '../shared/new_swap';
+
+interface Args {
+  sourceAsset: string;
+  destAsset: string;
+  destAddress: string;
+  maxBoostFeeBps: number;
+  refundAddress?: string;
+  minPrice?: string;
+  refundDuration: number;
+}
 
 async function newSwapCommand() {
-  const sourceAsset = parseAssetString(process.argv[2]);
-  const destAsset = parseAssetString(process.argv[3]);
-  const destAddress = process.argv[4];
-  const maxBoostFeeBps = Number(process.argv[5] || 0);
+  const args = yargs(hideBin(process.argv))
+    .command(
+      '$0 <sourceAsset> <destAsset> <destAddress> [maxBoostFeeBps] [refundAddress] [minPrice] [refundDuration]',
+      'Request a new swap with the provided parameters',
+      (a) => {
+        console.log('Parsing options');
+        return a
+          .positional('sourceAsset', {
+            describe: 'The source currency ("Btc", "Eth", "Dot", "Usdc")',
+            type: 'string',
+          })
+          .positional('destAsset', {
+            describe: 'The destination currency ("Btc", "Eth", "Dot", "Usdc")',
+            type: 'string',
+          })
+          .positional('destAddress', {
+            describe: 'The destination address',
+            type: 'string',
+          })
+          .option('maxBoostFeeBps', {
+            describe: 'The max boost fee bps (default: 0 (no boosting))',
+            type: 'number',
+            default: 0,
+            demandOption: false,
+          })
+          .option('refundAddress', {
+            describe: 'Fill or Kill refund address',
+            type: 'string',
+            demandOption: false,
+          })
+          .option('minPrice', {
+            describe: 'Fill or Kill minimum price',
+            type: 'string',
+            demandOption: false,
+          })
+          .option('refundDuration', {
+            describe: 'Fill or kill duration in blocks to retry swap before refunding',
+            type: 'number',
+            demandOption: false,
+            default: 0,
+          });
+      },
+    )
+    .help('h').argv as unknown as Args;
 
-  console.log(`Requesting swap ${sourceAsset} -> ${destAsset}`);
+  if ((args.refundAddress === undefined) !== (args.minPrice === undefined)) {
+    throw new Error('Must specify both refundAddress and minimumPrice when using refund options');
+  }
+  const refundParameters: RefundParameters | undefined =
+    args.refundAddress !== undefined
+      ? {
+          retryDurationBlocks: args.refundDuration,
+          refundAddress: args.refundAddress,
+          minPrice: args.minPrice ? args.minPrice : '0',
+        }
+      : undefined;
 
   await requestNewSwap(
-    sourceAsset as InternalAsset,
-    destAsset as InternalAsset,
-    destAddress,
-    undefined,
-    undefined,
-    undefined,
-    true,
-    maxBoostFeeBps,
+    parseAssetString(args.sourceAsset) as InternalAsset,
+    parseAssetString(args.destAsset) as InternalAsset,
+    args.destAddress,
+    undefined, // tag
+    undefined, // messageMetadata
+    undefined, // brokerCommissionBps
+    true, // log
+    args.maxBoostFeeBps,
+    refundParameters,
   );
 }
 

--- a/bouncer/commands/new_swap.ts
+++ b/bouncer/commands/new_swap.ts
@@ -61,7 +61,7 @@ async function newSwapCommand() {
             demandOption: false,
           })
           .option('refundDuration', {
-            describe: 'Fill or kill duration in blocks to retry swap before refunding',
+            describe: 'Fill or kill duration in blocks to retry the swap before refunding',
             type: 'number',
             demandOption: false,
             default: 0,
@@ -74,11 +74,11 @@ async function newSwapCommand() {
     throw new Error('Must specify both refundAddress and minimumPrice when using refund options');
   }
   const refundParameters: RefundParameters | undefined =
-    args.refundAddress !== undefined
+    args.refundAddress !== undefined && args.minPrice !== undefined
       ? {
           retryDurationBlocks: args.refundDuration,
           refundAddress: args.refundAddress,
-          minPrice: args.minPrice ? args.minPrice : '0',
+          minPrice: args.minPrice,
         }
       : undefined;
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1537

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

- Refactored the new swap command to use yargs to allow for more complex command line arguments.
- Added the 3 FoK refund parmas as command line options.
- Changed the `maxBoostFeeBps` to a command line option instead of an optional positional argument.