### PR TITLE
feat: elections pallet tests

### DIFF
--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -216,30 +216,33 @@ mod benchmarks {
 	}
 
 	#[cfg(test)]
-	use crate::mock::*;
+	mod tests {
+		use super::*;
 
-	#[cfg(test)]
-	use crate::Instance1;
+		use crate::{mock::*, tests::ElectoralSystemTestExt, Instance1};
 
-	#[test]
-	fn benchmark_works() {
-		new_test_ext().execute_with(|| {
-			_vote::<Test, Instance1>(10, true);
-		});
-		new_test_ext().execute_with(|| {
-			_stop_ignoring_my_votes::<Test, Instance1>(true);
-		});
-		new_test_ext().execute_with(|| {
-			_ignore_my_votes::<Test, Instance1>(true);
-		});
-		new_test_ext().execute_with(|| {
-			_recheck_contributed_to_consensuses::<Test, Instance1>(true);
-		});
-		new_test_ext().execute_with(|| {
-			_delete_vote::<Test, Instance1>(true);
-		});
-		new_test_ext().execute_with(|| {
-			_provide_shared_data::<Test, Instance1>(true);
-		});
+		macro_rules! benchmark_tests {
+			( $( $test_name:ident: $test_fn:ident ( $( $arg:expr ),* ) ),+ $(,)? ) => {
+				$(
+					#[test]
+					fn $test_name() {
+						election_test_ext(Default::default())
+							.new_election()
+							.then_execute_with(|_| {
+								$test_fn::<Test, Instance1>( $( $arg, )* true );
+							});
+					}
+				)+
+			};
+		}
+
+		benchmark_tests! {
+			test_vote: _vote(10),
+			test_stop_ignoring_my_votes: _stop_ignoring_my_votes(),
+			test_ignore_my_votes: _ignore_my_votes(),
+			test_recheck_contributed_to_consensuses: _recheck_contributed_to_consensuses(),
+			test_delete_vote: _delete_vote(),
+			test_provide_shared_data: _provide_shared_data(),
+		}
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -214,7 +214,7 @@ mod access {
 
 	/// Represents the current consensus, and how it has changed since it was last checked (i.e.
 	/// 'check_consensus' was called).
-	#[cfg_attr(test, derive(Clone))]
+	#[cfg_attr(test, derive(Clone, PartialEq, Eq, Debug))]
 	pub enum ConsensusStatus<Consensus> {
 		/// You did not have consensus when previously checked, but now consensus has been gained.
 		Gained {

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -428,11 +428,11 @@ pub mod mocks {
 
 	pub struct MockReadAccess<'es, ES: ElectoralSystem> {
 		election_identifier: ElectionIdentifierOf<ES>,
-		electoral_system: &'es MockElectoralSystem<ES>,
+		electoral_system: &'es MockAccess<ES>,
 	}
 	pub struct MockWriteAccess<'es, ES: ElectoralSystem> {
 		election_identifier: ElectionIdentifierOf<ES>,
-		electoral_system: &'es mut MockElectoralSystem<ES>,
+		electoral_system: &'es mut MockAccess<ES>,
 	}
 
 	pub struct MockElection<ES: ElectoralSystem> {
@@ -442,7 +442,7 @@ pub mod mocks {
 		consensus_status: ConsensusStatus<ES::Consensus>,
 	}
 
-	pub struct MockElectoralSystem<ES: ElectoralSystem> {
+	pub struct MockAccess<ES: ElectoralSystem> {
 		electoral_settings: ES::ElectoralSettings,
 		unsynchronised_state: ES::ElectoralUnsynchronisedState,
 		unsynchronised_state_map:
@@ -451,7 +451,7 @@ pub mod mocks {
 		unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
 	}
 
-	impl<ES: ElectoralSystem> MockElectoralSystem<ES> {
+	impl<ES: ElectoralSystem> MockAccess<ES> {
 		pub fn election_read_access(&self, id: ElectionIdentifierOf<ES>) -> MockReadAccess<'_, ES> {
 			MockReadAccess { election_identifier: id, electoral_system: self }
 		}
@@ -587,7 +587,7 @@ pub mod mocks {
 		}
 	}
 
-	impl<ES: ElectoralSystem> MockElectoralSystem<ES> {
+	impl<ES: ElectoralSystem> MockAccess<ES> {
 		pub fn new(
 			unsynchronised_state: ES::ElectoralUnsynchronisedState,
 			unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
@@ -617,7 +617,7 @@ pub mod mocks {
 		}
 	}
 
-	impl<ES: ElectoralSystem> ElectoralReadAccess for MockElectoralSystem<ES> {
+	impl<ES: ElectoralSystem> ElectoralReadAccess for MockAccess<ES> {
 		type ElectoralSystem = ES;
 		type ElectionReadAccess<'es> = MockReadAccess<'es, ES>;
 
@@ -659,7 +659,7 @@ pub mod mocks {
 		}
 	}
 
-	impl<ES: ElectoralSystem> ElectoralWriteAccess for MockElectoralSystem<ES> {
+	impl<ES: ElectoralSystem> ElectoralWriteAccess for MockAccess<ES> {
 		type ElectionWriteAccess<'a> = MockWriteAccess<'a, ES>;
 
 		fn new_election(

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -284,6 +284,8 @@ mod access {
 		fn state(
 			&self,
 		) -> Result<<Self::ElectoralSystem as ElectoralSystem>::ElectionState, CorruptStorageError>;
+		#[cfg(test)]
+		fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem>;
 	}
 
 	/// A trait allowing write access to the details about a single election
@@ -492,6 +494,11 @@ pub mod mocks {
 					CorruptStorageError,
 				> {
 					self.with_election(|e| e.state.clone())
+				}
+
+				#[cfg(test)]
+				fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
+					self.election_identifier
 				}
 			}
 

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -285,7 +285,9 @@ mod access {
 			&self,
 		) -> Result<<Self::ElectoralSystem as ElectoralSystem>::ElectionState, CorruptStorageError>;
 		#[cfg(test)]
-		fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem>;
+		fn election_identifier(
+			&self,
+		) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError>;
 	}
 
 	/// A trait allowing write access to the details about a single election
@@ -497,8 +499,10 @@ pub mod mocks {
 				}
 
 				#[cfg(test)]
-				fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
-					self.election_identifier
+				fn election_identifier(
+					&self,
+				) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
+					Ok(self.election_identifier)
 				}
 			}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems.rs
@@ -2,5 +2,7 @@ pub mod blockchain;
 pub mod change;
 pub mod composite;
 pub mod egress_success;
+#[cfg(test)]
+pub mod mock;
 pub mod monotonic_median;
 pub mod unsafe_median;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -427,11 +427,12 @@ macro_rules! generate_electoral_system_tuple_impls {
             }
             #[cfg(test)]
             fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
-                let extra = match self.ea.borrow().election_identifier().extra() {
+                let composite_identifier = self.ea.borrow().election_identifier();
+                let extra = match composite_identifier.extra() {
                     CompositeElectionIdentifierExtra::$current(extra) => extra,
                     _ => unreachable!(),
                 };
-                self.ea.borrow().election_identifier().with_extra(*extra)
+                composite_identifier.with_extra(*extra)
             }
         }
         impl<$($electoral_system: ElectoralSystem,)* H: Hooks<$($electoral_system),*> + 'static,  EA: ElectionWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), H>>> ElectionWriteAccess for CompositeElectionAccess<tags::$current, EA, EA> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -425,6 +425,14 @@ macro_rules! generate_electoral_system_tuple_impls {
                     _ => Err(CorruptStorageError::new())
                 }
             }
+            #[cfg(test)]
+            fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
+                let extra = match self.ea.borrow().election_identifier().extra() {
+                    CompositeElectionIdentifierExtra::$current(extra) => extra,
+                    _ => unreachable!(),
+                };
+                self.ea.borrow().election_identifier().with_extra(*extra)
+            }
         }
         impl<$($electoral_system: ElectoralSystem,)* H: Hooks<$($electoral_system),*> + 'static,  EA: ElectionWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), H>>> ElectionWriteAccess for CompositeElectionAccess<tags::$current, EA, EA> {
             fn set_state(&mut self, state: $current::ElectionState) -> Result<(), CorruptStorageError> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -426,13 +426,13 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
             }
             #[cfg(test)]
-            fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
-                let composite_identifier = self.ea.borrow().election_identifier();
+            fn election_identifier(&self) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
+                let composite_identifier = self.ea.borrow().election_identifier()?;
                 let extra = match composite_identifier.extra() {
-                    CompositeElectionIdentifierExtra::$current(extra) => extra,
-                    _ => unreachable!(),
-                };
-                composite_identifier.with_extra(*extra)
+                    CompositeElectionIdentifierExtra::$current(extra) => Ok(extra),
+                    _ => Err(CorruptStorageError::new()),
+                }?;
+                Ok(composite_identifier.with_extra(*extra))
             }
         }
         impl<$($electoral_system: ElectoralSystem,)* H: Hooks<$($electoral_system),*> + 'static,  EA: ElectionWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), H>>> ElectionWriteAccess for CompositeElectionAccess<tags::$current, EA, EA> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -1,0 +1,158 @@
