### PR TITLE
fix: api call migrations

### DIFF
--- a/state-chain/pallets/cf-broadcast/Cargo.toml
+++ b/state-chain/pallets/cf-broadcast/Cargo.toml
@@ -41,10 +41,10 @@ frame-benchmarking = { git = "https://github.com/chainflip-io/polkadot-sdk.git",
 frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 frame-system = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 sp-std = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
+sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1", default-features = false }
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
-sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 cf-test-utilities = { path = '../../test-utilities' }
 

--- a/state-chain/pallets/cf-broadcast/src/migrations.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations.rs
@@ -1,12 +1,12 @@
 use crate::Pallet;
 use cf_runtime_upgrade_utilities::{PlaceholderMigration, VersionedMigration};
 
+pub mod api_call_to_pending;
 pub mod move_transaction_fee_deficit;
-pub mod v4;
 
 pub type PalletMigration<T, I> = (
-	VersionedMigration<Pallet<T, I>, v4::Migration<T, I>, 3, 4>,
+	// migration 3 to 4 done at the runtime level
 	VersionedMigration<Pallet<T, I>, move_transaction_fee_deficit::Migration<T, I>, 4, 5>,
-	// migration 5 to 6 done at the runtime level
+	VersionedMigration<Pallet<T, I>, api_call_to_pending::Migration<T, I>, 5, 6>,
 	PlaceholderMigration<Pallet<T, I>, 6>,
 );

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1162,6 +1162,8 @@ type PalletMigrations = (
 	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, PolkadotInstance>,
 	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, BitcoinInstance>,
 	pallet_cf_threshold_signature::migrations::PalletMigration<Runtime, SolanaInstance>,
+	// TODO: Remove this after 1.5.1 is released
+	MigrateApicalls,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, EthereumInstance>,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, PolkadotInstance>,
 	pallet_cf_broadcast::migrations::PalletMigration<Runtime, BitcoinInstance>,
@@ -1185,41 +1187,40 @@ type PalletMigrations = (
 		10,
 		11,
 	>,
-	MigrateApicalls,
 );
 
 type MigrateApicalls = (
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, EthereumInstance>,
 		migrations::migrate_apicalls_to_store_signer::EthMigrateApicallsAndOnChainKey,
-		5,
-		6,
+		3,
+		4,
 	>,
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>,
 		migrations::migrate_apicalls_to_store_signer::DotMigrateApicallsAndOnChainKey,
-		5,
-		6,
+		3,
+		4,
 	>,
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>,
 		migrations::migrate_apicalls_to_store_signer::BtcMigrateApicallsAndOnChainKey,
-		5,
-		6,
+		3,
+		4,
 	>,
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>,
 		migrations::migrate_apicalls_to_store_signer::ArbMigrateApicallsAndOnChainKey,
-		5,
-		6,
+		3,
+		4,
 	>,
 	// The apicalls migration is not needed for solana since solana is not initizlized yet and so
 	// the storage items do not exist yet.
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, SolanaInstance>,
 		migrations::migrate_apicalls_to_store_signer::NoSolUpgrade,
-		5,
-		6,
+		3,
+		4,
 	>,
 );
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Changes the order of the migrations, and how the migration is achieved to simplify it.

The issue before this fix was:
The 3->4 migration drains the ThresholdSignature data storage, and inserts the PendingApiCalls storage. When we are draining from ThresholdSignatureData, we are decoding into the new ApiCall type (note the lack of an old ApiCall) type. 

 This now passes try-runtime on mainnet and perseverance. Given the migration has already occurred on sisyphos, there's no need to worry about fixing it. After this is applied to persa and mainnet the storage will be at the same version and correct, so they will be consistent.
