### PR TITLE
Feat: charging broker fee per chunk and in USDC

### DIFF
--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -57,7 +57,7 @@ async function getEarnedBrokerFees(brokerKeypair: KeyringPair): Promise<bigint> 
   await using chainflip = await getChainflipApi();
   // NOTE: All broker fees are collected in USDC now:
   const feeStr = (
-    await chainflip.query.swapping.earnedBrokerFees(brokerKeypair.address, feeAsset)
+    await chainflip.query.assetBalances.freeBalances(brokerKeypair.address, Assets.Usdc)
   ).toString();
   return BigInt(feeStr);
 }
@@ -67,9 +67,7 @@ async function getEarnedBrokerFees(brokerKeypair: KeyringPair): Promise<bigint> 
 async function testBrokerFees(inputAsset: Asset, seed?: string): Promise<void> {
   await using chainflip = await getChainflipApi();
   // Check the broker fees before the swap
-  const earnedBrokerFeesBefore = BigInt(
-    (await chainflip.query.assetBalances.freeBalances(broker.address, inputAsset)).toString(),
-  );
+  const earnedBrokerFeesBefore = getEarnedBrokerFees(broker);
   console.log(`${inputAsset} earnedBrokerFeesBefore:`, earnedBrokerFeesBefore);
 
   // Run a swap
@@ -152,9 +150,7 @@ async function testBrokerFees(inputAsset: Asset, seed?: string): Promise<void> {
   );
 
   // Check that the detected increase in earned broker fees matches the swap event values and it is equal to the expected amount (after the deposit fee is accounted for)
-  const earnedBrokerFeesAfter = BigInt(
-    (await chainflip.query.assetBalances.freeBalances(broker.address, inputAsset)).toString(),
-  );
+  const earnedBrokerFeesAfter = getEarnedBrokerFees(broker);
   console.log(`${inputAsset} earnedBrokerFeesAfter:`, earnedBrokerFeesAfter);
 
   assert(earnedBrokerFeesAfter > earnedBrokerFeesBefore, 'No increase in earned broker fees');

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -67,7 +67,7 @@ async function getEarnedBrokerFees(brokerKeypair: KeyringPair): Promise<bigint> 
 async function testBrokerFees(inputAsset: Asset, seed?: string): Promise<void> {
   await using chainflip = await getChainflipApi();
   // Check the broker fees before the swap
-  const earnedBrokerFeesBefore = getEarnedBrokerFees(broker);
+  const earnedBrokerFeesBefore = await getEarnedBrokerFees(broker);
   console.log(`${inputAsset} earnedBrokerFeesBefore:`, earnedBrokerFeesBefore);
 
   // Run a swap
@@ -150,7 +150,7 @@ async function testBrokerFees(inputAsset: Asset, seed?: string): Promise<void> {
   );
 
   // Check that the detected increase in earned broker fees matches the swap event values and it is equal to the expected amount (after the deposit fee is accounted for)
-  const earnedBrokerFeesAfter = getEarnedBrokerFees(broker);
+  const earnedBrokerFeesAfter = await getEarnedBrokerFees(broker);
   console.log(`${inputAsset} earnedBrokerFeesAfter:`, earnedBrokerFeesAfter);
 
   assert(earnedBrokerFeesAfter > earnedBrokerFeesBefore, 'No increase in earned broker fees');

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 // eslint-disable-next-line no-restricted-imports
 import { KeyringPair } from '@polkadot/keyring/types';
-import  Keyring  from '../polkadot/keyring';
+import Keyring from '../polkadot/keyring';
 import {
   brokerMutex,
   decodeDotAddressForContract,

--- a/bouncer/shared/broker_fee_collection.ts
+++ b/bouncer/shared/broker_fee_collection.ts
@@ -2,7 +2,9 @@
 import assert from 'assert';
 import { randomBytes } from 'crypto';
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
-import Keyring from '../polkadot/keyring';
+// eslint-disable-next-line no-restricted-imports
+import { KeyringPair } from '@polkadot/keyring/types';
+import  Keyring  from '../polkadot/keyring';
 import {
   brokerMutex,
   decodeDotAddressForContract,
@@ -11,16 +13,13 @@ import {
   observeBalanceIncrease,
   shortChainFromAsset,
   hexStringToBytesArray,
-  calculateFeeWithBps,
   amountToFineAmountBigInt,
   SwapRequestType,
   observeSwapRequested,
 } from '../shared/utils';
 import { getBalance } from '../shared/get_balance';
-import { doPerformSwap } from '../shared/perform_swap';
 import { getChainflipApi, observeEvent } from './utils/substrate';
 import { send } from './send';
-import { KeyringPair } from '@polkadot/keyring/types';
 
 const swapAssetAmount = {
   [Assets.Eth]: 1,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1288,8 +1288,7 @@ pub mod pallet {
 
 				let mut stable_amount = swap.stable_amount.unwrap_or_default();
 
-				let required_fees = &swap.swap.fees;
-				for fee_type in required_fees {
+				for fee_type in &swap.swap.fees {
 					let remaining_amount = match fee_type {
 						FeeType::NetworkFee => {
 							let FeeTaken { remaining_amount, fee } =
@@ -1304,8 +1303,7 @@ pub mod pallet {
 							remaining_amount
 						},
 					};
-
-					stable_amount = remaining_amount
+					stable_amount = remaining_amount;
 				}
 
 				swap.stable_amount = Some(stable_amount);
@@ -1740,13 +1738,13 @@ pub mod pallet {
 			let fees = {
 				let mut fees = Vec::with_capacity(2);
 
+				if !broker_fees.is_empty() {
+					fees.push(FeeType::BrokerFee(broker_fees));
+				}
+
 				// Network fee is not charged for network fee swaps:
 				if !matches!(swap_type, SwapType::NetworkFee) {
 					fees.push(FeeType::NetworkFee);
-				}
-
-				if !broker_fees.is_empty() {
-					fees.push(FeeType::BrokerFee(broker_fees));
 				}
 
 				fees

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1262,9 +1262,14 @@ pub mod pallet {
 					let fee =
 						Permill::from_parts(*bps as u32 * BASIS_POINTS_PER_MILLION) * stable_amount;
 
-					EarnedBrokerFees::<T>::mutate(account, STABLE_ASSET, |earned_fees| {
-						earned_fees.saturating_accrue(fee)
-					});
+					if let Err(err) = T::BalanceApi::try_credit_account(account, STABLE_ASSET, fee)
+					{
+						log_or_panic!(
+							"Failed to credit broker fee to account {:?} with error: {:?}",
+							account,
+							err
+						);
+					}
 
 					fee_accumulator.saturating_add(fee)
 				});

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -18,8 +18,7 @@ use cf_primitives::{
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, BalanceApi, DepositApi, ExecutionCondition, IngressEgressFeeApi,
-	NetworkFeeTaken, SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
-	SwappingApi,
+	SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType, SwappingApi,
 };
 use frame_support::{
 	pallet_prelude::*,
@@ -1189,8 +1188,7 @@ pub mod pallet {
 					let swap_request = SwapRequests::<T>::get(swap.swap.swap_request_id)
 						.expect("Swap request should exist");
 					let dca_state = match swap_request.state {
-						SwapRequestState::Ccm { dca_state, .. } => Some(dca_state),
-						SwapRequestState::Regular { dca_state, .. } => Some(dca_state),
+						SwapRequestState::UserSwap { dca_state, .. } => Some(dca_state),
 						_ => None,
 					};
 					let remaining_chunks =

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1738,13 +1738,13 @@ pub mod pallet {
 			let fees = {
 				let mut fees = Vec::with_capacity(2);
 
-				if !broker_fees.is_empty() {
-					fees.push(FeeType::BrokerFee(broker_fees));
-				}
-
 				// Network fee is not charged for network fee swaps:
 				if !matches!(swap_type, SwapType::NetworkFee) {
 					fees.push(FeeType::NetworkFee);
+				}
+
+				if !broker_fees.is_empty() {
+					fees.push(FeeType::BrokerFee(broker_fees));
 				}
 
 				fees

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -341,6 +341,7 @@ struct CcmState {
 	ccm_deposit_metadata: CcmDepositMetadata,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(CloneNoBound, DebugNoBound, PartialEq, Eq, Encode, Decode, TypeInfo)]
 #[scale_info(skip_type_params(T))]
 enum SwapRequestState<T: Config> {
@@ -1261,7 +1262,7 @@ pub mod pallet {
 					let fee =
 						Permill::from_parts(*bps as u32 * BASIS_POINTS_PER_MILLION) * stable_amount;
 
-					EarnedBrokerFees::<T>::mutate(&account, STABLE_ASSET, |earned_fees| {
+					EarnedBrokerFees::<T>::mutate(account, STABLE_ASSET, |earned_fees| {
 						earned_fees.saturating_accrue(fee)
 					});
 
@@ -1298,7 +1299,7 @@ pub mod pallet {
 						},
 						FeeType::BrokerFee(beneficiaries) => {
 							let FeeTaken { remaining_amount, fee } =
-								Self::take_broker_fees(stable_amount, &beneficiaries);
+								Self::take_broker_fees(stable_amount, beneficiaries);
 							swap.broker_fee_taken = Some(fee);
 							remaining_amount
 						},
@@ -1387,9 +1388,9 @@ pub mod pallet {
 					ccm,
 					output_address,
 					dca_state: DcaState { remaining_input_amount, accumulated_output_amount, .. },
-					broker_fees,
+					broker_fees: _,
 				} => {
-					if let Some(ccm) = ccm {
+					if let Some(_ccm) = ccm {
 						// TODO: add remaining DCA input to the refunded amount (DCA isn't yet
 						// implemented for CCM so we always refund the full amount)
 						Self::egress_for_swap(
@@ -1539,6 +1540,7 @@ pub mod pallet {
 							false
 						}
 					} else {
+						#[allow(clippy::collapsible_if)] // collapsing makes non-ccm case less clear
 						if let Some(chunk_input_amount) =
 							dca_state.prepare_next_chunk(Some((swap.swap_id(), output_amount)))
 						{

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1343,7 +1343,6 @@ pub mod pallet {
 		fn execute_batch(swaps: Vec<Swap<T>>) -> Result<Vec<SwapState<T>>, BatchExecutionError<T>> {
 			let mut swaps: Vec<_> = swaps.into_iter().map(SwapState::new).collect();
 
-			// Swap into Stable asset first, then take network/broker fees:
 			Self::swap_into_stable_taking_fees(&mut swaps)?;
 
 			// Swap from Stable asset, and complete the swap logic.

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -33,7 +33,6 @@ use frame_support::{
 	testing_prelude::bounded_vec,
 	traits::{Hooks, OriginTrait},
 };
-use itertools::Itertools;
 use sp_arithmetic::Permill;
 use sp_core::{H160, U256};
 use sp_std::iter;
@@ -41,7 +40,7 @@ use sp_std::iter;
 const GAS_BUDGET: AssetAmount = 1_000u128;
 const SWAP_REQUEST_ID: u64 = 1;
 const INIT_BLOCK: u64 = 1;
-const BROKER_FEE_BPS: u16 = 2;
+const BROKER_FEE_BPS: u16 = 10;
 
 static EVM_OUTPUT_ADDRESS: LazyLock<ForeignChainAddress> =
 	LazyLock::new(|| ForeignChainAddress::Eth([1; 20].into()));
@@ -278,15 +277,26 @@ fn process_all_swaps() {
 		assert_swaps_queue_is_empty();
 		let mut expected = swaps
 			.iter()
-			.map(|swap| MockEgressParameter::<AnyChain>::Swap {
-				asset: swap.output_asset,
-				amount: if swap.input_asset == Asset::Usdc || swap.output_asset == Asset::Usdc {
-					swap.input_amount * DEFAULT_SWAP_RATE
+			.map(|swap| {
+				let output_amount = if swap.input_asset == Asset::Usdc {
+					let fee = swap.input_amount * BROKER_FEE_BPS as u128 / 10_000;
+					(swap.input_amount - fee) * DEFAULT_SWAP_RATE
+				} else if swap.output_asset == Asset::Usdc {
+					let output_before_fee = swap.input_amount * DEFAULT_SWAP_RATE;
+					let fee = output_before_fee * BROKER_FEE_BPS as u128 / 10_000;
+					output_before_fee - fee
 				} else {
-					swap.input_amount * DEFAULT_SWAP_RATE * DEFAULT_SWAP_RATE
-				},
-				destination_address: swap.output_address.clone(),
-				fee: 0,
+					let intermediate_amount = swap.input_amount * DEFAULT_SWAP_RATE;
+					let fee = intermediate_amount * BROKER_FEE_BPS as u128 / 10_000;
+					(intermediate_amount - fee) * DEFAULT_SWAP_RATE
+				};
+
+				MockEgressParameter::<AnyChain>::Swap {
+					asset: swap.output_asset,
+					amount: output_amount,
+					destination_address: swap.output_address.clone(),
+					fee: 0,
+				}
 			})
 			.collect::<Vec<_>>();
 		expected.sort();
@@ -300,40 +310,105 @@ fn process_all_swaps() {
 
 #[test]
 fn expect_earned_fees_to_be_recorded() {
-	new_test_ext().execute_with(|| {
-		const ALICE: u64 = 2_u64;
-		const BOB: u64 = 3_u64;
+	const INPUT_AMOUNT: AssetAmount = 10_000;
+	const INTERMEDIATE_AMOUNT: AssetAmount = INPUT_AMOUNT * DEFAULT_SWAP_RATE;
 
-		swap_with_custom_broker_fee(
-			Asset::Flip,
-			Asset::Usdc,
-			100,
-			bounded_vec![Beneficiary { account: ALICE, bps: 200 }],
-		);
+	const ALICE: u64 = 2_u64;
+	const BOB: u64 = 3_u64;
 
-		assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Flip), 2);
+	const ALICE_FEE_BPS: u16 = 200;
+	const BOB_FEE_BPS: u16 = 100;
 
-		swap_with_custom_broker_fee(
-			Asset::Flip,
-			Asset::Usdc,
-			100,
-			bounded_vec![Beneficiary { account: ALICE, bps: 200 }],
-		);
+	// Expected values:
+	const ALICE_FEE_1: AssetAmount = INTERMEDIATE_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
+	// This swap starts with USDC, so it is deducted from the input amount:
+	const ALICE_FEE_2: AssetAmount = INPUT_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
+	const ALICE_FEE_3: AssetAmount = INTERMEDIATE_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
+	const BOB_FEE_1: AssetAmount = INTERMEDIATE_AMOUNT * BOB_FEE_BPS as u128 / 10_000;
 
-		assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Flip), 4);
+	new_test_ext()
+		.execute_with(|| {
+			swap_with_custom_broker_fee(
+				Asset::Flip,
+				Asset::Usdc,
+				INPUT_AMOUNT,
+				bounded_vec![Beneficiary { account: ALICE, bps: ALICE_FEE_BPS }],
+			);
+		})
+		.then_execute_at_block(3u32, |_| {})
+		.then_execute_with(|_| {
+			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+				swap_request_id: 1,
+				swap_id: 1,
+				network_fee: 0,
+				broker_fee: ALICE_FEE_1,
+				input_amount: INPUT_AMOUNT,
+				input_asset: Asset::Flip,
+				output_asset: Asset::Usdc,
+				output_amount: INTERMEDIATE_AMOUNT - ALICE_FEE_1,
+				intermediate_amount: None,
+			}));
 
-		swap_with_custom_broker_fee(
-			Asset::Eth,
-			Asset::Usdc,
-			100,
-			bounded_vec![
-				Beneficiary { account: ALICE, bps: 200 },
-				Beneficiary { account: BOB, bps: 200 }
-			],
-		);
-		assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Eth), 2);
-		assert_eq!(get_broker_balance::<Test>(&BOB, cf_primitives::Asset::Eth), 2);
-	});
+			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), ALICE_FEE_1);
+		})
+		.execute_with(|| {
+			swap_with_custom_broker_fee(
+				Asset::Usdc,
+				Asset::Flip,
+				INPUT_AMOUNT,
+				bounded_vec![Beneficiary { account: ALICE, bps: ALICE_FEE_BPS }],
+			);
+		})
+		.then_execute_at_block(5u32, |_| {})
+		.then_execute_with(|_| {
+			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+				swap_request_id: 2,
+				swap_id: 2,
+				network_fee: 0,
+				broker_fee: ALICE_FEE_2,
+				input_amount: INPUT_AMOUNT - ALICE_FEE_2,
+				input_asset: Asset::Usdc,
+				output_asset: Asset::Flip,
+				output_amount: (INPUT_AMOUNT - ALICE_FEE_2) * DEFAULT_SWAP_RATE,
+				intermediate_amount: None,
+			}));
+
+			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), ALICE_FEE_1 + ALICE_FEE_2);
+		})
+		.execute_with(|| {
+			swap_with_custom_broker_fee(
+				Asset::ArbEth,
+				Asset::Flip,
+				INPUT_AMOUNT,
+				bounded_vec![
+					Beneficiary { account: ALICE, bps: ALICE_FEE_BPS },
+					Beneficiary { account: BOB, bps: BOB_FEE_BPS }
+				],
+			);
+		})
+		.then_execute_at_block(7u32, |_| {})
+		.then_execute_with(|_| {
+			const TOTAL_FEES: AssetAmount = ALICE_FEE_3 + BOB_FEE_1;
+			const INTERMEDIATE_AMOUNT_AFTER_FEES: AssetAmount = INTERMEDIATE_AMOUNT - TOTAL_FEES;
+
+			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
+				swap_request_id: 3,
+				swap_id: 3,
+				network_fee: 0,
+				broker_fee: TOTAL_FEES,
+				input_amount: INPUT_AMOUNT,
+				input_asset: Asset::ArbEth,
+				output_asset: Asset::Flip,
+				output_amount: INTERMEDIATE_AMOUNT_AFTER_FEES * DEFAULT_SWAP_RATE,
+				intermediate_amount: Some(INTERMEDIATE_AMOUNT_AFTER_FEES),
+			}));
+
+			assert_eq!(
+				get_broker_balance::<Test>(&ALICE, Asset::Usdc),
+				ALICE_FEE_1 + ALICE_FEE_2 + ALICE_FEE_3
+			);
+			assert_eq!(get_broker_balance::<Test>(&BOB, Asset::Usdc), BOB_FEE_1);
+		});
 }
 
 #[test]
@@ -620,7 +695,6 @@ mod ccm {
 			input_asset,
 			output_asset,
 			input_amount,
-			broker_fee: 0,
 			request_type: SwapRequestTypeEncoded::Ccm {
 				ccm_deposit_metadata,
 				output_address: encoded_output_address,
@@ -995,7 +1069,6 @@ fn swap_by_witnesser_happy_path() {
 			input_asset: INPUT_ASSET,
 			output_asset: OUTPUT_ASSET,
 			input_amount: AMOUNT,
-			broker_fee: 0,
 			request_type: SwapRequestTypeEncoded::Regular {
 				output_address: encoded_output_address,
 			},
@@ -1248,6 +1321,7 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 					swap_request_id: 1,
 					swap_id: 1,
 					network_fee: 0,
+					broker_fee: 0,
 					input_amount: PRINCIPAL_AMOUNT,
 					input_asset: Asset::Usdc,
 					output_asset: Asset::Eth,
@@ -1264,6 +1338,7 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 					swap_request_id: 1,
 					swap_id: 2,
 					network_fee: 0,
+					broker_fee: 0,
 					input_amount: GAS_BUDGET,
 					input_asset: Asset::Usdc,
 					output_asset: Asset::Eth,
@@ -1602,6 +1677,7 @@ fn input_amount_excludes_network_fee() {
 				input_asset: FROM_ASSET,
 				output_asset: TO_ASSET,
 				network_fee,
+				broker_fee: 0,
 				input_amount: expected_input_amount,
 				output_amount: expected_input_amount * DEFAULT_SWAP_RATE,
 				intermediate_amount: None,
@@ -1678,7 +1754,7 @@ fn swap_with_custom_broker_fee(
 	amount: AssetAmount,
 	broker_fees: Beneficiaries<u64>,
 ) {
-	assert_ok!(<Pallet<Test> as SwapRequestHandler>::init_swap_request(
+	assert_ok!(Swapping::init_swap_request(
 		from,
 		amount,
 		to,
@@ -1698,98 +1774,58 @@ fn swap_with_custom_broker_fee(
 
 #[test]
 fn swap_broker_fee_calculated_correctly() {
-	new_test_ext().execute_with(|| {
-		let fees: [BasisPoints; 12] =
-			[1, 5, 10, 100, 200, 500, 1000, 1500, 2000, 5000, 7500, 10000];
-		const AMOUNT: AssetAmount = 100000;
+	const FEES_BPS: [BasisPoints; 12] =
+		[1, 5, 10, 100, 200, 500, 1000, 1500, 2000, 5000, 7500, 10000];
+	const INPUT_AMOUNT: AssetAmount = 100000;
 
-		// calculate broker fees for each asset available
-		Asset::all().for_each(|asset| {
-			let total_fees: u128 =
-				fees.iter().fold(0, |total_fees: u128, fee_bps: &BasisPoints| {
-					swap_with_custom_broker_fee(
-						asset,
-						Asset::Usdc,
-						AMOUNT,
-						bounded_vec![Beneficiary { account: ALICE, bps: *fee_bps }],
-					);
-					total_fees +
-						Permill::from_parts(*fee_bps as u32 * BASIS_POINTS_PER_MILLION) * AMOUNT
-				});
+	const INTERMEDIATE_AMOUNT: AssetAmount = INPUT_AMOUNT * DEFAULT_SWAP_RATE;
 
-			assert_eq!(get_broker_balance::<Test>(&ALICE, asset), total_fees);
+	let mut total_fees = 0;
+	for asset in Asset::all() {
+		if asset != Asset::Usdc {
+			for fee_bps in FEES_BPS {
+				total_fees += Permill::from_parts(fee_bps as u32 * BASIS_POINTS_PER_MILLION) *
+					INTERMEDIATE_AMOUNT;
+			}
+		}
+	}
+
+	new_test_ext()
+		.execute_with(|| {
+			Asset::all().for_each(|asset| {
+				if asset != Asset::Usdc {
+					for fee_bps in FEES_BPS {
+						swap_with_custom_broker_fee(
+							asset,
+							Asset::Usdc,
+							INPUT_AMOUNT,
+							bounded_vec![Beneficiary { account: ALICE, bps: fee_bps }],
+						);
+					}
+				}
+			});
+		})
+		.then_execute_at_block(3u32, |_| {})
+		.then_execute_with(|_| {
+			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), total_fees);
 		});
-	});
 }
 
 #[test]
 fn swap_broker_fee_cannot_exceed_amount() {
-	new_test_ext().execute_with(|| {
-		swap_with_custom_broker_fee(
-			Asset::Usdc,
-			Asset::Flip,
-			100,
-			bounded_vec![Beneficiary { account: ALICE, bps: 15000 }],
-		);
-
-		assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Usdc), 100);
-	});
-}
-
-#[test]
-fn swap_broker_fee_subtracted_from_swap_amount() {
-	new_test_ext().execute_with(|| {
-		let amounts: [AssetAmount; 6] = [50, 100, 200, 500, 1000, 10000];
-		let fees: [BasisPoints; 4] = [100, 1000, 5000, 10000];
-
-		const OUTPUT_ASSET: Asset = Asset::Flip;
-
-		let combinations = amounts.iter().cartesian_product(fees);
-
-		let execute_at = System::block_number() + SWAP_DELAY_BLOCKS as u64;
-
-		let mut swap_request_id = 1;
-		Asset::all().for_each(|asset| {
-			let mut total_fees = 0;
-			combinations.clone().for_each(|(amount, broker_fee)| {
-				swap_with_custom_broker_fee(
-					asset,
-					OUTPUT_ASSET,
-					*amount,
-					bounded_vec![Beneficiary { account: ALICE, bps: broker_fee }],
-				);
-				let broker_fee =
-					Permill::from_parts(broker_fee as u32 * BASIS_POINTS_PER_MILLION) * *amount;
-				total_fees += broker_fee;
-				assert_eq!(get_broker_balance::<Test>(&ALICE, asset), total_fees);
-
-				assert_has_matching_event!(
-					Test,
-					RuntimeEvent::Swapping(Event::SwapRequested {
-						swap_request_id: swap_request_id_in_event,
-						input_asset,
-						input_amount,
-						output_asset: OUTPUT_ASSET,
-						broker_fee: broker_fee_in_event,
-						..
-					}) if swap_request_id_in_event == &swap_request_id &&
-						  input_amount == amount &&
-						  input_asset == &asset &&
-						  broker_fee_in_event == &broker_fee
-				);
-
-				System::assert_has_event(RuntimeEvent::Swapping(Event::SwapScheduled {
-					swap_request_id,
-					swap_id: swap_request_id,
-					input_amount: amount - broker_fee,
-					swap_type: SwapType::Swap,
-					execute_at,
-				}));
-
-				swap_request_id += 1;
-			})
+	new_test_ext()
+		.execute_with(|| {
+			swap_with_custom_broker_fee(
+				Asset::Usdc,
+				Asset::Flip,
+				100,
+				bounded_vec![Beneficiary { account: ALICE, bps: 15000 }],
+			);
+		})
+		.then_execute_at_block(3u32, |_| {})
+		.then_execute_with(|_| {
+			assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Usdc), 100);
 		});
-	});
 }
 
 #[test]
@@ -2285,7 +2321,6 @@ fn network_fee_swap_gets_burnt() {
 				input_asset: INPUT_ASSET,
 				input_amount: AMOUNT,
 				output_asset: OUTPUT_ASSET,
-				broker_fee: 0,
 				request_type: SwapRequestTypeEncoded::NetworkFee,
 				origin: SwapOrigin::Internal,
 			}));
@@ -2326,7 +2361,6 @@ fn transaction_fees_are_collected() {
 				input_asset: INPUT_ASSET,
 				input_amount: AMOUNT,
 				output_asset: OUTPUT_ASSET,
-				broker_fee: 0,
 				request_type: SwapRequestTypeEncoded::IngressEgressFee,
 				origin: SwapOrigin::Internal,
 			}));
@@ -2454,7 +2488,7 @@ fn test_buy_back_flip() {
 		NetworkFee::set(NETWORK_FEE);
 
 		// Get some network fees, just like we did a swap.
-		let NetworkFeeTaken { remaining_amount, network_fee } =
+		let FeeTaken { remaining_amount, fee: network_fee } =
 			Swapping::take_network_fee(SWAP_AMOUNT);
 
 		// Sanity check the network fee.

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -93,7 +93,7 @@ fn create_test_swap(
 	output_asset: Asset,
 	amount: AssetAmount,
 	dca_params: Option<DcaParameters>,
-) -> Swap {
+) -> Swap<Test> {
 	SwapRequests::<Test>::insert(
 		id,
 		SwapRequest {
@@ -101,9 +101,11 @@ fn create_test_swap(
 			input_asset,
 			output_asset,
 			refund_params: None,
-			state: SwapRequestState::Regular {
+			state: SwapRequestState::UserSwap {
 				output_address: ForeignChainAddress::Eth(H160::zero()),
 				dca_state: DcaState::create_with_first_chunk(amount, dca_params).0,
+				ccm: None,
+				broker_fees: Default::default(),
 			},
 		},
 	);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -338,7 +338,7 @@ fn expect_earned_fees_to_be_recorded() {
 				bounded_vec![Beneficiary { account: ALICE, bps: ALICE_FEE_BPS }],
 			);
 		})
-		.then_execute_at_block(3u32, |_| {})
+		.then_execute_at_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64, |_| {})
 		.then_execute_with(|_| {
 			const AMOUNT_AFTER_BROKER_FEES: AssetAmount = INTERMEDIATE_AMOUNT - ALICE_FEE_1;
 			const NETWORK_FEE: AssetAmount =
@@ -1819,7 +1819,7 @@ fn swap_broker_fee_calculated_correctly() {
 				}
 			});
 		})
-		.then_execute_at_block(3u32, |_| {})
+		.then_execute_at_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64, |_| {})
 		.then_execute_with(|_| {
 			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), total_fees);
 		});
@@ -1836,7 +1836,7 @@ fn swap_broker_fee_cannot_exceed_amount() {
 				bounded_vec![Beneficiary { account: ALICE, bps: 15000 }],
 			);
 		})
-		.then_execute_at_block(3u32, |_| {})
+		.then_execute_at_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64, |_| {})
 		.then_execute_with(|_| {
 			assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Usdc), 100);
 		});

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -323,11 +323,20 @@ fn expect_earned_fees_to_be_recorded() {
 	const BOB_FEE_BPS: u16 = 100;
 
 	// Expected values:
-	const ALICE_FEE_1: AssetAmount = INTERMEDIATE_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
-	// This swap starts with USDC, so it is deducted from the input amount:
-	const ALICE_FEE_2: AssetAmount = INPUT_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
-	const ALICE_FEE_3: AssetAmount = INTERMEDIATE_AMOUNT * ALICE_FEE_BPS as u128 / 10_000;
-	const BOB_FEE_1: AssetAmount = INTERMEDIATE_AMOUNT * BOB_FEE_BPS as u128 / 10_000;
+	const NETWORK_FEE_1: AssetAmount = INTERMEDIATE_AMOUNT * NETWORK_FEE_PERCENT as u128 / 100;
+	const ALICE_FEE_1: AssetAmount =
+		(INTERMEDIATE_AMOUNT - NETWORK_FEE_1) * ALICE_FEE_BPS as u128 / 10_000;
+
+	// This swap starts with USDC, so the fees are deducted from the input amount:
+	const NETWORK_FEE_2: AssetAmount = INPUT_AMOUNT * NETWORK_FEE_PERCENT as u128 / 100;
+	const ALICE_FEE_2: AssetAmount =
+		(INPUT_AMOUNT - NETWORK_FEE_2) * ALICE_FEE_BPS as u128 / 10_000;
+
+	const NETWORK_FEE_3: AssetAmount = INTERMEDIATE_AMOUNT * NETWORK_FEE_PERCENT as u128 / 100;
+	const ALICE_FEE_3: AssetAmount =
+		(INTERMEDIATE_AMOUNT - NETWORK_FEE_3) * ALICE_FEE_BPS as u128 / 10_000;
+	const BOB_FEE_1: AssetAmount =
+		(INTERMEDIATE_AMOUNT - NETWORK_FEE_3) * BOB_FEE_BPS as u128 / 10_000;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -340,19 +349,15 @@ fn expect_earned_fees_to_be_recorded() {
 		})
 		.then_execute_at_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64, |_| {})
 		.then_execute_with(|_| {
-			const AMOUNT_AFTER_BROKER_FEES: AssetAmount = INTERMEDIATE_AMOUNT - ALICE_FEE_1;
-			const NETWORK_FEE: AssetAmount =
-				AMOUNT_AFTER_BROKER_FEES * NETWORK_FEE_PERCENT as u128 / 100;
-
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
 				swap_request_id: 1,
 				swap_id: 1,
-				network_fee: NETWORK_FEE,
+				network_fee: NETWORK_FEE_1,
 				broker_fee: ALICE_FEE_1,
 				input_amount: INPUT_AMOUNT,
 				input_asset: Asset::Flip,
 				output_asset: Asset::Usdc,
-				output_amount: AMOUNT_AFTER_BROKER_FEES - NETWORK_FEE,
+				output_amount: INTERMEDIATE_AMOUNT - NETWORK_FEE_1 - ALICE_FEE_1,
 				intermediate_amount: None,
 			}));
 
@@ -368,18 +373,16 @@ fn expect_earned_fees_to_be_recorded() {
 		})
 		.then_execute_at_block(5u32, |_| {})
 		.then_execute_with(|_| {
-			const AMOUNT_AFTER_BROKER_FEES: AssetAmount = INPUT_AMOUNT - ALICE_FEE_2;
-			const NETWORK_FEE: AssetAmount =
-				AMOUNT_AFTER_BROKER_FEES * NETWORK_FEE_PERCENT as u128 / 100;
+			const AMOUNT_AFTER_FEES: AssetAmount = INPUT_AMOUNT - NETWORK_FEE_2 - ALICE_FEE_2;
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
 				swap_request_id: 2,
 				swap_id: 2,
-				network_fee: NETWORK_FEE,
+				network_fee: NETWORK_FEE_2,
 				broker_fee: ALICE_FEE_2,
-				input_amount: AMOUNT_AFTER_BROKER_FEES - NETWORK_FEE,
+				input_amount: AMOUNT_AFTER_FEES,
 				input_asset: Asset::Usdc,
 				output_asset: Asset::Flip,
-				output_amount: (AMOUNT_AFTER_BROKER_FEES - NETWORK_FEE) * DEFAULT_SWAP_RATE,
+				output_amount: AMOUNT_AFTER_FEES * DEFAULT_SWAP_RATE,
 				intermediate_amount: None,
 			}));
 