+use crate::{
+	electoral_system::{
+		AuthorityVoteOf, ElectionReadAccess, ElectoralSystem, ElectoralWriteAccess,
+		VotePropertiesOf,
+	},
+	vote_storage::{self, VoteStorage},
+	CorruptStorageError, ElectionIdentifier,
+};
+use cf_primitives::AuthorityCount;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_std::vec::Vec;
+use std::{cell::RefCell, ops::Deref};
+
+/// Simple wrapped data type for testing.
+macro_rules! impl_wrapped_data {
+	( $name:ident, $t:ty ) => {
+		#[derive(
+			Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, Default,
+		)]
+		pub struct $name($t);
+		impl Deref for $name {
+			type Target = $t;
+			fn deref(&self) -> &Self::Target {
+				&self.0
+			}
+		}
+	};
+}
+
+thread_local! {
+	static VOTE_DESIRED: RefCell<bool> = RefCell::new(true);
+	static VOTE_NEEDED: RefCell<bool> = RefCell::new(true);
+	static VOTE_VALID: RefCell<bool> = RefCell::new(true);
+	static CONSENSUS: RefCell<Option<Consensus>> = RefCell::new(None);
+	static ON_FINALIZE_RETURN: RefCell<OnFinalizeReturn> = RefCell::new(Default::default());
+}
+
+impl_wrapped_data!(OnFinalizeReturn, u32);
+impl_wrapped_data!(Consensus, u32);
+
+pub struct MockElectoralSystem;
+
+impl MockElectoralSystem {
+	pub fn set_vote_desired(desired: bool) {
+		VOTE_DESIRED.with(|v| *v.borrow_mut() = desired);
+	}
+
+	pub fn set_vote_needed(needed: bool) {
+		VOTE_NEEDED.with(|v| *v.borrow_mut() = needed);
+	}
+
+	pub fn set_vote_valid(valid: bool) {
+		VOTE_VALID.with(|v| *v.borrow_mut() = valid);
+	}
+
+	pub fn vote_desired() -> bool {
+		VOTE_DESIRED.with(|v| *v.borrow())
+	}
+
+	pub fn vote_needed() -> bool {
+		VOTE_NEEDED.with(|v| *v.borrow())
+	}
+
+	pub fn vote_valid() -> bool {
+		VOTE_VALID.with(|v| *v.borrow())
+	}
+
+	pub fn set_consensus(consensus: Option<Consensus>) {
+		CONSENSUS.with(|v| *v.borrow_mut() = consensus);
+	}
+
+	pub fn consensus() -> Option<Consensus> {
+		CONSENSUS.with(|v| *v.borrow())
+	}
+
+	pub fn set_on_finalize_return(on_finalize_return: OnFinalizeReturn) {
+		ON_FINALIZE_RETURN.with(|v| *v.borrow_mut() = on_finalize_return);
+	}
+
+	pub fn on_finalize_return() -> OnFinalizeReturn {
+		ON_FINALIZE_RETURN.with(|v| *v.borrow())
+	}
+}
+
+impl ElectoralSystem for MockElectoralSystem {
+	type ElectoralUnsynchronisedState = ();
+	type ElectoralUnsynchronisedStateMapKey = ();
+	type ElectoralUnsynchronisedStateMapValue = ();
+
+	type ElectoralUnsynchronisedSettings = ();
+	type ElectoralSettings = ();
+	type ElectionIdentifierExtra = ();
+	type ElectionProperties = ();
+	type ElectionState = ();
+	// TODO: mock the vote storage
+	type Vote =
+		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<()>>;
+	type Consensus = Consensus;
+	type OnFinalizeContext = ();
+	type OnFinalizeReturn = OnFinalizeReturn;
+
+	fn generate_vote_properties(
+		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
+		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+	) -> Result<(), CorruptStorageError> {
+		todo!()
+	}
+
+	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
+		_electoral_access: &mut ElectoralAccess,
+		_election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
+		_context: &Self::OnFinalizeContext,
+	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
+		Ok(Self::on_finalize_return())
+	}
+
+	fn check_consensus<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
+		_election_access: &ElectionAccess,
+		_previous_consensus: Option<&Self::Consensus>,
+		_votes: Vec<(VotePropertiesOf<Self>, <Self::Vote as VoteStorage>::Vote)>,
+		_authorities: AuthorityCount,
+	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
+		Ok(Self::consensus())
+	}
+
+	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+		_election_identifier_with_extra: crate::electoral_system::ElectionIdentifierOf<Self>,
+		_election_access: &ElectionAccess,
+		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+	) -> Result<bool, CorruptStorageError> {
+		Ok(Self::vote_desired())
+	}
+
+	fn is_vote_needed(
+		_current_vote: (
+			VotePropertiesOf<Self>,
+			<Self::Vote as VoteStorage>::PartialVote,
+			AuthorityVoteOf<Self>,
+		),
+		_proposed_vote: (
+			<Self::Vote as VoteStorage>::PartialVote,
+			<Self::Vote as VoteStorage>::Vote,
+		),
+	) -> bool {
+		Self::vote_needed()
+	}
+
+	fn is_vote_valid<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+		_election_identifier: crate::electoral_system::ElectionIdentifierOf<Self>,
+		_election_access: &ElectionAccess,
+		_partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
+	) -> Result<bool, CorruptStorageError> {
+		Ok(Self::vote_valid())
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -112,11 +112,8 @@ mod test_unsafe_median {
 	fn if_consensus_update_unsynchronised_state() {
 		const INIT_UNSYNCHRONISED_STATE: u64 = 22;
 		const NEW_UNSYNCHRONISED_STATE: u64 = 33;
-		let mut electoral_system = MockElectoralSystem::<UnsafeMedian<u64, (), ()>>::new(
-			INIT_UNSYNCHRONISED_STATE,
-			(),
-			(),
-		);
+		let mut electoral_system =
+			MockAccess::<UnsafeMedian<u64, (), ()>>::new(INIT_UNSYNCHRONISED_STATE, (), ());
 
 		electoral_system.new_election((), (), ()).unwrap().set_consensus_status(
 			ConsensusStatus::Changed {
@@ -133,11 +130,8 @@ mod test_unsafe_median {
 	#[test]
 	fn if_no_consensus_do_not_update_unsynchronised_state() {
 		const INIT_UNSYNCHRONISED_STATE: u64 = 22;
-		let mut electoral_system = MockElectoralSystem::<UnsafeMedian<u64, (), ()>>::new(
-			INIT_UNSYNCHRONISED_STATE,
-			(),
-			(),
-		);
+		let mut electoral_system =
+			MockAccess::<UnsafeMedian<u64, (), ()>>::new(INIT_UNSYNCHRONISED_STATE, (), ());
 
 		electoral_system
 			.new_election((), (), ())
@@ -152,11 +146,8 @@ mod test_unsafe_median {
 	#[test]
 	fn check_consensus_correctly_calculates_median_when_all_authorities_vote() {
 		const INIT_UNSYNCHRONISED_STATE: u64 = 22;
-		let mut electoral_system = MockElectoralSystem::<UnsafeMedian<u64, (), ()>>::new(
-			INIT_UNSYNCHRONISED_STATE,
-			(),
-			(),
-		);
+		let mut electoral_system =
+			MockAccess::<UnsafeMedian<u64, (), ()>>::new(INIT_UNSYNCHRONISED_STATE, (), ());
 
 		let mut votes = (1..=10).map(|v| ((), v)).collect::<Vec<_>>();
 
@@ -186,7 +177,7 @@ mod test_unsafe_median {
 	#[test]
 	fn check_consensus_correctly_calculates_median_when_exactly_super_majority_authorities_vote() {
 		let mut electoral_system =
-			MockElectoralSystem::<UnsafeMedian<u64, (), ()>>::new(Default::default(), (), ());
+			MockAccess::<UnsafeMedian<u64, (), ()>>::new(Default::default(), (), ());
 
 		let mut votes = vec![((), 1u64), ((), 5), ((), 3), ((), 2), ((), 8), ((), 6)];
 
@@ -209,7 +200,7 @@ mod test_unsafe_median {
 	#[test]
 	fn fewer_than_supermajority_votes_does_not_get_consensus() {
 		let mut electoral_system =
-			MockElectoralSystem::<UnsafeMedian<u64, (), ()>>::new(Default::default(), (), ());
+			MockAccess::<UnsafeMedian<u64, (), ()>>::new(Default::default(), (), ());
 
 		let all_votes = vec![((), 1u64), ((), 5), ((), 3), ((), 2), ((), 8)];
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -612,8 +612,10 @@ pub mod pallet {
 					.ok_or_else(CorruptStorageError::new)
 			}
 			#[cfg(test)]
-			fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
-				self.election_identifier
+			fn election_identifier(
+				&self,
+			) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
+				Ok(self.election_identifier)
 			}
 		}
 		impl<T: Config<I>, I: 'static> ElectionWriteAccess for ElectionAccess<T, I> {

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -610,6 +610,10 @@ pub mod pallet {
 				ElectionState::<T, I>::get(self.unique_monotonic_identifier())
 					.ok_or_else(CorruptStorageError::new)
 			}
+			#[cfg(test)]
+			fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
+				self.election_identifier
+			}
 		}
 		impl<T: Config<I>, I: 'static> ElectionWriteAccess for ElectionAccess<T, I> {
 			fn set_state(

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -103,6 +103,7 @@
 
 #![feature(try_find)]
 #![feature(option_take_if)]
+#![cfg_attr(test, feature(closure_track_caller))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 #![doc = include_str!("../../cf-doc-head.md")]

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -1625,6 +1625,20 @@ pub mod pallet {
 				}
 			}
 		}
+
+		fn integrity_test() {
+			let properties_keys = ElectionProperties::<T, I>::iter_keys()
+				.map(|id| *id.unique_monotonic())
+				.collect::<BTreeSet<_>>();
+			let state_keys = ElectionState::<T, I>::iter_keys().collect::<BTreeSet<_>>();
+			debug_assert_eq!(
+				properties_keys,
+				state_keys,
+				"Expected election properties and state to have the same keys. In properties but not in state: {:?}. In state but not in properties: {:?}.",
+				properties_keys.difference(&state_keys).collect::<Vec<_>>(),
+				state_keys.difference(&properties_keys).collect::<Vec<_>>(),
+			);
+		}
 	}
 
 	// ---------------------------------------------------------------------------------------- //

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
 pub use crate::{self as pallet_cf_elections};
+use crate::{InitialStateOf, Pallet, UniqueMonotonicIdentifier};
 
-use crate::{electoral_systems, GenesisConfig as ElectionGenesisConfig};
 use cf_traits::{impl_mock_chainflip, AccountRoleRegistry};
-use frame_support::{derive_impl, instances::Instance1};
+use frame_support::{assert_ok, derive_impl, instances::Instance1, traits::OriginTrait};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -23,34 +23,82 @@ impl frame_system::Config for Test {
 impl pallet_cf_elections::Config<Instance1> for Test {
 	type RuntimeEvent = RuntimeEvent;
 
-	// Use the median electoral system as a simple way to test the election pallet
 	// TODO: Use Settings?
-	type ElectoralSystem = electoral_systems::unsafe_median::UnsafeMedian<u64, (), ()>;
+	type ElectoralSystem = crate::electoral_systems::mock::MockElectoralSystem;
 
 	type WeightInfo = ();
 }
 
 impl_mock_chainflip!(Test);
 
-pub const INITIAL_UNSYNCED_STATE: u64 = 44;
-
 cf_test_utilities::impl_test_helpers! {
 	Test,
 	RuntimeGenesisConfig {
 		system: Default::default(),
-		elections: ElectionGenesisConfig {
-			option_initial_state: Some(crate::InitialState {
-				unsynchronised_state: INITIAL_UNSYNCED_STATE,
-				unsynchronised_settings: (),
-				settings: ()
-			})
-		}
+		elections: Default::default(),
 	},
-	|| {
-		// We need valid validators to vote for things
-		MockEpochInfo::next_epoch((0..3).collect());
-		for id in &MockEpochInfo::current_authorities() {
-			<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(id).unwrap();
+}
+
+#[derive(Clone, Debug)]
+pub struct TestSetup {
+	pub initial_state: InitialStateOf<Test, Instance1>,
+	pub num_contributing_authorities: u64,
+	pub num_non_contributing_authorities: u64,
+}
+
+impl Default for TestSetup {
+	fn default() -> Self {
+		Self {
+			initial_state: InitialStateOf::<Test, _> {
+				unsynchronised_state: (),
+				unsynchronised_settings: (),
+				settings: (),
+			},
+			num_contributing_authorities: 3,
+			num_non_contributing_authorities: 0,
 		}
 	}
+}
+
+impl TestSetup {
+	pub fn all_authorities(&self) -> Vec<u64> {
+		(0..self.num_contributing_authorities + self.num_non_contributing_authorities).collect()
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct TestContext {
+	pub setup: TestSetup,
+	pub umis: Vec<UniqueMonotonicIdentifier>,
+}
+
+/// Set up a test for the election pallet.
+///
+/// Intializes the pallet with the given initial state and contributing authorities. The authorities
+/// are registered as validators and contributing authorities submit `stop_ignoring_my_votes`
+/// extrinsics.
+pub fn election_test_ext(test_setup: TestSetup) -> TestRunner<TestContext> {
+	new_test_ext()
+		.execute_with(|| {
+			assert_ok!(Pallet::<Test, _>::internally_initialize(test_setup.initial_state.clone()));
+			for id in test_setup.all_authorities() {
+				<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&id)
+					.unwrap();
+			}
+			MockEpochInfo::next_epoch(test_setup.all_authorities());
+
+			test_setup
+		})
+		.then_apply_extrinsics(|test_setup| {
+			(0..test_setup.num_contributing_authorities)
+				.map(|id| {
+					(
+						OriginTrait::signed(id),
+						crate::Call::<Test, _>::stop_ignoring_my_votes {},
+						Ok(()),
+					)
+				})
+				.collect::<Vec<_>>()
+		})
+		.map_context(|test_setup| TestContext { setup: test_setup, umis: Vec::new() })
 }

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -1,91 +1,251 @@
 #![cfg(test)]
-
-use super::*;
-use sp_std::collections::btree_set::BTreeSet;
 use std::collections::BTreeMap;
 
-use cf_traits::EpochInfo;
+use crate::{mock::*, *};
+use cf_primitives::AuthorityCount;
+use electoral_system::{
+	AuthorityVoteOf, ConsensusStatus, ElectionReadAccess, ElectoralReadAccess, ElectoralWriteAccess,
+};
+use electoral_systems::mock::MockElectoralSystem;
+use frame_support::traits::OriginTrait;
+use vote_storage::AuthorityVote;
 
-use electoral_system::{AuthorityVoteOf, ElectoralReadAccess};
-use frame_system::RawOrigin;
-use mock::{new_test_ext, MockEpochInfo, Test, INITIAL_UNSYNCED_STATE};
+pub trait ElectoralSystemTestExt: Sized {
+	fn assume_consensus(self) -> Self;
+	fn assume_no_consensus(self) -> Self;
+	fn expect_consensus(self, expected: ConsensusStatus<AuthorityCount>) -> Self;
+	fn new_election(self) -> Self;
+	fn submit_simple<I: 'static>(
+		self,
+		validator_ids: &[u64],
+		call: impl Fn(&u64) -> Call<Test, I>,
+	) -> Self
+	where
+		Test: Config<I>;
+	fn submit_votes<I: 'static>(
+		self,
+		validator_ids: &[u64],
+		vote: AuthorityVoteOf<MockElectoralSystem>,
+		expected_error: Option<Error<Test, I>>,
+	) -> Self
+	where
+		Test: Config<I, ElectoralSystem = MockElectoralSystem>;
+}
 
-#[test]
-fn happy_path_vote_and_consensus() {
-	const NEW_DATA: u64 = 23;
+impl ElectoralSystemTestExt for TestRunner<TestContext> {
+	/// Starts a new election, adding its unique monotonic identifier to the test context.
+	#[track_caller]
+	fn new_election(self) -> Self {
+		self.then_execute_with(
+			#[track_caller]
+			|mut ctx| {
+				let unique_monotonic_identifier =
+					*Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
+						electoral_access.new_election((), (), ())
+					})
+					.expect("New election should not corrupt storage.")
+					.election_identifier()
+					.unique_monotonic();
 
-	fn submit_vote_for(validator_id: u64) {
-		let electoral_data = Pallet::<Test, Instance1>::electoral_data(&validator_id).unwrap();
+				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectoralSystemStatus::Running));
 
-		for (election_identifier, _election_data) in electoral_data.current_elections {
-			Pallet::<Test, Instance1>::vote(
-				RawOrigin::Signed(validator_id).into(),
-				BoundedBTreeMap::try_from(
-					[(
-						election_identifier,
-						AuthorityVoteOf::<<Test as Config<Instance1>>::ElectoralSystem>::Vote(
-							NEW_DATA,
-						),
-					)]
-					.into_iter()
-					.collect::<BTreeMap<_, _>>(),
-				)
-				.unwrap(),
-			)
-			.unwrap();
-		}
+				Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
+					electoral_access
+						.election(ElectionIdentifier::new(unique_monotonic_identifier, ()))
+				})
+				.expect("Expected an initial election.");
+
+				ctx.umis.push(unique_monotonic_identifier);
+
+				ctx
+			},
+		)
 	}
 
-	new_test_ext()
-		// Run one block, which on_finalise will create the election for the median
-		.then_execute_at_next_block(|()| {
-			Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
-				assert_eq!(
-					electoral_access.unsynchronised_state().unwrap(),
-					INITIAL_UNSYNCED_STATE
-				);
-				Ok(())
-			})
-			.unwrap();
-		})
-		.then_execute_at_next_block(|()| {
-			assert_eq!(Status::<Test, Instance1>::get(), Some(ElectoralSystemStatus::Running));
+	#[track_caller]
+	fn assume_consensus(self) -> Self {
+		MockElectoralSystem::set_assume_consensus(true);
+		self
+	}
 
-			let current_authorities = MockEpochInfo::current_authorities();
-			for validator_id in current_authorities.clone() {
-				Pallet::<Test, Instance1>::stop_ignoring_my_votes(
-					RawOrigin::Signed(validator_id).into(),
+	#[track_caller]
+	fn assume_no_consensus(self) -> Self {
+		MockElectoralSystem::set_assume_consensus(false);
+		self
+	}
+
+	#[track_caller]
+	fn submit_votes<I: 'static>(
+		self,
+		validator_ids: &[u64],
+		vote: AuthorityVoteOf<MockElectoralSystem>,
+		expected_error: Option<Error<Test, I>>,
+	) -> Self
+	where
+		Test: Config<I, ElectoralSystem = MockElectoralSystem>,
+	{
+		self.then_apply_extrinsics(
+			#[track_caller]
+			|TestContext { umis, .. }| {
+				validator_ids
+					.iter()
+					.flat_map(|id| {
+						umis.iter().map(|umi| {
+							(
+								OriginTrait::signed(*id),
+								Call::<Test, I>::vote {
+									authority_votes: BoundedBTreeMap::try_from(
+										sp_std::iter::once((
+											ElectionIdentifier::new(*umi, ()),
+											vote.clone(),
+										))
+										.collect::<BTreeMap<_, _>>(),
+									)
+									.unwrap(),
+								},
+								expected_error.clone().map(|e| Err(e.into())).unwrap_or(Ok(())),
+							)
+						})
+					})
+					.collect::<Vec<_>>()
+			},
+		)
+	}
+
+	#[track_caller]
+	fn submit_simple<I: 'static>(
+		self,
+		validator_ids: &[u64],
+		call: impl Fn(&u64) -> Call<Test, I>,
+	) -> Self
+	where
+		Test: Config<I>,
+	{
+		self.then_apply_extrinsics(
+			#[track_caller]
+			|_ctx| validator_ids.iter().map(|id| (OriginTrait::signed(*id), call(id), Ok(()))),
+		)
+	}
+
+	#[track_caller]
+	fn expect_consensus(self, expected: ConsensusStatus<AuthorityCount>) -> Self {
+		self.inspect_context(
+			#[track_caller]
+			|TestContext { umis, .. }| {
+				assert!(!umis.is_empty(), "Asserted consensus on empty election set.");
+
+				for umi in umis {
+					let actual = MockElectoralSystem::consensus_status(*umi);
+					assert_eq!(
+					actual,
+					expected,
+					"Unexpected consensus status for election {:?} at {}.\nExpected: {:?}, Actual: {:?}",
+					umi, core::panic::Location::caller(), expected, actual
 				)
-				.unwrap()
-			}
+				}
+			},
+		)
+	}
+}
 
-			assert_ne!(NEW_DATA, INITIAL_UNSYNCED_STATE);
+#[test]
+fn consensus_state_transitions() {
+	const VOTE: AuthorityVoteOf<MockElectoralSystem> = AuthorityVote::Vote(());
 
-			let mut super_maj =
-				current_authorities.into_iter().take(2).collect::<BTreeSet<u64>>().into_iter();
+	election_test_ext(TestSetup { num_non_contributing_authorities: 2, ..Default::default() })
+		.new_election()
+		// Initial consensus state of the mock election system is `None`.
+		.expect_consensus(ConsensusStatus::None)
+		.assume_consensus()
+		// Consensus is updated when we process a block's on_finalize hook.
+		.expect_consensus(ConsensusStatus::None)
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Gained { most_recent: None, new: 0 })
+		// After one vote we have consensus on the number of votes.
+		.submit_votes(&[0], VOTE, Default::default())
+		.expect_consensus(ConsensusStatus::Changed { previous: 0, new: 1 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 1 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 1 })
+		// Another vote, consensus has changed.
+		.submit_votes(&[1], VOTE, Default::default())
+		.expect_consensus(ConsensusStatus::Changed { previous: 1, new: 2 })
+		// Consensus is lost.
+		.assume_no_consensus()
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 2 })
+		.submit_votes(&[1], VOTE, Default::default()) // Consensus is only updated if there is a vote.
+		.expect_consensus(ConsensusStatus::Lost { previous: 2 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::None)
+		// Consensus is regained with the old value.
+		.assume_consensus()
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::None)
+		.submit_votes(&[1], VOTE, Default::default()) // Consensus is only updated if there is a vote.
+		.expect_consensus(ConsensusStatus::Gained { most_recent: Some(2), new: 2 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 2 })
+		// Consensus is lost.
+		.assume_no_consensus()
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 2 })
+		.submit_votes(&[1], VOTE, Default::default()) // Consensus is only updated if there is a vote.
+		.expect_consensus(ConsensusStatus::Lost { previous: 2 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::None)
+		// Consensus is regained with a new value.
+		.assume_consensus()
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::None)
+		.submit_votes(&[2], VOTE, Default::default()) // Consensus is only updated if there is a vote.
+		.expect_consensus(ConsensusStatus::Gained { most_recent: Some(2), new: 3 })
+		.then_process_next_block()
+		.expect_consensus(ConsensusStatus::Unchanged { current: 3 })
+		// Non-contributing authorities do not affect consensus.
+		.submit_votes(&[3, 4], VOTE, Some(Error::<Test, _>::NotContributing))
+		.expect_consensus(ConsensusStatus::Unchanged { current: 3 })
+		.submit_simple(&[3, 4], |_| Call::<Test, _>::stop_ignoring_my_votes {})
+		.submit_votes(&[3, 4], VOTE, None)
+		.expect_consensus(ConsensusStatus::Changed { previous: 3, new: 5 });
+}
 
