### PR TITLE
feat: use encoded address in ccm deposit metadata in events

### DIFF
--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 pub use address::ForeignChainAddress;
 use address::{
-	AddressDerivationApi, AddressDerivationError, EncodedAddress, IntoForeignChainAddress,
-	ToHumanreadableAddress,
+	AddressConverter, AddressDerivationApi, AddressDerivationError, EncodedAddress,
+	IntoForeignChainAddress, ToHumanreadableAddress,
 };
 use cf_primitives::{
 	AssetAmount, BroadcastId, ChannelId, EgressId, EthAmount, Price, TransactionHash,
@@ -636,6 +636,16 @@ pub struct CcmDepositMetadataGeneric<Address> {
 
 pub type CcmDepositMetadata = CcmDepositMetadataGeneric<ForeignChainAddress>;
 pub type CcmDepositMetadataEncoded = CcmDepositMetadataGeneric<EncodedAddress>;
+
+impl CcmDepositMetadata {
+	pub fn to_encoded<Converter: AddressConverter>(self) -> CcmDepositMetadataEncoded {
+		CcmDepositMetadataEncoded {
+			source_chain: self.source_chain,
+			source_address: self.source_address.map(Converter::to_encoded_address),
+			channel_metadata: self.channel_metadata,
+		}
+	}
+}
 
 #[derive(
 	PartialEqNoBound,

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -628,11 +628,14 @@ pub struct CcmChannelMetadata {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Serialize, Deserialize)]
-pub struct CcmDepositMetadata {
+pub struct CcmDepositMetadataGeneric<Address> {
 	pub source_chain: ForeignChain,
-	pub source_address: Option<ForeignChainAddress>,
+	pub source_address: Option<Address>,
 	pub channel_metadata: CcmChannelMetadata,
 }
+
+pub type CcmDepositMetadata = CcmDepositMetadataGeneric<ForeignChainAddress>;
+pub type CcmDepositMetadataEncoded = CcmDepositMetadataGeneric<EncodedAddress>;
 
 #[derive(
 	PartialEqNoBound,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1966,7 +1966,14 @@ pub mod pallet {
 							output_address: T::AddressConverter::to_encoded_address(
 								output_address.clone(),
 							),
-							ccm_deposit_metadata: ccm_deposit_metadata.clone(),
+							ccm_deposit_metadata: cf_chains::CcmDepositMetadataEncoded {
+								source_chain: ccm_deposit_metadata.source_chain,
+								source_address: ccm_deposit_metadata
+									.source_address
+									.clone()
+									.map(T::AddressConverter::to_encoded_address),
+								channel_metadata: ccm_deposit_metadata.channel_metadata.clone(),
+							},
 						},
 				},
 				origin: origin.clone(),

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2093,9 +2093,9 @@ pub mod pallet {
 							output_address: T::AddressConverter::to_encoded_address(
 								output_address.clone(),
 							),
-							ccm_deposit_metadata: utilities::to_ccm_deposit_metadata_encoded::<
-								T::AddressConverter,
-							>(ccm_deposit_metadata.clone()),
+							ccm_deposit_metadata: ccm_deposit_metadata
+								.clone()
+								.to_encoded::<T::AddressConverter>(),
 						},
 				},
 				origin: origin.clone(),