@@ -398,18 +401,15 @@ fn expect_earned_fees_to_be_recorded() {
 		})
 		.then_execute_at_block(7u32, |_| {})
 		.then_execute_with(|_| {
-			const TOTAL_FEES: AssetAmount = ALICE_FEE_3 + BOB_FEE_1;
-			const AMOUNT_AFTER_BROKER_FEES: AssetAmount = INTERMEDIATE_AMOUNT - TOTAL_FEES;
-			const NETWORK_FEE: AssetAmount =
-				AMOUNT_AFTER_BROKER_FEES * NETWORK_FEE_PERCENT as u128 / 100;
+			const TOTAL_BROKER_FEES: AssetAmount = ALICE_FEE_3 + BOB_FEE_1;
 			const INTERMEDIATE_AMOUNT_AFTER_FEES: AssetAmount =
-				AMOUNT_AFTER_BROKER_FEES - NETWORK_FEE;
+				INTERMEDIATE_AMOUNT - NETWORK_FEE_3 - TOTAL_BROKER_FEES;
 
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
 				swap_request_id: 3,
 				swap_id: 3,
-				network_fee: NETWORK_FEE,
-				broker_fee: TOTAL_FEES,
+				network_fee: NETWORK_FEE_3,
+				broker_fee: TOTAL_BROKER_FEES,
 				input_amount: INPUT_AMOUNT,
 				input_asset: Asset::ArbEth,
 				output_asset: Asset::Flip,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1838,7 +1838,10 @@ fn swap_broker_fee_cannot_exceed_amount() {
 		})
 		.then_execute_at_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64, |_| {})
 		.then_execute_with(|_| {
-			assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Usdc), 100);
+			// The broker gets nothing: setting fees >100% isn't actually possible due to
+			// parameter validation, so how this is handled isn't really important as long as we
+			// don't create money out of thin air and don't panic:
+			assert_eq!(get_broker_balance::<Test>(&ALICE, cf_primitives::Asset::Usdc), 0);
 		});
 }
 

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -27,8 +27,7 @@ fn get_dca_state(request_id: SwapRequestId) -> DcaState {
 		.expect("request state does not exist")
 		.state
 	{
-		SwapRequestState::Ccm { dca_state, .. } => dca_state,
-		SwapRequestState::Regular { dca_state, .. } => dca_state,
+		SwapRequestState::UserSwap { dca_state, .. } => dca_state,
 		other => {
 			panic!("DCA not supported for {other:?}")
 		},
@@ -36,11 +35,11 @@ fn get_dca_state(request_id: SwapRequestId) -> DcaState {
 }
 
 fn get_ccm_gas_state(request_id: SwapRequestId) -> GasSwapState {
-	if let SwapRequestState::Ccm { gas_swap_state, .. } = SwapRequests::<Test>::get(request_id)
+	if let SwapRequestState::UserSwap { ccm: Some(ccm), .. } = SwapRequests::<Test>::get(request_id)
 		.expect("request state does not exist")
 		.state
 	{
-		gas_swap_state
+		ccm.gas_swap_state
 	} else {
 		panic!("Not a CCM swap");
 	}

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -2,8 +2,6 @@ use super::*;
 
 const INPUT_AMOUNT: AssetAmount = 40_000;
 const CHUNK_INTERVAL: u32 = 3;
-const BROKER_FEE: AssetAmount = INPUT_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
-const NET_AMOUNT: AssetAmount = INPUT_AMOUNT - BROKER_FEE;
 
 const INPUT_ASSET: Asset = Asset::Usdc;
 const OUTPUT_ASSET: Asset = Asset::Eth;
@@ -53,11 +51,13 @@ fn dca_happy_path() {
 	const CHUNK_1_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 	const CHUNK_2_BLOCK: u64 = CHUNK_1_BLOCK + CHUNK_INTERVAL as u64;
 
-	const CHUNK_AMOUNT: AssetAmount = NET_AMOUNT / 2;
-	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT * DEFAULT_SWAP_RATE;
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / 2;
+	const CHUNK_BROKER_FEE: AssetAmount = CHUNK_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const CHUNK_AMOUNT_AFTER_FEE: AssetAmount = CHUNK_AMOUNT - CHUNK_BROKER_FEE;
 
-	// 1:1 swap ratio
-	const TOTAL_OUTPUT_AMOUNT: AssetAmount = NET_AMOUNT * DEFAULT_SWAP_RATE;
+	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
+
+	const TOTAL_OUTPUT_AMOUNT: AssetAmount = CHUNK_OUTPUT * 2;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -107,7 +107,7 @@ fn dca_happy_path() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					..
 				})
@@ -132,7 +132,7 @@ fn dca_happy_path() {
 					remaining_input_amount: 0,
 					remaining_chunks: 0,
 					chunk_interval: CHUNK_INTERVAL,
-					accumulated_output_amount: CHUNK_AMOUNT * DEFAULT_SWAP_RATE
+					accumulated_output_amount: CHUNK_OUTPUT
 				}
 			);
 		})
