### PR TITLE
chore: tidy up solana vote impls

### DIFF
--- a/engine/src/witness/sol/egress_witnessing.rs
+++ b/engine/src/witness/sol/egress_witnessing.rs
@@ -35,7 +35,9 @@ pub async fn get_finalized_fee(
 						// doesn't get the tx. But "Processed" is timing out so we better
 						// retry with finalized.
 						commitment: Some(CommitmentConfig::finalized()),
-						// Getting also type 0 even if we don't use them atm
+						// Using 0 as max_supported_transaction_version to ensure we query all
+						// transactions regardless of version. This is not strictly necessary, but
+						// ensures we don't miss anything.
 						max_supported_transaction_version: Some(0),
 					},
 				)

--- a/engine/src/witness/sol/egress_witnessing.rs
+++ b/engine/src/witness/sol/egress_witnessing.rs
@@ -1,0 +1,114 @@
+use crate::sol::{
+	commitment_config::CommitmentConfig,
+	retry_rpc::{SolRetryRpcApi, SolRetryRpcClient},
+	rpc_client_api::{
+		RpcTransactionConfig, TransactionConfirmationStatus, TransactionStatus,
+		UiTransactionEncoding,
+	},
+};
+use anyhow::Result;
+use cf_chains::sol::{SolSignature, LAMPORTS_PER_SIGNATURE};
+use itertools::Itertools;
+
+pub async fn get_finalized_fee(
+	sol_client: &SolRetryRpcClient,
+	signature: SolSignature,
+) -> Result<u64> {
+	match sol_client
+		.get_signature_statuses(&[signature], false)
+		.await
+		.value
+		.iter()
+		.exactly_one()
+		.expect("We queried for exactly one signature.")
+	{
+		Some(TransactionStatus {
+			confirmation_status: Some(TransactionConfirmationStatus::Finalized),
+			..
+		}) => {
+			let transaction_meta = sol_client
+				.get_transaction(
+					&signature,
+					RpcTransactionConfig {
+						encoding: Some(UiTransactionEncoding::Json),
+						// Using finalized there could be a race condition where this
+						// doesn't get the tx. But "Processed" is timing out so we better
+						// retry with finalized.
+						commitment: Some(CommitmentConfig::finalized()),
+						// Getting also type 0 even if we don't use them atm
+						max_supported_transaction_version: Some(0),
+					},
+				)
+				.await
+				.transaction
+				.meta;
+
+			Ok(match transaction_meta {
+				Some(meta) => meta.fee,
+				// This shouldn't happen. Want to avoid Erroring. We either default to
+				// 5000 or return OK(()) so we don't submit transaction_succeeded and
+				// retry again later. Defaulting to avoid potentially getting stuck not
+				// witness something because no meta is returned.
+				None => LAMPORTS_PER_SIGNATURE,
+			})
+		},
+		Some(TransactionStatus { confirmation_status: other_status, .. }) => Err(anyhow::anyhow!(
+			"Transaction status is {:?}, waiting for {:?}.",
+			other_status,
+			TransactionConfirmationStatus::Finalized
+		)),
+		None => Err(anyhow::anyhow!("Unknown Transaction.")),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		settings::{NodeContainer, WsHttpEndpoints},
+		sol::retry_rpc::SolRetryRpcClient,
+	};
+
+	use cf_chains::{sol::SolSignature, Chain, Solana};
+	use futures_util::FutureExt;
+	use std::str::FromStr;
+	use utilities::task_scope;
+
+	use super::*;
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_egress_witnessing() {
+		task_scope::task_scope(|scope| {
+			async {
+				let client= SolRetryRpcClient::new(
+						scope,
+						NodeContainer {
+							primary: WsHttpEndpoints {
+								ws_endpoint: "wss://api.devnet.solana.com".into(),
+								http_endpoint: "https://api.devnet.solana.com".into(),
+							},
+							backup: None,
+						},
+						None,
+						Solana::WITNESS_PERIOD,
+					)
+					.await
+					.unwrap();
+
+				let monitored_tx_signature =
+					SolSignature::from_str(
+						"4udChXyRXrqBxUTr9F3nbTcPyvteLJtFQ3wM35J53NdP4GWwUp2wBwdTJEYs2aiNz7DyCqitok6ci7qqHPkRByb2").unwrap();
+
+				let fee = get_finalized_fee(&client, monitored_tx_signature).await.unwrap();
+
+				println!("{:?}", fee);
+				assert_eq!(fee, LAMPORTS_PER_SIGNATURE);
+
+				Ok(())
+			}
+			.boxed()
+		})
+		.await
+		.unwrap();
+	}
+}

