### PR TITLE
chore: Implement Token Holder Governance for Solana and Arbitrum

### DIFF
--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -586,8 +586,10 @@ impl BroadcastAnyChainGovKey for TokenholderGovernanceBroadcaster {
 			ForeignChain::Polkadot =>
 				Self::broadcast_gov_key::<Polkadot, PolkadotBroadcaster>(maybe_old_key, new_key),
 			ForeignChain::Bitcoin => Err(()),
-			ForeignChain::Arbitrum => Err(()),
-			ForeignChain::Solana => todo!(),
+			ForeignChain::Arbitrum =>
+				Self::broadcast_gov_key::<Arbitrum, ArbitrumBroadcaster>(maybe_old_key, new_key),
+			ForeignChain::Solana =>
+				Self::broadcast_gov_key::<Solana, SolanaBroadcaster>(maybe_old_key, new_key),
 		}
 	}
 
@@ -598,8 +600,10 @@ impl BroadcastAnyChainGovKey for TokenholderGovernanceBroadcaster {
 			ForeignChain::Polkadot =>
 				Self::is_govkey_compatible::<<Polkadot as Chain>::ChainCrypto>(key),
 			ForeignChain::Bitcoin => false,
-			ForeignChain::Arbitrum => false,
-			ForeignChain::Solana => todo!(),
+			ForeignChain::Arbitrum =>
+				Self::is_govkey_compatible::<<Arbitrum as Chain>::ChainCrypto>(key),
+			ForeignChain::Solana =>
+				Self::is_govkey_compatible::<<Solana as Chain>::ChainCrypto>(key),
 		}
 	}
 }


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Add missing `TokenholderGovernanceBroadcaster` implementation for Solana. When doing it I realized that there was no implementation for Arbitrum. If my understanding of that `TokenholderGovernance` is correct, that is to be able to set the on-chain GovKey with the AggKey. If so, Arbitrum needs it the same way as Ethereum, and same applies to Solana.