### PR TITLE
feat: liveness electoral system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7595,6 +7595,7 @@ dependencies = [
  "frame-system",
  "itertools 0.13.0",
  "log",
+ "nanorand",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",

--- a/engine/src/elections/voter_api.rs
+++ b/engine/src/elections/voter_api.rs
@@ -66,4 +66,4 @@ macro_rules! generate_voter_api_tuple_impls {
     }
 }
 
-generate_voter_api_tuple_impls!(tuple_5_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0)));
+generate_voter_api_tuple_impls!(tuple_6_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0), (FF, F0)));

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -39,6 +39,8 @@ pub const ACCRUAL_RATIO: (i32, u32) = (1, 1);
 
 const COMPUTE_PRICE: u64 = 1_000u64;
 
+const BLOCKS_BETWEEN_LIVENESS_CHECKS: u32 = 10;
+
 /// The offences committable within the protocol and their respective reputation penalty and
 /// suspension durations.
 pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
@@ -50,6 +52,7 @@ pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
 	// so there is no need to suspend them further.
 	(Offence::FailedToBroadcastTransaction, (10, 0)),
 	(Offence::GrandpaEquivocation, (50, HEARTBEAT_BLOCK_INTERVAL * 5)),
+	(Offence::FailedLivenessCheck(cf_chains::ForeignChain::Solana), (4, 0)),
 ];
 
 use crate::{
@@ -303,12 +306,14 @@ impl ExtBuilder {
 						(),
 						(),
 						(),
+						(),
 					),
 					unsynchronised_settings: (
 						(),
 						SolanaFeeUnsynchronisedSettings {
 							fee_multiplier: FixedU128::from_u32(1u32),
 						},
+						(),
 						(),
 						(),
 						(),
@@ -322,6 +327,7 @@ impl ExtBuilder {
 						},
 						(),
 						(),
+						BLOCKS_BETWEEN_LIVENESS_CHECKS,
 					),
 				}),
 			},

--- a/state-chain/node/src/chain_spec/common.rs
+++ b/state-chain/node/src/chain_spec/common.rs
@@ -54,7 +54,7 @@ const REPUTATION_PENALTY_LARGE: i32 = REPUTATION_PER_HEARTBEAT * 8; // Two hours
 
 // A penalty of 1 is missing an Ethereum witnessing every 15 seconds. We do liveness every minute.
 // which is equivalent to ~4 missed Ethereum witnessings.
-const LIVENESS_REPUTATION_PENALTY: i32 = 4;
+const LIVENESS_REPUTATION_PENALTY: i32 = REPUTATION_PER_HEARTBEAT / 5;
 
 /// The offences committable within the protocol and their respective reputation penalty and
 /// suspension durations.

--- a/state-chain/node/src/chain_spec/common.rs
+++ b/state-chain/node/src/chain_spec/common.rs
@@ -52,6 +52,10 @@ const REPUTATION_PENALTY_SMALL: i32 = REPUTATION_PER_HEARTBEAT; // 15 minutes to
 const REPUTATION_PENALTY_MEDIUM: i32 = REPUTATION_PER_HEARTBEAT * 4; // One hour to recover reputation
 const REPUTATION_PENALTY_LARGE: i32 = REPUTATION_PER_HEARTBEAT * 8; // Two hours to recover reputation
 
+// A penalty of 1 is missing an Ethereum witnessing every 15 seconds. We do liveness every minute.
+// which is equivalent to ~4 missed Ethereum witnessings.
+const LIVENESS_REPUTATION_PENALTY: i32 = 4;
+
 /// The offences committable within the protocol and their respective reputation penalty and
 /// suspension durations.
 pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
@@ -61,6 +65,10 @@ pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
 	(Offence::MissedAuthorshipSlot, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL)),
 	(Offence::FailedToBroadcastTransaction, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
 	(Offence::GrandpaEquivocation, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL * 5)),
