### PR TITLE
chore: solana serialize broadcast data

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,13 +1,6 @@
 # This CI runs a lot of the jobs in parallel to speed up development time. We also run a simpler suite of bouncer tests.
 name: Release Chainflip Development
-on:
-  pull_request:
-    branches:
-      - main
-      - "release/*"
-concurrency:
-  group: ${{ github.ref }}-release-development
-  cancel-in-progress: true
+on: push
 
 jobs:
   pre-check:

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,6 +1,13 @@
 # This CI runs a lot of the jobs in parallel to speed up development time. We also run a simpler suite of bouncer tests.
 name: Release Chainflip Development
-on: push
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/*"
+concurrency:
+  group: ${{ github.ref }}-release-development
+  cancel-in-progress: true
 
 jobs:
   pre-check:

--- a/engine/src/state_chain_observer/sc_observer.rs
+++ b/engine/src/state_chain_observer/sc_observer.rs
@@ -574,7 +574,7 @@ where
                                             let sol_rpc = sol_rpc.clone();
                                             let state_chain_client = state_chain_client.clone();
                                             scope.spawn(async move {
-                                                match sol_rpc.broadcast_transaction(payload).await {
+                                                match sol_rpc.broadcast_transaction(payload.serialized_transaction).await {
                                                     Ok(tx_signature) => info!("Solana TransactionBroadcastRequest {broadcast_id:?} success: tx_signature: {tx_signature:?}"),
                                                     Err(error) => {
                                                         error!("Error on Solana TransactionBroadcastRequest {broadcast_id:?}: {error:?}");

--- a/engine/src/state_chain_observer/sc_observer.rs
+++ b/engine/src/state_chain_observer/sc_observer.rs
@@ -574,7 +574,7 @@ where
                                             let sol_rpc = sol_rpc.clone();
                                             let state_chain_client = state_chain_client.clone();
                                             scope.spawn(async move {
-                                                match sol_rpc.broadcast_transaction(payload.finalize_and_serialize().expect("Failed to serialize payload")).await {
+                                                match sol_rpc.broadcast_transaction(payload).await {
                                                     Ok(tx_signature) => info!("Solana TransactionBroadcastRequest {broadcast_id:?} success: tx_signature: {tx_signature:?}"),
                                                     Err(error) => {
                                                         error!("Error on Solana TransactionBroadcastRequest {broadcast_id:?}: {error:?}");

--- a/state-chain/cf-integration-tests/Cargo.toml
+++ b/state-chain/cf-integration-tests/Cargo.toml
@@ -88,3 +88,6 @@ sp-transaction-pool = { git = "https://github.com/chainflip-io/polkadot-sdk.git"
 sp-version = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-consensus-grandpa = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
 sp-timestamp = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.6+1" }
+
+[features]
+try-runtime = ['frame-support/try-runtime', 'frame-system/try-runtime']

--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -12,6 +12,7 @@ mod authorities;
 mod funding;
 mod genesis;
 mod governance;
+mod migrations;
 mod new_epoch;
 mod solana;
 mod swapping;

--- a/state-chain/cf-integration-tests/src/migrations.rs
+++ b/state-chain/cf-integration-tests/src/migrations.rs
@@ -1,0 +1,1 @@
+mod serialize_solana_broadcast;

--- a/state-chain/cf-integration-tests/src/migrations/serialize_solana_broadcast.rs
+++ b/state-chain/cf-integration-tests/src/migrations/serialize_solana_broadcast.rs
@@ -1,0 +1,156 @@
+use cf_chains::sol::{
+	sol_tx_core::{CompiledInstruction, MessageHeader},
+	SolMessage, SolPubkey, SolSignature,
+};
+
+use cf_chains::sol::{SolHash, SolanaTransactionData};
+use genesis::with_test_defaults;
+use sp_runtime::AccountId32;
+
+use frame_support::traits::OnRuntimeUpgrade;
+use pallet_cf_broadcast::BroadcastData;
+use state_chain_runtime::{
+	migrations::serialize_solana_broadcast::{old, SerializeSolanaBroadcastMigration},
+	SolanaInstance,
+};
+
+use crate::*;
+
+use cf_chains::sol::SolTransaction;
+
+// Test data pulled from `state-chain/chains/src/sol/sol_tx_core.rs`
+#[test]
+fn test_migration() {
+	with_test_defaults().build().execute_with(|| {
+		let tx: SolTransaction = SolTransaction {
+            signatures: vec![
+                SolSignature(hex_literal::hex!(
+                    "d1144b223b6b600de4b2d96bdceb03573a3e9781953e4c668c57e505f017859d96543243b4d904dc2f02f2f5ab5db7ba4551c7e015e64078add4674ac2e7460c"
+                )),
+            ],
+            message: SolMessage {
+                header: MessageHeader {
+                    num_required_signatures: 1,
+                    num_readonly_signed_accounts: 0,
+                    num_readonly_unsigned_accounts: 8,
+                },
+                account_keys: vec![
+                    SolPubkey(hex_literal::hex!(
+                        "2e8944a76efbece296221e736627f4528a947578263a1172a9786410702d2ef2"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "22020a74fd97df45db96d2bbf4e485ccbec56945155ff8f668856be26c9de4a9"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "79c03bceb9ddea819e956b2b332e87fbbf49fc8968df78488e88cfaa366f3036"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "8cd28baa84f2067bbdf24513c2d44e44bf408f2e6da6e60762e3faa4a62a0adb"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "8d9871ed5fb2ee05765af23b7cabcc0d6b08ed370bb9f616a0d4dea40a25f870"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "b5b9d633289c8fd72fb05f33349bf4cc44e82add5d865311ae346d7c9a67b7dd"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "f53a2f4350451db5595a75e231519bc2758798f72550e57487722e7cbe954dbc"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "0000000000000000000000000000000000000000000000000000000000000000"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "0306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "06a7d517192c568ee08a845f73d29788cf035c3145b21ab344d8062ea9400000"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "0fb9ba52b1f09445f1e3a7508d59f0797923acf744fbe2da303fb06da859ee87"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "72b5d2051d300b10b74314b7e25ace9998ca66eb2c7fbc10ef130dd67028293c"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "a140fd3d05766f0087d57bf99df05731e894392ffcc8e8d7e960ba73c09824aa"
+                    )),
+                    SolPubkey(hex_literal::hex!(
+                        "a1e031c8bc9bec3b610cf7b36eb3bf3aa40237c9e5be2c7893878578439eb00b"
+                    )),
+                ],
+                recent_blockhash: SolHash(hex_literal::hex!(
+                    "f7f02ac4729abaa97c01aa6526ba909c3bcb16c7f47c7e13dfdc5a1b15f647b4"
+                ))
+                .into(),
+                instructions: vec![
+                    CompiledInstruction {
+                        program_id_index: 7,
+                        accounts: hex_literal::hex!("030900").to_vec(),
+                        data: hex_literal::hex!("04000000").to_vec(),
+                    },
+                    CompiledInstruction {
+                        program_id_index: 8,
+                        accounts: vec![],
+                        data: hex_literal::hex!("030a00000000000000").to_vec(),
+                    },
+                    CompiledInstruction {
+                        program_id_index: 8,
+                        accounts: vec![],
+                        data: hex_literal::hex!("0233620100").to_vec(),
+                    },
+                    CompiledInstruction {
+                        program_id_index: 12,
+                        accounts: hex_literal::hex!("0e00040507").to_vec(),
+                        data: hex_literal::hex!("8e24658f6c59298c080000000100000000000000ff").to_vec(),
+                    },
+                    CompiledInstruction {
+                        program_id_index: 12,
+                        accounts: hex_literal::hex!("0e000d01020b0a0607").to_vec(),
+                        data: hex_literal::hex!("494710642cb0c646080000000200000000000000ff06").to_vec(),
+                    },
+                ],
+            },
+        };
+
+		old::AwaitingBroadcast::insert(
+			22,
+			old::SolanaBroadcastData {
+				broadcast_id: 22,
+				transaction_payload: tx,
+				threshold_signature_payload: SolMessage::default(),
+				transaction_out_id: SolSignature::default(),
+				nominee: Some(AccountId32::from([11; 32])),
+			},
+		);
+
+		#[cfg(feature = "try-runtime")]
+		let state = SerializeSolanaBroadcastMigration::pre_upgrade().unwrap();
+		SerializeSolanaBroadcastMigration::on_runtime_upgrade();
+		#[cfg(feature = "try-runtime")]
+		SerializeSolanaBroadcastMigration::post_upgrade(state).unwrap();
+
+		let expected_serialized_tx = hex_literal::hex!("01d1144b223b6b600de4b2d96bdceb03573a3e9781953e4c668c57e505f017859d96543243b4d904dc2f02f2f5ab5db7ba4551c7e015e64078add4674ac2e7460c0100080f2e8944a76efbece296221e736627f4528a947578263a1172a9786410702d2ef222020a74fd97df45db96d2bbf4e485ccbec56945155ff8f668856be26c9de4a979c03bceb9ddea819e956b2b332e87fbbf49fc8968df78488e88cfaa366f30368cd28baa84f2067bbdf24513c2d44e44bf408f2e6da6e60762e3faa4a62a0adb8d9871ed5fb2ee05765af23b7cabcc0d6b08ed370bb9f616a0d4dea40a25f870b5b9d633289c8fd72fb05f33349bf4cc44e82add5d865311ae346d7c9a67b7ddf53a2f4350451db5595a75e231519bc2758798f72550e57487722e7cbe954dbc00000000000000000000000000000000000000000000000000000000000000000306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006a7d517192c568ee08a845f73d29788cf035c3145b21ab344d8062ea940000006ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a90fb9ba52b1f09445f1e3a7508d59f0797923acf744fbe2da303fb06da859ee8772b5d2051d300b10b74314b7e25ace9998ca66eb2c7fbc10ef130dd67028293ca140fd3d05766f0087d57bf99df05731e894392ffcc8e8d7e960ba73c09824aaa1e031c8bc9bec3b610cf7b36eb3bf3aa40237c9e5be2c7893878578439eb00bf7f02ac4729abaa97c01aa6526ba909c3bcb16c7f47c7e13dfdc5a1b15f647b40507030309000404000000080009030a0000000000000008000502336201000c050e00040507158e24658f6c59298c080000000100000000000000ff0c090e000d01020b0a060716494710642cb0c646080000000200000000000000ff06").to_vec();
+
+		let mut broadcast_iter =
+			pallet_cf_broadcast::AwaitingBroadcast::<Runtime, SolanaInstance>::iter();
+		let (first_broadcast_id, first_broadcast_data) = broadcast_iter.next().unwrap();
+		assert!(broadcast_iter.next().is_none());
+
+		assert_eq!(first_broadcast_id, 22);
+		assert_eq!(
+			first_broadcast_data,
+			BroadcastData {
+				broadcast_id: 22,
+				transaction_payload: SolanaTransactionData {
+					serialized_transaction: expected_serialized_tx,
+				},
+				threshold_signature_payload: SolMessage::default(),
+				transaction_out_id: SolSignature::default(),
+				nominee: Some(AccountId32::from([11; 32])),
+			}
+		);
+	});
+}

--- a/state-chain/cfe-events/src/tests.rs
+++ b/state-chain/cfe-events/src/tests.rs
@@ -8,7 +8,7 @@ use cf_chains::{
 	evm::{self, Address, ParityBit, H256},
 	sol::{
 		sol_tx_core::{CompiledInstruction, MessageHeader},
-		RawSolHash, SolMessage, SolPubkey, SolTransaction,
+		RawSolHash, SolMessage, SolPubkey, SolTransaction, SolanaTransactionData,
 	},
 };
 use cf_primitives::AccountId;
@@ -179,7 +179,7 @@ fn event_decoding() {
 		check_encoding(CfeEvent::SolTxBroadcastRequest(TxBroadcastRequest {
 				broadcast_id: 1,
 				nominee: AccountId::from([1; 32]),
-				payload: SolTransaction {
+				payload: SolanaTransactionData{ serialized_transaction: (SolTransaction {
 					signatures: vec![[9u8; 64].into()],
 					message: SolMessage {
 						header: MessageHeader {
@@ -195,8 +195,9 @@ fn event_decoding() {
 							data: vec![31,41,51,61]
 						}],
 					},
-				},
-			}), "0f0100000001010101010101010101010101010101010101010101010101010101010101010409090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909020202040a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b04020401101f29333d");
+				}).finalize_and_serialize().unwrap()
+			}
+			}), "0f01000000010101010101010101010101010101010101010101010101010101010101010139020109090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909090909020202010a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b01020101041f29333d");
 	}
 
 	// P2P registration/deregistration

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -45,6 +45,11 @@ pub const CCM_BYTES_PER_ACCOUNT: usize = 33usize;
 pub const MAX_CCM_BYTES_SOL: usize = MAX_TRANSACTION_LENGTH - 527usize; // 705 bytes left
 pub const MAX_CCM_BYTES_USDC: usize = MAX_TRANSACTION_LENGTH - 740usize; // 492 bytes left
 
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq)]
+pub struct SolanaTransactionData {
+	pub serialized_transaction: Vec<u8>,
+}
+
 impl Chain for Solana {
 	const NAME: &'static str = "Solana";
 	const GAS_ASSET: Self::ChainAsset = assets::sol::Asset::Sol;
@@ -63,7 +68,7 @@ impl Chain for Solana {
 	type DepositFetchId = SolanaDepositFetchId;
 	type DepositChannelState = AccountBump;
 	type DepositDetails = ();
-	type Transaction = SolTransaction;
+	type Transaction = SolanaTransactionData;
 	type TransactionMetadata = ();
 	// There is no need for replay protection on Solana since it uses blockhashes.
 	type ReplayProtectionParams = ();

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -8,7 +8,7 @@ use sol_prim::{AccountBump, SlotNumber};
 
 use crate::{address, assets, DepositChannel, FeeEstimationApi, FeeRefundCalculator, TypeInfo};
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
-use frame_support::Parameter;
+use frame_support::{sp_runtime::RuntimeDebug, Parameter};
 use serde::{Deserialize, Serialize};
 use sp_runtime::traits::Member;
 
@@ -222,7 +222,7 @@ impl FeeEstimationApi<Solana> for SolTrackedData {
 	}
 }
 
-impl FeeRefundCalculator<Solana> for SolTransaction {
+impl FeeRefundCalculator<Solana> for SolanaTransactionData {
 	fn return_fee_refund(
 		&self,
 		fee_paid: <Solana as Chain>::TransactionFee,

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -45,6 +45,7 @@ pub const CCM_BYTES_PER_ACCOUNT: usize = 33usize;
 pub const MAX_CCM_BYTES_SOL: usize = MAX_TRANSACTION_LENGTH - 527usize; // 705 bytes left
 pub const MAX_CCM_BYTES_USDC: usize = MAX_TRANSACTION_LENGTH - 740usize; // 492 bytes left
 
+// Use serialized transaction
 #[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, Default, PartialEq, Eq)]
 pub struct SolanaTransactionData {
 	pub serialized_transaction: Vec<u8>,

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -1,3 +1,4 @@
+use cf_runtime_utilities::log_or_panic;
 use codec::{Decode, Encode};
 use core::marker::PhantomData;
 use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
@@ -5,7 +6,6 @@ use scale_info::TypeInfo;
 use sol_prim::consts::SOL_USDC_DECIMAL;
 use sp_core::RuntimeDebug;
 use sp_std::{boxed::Box, vec, vec::Vec};
-use cf_runtime_utilities::log_or_panic;
 
 use crate::{
 	ccm_checker::{
@@ -390,7 +390,8 @@ impl<Env: 'static> ApiCall<SolanaCrypto> for SolanaApi<Env> {
 	fn chain_encoded(&self) -> Vec<u8> {
 		self.transaction.clone().finalize_and_serialize().unwrap_or_else(|err| {
 			log_or_panic!(
-				"Failed to serialize Solana Transaction {:?}.",
+				"Failed to serialize Solana Transaction {:?}. Error: {:?}",
+				self.transaction,
 				err
 			);
 			Vec::default()

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -5,7 +5,7 @@ use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 use scale_info::TypeInfo;
 use sol_prim::consts::SOL_USDC_DECIMAL;
 use sp_core::RuntimeDebug;
-use sp_std::{boxed::Box, vec, vec::Vec};
+use sp_std::{vec, vec::Vec};
 
 use crate::{
 	ccm_checker::{

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -4,7 +4,8 @@ use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 use scale_info::TypeInfo;
 use sol_prim::consts::SOL_USDC_DECIMAL;
 use sp_core::RuntimeDebug;
-use sp_std::{vec, vec::Vec};
+use sp_std::{boxed::Box, vec, vec::Vec};
+use cf_runtime_utilities::log_or_panic;
 
 use crate::{
 	ccm_checker::{
@@ -387,7 +388,13 @@ impl<Env: 'static> ApiCall<SolanaCrypto> for SolanaApi<Env> {
 	}
 
 	fn chain_encoded(&self) -> Vec<u8> {
-		self.transaction.clone().finalize_and_serialize().unwrap_or_default()
+		self.transaction.clone().finalize_and_serialize().unwrap_or_else(|err| {
+			log_or_panic!(
+				"Failed to serialize Solana Transaction {:?}.",
+				err
+			);
+			Vec::default()
+		})
 	}
 
 	fn is_signed(&self) -> bool {

--- a/state-chain/chains/src/sol/benchmarking.rs
+++ b/state-chain/chains/src/sol/benchmarking.rs
@@ -35,7 +35,7 @@ impl BenchmarkValue for SolMessage {
 impl BenchmarkValue for SolanaTransactionData {
 	fn benchmark_value() -> Self {
 		SolanaTransactionData {
-			serialized_transaction: SolTransaction::new_unsigned(SolMessage::benchmark_value())
+			serialized_transaction: SolTransaction::benchmark_value()
 				.finalize_and_serialize()
 				.expect("Failed to serialize payload"),
 		}

--- a/state-chain/chains/src/sol/benchmarking.rs
+++ b/state-chain/chains/src/sol/benchmarking.rs
@@ -2,6 +2,7 @@
 
 use super::{
 	api::SolanaApi, SolAddress, SolHash, SolMessage, SolSignature, SolTrackedData, SolTransaction,
+	SolanaTransactionData,
 };
 
 use crate::benchmarking_value::{BenchmarkValue, BenchmarkValueExtended};
@@ -31,9 +32,13 @@ impl BenchmarkValue for SolMessage {
 	}
 }
 
-impl BenchmarkValue for SolTransaction {
+impl BenchmarkValue for SolanaTransactionData {
 	fn benchmark_value() -> Self {
-		SolTransaction::new_unsigned(SolMessage::benchmark_value())
+		SolanaTransactionData {
+			serialized_transaction: SolTransaction::new_unsigned(SolMessage::benchmark_value())
+				.finalize_and_serialize()
+				.expect("Failed to serialize payload"),
+		}
 	}
 }
 

--- a/state-chain/chains/src/sol/benchmarking.rs
+++ b/state-chain/chains/src/sol/benchmarking.rs
@@ -32,6 +32,12 @@ impl BenchmarkValue for SolMessage {
 	}
 }
 
+impl BenchmarkValue for SolTransaction {
+	fn benchmark_value() -> Self {
+		SolTransaction::new_unsigned(SolMessage::benchmark_value())
+	}
+}
+
 impl BenchmarkValue for SolanaTransactionData {
 	fn benchmark_value() -> Self {
 		SolanaTransactionData {

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -56,7 +56,7 @@ pub enum PalletOffence {
 	FailedToBroadcastTransaction,
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(6);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/state-chain/pallets/cf-cfe-interface/src/migrations.rs
+++ b/state-chain/pallets/cf-cfe-interface/src/migrations.rs
@@ -1,4 +1,36 @@
-use crate::Pallet;
 use cf_runtime_upgrade_utilities::PlaceholderMigration;
 
+use crate::{Config, Pallet};
+use frame_support::traits::OnRuntimeUpgrade;
+#[cfg(feature = "try-runtime")]
+use frame_support::{pallet_prelude::DispatchError, sp_runtime};
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
 pub type PalletMigration<T> = PlaceholderMigration<Pallet<T>, 0>;
+
+// This migration should only be run at the start of all migrations, in case another migration
+// needs to trigger an event like a Broadcast for example
+pub struct ClearEvents<T: Config>(sp_std::marker::PhantomData<T>);
+
+impl<T: Config> OnRuntimeUpgrade for ClearEvents<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+		Ok(Default::default())
+	}
+
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		crate::CfeEvents::<T>::kill();
+		frame_support::weights::Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		frame_support::ensure!(
+			crate::CfeEvents::<T>::get().is_empty(),
+			"CfeEvents is not empty after upgrade."
+		);
+
+		Ok(())
+	}
+}

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -339,11 +339,7 @@ impl TransactionBuilder<Solana, SolanaApi<SolEnvironment>> for SolanaTransaction
 		signed_call: &SolanaApi<SolEnvironment>,
 	) -> <Solana as Chain>::Transaction {
 		SolanaTransactionData {
-			serialized_transaction: signed_call
-				.transaction
-				.clone()
-				.finalize_and_serialize()
-				.expect("Failed to serialize payload"),
+			serialized_transaction: signed_call.chain_encoded(),
 		}
 	}
 

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -338,11 +338,13 @@ impl TransactionBuilder<Solana, SolanaApi<SolEnvironment>> for SolanaTransaction
 	fn build_transaction(
 		signed_call: &SolanaApi<SolEnvironment>,
 	) -> <Solana as Chain>::Transaction {
-		signed_call
-			.transaction
-			.clone()
-			.finalize_and_serialize()
-			.expect("Failed to serialize payload")
+		SolanaTransactionData {
+			serialized_transaction: signed_call
+				.transaction
+				.clone()
+				.finalize_and_serialize()
+				.expect("Failed to serialize payload"),
+		}
 	}
 
 	fn refresh_unsigned_data(_tx: &mut <Solana as Chain>::Transaction) {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -52,7 +52,7 @@ use cf_chains::{
 			AllNonceAccounts, ApiEnvironment, ComputePrice, CurrentAggKey, DurableNonce,
 			DurableNonceAndAccount, RecoverDurableNonce, SolanaApi, SolanaEnvironment,
 		},
-		SolAddress, SolAmount, SolApiEnvironment, SolanaCrypto,
+		SolAddress, SolAmount, SolApiEnvironment, SolanaCrypto, SolanaTransactionData,
 	},
 	AnyChain, ApiCall, Arbitrum, CcmChannelMetadata, CcmDepositMetadata, Chain, ChainCrypto,
 	ChainEnvironment, ChainState, ChannelRefundParameters, DepositChannel, ForeignChain,

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -338,9 +338,7 @@ impl TransactionBuilder<Solana, SolanaApi<SolEnvironment>> for SolanaTransaction
 	fn build_transaction(
 		signed_call: &SolanaApi<SolEnvironment>,
 	) -> <Solana as Chain>::Transaction {
-		SolanaTransactionData {
-			serialized_transaction: signed_call.chain_encoded(),
-		}
+		SolanaTransactionData { serialized_transaction: signed_call.chain_encoded() }
 	}
 
 	fn refresh_unsigned_data(_tx: &mut <Solana as Chain>::Transaction) {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -338,7 +338,11 @@ impl TransactionBuilder<Solana, SolanaApi<SolEnvironment>> for SolanaTransaction
 	fn build_transaction(
 		signed_call: &SolanaApi<SolEnvironment>,
 	) -> <Solana as Chain>::Transaction {
-		signed_call.transaction.clone()
+		signed_call
+			.transaction
+			.clone()
+			.finalize_and_serialize()
+			.expect("Failed to serialize payload")
 	}
 
 	fn refresh_unsigned_data(_tx: &mut <Solana as Chain>::Transaction) {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1205,6 +1205,8 @@ type AllMigrations = (
 	pallet_cf_environment::migrations::VersionUpdate<Runtime>,
 	PalletMigrations,
 	MigrationsForV1_7,
+	migrations::housekeeping::Migration,
+	migrations::reap_old_accounts::Migration,
 );
 
 /// All the pallet-specific migrations and migrations that depend on pallet migration order. Do not
@@ -1247,8 +1249,6 @@ type PalletMigrations = (
 );
 
 type MigrationsForV1_7 = (
-	migrations::housekeeping::Migration,
-	migrations::reap_old_accounts::Migration,
 	// Only the Solana Transaction type has changed
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, SolanaInstance>,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -19,6 +19,7 @@ use crate::{
 		},
 		Offence,
 	},
+	migrations::serialize_solana_broadcast::{NoopUpgrade, SerializeSolanaBroadcastMigration},
 	monitoring_apis::{
 		AuthoritiesInfo, BtcUtxos, EpochState, ExternalChainsBlockHeight, FeeImbalance, FlipSupply,
 		LastRuntimeUpgradeInfo, MonitoringData, OpenDepositChannels, PendingBroadcasts,
@@ -51,6 +52,7 @@ use cf_chains::{
 	TransactionBuilder,
 };
 use cf_primitives::{BroadcastId, EpochIndex, NetworkEnvironment, STABLE_ASSET};
+use cf_runtime_upgrade_utilities::VersionedMigration;
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, DummyEgressSuccessWitnesser,
 	DummyIngressSource, GetBlockHeight, NoLimit, SwapLimits, SwapLimitsProvider,
@@ -1189,11 +1191,15 @@ pub type PalletExecutionOrder = (
 );
 
 /// Contains:
+/// - ClearEvents in CfeInterface migration. Don't remove this.
 /// - The VersionUpdate migration. Don't remove this.
 /// - Individual pallet migrations. Don't remove these unless there's a good reason. Prefer to
 ///   disable these at the pallet level (ie. set it to () or PhantomData).
 /// - Release-specific migrations: remove these if they are no longer needed.
 type AllMigrations = (
+	// This ClearEvents should only be run at the start of all migrations. This is in case another
+	// migration needs to trigger an event like a Broadcast for example.
+	pallet_cf_cfe_interface::migrations::ClearEvents<Runtime>,
 	// DO NOT REMOVE `VersionUpdate`. THIS IS REQUIRED TO UPDATE THE VERSION FOR THE CFES EVERY
 	// UPGRADE
 	pallet_cf_environment::migrations::VersionUpdate<Runtime>,
@@ -1240,8 +1246,21 @@ type PalletMigrations = (
 	pallet_cf_cfe_interface::migrations::PalletMigration<Runtime>,
 );
 
-type MigrationsForV1_7 =
-	(migrations::housekeeping::Migration, migrations::reap_old_accounts::Migration);
+type MigrationsForV1_7 = (
+	migrations::housekeeping::Migration,
+	migrations::reap_old_accounts::Migration,
+	// Only the Solana Transaction type has changed
+	VersionedMigration<
+		pallet_cf_broadcast::Pallet<Runtime, SolanaInstance>,
+		SerializeSolanaBroadcastMigration,
+		6,
+		7,
+	>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, EthereumInstance>, NoopUpgrade, 6, 7>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 6, 7>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 6, 7>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 6, 7>,
+);
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -2,3 +2,4 @@
 
 pub mod housekeeping;
 pub mod reap_old_accounts;
+pub mod serialize_solana_broadcast;

--- a/state-chain/runtime/src/migrations/serialize_solana_broadcast.rs
+++ b/state-chain/runtime/src/migrations/serialize_solana_broadcast.rs
@@ -1,0 +1,85 @@
+use frame_support::traits::OnRuntimeUpgrade;
+use pallet_cf_broadcast::BroadcastData;
+
+use crate::*;
+use frame_support::pallet_prelude::Weight;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::DispatchError;
+
+use cf_chains::sol::{SolTransaction, SolanaTransactionData};
+use codec::{Decode, Encode};
+
+pub mod old {
+	use cf_chains::sol::{SolMessage, SolSignature};
+	use cf_primitives::BroadcastId;
+	use frame_support::{pallet_prelude::OptionQuery, Twox64Concat};
+
+	use super::*;
+
+	#[derive(PartialEq, Eq, Encode, Decode)]
+	pub struct SolanaBroadcastData {
+		pub broadcast_id: BroadcastId,
+		pub transaction_payload: SolTransaction,
+		pub threshold_signature_payload: SolMessage,
+		pub transaction_out_id: SolSignature,
+		pub nominee: Option<<Runtime as frame_system::Config>::AccountId>,
+	}
+
+	#[frame_support::storage_alias]
+	pub type AwaitingBroadcast =
+		StorageMap<SolanaBroadcaster, Twox64Concat, BroadcastId, SolanaBroadcastData, OptionQuery>;
+}
+
+pub struct SerializeSolanaBroadcastMigration;
+
+// Tests for this migration are in:
+// state-chain/cf-integration-tests/src/migrations/serialize_solana_broadcast.rs
+impl OnRuntimeUpgrade for SerializeSolanaBroadcastMigration {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok((old::AwaitingBroadcast::iter().count() as u64).encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		pallet_cf_broadcast::AwaitingBroadcast::<Runtime, SolanaInstance>::translate_values::<
+			old::SolanaBroadcastData,
+			_,
+		>(|old_sol_broadcast_data| {
+			Some(BroadcastData::<Runtime, SolanaInstance> {
+				broadcast_id: old_sol_broadcast_data.broadcast_id,
+				transaction_payload: SolanaTransactionData {
+					serialized_transaction: old_sol_broadcast_data
+						.transaction_payload
+						.finalize_and_serialize()
+						.ok()?,
+				},
+				threshold_signature_payload: old_sol_broadcast_data.threshold_signature_payload,
+				transaction_out_id: old_sol_broadcast_data.transaction_out_id,
+				nominee: old_sol_broadcast_data.nominee,
+			})
+		});
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let pre_awaiting_broadcast_count = <u64>::decode(&mut state.as_slice())
+			.map_err(|_| DispatchError::from("Failed to decode state"))?;
+
+		let post_awaiting_broadcast_count =
+			pallet_cf_broadcast::AwaitingBroadcast::<Runtime, SolanaInstance>::iter().count()
+				as u64;
+
+		assert_eq!(pre_awaiting_broadcast_count, post_awaiting_broadcast_count);
+		Ok(())
+	}
+}
+
+pub struct NoopUpgrade;
+
+impl OnRuntimeUpgrade for NoopUpgrade {
+	fn on_runtime_upgrade() -> Weight {
+		Weight::zero()
+	}
+}


### PR DESCRIPTION
Closes: PRO-1634

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Use serialized data as the transaction passed to the engine instead of the regular transaction. The regular transaction is quite annoying/difficult to serialize into the raw transaction in case it needs to be broadcasted manually