### PR TITLE
fix: qualify nodes based on reputation

### DIFF
--- a/state-chain/cf-integration-tests/src/genesis.rs
+++ b/state-chain/cf-integration-tests/src/genesis.rs
@@ -1,3 +1,4 @@
+use pallet_cf_reputation::HeartbeatQualification;
 use sp_std::collections::btree_set::BTreeSet;
 
 use crate::mock_runtime::{
@@ -76,7 +77,10 @@ fn state_of_genesis_is_as_expected() {
 		}
 
 		for account in accounts.iter() {
-			assert!(Reputation::is_qualified(account), "Genesis nodes start online");
+			assert!(
+				HeartbeatQualification::<Runtime>::is_qualified(account),
+				"Genesis nodes start online"
+			);
 		}
 
 		assert_eq!(Emissions::last_supply_update_block(), 0, "no emissions");

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -419,7 +419,7 @@ where
 		Reputations::<T>::get(validator_id).reputation_points >= cutoff
 	}
 
-	fn take_qualified(validators: BTreeSet<T::ValidatorId>) -> BTreeSet<T::ValidatorId> {
+	fn filter_qualified(validators: BTreeSet<T::ValidatorId>) -> BTreeSet<T::ValidatorId> {
 		let reputations = Reputations::<T>::iter()
 			.map(|(id, ReputationTracker { reputation_points, .. })| (id, reputation_points))
 			.collect::<BTreeMap<_, _>>();
@@ -496,7 +496,7 @@ impl<T: Config, L: OffenceList<T>> QualifyNode<T::ValidatorId> for ExclusionList
 		!Pallet::<T>::validators_suspended_for(L::OFFENCES).contains(validator_id)
 	}
 
-	fn take_qualified(validators: BTreeSet<T::ValidatorId>) -> BTreeSet<T::ValidatorId> {
+	fn filter_qualified(validators: BTreeSet<T::ValidatorId>) -> BTreeSet<T::ValidatorId> {
 		validators
 			.difference(&Pallet::<T>::validators_suspended_for(L::OFFENCES))
 			.cloned()

--- a/state-chain/pallets/cf-reputation/src/tests.rs
+++ b/state-chain/pallets/cf-reputation/src/tests.rs
@@ -415,12 +415,12 @@ mod reporting_adapter_test {
 fn submitting_heartbeat_more_than_once_in_an_interval() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)));
-		assert!(ReputationPallet::is_qualified(&ALICE), "Alice should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be online");
 		assert_ok!(ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)));
-		assert!(ReputationPallet::is_qualified(&ALICE), "Alice should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be online");
 		advance_by_hearbeat_intervals(1);
 		assert_ok!(ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)));
-		assert!(ReputationPallet::is_qualified(&ALICE), "Alice should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be online");
 	});
 }
 
@@ -428,7 +428,7 @@ fn submitting_heartbeat_more_than_once_in_an_interval() {
 fn we_should_see_missing_nodes_when_not_having_submitted_one_interval() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)));
-		assert!(ReputationPallet::is_qualified(&ALICE), "Alice should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be online");
 		advance_by_hearbeat_intervals(1);
 		assert_eq!(
 			ReputationPallet::current_network_state().offline,
@@ -467,15 +467,15 @@ fn only_authorities_should_appear_in_network_state() {
 			"Alice should be an authority"
 		);
 
-		assert!(ReputationPallet::is_qualified(&BOB), "Bob should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&BOB), "Bob should be online");
 
-		assert!(ReputationPallet::is_qualified(&ALICE), "Alice should be online");
+		assert!(HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be online");
 
 		advance_by_hearbeat_intervals(3);
 
-		assert!(!ReputationPallet::is_qualified(&BOB), "Bob should be offline");
+		assert!(!HeartbeatQualification::<Test>::is_qualified(&BOB), "Bob should be offline");
 
-		assert!(!ReputationPallet::is_qualified(&ALICE), "Alice should be offline");
+		assert!(!HeartbeatQualification::<Test>::is_qualified(&ALICE), "Alice should be offline");
 
 		assert!(
 			ReputationPallet::current_network_state().online.is_empty(),
@@ -494,13 +494,13 @@ fn only_authorities_should_appear_in_network_state() {
 fn in_safe_mode_you_dont_lose_reputation_for_being_offline() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(ReputationPallet::heartbeat(RuntimeOrigin::signed(BOB)));
-		assert!(ReputationPallet::is_qualified(&BOB));
+		assert!(HeartbeatQualification::<Test>::is_qualified(&BOB));
 		let reputation = reputation_points(&BOB);
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
 			reputation: PalletSafeMode { reporting_enabled: false },
 		});
 		advance_by_hearbeat_intervals(3);
-		assert!(!ReputationPallet::is_qualified(&BOB));
+		assert!(!HeartbeatQualification::<Test>::is_qualified(&BOB));
 		assert_eq!(reputation, reputation_points(&BOB));
 	});
 }
