### PR TITLE
refactor: Strongly-typed identifiers for SwapId/SwapRequestId

### DIFF
--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -18,7 +18,7 @@ use cf_chains::{
 	ForeignChainAddress, RequiresSignatureRefresh, SetAggKeyWithAggKey, SetAggKeyWithAggKeyError,
 	Solana, SwapOrigin, TransactionBuilder,
 };
-use cf_primitives::{AccountRole, AuthorityCount, ForeignChain, SwapId};
+use cf_primitives::{AccountRole, AuthorityCount, ForeignChain, SwapRequestId};
 use cf_test_utilities::{assert_events_match, assert_has_matching_event};
 use cf_utilities::bs58_array;
 use codec::Encode;
@@ -73,7 +73,7 @@ fn schedule_deposit_to_swap(
 	from: Asset,
 	to: Asset,
 	ccm: Option<CcmChannelMetadata>,
-) -> SwapId {
+) -> SwapRequestId {
 	assert_ok!(Swapping::request_swap_deposit_address_with_affiliates(
 		RuntimeOrigin::signed(who.clone()),
 		from,
@@ -161,8 +161,8 @@ fn can_build_solana_batch_all() {
 
 			// Initiate 2 swaps - Sol -> SolUsdc and SolUsdc -> Sol
 			// This will results in 2 fetches and 2 transfers of different assets.
-			assert_eq!(schedule_deposit_to_swap(ALICE, Asset::Sol, Asset::SolUsdc, None), 1);
-			assert_eq!(schedule_deposit_to_swap(BOB, Asset::SolUsdc, Asset::Sol, None), 3);
+			assert_eq!(schedule_deposit_to_swap(ALICE, Asset::Sol, Asset::SolUsdc, None), 1.into());
+			assert_eq!(schedule_deposit_to_swap(BOB, Asset::SolUsdc, Asset::Sol, None), 3.into());
 
 			// Verify the correct API call has been built, signed and broadcasted
 
@@ -299,7 +299,7 @@ fn can_send_solana_ccm() {
 					Asset::SolUsdc,
 					Some(sol_test_values::ccm_parameter().channel_metadata)
 				),
-				1
+				1.into()
 			);
 			assert_eq!(
 				schedule_deposit_to_swap(
@@ -308,7 +308,7 @@ fn can_send_solana_ccm() {
 					Asset::Sol,
 					Some(sol_test_values::ccm_parameter().channel_metadata)
 				),
-				3
+				3.into()
 			);
 
 			// Wait until calls are built, signed and broadcasted.

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -22,7 +22,7 @@ use cf_chains::{
 	TransactionBuilder, TransferAssetParams,
 };
 use cf_primitives::{
-	AccountId, AccountRole, Asset, AssetAmount, AuthorityCount, FLIPPERINOS_PER_FLIP,
+	AccountId, AccountRole, Asset, AssetAmount, AuthorityCount, SwapId, FLIPPERINOS_PER_FLIP,
 	GENESIS_EPOCH, STABLE_ASSET, SWAP_DELAY_BLOCKS,
 };
 use cf_test_utilities::{assert_events_eq, assert_events_match, assert_has_matching_event};
@@ -677,7 +677,7 @@ fn failed_swaps_are_rolled_back() {
 			) => (),
 			RuntimeEvent::Swapping(
 				pallet_cf_swapping::Event::SwapExecuted {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					..
 				},
 			) => ()

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -14,7 +14,7 @@ use cf_chains::{
 use cf_primitives::{
 	chains::assets::any::{self, AssetMap},
 	AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, EpochIndex, ForeignChain,
-	NetworkEnvironment, SemVer, SwapId,
+	NetworkEnvironment, SemVer, SwapId, SwapRequestId,
 };
 use cf_utilities::rpc::NumberOrHex;
 use core::ops::Range;
@@ -157,7 +157,7 @@ impl From<MonitoringData> for RpcMonitoringData {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScheduledSwap {
 	pub swap_id: SwapId,
-	pub swap_request_id: SwapId,
+	pub swap_request_id: SwapRequestId,
 	pub base_asset: Asset,
 	pub quote_asset: Asset,
 	pub side: Side,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -185,7 +185,7 @@ pub struct SwapLegInfo {
 impl<T: Config> Swap<T> {
 	fn new(
 		swap_id: SwapId,
-		swap_request_id: SwapId,
+		swap_request_id: SwapRequestId,
 		from: Asset,
 		to: Asset,
 		input_amount: AssetAmount,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -999,11 +999,21 @@ fn swaps_get_retried_after_failure() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: SwapRequestId(2), .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: SwapRequestId(2) }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(2),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(2)
+				}),
 				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: SwapRequestId(1), .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: SwapRequestId(1) }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(1),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(1)
+				}),
 			);
 		});
 }
