### PR TITLE
chore: rename `inspect_storage` to `then_execute_with_keep_context`.

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -354,7 +354,7 @@ fn addresses_are_getting_reused() {
 			),
 			(DepositRequest::Liquidity { lp_account: ALICE, asset: eth::Asset::Eth }, 0u32.into()),
 		])
-		.inspect_storage(|deposit_details| {
+		.then_execute_with_keep_context(|deposit_details| {
 			assert_eq!(ChannelIdCounter::<Test, _>::get(), deposit_details.len() as u64);
 		})
 		// Simulate broadcast success.
@@ -379,7 +379,7 @@ fn addresses_are_getting_reused() {
 			channels[0].clone()
 		})
 		// Check that the used address is now deployed and in the pool of available addresses.
-		.inspect_storage(|(_request, channel_id, address)| {
+		.then_execute_with_keep_context(|(_request, channel_id, address)| {
 			expect_size_of_address_pool(1);
 			// Address 1 is free to use and in the pool of available addresses
 			assert_eq!(DepositChannelPool::<Test, _>::get(channel_id).unwrap().address, *address);
@@ -390,7 +390,7 @@ fn addresses_are_getting_reused() {
 			destination_address: ForeignChainAddress::Eth(Default::default()),
 		}])
 		// The address should have been taken from the pool and the id counter unchanged.
-		.inspect_storage(|_| {
+		.then_execute_with_keep_context(|_| {
 			expect_size_of_address_pool(0);
 			assert_eq!(ChannelIdCounter::<Test, _>::get(), 2);
 		});
@@ -768,7 +768,7 @@ fn multi_use_deposit_same_block() {
 			assert!(ctx.len() == 1);
 			ctx.pop().unwrap()
 		})
-		.inspect_storage(|(_, _, deposit_address)| {
+		.then_execute_with_keep_context(|(_, _, deposit_address)| {
 			assert!(
 				DepositChannelLookup::<Test, _>::get(deposit_address)
 					.unwrap()
@@ -798,7 +798,7 @@ fn multi_use_deposit_same_block() {
 			.unwrap();
 			(request, channel_id, deposit_address)
 		})
-		.inspect_storage(|(_, channel_id, deposit_address)| {
+		.then_execute_with_keep_context(|(_, channel_id, deposit_address)| {
 			assert_eq!(
 				DepositChannelLookup::<Test, _>::get(deposit_address)
 					.unwrap()
@@ -846,7 +846,7 @@ fn multi_use_deposit_same_block() {
 			MockEgressBroadcaster::dispatch_all_success_callbacks();
 			ctx
 		})
-		.inspect_storage(|(_, _, deposit_address)| {
+		.then_execute_with_keep_context(|(_, _, deposit_address)| {
 			assert_eq!(
 				DepositChannelLookup::<Test, _>::get(deposit_address)
 					.unwrap()
@@ -1088,7 +1088,7 @@ fn channel_reuse_with_different_assets() {
 			MockEgressBroadcaster::dispatch_all_success_callbacks();
 			ctx
 		})
-		.inspect_storage(|(request, _, address)| {
+		.then_execute_with_keep_context(|(request, _, address)| {
 			let asset = request.source_asset();
 			assert_eq!(asset, ASSET_1);
 			assert!(
@@ -1101,7 +1101,7 @@ fn channel_reuse_with_different_assets() {
 			BlockHeightProvider::<MockEthereum>::set_block_height(recycle_block);
 			channel_id
 		})
-		.inspect_storage(|channel_id| {
+		.then_execute_with_keep_context(|channel_id| {
 			assert!(DepositChannelLookup::<Test, _>::get(ALICE_ETH_ADDRESS).is_none());
 			assert!(
 				DepositChannelPool::<Test, _>::iter_values().next().unwrap().channel_id ==
@@ -1115,7 +1115,7 @@ fn channel_reuse_with_different_assets() {
 		}])
 		.map_context(|mut result| result.pop().unwrap())
 		// Ensure that the deposit channel's asset is updated.
-		.inspect_storage(|(request, _, address)| {
+		.then_execute_with_keep_context(|(request, _, address)| {
 			let asset = request.source_asset();
 			assert_eq!(asset, ASSET_2);
 			assert!(

--- a/state-chain/test-utilities/src/rich_test_externalities.rs
+++ b/state-chain/test-utilities/src/rich_test_externalities.rs
@@ -128,7 +128,7 @@ where
 	/// Transforms the test context. Analogous to [std::iter::Iterator::map].
 	///
 	/// Storage is not accessible in this closure. This means that assert_noop! won't work. If
-	/// storage access is required, use `inspect_storage`.
+	/// storage access is required, use `then_execute_with` or `then_execute_with_keep_context`.
 	#[track_caller]
 	pub fn map_context<R>(self, f: impl FnOnce(Ctx) -> R) -> TestExternalities<Runtime, R> {
 		TestExternalities { ext: self.ext, context: f(self.context) }
@@ -146,9 +146,14 @@ where
 
 	/// Access the storage without changing the test context.
 	///
-	/// Use this for assertions, for example testing invariants.
+	/// Use this when you want to read or mutate the storage without
+	/// changing the test context. Also useful for assertions,
+	/// for example for testing invariants.
 	#[track_caller]
-	pub fn inspect_storage(self, f: impl FnOnce(&Ctx)) -> TestExternalities<Runtime, Ctx> {
+	pub fn then_execute_with_keep_context(
+		self,
+		f: impl FnOnce(&Ctx),
+	) -> TestExternalities<Runtime, Ctx> {
 		self.then_execute_with(
 			#[track_caller]
 			|context| {
@@ -431,7 +436,7 @@ mod test_examples {
 				]
 			})
 			// Use inspect when you don't want to write to storage.
-			.inspect_storage(|_| {
+			.then_execute_with_keep_context(|_| {
 				assert!(matches!(
 					System::events().into_iter().map(|e| e.event).collect::<Vec<_>>().as_slice(),
 					[


### PR DESCRIPTION
# Pull Request

Part of: PRO-989

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

During #5270 I noticed that it would be nice to have a test utility function which works like `then_execute_with`, but instead of requiring the user to forward or construct a new context it simply retains the old one.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
