### PR TITLE
chore: Cleanup DispatchError that contains strings

### DIFF
--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -96,9 +96,12 @@ impl<E> TransferFallback<Arbitrum> for ArbitrumApi<E>
 where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
-	fn new_unsigned(transfer_param: TransferAssetParams<Arbitrum>) -> Result<Self, DispatchError> {
+	fn new_unsigned(
+		transfer_param: TransferAssetParams<Arbitrum>,
+	) -> Result<Self, TransferFallbackError> {
 		let transfer_param = EncodableTransferAssetParams {
-			asset: E::token_address(transfer_param.asset).ok_or(DispatchError::CannotLookup)?,
+			asset: E::token_address(transfer_param.asset)
+				.ok_or(TransferFallbackError::CannotLookupTokenAddress)?,
 			to: transfer_param.to,
 			amount: transfer_param.amount,
 		};

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -148,8 +148,10 @@ impl<E: ReplayProtectionProvider<Bitcoin>> ExecutexSwapAndCall<Bitcoin> for Bitc
 
 // transfer_fallback is unsupported for Bitcoin.
 impl<E: ReplayProtectionProvider<Bitcoin>> TransferFallback<Bitcoin> for BitcoinApi<E> {
-	fn new_unsigned(_transfer_param: TransferAssetParams<Bitcoin>) -> Result<Self, DispatchError> {
-		Err(DispatchError::Other("Bitcoin's TransferFallback is not supported."))
+	fn new_unsigned(
+		_transfer_param: TransferAssetParams<Bitcoin>,
+	) -> Result<Self, TransferFallbackError> {
+		Err(TransferFallbackError::Unsupported)
 	}
 }
 

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -138,8 +138,10 @@ impl<E> TransferFallback<Polkadot> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(_transfer_param: TransferAssetParams<Polkadot>) -> Result<Self, DispatchError> {
-		Err(DispatchError::Other("TransferFallback is not supported for the Polkadot chain."))
+	fn new_unsigned(
+		_transfer_param: TransferAssetParams<Polkadot>,
+	) -> Result<Self, TransferFallbackError> {
+		Err(TransferFallbackError::Unsupported)
 	}
 }
 

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -220,9 +220,12 @@ impl<E> TransferFallback<Ethereum> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(transfer_param: TransferAssetParams<Ethereum>) -> Result<Self, DispatchError> {
+	fn new_unsigned(
+		transfer_param: TransferAssetParams<Ethereum>,
+	) -> Result<Self, TransferFallbackError> {
 		let transfer_param = EncodableTransferAssetParams {
-			asset: E::token_address(transfer_param.asset).ok_or(DispatchError::CannotLookup)?,
+			asset: E::token_address(transfer_param.asset)
+				.ok_or(TransferFallbackError::CannotLookupTokenAddress)?,
 			to: transfer_param.to,
 			amount: transfer_param.amount,
 		};

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -500,6 +500,9 @@ pub enum AllBatchError {
 	/// Unable to select Utxos.
 	UtxoSelectionFailed,
 
+	/// Failed to build Solana transaction.
+	FailedToBuildSolanaTransaction(SolanaTransactionBuildingError),
+
 	/// Some other DispatchError occurred.
 	DispatchError(DispatchError),
 }
@@ -548,8 +551,15 @@ pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
 	) -> Result<Self, ExecutexSwapAndCallError>;
 }
 
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]
+pub enum TransferFallbackError {
+	/// The chain does not support this functionality.
+	Unsupported,
+	/// Failed to lookup the given token address, so the asset is invalid.
+	CannotLookupTokenAddress,
+}
 pub trait TransferFallback<C: Chain>: ApiCall<C::ChainCrypto> {
-	fn new_unsigned(transfer_param: TransferAssetParams<C>) -> Result<Self, DispatchError>;
+	fn new_unsigned(transfer_param: TransferAssetParams<C>) -> Result<Self, TransferFallbackError>;
 }
 
 pub trait FeeRefundCalculator<C: Chain> {

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -421,16 +421,6 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
-		/// DEPRECATED. This call is no longer used.
-		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::transaction_failed())]
-		pub fn transaction_signing_failure(
-			_origin: OriginFor<T>,
-			_broadcast_attempt_id: (BroadcastId, AttemptCount),
-		) -> DispatchResultWithPostInfo {
-			Err(DispatchError::Other("Deprecated").into())
-		}
-
 		/// A callback to be used when a threshold signature request completes. Retrieves the
 		/// requested signature, uses the configured [TransactionBuilder] to build the transaction.
 		/// Initiates the broadcast sequence if `should_broadcast` is set to true, otherwise insert

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -110,6 +110,8 @@ pub mod pallet {
 		EthAddressNotUpdateable,
 		/// The nonce account is currently not being used or does not exist.
 		NonceAccountNotBeingUsedOrDoesNotExist,
+		/// The given UTXO parameters are invalid.
+		InvalidUtxoParameters,
 	}
 
 	#[pallet::pallet]
@@ -379,7 +381,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			T::EnsureGovernance::ensure_origin(origin)?;
 
-			ensure!(params.are_valid(), DispatchError::Other("Invalid parameters"));
+			ensure!(params.are_valid(), Error::<T>::InvalidUtxoParameters);
 
 			ConsolidationParameters::<T>::set(params);
 

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -560,22 +560,6 @@ pub mod pallet {
 			Ok(().into())
 		}
 
-		/// This call is now deprecated.
-		/// The functionality has been moved to the Validator pallet
-		#[pallet::call_index(4)]
-		#[pallet::weight(Weight::from_parts(0, 0))]
-		pub fn stop_bidding(_origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			Err(DispatchError::Other("Deprecated").into())
-		}
-
-		/// This call is now deprecated.
-		/// The functionality has been moved to the Validator pallet
-		#[pallet::call_index(5)]
-		#[pallet::weight(Weight::from_parts(0, 0))]
-		pub fn start_bidding(_origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			Err(DispatchError::Other("Deprecated").into())
-		}
-
 		/// Updates the minimum funding required for an account, the extrinsic is gated with
 		/// governance.
 		///

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -918,10 +918,10 @@ pub mod pallet {
 				},
 				// The only way this can fail is if the target chain is unsupported, which should
 				// never happen.
-				Err(_) => {
+				Err(err) => {
 					log_or_panic!(
-						"Failed to construct TransferFallback call. Asset: {:?}, amount: {:?}, Destination: {:?}",
-						asset, amount, destination_address
+						"Failed to construct TransferFallback call. Asset: {:?}, amount: {:?}, Destination: {:?}, Error: {:?}",
+						asset, amount, destination_address, err
 					);
 				},
 			};

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -731,7 +731,7 @@ fn test_expect_validator_register_fails() {
 		// Trying to register again passes the funding check but fails for other reasons.
 		assert_noop!(
 			Pallet::<Test>::register_as_validator(RuntimeOrigin::signed(ID)),
-			DispatchError::Other("Account already registered")
+			cf_traits::mocks::account_role_registry::ALREADY_REGISTERED_ERROR,
 		);
 	});
 }