@@ -1433,7 +1443,7 @@ mod swap_batching {
 
 	#[test]
 	fn single_swap() {
-		let swap1 = Swap::new(0, 0, Asset::Btc, Asset::Usdc, 1000, None, []);
+		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 1000, None, []);
 		let mut swaps = vec![swap1.clone()];
 
 		let swap_states = vec![swap1.to_state(None)];
@@ -1451,9 +1461,9 @@ mod swap_batching {
 
 	#[test]
 	fn swaps_fail_into_stable() {
-		let swap1 = Swap::new(0, 0, Asset::Btc, Asset::Usdc, 500, None, []);
-		let swap2 = Swap::new(1, 1, Asset::Btc, Asset::Eth, 1000, None, []);
-		let swap3 = Swap::new(2, 2, Asset::Eth, Asset::Usdc, 1000, None, []);
+		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 500, None, []);
+		let swap2 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1000, None, []);
+		let swap3 = Swap::new(2.into(), 2.into(), Asset::Eth, Asset::Usdc, 1000, None, []);
 
 		let mut swaps = vec![swap1.clone(), swap2.clone(), swap3.clone()];
 
@@ -1475,9 +1485,9 @@ mod swap_batching {
 	fn swaps_fail_from_stable() {
 		// BTC swap should be removed because it would result in a larger amount
 		// of USDC and thus will have higher impact on the Eth pool
-		let swap1 = Swap::new(1, 1, Asset::Btc, Asset::Eth, 1, None, []);
-		let swap2 = Swap::new(2, 2, Asset::Usdc, Asset::Eth, 1000, None, []);
-		let swap3 = Swap::new(3, 3, Asset::Eth, Asset::Usdc, 100, None, []);
+		let swap1 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1, None, []);
+		let swap2 = Swap::new(2.into(), 2.into(), Asset::Usdc, Asset::Eth, 1000, None, []);
+		let swap3 = Swap::new(3.into(), 3.into(), Asset::Eth, Asset::Usdc, 100, None, []);
 
 		let mut swaps = vec![swap1.clone(), swap2.clone(), swap3.clone()];
 
@@ -1534,11 +1544,11 @@ mod swap_batching {
 				assert_event_sequence!(
 					Test,
 					RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
-					RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 2, .. }),
+					RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
 					RuntimeEvent::Swapping(Event::SwapEgressScheduled { .. }),
 					RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
 					RuntimeEvent::Swapping(Event::SwapRescheduled {
-						swap_id: 1,
+						swap_id: SwapId(1),
 						execute_at: SWAP_RESCHEDULED_BLOCK
 					}),
 				);
@@ -1555,7 +1565,7 @@ mod swap_batching {
 			.then_execute_with(|_| {
 				assert_has_matching_event!(
 					Test,
-					RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+					RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 				);
 
 				assert_eq!(CollectedNetworkFee::<Test>::get(), 1500 + 2000);
@@ -1600,8 +1610,8 @@ mod swap_batching {
 					Test,
 					RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
 					RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
-					RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: 2, .. }),
-					RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: 1, .. }),
+					RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: SwapId(2), .. }),
+					RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: SwapId(1), .. }),
 				);
 
 				assert_eq!(CollectedNetworkFee::<Test>::get(), 0);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -40,7 +40,7 @@ use sp_std::iter;
 
 const GAS_BUDGET: AssetAmount = 1_000u128;
 const INPUT_AMOUNT: AssetAmount = 40_000;
-const SWAP_REQUEST_ID: u64 = 1;
+const SWAP_REQUEST_ID: SwapRequestId = SwapRequestId(1);
 const INIT_BLOCK: u64 = 1;
 const BROKER_FEE_BPS: u16 = 10;
 const INPUT_ASSET: Asset = Asset::Usdc;
@@ -118,9 +118,9 @@ fn create_test_swap(
 	dca_params: Option<DcaParameters>,
 ) -> Swap<Test> {
 	SwapRequests::<Test>::insert(
-		id,
+		SwapRequestId::from(id),
 		SwapRequest {
-			id,
+			id: id.into(),
 			input_asset,
 			output_asset,
 			refund_params: None,
@@ -133,7 +133,7 @@ fn create_test_swap(
 		},
 	);
 
-	Swap::new(id, id, input_asset, output_asset, amount, None, [FeeType::NetworkFee])
+	Swap::new(id.into(), id.into(), input_asset, output_asset, amount, None, [FeeType::NetworkFee])
 }
 
 // Returns some test data
@@ -377,10 +377,13 @@ fn expect_swap_id_to_be_emitted() {
 					channel_id: 0,
 					..
 				}),
-				RuntimeEvent::Swapping(Event::SwapRequested { swap_request_id: 1, .. }),
+				RuntimeEvent::Swapping(Event::SwapRequested {
+					swap_request_id: SwapRequestId(1),
+					..
+				}),
 				RuntimeEvent::Swapping(Event::SwapScheduled {
-					swap_request_id: 1,
-					swap_id: 1,
+					swap_request_id: SwapRequestId(1),
+					swap_id: SwapId(1),
 					input_amount: AMOUNT,
 					..
 				})
@@ -390,13 +393,15 @@ fn expect_swap_id_to_be_emitted() {
 		.then_execute_with(|_| {
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-					swap_request_id: 1,
+					swap_request_id: SwapRequestId(1),
 					egress_id: (ForeignChain::Ethereum, 1),
 					..
 				}),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: 1 }),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(1)
+				}),
 			);
 		});
 }