@@ -145,8 +145,9 @@ fn dca_happy_path() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 2,
-					input_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
+					broker_fee: CHUNK_BROKER_FEE,
 					..
 				}),
 				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
@@ -166,7 +167,9 @@ fn dca_happy_path() {
 fn dca_single_chunk() {
 	const CHUNK_1_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 
-	const EGRESS_AMOUNT: AssetAmount = NET_AMOUNT * DEFAULT_SWAP_RATE;
+	const BROKER_FEE: AssetAmount = INPUT_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const INPUT_AMOUNT_AFTER_FEE: AssetAmount = INPUT_AMOUNT - BROKER_FEE;
+	const EGRESS_AMOUNT: AssetAmount = INPUT_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -192,7 +195,7 @@ fn dca_single_chunk() {
 				RuntimeEvent::Swapping(Event::SwapScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: NET_AMOUNT,
+					input_amount: INPUT_AMOUNT,
 					execute_at: CHUNK_1_BLOCK,
 					..
 				})
@@ -217,8 +220,9 @@ fn dca_single_chunk() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: NET_AMOUNT,
+					input_amount: INPUT_AMOUNT_AFTER_FEE,
 					output_amount: EGRESS_AMOUNT,
+					broker_fee: BROKER_FEE,
 					..
 				}),
 				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
