### PR TITLE
fix: ccm transfers should charge broker fee

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -301,6 +301,7 @@ pub mod pallet {
 		CcmTransfer {
 			destination_asset: Asset,
 			destination_address: ForeignChainAddress,
+			broker_fees: Beneficiaries<AccountId>,
 			channel_metadata: CcmChannelMetadata,
 			refund_params: Option<ChannelRefundParameters>,
 		},
@@ -1558,6 +1559,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ChannelAction::CcmTransfer {
 				destination_asset,
 				destination_address,
+				broker_fees,
 				channel_metadata,
 				refund_params,
 			} => {
@@ -1573,7 +1575,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						},
 						output_address: destination_address,
 					},
-					Default::default(),
+					broker_fees,
 					refund_params,
 					swap_origin,
 				) {
@@ -2056,6 +2058,7 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 				Some(msg) => ChannelAction::CcmTransfer {
 					destination_asset,
 					destination_address,
+					broker_fees,
 					channel_metadata: msg,
 					refund_params,
 				},

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/add_refund_params.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/add_refund_params.rs
@@ -18,6 +18,7 @@ pub(super) mod old {
 		CcmTransfer {
 			destination_asset: Asset,
 			destination_address: ForeignChainAddress,
+			broker_fees: Beneficiaries<AccountId>,
 			channel_metadata: CcmChannelMetadata,
 		},
 	}
@@ -76,10 +77,12 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 					old::ChannelAction::CcmTransfer {
 						destination_asset,
 						destination_address,
+						broker_fees,
 						channel_metadata,
 					} => ChannelAction::CcmTransfer {
 						destination_asset,
 						destination_address,
+						broker_fees,
 						channel_metadata,
 						refund_params: None,
 					},
@@ -158,6 +161,7 @@ mod tests {
 				action: old::ChannelAction::CcmTransfer {
 					destination_asset: Asset::Flip,
 					destination_address: output_address.clone(),
+					broker_fees: Default::default(),
 					channel_metadata: CcmChannelMetadata {
 						message: vec![0u8, 1u8, 2u8, 3u8, 4u8].try_into().unwrap(),
 						gas_budget: 50 * 10u128.pow(18),
@@ -202,6 +206,7 @@ mod tests {
 					action: ChannelAction::CcmTransfer {
 						destination_asset: Asset::Flip,
 						destination_address: output_address.clone(),
+						broker_fees: Default::default(),
 						channel_metadata: CcmChannelMetadata {
 							message: vec![0u8, 1u8, 2u8, 3u8, 4u8].try_into().unwrap(),
 							gas_budget: 50 * 10u128.pow(18),


### PR DESCRIPTION
# Pull Request

Closes: PRO-1545

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Adds the broker fees to the ChannelAction::CcmTransfer variant and passes them to the swap request.

I will add the migration in the release branch since this is going straight to release/1.5.