### PR TITLE
refactor: always supply all votes to ElectoralSystem::check_consensus

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
@@ -1,12 +1,11 @@
 use crate::{
 	electoral_system::{
-		AuthorityVoteOf, ElectionIdentifierOf, ElectionReadAccess, ElectionWriteAccess,
-		ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
+		AuthorityVoteOf, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
+		ElectionWriteAccess, ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError,
 };
-use cf_primitives::AuthorityCount;
 use cf_utilities::success_threshold_from_share_count;
 use frame_support::{
 	pallet_prelude::{MaybeSerializeDeserialize, Member},
@@ -101,14 +100,15 @@ impl<
 		_election_identifier: ElectionIdentifierOf<Self>,
 		_election_access: &ElectionAccess,
 		_previous_consensus: Option<&Self::Consensus>,
-		votes: Vec<(VotePropertiesOf<Self>, <Self::Vote as VoteStorage>::Vote, Self::ValidatorId)>,
-		authorities: AuthorityCount,
+		consensus_votes: ConsensusVotes<Self>,
 	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
-		let votes_count = votes.len();
-		let success_threshold = success_threshold_from_share_count(authorities) as usize;
-		Ok(if votes_count != 0 && votes_count >= success_threshold {
+		let num_authorities = consensus_votes.num_authorities();
+		let active_votes = consensus_votes.active_votes();
+		let num_active_votes = active_votes.len() as u32;
+		let success_threshold = success_threshold_from_share_count(num_authorities);
+		Ok(if num_active_votes >= success_threshold {
 			let mut counts = BTreeMap::new();
-			for (_, vote, _validator_id) in votes {
+			for vote in active_votes {
 				counts.entry(vote).and_modify(|count| *count += 1).or_insert(1);
 			}
 			counts.iter().find_map(|(vote, count)| {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -1,7 +1,7 @@
 use crate::{
 	electoral_system::{
-		AuthorityVoteOf, ConsensusStatus, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralWriteAccess, VotePropertiesOf,
+		AuthorityVoteOf, ConsensusStatus, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess,
+		ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
 	},
 	mock::Test,
 	vote_storage::{self, VoteStorage},
@@ -150,10 +150,13 @@ impl ElectoralSystem for MockElectoralSystem {
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_election_access: &ElectionAccess,
 		_previous_consensus: Option<&Self::Consensus>,
-		votes: Vec<(VotePropertiesOf<Self>, <Self::Vote as VoteStorage>::Vote, Self::ValidatorId)>,
-		_authorities: AuthorityCount,
+		consensus_votes: ConsensusVotes<Self>,
 	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
-		Ok(if Self::should_assume_consensus() { Some(votes.len() as AuthorityCount) } else { None })
+		Ok(if Self::should_assume_consensus() {
+			Some(consensus_votes.active_votes().len() as AuthorityCount)
+		} else {
+			None
+		})
 	}
 
 	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -1,12 +1,10 @@
 use crate::{
 	electoral_system::{
-		ConsensusStatus, ElectionIdentifierOf, ElectionReadAccess, ElectionWriteAccess,
-		ElectoralReadAccess, ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
+		ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
+		ElectionWriteAccess, ElectoralReadAccess, ElectoralSystem, ElectoralWriteAccess,
 	},
-	vote_storage::VoteStorage,
 	CorruptStorageError, ElectionIdentifier, UniqueMonotonicIdentifier,
 };
-use cf_primitives::AuthorityCount;
 use codec::Encode;
 use frame_support::{
 	ensure, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound, StorageHasher, Twox64Concat,
@@ -114,14 +112,9 @@ macro_rules! impl_read_access {
 			pub fn check_consensus(
 				&self,
 				previous_consensus: Option<&ES::Consensus>,
-				votes: Vec<(
-					VotePropertiesOf<ES>,
-					<ES::Vote as VoteStorage>::Vote,
-					ES::ValidatorId,
-				)>,
-				authorities: AuthorityCount,
+				votes: ConsensusVotes<ES>,
 			) -> Result<Option<ES::Consensus>, CorruptStorageError> {
-				ES::check_consensus(self.identifier(), self, previous_consensus, votes, authorities)
+				ES::check_consensus(self.identifier(), self, previous_consensus, votes)
 			}
 		}
 	};

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -1,12 +1,11 @@
 use crate::{
 	electoral_system::{
-		AuthorityVoteOf, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
+		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
 		ElectoralWriteAccess, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError, ElectionIdentifier,
 };
-use cf_primitives::AuthorityCount;
 use cf_utilities::success_threshold_from_share_count;
 use frame_support::{
 	pallet_prelude::{MaybeSerializeDeserialize, Member},
@@ -100,20 +99,17 @@ impl<
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_election_access: &ElectionAccess,
 		_previous_consensus: Option<&Self::Consensus>,
-		mut votes: Vec<(
-			VotePropertiesOf<Self>,
-			<Self::Vote as VoteStorage>::Vote,
-			Self::ValidatorId,
-		)>,
-		authorities: AuthorityCount,
+		consensus_votes: ConsensusVotes<Self>,
 	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
-		let votes_count = votes.len();
-		let threshold = success_threshold_from_share_count(authorities) as usize;
-		Ok(if votes_count != 0 && votes_count >= threshold {
+		let num_authorities = consensus_votes.num_authorities();
+		let success_threshold = success_threshold_from_share_count(num_authorities);
+		let mut active_votes = consensus_votes.active_votes();
+		let num_active_votes = active_votes.len() as u32;
+		Ok(if num_active_votes != 0 && num_active_votes >= success_threshold {
 			// Calculating the median this way means atleast 2/3 of validators would be needed to
 			// increase the calculated median.
-			let (_, (_properties, median_vote, _validator_id), _) =
-				votes.select_nth_unstable(authorities as usize - threshold);
+			let (_, median_vote, _) =
+				active_votes.select_nth_unstable((num_authorities - success_threshold) as usize);
 			Some(median_vote.clone())
 		} else {
 			None

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -105,7 +105,7 @@ impl<
 		let success_threshold = success_threshold_from_share_count(num_authorities);
 		let mut active_votes = consensus_votes.active_votes();
 		let num_active_votes = active_votes.len() as u32;
-		Ok(if num_active_votes != 0 && num_active_votes >= success_threshold {
+		Ok(if num_active_votes >= success_threshold {
 			// Calculating the median this way means atleast 2/3 of validators would be needed to
 			// increase the calculated median.
 			let (_, median_vote, _) =

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
@@ -5,3 +5,4 @@ pub(crate) use crate::register_checks;
 pub mod change;
 pub mod monotonic_median;
 pub mod unsafe_median;
+pub mod utils;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
@@ -191,7 +191,6 @@ fn minority_can_not_influence_consensus() {
 			votes: (0..honest_votes)
 				.map(|_| ConsensusVote { vote: Some(((), HONEST_VALUE)), validator_id: () })
 				.chain(
-					// didn't vote at all
 					(0..dishonest_votes).map(|_| ConsensusVote {
 						vote: Some(((), DISHONEST_VALUE)),
 						validator_id: (),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/utils.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/utils.rs
@@ -1,0 +1,27 @@
+use cf_primitives::AuthorityCount;
+
+use crate::{
+	electoral_system::{ConsensusVote, ConsensusVotes, ElectoralSystem},
+	vote_storage::VoteStorage,
+};
+
+// Used in the unsafe_median and monotonic_median tests.
+pub fn generate_votes<ES>(
+	success_votes: AuthorityCount,
+	authority_count: AuthorityCount,
+) -> ConsensusVotes<ES>
+where
+	ES: ElectoralSystem<ValidatorId = ()>,
+	ES::Vote: VoteStorage<Properties = ()>,
+	ES::Vote: VoteStorage<Vote = u64>,
+{
+	ConsensusVotes {
+		votes: (0..success_votes)
+			.map(|v| ConsensusVote { vote: Some(((), v as u64)), validator_id: () })
+			.chain(
+				(0..(authority_count - success_votes))
+					.map(|_| ConsensusVote { vote: None, validator_id: () }),
+			)
+			.collect(),
+	}
+}

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -740,20 +740,14 @@ pub mod pallet {
 								},
 								validator_id,
 							)
-						).map(|(vote, validator_id)| {
-							(if ContributingAuthorities::<T, I>::contains_key(&validator_id) {
-								Some(vote)
-							} else {
-								None
-							}, validator_id)
-						}).map(|(vote_components, validator_id)| {
-							if let Some(vote_components) = vote_components {
+						).map(|(vote_components, validator_id)| {
+							if ContributingAuthorities::<T, I>::contains_key(&validator_id) {
 								match <<T::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::components_into_authority_vote(vote_components, |shared_data_hash| {
 									// We don't bother to check if the reference has expired, as if we have the data we may as well use it, even if it was provided after the shared data reference expired (But before the reference was cleaned up `on_finalize`).
 									Ok(SharedData::<T, I>::get(shared_data_hash))
 								}) {
-									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))),
 									// Only a full vote can count towards consensus.
+									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))), 
 									Ok(Some((_properties, AuthorityVote::PartialVote(_)))) => Ok(None),
 									Ok(None) => Ok(None),
 									Err(e) => Err(e),
@@ -766,8 +760,7 @@ pub mod pallet {
 									validator_id
 								}
 							)
-						})
-						.collect::<Result<Vec<_>, _>>()?;
+						}).collect::<Result<Vec<_>, _>>()?;
 
 						debug_assert!(votes.len() == current_authorities_count as usize);
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -137,6 +137,7 @@ pub mod pallet {
 	use cf_primitives::{AuthorityCount, EpochIndex};
 	use cf_traits::{AccountRoleRegistry, Chainflip, EpochInfo};
 
+	use crate::electoral_system::{ConsensusVote, ConsensusVotes};
 	use access_impls::{ElectionAccess, ElectoralAccess};
 	use bitmap_components::ElectionBitmapComponents;
 	use electoral_system::{
@@ -739,18 +740,36 @@ pub mod pallet {
 								},
 								validator_id,
 							)
-						).filter(|(_, validator_id)| {
-							ContributingAuthorities::<T, I>::contains_key(validator_id)
-						}).filter_map(|(vote_components, validator_id)| {
-							<<T::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::components_into_authority_vote(vote_components, |shared_data_hash| {
-								// We don't bother to check if the reference has expired, as if we have the data we may as well use it, even if it was provided after the shared data reference expired (But before the reference was cleaned up `on_finalize`).
-								Ok(SharedData::<T, I>::get(shared_data_hash))
-							}).map(|vote| vote.map(|vote| (vote.0, vote.1, validator_id))).transpose()
-						}).filter_map_ok(|(properties, authority_vote, validator_id)| match authority_vote {
-							AuthorityVote::Vote(vote) => Some((properties, vote, validator_id)),
-							_ => None,
+						).map(|(vote, validator_id)| {
+							(if ContributingAuthorities::<T, I>::contains_key(&validator_id) {
+								Some(vote)
+							} else {
+								None
+							}, validator_id)
+						}).map(|(vote_components, validator_id)| {
+							if let Some(vote_components) = vote_components {
+								match <<T::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::components_into_authority_vote(vote_components, |shared_data_hash| {
+									// We don't bother to check if the reference has expired, as if we have the data we may as well use it, even if it was provided after the shared data reference expired (But before the reference was cleaned up `on_finalize`).
+									Ok(SharedData::<T, I>::get(shared_data_hash))
+								}) {
+									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))),
+									// Only a full vote can count towards consensus.
+									Ok(Some((_properties, AuthorityVote::PartialVote(_)))) => Ok(None),
+									Ok(None) => Ok(None),
+									Err(e) => Err(e),
+								}
+							} else {
+								Ok(None)
+							}.map(|props_and_vote|
+								ConsensusVote {
+									vote: props_and_vote,
+									validator_id
+								}
+							)
 						})
 						.collect::<Result<Vec<_>, _>>()?;
+
+						debug_assert!(votes.len() == current_authorities_count as usize);
 
 						// Remove individual components from non-authorities
 						for (validator_id, (_, individual_component)) in individual_components {
@@ -777,8 +796,7 @@ pub mod pallet {
 										Some(&consensus_history.most_recent)
 									}
 								}),
-								votes,
-								current_authorities_count,
+								ConsensusVotes { votes },
 							)?;
 
 						ElectionConsensusHistory::<T, I>::set(

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -747,7 +747,7 @@ pub mod pallet {
 									Ok(SharedData::<T, I>::get(shared_data_hash))
 								}) {
 									// Only a full vote can count towards consensus.
-									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))), 
+									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))),
 									Ok(Some((_properties, AuthorityVote::PartialVote(_)))) => Ok(None),
 									Ok(None) => Ok(None),
 									Err(e) => Err(e),


### PR DESCRIPTION
# Pull Request

Part of: PRO-1645

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

We always want to supply all votes to check_consensus, to allow us to take action on particular validator ids who have *not* voted - not just on those who have voted.