-			submit_vote_for(super_maj.next().unwrap());
-			super_maj.next().unwrap()
-		})
-		// Only one vote means we have not reached consensus, so the state should not change
-		.then_execute_at_next_block(|next_validator| {
-			Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
-				assert_eq!(
-					electoral_access.unsynchronised_state().unwrap(),
-					INITIAL_UNSYNCED_STATE
-				);
-				Ok(())
-			})
-			.unwrap();
+#[test]
+fn authority_removes_and_re_adds_itself_from_contributing_set() {
+	const VOTE: AuthorityVoteOf<MockElectoralSystem> = AuthorityVote::Vote(());
 
-			submit_vote_for(next_validator);
-		})
-		// 2 votes is now consensus, so the state should be updated
-		.then_execute_at_next_block(|()| {
-			Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
-				assert_eq!(electoral_access.unsynchronised_state().unwrap(), NEW_DATA);
-				Ok(())
-			})
-			.unwrap();
-		});
+	election_test_ext(Default::default())
+		.new_election()
+		.assume_consensus()
+		.submit_votes(&[0, 1, 2], VOTE, None)
+		.expect_consensus(ConsensusStatus::Gained { most_recent: None, new: 3 })
+		.submit_simple(&[1], |_| Call::<Test, _>::ignore_my_votes {})
+		.expect_consensus(ConsensusStatus::Changed { previous: 3, new: 2 })
+		.submit_simple(&[1], |_| Call::<Test, _>::stop_ignoring_my_votes {})
+		.expect_consensus(ConsensusStatus::Changed { previous: 2, new: 3 })
+		// Validator 1 deletes its vote.
+		.then_apply_extrinsics(
+			#[track_caller]
+			|TestContext { umis, .. }| {
+				umis.iter()
+					.map(|umi| {
+						(
+							OriginTrait::signed(1),
+							Call::<Test, _>::delete_vote {
+								election_identifier: ElectionIdentifier::new(*umi, ()),
+							},
+							Ok(()),
+						)
+					})
+					.collect::<Vec<_>>()
+			},
+		)
+		.expect_consensus(ConsensusStatus::Changed { previous: 3, new: 2 })
+		.submit_simple(&[1], |_| Call::<Test, _>::ignore_my_votes {})
+		.submit_votes(&[1], VOTE, Some(Error::<Test, _>::NotContributing))
+		.expect_consensus(ConsensusStatus::Unchanged { current: 2 })
+		.submit_simple(&[1], |_| Call::<Test, _>::stop_ignoring_my_votes {})
+		.submit_votes(&[1], VOTE, None)
+		.expect_consensus(ConsensusStatus::Changed { previous: 2, new: 3 });
 }

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -45,6 +45,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 					})
 					.expect("New election should not corrupt storage.")
 					.election_identifier()
