### PR TITLE
fix: use encoded addresses in refund params for events

### DIFF
--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -347,7 +347,7 @@ pub struct SwapDepositAddress {
 	pub channel_id: ChannelId,
 	pub source_chain_expiry_block: NumberOrHex,
 	pub channel_opening_fee: U256,
-	pub refund_parameters: Option<ChannelRefundParameters>,
+	pub refund_parameters: Option<ChannelRefundParameters<AddressString>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -454,7 +454,11 @@ pub trait BrokerApi: SignedExtrinsicApi + StorageApi + Sized + Send + Sync + 'st
 				channel_id: *channel_id,
 				source_chain_expiry_block: (*source_chain_expiry_block).into(),
 				channel_opening_fee: (*channel_opening_fee).into(),
-				refund_parameters: refund_parameters.clone(),
+				refund_parameters: refund_parameters.as_ref().map(|params| {
+					params.map_address(|refund_address| {
+						AddressString::from_encoded_address(&refund_address)
+					})
+				}),
 			})
 		} else {
 			bail!("No SwapDepositAddressReady event was found");

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -698,8 +698,18 @@ pub struct SwapRefundParameters {
 #[derive(
 	Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize, Deserialize,
 )]
-pub struct ChannelRefundParameters {
+pub struct ChannelRefundParameters<A> {
 	pub retry_duration: cf_primitives::BlockNumber,
-	pub refund_address: ForeignChainAddress,
+	pub refund_address: A,
 	pub min_price: Price,
+}
+
+impl<A: Clone> ChannelRefundParameters<A> {
+	pub fn map_address<B, F: FnOnce(A) -> B>(&self, f: F) -> ChannelRefundParameters<B> {
+		ChannelRefundParameters {
+			retry_duration: self.retry_duration,
+			refund_address: f(self.refund_address.clone()),
+			min_price: self.min_price,
+		}
+	}
 }

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -293,7 +293,7 @@ pub mod pallet {
 			destination_asset: Asset,
 			destination_address: ForeignChainAddress,
 			broker_fees: Beneficiaries<AccountId>,
-			refund_params: Option<ChannelRefundParameters>,
+			refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 		},
 		LiquidityProvision {
 			lp_account: AccountId,
@@ -303,7 +303,7 @@ pub mod pallet {
 			destination_address: ForeignChainAddress,
 			broker_fees: Beneficiaries<AccountId>,
 			channel_metadata: CcmChannelMetadata,
-			refund_params: Option<ChannelRefundParameters>,
+			refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 		},
 	}
 
@@ -2079,7 +2079,7 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 		broker_id: T::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
 		boost_fee: BasisPoints,
-		refund_params: Option<ChannelRefundParameters>,
+		refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 	) -> Result<
 		(ChannelId, ForeignChainAddress, <T::TargetChain as Chain>::ChainBlockNumber, Self::Amount),
 		DispatchError,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -275,7 +275,7 @@ struct SwapRequest {
 	id: SwapRequestId,
 	input_asset: Asset,
 	output_asset: Asset,
-	refund_params: Option<ChannelRefundParameters>,
+	refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 	state: SwapRequestState,
 }
 
