### PR TITLE
fix: prewitness deposits without delaying for a block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "chainflip-api",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-broadcast 0.5.1",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3389,7 +3389,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "cf-engine-dylib",
@@ -12551,7 +12551,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "cf-amm",
  "cf-chains",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.4.6"
+version = "1.4.7"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.4.6"
+version = "1.4.7"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.4.6"
+version = "1.4.7"
 edition = "2021"
 
 [lints]

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "cf-engine-dylib"
-version = "1.4.6"
+version = "1.4.7"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_4_6"
+name = "chainflip_engine_v1_4_7"
 path = 'src/lib.rs'
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.4.6"
+version = "1.4.7"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.4.6"
+version = "1.4.7"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
@@ -24,8 +24,8 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_4_6.so",
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_4_6.so",
+        "target/release/libchainflip_engine_v1_4_7.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_4_7.so",
         "755",
     ],
     # The old version gets put into target/release by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -12,7 +12,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.4.6")]
+	#[engine_proc_macros::link_engine_library_version("1.4.7")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -11,7 +11,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.3.5";
-pub const NEW_VERSION: &str = "1.4.6";
+pub const NEW_VERSION: &str = "1.4.7";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "chainflip-engine"
-version = "1.4.6"
+version = "1.4.7"
 
 [lib]
 crate-type = ["lib"]

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/monitored_items.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/monitored_items.rs
@@ -30,7 +30,7 @@ fn is_header_ready<Inner: ChunkedByVault>(
 	index: Inner::Index,
 	chain_state: &ChainState<Inner::Chain>,
 ) -> bool {
-	index < chain_state.block_height
+	index <= chain_state.block_height
 }
 
 /// This helps ensure a set of items we want to witness are consistent for each block across all

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = '<TODO>'
 name = 'chainflip-node'
 publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
-version = "1.4.6"
+version = "1.4.7"
 
 [[bin]]
 name = 'chainflip-node'

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1752,7 +1752,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn expiry_and_recycle_block_height(
 	) -> (TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>)
 	{
-		let current_height = T::ChainTracking::get_block_height();
+		let current_height =
+			T::ChainTracking::get_block_height() + <T::TargetChain as Chain>::WITNESS_PERIOD;
 		debug_assert!(<T::TargetChain as Chain>::is_block_witness_root(current_height));
 
 		let lifetime = DepositChannelLifetime::<T, I>::get();

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1752,6 +1752,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn expiry_and_recycle_block_height(
 	) -> (TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>)
 	{
+		// Goals:
+		// 1. When chain tracking reaches a particular block number, we want to be able to process
+		//   that block immediately on the CFE.
+		// 2. The CFE's need to have a consistent view of what we want to witness (channels) in
+		//    order to
+		//   come to consensus.
+
+		// We open deposit channels for the block after the current chain tracking block, so that
+		// the set of channels open at the *current chain tracking* block does not change after
+		// chain tracking reaches that block. This achieves the second goal. We achieve the first
+		// goal by using this in conjunction with waiting until the chain tracking reaches a
+		// particular block before we process it on the CFE.
+
+		// This relates directly to the code in
+		// `engine/src/witness/common/chunked_chain_source/chunked_by_vault/deposit_addresses.rs`
+		// and `engine/src/witness/common/chunked_chain_source/chunked_by_vault/monitored_items.rs`
 		let current_height =
 			T::ChainTracking::get_block_height() + <T::TargetChain as Chain>::WITNESS_PERIOD;
 		debug_assert!(<T::TargetChain as Chain>::is_block_witness_root(current_height));

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -497,7 +497,8 @@ fn can_process_ccm_deposit() {
 
 		assert_eq!(
 			DepositChannelLookup::<Test, ()>::get(deposit_address).unwrap().opened_at,
-			BlockHeightProvider::<MockEthereum>::get_block_height()
+			BlockHeightProvider::<MockEthereum>::get_block_height() +
+				<MockEthereum as Chain>::WITNESS_PERIOD
 		);
 
 		// Making a deposit should trigger CcmHandler.

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'state-chain-runtime'
-version = '1.4.6'
+version = '1.4.7'
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
 edition = '2021'
 homepage = 'https://chainflip.io'


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Means we won't delay the prewitnessing of a particular. Previously we would wait for the *next* external chain block before prewitnessing.

This release would have to be done runtime upgrade first and then CFE upgrades.