+					.expect("New election should have an identifier.")
 					.unique_monotonic();
 
 				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectoralSystemStatus::Running));

--- a/state-chain/test-utilities/src/lib.rs
+++ b/state-chain/test-utilities/src/lib.rs
@@ -142,10 +142,10 @@ macro_rules! impl_test_helpers {
 			TestRunner::<()>::new($genesis).execute_with($init)
 		}
 	};
-	( $runtime:ty, $genesis:expr ) => {
+	( $runtime:ty, $genesis:expr $(,)? ) => {
 		$crate::impl_test_helpers!($runtime, $genesis, || {});
 	};
-	( $runtime:ty ) => {
+	( $runtime:ty $(,)? ) => {
 		$crate::impl_test_helpers!($runtime, RuntimeGenesisConfig::default());
 	};
 }

--- a/state-chain/test-utilities/src/lib.rs
+++ b/state-chain/test-utilities/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(closure_track_caller)]
 use frame_system::Config;
 
 mod rich_test_externalities;

--- a/state-chain/test-utilities/src/rich_test_externalities.rs
+++ b/state-chain/test-utilities/src/rich_test_externalities.rs
@@ -167,6 +167,21 @@ where
 		self.ext.execute_at_next_block(move || f(context))
 	}
 
+	/// Process the next `n` blocks, including hooks.
+	#[track_caller]
+	pub fn then_process_blocks(mut self, n: u32) -> TestExternalities<Runtime, Ctx> {
+		for _ in 0..n {
+			self = self.then_process_next_block();
+		}
+		self
+	}
+
+	/// Process the next block, including hooks.
+	#[track_caller]
+	pub fn then_process_next_block(self) -> TestExternalities<Runtime, Ctx> {
+		self.then_execute_at_next_block(|context| context)
+	}
+
 	/// Execute the given closure as if it was an extrinsic at a specific block number.
 	///
 	/// The closure's return value is next context.
