### PR TITLE
tests for ensure governance checks

### DIFF
--- a/state-chain/pallets/cf-account-roles/src/mock.rs
+++ b/state-chain/pallets/cf-account-roles/src/mock.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{self as pallet_cf_account_roles, Config};
-use cf_traits::mocks::ensure_origin_mock::NeverFailingOriginCheck;
+use cf_traits::mocks::ensure_origin_mock::OnlyAllowRootOrigin;
 
 use frame_support::{
 	derive_impl,
@@ -50,7 +50,7 @@ impl frame_system::Config for Test {
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type EnsureGovernance = NeverFailingOriginCheck<Self>;
+	type EnsureGovernance = OnlyAllowRootOrigin<Self>;
 	type WeightInfo = ();
 }
 

--- a/state-chain/pallets/cf-account-roles/src/tests.rs
+++ b/state-chain/pallets/cf-account-roles/src/tests.rs
@@ -147,7 +147,7 @@ fn test_setting_vanity_names_() {
 
 		assert_noop!(
 			AccountRolesPallet::set_vanity_name(
-				RuntimeOrigin::signed(1),
+				RuntimeOrigin::signed(100),
 				BoundedVec::try_from(vec![0xfe, 0xff]).unwrap()
 			),
 			Error::<Test>::InvalidCharactersInName

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -71,7 +71,6 @@ pub mod pallet {
 		pallet_prelude::{OptionQuery, *},
 		traits::EnsureOrigin,
 	};
-	use frame_system::pallet_prelude::*;
 
 	/// Type alias for the instance's configured Transaction.
 	pub type TransactionFor<T, I> = <<T as Config<I>>::TargetChain as Chain>::Transaction;
@@ -572,7 +571,7 @@ pub mod pallet {
 		#[pallet::weight(Weight::zero())]
 		#[pallet::call_index(3)]
 		pub fn stress_test(origin: OriginFor<T>, how_many: u32) -> DispatchResult {
-			ensure_root(origin)?;
+			T::EnsureGovernance::ensure_origin(origin)?;
 
 			let payload = PayloadFor::<T, I>::decode(&mut &[0xcf; 32][..])
 				.map_err(|_| Error::<T, I>::InvalidPayload)?;

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -136,7 +136,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Test {
 	type ThresholdSigner = MockThresholdSigner<MockEthereumChainCrypto, RuntimeCall>;
 	type BroadcastSignerNomination = MockNominator;
 	type OffenceReporter = MockOffenceReporter;
-	type EnsureThresholdSigned = NeverFailingOriginCheck<Self>;
+	type EnsureThresholdSigned = FailOnNoneOrigin<Self>;
 	type WeightInfo = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type BroadcastCallable = MockCallback;

--- a/state-chain/pallets/cf-chain-tracking/src/tests.rs
+++ b/state-chain/pallets/cf-chain-tracking/src/tests.rs
@@ -1,7 +1,11 @@
 #![cfg(test)]
-use crate::{mock::*, Call as PalletCall, ChainState, Error, Event as PalletEvent};
+use crate::{
+	mock::*, Call as PalletCall, ChainState, CurrentChainState, Error, Event as PalletEvent,
+	FeeMultiplier,
+};
 use cf_chains::mocks::MockTrackedData;
-use frame_support::{pallet_prelude::DispatchResult, traits::OriginTrait};
+use frame_support::{assert_noop, assert_ok, pallet_prelude::DispatchResult, traits::OriginTrait};
+use sp_runtime::FixedU128;
 
 trait TestChainTracking {
 	fn test_chain_tracking_update(
@@ -63,4 +67,47 @@ fn chain_tracking_can_only_advance() {
 		.test_chain_tracking_update(START_BLOCK + 10, Ok(()))
 		.test_chain_tracking_update(START_BLOCK + 10, Err(Error::<Test>::StaleDataSubmitted.into()))
 		.test_chain_tracking_update(START_BLOCK + 9, Err(Error::<Test>::StaleDataSubmitted.into()));
+}
+
+#[test]
+fn can_update_fee_multiplier() {
+	new_test_ext().execute_with(|| {
+		const NEW_FEE_MULTIPLIER: FixedU128 = FixedU128::from_u32(2);
+		assert_ne!(FeeMultiplier::<Test>::get(), NEW_FEE_MULTIPLIER);
+		assert_ok!(MockChainTracking::update_fee_multiplier(
+			OriginTrait::root(),
+			NEW_FEE_MULTIPLIER
+		));
+		assert_noop!(
+			MockChainTracking::update_fee_multiplier(OriginTrait::signed(100), NEW_FEE_MULTIPLIER),
+			sp_runtime::traits::BadOrigin
+		);
+		assert_eq!(FeeMultiplier::<Test>::get(), NEW_FEE_MULTIPLIER);
+	});
+}
+
+#[test]
+fn can_update_chain_state() {
+	new_test_ext().execute_with(|| {
+		let new_chain_state = ChainState {
+			block_height: 1,
+			tracked_data: MockTrackedData::new(Default::default(), Default::default()),
+		};
+		assert_ne!(
+			CurrentChainState::<Test>::get().unwrap().block_height,
+			new_chain_state.block_height
+		);
+		assert_noop!(
+			MockChainTracking::update_chain_state(OriginTrait::none(), new_chain_state.clone()),
+			sp_runtime::DispatchError::BadOrigin,
+		);
+		assert_ok!(MockChainTracking::update_chain_state(
+			OriginTrait::root(),
+			new_chain_state.clone(),
+		));
+		assert_eq!(
+			CurrentChainState::<Test>::get().unwrap().block_height,
+			new_chain_state.block_height
+		);
+	});
 }

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -636,3 +636,49 @@ fn cannot_governance_recover_unused_sol_durable_nonce() {
 		);
 	});
 }
+
+#[test]
+fn ensure_governance_origin_checks() {
+	let non_gov_origin: RuntimeOrigin = OriginTrait::signed(100);
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Environment::witness_polkadot_vault_creation(
+				non_gov_origin.clone(),
+				Default::default(),
+				cf_primitives::TxId { block_number: 0, extrinsic_index: 0 },
+			),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::witness_current_bitcoin_block_number_for_key(
+				non_gov_origin.clone(),
+				0,
+				Default::default(),
+			),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::update_safe_mode(non_gov_origin.clone(), SafeModeUpdate::CodeRed),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::update_consolidation_parameters(
+				non_gov_origin.clone(),
+				Default::default(),
+			),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::witness_initialize_arbitrum_vault(non_gov_origin.clone(), 0),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::witness_initialize_solana_vault(non_gov_origin.clone(), 0),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Environment::force_recover_sol_nonce(non_gov_origin, Default::default(), None),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -633,3 +633,13 @@ mod test_tx_payments {
 		});
 	}
 }
+
+#[test]
+fn only_governance_can_set_slashing_rate() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Flip::set_slashing_rate(RuntimeOrigin::signed(ALICE), Permill::from_percent(0)),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -166,7 +166,7 @@ impl pallet_cf_funding::Config for Test {
 	type FunderId = AccountId;
 	type Broadcaster = MockFundingBroadcaster;
 	type ThresholdCallable = RuntimeCall;
-	type EnsureThresholdSigned = NeverFailingOriginCheck<Self>;
+	type EnsureThresholdSigned = FailOnNoneOrigin<Self>;
 	type RedemptionChecker = MockRedemptionChecker;
 	type SafeMode = MockRuntimeSafeMode;
 	type RegisterRedemption = MockRegisterRedemption;

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -1755,3 +1755,21 @@ fn account_references_must_be_zero_for_full_redeem() {
 		);
 	});
 }
+
+#[test]
+fn only_governance_can_update_settings() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Funding::update_minimum_funding(RuntimeOrigin::signed(ALICE), 0),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Funding::update_restricted_addresses(RuntimeOrigin::signed(ALICE), vec![], vec![]),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Funding::update_redemption_tax(RuntimeOrigin::signed(ALICE), 0),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -35,7 +35,7 @@ use cf_traits::{
 	GetBlockHeight, SafeMode, ScheduledEgressDetails, SwapLimitsProvider, SwapRequestType,
 };
 use frame_support::{
-	assert_err, assert_ok,
+	assert_err, assert_noop, assert_ok,
 	traits::{Hooks, OriginTrait},
 	weights::Weight,
 };
@@ -1286,6 +1286,10 @@ fn failed_ccm_is_stored() {
 		let broadcast_id = 1;
 		assert_eq!(FailedForeignChainCalls::<Test, ()>::get(epoch), vec![]);
 
+		assert_noop!(
+			IngressEgress::ccm_broadcast_failed(RuntimeOrigin::signed(ALICE), broadcast_id,),
+			sp_runtime::DispatchError::BadOrigin
+		);
 		assert_ok!(IngressEgress::ccm_broadcast_failed(RuntimeOrigin::root(), broadcast_id,));
 
 		assert_eq!(
@@ -1560,6 +1564,15 @@ fn can_update_all_config_items() {
 				minimum_deposit: NEW_MIN_DEPOSIT_ETH
 			}),
 		);
+
+		// Make sure that only governance can update the config
+		assert_noop!(
+			IngressEgress::update_pallet_config(
+				OriginTrait::signed(ALICE),
+				vec![].try_into().unwrap()
+			),
+			sp_runtime::traits::BadOrigin
+		);
 	});
 }
 
