### PR TITLE
fix: CcmFailed event erased due to storage rollback

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -978,7 +978,7 @@ pub mod pallet {
 			let destination_address_internal =
 				Self::validate_destination_address(&destination_address, destination_asset)?;
 
-			Self::init_swap_request(
+			if Self::init_swap_request(
 				source_asset,
 				deposit_amount,
 				destination_asset,
@@ -992,7 +992,11 @@ pub mod pallet {
 				// NOTE: DCA not yet supported for swaps from the contract
 				None,
 				SwapOrigin::Vault { tx_hash },
-			)?;
+			)
+			.is_err()
+			{
+				log::error!("Ccm failed. Check `CcmFailed` event.");
+			}
 
 			Ok(())
 		}
@@ -2218,7 +2222,7 @@ pub mod pallet {
 									swap_request_id: request_id,
 								});
 
-								return Err(DispatchError::Other("Invalid CCM parameters"));
+								return Err(Error::<T>::InvalidCcm.into());
 							},
 						};
 

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -2658,7 +2658,7 @@ fn failed_ccm_deposit_can_deposit_event() {
 		let ccm = generate_ccm_deposit();
 
 		let destination_address = EncodedAddress::Dot(Default::default());
-		// Expect to panic with invalid CCM.
+
 		assert_ok!(Swapping::ccm_deposit(
 			RuntimeOrigin::root(),
 			Asset::Btc,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1628

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Fixed a bug where `CcmFailed` event is erased due to storage rollback