### PR TITLE
test(bouncer): add test for new utility

### DIFF
--- a/bouncer/commands/run_test.ts
+++ b/bouncer/commands/run_test.ts
@@ -39,6 +39,7 @@ import { testBoostingSwap } from '../tests/boost';
 import { ConsoleColors, ConsoleLogColors } from '../shared/utils';
 import { testDeltaBasedIngress } from '../tests/delta_based_ingress';
 import { testCancelOrdersBatch } from '../tests/create_and_delete_multiple_orders';
+import { depositChannelCreation } from '../tests/request_swap_deposit_address_with_affiliates';
 
 async function main() {
   const testName = process.argv[2];
@@ -65,6 +66,7 @@ async function main() {
     testSwapAfterDisconnection,
     testDeltaBasedIngress,
     testCancelOrdersBatch,
+    depositChannelCreation,
   ];
 
   // Help message

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
       .createPure(polkadot.createType('ProxyType', 'Any'), 0, 0)
       .signAndSend(alice, { nonce: -1 }, (result) => {
         if (result.isError) {
-          handleSubstrateError(polkadot);
+          handleSubstrateError(polkadot)(result);
         }
         if (result.isInBlock) {
           console.log('Polkadot Vault created');
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
       ])
       .signAndSend(alice, { nonce: -1 }, (result) => {
         if (result.isError) {
-          handleSubstrateError(polkadot);
+          handleSubstrateError(polkadot)(result);
         }
         if (result.isInBlock) {
           unsubscribe();

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
       .createPure(polkadot.createType('ProxyType', 'Any'), 0, 0)
       .signAndSend(alice, { nonce: -1 }, (result) => {
         if (result.isError) {
-          handleSubstrateError(result);
+          handleSubstrateError(polkadot);
         }
         if (result.isInBlock) {
           console.log('Polkadot Vault created');
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
       ])
       .signAndSend(alice, { nonce: -1 }, (result) => {
         if (result.isError) {
-          handleSubstrateError(result);
+          handleSubstrateError(polkadot);
         }
         if (result.isInBlock) {
           unsubscribe();

--- a/bouncer/package.json
+++ b/bouncer/package.json
@@ -6,11 +6,13 @@
     "prettier:write": "prettier --write ."
   },
   "dependencies": {
-    "@chainflip/cli": "1.6.2",
+    "@chainflip/cli": "1.6.3",
+    "@chainflip/utils": "^0.4.0",
     "@coral-xyz/anchor": "^0.30.1",
     "@iarna/toml": "^2.2.5",
     "@polkadot/api": "^11.3.1",
     "@polkadot/keyring": "12.6.2",
+    "@polkadot/types": "^11.3.1",
     "@polkadot/util": "12.6.2",
     "@polkadot/util-crypto": "12.6.2",
     "@solana/spl-token": "^0.4.6",

--- a/bouncer/pnpm-lock.yaml
+++ b/bouncer/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       '@chainflip/cli':
-        specifier: 1.6.2
-        version: 1.6.2(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+        specifier: 1.6.3
+        version: 1.6.3(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)
+      '@chainflip/utils':
+        specifier: ^0.4.0
+        version: 0.4.0
       '@coral-xyz/anchor':
         specifier: ^0.30.1
         version: 0.30.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -23,6 +26,9 @@ importers:
       '@polkadot/keyring':
         specifier: 12.6.2
         version: 12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)
+      '@polkadot/types':
+        specifier: ^11.3.1
+        version: 11.3.1
       '@polkadot/util':
         specifier: 12.6.2
         version: 12.6.2
@@ -133,15 +139,18 @@ packages:
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
 
-  '@chainflip/bitcoin@1.0.2':
-    resolution: {integrity: sha512-OrkjJT5mH9+wvm7lSl09D2VlY/kEvqfFGgiLDvItxTUCrm/McADDiGontjXOwe3u4r8KdocPEF47jLHQLAg33A==}
+  '@chainflip/bitcoin@1.1.1':
+    resolution: {integrity: sha512-Jr6X/0QTSFYpTp23ZPhyioL6wL9x3Xpj6OGjadQKZyhobRN4BZkhLogv20HDYTJcRzVphzrTJArbEaNie04XVA==}
 
-  '@chainflip/cli@1.6.2':
-    resolution: {integrity: sha512-wV4bLsn1fqtUxVjEFcfaOnL5AjrgqZ9JxBRmRHTchOWt3+B5QHx0Ehn3pR1dN/9Jnqe0xMSAwBLuH6tJ7hAqQA==}
+  '@chainflip/cli@1.6.3':
+    resolution: {integrity: sha512-isbPdFbO0tmQ7+7OjWSyzKtuog7FOgvkeb7fIini88LHsTjTXf8UvoKGYncOgwvLVQIY+J7NDnSQQmKdBg7PUw==}
     hasBin: true
     peerDependencies:
       axios: ^1.x
       ethers: ^6.13.2
+
+  '@chainflip/extrinsics@1.6.1':
+    resolution: {integrity: sha512-sm3v2QguNW4/RiIZYHd+VRSxup2q4cVBY0VjbQJw6xYqhNCzZlt+Hl38Kni+TCHQu3hP/WgIF72yvvSs7/PBdg==}
 
   '@chainflip/rpc@1.6.7':
     resolution: {integrity: sha512-OIE2cqzDy9Oq9sHuxJKOtbjP438QwMFdc6tuWdAmjjPcHGATI0Ft/lIKeCutD/8uH/CumOzaOoBaT2pI6G78Gg==}
@@ -973,6 +982,9 @@ packages:
   base-x@4.0.0:
     resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
 
+  base-x@5.0.0:
+    resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -996,6 +1008,10 @@ packages:
     resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
     engines: {node: '>=8.0.0'}
 
+  bip174@3.0.0-rc.1:
+    resolution: {integrity: sha512-+8P3BpSairVNF2Nee6Ksdc1etIjWjBOi/MH0MwKtq9YaYp+S2Hk2uvup0e8hCT4IKlS58nXJyyQVmW92zPoD4Q==}
+    engines: {node: '>=18.0.0'}
+
   bitcoin-core@4.2.0:
     resolution: {integrity: sha512-QFmer//rZhyuYm0mBOVAmMhIG/EFmXDahC3a1LvNTwM8/KszxUGEAjvAT4tzm1FaDj4c7pQWMG/vOWtoKjeR3Q==}
     engines: {node: '>=7'}
@@ -1003,6 +1019,10 @@ packages:
   bitcoinjs-lib@6.1.6:
     resolution: {integrity: sha512-Fk8+Vc+e2rMoDU5gXkW9tD+313rhkm5h6N9HfZxXvYU9LedttVvmXKTgd9k5rsQJjkSfsv6XRM8uhJv94SrvcA==}
     engines: {node: '>=8.0.0'}
+
+  bitcoinjs-lib@7.0.0-rc.0:
+    resolution: {integrity: sha512-7CQgOIbREemKR/NT2uc3uO/fkEy+6CM0sLxboVVY6bv6DbZmPt3gg5Y/hhWgQFeZu5lfTbtVAv32MIxf7lMh4g==}
+    engines: {node: '>=18.0.0'}
 
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
@@ -1048,11 +1068,17 @@ packages:
   bs58@5.0.0:
     resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
 
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
   bs58check@2.1.2:
     resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
 
   bs58check@3.0.1:
     resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
+
+  bs58check@4.0.0:
+    resolution: {integrity: sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==}
 
   buffer-layout@1.2.2:
     resolution: {integrity: sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==}
@@ -2769,6 +2795,9 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tsx@4.16.2:
     resolution: {integrity: sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==}
     engines: {node: '>=18.0.0'}
@@ -2826,6 +2855,14 @@ packages:
     resolution: {integrity: sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==}
     engines: {node: '>=14.0.0'}
 
+  uint8array-tools@0.0.8:
+    resolution: {integrity: sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==}
+    engines: {node: '>=14.0.0'}
+
+  uint8array-tools@0.0.9:
+    resolution: {integrity: sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==}
+    engines: {node: '>=14.0.0'}
+
   ultron@1.1.1:
     resolution: {integrity: sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==}
 
@@ -2879,11 +2916,22 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  valibot@0.38.0:
+    resolution: {integrity: sha512-RCJa0fetnzp+h+KN9BdgYOgtsMAG9bfoJ9JSjIhFHobKWVWyzM3jjaeNTdpFK9tQtf3q1sguXeERJ/LcmdFE7w==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   varint@5.0.2:
     resolution: {integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==}
 
   varuint-bitcoin@1.1.2:
     resolution: {integrity: sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==}
+
+  varuint-bitcoin@2.0.0:
+    resolution: {integrity: sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3111,14 +3159,17 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@chainflip/bitcoin@1.0.2':
+  '@chainflip/bitcoin@1.1.1(typescript@5.5.3)':
     dependencies:
       '@chainflip/utils': 0.4.0
-      '@noble/hashes': 1.4.0
+      bitcoinjs-lib: 7.0.0-rc.0(typescript@5.5.3)
+    transitivePeerDependencies:
+      - typescript
 
-  '@chainflip/cli@1.6.2(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+  '@chainflip/cli@1.6.3(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@chainflip/bitcoin': 1.0.2
+      '@chainflip/bitcoin': 1.1.1(typescript@5.5.3)
+      '@chainflip/extrinsics': 1.6.1
       '@chainflip/rpc': 1.6.7
       '@chainflip/solana': 1.0.2
       '@chainflip/utils': 0.4.0
@@ -3130,7 +3181,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - supports-color
+      - typescript
       - utf-8-validate
+
+  '@chainflip/extrinsics@1.6.1': {}
 
   '@chainflip/rpc@1.6.7':
     dependencies:
@@ -3613,19 +3667,19 @@ snapshots:
       '@polkadot/types': 11.3.1
       '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   '@polkadot/types-codec@11.3.1':
     dependencies:
       '@polkadot/util': 12.6.2
       '@polkadot/x-bigint': 12.6.2
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   '@polkadot/types-create@11.3.1':
     dependencies:
       '@polkadot/types-codec': 11.3.1
       '@polkadot/util': 12.6.2
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   '@polkadot/types-known@11.3.1':
     dependencies:
@@ -3650,7 +3704,7 @@ snapshots:
       '@polkadot/util': 12.6.2
       '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
       rxjs: 7.8.1
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   '@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2)':
     dependencies:
@@ -4265,6 +4319,8 @@ snapshots:
 
   base-x@4.0.0: {}
 
+  base-x@5.0.0: {}
+
   base64-js@1.5.1: {}
 
   bcrypt-pbkdf@1.0.2:
@@ -4284,6 +4340,11 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   bip174@2.1.1: {}
+
+  bip174@3.0.0-rc.1:
+    dependencies:
+      uint8array-tools: 0.0.9
+      varuint-bitcoin: 2.0.0
 
   bitcoin-core@4.2.0:
     dependencies:
@@ -4305,6 +4366,18 @@ snapshots:
       bs58check: 3.0.1
       typeforce: 1.18.0
       varuint-bitcoin: 1.1.2
+
+  bitcoinjs-lib@7.0.0-rc.0(typescript@5.5.3):
+    dependencies:
+      '@noble/hashes': 1.4.0
+      bech32: 2.0.0
+      bip174: 3.0.0-rc.1
+      bs58check: 4.0.0
+      uint8array-tools: 0.0.9
+      valibot: 0.38.0(typescript@5.5.3)
+      varuint-bitcoin: 2.0.0
+    transitivePeerDependencies:
+      - typescript
 
   blakejs@1.2.1: {}
 
@@ -4371,6 +4444,10 @@ snapshots:
     dependencies:
       base-x: 4.0.0
 
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.0
+
   bs58check@2.1.2:
     dependencies:
       bs58: 4.0.1
@@ -4381,6 +4458,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
       bs58: 5.0.0
+
+  bs58check@4.0.0:
+    dependencies:
+      '@noble/hashes': 1.4.0
+      bs58: 6.0.0
 
   buffer-layout@1.2.2: {}
 
@@ -6409,6 +6491,8 @@ snapshots:
 
   tslib@2.6.3: {}
 
+  tslib@2.7.0: {}
+
   tsx@4.16.2:
     dependencies:
       esbuild: 0.21.5
@@ -6477,6 +6561,10 @@ snapshots:
 
   uint8array-tools@0.0.7: {}
 
+  uint8array-tools@0.0.8: {}
+
+  uint8array-tools@0.0.9: {}
+
   ultron@1.1.1: {}
 
   unbox-primitive@1.0.2:
@@ -6522,11 +6610,19 @@ snapshots:
 
   uuid@9.0.1: {}
 
+  valibot@0.38.0(typescript@5.5.3):
+    optionalDependencies:
+      typescript: 5.5.3
+
   varint@5.0.2: {}
 
   varuint-bitcoin@1.1.2:
     dependencies:
       safe-buffer: 5.2.1
+
+  varuint-bitcoin@2.0.0:
+    dependencies:
+      uint8array-tools: 0.0.8
 
   vary@1.1.2: {}
 

--- a/bouncer/shared/polkadot_utils.ts
+++ b/bouncer/shared/polkadot_utils.ts
@@ -1,10 +1,10 @@
 import { BN } from '@polkadot/util';
+import { AugmentedEvent, SubmittableExtrinsicFunction } from '@polkadot/api/types';
 import { aliceKeyringPair } from '../shared/polkadot_keyring';
 import { Event, polkadotSigningMutex, sleep } from '../shared/utils';
 import { getPolkadotApi } from './utils/substrate';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function handleDispatchError(result: any) {
+export async function handleDispatchError(result: { dispatchError?: string }) {
   await using polkadot = await getPolkadotApi();
   if (result.dispatchError) {
     const dispatchError = JSON.parse(result.dispatchError);
@@ -21,8 +21,10 @@ export async function handleDispatchError(result: any) {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function submitAndGetEvent(call: any, eventMatch: any): Promise<Event> {
+export async function submitAndGetEvent(
+  call: ReturnType<SubmittableExtrinsicFunction<'promise'>>,
+  eventMatch: AugmentedEvent<'promise'>,
+): Promise<Event> {
   const alice = await aliceKeyringPair();
   let done = false;
   let event: Event = { name: '', data: [], block: 0, event_index: 0 };

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -18,6 +18,7 @@ import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import { hexToU8a, u8aToHex, BN } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 import { EventParser, BorshCoder } from '@coral-xyz/anchor';
+import { ISubmittableResult } from '@polkadot/types/types';
 import { base58Decode, base58Encode } from '../polkadot/util-crypto';
 import { newDotAddress } from './new_dot_address';
 import { BtcAddressType, newBtcAddress } from './new_btc_address';
@@ -112,7 +113,7 @@ export function getContractAddress(chain: Chain, contract: string): string {
   }
 }
 
-export function shortChainFromAsset(asset: Asset): string {
+export function shortChainFromAsset(asset: Asset) {
   switch (asset) {
     case 'Dot':
       return 'Dot';
@@ -897,10 +898,8 @@ export function getEncodedSolAddress(address: string): string {
   return /^0x[a-fA-F0-9]+$/.test(address) ? encodeSolAddress(address) : address;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function handleSubstrateError(api: any) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (arg: any) => {
+export function handleSubstrateError(api: ApiPromise, exit = true) {
+  return (arg: ISubmittableResult) => {
     const { dispatchError } = arg;
     if (dispatchError) {
       let error;
@@ -910,8 +909,12 @@ export function handleSubstrateError(api: any) {
       } else {
         error = dispatchError.toString();
       }
-      console.log('Dispatch error:' + error);
-      process.exit(-1);
+      if (exit) {
+        console.log('Dispatch error:' + error);
+        process.exit(-1);
+      } else {
+        throw new Error('Dispatch error: ' + error);
+      }
     }
   };
 }

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -32,6 +32,7 @@ const getCachedDisposable = <T extends AsyncDisposable, F extends (...args: any[
       get(target, prop, receiver) {
         if (prop === Symbol.asyncDispose) {
           return () => {
+            connections -= 1;
             setTimeout(() => {
               if (connections === 0) {
                 const dispose = Reflect.get(

--- a/bouncer/tests/DCA_test.ts
+++ b/bouncer/tests/DCA_test.ts
@@ -42,7 +42,11 @@ async function testDCASwap(inputAsset: Asset, amount: number, numberOfChunks: nu
     0, // brokerCommissionBps
     false, // log
     0, // boostFeeBps
-    undefined, // FoK parameters
+    {
+      refundAddress: '0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF',
+      minPriceX128: '1',
+      retryDurationBlocks: 100,
+    }, // FoK parameters
     dcaParameters,
   );
 

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -13,6 +13,7 @@ import { testFillOrKill } from './fill_or_kill';
 import { testDCASwaps } from './DCA_test';
 import { testCancelOrdersBatch } from './create_and_delete_multiple_orders';
 import { testAllSwaps } from './all_swaps';
+import { depositChannelCreation } from './request_swap_deposit_address_with_affiliates';
 
 async function runAllConcurrentTests() {
   // Specify the number of nodes via providing an argument to this script.
@@ -41,6 +42,7 @@ async function runAllConcurrentTests() {
     testFillOrKill.run(),
     testDCASwaps.run(),
     testCancelOrdersBatch.run(),
+    depositChannelCreation.run(),
   ];
 
   // Tests that only work if there is more than one node

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -252,4 +252,4 @@ const main = async () => {
   }
 };
 
-export const testRotatesThroughBtcSwap = new ExecutableTest('Deposit-Channel-Creation', main, 360);
+export const depositChannelCreation = new ExecutableTest('Deposit-Channel-Creation', main, 360);

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -226,8 +226,6 @@ const main = async () => {
   await using api = await getChainflipApi();
   let nonce = (await api.rpc.system.accountNextIndex(account.address)).toJSON() as number;
 
-  console.log({ nonce });
-
   const allCases = [...baseCases, ...refundCases, dcaCase, withCommission, withAffiliates, ccmCase];
   const results = await Promise.allSettled(
     allCases.map((params) => requestSwapDepositAddress(api, params, () => nonce++)),
@@ -238,11 +236,16 @@ const main = async () => {
 
   results.forEach((result, i) => {
     if (result.status === 'fulfilled') {
-      console.log('✅', i);
+      console.log('✅', `request swap deposit address with affiliates ${i} passed`);
     } else {
       // realism 😔
       success = false;
-      console.error('❌', i, (result.reason as Error).message, allCases[i]);
+      console.error(
+        '❌',
+        `request swap deposit address with affiliates ${i} failed`,
+        (result.reason as Error).message,
+        allCases[i],
+      );
     }
   });
 

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -1,0 +1,255 @@
+import * as ss58 from '@chainflip/utils/ss58';
+import * as base58 from '@chainflip/utils/base58';
+import { isHex } from '@chainflip/utils/string';
+import { hexToBytes } from '@chainflip/utils/bytes';
+import { ApiPromise, Keyring } from '@polkadot/api';
+import { broker, chainConstants, getInternalAsset } from '@chainflip/cli';
+import assert from 'assert';
+import { z } from 'zod';
+import { getChainflipApi } from '../shared/utils/substrate';
+import { deferredPromise, handleSubstrateError, shortChainFromAsset } from '../shared/utils';
+import { ExecutableTest } from '../shared/executable_test';
+
+const keyring = new Keyring({ type: 'sr25519' });
+keyring.setSS58Format(2112);
+
+const account = keyring.addFromUri('//BROKER_2');
+const account2 = keyring.addFromUri('//BROKER_1');
+type NewSwapRequest = Parameters<(typeof broker)['buildExtrinsicPayload']>[0];
+
+const numberSchema = z.string().transform((n) => Number(n.replace(/,/g, '')));
+const bigintSchema = z.string().transform((n) => BigInt(n.replace(/,/g, '')));
+
+const shortChainSchema = z.enum(['Btc', 'Eth', 'Arb', 'Dot', 'Sol']);
+
+const addressTransforms = {
+  Btc: (address: string) => address,
+  Eth: (address: string) => address.toLowerCase(),
+  Arb: (address: string) => address.toLowerCase(),
+  Dot: (address: string) =>
+    isHex(address) ? ss58.encode({ data: address, ss58Format: 0 }) : address,
+  Sol: (address: string) => (isHex(address) ? base58.encode(hexToBytes(address)) : address),
+} as const;
+
+const eventSchema = z
+  .object({
+    event: z.object({
+      data: z.object({
+        destinationAddress: z.record(shortChainSchema, z.string()),
+        sourceAsset: z.string(),
+        destinationAsset: z.string(),
+        brokerCommissionRate: numberSchema,
+        channelMetadata: z
+          .object({ message: z.string(), gasBudget: bigintSchema, cfParameters: z.string() })
+          .nullable(),
+        boostFee: numberSchema,
+        affiliateFees: z.array(z.object({ account: z.string(), bps: numberSchema })),
+        refundParameters: z
+          .object({
+            retryDuration: numberSchema,
+            refundAddress: z.record(shortChainSchema, z.string()),
+            minPrice: bigintSchema,
+          })
+          .nullable(),
+        dcaParameters: z
+          .object({ numberOfChunks: numberSchema, chunkInterval: numberSchema })
+          .nullable(),
+      }),
+    }),
+  })
+  .transform((event) => event.event.data);
+
+const requestSwapDepositAddress = async (
+  chainflip: ApiPromise,
+  params: NewSwapRequest,
+  getNonce: () => number,
+) => {
+  const deferred = deferredPromise<z.output<typeof eventSchema>>();
+  const { promise, resolve, reject } = deferred;
+
+  const eventMatcher = chainflip.events.swapping.SwapDepositAddressReady;
+
+  // queue = queue.then(async () => {
+  const unsubscribe = await chainflip.tx.swapping
+    .requestSwapDepositAddressWithAffiliates(...broker.buildExtrinsicPayload(params, 'backspin'))
+    .signAndSend(account, { nonce: getNonce() }, (result) => {
+      if (!result.isInBlock) return;
+
+      if (result.dispatchError) {
+        try {
+          handleSubstrateError(chainflip, false)(result);
+        } catch (e) {
+          reject(e as Error);
+          return;
+        }
+      }
+
+      const event = result.events.find((record) => eventMatcher.is(record.event));
+      assert(event, 'SwapDepositAddressReady event not found');
+      resolve(eventSchema.parse(event.toHuman()));
+    });
+
+  const event = await promise.finally(unsubscribe);
+  // });
+
+  // const event = await promise;
+  const sourceAsset = getInternalAsset({ chain: params.srcChain, asset: params.srcAsset });
+  const destinationAsset = getInternalAsset({ chain: params.destChain, asset: params.destAsset });
+
+  assert.strictEqual(event.sourceAsset, sourceAsset, 'source asset is wrong');
+  assert.strictEqual(event.destinationAsset, destinationAsset, 'destination asset is wrong');
+
+  const destChain = shortChainFromAsset(destinationAsset);
+  const transformDestAddress = addressTransforms[destChain];
+
+  assert.strictEqual(
+    transformDestAddress(event.destinationAddress[destChain]!),
+    transformDestAddress(params.destAddress),
+    'destination address is wrong',
+  );
+  assert.strictEqual(event.brokerCommissionRate, params.commissionBps ?? 0);
+  assert.strictEqual(event.boostFee, params.maxBoostFeeBps ?? 0);
+
+  if (params.fillOrKillParams) {
+    assert.strictEqual(
+      event.refundParameters?.minPrice,
+      BigInt(params.fillOrKillParams.minPriceX128),
+    );
+    assert.strictEqual(
+      event.refundParameters?.retryDuration,
+      params.fillOrKillParams.retryDurationBlocks,
+    );
+    const sourceChain = shortChainFromAsset(sourceAsset);
+    const transformRefundAddress = addressTransforms[sourceChain];
+    assert.strictEqual(
+      transformRefundAddress(event.refundParameters!.refundAddress[sourceChain]!),
+      transformRefundAddress(params.fillOrKillParams.refundAddress),
+    );
+  }
+
+  if (params.affiliates) {
+    assert.deepStrictEqual(
+      params.affiliates
+        .toSorted((a, b) => a.account.localeCompare(b.account))
+        .map((aff) => ({ account: aff.account, bps: aff.commissionBps })),
+      event.affiliateFees.toSorted((a, b) => a.account.localeCompare(b.account)),
+    );
+  }
+
+  if (params.dcaParams) {
+    assert.deepStrictEqual(event.dcaParameters?.numberOfChunks, params.dcaParams.numberOfChunks);
+    assert.deepStrictEqual(event.dcaParameters.chunkInterval, params.dcaParams.chunkIntervalBlocks);
+  }
+
+  if (params.ccmParams) {
+    assert.deepStrictEqual(event.channelMetadata?.message, params.ccmParams.message);
+    assert.deepStrictEqual(event.channelMetadata.gasBudget, BigInt(params.ccmParams.gasBudget));
+    assert.deepStrictEqual(event.channelMetadata.cfParameters, params.ccmParams.cfParameters);
+  }
+};
+
+const addresses = {
+  Bitcoin: [
+    'n37AcBDN48pKxBR5DK1fSDFnzFuMhGq9wy', // P2PKH
+    '2MuBZJLi7VdTJgdTkeBfWFMMVvGUJYW9aAt', // P2SH
+    'bcrt1qzhzr5p67ukjyzfmxsh53a8rv3p06nqq0m3md3q', // P2WPKH
+    'bcrt1qqazrtdsvdnl8pv6ypz4jv9h7ud0fs5u4tullapvan2amku7eyujsum5wt8', // P2WSH
+    'bcrt1plrgeugjy6vsehsythzxy4jg5ga2zdvuf4zwjchynd78ldklacs4q52p6g5', // Taproot
+  ],
+  Ethereum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+  Arbitrum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+  Polkadot: ['1yMmfLti1k3huRQM2c47WugwonQMqTvQ2GUFxnU7Pcs7xPo'],
+  Solana: ['3yKDHJgzS2GbZB9qruoadRYtq8597HZifnRju7fHpdRC'],
+} as const;
+
+const entries = Object.entries as <T>(o: T) => [keyof T, T[keyof T]][];
+
+const baseCases = entries(addresses).flatMap(([destChain, addrs]) =>
+  addrs.map(
+    (destAddress) =>
+      ({
+        srcAsset: 'FLIP',
+        srcChain: 'Ethereum',
+        destChain,
+        destAsset: chainConstants[destChain].assets[0],
+        destAddress,
+      }) as NewSwapRequest,
+  ),
+);
+
+const refundCases = entries(addresses).flatMap(([srcChain, addrs]) =>
+  addrs.map(
+    (refundAddress) =>
+      ({
+        destAsset: 'FLIP',
+        destChain: 'Ethereum',
+        destAddress: addresses.Ethereum[0],
+        srcChain,
+        srcAsset: chainConstants[srcChain].assets[0],
+        fillOrKillParams: {
+          refundAddress,
+          minPriceX128: '1',
+          retryDurationBlocks: 100,
+        },
+      }) as NewSwapRequest,
+  ),
+);
+
+const dcaCase: NewSwapRequest = {
+  ...refundCases[0],
+  dcaParams: {
+    numberOfChunks: 7200,
+    chunkIntervalBlocks: 2,
+  },
+};
+
+const withCommission: NewSwapRequest = {
+  ...baseCases[0],
+  commissionBps: 100,
+};
+
+const withAffiliates: NewSwapRequest = {
+  ...baseCases[0],
+  affiliates: [{ account: account2.address, commissionBps: 100 }],
+};
+
+const ccmCase: NewSwapRequest = {
+  ...baseCases.find((c) => c.destChain === 'Arbitrum')!,
+  ccmParams: {
+    message: '0xcafebabe',
+    gasBudget: '1000000',
+    cfParameters: '0xdeadbeef',
+  },
+};
+
+const main = async () => {
+  await using api = await getChainflipApi();
+  let nonce = (await api.rpc.system.accountNextIndex(account.address)).toJSON() as number;
+
+  console.log({ nonce });
+
+  const allCases = [...baseCases, ...refundCases, dcaCase, withCommission, withAffiliates, ccmCase];
+  const results = await Promise.allSettled(
+    allCases.map((params) => requestSwapDepositAddress(api, params, () => nonce++)),
+  );
+
+  // optimism 🚀
+  let success = true;
+
+  results.forEach((result, i) => {
+    if (result.status === 'fulfilled') {
+      console.log('✅', i);
+    } else {
+      // realism 😔
+      success = false;
+      console.error('❌', i, (result.reason as Error).message, allCases[i]);
+    }
+  });
+
+  if (!success) {
+    console.error('Some tests failed');
+    process.exit(1);
+  }
+};
+
+export const testRotatesThroughBtcSwap = new ExecutableTest('Deposit-Channel-Creation', main, 360);

--- a/bouncer/tsconfig.json
+++ b/bouncer/tsconfig.json
@@ -9,8 +9,9 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
+      "ESNext",
       "ESNext.Disposable",
       "DOM"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,


### PR DESCRIPTION
# Pull Request

Closes: WEB-1499

## Summary

To enable integrators to more securely submit extrinsics to open swap deposit channels outside of the broker API, I created a helper that will go in the SDK that will return the parameters properly formatted for them, ready for submission with the Polkadot API.

This adds a test that ensures that the parameters that are generated by the utility submit the extrinsic to the state chain successfully and open channels with the expected attributes.

Also there are some type fixes (I can't help myself).
