### PR TITLE
test: egress success tests

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
@@ -3,6 +3,7 @@ pub(crate) use super::mocks;
 pub(crate) use crate::register_checks;
 
 pub mod change;
+pub mod egress_success;
 pub mod monotonic_median;
 pub mod unsafe_median;
 pub mod utils;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
@@ -1,0 +1,142 @@
+use super::{mocks::*, register_checks};
+use crate::{
+	electoral_system::{ConsensusVote, ConsensusVotes},
+	electoral_systems::egress_success::*,
+};
+
+use cf_primitives::AuthorityCount;
+
+thread_local! {
+	pub static HOOK_CALLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+pub struct MockHook;
+impl OnEgressSuccess<(), EgressData> for MockHook {
+	fn on_egress_success(_id: (), _egress_data: EgressData) {
+		HOOK_CALLED.with(|hook_called| hook_called.set(true));
+	}
+}
+
+impl MockHook {
+	pub fn called() -> bool {
+		HOOK_CALLED.with(|hook_called| hook_called.get())
+	}
+}
+
+type EgressData = u64;
+type SimpleEgressSuccess = EgressSuccess<(), EgressData, (), MockHook, ()>;
+
+register_checks! {
+	SimpleEgressSuccess {
+		hook_called(_pre, _post) {
+			assert!(MockHook::called(), "Hook should have been called!");
+		},
+		hook_not_called(_pre, _post) {
+			assert!(
+				!MockHook::called(),
+				"Hook should not have been called!"
+			);
+		},
+	}
+}
+
+const AUTHORITY_COUNT: AuthorityCount = 10;
+const THRESHOLD: AuthorityCount = cf_utilities::threshold_from_share_count(AUTHORITY_COUNT);
+const SUCCESS_THRESHOLD: AuthorityCount =
+	cf_utilities::success_threshold_from_share_count(AUTHORITY_COUNT);
+
+fn with_default_state() -> TestContext<SimpleEgressSuccess> {
+	TestSetup::<SimpleEgressSuccess>::default().build()
+}
+
+fn generate_votes(
+	correct_voters: AuthorityCount,
+	correct_value: u64,
+	incorrect_voters: AuthorityCount,
+	incorrect_value: u64,
+) -> ConsensusVotes<SimpleEgressSuccess> {
+	ConsensusVotes {
+		votes: (0..correct_voters)
+			.map(|_| ConsensusVote {
+				vote: Some(((), correct_value as EgressData)),
+				validator_id: (),
+			})
+			.chain((0..incorrect_voters).map(|_| ConsensusVote {
+				vote: Some(((), incorrect_value as EgressData)),
+				validator_id: (),
+			}))
+			.chain(
+				(0..AUTHORITY_COUNT - correct_voters - incorrect_voters)
+					.map(|_| ConsensusVote { vote: None, validator_id: () }),
+			)
+			.collect(),
+	}
+}
+
+#[test]
+fn consensus_not_possible_because_of_different_votes() {
+	with_default_state().expect_consensus(
+		ConsensusVotes {
+			votes: (0..AUTHORITY_COUNT)
+				.map(|i| ConsensusVote { vote: Some(((), i as EgressData)), validator_id: () })
+				.collect(),
+		},
+		None,
+	);
+}
+
+#[test]
+fn consensus_when_all_votes_the_same() {
+	with_default_state().expect_consensus(generate_votes(SUCCESS_THRESHOLD, 1, 0, 0), Some(1));
+}
+
+#[test]
+fn not_enough_votes_for_consensus() {
+	with_default_state().expect_consensus(generate_votes(THRESHOLD, 1, 0, 0), None);
+}
+
+#[test]
+fn minority_cannot_prevent_consensus() {
+	const CORRECT_VALUE: EgressData = 1;
+	const INCORRECT_VALUE: EgressData = 2;
+	with_default_state().expect_consensus(
+		generate_votes(
+			SUCCESS_THRESHOLD,
+			CORRECT_VALUE,
+			AUTHORITY_COUNT - SUCCESS_THRESHOLD,
+			INCORRECT_VALUE,
+		),
+		Some(CORRECT_VALUE),
+	);
+}
+
+#[test]
+fn finalization_after_vote_success_calls_hook_deletes_election() {
+	with_default_state()
+		.test_on_finalize(
+			&(),
+			|_| {
+				assert!(!MockHook::called());
+			},
+			vec![Check::<SimpleEgressSuccess>::hook_not_called(), Check::assert_unchanged()],
+		)
+		.expect_consensus(generate_votes(SUCCESS_THRESHOLD - 1, EgressData::default(), 0, 0), None)
+		.test_on_finalize(
+			&(),
+			|_| {
+				assert!(!MockHook::called());
+			},
+			vec![Check::<SimpleEgressSuccess>::hook_not_called(), Check::assert_unchanged()],
+		)
+		.expect_consensus(
+			generate_votes(AUTHORITY_COUNT, EgressData::default(), 0, 0),
+			Some(EgressData::default()),
+		)
+		.test_on_finalize(
+			&(),
+			|_| {
+				assert!(!MockHook::called());
+			},
+			vec![Check::<SimpleEgressSuccess>::hook_called(), Check::last_election_deleted()],
+		);
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1592

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

This is close to a copy paste of the Change tests. Just renamed some things and modified to the finalise test to better reflect the behaviour which is slightly different to the Change system.

Deliberately not deduplicating anything here because the Change electoral system will eventually become a more specific nonce witnessing electoral system, which is WIP now.