@@ -238,7 +242,7 @@ fn dca_single_chunk() {
 fn dca_with_fok_full_refund() {
 	const CHUNK_1_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 	const NUMBER_OF_CHUNKS: u32 = 2;
-	const CHUNK_AMOUNT: AssetAmount = NET_AMOUNT / NUMBER_OF_CHUNKS as u128;
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / NUMBER_OF_CHUNKS as u128;
 
 	// Allow for one retry for good measure:
 	const REFUND_BLOCK: u64 = CHUNK_1_BLOCK + (DEFAULT_SWAP_RETRY_DELAY_BLOCKS as u64);
@@ -328,7 +332,7 @@ fn dca_with_fok_full_refund() {
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
 					asset: INPUT_ASSET,
-					amount: NET_AMOUNT,
+					amount: INPUT_AMOUNT,
 					..
 				})
 			);
@@ -343,11 +347,13 @@ fn dca_with_fok_partial_refund() {
 		CHUNK_2_BLOCK + (DEFAULT_SWAP_RETRY_DELAY_BLOCKS as u64);
 
 	const NUMBER_OF_CHUNKS: u32 = 4;
-	const CHUNK_AMOUNT: AssetAmount = NET_AMOUNT / NUMBER_OF_CHUNKS as u128;
-	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT * DEFAULT_SWAP_RATE;
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / NUMBER_OF_CHUNKS as u128;
+	const CHUNK_BROKER_FEE: AssetAmount = CHUNK_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const CHUNK_AMOUNT_AFTER_FEE: AssetAmount = CHUNK_AMOUNT - CHUNK_BROKER_FEE;
+	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
 
 	// The test will be set up as to execute one chunk only and refund the rest
-	const REFUNDED_AMOUNT: AssetAmount = NET_AMOUNT - CHUNK_AMOUNT;
+	const REFUNDED_AMOUNT: AssetAmount = INPUT_AMOUNT - CHUNK_AMOUNT;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -404,7 +410,7 @@ fn dca_with_fok_partial_refund() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					..
 				})
