### PR TITLE
chore: allow benchmarks to run

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -634,9 +634,6 @@ pub mod pallet {
 		BoostPoolCreated {
 			boost_pool: BoostPoolId<T::TargetChain>,
 		},
-		MaxSwapRetryDurationSet {
-			max_swap_retry_duration_blocks: BlockNumber,
-		},
 	}
 
 	#[derive(CloneNoBound, PartialEqNoBound, EqNoBound)]

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -30,9 +30,9 @@ use cf_chains::{
 	ExecutexSwapAndCall, FetchAssetParams, ForeignChainAddress, SwapOrigin, TransferAssetParams,
 };
 use cf_primitives::{
-	Asset, AssetAmount, BasisPoints, Beneficiaries, BlockNumber, BoostPoolTier, BroadcastId,
-	ChannelId, DcaParameters, EgressCounter, EgressId, EpochIndex, ForeignChain,
-	PrewitnessedDepositId, SwapRequestId, ThresholdSignatureRequestId, SWAP_DELAY_BLOCKS,
+	Asset, AssetAmount, BasisPoints, Beneficiaries, BoostPoolTier, BroadcastId, ChannelId,
+	DcaParameters, EgressCounter, EgressId, EpochIndex, ForeignChain, PrewitnessedDepositId,
+	SwapRequestId, ThresholdSignatureRequestId, SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -668,29 +668,18 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub flip_buy_interval: BlockNumberFor<T>,
-		pub swap_retry_delay: BlockNumberFor<T>,
-		pub max_swap_retry_duration_blocks: BlockNumber,
-		pub max_swap_request_duration_blocks: BlockNumber,
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			FlipBuyInterval::<T>::set(self.flip_buy_interval);
-			SwapRetryDelay::<T>::set(self.swap_retry_delay);
-			MaxSwapRetryDurationBlocks::<T>::set(self.max_swap_retry_duration_blocks);
-			MaxSwapRequestDurationBlocks::<T>::set(self.max_swap_request_duration_blocks);
 		}
 	}
 
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self {
-				flip_buy_interval: BlockNumberFor::<T>::zero(),
-				swap_retry_delay: DefaultSwapRetryDelay::<T>::get(),
-				max_swap_retry_duration_blocks: DEFAULT_MAX_SWAP_RETRY_DURATION_BLOCKS,
-				max_swap_request_duration_blocks: DEFAULT_MAX_SWAP_REQUEST_DURATION_BLOCKS,
-			}
+			Self { flip_buy_interval: BlockNumberFor::<T>::zero() }
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue with genesis that was preventing benchmarks from running. 
Also removed an unused event. 

See commits. 