### PR TITLE
feat: support use of zepter for feature checks

### DIFF
--- a/.zepter.yaml
+++ b/.zepter.yaml
@@ -45,7 +45,7 @@ workflows:
 # Will be displayed when any workflow fails:
 help:
   text: |
-    It looks like one more more Zetper feature checks failed; please check the console output.
+    It looks like one more more Zepter feature checks failed; please check the console output.
     You can try to automatically address them by running `zepter`.
   links:
     - "https://github.com/paritytech/polkadot-sdk/issues/1831"

--- a/.zepter.yaml
+++ b/.zepter.yaml
@@ -1,0 +1,48 @@
+# Configuration for the Zepter CLI to ensure correct feature configuration in the Rust workspace.
+# <https://crates.io/crates/zepter>
+
+version:
+  # File format for parsing it:
+  format: 1
+  # Minimum version of the binary that is expected to work. This is just for printing a nice error
+  # message when someone tries to use an older version.
+  binary: 0.13.2
+
+# The examples in this file assume crate `A` to have a dependency on crate `B`.
+workflows:
+  # Check that everything is good without modifying anything:
+  check:
+    - [
+        "lint",
+        # Check that `A` activates the features of `B`.
+        "propagate-feature",
+        # These are the features to check:
+        "--features=try-runtime,runtime-benchmarks,std",
+        # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
+        "--left-side-feature-missing=ignore",
+        # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.
+        "--left-side-outside-workspace=ignore",
+        # Some features imply that they activate a specific dependency as non-optional. Otherwise the default behaviour with a `?` is used.
+        "--feature-enables-dep=try-runtime:frame-try-runtime,runtime-benchmarks:frame-benchmarking",
+        # Show the paths of failed crates to have them clickable in the terminal: 
+        "--show-path",
+        # Aux
+        "--offline",
+        "--locked",
+        "--quiet",
+      ]
+      # Format the features into canonical format:
+    - ["format", "features", "--offline", "--locked", "--quiet"]
+  # Same as `check`, but actually fix the issues instead of just reporting them:
+  default:
+    - [$check.0, "--fix"]
+    - [$check.1, "--fix"]
+
+# Will be displayed when any workflow fails:
+help:
+  text: |
+    It looks like one more more Zetper feature checks failed; please check the console output.
+    You can try to automatically address them by running `zepter`.
+  links:
+    - "https://github.com/paritytech/polkadot-sdk/issues/1831"
+    - "https://github.com/ggwpez/zepter"

--- a/.zepter.yaml
+++ b/.zepter.yaml
@@ -1,5 +1,9 @@
 # Configuration for the Zepter CLI to ensure correct feature configuration in the Rust workspace.
 # <https://crates.io/crates/zepter>
+#
+# `cargo install zepter -f --locked` to install the CLI.
+#
+# Then `zepter check` to check the workspace and `zepter` to fix the issues.
 
 version:
   # File format for parsing it:

--- a/.zepter.yaml
+++ b/.zepter.yaml
@@ -12,7 +12,7 @@ version:
   # message when someone tries to use an older version.
   binary: 0.13.2
 
-# The examples in this file assume crate `A` to have a dependency on crate `B`.
+# The explanatory comments in this file assume crate `A` to have a dependency on crate `B`.
 workflows:
   # Check that everything is good without modifying anything:
   check:


### PR DESCRIPTION
# Pull Request

Closes: PRO-1474

Zepter is a tool that helps make sure cargo features are applied/propagated correctly. 

This PR just contains the default zepter config. 

To run it, you need to install zepter:

`cargo install zepter -f --locked`

Then `zepter check` to check and `zepter` to fix the issues.

For now I didn't include the applied changes - we will apply them *after* the next polkadot sdk update to avoid additional merge conflicts.