### PR TITLE
Denote broadcast timeout in target chain blocks.

### DIFF
--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -326,24 +326,19 @@ impl ExtBuilder {
 				}),
 			},
 			ethereum_broadcaster: state_chain_runtime::EthereumBroadcasterConfig {
-				broadcast_timeout: 5 * MINUTES,
-				..Default::default()
+				broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM
 			},
 			polkadot_broadcaster: state_chain_runtime::PolkadotBroadcasterConfig {
-				broadcast_timeout: 4 * MINUTES,
-				..Default::default()
+				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT
 			},
 			bitcoin_broadcaster: state_chain_runtime::BitcoinBroadcasterConfig {
-				broadcast_timeout: 90 * MINUTES,
-				..Default::default()
+				broadcast_timeout: 9 // = 90 minutes
 			},
 			arbitrum_broadcaster: state_chain_runtime::ArbitrumBroadcasterConfig {
-				broadcast_timeout: 2 * MINUTES,
-				..Default::default()
+				broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM
 			},
 			solana_broadcaster: state_chain_runtime::SolanaBroadcasterConfig {
-				broadcast_timeout: 4 * MINUTES,
-				..Default::default()
+				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA
 			},
 		})
 	}

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -326,19 +326,19 @@ impl ExtBuilder {
 				}),
 			},
 			ethereum_broadcaster: state_chain_runtime::EthereumBroadcasterConfig {
-				broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM
+				broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM,
 			},
 			polkadot_broadcaster: state_chain_runtime::PolkadotBroadcasterConfig {
-				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT
+				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT,
 			},
 			bitcoin_broadcaster: state_chain_runtime::BitcoinBroadcasterConfig {
-				broadcast_timeout: 9 // = 90 minutes
+				broadcast_timeout: 9, // = 90 minutes
 			},
 			arbitrum_broadcaster: state_chain_runtime::ArbitrumBroadcasterConfig {
-				broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM
+				broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM,
 			},
 			solana_broadcaster: state_chain_runtime::SolanaBroadcasterConfig {
-				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA
+				broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA,
 			},
 		})
 	}

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -840,28 +840,23 @@ fn testnet_genesis(
 
 		// instance1
 		ethereum_broadcaster: state_chain_runtime::EthereumBroadcasterConfig {
-			broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM,
-			..Default::default()
+			broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM
 		},
 		// instance2
 		polkadot_broadcaster: state_chain_runtime::PolkadotBroadcasterConfig {
-			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT,
-			..Default::default()
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT
 		},
 		// instance3
 		bitcoin_broadcaster: state_chain_runtime::BitcoinBroadcasterConfig {
-			broadcast_timeout: 9, // = 90 minutes
-			..Default::default()
+			broadcast_timeout: 9 // = 90 minutes
 		},
 		// instance 4
 		arbitrum_broadcaster: state_chain_runtime::ArbitrumBroadcasterConfig {
-			broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM,
-			..Default::default()
+			broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM
 		},
 		// instance 5
 		solana_broadcaster: state_chain_runtime::SolanaBroadcasterConfig {
-			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA,
-			..Default::default()
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA
 		},
 	})
 	.expect("Genesis config is JSON-compatible.")

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -22,7 +22,10 @@ use sp_core::{
 };
 use state_chain_runtime::{
 	chainflip::{solana_elections, Offence},
-	constants::common::MINUTES,
+	constants::common::{
+		BLOCKS_PER_MINUTE_ARBITRUM, BLOCKS_PER_MINUTE_ETHEREUM, BLOCKS_PER_MINUTE_POLKADOT,
+		BLOCKS_PER_MINUTE_SOLANA,
+	},
 	opaque::SessionKeys,
 	AccountId, BlockNumber, FlipBalance, RuntimeGenesisConfig, SetSizeParameters, Signature,
 	SolanaElectionsConfig, WASM_BINARY,
@@ -837,27 +840,27 @@ fn testnet_genesis(
 
 		// instance1
 		ethereum_broadcaster: state_chain_runtime::EthereumBroadcasterConfig {
-			broadcast_timeout: 5 * MINUTES,
+			broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM,
 			..Default::default()
 		},
 		// instance2
 		polkadot_broadcaster: state_chain_runtime::PolkadotBroadcasterConfig {
-			broadcast_timeout: 4 * MINUTES,
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT,
 			..Default::default()
 		},
 		// instance3
 		bitcoin_broadcaster: state_chain_runtime::BitcoinBroadcasterConfig {
-			broadcast_timeout: 90 * MINUTES,
+			broadcast_timeout: 9, // = 90 minutes
 			..Default::default()
 		},
 		// instance 4
 		arbitrum_broadcaster: state_chain_runtime::ArbitrumBroadcasterConfig {
-			broadcast_timeout: 2 * MINUTES,
+			broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM,
 			..Default::default()
 		},
 		// instance 5
 		solana_broadcaster: state_chain_runtime::SolanaBroadcasterConfig {
-			broadcast_timeout: 4 * MINUTES,
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA,
 			..Default::default()
 		},
 	})

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -840,23 +840,23 @@ fn testnet_genesis(
 
 		// instance1
 		ethereum_broadcaster: state_chain_runtime::EthereumBroadcasterConfig {
-			broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM
+			broadcast_timeout: 5 * BLOCKS_PER_MINUTE_ETHEREUM,
 		},
 		// instance2
 		polkadot_broadcaster: state_chain_runtime::PolkadotBroadcasterConfig {
-			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_POLKADOT,
 		},
 		// instance3
 		bitcoin_broadcaster: state_chain_runtime::BitcoinBroadcasterConfig {
-			broadcast_timeout: 9 // = 90 minutes
+			broadcast_timeout: 9, // = 90 minutes
 		},
 		// instance 4
 		arbitrum_broadcaster: state_chain_runtime::ArbitrumBroadcasterConfig {
-			broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM
+			broadcast_timeout: 2 * BLOCKS_PER_MINUTE_ARBITRUM,
 		},
 		// instance 5
 		solana_broadcaster: state_chain_runtime::SolanaBroadcasterConfig {
-			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA
+			broadcast_timeout: 4 * BLOCKS_PER_MINUTE_SOLANA,
 		},
 	})
 	.expect("Genesis config is JSON-compatible.")

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -79,7 +79,9 @@ mod benchmarks {
 	fn on_initialize(t: Linear<1, 50>, r: Linear<1, 50>) {
 		let caller: T::AccountId = whitelisted_caller();
 		// We add one because one is added at genesis
-		let timeout_target_block = T::ChainTracking::get_block_height() + crate::BroadcastTimeout::<T, I>::get() + 1u32.into();
+		let timeout_target_block = T::ChainTracking::get_block_height() +
+			crate::BroadcastTimeout::<T, I>::get() +
+			1u32.into();
 		let timeout_block = frame_system::Pallet::<T>::block_number() +
 			// crate::BroadcastTimeout::<T, I>::get() +
 			1_u32.into();
@@ -128,7 +130,8 @@ mod benchmarks {
 	fn on_signature_ready() {
 		let broadcast_id = 0;
 		frame_system::Pallet::<T>::set_block_number(100u32.into());
-		let timeout_block = T::ChainTracking::get_block_height() + crate::BroadcastTimeout::<T, I>::get();
+		let timeout_block =
+			T::ChainTracking::get_block_height() + crate::BroadcastTimeout::<T, I>::get();
 		insert_transaction_broadcast_attempt::<T, I>(Some(whitelisted_caller()), broadcast_id);
 		let call = generate_on_signature_ready_call::<T, I>();
 

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -82,9 +82,7 @@ mod benchmarks {
 		let timeout_target_block = T::ChainTracking::get_block_height() +
 			crate::BroadcastTimeout::<T, I>::get() +
 			1u32.into();
-		let timeout_block = frame_system::Pallet::<T>::block_number() +
-			// crate::BroadcastTimeout::<T, I>::get() +
-			1_u32.into();
+		let timeout_block = frame_system::Pallet::<T>::block_number() + 1_u32.into();
 		// Complexity parameter for expiry queue.
 
 		let mut broadcast_id = 0;

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -92,7 +92,8 @@ mod benchmarks {
 			insert_transaction_broadcast_attempt::<T, I>(Some(caller.clone().into()), broadcast_id);
 			Timeouts::<T, I>::append((
 				timeout_target_block,
-				BTreeSet::from([(broadcast_id, T::ValidatorId::from(caller.clone()))]),
+				broadcast_id,
+				T::ValidatorId::from(caller.clone()),
 			));
 		}
 		for _ in 1..r {
@@ -145,7 +146,7 @@ mod benchmarks {
 		assert_eq!(Pallet::<T, I>::attempt_count(broadcast_id), 0);
 		assert!(Timeouts::<T, I>::get()
 			.iter()
-			.any(|(chainblock, _)| *chainblock == timeout_chainblock));
+			.any(|(chainblock, _, _)| *chainblock == timeout_chainblock));
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -79,8 +79,9 @@ mod benchmarks {
 	fn on_initialize(t: Linear<1, 50>, r: Linear<1, 50>) {
 		let caller: T::AccountId = whitelisted_caller();
 		// We add one because one is added at genesis
+		let timeout_target_block = T::ChainTracking::get_block_height() + crate::BroadcastTimeout::<T, I>::get() + 1u32.into();
 		let timeout_block = frame_system::Pallet::<T>::block_number() +
-			crate::BroadcastTimeout::<T, I>::get() +
+			// crate::BroadcastTimeout::<T, I>::get() +
 			1_u32.into();
 		// Complexity parameter for expiry queue.
 
@@ -89,7 +90,7 @@ mod benchmarks {
 		for _ in 1..t {
 			broadcast_id += 1;
 			insert_transaction_broadcast_attempt::<T, I>(Some(caller.clone().into()), broadcast_id);
-			Timeouts::<T, I>::mutate(timeout_block, |timeouts| {
+			Timeouts::<T, I>::mutate(timeout_target_block, |timeouts| {
 				timeouts.insert((broadcast_id, caller.clone().into()))
 			});
 		}
@@ -127,8 +128,7 @@ mod benchmarks {
 	fn on_signature_ready() {
 		let broadcast_id = 0;
 		frame_system::Pallet::<T>::set_block_number(100u32.into());
-		let timeout_block =
-			frame_system::Pallet::<T>::block_number() + crate::BroadcastTimeout::<T, I>::get();
+		let timeout_block = T::ChainTracking::get_block_height() + crate::BroadcastTimeout::<T, I>::get();
 		insert_transaction_broadcast_attempt::<T, I>(Some(whitelisted_caller()), broadcast_id);
 		let call = generate_on_signature_ready_call::<T, I>();
 

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -284,7 +284,6 @@ pub mod pallet {
 	pub type Timeouts<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Twox64Concat,
-		// BlockNumberFor<T>,
 		ChainBlockNumberFor<T, I>,
 		BTreeSet<(BroadcastId, T::ValidatorId)>,
 		ValueQuery,
@@ -913,7 +912,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 			Timeouts::<T, I>::append(
 				T::ChainTracking::get_block_height() + BroadcastTimeout::<T, I>::get(),
-				// frame_system::Pallet::<T>::block_number() + BroadcastTimeout::<T, I>::get(),
 				(broadcast_id, nominated_signer.clone()),
 			);
 

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -413,7 +413,7 @@ pub mod pallet {
 			Timeouts::<T, I>::mutate(|timeouts| {
 				timeouts.retain(|(expiry_block, broadcast_id, nominee)| {
 					if *expiry_block <= current_chain_block {
-						expiries.insert((broadcast_id.clone(), nominee.clone()));
+						expiries.insert((*broadcast_id, nominee.clone()));
 						false
 					} else {
 						true

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -421,7 +421,6 @@ pub mod pallet {
 				if ix <= current_chain_block {
 					expiries.append(&mut val.clone());
 					expired_keys.push(ix);
-					break;
 				}
 			}
 			for key in expired_keys {

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -418,11 +418,9 @@ pub mod pallet {
 			// and separately the expired values, after that iterate again to delete all collected
 			// keys from storage.
 			Timeouts::<T, I>::mutate(|timeouts| {
-				// NB: As per documentation, retain visits every element exactly once,
-				// and can thus be used for iterations with state change.
-				timeouts.retain(|(ix, val)| {
-					if *ix <= current_chain_block {
-						expiries.append(&mut val.clone());
+				timeouts.retain(|(expiry_block, broadcast_ids)| {
+					if *expiry_block <= current_chain_block {
+						expiries.append(&mut broadcast_ids.clone());
 						false
 					} else {
 						true

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -182,8 +182,12 @@ pub mod pallet {
 		/// Safe Mode access.
 		type SafeMode: Get<PalletSafeMode<I>>;
 
-		/// The save mode block margin
+		/// The safe mode block margin
 		type SafeModeBlockMargin: Get<BlockNumberFor<Self>>;
+
+		/// The safe mode block margin. During safe mode, the timeout is pushed back
+		/// by this number of blocks every time it runs out.
+		type SafeModeBlockMarginForTargetChain: Get<ChainBlockNumberFor<Self, I>>;
 
 		/// The policy on which decide when we slow down the retry of a broadcast.
 		type RetryPolicy: RetryPolicy<
@@ -205,8 +209,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config<I>, I: 'static = ()> {
-		pub broadcast_timeout: BlockNumberFor<T>,
-		pub _phantom: PhantomData<I>,
+		pub broadcast_timeout: ChainBlockNumberFor<T, I>,
 	}
 
 	#[pallet::genesis_build]
@@ -218,7 +221,7 @@ pub mod pallet {
 
 	impl<T: Config<I>, I: 'static> Default for GenesisConfig<T, I> {
 		fn default() -> Self {
-			Self { broadcast_timeout: Default::default(), _phantom: Default::default() }
+			Self { broadcast_timeout: Default::default() }
 		}
 	}
 
@@ -281,7 +284,8 @@ pub mod pallet {
 	pub type Timeouts<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Twox64Concat,
-		BlockNumberFor<T>,
+		// BlockNumberFor<T>,
+		ChainBlockNumberFor<T, I>,
 		BTreeSet<(BroadcastId, T::ValidatorId)>,
 		ValueQuery,
 	>;
@@ -330,14 +334,14 @@ pub mod pallet {
 	/// The current timeout duration for the broadcast, measured in number of blocks.
 	#[pallet::storage]
 	pub type BroadcastTimeout<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, BlockNumberFor<T>, ValueQuery, DefaultBroadcastTimeout<T, I>>;
+		StorageValue<_, ChainBlockNumberFor<T, I>, ValueQuery, DefaultBroadcastTimeout<T, I>>;
 
 	const DEFAULT_BROADCAST_TIMEOUT: u32 = 100;
 
 	pub struct DefaultBroadcastTimeout<T, I>(PhantomData<(T, I)>);
 
-	impl<T: Config<I>, I: 'static> Get<BlockNumberFor<T>> for DefaultBroadcastTimeout<T, I> {
-		fn get() -> BlockNumberFor<T> {
+	impl<T: Config<I>, I: 'static> Get<ChainBlockNumberFor<T, I>> for DefaultBroadcastTimeout<T, I> {
+		fn get() -> ChainBlockNumberFor<T, I> {
 			DEFAULT_BROADCAST_TIMEOUT.into()
 		}
 	}
@@ -405,7 +409,26 @@ pub mod pallet {
 			// We treat a time out here as a Broadcast Failure. This is handled the same way - the
 			// current broadcaster is reported as Failed to broadcast, and a new broadcaster is
 			// nominated. If there are no more broadcaster available, then the broadcast is aborted.
-			let mut expiries = Timeouts::<T, I>::take(block_number);
+
+			let current_chain_block = T::ChainTracking::get_block_height();
+
+			// take all broadcasts which have timed out. Since iterators break if we update
+			// the map during iteration, we do this in two steps: first collect all expired_keys
+			// and separately the expired values, after that iterate again to delete all collected
+			// keys from storage.
+			let mut expired_keys = Vec::new();
+			let mut expiries = BTreeSet::new();
+			for (ix, val) in Timeouts::<T, I>::iter() {
+				if ix <= current_chain_block {
+					expiries.append(&mut val.clone());
+					expired_keys.push(ix);
+					break;
+				}
+			}
+			for key in expired_keys {
+				Timeouts::<T, I>::remove(key);
+			}
+
 			let pending_broadcasts = PendingBroadcasts::<T, I>::get();
 			let mut delayed_retries = DelayedBroadcastRetryQueue::<T, I>::take(block_number);
 			let expiry_count = expiries.len();
@@ -442,7 +465,7 @@ pub mod pallet {
 				}
 			} else {
 				Timeouts::<T, I>::mutate(
-					block_number.saturating_add(T::SafeModeBlockMargin::get()),
+					current_chain_block.saturating_add(T::SafeModeBlockMarginForTargetChain::get()),
 					|current| current.append(&mut expiries),
 				);
 				DelayedBroadcastRetryQueue::<T, I>::mutate(
@@ -889,7 +912,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			AwaitingBroadcast::<T, I>::insert(broadcast_id, broadcast_data.clone());
 
 			Timeouts::<T, I>::append(
-				frame_system::Pallet::<T>::block_number() + BroadcastTimeout::<T, I>::get(),
+				T::ChainTracking::get_block_height() + BroadcastTimeout::<T, I>::get(),
+				// frame_system::Pallet::<T>::block_number() + BroadcastTimeout::<T, I>::get(),
 				(broadcast_id, nominated_signer.clone()),
 			);
 

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -60,7 +60,7 @@ pub enum PalletConfigUpdate {
 	BroadcastTimeout { blocks: u32 },
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(8);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(9);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/state-chain/pallets/cf-broadcast/src/migrations.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations.rs
@@ -7,5 +7,5 @@ mod migrate_timeouts;
 pub type PalletMigration<T, I> = (
 	VersionedMigration<Pallet<T, I>, initialize_broadcast_timeout_storage::Migration<T, I>, 6, 7>,
 	VersionedMigration<Pallet<T, I>, migrate_timeouts::Migration<T, I>, 7, 8>,
-	PlaceholderMigration<Pallet<T, I>, 7>,
+	PlaceholderMigration<Pallet<T, I>, 8>,
 );

--- a/state-chain/pallets/cf-broadcast/src/migrations.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations.rs
@@ -2,8 +2,10 @@ use crate::Pallet;
 use cf_runtime_upgrade_utilities::{PlaceholderMigration, VersionedMigration};
 
 mod initialize_broadcast_timeout_storage;
+mod migrate_timeouts;
 
 pub type PalletMigration<T, I> = (
 	VersionedMigration<Pallet<T, I>, initialize_broadcast_timeout_storage::Migration<T, I>, 6, 7>,
+	VersionedMigration<Pallet<T, I>, migrate_timeouts::Migration<T, I>, 7, 8>,
 	PlaceholderMigration<Pallet<T, I>, 7>,
 );

--- a/state-chain/pallets/cf-broadcast/src/migrations/initialize_broadcast_timeout_storage.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/initialize_broadcast_timeout_storage.rs
@@ -1,12 +1,19 @@
-use cf_primitives::{BlockNumber, MILLISECONDS_PER_BLOCK};
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use old::maybe_get_timeout_for_type;
 
 use crate::*;
 
-// MINUTES constant copied from `runtime/src/constants.rs`,
+// Constants copied from `runtime/src/constants.rs`,
 // in order to use same timeout values as given in `node/src/chain_spec.rs`
-const MINUTES: BlockNumber = 60_000 / (MILLISECONDS_PER_BLOCK as BlockNumber);
+pub const MILLISECONDS_PER_BLOCK_ETHEREUM: u32 = 14 * 1000;
+pub const MILLISECONDS_PER_BLOCK_POLKADOT: u32 = 6 * 1000;
+pub const MILLISECONDS_PER_BLOCK_ARBITRUM: u32 = 250;
+pub const MILLISECONDS_PER_BLOCK_SOLANA: u32 = 400;
+
+pub const BLOCKS_PER_MINUTE_ETHEREUM: u32 = 60000 / MILLISECONDS_PER_BLOCK_ETHEREUM;
+pub const BLOCKS_PER_MINUTE_POLKADOT: u32 = 60000 / MILLISECONDS_PER_BLOCK_POLKADOT;
+pub const BLOCKS_PER_MINUTE_ARBITRUM: u32 = 60000 / MILLISECONDS_PER_BLOCK_ARBITRUM;
+pub const BLOCKS_PER_MINUTE_SOLANA: u32 = 60000 / MILLISECONDS_PER_BLOCK_SOLANA;
 
 mod old {
 	use cf_primitives::BlockNumber;
@@ -15,20 +22,21 @@ mod old {
 
 	// Same timeout values as previously defined in `#[pallet::constant]`s
 	// and same as currently used in `node/src/chain_spec.rs`
-	pub const ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 5 * MINUTES;
-	pub const POLKADOT_BROADCAST_TIMEOUT: BlockNumber = 4 * MINUTES;
-	pub const BITCOIN_BROADCAST_TIMEOUT: BlockNumber = 90 * MINUTES;
-	pub const ARBITRUM_BROADCAST_TIMEOUT: BlockNumber = 2 * MINUTES;
-	pub const SOLANA_BROADCAST_TIMEOUT: BlockNumber = 4 * MINUTES;
+	pub const ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 5 * BLOCKS_PER_MINUTE_ETHEREUM;
+	pub const POLKADOT_BROADCAST_TIMEOUT: BlockNumber = 4 * BLOCKS_PER_MINUTE_POLKADOT;
+	pub const BITCOIN_BROADCAST_TIMEOUT: BlockNumber = 9;
+	pub const ARBITRUM_BROADCAST_TIMEOUT: BlockNumber = 2 * BLOCKS_PER_MINUTE_ARBITRUM;
+	pub const SOLANA_BROADCAST_TIMEOUT: BlockNumber = 4 * BLOCKS_PER_MINUTE_SOLANA;
 
 	// For testing purposes we also have to set the timeout for the mock configuration,
 	// following `BROADCAST_EXPIRY_BLOCKS` in `mock.rs`
-	pub const MOCK_ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 4; //
+	pub const MOCK_ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 4;
 
-	pub fn maybe_get_timeout_for_type<T: Config<I>, I: 'static>() -> Option<BlockNumberFor<T>> {
+	pub fn maybe_get_timeout_for_type<T: Config<I>, I: 'static>(
+	) -> Option<ChainBlockNumberFor<T, I>> {
 		// Choose timeout value based on statically defined chain name.
 		// It should be the same as the previously used constants.
-		let timeout: BlockNumberFor<T> = match T::TargetChain::NAME {
+		let timeout: ChainBlockNumberFor<T, I> = match T::TargetChain::NAME {
 			"Ethereum" => old::ETHEREUM_BROADCAST_TIMEOUT,
 			"Polkadot" => old::POLKADOT_BROADCAST_TIMEOUT,
 			"Bitcoin" => old::BITCOIN_BROADCAST_TIMEOUT,

--- a/state-chain/pallets/cf-broadcast/src/migrations/initialize_broadcast_timeout_storage.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/initialize_broadcast_timeout_storage.rs
@@ -22,7 +22,7 @@ mod old {
 
 	// Same timeout values as previously defined in `#[pallet::constant]`s
 	// and same as currently used in `node/src/chain_spec.rs`
-	pub const ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 5 * BLOCKS_PER_MINUTE_ETHEREUM;
+	pub const ETHEREUM_BROADCAST_TIMEOUT: BlockNumber = 5 * BLOCKS_PER_MINUTE_ETHEREUM; // note, due to rounding, this is effectively ~4.7 min
 	pub const POLKADOT_BROADCAST_TIMEOUT: BlockNumber = 4 * BLOCKS_PER_MINUTE_POLKADOT;
 	pub const BITCOIN_BROADCAST_TIMEOUT: BlockNumber = 9;
 	pub const ARBITRUM_BROADCAST_TIMEOUT: BlockNumber = 2 * BLOCKS_PER_MINUTE_ARBITRUM;

--- a/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
@@ -57,8 +57,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 		for (broadcast_id, nominee) in data.timeouts {
 			let (new_timeout, _, _) = new_timeouts
 				.iter()
-				.filter(|(_, id, nom)| (id, nom) == (&broadcast_id, &nominee))
-				.next()
+				.find(|(_, id, nom)| (id, nom) == (&broadcast_id, &nominee))
 				.unwrap();
 			assert!(*new_timeout >= data.target_chainblock);
 		}

--- a/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
@@ -1,0 +1,92 @@
+use cf_traits::mocks::block_height_provider::BlockHeightProvider;
+use frame_support::{pallet_prelude::ValueQuery, traits::OnRuntimeUpgrade, weights::Weight};
+
+use crate::*;
+
+mod old {
+	use super::*;
+
+	#[frame_support::storage_alias]
+	pub type Timeouts<T: Config<I>, I: 'static> = StorageMap<
+		Pallet<T, I>,
+		Twox64Concat,
+		BlockNumberFor<T>,
+		BTreeSet<(BroadcastId, <T as Chainflip>::ValidatorId)>,
+		ValueQuery,
+	>;
+}
+
+pub struct Migration<T: Config<I>, I: 'static>(PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
+	fn on_runtime_upgrade() -> Weight {
+		// Instead of trying to translate the previous timeout into external chain blocks,
+		// we simply reset the remaining timeout duration to the new `BroadcastTimeout` value.
+		let new_timeout = BlockHeightProvider::<T::TargetChain>::get_block_height() +
+			BroadcastTimeout::<T, I>::get();
+		let mut old_keys = Vec::new();
+		for (key, timeouts) in old::Timeouts::<T, I>::iter() {
+			old_keys.push(key);
+			for (broadcast_id, nominee) in timeouts {
+				Timeouts::<T, I>::append((new_timeout, broadcast_id, nominee))
+			}
+		}
+
+		for key in old_keys {
+			old::Timeouts::<T, I>::remove(key);
+		}
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let mut timeouts = Vec::new();
+		for (_, old_broadcast_ids) in old::Timeouts::<T, I>::iter() {
+			for (old_broadcast_id, old_nominee) in old_broadcast_ids {
+				timeouts.push((old_broadcast_id, old_nominee))
+			}
+		}
+		let data: MigrationData<T, I> = MigrationData {
+			timeouts,
+			new_timeout_chainblock: BlockHeightProvider::<T::TargetChain>::get_block_height() +
+				BroadcastTimeout::<T, I>::get(),
+		};
+		Ok(data.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let data = MigrationData::<T, I>::decode(&mut &state[..]).unwrap();
+		let new_timeouts = Timeouts::<T, I>::get();
+
+		for (broadcast_id, nominee) in data.timeouts {
+			assert!(new_timeouts.contains(&(data.new_timeout_chainblock, broadcast_id, nominee)))
+		}
+		Ok(())
+	}
+}
+
+#[derive(Encode, Decode)]
+pub struct MigrationData<T: Config<I>, I: 'static> {
+	pub timeouts: Vec<(BroadcastId, <T as Chainflip>::ValidatorId)>,
+	pub new_timeout_chainblock: ChainBlockNumberFor<T, I>,
+}
+
+#[cfg(test)]
+mod migration_tests {
+
+	#[test]
+	fn test_migration() {
+		use super::*;
+		use crate::mock::*;
+
+		new_test_ext().execute_with(|| {
+			let state = super::Migration::<Test, _>::pre_upgrade().unwrap();
+			// Perform runtime migration.
+			super::Migration::<Test, _>::on_runtime_upgrade();
+			#[cfg(feature = "try-runtime")]
+			super::Migration::<Test, _>::post_upgrade(state).unwrap();
+		});
+	}
+}

--- a/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations/migrate_timeouts.rs
@@ -1,4 +1,3 @@
-use cf_traits::mocks::block_height_provider::BlockHeightProvider;
 use frame_support::{pallet_prelude::ValueQuery, traits::OnRuntimeUpgrade, weights::Weight};
 
 use crate::*;
@@ -22,8 +21,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 	fn on_runtime_upgrade() -> Weight {
 		// Instead of trying to translate the previous timeout into external chain blocks,
 		// we simply reset the remaining timeout duration to the new `BroadcastTimeout` value.
-		let new_timeout = BlockHeightProvider::<T::TargetChain>::get_block_height() +
-			BroadcastTimeout::<T, I>::get();
+		let new_timeout = T::ChainTracking::get_block_height() + BroadcastTimeout::<T, I>::get();
 		for (_, timeouts) in old::Timeouts::<T, I>::drain() {
 			for (broadcast_id, nominee) in timeouts {
 				Timeouts::<T, I>::append((new_timeout, broadcast_id, nominee))
@@ -42,7 +40,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 		}
 		let data: MigrationData<T, I> = MigrationData {
 			timeouts,
-			target_chainblock: BlockHeightProvider::<T::TargetChain>::get_block_height() +
+			target_chainblock: T::ChainTracking::get_block_height() +
 				BroadcastTimeout::<T, I>::get(),
 		};
 		Ok(data.encode())

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -143,6 +143,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Test {
 	type SafeMode = MockRuntimeSafeMode;
 	type BroadcastReadyProvider = MockBroadcastReadyProvider;
 	type SafeModeBlockMargin = ConstU64<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU64<10>;
 	type ChainTracking = BlockHeightProvider<MockEthereum>;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<MockEthereumChainCrypto>;
 	type RetryPolicy = MockRetryPolicy;
@@ -156,7 +157,6 @@ cf_test_utilities::impl_test_helpers! {
 	RuntimeGenesisConfig {
 		broadcaster: pallet_cf_broadcast::GenesisConfig {
 			broadcast_timeout: 4,
-			..Default::default()
 		},
 		..Default::default()
 	},

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -2,7 +2,9 @@
 
 use std::cell::RefCell;
 
-use crate::{self as pallet_cf_broadcast, Instance1, PalletOffence, PalletSafeMode};
+use crate::{
+	self as pallet_cf_broadcast, ChainBlockNumberFor, Instance1, PalletOffence, PalletSafeMode,
+};
 use cf_chains::{
 	eth::Ethereum,
 	evm::EvmCrypto,
@@ -71,6 +73,7 @@ impl frame_system::Config for Test {
 }
 
 pub const BROADCAST_EXPIRY_BLOCKS: BlockNumberFor<Test> = 4;
+pub const SAFEMODE_CHAINBLOCK_MARGIN: ChainBlockNumberFor<Test, Instance1> = 10;
 
 pub type MockOffenceReporter =
 	cf_traits::mocks::offence_reporting::MockOffenceReporter<u64, PalletOffence>;
@@ -143,7 +146,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Test {
 	type SafeMode = MockRuntimeSafeMode;
 	type BroadcastReadyProvider = MockBroadcastReadyProvider;
 	type SafeModeBlockMargin = ConstU64<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU64<10>;
+	type SafeModeChainBlockMargin = ConstU64<SAFEMODE_CHAINBLOCK_MARGIN>;
 	type ChainTracking = BlockHeightProvider<MockEthereum>;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<MockEthereumChainCrypto>;
 	type RetryPolicy = MockRetryPolicy;

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -365,7 +365,7 @@ fn test_signature_request_expiry() {
 			assert_eq!(Broadcaster::attempt_count(broadcast_id), 0);
 			broadcast_id
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expiry)
 		})
 		.then_execute_at_next_block(|broadcast_id| {
@@ -396,7 +396,7 @@ fn test_transmission_request_expiry() {
 				BlockHeightProvider::<MockEthereum>::get_block_height() + BROADCAST_EXPIRY_BLOCKS;
 			broadcast_id
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expiry)
 		})
 		.then_execute_at_next_block(|broadcast_id| {
@@ -404,7 +404,7 @@ fn test_transmission_request_expiry() {
 			check_end_state(broadcast_id);
 			broadcast_id
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::mutate_block_height(|height| height + 1)
 		})
 		.then_execute_at_next_block(|broadcast_id| {
@@ -439,7 +439,7 @@ fn re_request_threshold_signature_on_invalid_tx_params() {
 				BlockHeightProvider::<MockEthereum>::get_block_height() + BROADCAST_EXPIRY_BLOCKS;
 			broadcast_id
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(external_expiry)
 		})
 		.then_execute_at_block(expiry, |broadcast_id| {
@@ -693,7 +693,7 @@ fn retry_with_threshold_signing_still_allows_late_success_witness_second_attempt
 			(nominee, broadcast_data)
 		})
 		// The broadcast times out
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expected_expiry_block)
 		})
 		.then_process_next_block()
@@ -971,7 +971,7 @@ fn timed_out_broadcaster_are_reported() {
 			assert!(FailedBroadcasters::<Test, Instance1>::get(broadcast_id).is_empty());
 			(broadcast_id, nominee)
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expiry)
 		})
 		.then_execute_at_next_block(|(broadcast_id, nominee)| {
@@ -1027,7 +1027,7 @@ fn broadcast_timeout_works_when_external_chain_advances_multiple_blocks() {
 			(broadcast_ids, expiry)
 		})
 		// add start a second broadcast during the next external block
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::mutate_block_height(|height| height + 1)
 		})
 		.then_execute_with(|(mut broadcast_ids, expiry)| {
@@ -1039,7 +1039,7 @@ fn broadcast_timeout_works_when_external_chain_advances_multiple_blocks() {
 		.then_process_next_block()
 		.then_process_next_block()
 		// move external block height into the future past both timeouts
-		.then_execute_with_and_keep_context(|(_, expiry)| {
+		.then_execute_with_keep_context(|(_, expiry)| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expiry + 5)
 		})
 		.then_process_next_block()
@@ -1065,15 +1065,13 @@ fn aborted_broadcasts_can_still_succeed() {
 	new_test_ext()
 		.execute_with(|| {
 			let (broadcast_id, transaction_out_id) = start_mock_broadcast();
-			// external_expiry = System::block_number()
-			// 	.saturating_add(crate::BroadcastTimeout::<Test, Instance1>::get());
 			external_expiry = BlockHeightProvider::<MockEthereum>::get_block_height()
 				.saturating_add(crate::BroadcastTimeout::<Test, Instance1>::get());
 			ready_to_abort_broadcast(broadcast_id);
 
 			(broadcast_id, transaction_out_id)
 		})
-		.then_execute_with_and_keep_context(|_| {
+		.then_execute_with_keep_context(|_| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(external_expiry)
 		})
 		.then_execute_at_next_block(|ctx| ctx)

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -167,7 +167,7 @@ fn get_timeouts_for(
 	let mut result = BTreeSet::new();
 	for (timeout, broadcast_id, nominee) in Timeouts::<Test, Instance1>::get() {
 		if timeout == chainblock {
-			result.insert((broadcast_id, nominee).clone());
+			result.insert((broadcast_id, nominee));
 		}
 	}
 	result

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -1051,7 +1051,6 @@ fn broadcast_timeout_works_when_external_chain_advances_multiple_blocks() {
 			(broadcast_ids, max(expiry1, expiry2))
 		})
 		.then_process_next_block()
-		.then_process_next_block()
 		// move external block height into the future past both timeouts
 		.then_execute_with_keep_context(|(_, expiry)| {
 			BlockHeightProvider::<MockEthereum>::set_block_height(expiry + 1)

--- a/state-chain/runtime/src/constants.rs
+++ b/state-chain/runtime/src/constants.rs
@@ -59,6 +59,19 @@ pub mod common {
 	pub const DAYS: BlockNumber = HOURS * 24;
 	pub const YEAR: BlockNumber = DAYS * 365;
 
+	// Measurements for other chains
+	pub const MILLISECONDS_PER_BLOCK_ETHEREUM: u64 = 14 * 1000;
+	pub const MILLISECONDS_PER_BLOCK_POLKADOT: u32 = 6 * 1000;
+	pub const MILLISECONDS_PER_BLOCK_BITCOIN: u64 = 10 * 60 * 1000;
+	pub const MILLISECONDS_PER_BLOCK_ARBITRUM: u64 = 250;
+	pub const MILLISECONDS_PER_BLOCK_SOLANA: u64 = 400;
+
+	pub const BLOCKS_PER_MINUTE_ETHEREUM: u64 = 60000 / MILLISECONDS_PER_BLOCK_ETHEREUM;
+	pub const BLOCKS_PER_MINUTE_POLKADOT: u32 = 60000 / MILLISECONDS_PER_BLOCK_POLKADOT;
+	// no constant for bitcoin since the block time is too large
+	pub const BLOCKS_PER_MINUTE_ARBITRUM: u64 = 60000 / MILLISECONDS_PER_BLOCK_ARBITRUM;
+	pub const BLOCKS_PER_MINUTE_SOLANA: u64 = 60000 / MILLISECONDS_PER_BLOCK_SOLANA;
+
 	/// Percent of the epoch we are allowed to redeem
 	pub const REDEMPTION_PERIOD_AS_PERCENTAGE: u8 = 50;
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -859,6 +859,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_ETHEREUM>;
 	type ChainTracking = EthereumChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -884,6 +885,7 @@ impl pallet_cf_broadcast::Config<Instance2> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU32<BLOCKS_PER_MINUTE_POLKADOT>;
 	type ChainTracking = PolkadotChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -909,6 +911,7 @@ impl pallet_cf_broadcast::Config<Instance3> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU64<1>; // 10 minutes
 	type ChainTracking = BitcoinChainTracking;
 	type RetryPolicy = BitcoinRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -934,6 +937,7 @@ impl pallet_cf_broadcast::Config<Instance4> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_ARBITRUM>;
 	type ChainTracking = ArbitrumChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -966,6 +970,7 @@ impl pallet_cf_broadcast::Config<Instance5> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
+	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_SOLANA>;
 	type ChainTracking = SolanaChainTrackingProvider;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1253,13 +1253,13 @@ type MigrationsForV1_7 = (
 	VersionedMigration<
 		pallet_cf_broadcast::Pallet<Runtime, SolanaInstance>,
 		SerializeSolanaBroadcastMigration,
-		7,
 		8,
+		9,
 	>,
-	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, EthereumInstance>, NoopUpgrade, 7, 8>,
-	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 7, 8>,
-	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 7, 8>,
-	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 7, 8>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, EthereumInstance>, NoopUpgrade, 8, 9>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 8, 9>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 8, 9>,
+	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 8, 9>,
 );
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -859,7 +859,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_ETHEREUM>;
+	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_ETHEREUM>;
 	type ChainTracking = EthereumChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -885,7 +885,7 @@ impl pallet_cf_broadcast::Config<Instance2> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU32<BLOCKS_PER_MINUTE_POLKADOT>;
+	type SafeModeChainBlockMargin = ConstU32<BLOCKS_PER_MINUTE_POLKADOT>;
 	type ChainTracking = PolkadotChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -911,7 +911,7 @@ impl pallet_cf_broadcast::Config<Instance3> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU64<1>; // 10 minutes
+	type SafeModeChainBlockMargin = ConstU64<1>; // 10 minutes
 	type ChainTracking = BitcoinChainTracking;
 	type RetryPolicy = BitcoinRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -937,7 +937,7 @@ impl pallet_cf_broadcast::Config<Instance4> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_ARBITRUM>;
+	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_ARBITRUM>;
 	type ChainTracking = ArbitrumChainTracking;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;
@@ -970,7 +970,7 @@ impl pallet_cf_broadcast::Config<Instance5> for Runtime {
 	type WeightInfo = pallet_cf_broadcast::weights::PalletWeight<Runtime>;
 	type SafeMode = RuntimeSafeMode;
 	type SafeModeBlockMargin = ConstU32<10>;
-	type SafeModeBlockMarginForTargetChain = ConstU64<BLOCKS_PER_MINUTE_SOLANA>;
+	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_SOLANA>;
 	type ChainTracking = SolanaChainTrackingProvider;
 	type RetryPolicy = DefaultRetryPolicy;
 	type LiabilityTracker = AssetBalances;

--- a/state-chain/traits/src/mocks/block_height_provider.rs
+++ b/state-chain/traits/src/mocks/block_height_provider.rs
@@ -20,11 +20,8 @@ impl<C: Chain> BlockHeightProvider<C> {
 		Self::put_value(BLOCK_HEIGHT_KEY, height);
 	}
 
-	pub fn mutate_block_height<F>(f: F)
-	where
-		F: FnOnce(C::ChainBlockNumber) -> C::ChainBlockNumber,
-	{
-		Self::set_block_height(f(Self::get_block_height()));
+	pub fn increment_block_height() {
+		Self::set_block_height(Self::get_block_height() + 1u32.into());
 	}
 }
 

--- a/state-chain/traits/src/mocks/block_height_provider.rs
+++ b/state-chain/traits/src/mocks/block_height_provider.rs
@@ -19,6 +19,12 @@ impl<C: Chain> BlockHeightProvider<C> {
 	pub fn set_block_height(height: C::ChainBlockNumber) {
 		Self::put_value(BLOCK_HEIGHT_KEY, height);
 	}
+
+	pub fn mutate_block_height<F>(f: F)
+		where F : FnOnce(C::ChainBlockNumber) -> C::ChainBlockNumber
+	{
+		Self::set_block_height(f(Self::get_block_height()));
+	}
 }
 
 const DEFAULT_BLOCK_HEIGHT: u32 = 1337;

--- a/state-chain/traits/src/mocks/block_height_provider.rs
+++ b/state-chain/traits/src/mocks/block_height_provider.rs
@@ -21,7 +21,8 @@ impl<C: Chain> BlockHeightProvider<C> {
 	}
 
 	pub fn mutate_block_height<F>(f: F)
-		where F : FnOnce(C::ChainBlockNumber) -> C::ChainBlockNumber
+	where
+		F: FnOnce(C::ChainBlockNumber) -> C::ChainBlockNumber,
 	{
 		Self::set_block_height(f(Self::get_block_height()));
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-989

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This change involves the following (in the broadcast pallet):
 - `BroadcastTimeout` is now specified in `ChainBlockNumberFor<T,I>`
 - `Timeouts` is now specified in `ChainBlockNumberFor<T,I>`
 - A new constant `SafeModeBlockMarginForTargetChain`, also in `ChainBlockNumberFor<T,I>` is introduced since the previously used `SafeModeBlockMargin` stays denominated in `BlockNumberFor<T>` for other purposes.
 - For convenience, introduction of block time constants for all target chains.
 - Update the migration introduced in #5258 since it hasn't been released yet.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
