### PR TITLE
chore: bump asset-balances to match release

### DIFF
--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -31,10 +31,10 @@ assets = [
     # The old version gets put into target/release by the package github actions workflow.
     # It downloads the correct version from the releases page.
     [
-        "target/release/libchainflip_engine_v1_6_3.so",
+        "target/release/libchainflip_engine_v1_6_7.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_3.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_7.so",
         "755",
     ],
 ]

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -2,7 +2,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.6.3")]
+	#[engine_proc_macros::link_engine_library_version("1.6.7")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -10,7 +10,7 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.6.3";
+pub const OLD_VERSION: &str = "1.6.7";
 pub const NEW_VERSION: &str = "1.7.0";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";

--- a/state-chain/pallets/cf-asset-balances/src/lib.rs
+++ b/state-chain/pallets/cf-asset-balances/src/lib.rs
@@ -26,7 +26,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(0);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
 
 pub const REFUND_FEE_MULTIPLE: AssetAmount = 100;
 


### PR DESCRIPTION
## Summary

Version bump had not yet been pulled across to main from release - meaning try-runtime/migrations would fail due to version mismatch.

See: ea83d71bf70b37ce0224160255b89ee710d3c359