@@ -513,17 +513,25 @@ fn should_properly_check_if_validator_is_qualified() {
 			&EVE
 		));
 
-		let mut test_set = vec![ALICE, BOB, EVE];
+		let test_set = BTreeSet::from_iter([ALICE, BOB, EVE]);
 
 		// single validator is always qualified
 		ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)).unwrap();
 		assert!(ReputationPointsQualification::<Test>::is_qualified(&ALICE));
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(iter::once(ALICE).collect()),
+			iter::once(ALICE).collect()
+		);
 
 		// test when network has 3 validators
-		for id in test_set.iter() {
+		for id in &test_set {
 			ReputationPallet::heartbeat(RuntimeOrigin::signed(*id)).unwrap();
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			test_set
+		);
 
 		// If there are 3 validators and 33rd percentile validator has  lower reputation than the
 		// other (so 1 validator has worse reputation than the other 2, they should not be
@@ -537,29 +545,39 @@ fn should_properly_check_if_validator_is_qualified() {
 		ReputationPallet::penalise_offline_authorities(vec![EVE]);
 		assert!(reputation_points(&EVE) < 0);
 		assert!(reputation_points(&ALICE) >= 0);
-		for id in test_set.iter() {
+		for id in &test_set {
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			test_set
+		);
 
 		// Check that updating reputations properly calculates qualifications
 		move_forward_hearbeat_interval_and_submit_heartbeat(ALICE);
 		move_forward_hearbeat_interval_and_submit_heartbeat(BOB);
 
 		assert!(!ReputationPointsQualification::<Test>::is_qualified(&EVE));
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			test_set.into_iter().filter(|id| *id != EVE).collect()
+		);
 
 		// Test with a bunch of validators
-		for id in 300..500u64 {
-			test_set.push(id);
-
-			assert_ok!(
-				<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&id)
-			);
-			ReputationPallet::heartbeat(RuntimeOrigin::signed(id)).unwrap();
-			assert!(ReputationPointsQualification::<Test>::is_qualified(&id));
-		}
+		let mut test_set =
+			(300..500u64)
+				.inspect(|id| {
+					assert_ok!(
+						<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(id)
+					);
+					ReputationPallet::heartbeat(RuntimeOrigin::signed(*id)).unwrap();
+					assert!(ReputationPointsQualification::<Test>::is_qualified(id));
+				})
+				.collect::<Vec<_>>();
 
 		// just so that ALICE, BOB and EVE are at the end to make testing bit easier
-		test_set.reverse();
+		test_set.extend([ALICE, BOB, EVE]);
+
 		let (first_third, rest) = test_set.split_at(test_set.len() / 3);
 
 		// make one third of validators misbehave
@@ -577,21 +595,74 @@ fn should_properly_check_if_validator_is_qualified() {
 		// Except poor Eve, they are still disqualified
 		assert!(reputation_points(&EVE) < 0);
 		assert!(!ReputationPointsQualification::<Test>::is_qualified(&EVE));
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(
+				test_set.iter().copied().collect()
+			),
+			test_set.iter().copied().filter(|id| *id != EVE).collect()
+		);
 
-		// Deduct reputation until below 0
-		for _ in 0..=current_reputation_of_third_of_validators / MISSED_HEARTBEAT_PENALTY_POINTS + 1
-		{
-			ReputationPallet::penalise_offline_authorities(first_third.to_vec());
+		// Set reputation to negative for 1/3 of validators
+		let bad_rep = Reputations::<Test>::get(EVE).reputation_points - 1;
+		for id in first_third {
+			Reputations::<Test>::mutate(id, |reputation| {
+				reputation.reputation_points = bad_rep;
+			});
 		}
 
-		// Now the first third of validators will not be qualified anymore
+		// Now the first third of validators will not be qualified anymore but the rest are,
+		// including EVE.
 		for id in first_third {
 			assert!(!ReputationPointsQualification::<Test>::is_qualified(id));
 		}
-
-		// And rest of them are
 		for id in rest {
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
+		assert_eq!(
+			ReputationPointsQualification::<Test>::take_qualified(
+				test_set.iter().copied().collect()
+			),
+			rest.iter().copied().collect()
+		);
 	});
+}
+
+#[test]
+fn reputation_cutoff_threshold() {
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, -1, 0, 1, 1,
+		]),
+		-1
+	);
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, 0, 1, 1,
+		]),
+		-1
+	);
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, 0, 1, 1, 1
+		]),
+		0
+	);
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, 0, 1, 1, 1, 1
+		]),
+		0
+	);
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, 0, 1, 1, 1, 1, 1
+		]),
+		0
+	);
+	assert_eq!(
+		ReputationPointsQualification::<Test>::reputation_qualification_cutoff(vec![
+			-1, -1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+		]),
+		0
+	);
 }

