### PR TITLE
fix: upgrade-test to use latest job

### DIFF
--- a/.github/actions/get-workflow-commit/action.yml
+++ b/.github/actions/get-workflow-commit/action.yml
@@ -27,7 +27,6 @@ runs:
             owner,
             repo,
             workflow_id,
-            status: 'success',
             event: 'push',
           });
           const run = runs.data.workflow_runs[0];


### PR DESCRIPTION
Latest successful can be wrong due to force version bump.