+	(
+		Offence::FailedLivenessCheck(cf_chains::ForeignChain::Solana),
+		(LIVENESS_REPUTATION_PENALTY, 0),
+	),
 ];
 
 /// Daily slashing rate 0.1% (of the bond) for offline authority

--- a/state-chain/pallets/cf-elections/Cargo.toml
+++ b/state-chain/pallets/cf-elections/Cargo.toml
@@ -33,6 +33,9 @@ serde = { default_features = false, version = '1.0.195', features = [
   'alloc',
   'derive',
 ] }
+nanorand = { version = '0.7.0', default-features = false, features = [
+  'wyrand',
+] }
 
 # Parity deps
 codec = { package = 'parity-scale-codec', version = '3.6.1', default-features = false, features = [

--- a/state-chain/pallets/cf-elections/src/electoral_systems.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems.rs
@@ -2,6 +2,7 @@ pub mod blockchain;
 pub mod change;
 pub mod composite;
 pub mod egress_success;
+pub mod liveness;
 #[cfg(test)]
 pub mod mock;
 pub mod monotonic_median;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -31,6 +31,7 @@ mod tags {
 	pub struct C;
 	pub struct D;
 	pub struct EE;
+	pub struct FF;
 }
 
 macro_rules! generate_electoral_system_tuple_impls {
@@ -595,4 +596,4 @@ macro_rules! generate_electoral_system_tuple_impls {
     };
 }
 
-generate_electoral_system_tuple_impls!(tuple_5_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0)));
+generate_electoral_system_tuple_impls!(tuple_6_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0), (FF, F0)));