@@ -492,7 +498,13 @@ fn dca_with_fok_fully_executed() {
 	const CHUNK_1_RETRY_BLOCK: u64 = CHUNK_1_BLOCK + (DEFAULT_SWAP_RETRY_DELAY_BLOCKS as u64);
 	const CHUNK_2_BLOCK: u64 = CHUNK_1_RETRY_BLOCK + CHUNK_INTERVAL as u64;
 	const NUMBER_OF_CHUNKS: u32 = 2;
-	const CHUNK_AMOUNT: AssetAmount = NET_AMOUNT / NUMBER_OF_CHUNKS as u128;
+
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / NUMBER_OF_CHUNKS as u128;
+	const CHUNK_BROKER_FEE: AssetAmount = CHUNK_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const CHUNK_AMOUNT_AFTER_FEE: AssetAmount = CHUNK_AMOUNT - CHUNK_BROKER_FEE;
+	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
+
+	const TOTAL_OUTPUT: AssetAmount = CHUNK_OUTPUT * 2;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -505,7 +517,7 @@ fn dca_with_fok_fully_executed() {
 				}),
 				Some(TestRefundParams {
 					retry_duration: DEFAULT_SWAP_RETRY_DELAY_BLOCKS,
-					min_output: INPUT_AMOUNT,
+					min_output: CHUNK_OUTPUT,
 				}),
 				false,
 			)]);
