### PR TITLE
fix: expire all previous epochs

### DIFF
--- a/state-chain/cf-integration-tests/src/authorities.rs
+++ b/state-chain/cf-integration-tests/src/authorities.rs
@@ -59,10 +59,10 @@ pub fn fund_authorities_and_join_auction(
 /// by going through the correct sequence in sync.
 #[test]
 fn authority_rotates_with_correct_sequence() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -162,7 +162,7 @@ fn authorities_earn_rewards_for_authoring_blocks() {
 	// set
 	const MAX_AUTHORITIES: AuthorityCount = 3;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -206,7 +206,7 @@ fn genesis_nodes_rotated_out_accumulate_rewards_correctly() {
 	// set
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -273,7 +273,7 @@ fn authority_rotation_can_succeed_after_aborted_by_safe_mode() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -328,7 +328,7 @@ fn authority_rotation_cannot_be_aborted_after_key_handover_and_completes_even_on
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -371,7 +371,7 @@ fn authority_rotation_can_recover_after_keygen_fails() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -424,7 +424,7 @@ fn authority_rotation_can_recover_after_key_handover_fails() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -502,7 +502,7 @@ fn can_move_through_multiple_epochs() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -524,7 +524,7 @@ fn cant_rotate_if_previous_rotation_is_pending() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/authorities.rs
+++ b/state-chain/cf-integration-tests/src/authorities.rs
@@ -559,7 +559,7 @@ fn waits_for_governance_when_apicall_fails() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/broadcasting.rs
+++ b/state-chain/cf-integration-tests/src/broadcasting.rs
@@ -12,10 +12,10 @@ use state_chain_runtime::{
 
 #[test]
 fn bitcoin_broadcast_delay_works() {
-	const EPOCH_BLOCKS: u32 = 200;
+	const EPOCH_DURATION_BLOCKS: u32 = 200;
 	const MAX_AUTHORITIES: AuthorityCount = 150;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -22,10 +22,10 @@ use state_chain_runtime::{
 // We have a set of nodes that are funded and can redeem in the redeeming period and
 // not redeem when out of the period
 fn cannot_redeem_funds_out_of_redemption_period() {
-	const EPOCH_BLOCKS: u32 = 100;
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 3;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -68,7 +68,7 @@ fn cannot_redeem_funds_out_of_redemption_period() {
 			}
 
 			let end_of_redemption_period =
-				EPOCH_BLOCKS * REDEMPTION_PERIOD_AS_PERCENTAGE as u32 / 100;
+				EPOCH_DURATION_BLOCKS * REDEMPTION_PERIOD_AS_PERCENTAGE as u32 / 100;
 			// Move to end of the redemption period
 			System::set_block_number(end_of_redemption_period + 1);
 			// We will try to redeem
@@ -125,7 +125,7 @@ fn cannot_redeem_funds_out_of_redemption_period() {
 fn funded_node_is_added_to_backups() {
 	const EPOCH_BLOCKS: u32 = 10_000_000;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		// As we run a rotation at genesis we will need accounts to support
 		// having 5 authorities as the default is 3 (Alice, Bob and Charlie)
 		.accounts(vec![
@@ -149,7 +149,7 @@ fn backup_reward_is_calculated_linearly() {
 	const MAX_AUTHORITIES: u32 = 10;
 	const NUM_BACKUPS: u32 = 20;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -194,7 +194,7 @@ fn can_calculate_account_apy() {
 	const MAX_AUTHORITIES: u32 = 10;
 	const NUM_BACKUPS: u32 = 20;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -246,7 +246,7 @@ fn apy_can_be_above_100_percent() {
 	const MAX_AUTHORITIES: u32 = 2;
 	const NUM_BACKUPS: u32 = 2;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -282,7 +282,7 @@ fn backup_rewards_event_gets_emitted_on_heartbeat_interval() {
 	const NUM_BACKUPS: u32 = 20;
 	const MAX_AUTHORITIES: u32 = 100;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.accounts(
 			(0..MAX_AUTHORITIES as u8)
 				.map(|i| (AccountId32::from([i; 32]), AccountRole::Validator, GENESIS_BALANCE))

--- a/state-chain/cf-integration-tests/src/genesis.rs
+++ b/state-chain/cf-integration-tests/src/genesis.rs
@@ -14,7 +14,7 @@ use state_chain_runtime::{
 };
 pub const GENESIS_BALANCE: FlipBalance = TOTAL_ISSUANCE / 100;
 
-const BLOCKS_PER_EPOCH: u32 = 1000;
+const EPOCH_DURATION: u32 = 1000;
 
 pub fn with_test_defaults() -> ExtBuilder {
 	ExtBuilder::default()
@@ -26,7 +26,7 @@ pub fn with_test_defaults() -> ExtBuilder {
 			(AccountId::from(LIQUIDITY_PROVIDER), AccountRole::LiquidityProvider, GENESIS_BALANCE),
 		])
 		.root(AccountId::from(ERIN))
-		.blocks_per_epoch(BLOCKS_PER_EPOCH)
+		.epoch_duration(EPOCH_DURATION)
 }
 
 #[test]
@@ -62,8 +62,8 @@ fn state_of_genesis_is_as_expected() {
 		}
 
 		assert_eq!(
-			Validator::blocks_per_epoch(),
-			BLOCKS_PER_EPOCH,
+			Validator::epoch_duration(),
+			EPOCH_DURATION,
 			"epochs will not rotate automatically from genesis"
 		);
 

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -67,7 +67,7 @@ use cf_primitives::{
 pub struct ExtBuilder {
 	pub genesis_accounts: Vec<(AccountId, AccountRole, FlipBalance)>,
 	root: Option<AccountId>,
-	blocks_per_epoch: BlockNumber,
+	epoch_duration: BlockNumber,
 	max_authorities: AuthorityCount,
 	min_authorities: AuthorityCount,
 }
@@ -79,7 +79,7 @@ impl Default for ExtBuilder {
 			min_authorities: 1,
 			genesis_accounts: Default::default(),
 			root: Default::default(),
-			blocks_per_epoch: Default::default(),
+			epoch_duration: Default::default(),
 		}
 	}
 }
@@ -103,8 +103,8 @@ impl ExtBuilder {
 		self
 	}
 
-	pub fn blocks_per_epoch(mut self, blocks_per_epoch: BlockNumber) -> Self {
-		self.blocks_per_epoch = blocks_per_epoch;
+	pub fn epoch_duration(mut self, epoch_duration: BlockNumber) -> Self {
+		self.epoch_duration = epoch_duration;
 		self
 	}
 
@@ -184,7 +184,7 @@ impl ExtBuilder {
 					})
 					.collect(),
 				genesis_backups: Default::default(),
-				blocks_per_epoch: self.blocks_per_epoch,
+				epoch_duration: self.epoch_duration,
 				bond: self
 					.genesis_accounts
 					.iter()

--- a/state-chain/cf-integration-tests/src/network.rs
+++ b/state-chain/cf-integration-tests/src/network.rs
@@ -691,7 +691,7 @@ impl Network {
 	/// Move to the last block of the epoch - next block will start Authority rotation
 	pub fn move_to_the_end_of_epoch(&mut self) {
 		let current_block = System::block_number();
-		let target = Validator::current_epoch_started_at() + Validator::blocks_per_epoch();
+		let target = Validator::current_epoch_started_at() + Validator::epoch_duration();
 		if target > current_block {
 			self.move_forward_blocks(target - current_block - 1)
 		}

--- a/state-chain/cf-integration-tests/src/new_epoch.rs
+++ b/state-chain/cf-integration-tests/src/new_epoch.rs
@@ -17,9 +17,9 @@ use state_chain_runtime::{
 
 #[test]
 fn auction_repeats_after_failure_because_of_liveness() {
-	const EPOCH_BLOCKS: BlockNumber = 1000;
+	const EPOCH_DURATION_BLOCKS: BlockNumber = 1000;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		// As we run a rotation at genesis we will need accounts to support
 		// having 5 authorities as the default is 3 (Alice, Bob and Charlie)
 		.accounts(vec![
@@ -107,7 +107,7 @@ fn epoch_rotates() {
 	const EPOCH_BLOCKS: BlockNumber = 1000;
 	const MAX_SET_SIZE: AuthorityCount = 5;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.min_authorities(MAX_SET_SIZE)
 		.build()
 		.execute_with(|| {
@@ -247,7 +247,7 @@ fn can_consolidate_bitcoin_utxos() {
 	const MAX_AUTHORITIES: AuthorityCount = 5;
 	const CONSOLIDATION_SIZE: u32 = 2;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.build()
 		.execute_with(|| {
 			let (mut testnet, _, _) =

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -656,7 +656,7 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -149,10 +149,10 @@ fn schedule_deposit_to_swap(
 
 #[test]
 fn can_build_solana_batch_all() {
-	const EPOCH_BLOCKS: u32 = 100;
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -225,7 +225,7 @@ fn can_rotate_solana_vault() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -284,7 +284,7 @@ fn can_send_solana_ccm() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -363,7 +363,7 @@ fn solana_ccm_fails_with_invalid_input() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -518,7 +518,7 @@ fn failed_ccm_does_not_consume_durable_nonce() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -580,7 +580,7 @@ fn solana_resigning() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -760,10 +760,10 @@ fn ethereum_ccm_can_calculate_gas_limits() {
 
 #[test]
 fn can_resign_failed_ccm() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -871,7 +871,7 @@ fn can_handle_failed_vault_transfer() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/witnessing.rs
+++ b/state-chain/cf-integration-tests/src/witnessing.rs
@@ -16,10 +16,10 @@ use pallet_cf_witnesser::{CallHash, CallHashExecuted, WitnessDeadline};
 
 #[test]
 fn can_punish_failed_witnesser() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 50;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -46,7 +46,7 @@ fn can_punish_failed_witnesser() {
 			assert_ok!(Reputation::set_penalty(
 				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 				Offence::FailedToWitnessInTime,
-				Penalty { reputation: -100, suspension: EPOCH_BLOCKS },
+				Penalty { reputation: -100, suspension: EPOCH_DURATION_BLOCKS },
 			));
 
 			// Before the deadline is set, no one has been reported.

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -67,7 +67,7 @@ use std::{
 pub mod monitoring;
 pub mod order_fills;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RpcRedemptionsInfo {
 	pub total_balance: NumberOrHex,
 	pub count: u32,

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -69,7 +69,7 @@ pub mod order_fills;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RpcEpochState {
-	pub blocks_per_epoch: u32,
+	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
 	pub current_epoch_index: u32,
 	pub min_active_bid: Option<NumberOrHex>,
@@ -78,7 +78,7 @@ pub struct RpcEpochState {
 impl From<EpochState> for RpcEpochState {
 	fn from(rotation_state: EpochState) -> Self {
 		Self {
-			blocks_per_epoch: rotation_state.blocks_per_epoch,
+			epoch_duration: rotation_state.epoch_duration,
 			current_epoch_started_at: rotation_state.current_epoch_started_at,
 			current_epoch_index: rotation_state.current_epoch_index,
 			rotation_phase: rotation_state.rotation_phase,
@@ -364,7 +364,7 @@ type RpcSuspensions = Vec<(Offence, Vec<(u32, state_chain_runtime::AccountId)>)>
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RpcAuctionState {
-	blocks_per_epoch: u32,
+	epoch_duration: u32,
 	current_epoch_started_at: u32,
 	redemption_period_as_percentage: u8,
 	min_funding: NumberOrHex,
@@ -375,7 +375,7 @@ pub struct RpcAuctionState {
 impl From<AuctionState> for RpcAuctionState {
 	fn from(auction_state: AuctionState) -> Self {
 		Self {
-			blocks_per_epoch: auction_state.blocks_per_epoch,
+			epoch_duration: auction_state.epoch_duration,
 			current_epoch_started_at: auction_state.current_epoch_started_at,
 			redemption_period_as_percentage: auction_state.redemption_period_as_percentage,
 			min_funding: auction_state.min_funding.into(),

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::boost_pool_rpc::BoostPoolFeesRpc;
+use crate::{boost_pool_rpc::BoostPoolFeesRpc, monitoring::RpcEpochStateV2};
 use boost_pool_rpc::BoostPoolDetailsRpc;
 use cf_amm::{
 	common::{Amount as AmmAmount, PoolPairsMap, Side, Tick},
@@ -46,7 +46,7 @@ use state_chain_runtime::{
 	chainflip::{BlockUpdate, Offence},
 	constants::common::TX_FEE_MULTIPLIER,
 	monitoring_apis::{
-		ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, EpochState, ExternalChainsBlockHeight,
+		ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, ExternalChainsBlockHeight,
 		FeeImbalance, FlipSupply, LastRuntimeUpgradeInfo, MonitoringData, OpenDepositChannels,
 		PendingBroadcasts, PendingTssCeremonies, RedemptionsInfo, SolanaNonces,
 	},
@@ -67,26 +67,7 @@ use std::{
 pub mod monitoring;
 pub mod order_fills;
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct RpcEpochState {
-	pub epoch_duration: u32,
-	pub current_epoch_started_at: u32,
-	pub current_epoch_index: u32,
-	pub min_active_bid: Option<NumberOrHex>,
-	pub rotation_phase: String,
-}
-impl From<EpochState> for RpcEpochState {
-	fn from(rotation_state: EpochState) -> Self {
-		Self {
-			epoch_duration: rotation_state.epoch_duration,
-			current_epoch_started_at: rotation_state.current_epoch_started_at,
-			current_epoch_index: rotation_state.current_epoch_index,
-			rotation_phase: rotation_state.rotation_phase,
-			min_active_bid: rotation_state.min_active_bid.map(Into::into),
-		}
-	}
-}
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct RpcRedemptionsInfo {
 	pub total_balance: NumberOrHex,
 	pub count: u32,
@@ -117,7 +98,7 @@ impl From<FlipSupply> for RpcFlipSupply {
 pub struct RpcMonitoringData {
 	pub external_chains_height: ExternalChainsBlockHeight,
 	pub btc_utxos: BtcUtxos,
-	pub epoch: RpcEpochState,
+	pub epoch: RpcEpochStateV2,
 	pub pending_redemptions: RpcRedemptionsInfo,
 	pub pending_broadcasts: PendingBroadcasts,
 	pub pending_tss: PendingTssCeremonies,

--- a/state-chain/custom-rpc/src/monitoring.rs
+++ b/state-chain/custom-rpc/src/monitoring.rs
@@ -25,7 +25,7 @@ impl From<EpochState> for RpcEpochState {
 		}
 	}
 }
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RpcEpochState {
 	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
@@ -36,7 +36,7 @@ pub struct RpcEpochState {
 
 // Temporary struct to hold the deprecated blocks_per_epoch field.
 // Can be deleted after v1.7 is released (meaning: after the version is bumped to 1.8).
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct RpcEpochStateV2 {
 	#[deprecated(
 		since = "1.8.0",

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -547,7 +547,7 @@ fn testnet_genesis(
 	genesis_funding_amount: u128,
 	minimum_funding: u128,
 	redemption_tax: u128,
-	blocks_per_epoch: BlockNumber,
+	epoch_duration: BlockNumber,
 	redemption_ttl_secs: u64,
 	current_authority_emission_inflation_perbill: u32,
 	backup_node_emission_inflation_perbill: u32,
@@ -659,7 +659,7 @@ fn testnet_genesis(
 					}
 				})
 				.collect::<_>(),
-			blocks_per_epoch,
+			epoch_duration,
 			redemption_period_as_percentage,
 			backup_reward_node_percentage: Percent::from_percent(33),
 			bond: all_accounts

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -6,6 +6,6 @@ mod rename_blocks_per_epoch;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<Pallet<T>, delete_old_epoch_data::Migration<T>, 3, 4>,
-	VersionedMigration<Pallet<T>, rename_blocks_per_epoch::BlocksPerEpochMigration<T>, 3, 5>,
+	VersionedMigration<Pallet<T>, rename_blocks_per_epoch::BlocksPerEpochMigration<T>, 4, 5>,
 	PlaceholderMigration<Pallet<T>, 5>,
 );

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -2,8 +2,10 @@ use crate::Pallet;
 use cf_runtime_upgrade_utilities::{PlaceholderMigration, VersionedMigration};
 
 mod delete_old_epoch_data;
+mod rename_blocks_per_epoch;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<Pallet<T>, delete_old_epoch_data::Migration<T>, 3, 4>,
-	PlaceholderMigration<Pallet<T>, 4>,
+	VersionedMigration<Pallet<T>, rename_blocks_per_epoch::BlocksPerEpochMigration<T>, 3, 5>,
+	PlaceholderMigration<Pallet<T>, 5>,
 );

--- a/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
@@ -1,0 +1,65 @@
+use crate::*;
+use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::sp_runtime::DispatchError;
+
+pub mod old {
+	use super::*;
+
+	#[frame_support::storage_alias]
+	pub type BlocksPerEpoch<T: Config> = StorageValue<Config, BlockNumberFor<T>, ValueQuery>;
+}
+
+pub struct BlocksPerEpochMigration<T: Config>(sp_std::marker::PhantomData<T>);
+
+// Rename BlocksPerEpoch -> EpochDuration
+impl<T: Config> OnRuntimeUpgrade for BlocksPerEpochMigration<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok(old::BlocksPerEpoch::<T>::get().encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		EpochDuration::<T>::put(old::BlocksPerEpoch::<T>::get());
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		assert_eq!(
+			EpochDuration::<T>::get(),
+			BlockNumberFor::<T>::decode(&mut &state[..]).unwrap()
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod migration_tests {
+	use crate::mock::Test;
+
+	use self::mock::new_test_ext;
+
+	use super::*;
+
+	#[test]
+	fn test_migration() {
+		new_test_ext().execute_with(|| {
+			old::BlocksPerEpoch::<Test>::put(100);
+			assert_ne!(EpochDuration::<Test>::get(), 100);
+
+			#[cfg(feature = "try-runtime")]
+			let state: Vec<u8> = BlocksPerEpochMigration::<Test>::pre_upgrade().unwrap();
+
+			BlocksPerEpochMigration::<Test>::on_runtime_upgrade();
+
+			#[cfg(feature = "try-runtime")]
+			BlocksPerEpochMigration::<Test>::post_upgrade(state).unwrap();
+
+			assert_eq!(EpochDuration::<Test>::get(), 100);
+		});
+	}
+}

--- a/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
@@ -23,7 +23,7 @@ impl<T: Config> OnRuntimeUpgrade for BlocksPerEpochMigration<T> {
 	}
 
 	fn on_runtime_upgrade() -> Weight {
-		EpochDuration::<T>::put(old::BlocksPerEpoch::<T>::get());
+		EpochDuration::<T>::put(old::BlocksPerEpoch::<T>::take());
 		Weight::zero()
 	}
 
@@ -33,6 +33,7 @@ impl<T: Config> OnRuntimeUpgrade for BlocksPerEpochMigration<T> {
 			EpochDuration::<T>::get(),
 			BlockNumberFor::<T>::decode(&mut &state[..]).unwrap()
 		);
+		assert!(!old::BlocksPerEpoch::<T>::exists());
 		Ok(())
 	}
 }

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -190,7 +190,7 @@ cf_test_utilities::impl_test_helpers! {
 		validator_pallet: ValidatorPalletConfig {
 			genesis_authorities: BTreeSet::from(GENESIS_AUTHORITIES),
 			genesis_backups: Default::default(),
-			blocks_per_epoch: EPOCH_DURATION,
+			epoch_duration: EPOCH_DURATION,
 			bond: GENESIS_BOND,
 			redemption_period_as_percentage: REDEMPTION_PERCENTAGE_AT_GENESIS,
 			backup_reward_node_percentage: Percent::from_percent(34),

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1363,7 +1363,7 @@ fn can_determine_is_auction_phase() {
 
 		// In Idle phase, must be within certain % of epoch progress.
 		CurrentEpochStartedAt::<Test>::set(1_000);
-		BlocksPerEpoch::<Test>::set(100);
+		EpochDuration::<Test>::set(100);
 		RedemptionPeriodAsPercentage::<Test>::set(Percent::from_percent(85));
 
 		// First block of auction phase = 1_000 + 100 * 85% = 1085
@@ -1446,7 +1446,7 @@ fn can_update_all_config_items() {
 		assert_ne!(RegistrationBondPercentage::<Test>::get(), NEW_REGISTRATION_BOND_PERCENTAGE);
 		assert_ne!(AuthoritySetMinSize::<Test>::get(), NEW_AUTHORITY_SET_MIN_SIZE);
 		assert_ne!(BackupRewardNodePercentage::<Test>::get(), NEW_BACKUP_REWARD_NODE_PERCENTAGE);
-		assert_ne!(BlocksPerEpoch::<Test>::get(), NEW_EPOCH_DURATION as u64);
+		assert_ne!(EpochDuration::<Test>::get(), NEW_EPOCH_DURATION as u64);
 		assert_ne!(AuctionParameters::<Test>::get(), NEW_AUCTION_PARAMETERS);
 		assert_ne!(MinimumReportedCfeVersion::<Test>::get(), NEW_MINIMUM_REPORTED_CFE_VERSION);
 		assert_ne!(
@@ -1495,7 +1495,7 @@ fn can_update_all_config_items() {
 		assert_eq!(RegistrationBondPercentage::<Test>::get(), NEW_REGISTRATION_BOND_PERCENTAGE);
 		assert_eq!(AuthoritySetMinSize::<Test>::get(), NEW_AUTHORITY_SET_MIN_SIZE);
 		assert_eq!(BackupRewardNodePercentage::<Test>::get(), NEW_BACKUP_REWARD_NODE_PERCENTAGE);
-		assert_eq!(BlocksPerEpoch::<Test>::get(), NEW_EPOCH_DURATION as u64);
+		assert_eq!(EpochDuration::<Test>::get(), NEW_EPOCH_DURATION as u64);
 		assert_eq!(AuctionParameters::<Test>::get(), NEW_AUCTION_PARAMETERS);
 		assert_eq!(MinimumReportedCfeVersion::<Test>::get(), NEW_MINIMUM_REPORTED_CFE_VERSION);
 		assert_eq!(

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1515,3 +1515,24 @@ fn can_update_all_config_items() {
 		);
 	});
 }
+
+#[test]
+fn should_expire_all_previous_epochs() {
+	new_test_ext().execute_with(|| {
+		ValidatorPallet::transition_to_next_epoch(vec![1], 100);
+		let first_epoch = ValidatorPallet::current_epoch();
+		ValidatorPallet::transition_to_next_epoch(vec![1], 100);
+		let second_epoch = ValidatorPallet::current_epoch();
+		ValidatorPallet::transition_to_next_epoch(vec![1], 100);
+		let third_epoch = ValidatorPallet::current_epoch();
+
+		assert_eq!(
+			HistoricalActiveEpochs::<Test>::get(1),
+			vec![first_epoch, second_epoch, third_epoch]
+		);
+
+		ValidatorPallet::expire_epoch(third_epoch);
+
+		assert_eq!(HistoricalActiveEpochs::<Test>::get(1).len(), 0);
+	});
+}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -611,7 +611,7 @@ impl pallet_aura::Config for Runtime {
 }
 
 parameter_types! {
-	pub storage BlocksPerEpoch: u64 = Validator::blocks_per_epoch().into();
+	pub storage BlocksPerEpoch: u64 = Validator::epoch_duration().into();
 }
 
 type KeyOwnerIdentification<T, Id> =
@@ -1384,7 +1384,7 @@ impl_runtime_apis! {
 			Environment::current_release_version()
 		}
 		fn cf_epoch_duration() -> u32 {
-			Validator::blocks_per_epoch()
+			Validator::epoch_duration()
 		}
 		fn cf_current_epoch_started_at() -> u32 {
 			Validator::current_epoch_started_at()
@@ -1487,7 +1487,7 @@ impl_runtime_apis! {
 			.ok()
 			.map(|auction_outcome| auction_outcome.bond);
 			AuctionState {
-				blocks_per_epoch: Validator::blocks_per_epoch(),
+				epoch_duration: Validator::epoch_duration(),
 				current_epoch_started_at: Validator::current_epoch_started_at(),
 				redemption_period_as_percentage: Validator::redemption_period_as_percentage().deconstruct(),
 				min_funding: MinimumFunding::<Runtime>::get().unique_saturated_into(),
@@ -2135,7 +2135,7 @@ impl_runtime_apis! {
 			.ok()
 			.map(|auction_outcome| auction_outcome.bond);
 			EpochState {
-				blocks_per_epoch: Validator::blocks_per_epoch(),
+				epoch_duration: Validator::epoch_duration(),
 				current_epoch_started_at: Validator::current_epoch_started_at(),
 				current_epoch_index: Validator::current_epoch(),
 				min_active_bid,

--- a/state-chain/runtime/src/monitoring_apis.rs
+++ b/state-chain/runtime/src/monitoring_apis.rs
@@ -30,7 +30,7 @@ pub struct BtcUtxos {
 
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
 pub struct EpochState {
-	pub blocks_per_epoch: u32,
+	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
 	pub current_epoch_index: u32,
 	pub min_active_bid: Option<u128>,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -107,7 +107,7 @@ pub struct RuntimeApiPenalty {
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct AuctionState {
-	pub blocks_per_epoch: u32,
+	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
 	pub redemption_period_as_percentage: u8,
 	pub min_funding: u128,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1613

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Changed the `expire_epoch` function to recursively expire all previous epochs that had not expired yet in chronological order. This should avoid the bug stated in the issue.
	- Added a test to make sure it expires as expected.
- Renamed `BlocksPerEpoch` -> `EpochDuration`
	- Added a migration and migration test for the rename.

#### Non-Breaking changes

I think this is non breaking, i'll let you tag it @dandanlen 