@@ -456,8 +461,8 @@ fn swap_by_deposit_happy_path() {
 			assert_eq!(
 				SwapQueue::<Test>::get(SWAP_BLOCK),
 				vec![Swap::new(
-					1,
-					1,
+					1.into(),
+					1.into(),
 					INPUT_ASSET,
 					OUTPUT_ASSET,
 					AMOUNT,
@@ -469,8 +474,8 @@ fn swap_by_deposit_happy_path() {
 			assert!(SwapRequests::<Test>::get(SWAP_REQUEST_ID).is_some());
 
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapScheduled {
-				swap_request_id: 1,
-				swap_id: 1,
+				swap_request_id: 1.into(),
+				swap_id: 1.into(),
 				input_amount: AMOUNT,
 				swap_type: SwapType::Swap,
 				execute_at: SWAP_BLOCK,
@@ -511,10 +516,42 @@ fn process_all_into_stable_swaps_first() {
 		assert_eq!(
 			SwapQueue::<Test>::get(SWAP_EXECUTION_BLOCK),
 			vec![
-				Swap::new(1, 1, Asset::Flip, Asset::Eth, AMOUNT, None, [FeeType::NetworkFee]),
-				Swap::new(2, 2, Asset::Btc, Asset::Eth, AMOUNT, None, [FeeType::NetworkFee]),
-				Swap::new(3, 3, Asset::Dot, Asset::Eth, AMOUNT, None, [FeeType::NetworkFee]),
-				Swap::new(4, 4, Asset::Usdc, Asset::Eth, AMOUNT, None, [FeeType::NetworkFee]),
+				Swap::new(
+					1.into(),
+					1.into(),
+					Asset::Flip,
+					Asset::Eth,
+					AMOUNT,
+					None,
+					[FeeType::NetworkFee]
+				),
+				Swap::new(
+					2.into(),
+					2.into(),
+					Asset::Btc,
+					Asset::Eth,
+					AMOUNT,
+					None,
+					[FeeType::NetworkFee]
+				),
+				Swap::new(
+					3.into(),
+					3.into(),
+					Asset::Dot,
+					Asset::Eth,
+					AMOUNT,
+					None,
+					[FeeType::NetworkFee]
+				),
+				Swap::new(
+					4.into(),
+					4.into(),
+					Asset::Usdc,
+					Asset::Eth,
+					AMOUNT,
+					None,
+					[FeeType::NetworkFee]
+				),
 			]
 		);
 
@@ -544,33 +581,33 @@ fn process_all_into_stable_swaps_first() {
 
 		assert_event_sequence!(
 			Test,
-			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_request_id: 1,
+				swap_request_id: SwapRequestId(1),
 				egress_id: (ForeignChain::Ethereum, 1),
 				amount,
 				..
 			}) if amount == usdc_amount_swapped_after_fee * DEFAULT_SWAP_RATE,
 			RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
-			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 2, .. }),
+			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
 			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_request_id: 2,
+				swap_request_id: SwapRequestId(2),
 				egress_id: (ForeignChain::Ethereum, 2),
 				amount,
 				..
 			}) if amount == usdc_amount_swapped_after_fee * DEFAULT_SWAP_RATE,
 			RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
-			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 3, .. }),
+			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(3), .. }),
 			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_request_id: 3,
+				swap_request_id: SwapRequestId(3),
 				egress_id: (ForeignChain::Ethereum, 3),
 				amount,
 				..
 			}) if amount == usdc_amount_swapped_after_fee * DEFAULT_SWAP_RATE,
 			RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
-			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 4, .. }),
+			RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(4), .. }),
 			RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-				swap_request_id: 4,
+				swap_request_id: SwapRequestId(4),
 				egress_id: (ForeignChain::Ethereum, 4),
 				amount,
 				..
@@ -627,8 +664,8 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-					swap_request_id: 1,
-					swap_id: 1,
+					swap_request_id: SwapRequestId(1),
+					swap_id: SwapId(1),
 					network_fee: 0,
 					broker_fee: 0,
 					input_amount: PRINCIPAL_AMOUNT,
@@ -644,8 +681,8 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-					swap_request_id: 1,
-					swap_id: 2,
+					swap_request_id: SwapRequestId(1),
+					swap_id: SwapId(2),
 					network_fee: 0,
 					broker_fee: 0,
 					input_amount: GAS_BUDGET,
@@ -678,21 +715,31 @@ fn can_handle_swaps_with_zero_outputs() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					output_asset: Asset::Eth,
 					output_amount: 0,
 					..
 				}),
-				RuntimeEvent::Swapping(Event::SwapEgressIgnored { swap_request_id: 1, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 1 }),
+				RuntimeEvent::Swapping(Event::SwapEgressIgnored {
+					swap_request_id: SwapRequestId(1),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(1)
+				}),
 				RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-					swap_id: 2,
+					swap_id: SwapId(2),
 					output_asset: Asset::Eth,
 					output_amount: 0,
 					..
 				}),
-				RuntimeEvent::Swapping(Event::SwapEgressIgnored { swap_request_id: 2, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 2 }),
+				RuntimeEvent::Swapping(Event::SwapEgressIgnored {
+					swap_request_id: SwapRequestId(2),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(2)
+				}),
 			);
 
 			// Swaps are not egressed when output is 0.
@@ -720,7 +767,7 @@ fn swap_excess_are_confiscated() {
 
 		// Excess fee is confiscated
 		System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapAmountConfiscated {
-			swap_request_id: 1,
+			swap_request_id: SwapRequestId(1),
 			asset: from,
 			total_amount: AMOUNT,
 			confiscated_amount: CONFISCATED_AMOUNT,
@@ -728,7 +775,7 @@ fn swap_excess_are_confiscated() {
 
 		assert_eq!(
 			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS)),
-			vec![Swap::new(1, 1, from, to, MAX_SWAP, None, [FeeType::NetworkFee])]
+			vec![Swap::new(1.into(), 1.into(), from, to, MAX_SWAP, None, [FeeType::NetworkFee])]
 		);
 		assert_eq!(CollectedRejectedFunds::<Test>::get(from), 900);
 	});
@@ -746,12 +793,20 @@ fn swaps_are_executed_according_to_execute_at_field() {
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 1, execute_at: 3, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(1),
+					execute_at: 3,
+					..
+				}),
 			);
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 2, execute_at: 3, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(2),
+					execute_at: 3,
+					..
+				}),
 			);
 		})
 		.then_execute_at_next_block(|_| {
@@ -761,12 +816,20 @@ fn swaps_are_executed_according_to_execute_at_field() {
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 3, execute_at: 4, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(3),
+					execute_at: 4,
+					..
+				}),
 			);
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 4, execute_at: 4, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(4),
+					execute_at: 4,
+					..
+				}),
 			);
 		})
 		.then_execute_at_next_block(|_| {
@@ -776,12 +839,22 @@ fn swaps_are_executed_according_to_execute_at_field() {
 			assert_eq!(System::block_number(), 3);
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 1, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 1 }),
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 2, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 2, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 2 }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(1),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(1)
+				}),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(2),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(2)
+				}),
 			);
 		})
 		.then_execute_at_next_block(|_| {
@@ -791,12 +864,22 @@ fn swaps_are_executed_according_to_execute_at_field() {
 			assert_eq!(System::block_number(), 4);
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 3, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 3, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 3 }),
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 4, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 4, .. }),
-				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted { swap_request_id: 4 }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(3), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(3),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(3)
+				}),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(4), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(4),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::<Test>::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(4)
+				}),
 			);
 		});
 }