--- a/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
@@ -1,0 +1,183 @@
+use crate::{
+	electoral_system::{
+		AuthorityVoteOf, ConsensusVote, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
+		ElectionWriteAccess, ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
+	},
+	vote_storage::{self, VoteStorage},
+	CorruptStorageError,
+};
+use cf_primitives::AuthorityCount;
+use cf_utilities::success_threshold_from_share_count;
+use frame_support::{
+	pallet_prelude::{MaybeSerializeDeserialize, Member},
+	Parameter,
+};
+
+use itertools::Itertools;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+
+pub struct Liveness<ChainBlockNumber, ChainBlockHash, BlockNumber, Hook, ValidatorId> {
+	_phantom: core::marker::PhantomData<(
+		ChainBlockNumber,
+		ChainBlockHash,
+		BlockNumber,
+		Hook,
+		ValidatorId,
+	)>,
+}
+
+pub trait OnCheckComplete<ValidatorId> {
+	fn on_check_complete(validator_ids: Vec<ValidatorId>);
+}
+
+impl<
+		ChainBlockNumber: Member + Parameter + Eq + From<u64> + Into<u64> + Copy,
+		ChainBlockHash: Member + Parameter + Eq + Ord,
+		BlockNumber: Member
+			+ Parameter
+			+ Eq
+			+ MaybeSerializeDeserialize
+			+ frame_support::sp_runtime::Saturating
+			+ Ord
+			+ Copy,
+		Hook: OnCheckComplete<ValidatorId> + 'static,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem for Liveness<ChainBlockNumber, ChainBlockHash, BlockNumber, Hook, ValidatorId>
+{
+	type ValidatorId = ValidatorId;
+	type ElectoralUnsynchronisedState = ();
+	type ElectoralUnsynchronisedStateMapKey = ();
+	type ElectoralUnsynchronisedStateMapValue = ();
+
+	type ElectoralUnsynchronisedSettings = ();
+	// How many SC blocks to wait before we consider the election complete.
+	type ElectoralSettings = BlockNumber;
+	type ElectionIdentifierExtra = ();
+
+	// The external chain block number that the engines will get the hash for.
+	type ElectionProperties = ChainBlockNumber;
+
+	// The SC block number that we started the election at.
+	type ElectionState = BlockNumber;
+	type Vote = vote_storage::bitmap::Bitmap<ChainBlockHash>;
+	type Consensus = Vec<Self::ValidatorId>;
+	// The current SC block number, and the current chain tracking height.
+	type OnFinalizeContext = (BlockNumber, ChainBlockNumber);
+	type OnFinalizeReturn = ();
+
+	fn generate_vote_properties(
+		_election_identifier: ElectionIdentifierOf<Self>,
+		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
+		Ok(())
+	}
+
+	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+		_election_identifier: ElectionIdentifierOf<Self>,
+		_election_access: &ElectionAccess,
+		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+	) -> Result<bool, CorruptStorageError> {
+		Ok(true)
+	}
+
+	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
+		electoral_access: &mut ElectoralAccess,
+		election_identifiers: Vec<ElectionIdentifierOf<Self>>,
+		(current_sc_block, current_chain_tracking_number): &Self::OnFinalizeContext,
+	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
+		fn block_number_to_check<ChainBlockNumber: Into<u64> + From<u64>>(
+			current_chain_tracking_number: ChainBlockNumber,
+		) -> ChainBlockNumber {
+			use nanorand::{Rng, WyRand};
+			let height: u64 = current_chain_tracking_number.into();
+
+			// 100 seems a reasonable number for all chains, fast or slow, most running nodes will
+			// have at least 100 blocks worth of state for any particular chain, while still
+			// providing enough variation.
+			const RANGE: u64 = 100;
+			WyRand::new_seed(height)
+				.generate_range((height.saturating_sub(RANGE))..height)
+				.into()
+		}
+
+		if let Some(election_identifier) = election_identifiers
+			.into_iter()
+			.at_most_one()
+			.map_err(|_| CorruptStorageError::new())?
+		{
+			let mut election_access = electoral_access.election_mut(election_identifier)?;
+
+			// Is the block the election started at + the duration we want the check to stay open
+			// for less than or equal to the current SC block?
+			if election_access.state()?.saturating_add(election_access.settings()?) <=
+				*current_sc_block
+			{
+				if let Some(bad_validators) = election_access.check_consensus()?.has_consensus() {
+					if !bad_validators.is_empty() {
+						Hook::on_check_complete(bad_validators);
+					}
+				}
+				election_access.delete();
+				electoral_access.new_election(
+					(),
+					block_number_to_check(*current_chain_tracking_number),
+					*current_sc_block,
+				)?;
+			}
+		} else {
+			electoral_access.new_election(
+				(),
+				block_number_to_check(*current_chain_tracking_number),
+				*current_sc_block,
+			)?;
+		}
+
+		Ok(())
+	}
+
+	fn check_consensus<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+		_election_identifier: ElectionIdentifierOf<Self>,
+		_election_access: &ElectionAccess,
+		_previous_consensus: Option<&Self::Consensus>,
+		consensus_votes: ConsensusVotes<Self>,
+	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
+		let num_authorities = consensus_votes.num_authorities();
+		let success_threshold = success_threshold_from_share_count(num_authorities);
+
+		let mut active_votes = BTreeMap::new();
+		let mut non_voters = Vec::new();
+		for ConsensusVote { vote, validator_id } in consensus_votes.votes {
+			match vote {
+				Some(vote) => {
+					active_votes.entry(vote.1).or_insert_with(Vec::new).push(validator_id);
+				},
+				None => non_voters.push(validator_id),
+			}
+		}
+
+		let (consensus_validators, non_consensus_validators): (Vec<_>, Vec<_>) =
+			active_votes.into_iter().partition(|(_, validator_ids)| {
+				validator_ids.len() as AuthorityCount >= success_threshold
+			});
+
+		debug_assert!(
+			consensus_validators.len() <= 1,
+			"there should only be one group that gained consensus"
+		);
+
+		Ok(if consensus_validators.len() == 1 {
+			Some(
+				non_consensus_validators
+					.into_iter()
+					.flat_map(|(_, validator_ids)| validator_ids)
+					.chain(non_voters)
+					.collect(),
+			)
+		} else {
+			// If we didn't gain consensus on a value, then we don't punish anyone. We assume
+			// there's an issue with the external network.
+			None
+		})
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -118,24 +118,8 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 	#[track_caller]
 	pub fn expect_consensus(
 		self,
-		consensus_votes: ConsensusVotes<ES>,
-		expected_consensus: Option<ES::Consensus>,
-	) -> Self {
-		Self::expect_consensus_by(
-			self,
-			consensus_votes,
-			expected_consensus,
-			|new_consensus, expected_consensus| {
-				assert_eq!(new_consensus, expected_consensus);
-			},
-		)
-	}
-
-	pub fn expect_consensus_by<C: FnOnce(Option<ES::Consensus>, Option<ES::Consensus>)>(
-		self,
 		mut consensus_votes: ConsensusVotes<ES>,
 		expected_consensus: Option<ES::Consensus>,
-		check: C,
 	) -> Self {
 		assert!(consensus_votes.num_authorities() > 0, "Cannot have zero authorities.");
 
@@ -153,7 +137,7 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 			.unwrap();
 
 		// Should assert on some condition about the consensus.
-		check(new_consensus.clone(), expected_consensus);
+		assert_eq!(new_consensus.clone(), expected_consensus);
 
 		self.inner_force_consensus_update(
 			current_election_id,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
@@ -4,6 +4,7 @@ pub(crate) use crate::register_checks;
 
 pub mod change;
 pub mod egress_success;
+pub mod liveness;
 pub mod monotonic_median;
 pub mod unsafe_median;
 pub mod utils;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/change.rs
@@ -46,7 +46,7 @@ const SUCCESS_THRESHOLD: AuthorityCount =
 	cf_utilities::success_threshold_from_share_count(AUTHORITY_COUNT);
 
 fn with_default_state() -> TestContext<SimpleChange> {
-	TestSetup::<SimpleChange>::default().build()
+	TestSetup::<SimpleChange>::default().build_with_initial_election()
 }
 
 fn generate_votes(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
@@ -46,7 +46,7 @@ const SUCCESS_THRESHOLD: AuthorityCount =
 	cf_utilities::success_threshold_from_share_count(AUTHORITY_COUNT);
 
 fn with_default_state() -> TestContext<SimpleEgressSuccess> {
-	TestSetup::<SimpleEgressSuccess>::default().build()
+	TestSetup::<SimpleEgressSuccess>::default().build_with_initial_election()
 }
 
 fn generate_votes(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -1,0 +1,205 @@
+use super::{mocks::*, register_checks};
+use crate::{
+	electoral_system::{ConsensusVote, ConsensusVotes},
+	electoral_systems::liveness::*,
+};
+
+pub type ChainBlockHash = u64;
+pub type ChainBlockNumber = u64;
+pub type BlockNumber = u32;
+pub type ValidatorId = u16;
+
+thread_local! {
+	pub static HOOK_CALLED_COUNT: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+}
+
+struct MockHook;
+
+impl OnCheckComplete<ValidatorId> for MockHook {
+	fn on_check_complete(_validator_ids: Vec<ValidatorId>) {
+		HOOK_CALLED_COUNT.with(|hook_called| hook_called.set(hook_called.get() + 1));
+	}
+}
+
+impl MockHook {
+	pub fn called() -> u8 {
+		HOOK_CALLED_COUNT.with(|hook_called| hook_called.get())
+	}
+}
+
+type SimpleLiveness =
+	Liveness<ChainBlockHash, ChainBlockNumber, BlockNumber, MockHook, ValidatorId>;
+
+register_checks! {
+	SimpleLiveness {
+		only_one_election(_pre, post) {
+			let election_ids = post.election_identifiers();
+			assert_eq!(election_ids.len(), 1, "Only one election should exist.");
+		},
+		hook_called_once(_pre, _post) {
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!");
+		},
+		hook_called_twice(_pre, _post) {
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!");
+		},
+		hook_not_called(_pre, _post) {
+			assert_eq!(
+				HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()),
+				0,
+				"Hook should not have been called!"
+			);
+		},
+	}
+}
+
+const CORRECT_VOTE: ChainBlockHash = 69420;
+const INCORRECT_VOTE: ChainBlockHash = 666;
+
+fn generate_votes(
+	correct_voters: Vec<ValidatorId>,
+	incorrect_voters: Vec<ValidatorId>,
+	did_not_vote: Vec<ValidatorId>,
+) -> ConsensusVotes<SimpleLiveness> {
+	ConsensusVotes {
+		votes: correct_voters
+			.into_iter()
+			.map(|v| ConsensusVote { vote: Some(((), CORRECT_VOTE)), validator_id: v })
+			.chain(
+				incorrect_voters
+					.into_iter()
+					.map(|v| ConsensusVote { vote: Some(((), INCORRECT_VOTE)), validator_id: v }),
+			)
+			.chain(did_not_vote.into_iter().map(|v| ConsensusVote { vote: None, validator_id: v }))
+			.collect(),
+	}
+}
+
+fn with_default_state() -> TestContext<SimpleLiveness> {
+	TestSetup::<SimpleLiveness>::default().build_with_initial_election()
+}
+
+#[test]
+fn all_vote_for_same_value_means_no_bad_validators() {
+	with_default_state()
+		.expect_consensus(generate_votes((0..50).collect(), vec![], vec![]), Some(vec![]));
+}
+
+#[test]
+fn no_votes_no_one_bad_validators() {
+	with_default_state().expect_consensus(generate_votes(vec![], vec![], (0..50).collect()), None);
+}
+
+fn check_consensus(
+	new_consensus: Option<Vec<ValidatorId>>,
+	expected_consensus: Option<Vec<ValidatorId>>,
+) {
+	let mut new_consensus = new_consensus.unwrap();
+	new_consensus.sort();
+	let mut expected_consensus = expected_consensus.unwrap();
+	expected_consensus.sort();
+	assert_eq!(new_consensus, expected_consensus);
+}
+
+#[test]
+fn consensus_with_bad_voters() {
+	let correct_voters: Vec<_> = (0..50).collect();
+	let incorrect_voters: Vec<_> = (50..60).collect();
+	let non_voters: Vec<_> = (60..70).collect();
+
+	with_default_state().expect_consensus_by(
+		generate_votes(correct_voters.clone(), incorrect_voters.clone(), vec![]),
+		Some(incorrect_voters.clone()),
+		check_consensus,
+	);
+
+	with_default_state().expect_consensus_by(
+		generate_votes(correct_voters.clone(), vec![], non_voters.clone()),
+		Some(non_voters.clone()),
+		check_consensus,
+	);
+
+	with_default_state().expect_consensus_by(
+		generate_votes(correct_voters, incorrect_voters.clone(), non_voters.clone()),
+		Some(incorrect_voters.into_iter().chain(non_voters).collect()),
+		check_consensus,
+	);
+}
+
+#[test]
+fn on_finalize() {
+	const INIT_BLOCK: BlockNumber = 100;
+	const BLOCKS_BETWEEN_CHECKS: BlockNumber = 10;
+	const INIT_CHAIN_TRACKING_BLOCK: ChainBlockNumber = 1000;
+
+	let correct_voters: Vec<_> = (0..50).collect();
+	let non_voters: Vec<_> = (60..70).collect();
+
+	TestSetup::default()
+		.with_electoral_settings(BLOCKS_BETWEEN_CHECKS)
+		.build()
+		.test_on_finalize(
+			&(INIT_BLOCK, INIT_CHAIN_TRACKING_BLOCK),
+			|_| assert_eq!(MockHook::called(), 0, "Hook should not have been called!"),
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_not_called(),
+			],
+		)
+		.expect_consensus_by(
+			generate_votes(correct_voters.clone(), vec![], non_voters.clone()),
+			Some(non_voters.clone()),
+			check_consensus,
+		)
+		.test_on_finalize(
+			// check duration has not yet elapsed, so no change
+			&(INIT_BLOCK + BLOCKS_BETWEEN_CHECKS - 1, INIT_CHAIN_TRACKING_BLOCK),
+			|_| {},
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_not_called(),
+			],
+		)
+		.test_on_finalize(
+			&(INIT_BLOCK + BLOCKS_BETWEEN_CHECKS, INIT_CHAIN_TRACKING_BLOCK),
+			|_| {},
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_called_once(),
+			],
+		)
+		.test_on_finalize(
+			// we should have reset to the hook not being called, and there's still just one
+			// election
+			&(INIT_BLOCK + BLOCKS_BETWEEN_CHECKS + 1, INIT_CHAIN_TRACKING_BLOCK),
+			|_| {},
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_called_once(),
+			],
+		)
+		// there have been no votes, so still only called once
+		.test_on_finalize(
+			// we should have reset to the hook not being called, and there's still just one
+			// election
+			&(INIT_BLOCK + BLOCKS_BETWEEN_CHECKS * 2, INIT_CHAIN_TRACKING_BLOCK),
+			|_| {},
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_called_once(),
+			],
+		)
+		.expect_consensus_by(
+			generate_votes(correct_voters.clone(), vec![], non_voters.clone()),
+			Some(non_voters),
+			check_consensus,
+		)
+		// we have votes now and expect nodes to be punished by having the hook called again.
+		.test_on_finalize(
+			&(INIT_BLOCK + BLOCKS_BETWEEN_CHECKS * 3, INIT_CHAIN_TRACKING_BLOCK),
+			|_| {},
+			vec![
+				Check::<SimpleLiveness>::only_one_election(),
+				Check::<SimpleLiveness>::hook_called_twice(),
+			],
+		);
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
@@ -15,7 +15,7 @@ fn with_default_setup() -> TestSetup<MonotonicMedianTest> {
 }
 
 fn with_default_context() -> TestContext<MonotonicMedianTest> {
-	with_default_setup().build()
+	with_default_setup().build_with_initial_election()
 }
 
 pub struct MockHook;