@@ -1669,6 +1682,16 @@ fn safe_mode_prevents_deposit_channel_creation() {
 				0,
 			),
 			crate::Error::<Test, _>::DepositChannelCreationDisabled
+		);
+	});
+}
+
+#[test]
+fn only_governance_can_enable_or_disable_egress() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			IngressEgress::enable_or_disable_egress(OriginTrait::none(), ETH_ETH, true),
+			DispatchError::BadOrigin
 		);
 	});
 }

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -91,7 +91,7 @@ fn get_available_amount(asset: eth::Asset, fee_tier: BoostPoolTier) -> AssetAmou
 // Setup accounts, create eth boost pools and ensure that ingress fee is `INGRESS_FEE`
 fn setup() {
 	assert_ok!(Pallet::<Test, _>::create_boost_pools(
-		RuntimeOrigin::signed(ALICE),
+		RuntimeOrigin::root(),
 		vec![
 			BoostPoolId { asset: eth::Asset::Eth, tier: TIER_5_BPS },
 			BoostPoolId { asset: eth::Asset::Eth, tier: TIER_10_BPS },
@@ -279,7 +279,7 @@ fn can_boost_non_eth_asset() {
 	fn test_for_asset(asset: eth::Asset) {
 		new_test_ext().execute_with(|| {
 			assert_ok!(Pallet::<Test, _>::create_boost_pools(
-				RuntimeOrigin::signed(ALICE),
+				RuntimeOrigin::root(),
 				vec![BoostPoolId { asset, tier: TIER_10_BPS },]
 			));
 
@@ -929,7 +929,7 @@ fn test_create_boost_pools() {
 
 		// Create all 3 pools in one go
 		assert_ok!(Pallet::<Test, _>::create_boost_pools(
-			RuntimeOrigin::signed(ALICE),
+			RuntimeOrigin::root(),
 			vec![
 				BoostPoolId { asset: eth::Asset::Eth, tier: TIER_5_BPS },
 				BoostPoolId { asset: eth::Asset::Eth, tier: TIER_10_BPS },
@@ -959,7 +959,7 @@ fn test_create_boost_pools() {
 		// Should not be able to create the same pool again
 		assert_noop!(
 			Pallet::<Test, _>::create_boost_pools(
-				RuntimeOrigin::signed(ALICE),
+				RuntimeOrigin::root(),
 				vec![BoostPoolId { asset: eth::Asset::Eth, tier: TIER_5_BPS }]
 			),
 			pallet_cf_ingress_egress::Error::<Test, ()>::BoostPoolAlreadyExists
@@ -971,10 +971,16 @@ fn test_create_boost_pools() {
 		// Should not be able to create a pool with a tier of 0
 		assert_noop!(
 			Pallet::<Test, _>::create_boost_pools(
-				RuntimeOrigin::signed(ALICE),
+				RuntimeOrigin::root(),
 				vec![BoostPoolId { asset: eth::Asset::Eth, tier: 0 }]
 			),
 			pallet_cf_ingress_egress::Error::<Test, ()>::InvalidBoostPoolTier
+		);
+
+		// Make sure that only governance can create boost pools
+		assert_noop!(
+			Pallet::<Test, _>::create_boost_pools(OriginTrait::none(), vec![]),
+			sp_runtime::traits::BadOrigin
 		);
 	});
 }

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -32,6 +32,18 @@ fn can_create_new_trading_pool() {
 			Error::<Test>::InvalidFeeAmount,
 		);
 
+		// Make sure only governance can create a new pool.
+		assert_noop!(
+			LiquidityPools::new_pool(
+				RuntimeOrigin::signed(ALICE),
+				unstable_asset,
+				STABLE_ASSET,
+				500_000u32,
+				default_price,
+			),
+			sp_runtime::traits::BadOrigin
+		);
+
 		// Create a new pool.
 		assert_ok!(LiquidityPools::new_pool(
 			RuntimeOrigin::root(),
@@ -1236,5 +1248,33 @@ fn test_cancel_orders_batch() {
 			.unwrap(),
 			0
 		)
+	});
+}
+
+#[test]
+fn only_governance_can_set_pool_fee() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			LiquidityPools::set_pool_fees(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Eth,
+				STABLE_ASSET,
+				0
+			),
+			sp_runtime::traits::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn only_governance_can_set_maximum_price_impact() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			LiquidityPools::set_maximum_price_impact(
+				RuntimeOrigin::signed(ALICE),
+				BoundedVec::try_from(vec![(Asset::Eth, None)]).unwrap()
+			),
+			sp_runtime::traits::BadOrigin
+		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -71,6 +71,12 @@ fn can_update_all_config_items() {
 				blocks: MAX_SWAP_REQUEST_DURATION
 			})
 		);
+
+		// Make sure that only governance can update the config
+		assert_noop!(
+			Swapping::update_pallet_config(OriginTrait::signed(ALICE), vec![].try_into().unwrap()),
+			sp_runtime::traits::BadOrigin
+		);
 	});
 }
 

--- a/state-chain/pallets/cf-threshold-signature/src/tests.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/tests.rs
@@ -1962,3 +1962,21 @@ fn can_recover_from_abort_key_rotation_after_key_handover_failed() {
 		do_full_key_rotation();
 	});
 }
+
+#[test]
+fn ensure_governance_origin_checks() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			EvmThresholdSigner::set_keygen_response_timeout(RuntimeOrigin::signed(ALICE), 1),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			EvmThresholdSigner::set_keygen_slash_amount(RuntimeOrigin::signed(ALICE), 1),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			EvmThresholdSigner::set_threshold_signature_timeout(RuntimeOrigin::signed(ALICE), 1),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -558,7 +558,7 @@ pub mod pallet {
 		/// Force a new epoch. From the next block we will try to move to a new
 		/// epoch and rotate our validators.
 		///
-		/// The dispatch origin of this function must be root.
+		/// The dispatch origin of this function must be governance.
 		///
 		/// ## Events
 		///

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -6,6 +6,7 @@ use cf_test_utilities::last_event;
 use cf_traits::{
 	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo, VaultActivator,
 };
+use frame_support::assert_noop;
 
 pub const NEW_AGG_PUBKEY: MockAggKey = MockAggKey(*b"newk");
 
@@ -82,5 +83,15 @@ fn vault_start_block_number_not_set_when_chain_not_initialized() {
 			PendingVaultActivation::<Test, _>::get().unwrap(),
 			VaultActivationStatus::Complete
 		));
+	});
+}
+
+#[test]
+fn only_governance_can_initialize_chain() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			VaultsPallet::initialize_chain(RuntimeOrigin::signed(100)),
+			sp_runtime::traits::BadOrigin,
+		);
 	});
 }

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -496,7 +496,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// This allows the root user to force through a witness call.
+		/// This allows the governance user to force through a witness call.
 		///
 		/// This can be useful when votes haven't reached the threshold because of witnesser
 		/// check-pointing issues or similar.