@@ -818,7 +901,7 @@ fn swaps_get_retried_after_failure() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapScheduled {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					execute_at: EXECUTE_AT_BLOCK,
 					..
 				}),
@@ -827,7 +910,7 @@ fn swaps_get_retried_after_failure() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapScheduled {
-					swap_id: 2,
+					swap_id: SwapId(2),
 					execute_at: EXECUTE_AT_BLOCK,
 					..
 				}),
@@ -840,12 +923,20 @@ fn swaps_get_retried_after_failure() {
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 3, execute_at: 4, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(3),
+					execute_at: 4,
+					..
+				}),
 			);
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapScheduled { swap_id: 4, execute_at: 4, .. }),
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_id: SwapId(4),
+					execute_at: 4,
+					..
+				}),
 			);
 		})
 		.then_execute_at_next_block(|_| {
@@ -859,7 +950,7 @@ fn swaps_get_retried_after_failure() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					execute_at: RETRY_AT_BLOCK
 				})
 			);
@@ -867,7 +958,7 @@ fn swaps_get_retried_after_failure() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
-					swap_id: 2,
+					swap_id: SwapId(2),
 					execute_at: RETRY_AT_BLOCK
 				})
 			);
@@ -883,12 +974,22 @@ fn swaps_get_retried_after_failure() {
 		.then_execute_with(|_| {
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 3, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 3, .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: 3 }),
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 4, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 4, .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: 4 }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(3), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(3),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(3)
+				}),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(4), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(4),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(4)
+				}),
 			);
 		})
 		.then_process_blocks_until_block(RETRY_AT_BLOCK)
@@ -897,12 +998,12 @@ fn swaps_get_retried_after_failure() {
 			// now be successful):
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 2, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 2, .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: 2 }),
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: 1, .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: 1 }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: SwapRequestId(2), .. }),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: SwapRequestId(2) }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: SwapRequestId(1), .. }),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: SwapRequestId(1) }),
 			);
 		});
 }