@@ -236,7 +251,7 @@ where
 			if should_break {
 				break next
 			} else {
-				self = next.then_execute_at_next_block(|context| context);
+				self = next.then_process_next_block();
 			}
 		}
 	}

--- a/state-chain/test-utilities/src/rich_test_externalities.rs
+++ b/state-chain/test-utilities/src/rich_test_externalities.rs
@@ -52,8 +52,10 @@ impl<Runtime: HasAllPallets> RichExternalities<Runtime> {
 		mut self,
 		f: impl FnOnce() -> Ctx,
 	) -> TestExternalities<Runtime, Ctx> {
-		let block_number =
-			self.0.execute_with(|| frame_system::Pallet::<Runtime>::block_number()) + 1u32.into();
+		let block_number = self.0.execute_with(
+			#[track_caller]
+			|| frame_system::Pallet::<Runtime>::block_number(),
+		) + 1u32.into();
 		self.execute_at_block::<Ctx>(block_number, f)
 	}
 
@@ -65,17 +67,20 @@ impl<Runtime: HasAllPallets> RichExternalities<Runtime> {
 		block_number: impl Into<BlockNumberFor<Runtime>>,
 		f: impl FnOnce() -> Ctx,
 	) -> TestExternalities<Runtime, Ctx> {
-		let context = self.0.execute_with(|| {
-			let block_number = block_number.into();
-			frame_system::Pallet::<Runtime>::reset_events();
-			frame_system::Pallet::<Runtime>::set_block_number(block_number);
-			Runtime::on_initialize(block_number);
-			let context = f();
-			Runtime::on_idle(block_number, Weight::MAX);
-			Runtime::on_finalize(block_number);
-			Runtime::integrity_test();
-			context
-		});
+		let context = self.0.execute_with(
+			#[track_caller]
+			|| {
+				let block_number = block_number.into();
+				frame_system::Pallet::<Runtime>::reset_events();
+				frame_system::Pallet::<Runtime>::set_block_number(block_number);
+				Runtime::on_initialize(block_number);
+				let context = f();
+				Runtime::on_idle(block_number, Weight::MAX);
+				Runtime::on_finalize(block_number);
+				Runtime::integrity_test();
+				context
+			},
+		);
 		TestExternalities { ext: self, context }
 	}
 }