@@ -511,7 +511,7 @@ pub mod pallet {
 			call: Box<<T as Config>::RuntimeCall>,
 			epoch_index: EpochIndex,
 		) -> DispatchResult {
-			ensure_root(origin)?;
+			T::EnsureGovernance::ensure_origin(origin)?;
 
 			ensure!(epoch_index > T::EpochInfo::last_expired_epoch(), Error::<T>::EpochExpired);
 

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -736,3 +736,32 @@ fn test_extra_call_data() {
 		.is_none(),);
 	});
 }
+
+#[test]
+fn only_governance_can_force_witness() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Witnesser::force_witness(
+				RuntimeOrigin::signed(100),
+				Box::new(RuntimeCall::Dummy(pallet_dummy::Call::<Test>::increment_value {})),
+				MockEpochInfo::epoch_index()
+			),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}
+
+#[test]
+fn ensure_witnessed_origin_checks() {
+	new_test_ext().execute_with(|| {
+		let call = Box::new(RuntimeCall::Dummy(pallet_dummy::Call::<Test>::increment_value {}));
+		assert_noop!(
+			Witnesser::prewitness(RuntimeOrigin::none(), call.clone()),
+			sp_runtime::traits::BadOrigin,
+		);
+		assert_noop!(
+			Witnesser::prewitness_and_execute(RuntimeOrigin::none(), call),
+			sp_runtime::traits::BadOrigin,
+		);
+	});
+}

