### PR TITLE
chore: remove redundant benchmark

### DIFF
--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -108,42 +108,6 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn recheck_contributed_to_consensuses() {
-		let caller = ready_validator_for_vote::<T, I>();
-		let validator_id: T::ValidatorId = caller.clone().into();
-		let epoch = T::EpochInfo::epoch_index();
-
-		let elections = Pallet::<T, I>::electoral_data(&validator_id).unwrap().current_elections;
-		let next_election = elections.into_iter().next().unwrap();
-
-		Pallet::<T, I>::vote(
-			RawOrigin::Signed(caller).into(),
-			BoundedBTreeMap::try_from(
-				[(
-					next_election.0,
-					AuthorityVoteOf::<T::ElectoralSystem>::Vote(BenchmarkValue::benchmark_value()),
-				)]
-				.into_iter()
-				.collect::<BTreeMap<_, _>>(),
-			)
-			.unwrap(),
-		)
-		.unwrap();
-
-		ElectionConsensusHistoryUpToDate::<T, I>::insert(next_election.0.unique_monotonic(), epoch);
-
-		#[block]
-		{
-			let _ = Pallet::<T, I>::recheck_contributed_to_consensuses(epoch, &validator_id, epoch);
-		}
-
-		assert!(
-			ElectionConsensusHistoryUpToDate::<T, I>::iter().count() == 0,
-			"Expected ElectionConsensusHistoryUpToDate to be empty! Benchmark requirement are not met!"
-		);
-	}
-
-	#[benchmark]
 	fn delete_vote() {
 		let caller = ready_validator_for_vote::<T, I>();
 		let validator_id: T::ValidatorId = caller.clone().into();
@@ -188,9 +152,6 @@ mod benchmarks {
 	#[test]
 	fn benchmark_works() {
 		new_test_ext().execute_with(|| {
-			_recheck_contributed_to_consensuses::<Test, Instance1>(true);
-		});
-		new_test_ext().execute_with(|| {
 			_vote::<Test, Instance1>(10, true);
 		});
 		new_test_ext().execute_with(|| {
@@ -198,6 +159,9 @@ mod benchmarks {
 		});
 		new_test_ext().execute_with(|| {
 			_ignore_my_votes::<Test, Instance1>(true);
+		});
+		new_test_ext().execute_with(|| {
+			_delete_vote::<Test, Instance1>(true);
 		});
 	}
 }

--- a/state-chain/pallets/cf-elections/src/weights.rs
+++ b/state-chain/pallets/cf-elections/src/weights.rs
@@ -36,7 +36,6 @@ pub trait WeightInfo {
 	fn stop_ignoring_my_votes() -> Weight;
 	fn ignore_my_votes() -> Weight;
 	fn delete_vote() -> Weight;
-	fn recheck_contributed_to_consensuses() -> Weight;
 }
 
 /// Weights for pallet_cf_elections using the Substrate node and recommended hardware.
@@ -116,23 +115,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 		// Minimum execution time: 28_000_000 picoseconds.
 		Weight::from_parts(29_000_000, 4850)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
-	}
-	/// Storage: `SolanaElections::ElectionConsensusHistoryUpToDate` (r:2 w:1)
-	/// Proof: `SolanaElections::ElectionConsensusHistoryUpToDate` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::BitmapComponents` (r:1 w:0)
-	/// Proof: `SolanaElections::BitmapComponents` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::IndividualComponents` (r:1 w:0)
-	/// Proof: `SolanaElections::IndividualComponents` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::SharedData` (r:1 w:0)
-	/// Proof: `SolanaElections::SharedData` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn recheck_contributed_to_consensuses() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `543`
-		//  Estimated: `6483`
-		// Minimum execution time: 21_000_000 picoseconds.
-		Weight::from_parts(22_000_000, 6483)
-			.saturating_add(T::DbWeight::get().reads(5_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
 	fn delete_vote() -> Weight {
@@ -223,23 +205,6 @@ impl WeightInfo for () {
 		// Minimum execution time: 28_000_000 picoseconds.
 		Weight::from_parts(29_000_000, 4850)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
-	}
-	/// Storage: `SolanaElections::ElectionConsensusHistoryUpToDate` (r:2 w:1)
-	/// Proof: `SolanaElections::ElectionConsensusHistoryUpToDate` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::BitmapComponents` (r:1 w:0)
-	/// Proof: `SolanaElections::BitmapComponents` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::IndividualComponents` (r:1 w:0)
-	/// Proof: `SolanaElections::IndividualComponents` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SolanaElections::SharedData` (r:1 w:0)
-	/// Proof: `SolanaElections::SharedData` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn recheck_contributed_to_consensuses() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `543`
-		//  Estimated: `6483`
-		// Minimum execution time: 21_000_000 picoseconds.
-		Weight::from_parts(22_000_000, 6483)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	fn delete_vote() -> Weight {
 		// Proof Size summary in bytes:


### PR DESCRIPTION
# Pull Request

## Summary

Removed the redundant benchmarking for `recheck_contributed_to_consensuses`