--- a/state-chain/traits/src/mocks/account_role_registry.rs
+++ b/state-chain/traits/src/mocks/account_role_registry.rs
@@ -1,7 +1,7 @@
 use super::{MockPallet, MockPalletStorage};
 use crate::AccountRoleRegistry;
 use cf_primitives::AccountRole;
-use frame_support::sp_runtime::DispatchResult;
+use frame_support::{pallet_prelude::DispatchError, sp_runtime::DispatchResult};
 use frame_system::{ensure_signed, Config};
 
 pub struct MockAccountRoleRegistry;
@@ -11,6 +11,8 @@ impl MockPallet for MockAccountRoleRegistry {
 }
 
 const ACCOUNT_ROLES: &[u8] = b"AccountRoles";
+pub const ALREADY_REGISTERED_ERROR: DispatchError =
+	DispatchError::Other("Account already registered");
 
 impl<T: Config> AccountRoleRegistry<T> for MockAccountRoleRegistry {
 	fn register_account_role(
@@ -20,7 +22,7 @@ impl<T: Config> AccountRoleRegistry<T> for MockAccountRoleRegistry {
 		if <Self as MockPalletStorage>::get_storage::<_, AccountRole>(ACCOUNT_ROLES, account_id)
 			.is_some()
 		{
-			return Err("Account already registered".into())
+			return Err(ALREADY_REGISTERED_ERROR)
 		}
 		<Self as MockPalletStorage>::put_storage(ACCOUNT_ROLES, account_id, role);
 		Ok(())

--- a/state-chain/traits/src/mocks/api_call.rs
+++ b/state-chain/traits/src/mocks/api_call.rs
@@ -4,7 +4,7 @@ use cf_chains::{
 	btc::BitcoinCrypto, evm::EvmCrypto, AllBatch, AllBatchError, ApiCall, Bitcoin, Chain,
 	ChainCrypto, ChainEnvironment, ConsolidationError, Ethereum, ExecutexSwapAndCall,
 	ExecutexSwapAndCallError, FetchAssetParams, ForeignChainAddress, TransferAssetParams,
-	TransferFallback,
+	TransferFallback, TransferFallbackError,
 };
 use cf_primitives::{chains::assets, EgressId, ForeignChain};
 use codec::{Decode, Encode};
@@ -175,9 +175,11 @@ pub struct MockEthTransferFallback<MockEvmEnvironment> {
 }
 
 impl TransferFallback<Ethereum> for MockEthereumApiCall<MockEvmEnvironment> {
-	fn new_unsigned(transfer_param: TransferAssetParams<Ethereum>) -> Result<Self, DispatchError> {
+	fn new_unsigned(
+		transfer_param: TransferAssetParams<Ethereum>,
+	) -> Result<Self, TransferFallbackError> {
 		if MockEvmEnvironment::lookup(transfer_param.asset).is_none() {
-			Err(DispatchError::CannotLookup)
+			Err(TransferFallbackError::CannotLookupTokenAddress)
 		} else {
 			Ok(Self::TransferFallback(MockEthTransferFallback {
 				nonce: Default::default(),
@@ -259,8 +261,10 @@ pub struct MockBtcTransferFallback<MockBtcEnvironment> {
 }
 
 impl TransferFallback<Bitcoin> for MockBitcoinApiCall<MockBtcEnvironment> {
-	fn new_unsigned(_transfer_param: TransferAssetParams<Bitcoin>) -> Result<Self, DispatchError> {
-		Err(DispatchError::CannotLookup)
+	fn new_unsigned(
+		_transfer_param: TransferAssetParams<Bitcoin>,
+	) -> Result<Self, TransferFallbackError> {
+		Err(TransferFallbackError::Unsupported)
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1617

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Cleaned up strings used in DispatchError::Others. Refactored them into named errors if appropriate.
Removed deprecated extrinsics.