--- a/engine/src/witness/sol/egress_witnessing.rs
+++ b/engine/src/witness/sol/egress_witnessing.rs
@@ -57,6 +57,8 @@ pub async fn get_finalized_fee(
 			other_status,
 			TransactionConfirmationStatus::Finalized
 		)),
+		// TODO: Consider distinguishing this case as `Ok(None)` to indicate that the
+		// request returned a response, but the tx is not available yet.
 		None => Err(anyhow::anyhow!("Unknown Transaction.")),
 	}
 }

--- a/engine/src/witness/sol/fee_tracking.rs
+++ b/engine/src/witness/sol/fee_tracking.rs
@@ -1,0 +1,24 @@
+use crate::sol::{
+	retry_rpc::{SolRetryRpcApi, SolRetryRpcClient},
+	rpc_client_api::RpcPrioritizationFee,
+};
+
+pub async fn get_median_prioritization_fee(sol_client: &SolRetryRpcClient) -> Option<u64> {
+	let mut fees = sol_client
+		.get_recent_prioritization_fees()
+		.await
+		.into_iter()
+		.map(|RpcPrioritizationFee { prioritization_fee, .. }| prioritization_fee)
+		.collect::<Vec<_>>();
+
+	if fees.is_empty() {
+		// No fees were paid, we should not need to pay any either.
+		None
+	} else {
+		let median_index = fees.len().saturating_sub(1) / 2;
+		// Note `select_nth_unstable` panics on an empty slice, but we've already handled that
+		// case.
+		let (_, median, _) = fees.select_nth_unstable(median_index);
+		Some(*median)
+	}
+}

--- a/engine/src/witness/sol/fee_tracking.rs
+++ b/engine/src/witness/sol/fee_tracking.rs
@@ -4,17 +4,15 @@ use crate::sol::{
 };
 
 pub async fn get_median_prioritization_fee(sol_client: &SolRetryRpcClient) -> Option<u64> {
-	let mut fees = sol_client
-		.get_recent_prioritization_fees()
-		.await
-		.into_iter()
-		.map(|RpcPrioritizationFee { prioritization_fee, .. }| prioritization_fee)
-		.collect::<Vec<_>>();
+	let fees = sol_client.get_recent_prioritization_fees().await;
 
 	if fees.is_empty() {
-		// No fees were paid, we should not need to pay any either.
 		None
 	} else {
+		let mut fees = fees
+			.into_iter()
+			.map(|RpcPrioritizationFee { prioritization_fee, .. }| prioritization_fee)
+			.collect::<Vec<_>>();
 		let median_index = fees.len().saturating_sub(1) / 2;
 		// Note `select_nth_unstable` panics on an empty slice, but we've already handled that
 		// case.


### PR DESCRIPTION
This is a refactor / tidy up I did as I was debugging other issues. 

Some minor changes to behaviour, specifically these two case:
- when the rpc returns no priority fees -> now we return a default value MIN_PRIORITIZATION_FEE
- when the rpc returns no new durable nonce -> now we return the *old* nonce instead of erroring, and the impl of the `Change` electoral system handles the rest.


Details from the commit message:

- move implementation details into their own modules.
- make impls return Option instead of Vec and take single arg where appropriate
- remove unused data and assertions (slot, signature comparison etc)
- Handle case when there are no Prio Fees (add MIN_PRIORITIZATION_FEE)
- Durable Nonce default to old nonce if the new one isn't witnessed (election logic handles this).
