### PR TITLE
fix: increase init timeout for backup test

### DIFF
--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -959,7 +959,7 @@ mod tests {
 
 		task_scope(|scope| {
 			async move {
-				const INITIAL_TIMEOUT: Duration = Duration::from_millis(100);
+				const INITIAL_TIMEOUT: Duration = Duration::from_millis(300);
 
 				let retrier_client = RetrierClient::new(
 					scope,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1685

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Should fix flakiness for this timing based test - was pretty uncommon before, but this should make it even more uncommon.