@@ -131,7 +131,7 @@ fn finalize_election_state_can_not_decrease() {
 		MockHook::reset();
 		with_default_setup()
 			.with_unsynchronised_state(INTITIAL_STATE)
-			.build()
+			.build_with_initial_election()
 			// It's possible for authorities to come to consensus on a lower state,
 			// but this should not change the unsynchronised state.
 			.force_consensus_update(ConsensusStatus::Gained { most_recent: None, new: new_state })

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
@@ -16,7 +16,7 @@ fn with_default_setup() -> TestSetup<SimpleUnsafeMedian> {
 }
 
 fn with_default_context() -> TestContext<SimpleUnsafeMedian> {
-	with_default_setup().build()
+	with_default_setup().build_with_initial_election()
 }
 
 register_checks! {

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -124,7 +124,7 @@ use frame_system::pallet_prelude::*;
 
 pub use pallet::*;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(0);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
 
 pub use pallet::UniqueMonotonicIdentifier;
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -504,7 +504,7 @@ pub mod pallet {
 	/// Stores governance-controlled settings regarding the elections. These settings can be changed
 	/// at anytime, but that change will only affect newly created elections.
 	#[pallet::storage]
-	pub(crate) type ElectoralSettings<T: Config<I>, I: 'static = ()> = StorageMap<
+	pub type ElectoralSettings<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Twox64Concat,
 		UniqueMonotonicIdentifier,

--- a/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
@@ -274,8 +274,4 @@ macro_rules! generate_vote_storage_tuple_impls {
     }
 }
 
-generate_vote_storage_tuple_impls!(tuple_1_impls: (A));
-generate_vote_storage_tuple_impls!(tuple_2_impls: (A, B));
-generate_vote_storage_tuple_impls!(tuple_3_impls: (A, B, C));
-generate_vote_storage_tuple_impls!(tuple_4_impls: (A, B, C, D));
-generate_vote_storage_tuple_impls!(tuple_5_impls: (A, B, C, D, EE));
+generate_vote_storage_tuple_impls!(tuple_6_impls: (A, B, C, D, EE, FF));

--- a/state-chain/pallets/cf-elections/src/vote_storage/individual/composite.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/individual/composite.rs
@@ -74,10 +74,6 @@ macro_rules! generate_individual_vote_storage_tuple_impls {
         }
     }
 }