--- a/state-chain/pallets/cf-reputation/src/tests.rs
+++ b/state-chain/pallets/cf-reputation/src/tests.rs
@@ -519,7 +519,7 @@ fn should_properly_check_if_validator_is_qualified() {
 		ReputationPallet::heartbeat(RuntimeOrigin::signed(ALICE)).unwrap();
 		assert!(ReputationPointsQualification::<Test>::is_qualified(&ALICE));
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(iter::once(ALICE).collect()),
+			ReputationPointsQualification::<Test>::filter_qualified(iter::once(ALICE).collect()),
 			iter::once(ALICE).collect()
 		);
 
@@ -529,7 +529,7 @@ fn should_properly_check_if_validator_is_qualified() {
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			ReputationPointsQualification::<Test>::filter_qualified(test_set.clone()),
 			test_set
 		);
 
@@ -549,7 +549,7 @@ fn should_properly_check_if_validator_is_qualified() {
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			ReputationPointsQualification::<Test>::filter_qualified(test_set.clone()),
 			test_set
 		);
 
@@ -559,7 +559,7 @@ fn should_properly_check_if_validator_is_qualified() {
 
 		assert!(!ReputationPointsQualification::<Test>::is_qualified(&EVE));
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(test_set.clone()),
+			ReputationPointsQualification::<Test>::filter_qualified(test_set.clone()),
 			test_set.into_iter().filter(|id| *id != EVE).collect()
 		);
 
