### PR TITLE
fix: don't exit if we can't remove a file that already doesn't exist

### DIFF
--- a/localnet/common.sh
+++ b/localnet/common.sh
@@ -102,7 +102,7 @@ build-localnet() {
   DOT_GENESIS_HASH=$(echo $REPLY | grep -o '\"result\":\"0x[^"]*' | grep -o '0x.*')
 
   echo "🐛 Fix solana symlink issue ..."
-  rm $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
+  rm -f $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
   ln -s $SOLANA_BASE_PATH/test-ledger/accounts/snapshot/100 $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
 
   if which solana-test-validator >>$DEBUG_OUTPUT_DESTINATION 2>&1; then

--- a/localnet/common.sh
+++ b/localnet/common.sh
@@ -102,8 +102,7 @@ build-localnet() {
   DOT_GENESIS_HASH=$(echo $REPLY | grep -o '\"result\":\"0x[^"]*' | grep -o '0x.*')
 
   echo "🐛 Fix solana symlink issue ..."
-  rm -f $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
-  ln -s $SOLANA_BASE_PATH/test-ledger/accounts/snapshot/100 $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
+  ln -sf $SOLANA_BASE_PATH/test-ledger/accounts/snapshot/100 $SOLANA_BASE_PATH/test-ledger/snapshot/100/accounts_hardlinks/account_path_0
 
   if which solana-test-validator >>$DEBUG_OUTPUT_DESTINATION 2>&1; then
     echo "☀️ Waiting for Solana node to start"


### PR DESCRIPTION
# Pull Request


## Summary

Ran into this when trying to start a new network. The script shouldn't exit if the file we are trying to remove already doesn't exit, and `-f` achieves this.