### PR TITLE
fix: downgrade log message severity for voting / retrier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "chainflip-api",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast 0.5.1",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-ingress-egress-tracker"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3382,7 +3382,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -12662,7 +12662,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "cf-amm",
  "cf-chains",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = '2021'
 build = 'build.rs'
 name = "chainflip-cli"
-version = "1.6.0"
+version = "1.6.1"
 
 [lints]
 workspace = true

--- a/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
+++ b/api/bin/chainflip-ingress-egress-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-ingress-egress-tracker"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 
 [lints]

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "cf-engine-dylib"
-version = "1.6.0"
+version = "1.6.1"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_6_0"
+name = "chainflip_engine_v1_6_1"
 path = 'src/lib.rs'
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2021'
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.6.0"
+version = "1.6.1"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
@@ -24,10 +24,10 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_6_0.so",
+        "target/release/libchainflip_engine_v1_6_1.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_0.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_1.so",
         "755",
     ],
     # The old version gets put into target/release by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -12,7 +12,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.6.0")]
+	#[engine_proc_macros::link_engine_library_version("1.6.1")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -11,7 +11,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.5.1";
-pub const NEW_VERSION: &str = "1.6.0";
+pub const NEW_VERSION: &str = "1.6.1";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = 'build.rs'
 edition = '2021'
 name = "chainflip-engine"
-version = "1.6.0"
+version = "1.6.1"
 
 [lib]
 crate-type = ["lib"]

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -21,7 +21,7 @@ use std::{
 	collections::{BTreeMap, HashMap},
 	sync::Arc,
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
 use voter_api::VoterApi;
 
@@ -177,7 +177,7 @@ where
 						pending_submissions.insert(election_identifier,	(partial_vote, vote));
 					},
 					Err(error) => {
-						error!("Voting task for election '{:?}' failed with error: '{:?}'.", election_identifier, error);
+						warn!("Voting task for election '{:?}' failed with error: '{:?}'.", election_identifier, error);
 					}
 				}
 			},

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -443,9 +443,9 @@ where
 
 							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}` requested with `{primary_or_backup:?}`, attempt `{attempt}`: {e}. Delaying for {:?}", sleep_duration);
 							if attempt == 0 && !matches!(retry_limit, RetryLimit::Limit(1)) {
-								tracing::warn!(error_message);
+								tracing::debug!(error_message);
 							} else {
-								tracing::error!(error_message);
+								tracing::warn!(error_message);
 							}
 
 							client_selector.request_failed(primary_or_backup);

--- a/engine/src/sol/retry_rpc.rs
+++ b/engine/src/sol/retry_rpc.rs
@@ -25,7 +25,7 @@ pub struct SolRetryRpcClient {
 	witness_period: u64,
 }
 
-const SOLANA_RPC_TIMEOUT: Duration = Duration::from_millis(1000);
+const SOLANA_RPC_TIMEOUT: Duration = Duration::from_secs(4);
 const MAX_CONCURRENT_SUBMISSIONS: u32 = 100;
 
 const MAX_BROADCAST_RETRIES: Attempt = 10;

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = '<TODO>'
 name = 'chainflip-node'
 publish = false
 repository = 'https://github.com/chainflip-io/chainflip-backend'
-version = "1.6.0"
+version = "1.6.1"
 
 [[bin]]
 name = 'chainflip-node'

--- a/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
@@ -13,7 +13,9 @@ macro_rules! generate_vote_storage_tuple_impls {
 
             use codec::{Encode, Decode};
             use scale_info::TypeInfo;
+            #[cfg(feature = "runtime-benchmarks")]
             use cf_chains::benchmarking_value::BenchmarkValue;
+
 
             #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
             pub enum CompositeVoteProperties<$($t,)*> {

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'state-chain-runtime'
-version = '1.6.0'
+version = '1.6.1'
 authors = ['Chainflip Team <https://github.com/chainflip-io>']
 edition = '2021'
 homepage = 'https://chainflip.io'


### PR DESCRIPTION
Minor hotfixes for the 1.6 release:

- downgrade error severity to reduce log spam
- increase the sol rpc timeout to 4 secs