@@ -569,7 +581,7 @@ fn dca_with_fok_fully_executed() {
 		})
 		.then_execute_at_block(CHUNK_1_RETRY_BLOCK, |_| {
 			// Set the price back to normal, so that the fist chunk is successful
-			SwapRate::set(1.0);
+			SwapRate::set(DEFAULT_SWAP_RATE as f64);
 		})
 		.then_execute_with(|_| {
 			assert_event_sequence!(
@@ -577,8 +589,9 @@ fn dca_with_fok_fully_executed() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: CHUNK_AMOUNT,
-					output_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
+					output_amount: CHUNK_OUTPUT,
+					broker_fee: CHUNK_BROKER_FEE,
 					..
 				}),
 				// Second chunk should be scheduled 2 blocks after the first is executed:
@@ -598,7 +611,7 @@ fn dca_with_fok_fully_executed() {
 					remaining_input_amount: 0,
 					remaining_chunks: 0,
 					chunk_interval: CHUNK_INTERVAL,
-					accumulated_output_amount: CHUNK_AMOUNT
+					accumulated_output_amount: CHUNK_OUTPUT
 				}
 			);
 		})
@@ -611,15 +624,15 @@ fn dca_with_fok_fully_executed() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 2,
-					input_amount: CHUNK_AMOUNT,
-					output_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
+					output_amount: CHUNK_OUTPUT,
 					..
 				}),
 				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
 					asset: OUTPUT_ASSET,
