### PR TITLE
fix: change try_from_iter into from_iter_or_default

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -264,23 +264,21 @@ impl RpcAccountInfo {
 	fn broker(balance: u128, broker_info: BrokerInfo) -> Self {
 		Self::Broker {
 			flip_balance: balance.into(),
-			earned_fees: cf_chains::assets::any::AssetMap::try_from_iter(
+			earned_fees: cf_chains::assets::any::AssetMap::from_iter_or_default(
 				broker_info
 					.earned_fees
 					.iter()
 					.map(|(asset, balance)| (*asset, (*balance).into())),
-			)
-			.unwrap(),
+			),
 		}
 	}
 
 	fn lp(info: LiquidityProviderInfo, network: NetworkEnvironment, balance: u128) -> Self {
 		Self::LiquidityProvider {
 			flip_balance: balance.into(),
-			balances: cf_chains::assets::any::AssetMap::try_from_iter(
+			balances: cf_chains::assets::any::AssetMap::from_iter_or_default(
 				info.balances.iter().map(|(asset, balance)| (*asset, (*balance).into())),
-			)
-			.unwrap(),
+			),
 			refund_addresses: info
 				.refund_addresses
 				.into_iter()

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -114,12 +114,11 @@ impl BalanceApi for MockBalanceApi {
 
 	fn free_balances(who: &Self::AccountId) -> assets::any::AssetMap<cf_primitives::AssetAmount> {
 		BALANCE_MAP.with(|balance_map| {
-			assets::any::AssetMap::try_from_iter(
+			assets::any::AssetMap::from_iter_or_default(
 				Asset::all().map(|asset| {
 					(asset, balance_map.borrow().get(who).cloned().unwrap_or_default())
 				}),
 			)
-			.unwrap()
 		})
 	}
 

--- a/state-chain/traits/src/mocks/balance_api.rs
+++ b/state-chain/traits/src/mocks/balance_api.rs
@@ -72,10 +72,9 @@ impl BalanceApi for MockBalance {
 	}
 
 	fn free_balances(who: &Self::AccountId) -> AssetMap<AssetAmount> {
-		AssetMap::try_from_iter(Asset::all().map(|asset| {
+		AssetMap::from_iter_or_default(Asset::all().map(|asset| {
 			(asset, Self::get_storage(FREE_BALANCES, (who, asset)).unwrap_or_default())
 		}))
-		.unwrap()
 	}
 
 	fn get_balance(who: &Self::AccountId, asset: Asset) -> AssetAmount {

--- a/utilities/src/with_std/rpc.rs
+++ b/utilities/src/with_std/rpc.rs
@@ -8,6 +8,12 @@ pub enum NumberOrHex {
 	Hex(U256),
 }
 
+impl Default for NumberOrHex {
+	fn default() -> Self {
+		Self::Hex(Default::default())
+	}
+}
+
 impl Serialize for NumberOrHex {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where


### PR DESCRIPTION
This makes the fn infallible, and prevents some strange pre/post runtime upgrade effects.

This is a cherry pick of #5218 (release/1.5)

Also needs to be picked to release/1.6