### PR TITLE
LP API cancel_all_orders use cf_available_pools

### DIFF
--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -552,7 +552,7 @@ impl RpcServer for RpcServerImpl {
 					base_asset: pool.base,
 					quote_asset: pool.quote,
 					side: Side::Sell,
-					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+					id: order.id.try_into().expect("Internal AMM OrderId is a u64"),
 				});
 			}
 			for order in orders.limit_orders.bids {
@@ -560,7 +560,7 @@ impl RpcServer for RpcServerImpl {
 					base_asset: pool.base,
 					quote_asset: pool.quote,
 					side: Side::Buy,
-					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+					id: order.id.try_into().expect("Internal AMM OrderId is a u64"),
 				});
 			}
 		}

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -544,7 +544,7 @@ impl RpcServer for RpcServerImpl {
 				orders_to_delete.push(CloseOrder::Range {
 					base_asset: pool.base,
 					quote_asset: pool.quote,
-					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+					id: order.id.try_into().expect("Internal AMM OrderId is a u64"),
 				});
 			}
 			for order in orders.limit_orders.asks {

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -519,52 +519,49 @@ impl RpcServer for RpcServerImpl {
 		wait_for: Option<WaitFor>,
 	) -> RpcResult<Vec<ApiWaitForResult<Vec<LimitOrRangeOrder>>>> {
 		let mut orders_to_delete: Vec<CloseOrder> = vec![];
-		let pool_environment = self
+		let pool_pairs = self
 			.api
 			.state_chain_client
 			.base_rpc_client
 			.raw_rpc_client
-			.cf_pools_environment(None)
+			.cf_available_pools(None)
 			.await?;
-
-		for base_asset in Asset::all().filter(|asset| *asset != Asset::Usdc) {
-			if let Some(pool) = pool_environment.fees[base_asset] {
-				let orders = self
-					.api
-					.state_chain_client
-					.base_rpc_client
-					.raw_rpc_client
-					.cf_pool_orders(
-						base_asset,
-						pool.quote_asset,
-						Some(self.api.state_chain_client.account_id()),
-						None,
-						None,
-					)
-					.await?;
-				for order in orders.range_orders {
-					orders_to_delete.push(CloseOrder::Range {
-						base_asset,
-						quote_asset: pool.quote_asset,
-						id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
-					});
-				}
-				for order in orders.limit_orders.asks {
-					orders_to_delete.push(CloseOrder::Limit {
-						base_asset,
-						quote_asset: pool.quote_asset,
-						side: Side::Sell,
-						id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
-					});
-				}
-				for order in orders.limit_orders.bids {
-					orders_to_delete.push(CloseOrder::Limit {
-						base_asset,
-						quote_asset: pool.quote_asset,
-						side: Side::Buy,
-						id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
-					});
-				}
+		for pool in pool_pairs {
+			let orders = self
+				.api
+				.state_chain_client
+				.base_rpc_client
+				.raw_rpc_client
+				.cf_pool_orders(
+					pool.base,
+					pool.quote,
+					Some(self.api.state_chain_client.account_id()),
+					None,
+					None,
+				)
+				.await?;
+			for order in orders.range_orders {
+				orders_to_delete.push(CloseOrder::Range {
+					base_asset: pool.base,
+					quote_asset: pool.quote,
+					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+				});
+			}
+			for order in orders.limit_orders.asks {
+				orders_to_delete.push(CloseOrder::Limit {
+					base_asset: pool.base,
+					quote_asset: pool.quote,
+					side: Side::Sell,
+					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+				});
+			}
+			for order in orders.limit_orders.bids {
+				orders_to_delete.push(CloseOrder::Limit {
+					base_asset: pool.base,
+					quote_asset: pool.quote,
+					side: Side::Buy,
+					id: order.id.try_into().expect("Internal AMM OrderId is be u64"),
+				});
 			}
 		}
 

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1149,7 +1149,7 @@ impl<T: Config> PoolApi for Pallet<T> {
 	}
 
 	fn pools() -> Vec<PoolPairsMap<Asset>> {
-		Self::pools()
+		Pools::<T>::iter_keys().map(|asset_pair| asset_pair.assets()).collect()
 	}
 }
 
@@ -1831,10 +1831,6 @@ impl<T: Config> Pallet<T> {
 			pool.range_orders_cache.keys().cloned(),
 		)
 		.collect())
-	}
-
-	pub fn pools() -> Vec<PoolPairsMap<Asset>> {
-		Pools::<T>::iter_keys().map(|asset_pair| asset_pair.assets()).collect()
 	}
 
 	pub fn pool_info(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1605

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Updated lp api cancel_all_orders to use cf_available_pools to query for the available pools instead of looping through all the assets and checking if the fees are set (makes thing more readable and understandable, that's one of the main reason we added cf_available_pools)

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