-					// full amount should be egressed:
-					amount: NET_AMOUNT,
+					// Total amount from all chunks should be egressed:
+					amount: TOTAL_OUTPUT,
 					..
 				}),
 				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
@@ -638,11 +651,13 @@ fn dca_with_ccm_happy_path() {
 	// and we apply the default swap delay to them (rather than chunk interval)
 	const GAS_BLOCK: u64 = CHUNK_1_BLOCK + SWAP_DELAY_BLOCKS as u64;
 
-	const PRINCIPAL_AMOUNT: AssetAmount = NET_AMOUNT - GAS_BUDGET;
+	const PRINCIPAL_AMOUNT: AssetAmount = INPUT_AMOUNT - GAS_BUDGET;
 
 	const CHUNK_AMOUNT: AssetAmount = PRINCIPAL_AMOUNT / 2;
+	const CHUNK_BROKER_FEE: AssetAmount = CHUNK_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const CHUNK_AMOUNT_AFTER_FEE: AssetAmount = CHUNK_AMOUNT - CHUNK_BROKER_FEE;
 
-	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT * DEFAULT_SWAP_RATE;
+	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
 
 	new_test_ext()
 		.execute_with(|| {
@@ -702,7 +717,7 @@ fn dca_with_ccm_happy_path() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 1,
-					input_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					..
 				}),
@@ -731,7 +746,7 @@ fn dca_with_ccm_happy_path() {
 					remaining_input_amount: 0,
 					remaining_chunks: 0,
 					chunk_interval: CHUNK_INTERVAL,
-					accumulated_output_amount: CHUNK_AMOUNT * DEFAULT_SWAP_RATE
+					accumulated_output_amount: CHUNK_OUTPUT
 				}
 			);
 