@@ -2208,9 +2208,9 @@ pub mod pallet {
 								Self::deposit_event(Event::<T>::CcmFailed {
 									reason,
 									destination_address: encoded_destination_address,
-									deposit_metadata: utilities::to_ccm_deposit_metadata_encoded::<
-										T::AddressConverter,
-									>(ccm_deposit_metadata.clone()),
+									deposit_metadata: ccm_deposit_metadata
+										.clone()
+										.to_encoded::<T::AddressConverter>(),
 									origin: origin.clone(),
 								});
 
@@ -2394,8 +2394,6 @@ impl<T: Config> ExecutionCondition for NoPendingSwaps<T> {
 }
 
 pub(crate) mod utilities {
-	use cf_chains::{address::AddressConverter, CcmDepositMetadataEncoded};
-
 	use super::*;
 
 	pub(crate) fn calculate_network_fee(
@@ -2439,16 +2437,6 @@ pub(crate) mod utilities {
 				params.min_price,
 			))
 			.unwrap_or(u128::MAX),
-		}
-	}
-
-	pub(super) fn to_ccm_deposit_metadata_encoded<Converter: AddressConverter>(
-		ccm_deposit_metadata: CcmDepositMetadata,
-	) -> CcmDepositMetadataEncoded {
-		CcmDepositMetadataEncoded {
-			source_chain: ccm_deposit_metadata.source_chain,
-			source_address: ccm_deposit_metadata.source_address.map(Converter::to_encoded_address),
-			channel_metadata: ccm_deposit_metadata.channel_metadata,
 		}
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -527,6 +527,8 @@ pub mod pallet {
 			output_asset: Asset,
 			origin: SwapOrigin,
 			request_type: SwapRequestTypeEncoded,
+			refund_parameters: Option<ChannelRefundParametersEncoded>,
+			dca_parameters: Option<DcaParameters>,
 		},
 		SwapRequestCompleted {
 			swap_request_id: SwapRequestId,
@@ -1972,6 +1974,10 @@ pub mod pallet {
 						},
 				},
 				origin: origin.clone(),
+				refund_parameters: refund_params
+					.clone()
+					.map(|params| params.map_address(T::AddressConverter::to_encoded_address)),
+				dca_parameters: dca_params.clone(),
 			});
 
 			match request_type {

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -719,6 +719,8 @@ mod ccm {
 				ccm_deposit_metadata: ccm_deposit_metadata_encoded,
 				output_address: encoded_output_address,
 			},
+			dca_parameters: None,
+			refund_parameters: None,
 			origin,
 		}));
 	}
@@ -1092,6 +1094,8 @@ fn swap_by_witnesser_happy_path() {
 			request_type: SwapRequestTypeEncoded::Regular {
 				output_address: encoded_output_address,
 			},
+			refund_parameters: None,
+			dca_parameters: None,
 			origin: ORIGIN,
 		}));
 
@@ -2345,6 +2349,8 @@ fn network_fee_swap_gets_burnt() {
 				input_amount: AMOUNT,
 				output_asset: OUTPUT_ASSET,
 				request_type: SwapRequestTypeEncoded::NetworkFee,
+				refund_parameters: None,
+				dca_parameters: None,
 				origin: SwapOrigin::Internal,
 			}));
 			assert_has_matching_event!(Test, RuntimeEvent::Swapping(Event::SwapScheduled { .. }),);
@@ -2385,6 +2391,8 @@ fn transaction_fees_are_collected() {
 				input_amount: AMOUNT,
 				output_asset: OUTPUT_ASSET,
 				request_type: SwapRequestTypeEncoded::IngressEgressFee,
+				refund_parameters: None,
+				dca_parameters: None,
 				origin: SwapOrigin::Internal,
 			}));
 

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -182,6 +182,10 @@ fn assert_failed_ccm(
 	)
 	.is_err());
 
+	let ccm_metadata_encoded = utilities::to_ccm_deposit_metadata_encoded::<
+		<Test as pallet::Config>::AddressConverter,
+	>(ccm.clone());
+
 	assert_event_sequence!(
 		Test,
 		RuntimeEvent::Swapping(Event::SwapRequested { .. }),
@@ -190,7 +194,7 @@ fn assert_failed_ccm(
 			destination_address: ref address_in_event,
 			deposit_metadata: ref metadata_in_event,
 			..
-		}) if reason_in_event == &reason && address_in_event == &MockAddressConverter::to_encoded_address(destination_address) && metadata_in_event == &ccm,
+		}) if reason_in_event == &reason && address_in_event == &MockAddressConverter::to_encoded_address(destination_address) && metadata_in_event == &ccm_metadata_encoded,
 		RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
 	);
 }