@@ -443,7 +443,7 @@ pub mod pallet {
 			boost_fee: BasisPoints,
 			channel_opening_fee: T::Amount,
 			affiliate_fees: Affiliates<T::AccountId>,
-			refund_parameters: Option<ChannelRefundParameters>,
+			refund_parameters: Option<ChannelRefundParameters<EncodedAddress>>,
 		},
 		/// A swap is scheduled for the first time
 		SwapScheduled {
@@ -994,7 +994,7 @@ pub mod pallet {
 			channel_metadata: Option<CcmChannelMetadata>,
 			boost_fee: BasisPoints,
 			affiliate_fees: Affiliates<T::AccountId>,
-			refund_parameters: Option<ChannelRefundParameters>,
+			refund_parameters: Option<ChannelRefundParameters<ForeignChainAddress>>,
 		) -> DispatchResult {
 			let broker = T::AccountRoleRegistry::ensure_broker(origin)?;
 			let (beneficiaries, total_bps) = {
@@ -1062,7 +1062,8 @@ pub mod pallet {
 				boost_fee,
 				channel_opening_fee,
 				affiliate_fees,
-				refund_parameters,
+				refund_parameters: refund_parameters
+					.map(|params| params.map_address(T::AddressConverter::to_encoded_address)),
 			});
 
 			Ok(())
@@ -1614,7 +1615,7 @@ pub mod pallet {
 			output_asset: Asset,
 			request_type: SwapRequestType,
 			broker_fees: Beneficiaries<Self::AccountId>,
-			refund_params: Option<ChannelRefundParameters>,
+			refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 			origin: SwapOrigin,
 		) -> Result<SwapRequestId, DispatchError> {
 			let (net_amount, broker_fee) = {

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1901,7 +1901,7 @@ fn deposit_address_ready_event_contains_correct_parameters() {
 				boost_fee: BOOST_FEE,
 				refund_parameters: Some(ref refund_params_in_event),
 				..
-			}) if refund_params_in_event == &refund_parameters
+			}) if *refund_params_in_event == refund_parameters.map_address(MockAddressConverter::to_encoded_address)
 		);
 	});
 }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -653,7 +653,7 @@ macro_rules! impl_deposit_api_for_anychain {
 				broker_id: Self::AccountId,
 				channel_metadata: Option<CcmChannelMetadata>,
 				boost_fee: BasisPoints,
-				refund_parameters: Option<ChannelRefundParameters>,
+				refund_parameters: Option<ChannelRefundParameters<ForeignChainAddress>>,
 			) -> Result<(ChannelId, ForeignChainAddress, <AnyChain as cf_chains::Chain>::ChainBlockNumber, FlipBalance), DispatchError> {
 				match source_asset.into() {
 					$(

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -732,7 +732,7 @@ pub trait DepositApi<C: Chain> {
 		broker_id: Self::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
 		boost_fee: BasisPoints,
-		refund_params: Option<ChannelRefundParameters>,
+		refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 	) -> Result<(ChannelId, ForeignChainAddress, C::ChainBlockNumber, Self::Amount), DispatchError>;
 }
 

--- a/state-chain/traits/src/mocks/deposit_handler.rs
+++ b/state-chain/traits/src/mocks/deposit_handler.rs
@@ -124,7 +124,7 @@ impl<C: Chain, T: Chainflip> DepositApi<C> for MockDepositHandler<C, T> {
 		broker_id: Self::AccountId,
 		channel_metadata: Option<CcmChannelMetadata>,
 		boost_fee: BasisPoints,
-		_refund_params: Option<ChannelRefundParameters>,
+		_refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 	) -> Result<
 		(cf_primitives::ChannelId, ForeignChainAddress, C::ChainBlockNumber, Self::Amount),
 		DispatchError,

--- a/state-chain/traits/src/mocks/swap_request_api.rs
+++ b/state-chain/traits/src/mocks/swap_request_api.rs
@@ -1,5 +1,5 @@
 use crate::{swapping::SwapRequestType, EgressApi, SwapRequestHandler};
-use cf_chains::{Chain, ChannelRefundParameters, SwapOrigin};
+use cf_chains::{Chain, ChannelRefundParameters, ForeignChainAddress, SwapOrigin};
 use cf_primitives::{Asset, AssetAmount, Beneficiaries, SwapRequestId};
 use codec::{Decode, Encode};
 use frame_support::sp_runtime::DispatchError;
@@ -44,7 +44,7 @@ where
 		output_asset: Asset,
 		swap_type: SwapRequestType,
 		_broker_fees: Beneficiaries<Self::AccountId>,
-		_refund_params: Option<ChannelRefundParameters>,
+		_refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 		_origin: SwapOrigin,
 	) -> Result<SwapRequestId, DispatchError> {
 		Self::mutate_value(SWAP_REQUESTS, |swaps: &mut Option<Vec<MockSwapRequest>>| {

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -33,7 +33,7 @@ pub trait SwapRequestHandler {
 		output_asset: Asset,
 		request_type: SwapRequestType,
 		broker_fees: Beneficiaries<Self::AccountId>,
-		refund_params: Option<ChannelRefundParameters>,
+		refund_params: Option<ChannelRefundParameters<ForeignChainAddress>>,
 		origin: SwapOrigin,
 	) -> Result<SwapRequestId, DispatchError>;
 }


### PR DESCRIPTION
Cherry pick of changes from #5135