--- a/state-chain/traits/src/mocks.rs
+++ b/state-chain/traits/src/mocks.rs
@@ -48,7 +48,8 @@ macro_rules! impl_mock_chainflip {
 			impl_mock_epoch_info,
 			mocks::{
 				account_role_registry::MockAccountRoleRegistry,
-				ensure_origin_mock::NeverFailingOriginCheck, funding_info::MockFundingInfo,
+				ensure_origin_mock::{FailOnNoneOrigin, OnlyAllowRootOrigin},
+				funding_info::MockFundingInfo,
 			},
 			Chainflip,
 		};
@@ -64,10 +65,10 @@ macro_rules! impl_mock_chainflip {
 			type Amount = u128;
 			type ValidatorId = <$runtime as frame_system::Config>::AccountId;
 			type RuntimeCall = RuntimeCall;
-			type EnsureWitnessed = NeverFailingOriginCheck<Self>;
-			type EnsurePrewitnessed = NeverFailingOriginCheck<Self>;
-			type EnsureWitnessedAtCurrentEpoch = NeverFailingOriginCheck<Self>;
-			type EnsureGovernance = NeverFailingOriginCheck<Self>;
+			type EnsureWitnessed = FailOnNoneOrigin<Self>;
+			type EnsurePrewitnessed = FailOnNoneOrigin<Self>;
+			type EnsureWitnessedAtCurrentEpoch = FailOnNoneOrigin<Self>;
+			type EnsureGovernance = OnlyAllowRootOrigin<Self>;
 			type EpochInfo = MockEpochInfo;
 			type AccountRoleRegistry = MockAccountRoleRegistry;
 			type FundingInfo = MockFundingInfo<Self>;

--- a/state-chain/traits/src/mocks/ensure_origin_mock.rs
+++ b/state-chain/traits/src/mocks/ensure_origin_mock.rs
@@ -1,13 +1,39 @@
 use std::marker::PhantomData;
-pub struct NeverFailingOriginCheck<T>(PhantomData<T>);
+
+/// Used by default on most mocks for any non-governance origin checks.
+pub struct FailOnNoneOrigin<T>(PhantomData<T>);
 
 impl<T: frame_system::Config> frame_support::traits::EnsureOrigin<T::RuntimeOrigin>
-	for NeverFailingOriginCheck<T>
+	for FailOnNoneOrigin<T>
 {
 	type Success = ();
 
-	fn try_origin(_o: T::RuntimeOrigin) -> Result<Self::Success, T::RuntimeOrigin> {
-		Ok(())
+	fn try_origin(o: T::RuntimeOrigin) -> Result<Self::Success, T::RuntimeOrigin> {
+		match o.clone().into() {
+			Ok(frame_system::RawOrigin::None) => Err(o),
+			_ => Ok(()),
+		}
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin() -> Result<T::RuntimeOrigin, ()> {
+		Ok(frame_system::RawOrigin::Root.into())
+	}
+}
+
+/// Used by default on most mocks for governance origin checks.
+pub struct OnlyAllowRootOrigin<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> frame_support::traits::EnsureOrigin<T::RuntimeOrigin>
+	for OnlyAllowRootOrigin<T>
+{
+	type Success = ();
+
+	fn try_origin(o: T::RuntimeOrigin) -> Result<Self::Success, T::RuntimeOrigin> {
+		match o.clone().into() {
+			Ok(frame_system::RawOrigin::Root) => Ok(()),
+			_ => Err(o),
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1638

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Removed the `NeverFailingOriginCheck` and added `FailOnNoneOrigin` & `OnlyAllowRootOrigin` instead. These allow us to test that the origin is being checked.
	- Mocks defaultly use `OnlyAllowRootOrigin` for governance checks and `FailOnNoneOrigin` for all others.
- Added tests for every governance extrinsic except for the ones in the elections pallet.
- Added a few test for non-governance origin checks.
- Changed the governance pallet to use the actual ensure governance check instead of a mock.
- Added several missing tests for extrinsics.
- Changed 2 extrinsics from a root origin check to a governance check.
- Looked over all other extrinsics to try and find any missing/incorrect origin checks. all good :)