@@ -967,8 +1068,8 @@ fn test_get_scheduled_swap_legs() {
 			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip, None),
 			vec![
 				SwapLegInfo {
-					swap_id: 1,
-					swap_request_id: 1,
+					swap_id: SwapId(1),
+					swap_request_id: SwapRequestId(1),
 					base_asset: Asset::Flip,
 					quote_asset: Asset::Usdc,
 					side: Side::Sell,
@@ -979,8 +1080,8 @@ fn test_get_scheduled_swap_legs() {
 					chunk_interval: SWAP_DELAY_BLOCKS,
 				},
 				SwapLegInfo {
-					swap_id: 2,
-					swap_request_id: 2,
+					swap_id: SwapId(2),
+					swap_request_id: SwapRequestId(2),
 					base_asset: Asset::Flip,
 					quote_asset: Asset::Usdc,
 					side: Side::Buy,
@@ -991,8 +1092,8 @@ fn test_get_scheduled_swap_legs() {
 					chunk_interval: SWAP_DELAY_BLOCKS,
 				},
 				SwapLegInfo {
-					swap_id: 4,
-					swap_request_id: 4,
+					swap_id: SwapId(4),
+					swap_request_id: SwapRequestId(4),
 					base_asset: Asset::Flip,
 					quote_asset: Asset::Usdc,
 					side: Side::Sell,
@@ -1003,8 +1104,8 @@ fn test_get_scheduled_swap_legs() {
 					chunk_interval: SWAP_DELAY_BLOCKS,
 				},
 				SwapLegInfo {
-					swap_id: 5,
-					swap_request_id: 5,
+					swap_id: SwapId(5),
+					swap_request_id: SwapRequestId(5),
 					base_asset: Asset::Flip,
 					quote_asset: Asset::Usdc,
 					side: Side::Buy,
@@ -1043,8 +1144,8 @@ fn test_get_scheduled_swap_legs_fallback() {
 			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth, Some(sqrt_price)),
 			vec![
 				SwapLegInfo {
-					swap_id: 1,
-					swap_request_id: 1,
+					swap_id: SwapId(1),
+					swap_request_id: SwapRequestId(1),
 					base_asset: Asset::Eth,
 					quote_asset: Asset::Usdc,
 					side: Side::Buy,
@@ -1055,8 +1156,8 @@ fn test_get_scheduled_swap_legs_fallback() {
 					chunk_interval: SWAP_DELAY_BLOCKS,
 				},
 				SwapLegInfo {
-					swap_id: 2,
-					swap_request_id: 2,
+					swap_id: SwapId(2),
+					swap_request_id: SwapRequestId(2),
 					base_asset: Asset::Eth,
 					quote_asset: Asset::Usdc,
 					side: Side::Sell,
@@ -1088,8 +1189,8 @@ fn test_get_scheduled_swap_legs_for_dca() {
 		assert_eq!(
 			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth, None),
 			vec![SwapLegInfo {
-				swap_id: 1,
-				swap_request_id: 1,
+				swap_id: SwapId(1),
+				swap_request_id: SwapRequestId(1),
 				base_asset: Asset::Eth,
 				quote_asset: Asset::Usdc,
 				side: Side::Buy,
@@ -1232,7 +1333,7 @@ fn test_buy_back_flip() {
 			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS))
 				.first()
 				.expect("Should have scheduled a swap usdc -> flip"),
-			&Swap::new(1, 1, STABLE_ASSET, Asset::Flip, network_fee, None, [],)
+			&Swap::new(1.into(), 1.into(), STABLE_ASSET, Asset::Flip, network_fee, None, [],)
 		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -119,8 +119,8 @@ fn can_process_ccms_via_swap_deposit_address() {
 			assert_eq!(
 				SwapQueue::<Test>::get(PRINCIPAL_SWAP_BLOCK),
 				vec![Swap::new(
-					1,
-					1,
+					1.into(),
+					1.into(),
 					Asset::Dot,
 					Asset::Eth,
 					DEPOSIT_AMOUNT - GAS_BUDGET,
@@ -135,8 +135,8 @@ fn can_process_ccms_via_swap_deposit_address() {
 			assert_eq!(
 				SwapQueue::<Test>::get(GAS_SWAP_BLOCK),
 				vec![Swap::new(
-					2,
-					1,
+					2.into(),
+					1.into(),
 					Asset::Dot,
 					Asset::Eth,
 					GAS_BUDGET,
@@ -147,7 +147,7 @@ fn can_process_ccms_via_swap_deposit_address() {
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 			);
 		})
 		.then_process_blocks_until_block(GAS_SWAP_BLOCK)
@@ -161,7 +161,7 @@ fn can_process_ccms_via_swap_deposit_address() {
 
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 2, .. }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
 			);
 		});
 }
@@ -215,7 +215,7 @@ fn ccm_principal_swap_only() {
 			assert_eq!(
 				SwapQueue::<Test>::get(PRINCIPAL_SWAP_BLOCK),
 				vec![Swap::new(
-					1,
+					1.into(),
 					SWAP_REQUEST_ID,
 					INPUT_ASSET,
 					OUTPUT_ASSET,
@@ -229,7 +229,7 @@ fn ccm_principal_swap_only() {
 		.then_execute_with(|_| {
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 			);
 
 			assert_has_matching_event!(
@@ -270,7 +270,7 @@ fn ccm_gas_swap_only() {
 			assert_eq!(
 				SwapQueue::<Test>::get(GAS_SWAP_BLOCK),
 				vec![Swap::new(
-					1,
+					1.into(),
 					SWAP_REQUEST_ID,
 					INPUT_ASSET,
 					GAS_ASSET,
@@ -284,7 +284,7 @@ fn ccm_gas_swap_only() {
 		.then_execute_with(|_| {
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: 1, .. }),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 			);
 
 			assert_has_matching_event!(

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -124,9 +124,9 @@ fn max_swap_amount_can_be_removed() {
 		assert_eq!(
 			SwapQueue::<Test>::get(execute_at),
 			vec![
-				Swap::new(1, 1, from, to, max_swap, None, [FeeType::NetworkFee]),
+				Swap::new(1.into(), 1.into(), from, to, max_swap, None, [FeeType::NetworkFee]),
 				// New swap takes the full amount.
-				Swap::new(2, 2, from, to, amount, None, [FeeType::NetworkFee]),
+				Swap::new(2.into(), 2.into(), from, to, amount, None, [FeeType::NetworkFee]),
 			]
 		);
 		// No no funds are confiscated.
@@ -188,7 +188,7 @@ fn can_swap_below_max_amount() {
 
 		assert_eq!(
 			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS)),
-			vec![Swap::new(1, 1, from, to, amount, None, [FeeType::NetworkFee]),]
+			vec![Swap::new(1.into(), 1.into(), from, to, amount, None, [FeeType::NetworkFee]),]
 		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -35,7 +35,7 @@ fn setup_dca_swap(
 		Test,
 		RuntimeEvent::Swapping(Event::SwapScheduled {
 			swap_request_id: SWAP_REQUEST_ID,
-			swap_id: 1,
+			swap_id: SwapId(1),
 			input_amount,
 			execute_at,
 			..
@@ -47,7 +47,7 @@ fn setup_dca_swap(
 	assert_eq!(
 		get_dca_state(SWAP_REQUEST_ID),
 		DcaState {
-			status: DcaStatus::ChunkScheduled(1),
+			status: DcaStatus::ChunkScheduled(1.into()),
 			remaining_input_amount: INPUT_AMOUNT - chunk_amount,
 			remaining_chunks: number_of_chunks - 1,
 			chunk_interval,
@@ -65,7 +65,7 @@ fn assert_chunk_1_executed(number_of_chunks: u32) {
 		Test,
 		RuntimeEvent::Swapping(Event::SwapExecuted {
 			swap_request_id: SWAP_REQUEST_ID,
-			swap_id: 1,
+			swap_id: SwapId(1),
 			input_amount,
 			output_amount,
 			..
@@ -77,7 +77,7 @@ fn assert_chunk_1_executed(number_of_chunks: u32) {
 		Test,
 		RuntimeEvent::Swapping(Event::SwapScheduled {
 			swap_request_id: SWAP_REQUEST_ID,
-			swap_id: 2,
+			swap_id: SwapId(2),
 			input_amount,
 			execute_at,
 			..
@@ -87,7 +87,7 @@ fn assert_chunk_1_executed(number_of_chunks: u32) {
 	assert_eq!(
 		get_dca_state(SWAP_REQUEST_ID),
 		DcaState {
-			status: DcaStatus::ChunkScheduled(2),
+			status: DcaStatus::ChunkScheduled(2.into()),
 			remaining_input_amount: INPUT_AMOUNT - (chunk_amount * 2),
 			remaining_chunks: number_of_chunks - 2,
 			chunk_interval: CHUNK_INTERVAL,
@@ -151,7 +151,7 @@ fn dca_happy_path() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 2,
+					swap_id: SwapId(2),
 					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					broker_fee: CHUNK_BROKER_FEE,
@@ -189,7 +189,7 @@ fn dca_single_chunk() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 1,
+					swap_id: SwapId(1),
 					input_amount: INPUT_AMOUNT_AFTER_FEE,
 					output_amount: EGRESS_AMOUNT,
 					broker_fee: BROKER_FEE,
@@ -235,7 +235,7 @@ fn dca_with_fok_full_refund() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					execute_at: REFUND_BLOCK
 				})
 			);
@@ -244,7 +244,7 @@ fn dca_with_fok_full_refund() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1),
+					status: DcaStatus::ChunkScheduled(1.into()),
 					remaining_input_amount: CHUNK_AMOUNT,
 					remaining_chunks: 1,
 					chunk_interval: CHUNK_INTERVAL,
@@ -313,7 +313,7 @@ fn dca_with_fok_partial_refund() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
-					swap_id: 2,
+					swap_id: SwapId(2),
 					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK
 				})
 			);
@@ -322,7 +322,7 @@ fn dca_with_fok_partial_refund() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2),
+					status: DcaStatus::ChunkScheduled(2.into()),
 					remaining_input_amount: REFUNDED_AMOUNT - CHUNK_AMOUNT,
 					remaining_chunks: 2,
 					chunk_interval: CHUNK_INTERVAL,
@@ -391,7 +391,7 @@ fn dca_with_fok_fully_executed() {
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
-					swap_id: 1,
+					swap_id: SwapId(1),
 					execute_at: CHUNK_1_RETRY_BLOCK,
 					..
 				})
@@ -401,7 +401,7 @@ fn dca_with_fok_fully_executed() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1),
+					status: DcaStatus::ChunkScheduled(1.into()),
 					remaining_input_amount: CHUNK_AMOUNT,
 					remaining_chunks: 1,
 					chunk_interval: CHUNK_INTERVAL,
@@ -418,7 +418,7 @@ fn dca_with_fok_fully_executed() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 1,
+					swap_id: SwapId(1),
 					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					broker_fee: CHUNK_BROKER_FEE,
@@ -427,7 +427,7 @@ fn dca_with_fok_fully_executed() {
 				// Second chunk should be scheduled 2 blocks after the first is executed:
 				RuntimeEvent::Swapping(Event::SwapScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 2,
+					swap_id: SwapId(2),
 					input_amount: CHUNK_AMOUNT,
 					execute_at: CHUNK_2_BLOCK,
 					..
@@ -437,7 +437,7 @@ fn dca_with_fok_fully_executed() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2),
+					status: DcaStatus::ChunkScheduled(2.into()),
 					remaining_input_amount: 0,
 					remaining_chunks: 0,
 					chunk_interval: CHUNK_INTERVAL,
@@ -453,7 +453,7 @@ fn dca_with_fok_fully_executed() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 2,
+					swap_id: SwapId(2),
 					input_amount: CHUNK_AMOUNT_AFTER_FEE,
 					output_amount: CHUNK_OUTPUT,
 					..
@@ -522,7 +522,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 1,
+					swap_id: SwapId(1),
 					input_amount,
 					..
 					// All chunks should be 0 amount except the last one
@@ -533,7 +533,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1),
+					status: DcaStatus::ChunkScheduled(1.into()),
 					// Still the full amount remaining because the first chunk is 0
 					remaining_input_amount: INPUT_AMOUNT,
 					remaining_chunks: NUMBER_OF_CHUNKS - 1,
@@ -548,7 +548,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 1,
+					swap_id: SwapId(1),
 					input_amount,
 					output_amount,
 					..
@@ -560,7 +560,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 2,
+					swap_id: SwapId(2),
 					input_amount,
 					..
 					// All chunks should be 0 amount except the last one
@@ -570,7 +570,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2),
+					status: DcaStatus::ChunkScheduled(2.into()),
 					remaining_input_amount: INPUT_AMOUNT,
 					remaining_chunks: NUMBER_OF_CHUNKS - 2,
 					chunk_interval: CHUNK_INTERVAL,
@@ -587,7 +587,7 @@ fn can_handle_dca_chunk_size_of_zero() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapExecuted {
 					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: 3,
+					swap_id: SwapId(3),
 					input_amount,
 					output_amount,
 					..
@@ -623,7 +623,7 @@ mod ccm_tests {
 
 	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
 
-	const GAS_SWAP_ID: SwapId = 3;
+	const GAS_SWAP_ID: SwapId = SwapId(3);
 
 	#[track_caller]
 	fn setup_ccm_dca_swap(
@@ -653,7 +653,7 @@ mod ccm_tests {
 			Test,
 			RuntimeEvent::Swapping(Event::SwapScheduled {
 				swap_request_id: SWAP_REQUEST_ID,
-				swap_id: 1,
+				swap_id: SwapId(1),
 				input_amount: CHUNK_AMOUNT,
 				execute_at: CHUNK_1_BLOCK,
 				..
@@ -663,7 +663,7 @@ mod ccm_tests {
 		assert_eq!(
 			get_dca_state(SWAP_REQUEST_ID),
 			DcaState {
-				status: DcaStatus::ChunkScheduled(1),
+				status: DcaStatus::ChunkScheduled(1.into()),
 				remaining_input_amount: CHUNK_AMOUNT,
 				remaining_chunks: 1,
 				chunk_interval,
@@ -685,14 +685,14 @@ mod ccm_tests {
 			Test,
 			RuntimeEvent::Swapping(Event::SwapExecuted {
 				swap_request_id: SWAP_REQUEST_ID,
-				swap_id: 1,
+				swap_id: SwapId(1),
 				input_amount: CHUNK_AMOUNT_AFTER_FEE,
 				output_amount: CHUNK_OUTPUT,
 				..
 			}),
 			RuntimeEvent::Swapping(Event::SwapScheduled {
 				swap_request_id: SWAP_REQUEST_ID,
-				swap_id: 2,
+				swap_id: SwapId(2),
 				input_amount: CHUNK_AMOUNT,
 				execute_at: CHUNK_2_BLOCK,
 				swap_type: SwapType::CcmPrincipal,
@@ -711,7 +711,7 @@ mod ccm_tests {
 		assert_eq!(
 			get_dca_state(SWAP_REQUEST_ID),
 			DcaState {
-				status: DcaStatus::ChunkScheduled(2),
+				status: DcaStatus::ChunkScheduled(2.into()),
 				remaining_input_amount: 0,
 				remaining_chunks: 0,
 				chunk_interval: CHUNK_INTERVAL,
@@ -741,7 +741,7 @@ mod ccm_tests {
 					Test,
 					RuntimeEvent::Swapping(Event::SwapExecuted {
 						swap_request_id: SWAP_REQUEST_ID,
-						swap_id: 3,
+						swap_id: SwapId(3),
 						input_amount: GAS_BUDGET,
 						output_amount,
 						..
@@ -752,7 +752,7 @@ mod ccm_tests {
 				assert_eq!(
 					get_dca_state(SWAP_REQUEST_ID),
 					DcaState {
-						status: DcaStatus::ChunkScheduled(2),
+						status: DcaStatus::ChunkScheduled(2.into()),
 						remaining_input_amount: 0,
 						remaining_chunks: 0,
 						chunk_interval: CHUNK_INTERVAL,
@@ -773,7 +773,7 @@ mod ccm_tests {
 					Test,
 					RuntimeEvent::Swapping(Event::SwapExecuted {
 						swap_request_id: SWAP_REQUEST_ID,
-						swap_id: 2,
+						swap_id: SwapId(2),
 						input_amount: CHUNK_AMOUNT_AFTER_FEE,
 						output_amount: CHUNK_OUTPUT,
 						..
@@ -929,14 +929,14 @@ mod ccm_tests {
 					Test,
 					RuntimeEvent::Swapping(Event::SwapExecuted {
 						swap_request_id: SWAP_REQUEST_ID,
-						swap_id: 1,
+						swap_id: SwapId(1),
 						input_amount: CHUNK_AMOUNT_AFTER_FEE,
 						output_amount: CHUNK_OUTPUT,
 						..
 					}),
 					RuntimeEvent::Swapping(Event::SwapScheduled {
 						swap_request_id: SWAP_REQUEST_ID,
-						swap_id: 2,
+						swap_id: SwapId(2),
 						input_amount: CHUNK_AMOUNT,
 						execute_at: CHUNK_2_BLOCK,
 						swap_type: SwapType::CcmPrincipal,
@@ -955,7 +955,7 @@ mod ccm_tests {
 				assert_eq!(
 					get_dca_state(SWAP_REQUEST_ID),
 					DcaState {
-						status: DcaStatus::ChunkScheduled(2),
+						status: DcaStatus::ChunkScheduled(2.into()),
 						remaining_input_amount: 0,
 						remaining_chunks: 0,
 						chunk_interval: CHUNK_INTERVAL,

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -98,7 +98,7 @@ fn test_buy_back_flip() {
 			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS))
 				.first()
 				.expect("Should have scheduled a swap usdc -> flip"),
-			&Swap::new(1, 1, STABLE_ASSET, Asset::Flip, network_fee, None, [],)
+			&Swap::new(1.into(), 1.into(), STABLE_ASSET, Asset::Flip, network_fee, None, [],)
 		);
 	});
 }
@@ -350,8 +350,8 @@ fn input_amount_excludes_network_fee() {
 			let expected_input_amount = AMOUNT - network_fee;
 
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_request_id: 1,
-				swap_id: 1,
+				swap_request_id: 1.into(),
+				swap_id: 1.into(),
 				input_asset: FROM_ASSET,
 				output_asset: TO_ASSET,
 				network_fee,
@@ -435,8 +435,8 @@ fn expect_earned_fees_to_be_recorded() {
 		.then_process_blocks_until_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64)
 		.then_execute_with(|_| {
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_request_id: 1,
-				swap_id: 1,
+				swap_request_id: 1.into(),
+				swap_id: 1.into(),
 				network_fee: NETWORK_FEE_1,
 				broker_fee: ALICE_FEE_1,
 				input_amount: INPUT_AMOUNT,
@@ -460,8 +460,8 @@ fn expect_earned_fees_to_be_recorded() {
 		.then_execute_with(|_| {
 			const AMOUNT_AFTER_FEES: AssetAmount = INPUT_AMOUNT - NETWORK_FEE_2 - ALICE_FEE_2;
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_request_id: 2,
-				swap_id: 2,
+				swap_request_id: 2.into(),
+				swap_id: 2.into(),
 				network_fee: NETWORK_FEE_2,
 				broker_fee: ALICE_FEE_2,
 				input_amount: AMOUNT_AFTER_FEES,
@@ -491,8 +491,8 @@ fn expect_earned_fees_to_be_recorded() {
 				INTERMEDIATE_AMOUNT - NETWORK_FEE_3 - TOTAL_BROKER_FEES;
 
 			System::assert_has_event(RuntimeEvent::Swapping(Event::<Test>::SwapExecuted {
-				swap_request_id: 3,
-				swap_id: 3,
+				swap_request_id: 3.into(),
+				swap_id: 3.into(),
 				network_fee: NETWORK_FEE_3,
 				broker_fee: TOTAL_BROKER_FEES,
 				input_amount: INPUT_AMOUNT,

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -133,8 +133,13 @@ fn price_limit_is_respected_in_fok_swap() {
 					swap_request_id: SwapRequestId(1)
 				}),
 				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: FOK_SWAP_2_ID, .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled { swap_request_id: SwapRequestId(3), .. }),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted { swap_request_id: SwapRequestId(3) }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(3),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(3)
+				}),
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: FOK_SWAP_1_ID,
 					execute_at: SWAP_RETRIED_AT_BLOCK
@@ -233,8 +238,8 @@ fn fok_swap_gets_refunded_due_to_price_limit() {
 
 #[test]
 fn storage_state_rolls_back_on_fok_violation() {
-	const FOK_SWAP_ID: u64 = 1;
-	const OTHER_SWAP_ID: u64 = 2;
+	const FOK_SWAP_ID: SwapId = SwapId(1);
+	const OTHER_SWAP_ID: SwapId = SwapId(2);
 
 	const SWAPS_SCHEDULED_FOR_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -21,7 +21,7 @@ pub mod chains;
 
 #[macro_export]
 macro_rules! define_wrapper_type {
-	($name: ident, $inner: ty, extra_derives: $( $extra_derive: ident ),* ) => {
+	($name: ident, $inner: ty $(, extra_derives: $( $extra_derive: ident ),*)? ) => {
 
 		#[derive(
 			Clone,
@@ -34,7 +34,7 @@ macro_rules! define_wrapper_type {
 			TypeInfo,
 			MaxEncodedLen,
 			Default,
-			$( $extra_derive ),*
+			$($( $extra_derive ),*)?
 		)]
 		pub struct $name(pub $inner);
 
@@ -64,11 +64,6 @@ macro_rules! define_wrapper_type {
 			}
 		}
 	};
-
-	($name: ident, $inner: ty) => {
-		$crate::define_wrapper_type!($name, $inner, extra_derives:)
-	};
-
 }
 
 pub use chains::{assets::any::Asset, ForeignChain};

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -14,6 +14,7 @@ use sp_core::{ConstU32, U256};
 use sp_std::{
 	cmp::{Ord, PartialOrd},
 	fmt,
+	ops::{Deref, DerefMut},
 	vec::Vec,
 };
 pub mod chains;
@@ -36,7 +37,7 @@ macro_rules! define_wrapper_type {
 		)]
 		pub struct $name(pub $inner);
 
-		impl std::ops::Deref for $name {
+		impl Deref for $name {
 			type Target = $inner;
 
 			fn deref(&self) -> &Self::Target {
@@ -44,7 +45,7 @@ macro_rules! define_wrapper_type {
 			}
 		}
 
-		impl std::ops::DerefMut for $name {
+		impl DerefMut for $name {
 			fn deref_mut(&mut self) -> &mut Self::Target {
 				&mut self.0
 			}

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -19,8 +19,10 @@ use sp_std::{
 };
 pub mod chains;
 
+#[macro_export]
 macro_rules! define_wrapper_type {
-	($name: ident, $inner: ty) => {
+	($name: ident, $inner: ty, extra_derives: $( $extra_derive: ident ),* ) => {
+
 		#[derive(
 			Clone,
 			Copy,
@@ -32,8 +34,7 @@ macro_rules! define_wrapper_type {
 			TypeInfo,
 			MaxEncodedLen,
 			Default,
-			serde::Serialize,
-			serde::Deserialize,
+			$( $extra_derive ),*
 		)]
 		pub struct $name(pub $inner);
 
@@ -63,6 +64,11 @@ macro_rules! define_wrapper_type {
 			}
 		}
 	};
+
+	($name: ident, $inner: ty) => {
+		$crate::define_wrapper_type!($name, $inner, extra_derives:)
+	};
+
 }
 
 pub use chains::{assets::any::Asset, ForeignChain};
@@ -92,8 +98,9 @@ pub type BasisPoints = u16;
 
 pub type BroadcastId = u32;
 
-define_wrapper_type!(SwapId, u64);
-define_wrapper_type!(SwapRequestId, u64);
+define_wrapper_type!(SwapId, u64, extra_derives: Serialize, Deserialize);
+
+define_wrapper_type!(SwapRequestId, u64, extra_derives: Serialize, Deserialize);
 
 pub type PrewitnessedDepositId = u64;
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -13,9 +13,56 @@ use serde::{Deserialize, Serialize};
 use sp_core::{ConstU32, U256};
 use sp_std::{
 	cmp::{Ord, PartialOrd},
+	fmt,
 	vec::Vec,
 };
 pub mod chains;
+
+macro_rules! define_wrapper_type {
+	($name: ident, $inner: ty) => {
+		#[derive(
+			Clone,
+			Copy,
+			RuntimeDebug,
+			PartialEq,
+			Eq,
+			Encode,
+			Decode,
+			TypeInfo,
+			MaxEncodedLen,
+			Default,
+			serde::Serialize,
+			serde::Deserialize,
+		)]
+		pub struct $name(pub $inner);
+
+		impl std::ops::Deref for $name {
+			type Target = $inner;
+
+			fn deref(&self) -> &Self::Target {
+				&self.0
+			}
+		}
+
+		impl std::ops::DerefMut for $name {
+			fn deref_mut(&mut self) -> &mut Self::Target {
+				&mut self.0
+			}
+		}
+
+		impl From<$inner> for $name {
+			fn from(value: $inner) -> Self {
+				$name(value)
+			}
+		}
+
+		impl fmt::Display for $name {
+			fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+				write!(f, "{}", self.0)
+			}
+		}
+	};
+}
 
 pub use chains::{assets::any::Asset, ForeignChain};
 
@@ -44,8 +91,8 @@ pub type BasisPoints = u16;
 
 pub type BroadcastId = u32;
 
-pub type SwapId = u64;
-pub type SwapRequestId = u64;
+define_wrapper_type!(SwapId, u64);
+define_wrapper_type!(SwapRequestId, u64);
 
 pub type PrewitnessedDepositId = u64;
 

--- a/state-chain/traits/src/mocks/swap_request_api.rs
+++ b/state-chain/traits/src/mocks/swap_request_api.rs
@@ -74,6 +74,6 @@ where
 			_ => { /* do nothing */ },
 		};
 
-		id as SwapRequestId
+		(id as u64).into()
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1548

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Previously, `SwapId` and `SwapRequestId` were both type aliases for `u64`, making them easy to accidentally misuse. This PR changes them to be struct wrappers around `u64`, generated with a new macro, `define_wrapper_type`.

The macro implements `From<$inner>` for the wrapper struct, such that strongly-typed ids can now be created by, e.g., `my_u64.into()`. It also implements the `Deref` and `DerefMut` traits to access the underlying `u64` value.

One particular problem during implementation was that multiple test files in the swapping pallet use macros such as `assert_event_sequence` which expect patterns to be passed in. Previously, literal values for both SwapId and SwapRequestId were used in such calls. In order to preserve such a usage pattern, the **constructor for the new struct wrappers have to be public**. This is because calls such as `.into()` are not valid in patterns.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