-
-generate_individual_vote_storage_tuple_impls!(tuple_0_impls: ());
-generate_individual_vote_storage_tuple_impls!(tuple_1_impls: (A));
+#[cfg(test)]
 generate_individual_vote_storage_tuple_impls!(tuple_2_impls: (A, B));
-generate_individual_vote_storage_tuple_impls!(tuple_3_impls: (A, B, C));
-generate_individual_vote_storage_tuple_impls!(tuple_4_impls: (A, B, C, D));
-generate_individual_vote_storage_tuple_impls!(tuple_5_impls: (A, B, C, D, EE));
+generate_individual_vote_storage_tuple_impls!(tuple_6_impls: (A, B, C, D, EE, FF));

--- a/state-chain/runtime/src/chainflip/offences.rs
+++ b/state-chain/runtime/src/chainflip/offences.rs
@@ -1,4 +1,5 @@
 use crate::Runtime;
+use cf_chains::ForeignChain;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::RuntimeDebug;
 use pallet_cf_reputation::OffenceList;
@@ -36,6 +37,8 @@ pub enum Offence {
 	ParticipateKeyHandoverFailed,
 	/// A authority failed to Witness a call in time.
 	FailedToWitnessInTime,
+	/// Failed to Complete Liveness Check for chain.
+	FailedLivenessCheck(ForeignChain),
 }
 
 /// Nodes should be excluded from keygen if they have been reported for any of the offences in this

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -31,7 +31,7 @@ use pallet_cf_elections::{
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::{DispatchResult, FixedPointNumber, FixedU128};
-use sp_std::vec::Vec;
+use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
 #[cfg(feature = "runtime-benchmarks")]
 use cf_chains::benchmarking_value::BenchmarkValue;
@@ -135,7 +135,7 @@ pub type SolanaLiveness = electoral_systems::liveness::Liveness<
 pub struct OnCheckCompleteHook;
 
 impl OnCheckComplete<<Runtime as Chainflip>::ValidatorId> for OnCheckCompleteHook {
-	fn on_check_complete(validator_ids: Vec<<Runtime as Chainflip>::ValidatorId>) {
+	fn on_check_complete(validator_ids: BTreeSet<<Runtime as Chainflip>::ValidatorId>) {
 		Reputation::report_many(Offence::FailedLivenessCheck(ForeignChain::Solana), validator_ids);
 	}
 }

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -60,6 +60,7 @@ use codec::{alloc::string::ToString, Decode, Encode};
 use core::ops::Range;
 use frame_support::instances::*;
 pub use frame_system::Call as SystemCall;
+use migrations::add_liveness_electoral_system_solana::LivenessSettingsMigration;
 use pallet_cf_governance::GovCallHash;
 use pallet_cf_ingress_egress::{
 	ChannelAction, DepositWitness, IngressOrEgress, OwedAmount, TargetChainAsset,
@@ -1264,6 +1265,7 @@ type MigrationsForV1_7 = (
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 8, 9>,
+	LivenessSettingsMigration,
 );
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1265,7 +1265,7 @@ type MigrationsForV1_7 = (
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 8, 9>,
-	LivenessSettingsMigration,
+	VersionedMigration<pallet_cf_elections::Pallet<Runtime, SolanaInstance>, LivenessSettingsMigration, 0, 1>,
 );
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1265,7 +1265,12 @@ type MigrationsForV1_7 = (
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, PolkadotInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, BitcoinInstance>, NoopUpgrade, 8, 9>,
 	VersionedMigration<pallet_cf_broadcast::Pallet<Runtime, ArbitrumInstance>, NoopUpgrade, 8, 9>,
-	VersionedMigration<pallet_cf_elections::Pallet<Runtime, SolanaInstance>, LivenessSettingsMigration, 0, 1>,
+	VersionedMigration<
+		pallet_cf_elections::Pallet<Runtime, SolanaInstance>,
+		LivenessSettingsMigration,
+		0,
+		1,
+	>,
 );
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -1,5 +1,6 @@
 //! Chainflip runtime storage migrations.
 
+pub mod add_liveness_electoral_system_solana;
 pub mod housekeeping;
 pub mod reap_old_accounts;
 pub mod serialize_solana_broadcast;

--- a/state-chain/runtime/src/migrations/add_liveness_electoral_system_solana.rs
+++ b/state-chain/runtime/src/migrations/add_liveness_electoral_system_solana.rs
@@ -1,0 +1,39 @@
+use crate::*;
+use frame_support::{pallet_prelude::Weight, storage::unhashed, traits::OnRuntimeUpgrade};
+use frame_system::pallet_prelude::BlockNumberFor;
+
+use pallet_cf_elections::{electoral_system::ElectoralSystem, Config, ElectoralSettings};
+#[cfg(feature = "try-runtime")]
+use sp_runtime::DispatchError;
+
+use codec::{Decode, Encode};
+
+pub struct LivenessSettingsMigration;
+
+const LIVENESS_CHECK_DURATION: BlockNumberFor<Runtime> = 10;
+
+// Because the Liveness electoral system is added to the end, and the rest of its types are the same
+// we can simply append the encoded bytes to the raw storage.
+impl OnRuntimeUpgrade for LivenessSettingsMigration {
+	fn on_runtime_upgrade() -> Weight {
+		for key in ElectoralSettings::<Runtime, SolanaInstance>::iter_keys() {
+			let mut raw_storage_at_key = unhashed::get_raw(&ElectoralSettings::<
+				Runtime,
+				SolanaInstance,
+			>::hashed_key_for(key))
+			.expect("We just got the keys directly from the storage");
+			raw_storage_at_key.extend(LIVENESS_CHECK_DURATION.encode());
+			ElectoralSettings::<Runtime, SolanaInstance>::insert(key, <<Runtime as Config<SolanaInstance>>::ElectoralSystem as ElectoralSystem>::ElectoralSettings::decode(&mut &raw_storage_at_key[..]).unwrap());
+		}
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		for (.., liveness_duration) in ElectoralSettings::<Runtime, SolanaInstance>::iter_values() {
+			assert_eq!(liveness_duration, LIVENESS_CHECK_DURATION);
+		}
+		Ok(())
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1645

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works - tested on 3 node localnet, took down a node and waited for a liveness completion and saw the node be punished :)
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Generic liveness electoral system that could be used for all chains. It works by asking the engines to return the block hash for a particular block number in a range from the current block height to 100 blocks below the current block height - this is to provide some variation on slower chains such as bitcoin. If we were to use the chain height and we're doing liveness every minute, then we would be returning the same value which is not ideal.

We punish any nodes who:
a) voted for the non-consensus value
b) did not vote when there was a consensus value

We don't punish nodes in any other scenarios such as:
- no one voted
- votes but no consensus

The offence contains the `ForeignChain` to identify it against other instances of the liveness system in the future to help with alerts and general observability. 