### PR TITLE
chore: set max wasm instances for rpc nodes

### DIFF
--- a/state-chain/node/package/berghain/chainflip-rpc-node.service
+++ b/state-chain/node/package/berghain/chainflip-rpc-node.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/chainflip-node \
     --rpc-cors=all \
     --rpc-methods=unsafe \
     --unsafe-rpc-external \
+    --max-runtime-instances 32 \
     --sync=warp
 
 [Install]

--- a/state-chain/node/package/perseverance/chainflip-rpc-node.service
+++ b/state-chain/node/package/perseverance/chainflip-rpc-node.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/chainflip-node \
     --rpc-cors=all \
     --rpc-methods=unsafe \
     --unsafe-rpc-external \
+    --max-runtime-instances 32 \
     --sync=warp
 
 [Install]

--- a/state-chain/node/package/sisyphos/chainflip-rpc-node.service
+++ b/state-chain/node/package/sisyphos/chainflip-rpc-node.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/chainflip-node \
     --rpc-cors=all \
     --rpc-methods=unsafe \
     --unsafe-rpc-external \
+    --max-runtime-instances 32 \
     --sync=warp
 
 [Install]


### PR DESCRIPTION
# Pull Request

Companion docker compose change: https://github.com/chainflip-io/chainflip-mainnet-apis/pull/5

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

The RPC nodes need to serve a lot of requests, so we can default the max runtime cache instances to the max for RPC nodes.