@@ -107,10 +112,13 @@ where
 	#[track_caller]
 	pub fn new<GenesisConfig: BuildStorage>(config: GenesisConfig) -> TestExternalities<Runtime> {
 		let mut ext: sp_io::TestExternalities = config.build_storage().unwrap().into();
-		ext.execute_with(|| {
-			frame_system::Pallet::<Runtime>::set_block_number(1u32.into());
-			Runtime::integrity_test();
-		});
+		ext.execute_with(
+			#[track_caller]
+			|| {
+				frame_system::Pallet::<Runtime>::set_block_number(1u32.into());
+				Runtime::integrity_test();
+			},
+		);
 		TestExternalities { ext: RichExternalities::new(ext), context: () }
 	}
 
@@ -127,7 +135,10 @@ where
 	#[track_caller]
 	pub fn then_execute_with<R>(self, f: impl FnOnce(Ctx) -> R) -> TestExternalities<Runtime, R> {
 		let context = self.context;
-		self.ext.execute_with(move || f(context))
+		self.ext.execute_with(
+			#[track_caller]
+			move || f(context),
+		)
 	}
 
 	/// Access the storage without changing the test context.
@@ -135,10 +146,13 @@ where
 	/// Use this for assertions, for example testing invariants.
 	#[track_caller]
 	pub fn inspect_storage(self, f: impl FnOnce(&Ctx)) -> TestExternalities<Runtime, Ctx> {
-		self.then_execute_with(|context| {
-			f(&context);
-			context
-		})
+		self.then_execute_with(
+			#[track_caller]
+			|context| {
+				f(&context);
+				context
+			},
+		)
 	}
 
 	/// Inspect the test context without accessing storage.