@@ -688,14 +692,9 @@ mod ccm {
 	#[track_caller]
 	fn init_ccm_swap_request(input_asset: Asset, output_asset: Asset, input_amount: AssetAmount) {
 		let ccm_deposit_metadata = generate_ccm_deposit();
-		let ccm_deposit_metadata_encoded = cf_chains::CcmDepositMetadataEncoded {
-			source_chain: ccm_deposit_metadata.source_chain,
-			source_address: ccm_deposit_metadata
-				.clone()
-				.source_address
-				.map(MockAddressConverter::to_encoded_address),
-			channel_metadata: ccm_deposit_metadata.channel_metadata.clone(),
-		};
+		let ccm_deposit_metadata_encoded = utilities::to_ccm_deposit_metadata_encoded::<
+			<Test as pallet::Config>::AddressConverter,
+		>(ccm_deposit_metadata.clone());
 		let output_address = (*EVM_OUTPUT_ADDRESS).clone();
 		let encoded_output_address =
 			MockAddressConverter::to_encoded_address(output_address.clone());

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -688,6 +688,14 @@ mod ccm {
 	#[track_caller]
 	fn init_ccm_swap_request(input_asset: Asset, output_asset: Asset, input_amount: AssetAmount) {
 		let ccm_deposit_metadata = generate_ccm_deposit();
+		let ccm_deposit_metadata_encoded = cf_chains::CcmDepositMetadataEncoded {
+			source_chain: ccm_deposit_metadata.source_chain,
+			source_address: ccm_deposit_metadata
+				.clone()
+				.source_address
+				.map(MockAddressConverter::to_encoded_address),
+			channel_metadata: ccm_deposit_metadata.channel_metadata.clone(),
+		};
 		let output_address = (*EVM_OUTPUT_ADDRESS).clone();
 		let encoded_output_address =
 			MockAddressConverter::to_encoded_address(output_address.clone());
@@ -696,10 +704,7 @@ mod ccm {
 			input_asset,
 			input_amount,
 			output_asset,
-			SwapRequestType::Ccm {
-				ccm_deposit_metadata: ccm_deposit_metadata.clone(),
-				output_address
-			},
+			SwapRequestType::Ccm { ccm_deposit_metadata, output_address },
 			Default::default(),
 			None,
 			None,
@@ -712,7 +717,7 @@ mod ccm {
 			output_asset,
 			input_amount,
 			request_type: SwapRequestTypeEncoded::Ccm {
-				ccm_deposit_metadata,
+				ccm_deposit_metadata: ccm_deposit_metadata_encoded,
 				output_address: encoded_output_address,
 			},
 			origin,

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -62,17 +62,17 @@ fn dca_happy_path() {
 		.execute_with(|| {
 			assert_eq!(System::block_number(), INIT_BLOCK);
 
-			insert_swaps(&[params(
-				Some(DcaParameters { number_of_chunks: 2, chunk_interval: CHUNK_INTERVAL }),
-				None,
-				false,
-			)]);
+			const DCA_PARAMS: DcaParameters =
+				DcaParameters { number_of_chunks: 2, chunk_interval: CHUNK_INTERVAL };
+
+			insert_swaps(&[params(Some(DCA_PARAMS), None, false)]);
 
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					swap_request_id: SWAP_REQUEST_ID,
 					input_amount: INPUT_AMOUNT,
+					dca_parameters: Some(DCA_PARAMS),
 					..
 				})
 			);

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -1,4 +1,6 @@
-use cf_chains::{CcmDepositMetadata, ChannelRefundParameters, ForeignChainAddress, SwapOrigin};
+use cf_chains::{
+	CcmDepositMetadataGeneric, ChannelRefundParameters, ForeignChainAddress, SwapOrigin,
+};
 use cf_primitives::{Asset, AssetAmount, Beneficiaries, DcaParameters, SwapRequestId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::sp_runtime::DispatchError;
@@ -18,7 +20,7 @@ pub enum SwapRequestTypeGeneric<Address> {
 	NetworkFee,
 	IngressEgressFee,
 	Regular { output_address: Address },
-	Ccm { output_address: Address, ccm_deposit_metadata: CcmDepositMetadata },
+	Ccm { output_address: Address, ccm_deposit_metadata: CcmDepositMetadataGeneric<Address> },
 }
 
 pub type SwapRequestType = SwapRequestTypeGeneric<ForeignChainAddress>;


### PR DESCRIPTION
# Pull Request

Closes: PRO-1597

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Made `CcmDepositMetadata` generic so we can encode the address inside of it when outputting it in the swap requested event and the ccm failed event.