@@ -596,7 +596,7 @@ fn should_properly_check_if_validator_is_qualified() {
 		assert!(reputation_points(&EVE) < 0);
 		assert!(!ReputationPointsQualification::<Test>::is_qualified(&EVE));
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(
+			ReputationPointsQualification::<Test>::filter_qualified(
 				test_set.iter().copied().collect()
 			),
 			test_set.iter().copied().filter(|id| *id != EVE).collect()
@@ -619,7 +619,7 @@ fn should_properly_check_if_validator_is_qualified() {
 			assert!(ReputationPointsQualification::<Test>::is_qualified(id));
 		}
 		assert_eq!(
-			ReputationPointsQualification::<Test>::take_qualified(
+			ReputationPointsQualification::<Test>::filter_qualified(
 				test_set.iter().copied().collect()
 			),
 			rest.iter().copied().collect()

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -60,7 +60,7 @@ use pallet_cf_pools::{
 	UnidirectionalPoolDepth,
 };
 
-use pallet_cf_reputation::{ExclusionList, ReputationPointsQualification};
+use pallet_cf_reputation::{ExclusionList, HeartbeatQualification, ReputationPointsQualification};
 use pallet_cf_swapping::{CcmSwapAmounts, SwapLegInfo};
 use pallet_cf_validator::SetSizeMaximisingAuctionResolver;
 use pallet_transaction_payment::{ConstFeeMultiplier, Multiplier};
@@ -212,7 +212,7 @@ impl pallet_cf_validator::Config for Runtime {
 	);
 	type MissedAuthorshipSlots = chainflip::MissedAuraSlots;
 	type KeygenQualification = (
-		Reputation,
+		HeartbeatQualification<Self>,
 		(
 			ExclusionList<Self, chainflip::KeygenExclusionOffences>,
 			(
@@ -1359,7 +1359,7 @@ impl_runtime_apis! {
 				is_current_authority,
 				is_current_backup,
 				is_qualified: is_bidding && is_qualified,
-				is_online: Reputation::is_qualified(account_id),
+				is_online: HeartbeatQualification::<Runtime>::is_qualified(account_id),
 				is_bidding,
 				bound_redeem_address,
 				apy_bp,
@@ -2010,8 +2010,8 @@ impl_runtime_apis! {
 				backups: backups.len() as u32,
 				online_backups: 0,
 			};
-			authorities.retain(Reputation::is_qualified);
-			backups.retain(|elem, _| Reputation::is_qualified(elem));
+			authorities.retain(HeartbeatQualification::<Runtime>::is_qualified);
+			backups.retain(|id, _| HeartbeatQualification::<Runtime>::is_qualified(id));
 			result.online_authorities = authorities.len() as u32;
 			result.online_backups = backups.len() as u32;
 			result

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -587,13 +587,20 @@ pub trait WaivedFees {
 /// Note that when implementing this, it is sufficient to implement is_qualified. However, if
 /// there is a high fixed cost to check if a single node is qualified (for example if we need to
 /// compute some precondition or criterion), it is recommended to implement take_qualified as well.
-pub trait QualifyNode<Id: Ord> {
+pub trait QualifyNode<Id: Ord + Clone> {
 	/// Is the node qualified to be an authority and meet our expectations of one
 	fn is_qualified(validator_id: &Id) -> bool;
 
 	/// Filter out the unqualified nodes from a list of potential nodes.
-	fn take_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
+	fn filter_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
 		validators.into_iter().filter(|v| Self::is_qualified(v)).collect()
+	}
+
+	/// Takes a vector of items and a id-selector function, and returns another vector containing
+	/// only the items whose id is qualified.
+	fn filter_qualified_by_key<T>(items: Vec<T>, f: impl Fn(&T) -> &Id) -> Vec<T> {
+		let qualified = Self::filter_qualified(items.iter().map(&f).cloned().collect());
+		items.into_iter().filter(|i| qualified.contains(f(i))).collect()
 	}
 }
 
@@ -608,7 +615,7 @@ impl<T: Chainflip, R: frame_support::traits::ValidatorRegistration<T::ValidatorI
 	}
 }
 
-impl<Id: Ord, A, B> QualifyNode<Id> for (A, B)
+impl<Id: Ord + Clone, A, B> QualifyNode<Id> for (A, B)
 where
 	A: QualifyNode<Id>,
 	B: QualifyNode<Id>,
@@ -617,8 +624,8 @@ where
 		A::is_qualified(validator_id) && B::is_qualified(validator_id)
 	}
 
-	fn take_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
-		B::take_qualified(A::take_qualified(validators))
+	fn filter_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
+		B::filter_qualified(A::filter_qualified(validators))
 	}
 }
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -583,13 +583,17 @@ pub trait WaivedFees {
 }
 
 /// Qualify what is considered as a potential authority for the network
+///
+/// Note that when implementing this, it is sufficient to implement is_qualified. However, if
+/// there is a high fixed cost to check if a single node is qualified (for example if we need to
+/// compute some precondition or criterion), it is recommended to implement take_qualified as well.
 pub trait QualifyNode<Id: Ord> {
 	/// Is the node qualified to be an authority and meet our expectations of one
 	fn is_qualified(validator_id: &Id) -> bool;
 
 	/// Filter out the unqualified nodes from a list of potential nodes.
-	fn filter_unqualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
-		validators.into_iter().filter(|v| !Self::is_qualified(v)).collect()
+	fn take_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
+		validators.into_iter().filter(|v| Self::is_qualified(v)).collect()
 	}
 }
 
@@ -613,8 +617,8 @@ where
 		A::is_qualified(validator_id) && B::is_qualified(validator_id)
 	}
 
-	fn filter_unqualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
-		B::filter_unqualified(A::filter_unqualified(validators))
+	fn take_qualified(validators: BTreeSet<Id>) -> BTreeSet<Id> {
+		B::take_qualified(A::take_qualified(validators))
 	}
 }
 

--- a/state-chain/traits/src/mocks/qualify_node.rs
+++ b/state-chain/traits/src/mocks/qualify_node.rs
@@ -17,7 +17,7 @@ impl<Id: Encode + Decode> QualifyAll<Id> {
 	}
 }
 
-impl<Id: Ord + Encode + Decode> QualifyNode<Id> for QualifyAll<Id> {
+impl<Id: Ord + Clone + Encode + Decode> QualifyNode<Id> for QualifyAll<Id> {
 	fn is_qualified(id: &Id) -> bool {
 		!Self::get_storage::<_, Vec<Id>>(b"EXCEPT", b"").unwrap_or_default().contains(id)
 	}


### PR DESCRIPTION
Fixes some issues I noticed while reviewing #5062. (Not strictly related to the PR itself, but still..)

1. The implementation of QualifyNode::filter_unqualified was wrong. Fortunately it was also unused (another mistake). 
2. We implemented the reputation-based qualification using is_qualified and the (buggy) default impl of filter_unqualified. The implementation using is_qualified is very ewxpensive (storage iteration over all validators for each validator, so n^2 storage reads).

I think the reason is wasn't noticed it probably that (a) it wasn't actually used (it should have been!) and (b) the naming was confusing.

I changed the name and made sure it's used when filtering backup validators.

I also created an explicit struct for the heartbeat-based qualification rather than using the Pallet.

Everything is squashed into a single commit, but it should be small enough to be reviewable as is. This is what the commit contains:

- Rename filter_unqualified to take_qualified
- Fix implementation (remove the `!`)
- Use take_qualified in the implementation
- Add clarifying documentation.
- Create HeartbeatQualification
- Move impls out of pallet module.
- Tests