@@ -164,7 +178,10 @@ where
 		f: impl FnOnce(Ctx) -> R,
 	) -> TestExternalities<Runtime, R> {
 		let context = self.context;
-		self.ext.execute_at_next_block(move || f(context))
+		self.ext.execute_at_next_block(
+			#[track_caller]
+			move || f(context),
+		)
 	}
 
 	/// Process the next `n` blocks, including hooks.
@@ -192,7 +209,11 @@ where
 		f: impl FnOnce(Ctx) -> R,
 	) -> TestExternalities<Runtime, R> {
 		let context = self.context;
-		self.ext.execute_at_block(block_number, move || f(context))
+		self.ext.execute_at_block(
+			block_number,
+			#[track_caller]
+			move || f(context),
+		)
 	}
 
 	/// Execute the given closure against all the runtime events.
@@ -204,13 +225,16 @@ where
 		mut f: impl FnMut(Ctx, Runtime::RuntimeEvent) -> Option<R>,
 	) -> TestExternalities<Runtime, (Ctx, Vec<R>)> {
 		let context = self.context.clone();
-		self.ext.execute_with(move || {
-			let r = frame_system::Pallet::<Runtime>::events()
-				.into_iter()
-				.filter_map(|e| f(context.clone(), e.event))
-				.collect();
-			(context, r)
-		})
+		self.ext.execute_with(
+			#[track_caller]
+			move || {
+				let r = frame_system::Pallet::<Runtime>::events()
+					.into_iter()
+					.filter_map(|e| f(context.clone(), e.event))
+					.collect();
+				(context, r)
+			},
+		)
 	}
 
 	/// Applies the provided extrinsics in the next block, asserting the expected result.
