### PR TITLE
chore: disable external RPC tests

### DIFF
--- a/engine/src/sol/rpc.rs
+++ b/engine/src/sol/rpc.rs
@@ -259,6 +259,7 @@ mod tests {
 		assert_eq!(encoded, "vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg");
 	}
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	async fn test_sol_asyc() {
 		let sol_rpc_client =
@@ -271,6 +272,7 @@ mod tests {
 			.unwrap();
 	}
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	async fn test_sol_devnet() {
 		let sol_rpc_client = SolRpcClient::new(
@@ -335,6 +337,7 @@ mod tests {
 		println!("block: {:?}", block);
 	}
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	async fn test_sol_transaction() {
 		let sol_rpc_client = SolRpcClient::new(

--- a/engine/src/witness/sol/nonce_witnessing.rs
+++ b/engine/src/witness/sol/nonce_witnessing.rs
@@ -166,6 +166,7 @@ mod tests {
 
 	use super::*;
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	async fn test_get_nonces() {
 		task_scope(|scope| {

--- a/engine/src/witness/sol/sol_deposits.rs
+++ b/engine/src/witness/sol/sol_deposits.rs
@@ -432,6 +432,7 @@ mod tests {
 
 	use super::*;
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	async fn test_get_deposit_channels_info() {
 		task_scope::task_scope(|scope| {
@@ -557,6 +558,7 @@ mod tests {
 		.unwrap();
 	}
 
+	#[ignore = "requires access to external RPC"]
 	#[tokio::test]
 	#[should_panic]
 	async fn test_fail_erroneus_fetch_account() {


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

We shouldn't be making external calls within unit tests as it introduces an external dependency to our unit tests. These can be left in the repo for easier testing though, as this has proven useful in the past.
