### PR TITLE
fix: only call monotonic median hook if state is updated.

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -79,8 +79,8 @@ impl<
 				electoral_access.mutate_unsynchronised_state(
 					|_electoral_access, unsynchronised_state| {
 						if consensus > *unsynchronised_state {
-							*unsynchronised_state = consensus;
-							Hook::on_change(consensus.clone());
+							*unsynchronised_state = consensus.clone();
+							Hook::on_change(consensus);
 						}
 
 						Ok(())

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -75,12 +75,12 @@ impl<
 			let mut election_access = electoral_access.election_mut(election_identifier)?;
 			if let Some(consensus) = election_access.check_consensus()?.has_consensus() {
 				election_access.delete();
-				Hook::on_change(consensus.clone());
 				electoral_access.new_election((), (), ())?;
 				electoral_access.mutate_unsynchronised_state(
 					|_electoral_access, unsynchronised_state| {
 						if consensus > *unsynchronised_state {
 							*unsynchronised_state = consensus;
+							Hook::on_change(consensus.clone());
 						}
 
 						Ok(())


### PR DESCRIPTION
Tiny change to prevent some unlikely (and consequence-free) runtime error cases to be hit.