### PR TITLE
fix: Redemption amount printed not consistent in rounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1800,7 @@ name = "chainflip-cli"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "bigdecimal",
  "cf-chains",
  "chainflip-api",
  "chainflip-engine",

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0"
+bigdecimal = "0.4.5"
 clap = { version = "3.2.16", features = ["derive", "env"] }
 config = "0.13.1"
 futures = "0.3.14"

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -23,9 +23,6 @@ use std::{io::Write, path::PathBuf, sync::Arc};
 use utilities::{clean_hex_address, round_f64, task_scope::task_scope};
 mod settings;
 
-// Using a set number of decimal places of accuracy to avoid floating point rounding errors
-const REDEMPTION_MAX_DECIMAL_PLACES: u32 = 6;
-
 #[tokio::main]
 async fn main() {
 	// TODO: call this implicitly from within the API?
@@ -182,11 +179,13 @@ async fn run_cli() -> Result<()> {
 
 /// Turns the amount of FLIP into a RedemptionAmount in Flipperinos.
 fn flip_to_redemption_amount(amount: Option<f64>) -> RedemptionAmount {
+	// Using a set number of decimal places of accuracy to avoid floating point rounding errors
+	const MAX_DECIMAL_PLACES: u32 = 6;
 	match amount {
 		Some(amount_float) => {
-			let atomic_amount = ((round_f64(amount_float, REDEMPTION_MAX_DECIMAL_PLACES) *
-				10_f64.powi(REDEMPTION_MAX_DECIMAL_PLACES as i32)) as u128) *
-				10_u128.pow(FLIP_DECIMALS - REDEMPTION_MAX_DECIMAL_PLACES);
+			let atomic_amount = ((round_f64(amount_float, MAX_DECIMAL_PLACES) *
+				10_f64.powi(MAX_DECIMAL_PLACES as i32)) as u128) *
+				10_u128.pow(FLIP_DECIMALS - MAX_DECIMAL_PLACES);
 			RedemptionAmount::Exact(atomic_amount)
 		},
 		None => RedemptionAmount::Max,

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -10,9 +10,12 @@ use api::{
 	queries::QueryApi,
 	AccountId32, BrokerApi, GovernanceApi, KeyPair, OperatorApi, StateChainApi, ValidatorApi,
 };
+use bigdecimal::BigDecimal;
 use cf_chains::eth::Address as EthereumAddress;
-use chainflip_api as api;
-use chainflip_api::primitives::state_chain_runtime;
+use chainflip_api::{
+	self as api,
+	primitives::{state_chain_runtime, FLIPPERINOS_PER_FLIP},
+};
 use clap::Parser;
 use futures::FutureExt;
 use serde::Serialize;
@@ -190,6 +193,12 @@ fn flip_to_redemption_amount(amount: Option<f64>) -> RedemptionAmount {
 	}
 }
 
+/// Turns an amount in Flipperinos back into a string representing
+/// this amount in FLIP.
+fn flipperino_to_flip_string(atomic_amount: u128) -> String {
+	(BigDecimal::from(atomic_amount) / FLIPPERINOS_PER_FLIP).to_string()
+}
+
 async fn request_redemption(
 	api: StateChainApi,
 	amount: Option<f64>,
@@ -215,9 +224,7 @@ async fn request_redemption(
 	let redeem_amount = flip_to_redemption_amount(amount);
 	match redeem_amount {
 		RedemptionAmount::Exact(atomic_amount) => {
-			println!(
-				"Submitting redemption with amount `{}.{}` FLIP (`{atomic_amount}` Flipperinos) to ETH address `{redeem_address:?}`.", atomic_amount >> REDEMPTION_MAX_DECIMAL_PLACES, atomic_amount % (1 << REDEMPTION_MAX_DECIMAL_PLACES)
-			);
+			println!( "Submitting redemption with amount `{}` FLIP (`{atomic_amount}` Flipperinos) to ETH address `{redeem_address:?}`.", flipperino_to_flip_string(atomic_amount));
 		},
 		RedemptionAmount::Max => {
 			println!("Submitting redemption with MAX amount to ETH address `{redeem_address:?}`.");
@@ -502,4 +509,21 @@ fn test_flip_to_redemption_amount() {
 		flip_to_redemption_amount(Some(4206900.1234564321)),
 		RedemptionAmount::Exact(4206900123456000000000000)
 	);
+}
+
+#[test]
+fn test_flipperino_flip_roundtrip() {
+	fn assert_eq_flip_string(amount: f64, result: String) {
+		match flip_to_redemption_amount(Some(amount)) {
+			RedemptionAmount::Max => panic!("Expected exact amount."),
+			RedemptionAmount::Exact(amount) =>
+				assert_eq!(flipperino_to_flip_string(amount), result),
+		}
+	}
+	assert_eq_flip_string(0.0, "0".into());
+	assert_eq_flip_string(1.0, "1".into());
+	assert_eq_flip_string(0.1, "0.1".into());
+	assert_eq_flip_string(17777.777777777777, "17777.777778".into());
+	assert_eq_flip_string(0.0000009, "0.000001".into());
+	assert_eq_flip_string(0.50000001, "0.5".into());
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1275
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

The code for printing the redemption amount in the chainflip-cli is printing two numbers: amount in FLIP and amount in Flipperinos. The latter is the authoritative one and is computed from the user input via rounding to 6 decimal places.

Previously the amount in FLIP was simply the user-entered amount and thus did not always match up with the flipperino amount. This change recomputes a decimal FLIP-valued representation of the authoritative flipperino amount when displaying the redemption amount. 

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