@@ -779,7 +794,7 @@ fn dca_with_ccm_happy_path() {
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
 					swap_id: 2,
-					input_amount: CHUNK_AMOUNT,
+					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					..
 				}),
@@ -792,11 +807,7 @@ fn dca_with_ccm_happy_path() {
 				}),
 			);
 
-			ccm::assert_ccm_egressed(
-				OUTPUT_ASSET,
-				PRINCIPAL_AMOUNT * DEFAULT_SWAP_RATE,
-				GAS_BUDGET * DEFAULT_SWAP_RATE,
-			)
+			ccm::assert_ccm_egressed(OUTPUT_ASSET, CHUNK_OUTPUT * 2, GAS_BUDGET * DEFAULT_SWAP_RATE)
 		});
 }
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -134,6 +134,8 @@ pub const SECONDS_PER_BLOCK: u64 = MILLISECONDS_PER_BLOCK / 1000;
 
 pub const BASIS_POINTS_PER_MILLION: u32 = 100;
 
+pub const MAX_BASIS_POINTS: u16 = 10_000;
+
 pub const STABLE_ASSET: Asset = Asset::Usdc;
 
 /// Determines the default (genesis) maximum allowed reduction of authority set size in

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -76,10 +76,6 @@ impl<T: frame_system::Config> PoolApi for T {
 	}
 }
 
-pub struct NetworkFeeTaken {
-	pub remaining_amount: AssetAmount,
-	pub network_fee: AssetAmount,
-}
 pub trait SwappingApi {
 	/// Process a single leg of a swap, into or from Stable asset. No network fee is taken.
 	fn swap_single_leg(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1540 and PRO-1483

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

The PR is indended to be reviewed by individual commits

- Broker fee now behaves exactly like network fee, charged at the same time (once we have intermediate amount) and in USDC.
- Moved `broker_fee` field from `SwapRequested` to `SwapExecuted` (FYI @zoheb391 and @acdibble). Don't think there are any other implications for the product, other than brokers noticing that only their USDC balance is changing.
- Updated tests; `swap_broker_fee_subtracted_from_swap_amount` was mostly a duplicate so I merged it with `expect_earned_fees_to_be_recorded`.
- Also, as discussed, combined `Ccm` and `Regular` variants from SwapRequestState into `UserSwap`. Didn't really result in code deduplication, but at least we no longer repeat swap parameters (like the newly added broker_fees).

Edit: Updated broker fee tests in bouncer. Because all fees are charged in USDC I ended up leaving only a test for one asset (as opposed to all assets). Keeping all assets seems no longer necessary, and wouldn't be trivial (would likely require running the tests sequentially or with multiple broker account).