@@ -223,18 +247,21 @@ where
 		self,
 		f: impl FnOnce(&Ctx) -> I,
 	) -> TestExternalities<Runtime, Ctx> {
-		let r = self.ext.execute_at_next_block(|| {
-			for (origin, call, expected_result) in f(&self.context) {
-				match expected_result {
-					Ok(_) => {
-						assert_ok!(call.dispatch_bypass_filter(origin));
-					},
-					Err(e) => {
-						assert_noop!(call.dispatch_bypass_filter(origin), e);
-					},
+		let r = self.ext.execute_at_next_block(
+			#[track_caller]
+			|| {
+				for (origin, call, expected_result) in f(&self.context) {
+					match expected_result {
+						Ok(_) => {
+							assert_ok!(call.dispatch_bypass_filter(origin));
+						},
+						Err(e) => {
+							assert_noop!(call.dispatch_bypass_filter(origin), e);
+						},
+					}
 				}
-			}
-		});
+			},
+		);
 		TestExternalities { ext: r.ext, context: self.context }
 	}
 


### PR DESCRIPTION
# Pull Request

This includes a mock for the ElectoralSystem trait, and some initial tests of the consensus transitions when votes are added / ignored / deleted.

It's still incomplete - the next step would be to implement a mock of the VoteStorage trait and then `generate_vote_properties`.