### PR TITLE
feat: witnessing btc smart contract swaps

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -147,8 +147,8 @@ impl From<DepositInfo<Bitcoin>> for WitnessInformation {
 			amount: value.amount.into(),
 			asset: value.asset.into(),
 			deposit_details: Some(DepositDetails::Bitcoin {
-				tx_id: value.deposit_details.tx_id,
-				vout: value.deposit_details.vout,
+				tx_id: value.deposit_details.utxo_id.tx_id,
+				vout: value.deposit_details.utxo_id.vout,
 			}),
 		}
 	}

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -207,7 +207,9 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 					deposit_amount,
 					destination_address,
 					tx_hash,
-					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_hash.into()]) },
+					deposit_details: Box::new(DepositDetails {
+						tx_hashes: Some(vec![tx_hash.into()]),
+					}),
 					// TODO: use real parameters when we can decode them
 					boost_fee: 0,
 					dca_params: None,

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -2,7 +2,7 @@ mod chain_tracking;
 
 use std::{collections::HashMap, sync::Arc};
 
-use cf_chains::Arbitrum;
+use cf_chains::{evm::DepositDetails, Arbitrum};
 use cf_primitives::EpochIndex;
 use futures_core::Future;
 use sp_core::H160;
@@ -207,6 +207,11 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 					deposit_amount,
 					destination_address,
 					tx_hash,
+					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_hash.into()]) },
+					// TODO: use real parameters when we can decode them
+					boost_fee: 0,
+					dca_params: None,
+					refund_params: None,
 				}
 			},
 		)

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -213,15 +213,15 @@ mod tests {
 		let txs = vec![
 			fake_transaction(vec![], Some(Amount::from_sat(FEE_0))),
 			fake_transaction(
-				fake_verbose_vouts(vec![(2324, vec![0, 32, 121, 9])]),
+				fake_verbose_vouts(vec![(2324, &DepositAddress::new([0; 32], 0))]),
 				Some(Amount::from_sat(FEE_1)),
 			),
 			fake_transaction(
-				fake_verbose_vouts(vec![(232232, vec![32, 32, 121, 9])]),
+				fake_verbose_vouts(vec![(232232, &DepositAddress::new([32; 32], 0))]),
 				Some(Amount::from_sat(FEE_2)),
 			),
 			fake_transaction(
-				fake_verbose_vouts(vec![(232232, vec![32, 32, 121, 9])]),
+				fake_verbose_vouts(vec![(232232, &DepositAddress::new([32; 32], 0))]),
 				Some(Amount::from_sat(FEE_3)),
 			),
 		];

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -1,6 +1,6 @@
 mod chain_tracking;
 mod deposits;
-mod smart_contract;
+pub mod smart_contract;
 pub mod source;
 
 use crate::{

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -144,9 +144,9 @@ fn deposit_witnesses(
 }
 
 fn map_script_addresses(
-	addresses: Vec<DepositChannelDetails<state_chain_runtime::Runtime, BitcoinInstance>>,
+	deposit_channels: Vec<DepositChannelDetails<state_chain_runtime::Runtime, BitcoinInstance>>,
 ) -> HashMap<Vec<u8>, DepositAddress> {
-	addresses
+	deposit_channels
 		.into_iter()
 		.map(|channel| {
 			assert_eq!(channel.deposit_channel.asset, btc::Asset::Btc);

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -168,10 +168,7 @@ pub mod tests {
 		absolute::{Height, LockTime},
 		Amount, ScriptBuf, Txid,
 	};
-	use cf_chains::{
-		btc::{deposit_address::DepositAddress, ScriptPubkey},
-		DepositChannel,
-	};
+	use cf_chains::{btc::deposit_address::DepositAddress, DepositChannel};
 	use pallet_cf_ingress_egress::{BoostStatus, ChannelAction};
 	use rand::{seq::SliceRandom, Rng, SeedableRng};
 	use sp_runtime::AccountId32;
@@ -195,16 +192,16 @@ pub mod tests {
 	}
 
 	fn fake_details(
-		address: ScriptPubkey,
+		deposit_address: DepositAddress,
 	) -> DepositChannelDetails<state_chain_runtime::Runtime, BitcoinInstance> {
 		DepositChannelDetails::<_, BitcoinInstance> {
 			opened_at: 1,
 			expires_at: 10,
 			deposit_channel: DepositChannel {
 				channel_id: 1,
-				address,
+				address: deposit_address.script_pubkey(),
 				asset: btc::Asset::Btc,
-				state: DepositAddress::new([0; 32], 1),
+				state: deposit_address,
 			},
 			action: ChannelAction::<AccountId32>::LiquidityProvision {
 				lp_account: AccountId32::new([0xab; 32]),
@@ -214,14 +211,16 @@ pub mod tests {
 		}
 	}
 
-	pub fn fake_verbose_vouts(vals_and_scripts: Vec<(u64, Vec<u8>)>) -> Vec<VerboseTxOut> {
-		vals_and_scripts
+	pub fn fake_verbose_vouts(
+		amounts_and_addresses: Vec<(u64, &DepositAddress)>,
+	) -> Vec<VerboseTxOut> {
+		amounts_and_addresses
 			.into_iter()
 			.enumerate()
-			.map(|(n, (value, script_bytes))| VerboseTxOut {
-				value: Amount::from_sat(value),
+			.map(|(n, (amount, address))| VerboseTxOut {
+				value: Amount::from_sat(amount),
 				n: n as u64,
-				script_pubkey: ScriptBuf::from(script_bytes),
+				script_pubkey: ScriptBuf::from(address.script_pubkey().bytes()),
 			})
 			.collect()
 	}
@@ -235,21 +234,16 @@ pub mod tests {
 
 	#[test]
 	fn filter_out_value_0() {
-		let btc_deposit_script: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
+		let deposit_address = DepositAddress::new([0; 32], 9);
 
 		const UTXO_WITNESSED_1: u64 = 2324;
 		let txs = vec![fake_transaction(
-			fake_verbose_vouts(vec![
-				(2324, btc_deposit_script.bytes()),
-				(0, btc_deposit_script.bytes()),
-			]),
+			fake_verbose_vouts(vec![(2324, &deposit_address), (0, &deposit_address)]),
 			None,
 		)];
 
-		let deposit_witnesses = deposit_witnesses(
-			&txs,
-			&map_script_addresses(vec![(fake_details(btc_deposit_script))]),
-		);
+		let deposit_witnesses =
+			deposit_witnesses(&txs, &map_script_addresses(vec![(fake_details(deposit_address))]));
 		assert_eq!(deposit_witnesses.len(), 1);
 		assert_eq!(deposit_witnesses[0].amount, UTXO_WITNESSED_1);
 	}
@@ -260,15 +254,15 @@ pub mod tests {
 		const UTXO_TO_DEPOSIT_2: u64 = 1234;
 		const UTXO_TO_DEPOSIT_3: u64 = 2000;
 
-		let btc_deposit_script: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
+		let deposit_address = DepositAddress::new([0; 32], 9);
 
 		let txs = vec![
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(UTXO_TO_DEPOSIT_2, btc_deposit_script.bytes()),
-					(12223, vec![0, 32, 121, 9]),
-					(LARGEST_UTXO_TO_DEPOSIT, btc_deposit_script.bytes()),
-					(UTXO_TO_DEPOSIT_3, btc_deposit_script.bytes()),
+					(UTXO_TO_DEPOSIT_2, &deposit_address),
+					(12223, &DepositAddress::new([0; 32], 10)),
+					(LARGEST_UTXO_TO_DEPOSIT, &deposit_address),
+					(UTXO_TO_DEPOSIT_3, &deposit_address),
 				]),
 				None,
 			),
@@ -276,7 +270,7 @@ pub mod tests {
 		];
 
 		let deposit_witnesses =
-			deposit_witnesses(&txs, &map_script_addresses(vec![fake_details(btc_deposit_script)]));
+			deposit_witnesses(&txs, &map_script_addresses(vec![fake_details(deposit_address)]));
 		assert_eq!(deposit_witnesses.len(), 1);
 		assert_eq!(deposit_witnesses[0].amount, LARGEST_UTXO_TO_DEPOSIT);
 	}
@@ -287,16 +281,16 @@ pub mod tests {
 		const UTXO_TO_DEPOSIT_2: u64 = 1234;
 		const UTXO_FOR_SECOND_DEPOSIT: u64 = 2000;
 
-		let btc_deposit_script_1: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
-		let btc_deposit_script_2: ScriptPubkey = DepositAddress::new([0; 32], 1232).script_pubkey();
+		let deposit_address_1 = DepositAddress::new([0; 32], 9);
+		let deposit_address_2 = DepositAddress::new([0; 32], 1232);
 
 		let txs = vec![
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(UTXO_TO_DEPOSIT_2, btc_deposit_script_1.bytes()),
-					(12223, vec![0, 32, 121, 9]),
-					(LARGEST_UTXO_TO_DEPOSIT, btc_deposit_script_1.bytes()),
-					(UTXO_FOR_SECOND_DEPOSIT, btc_deposit_script_2.bytes()),
+					(UTXO_TO_DEPOSIT_2, &deposit_address_1),
+					(12223, &DepositAddress::new([0; 32], 999)),
+					(LARGEST_UTXO_TO_DEPOSIT, &deposit_address_1),
+					(UTXO_FOR_SECOND_DEPOSIT, &deposit_address_2),
 				]),
 				None,
 			),
@@ -307,77 +301,81 @@ pub mod tests {
 			&txs,
 			// watching 2 addresses
 			&map_script_addresses(vec![
-				fake_details(btc_deposit_script_1.clone()),
-				fake_details(btc_deposit_script_2.clone()),
+				fake_details(deposit_address_1.clone()),
+				fake_details(deposit_address_2.clone()),
 			]),
 		);
 
 		// We should have one deposit per address.
 		assert_eq!(deposit_witnesses.len(), 2);
 		assert_eq!(deposit_witnesses[0].amount, UTXO_FOR_SECOND_DEPOSIT);
-		assert_eq!(deposit_witnesses[0].deposit_address, btc_deposit_script_2);
+		assert_eq!(deposit_witnesses[0].deposit_address, deposit_address_2.script_pubkey());
 		assert_eq!(deposit_witnesses[1].amount, LARGEST_UTXO_TO_DEPOSIT);
-		assert_eq!(deposit_witnesses[1].deposit_address, btc_deposit_script_1);
+		assert_eq!(deposit_witnesses[1].deposit_address, deposit_address_1.script_pubkey());
 	}
 
 	#[test]
 	fn deposit_witnesses_ordering_is_consistent() {
-		let btc_deposit_script_1: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
-		let btc_deposit_script_2: ScriptPubkey = DepositAddress::new([0; 32], 1232).script_pubkey();
+		let address_1 = DepositAddress::new([0; 32], 9);
+		let address_2 = DepositAddress::new([0; 32], 1232);
+		DepositAddress::new([0; 32], 0);
 
-		let script_addresses = map_script_addresses(vec![
-			fake_details(btc_deposit_script_1.clone()),
-			fake_details(btc_deposit_script_2.clone()),
+		let addresses = map_script_addresses(vec![
+			fake_details(address_1.clone()),
+			fake_details(address_2.clone()),
 		]);
 
 		let txs: Vec<VerboseTransaction> = vec![
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(3, btc_deposit_script_1.bytes()),
-					(5, vec![3]),
-					(7, btc_deposit_script_1.bytes()),
-					(11, btc_deposit_script_2.bytes()),
+					(3, &address_1),
+					(5, &DepositAddress::new([3; 32], 0)),
+					(7, &address_1),
+					(11, &address_2),
 				]),
 				None,
 			),
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(13, btc_deposit_script_2.bytes()),
-					(17, btc_deposit_script_2.bytes()),
-					(19, vec![5]),
-					(23, btc_deposit_script_1.bytes()),
+					(13, &address_2),
+					(17, &address_2),
+					(19, &DepositAddress::new([5; 32], 0)),
+					(23, &address_1),
 				]),
 				None,
 			),
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(13, btc_deposit_script_2.bytes()),
-					(19, vec![7]),
-					(23, btc_deposit_script_1.bytes()),
+					(13, &address_2),
+					(19, &DepositAddress::new([7; 32], 0)),
+					(23, &address_1),
 				]),
 				None,
 			),
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(29, btc_deposit_script_1.bytes()),
-					(31, btc_deposit_script_2.bytes()),
-					(37, vec![11]),
+					(29, &address_1),
+					(31, &address_2),
+					(37, &DepositAddress::new([11; 32], 0)),
 				]),
 				None,
 			),
 			fake_transaction(
-				fake_verbose_vouts(vec![(41, btc_deposit_script_2.bytes()), (43, vec![17])]),
+				fake_verbose_vouts(vec![(41, &address_2), (43, &DepositAddress::new([17; 32], 0))]),
 				None,
 			),
 			fake_transaction(
-				fake_verbose_vouts(vec![(47, btc_deposit_script_1.bytes()), (53, vec![19])]),
+				fake_verbose_vouts(vec![(47, &address_1), (53, &DepositAddress::new([19; 32], 0))]),
 				None,
 			),
 			fake_transaction(
-				fake_verbose_vouts(vec![(61, vec![23]), (59, btc_deposit_script_2.bytes())]),
+				fake_verbose_vouts(vec![(61, &DepositAddress::new([23; 32], 0)), (59, &address_2)]),
 				None,
 			),
-			fake_transaction(fake_verbose_vouts(vec![(67, vec![29])]), None),
+			fake_transaction(
+				fake_verbose_vouts(vec![(67, &DepositAddress::new([29; 32], 0))]),
+				None,
+			),
 		];
 
 		let mut rng = rand::rngs::StdRng::from_seed([3; 32]);
@@ -385,36 +383,36 @@ pub mod tests {
 		for _i in 0..10 {
 			let n = rng.gen_range(0..txs.len());
 			let test_txs = txs.as_slice().choose_multiple(&mut rng, n).cloned().collect::<Vec<_>>();
-			assert!((0..10).map(|_| deposit_witnesses(&test_txs, &script_addresses)).all_equal());
+			assert!((0..10).map(|_| deposit_witnesses(&test_txs, &addresses)).all_equal());
 		}
 	}
 
 	#[test]
 	fn deposit_witnesses_several_diff_tx() {
-		let btc_deposit_script: ScriptPubkey = DepositAddress::new([0; 32], 9).script_pubkey();
+		let address = DepositAddress::new([0; 32], 9);
 
 		const UTXO_WITNESSED_1: u64 = 2324;
 		const UTXO_WITNESSED_2: u64 = 1234;
 		let txs = vec![
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(UTXO_WITNESSED_1, btc_deposit_script.bytes()),
-					(12223, vec![0, 32, 121, 9]),
-					(UTXO_WITNESSED_1 - 1, btc_deposit_script.bytes()),
+					(UTXO_WITNESSED_1, &address),
+					(12223, &DepositAddress::new([0; 32], 11)),
+					(UTXO_WITNESSED_1 - 1, &address),
 				]),
 				None,
 			),
 			fake_transaction(
 				fake_verbose_vouts(vec![
-					(UTXO_WITNESSED_2 - 10, btc_deposit_script.bytes()),
-					(UTXO_WITNESSED_2, btc_deposit_script.bytes()),
+					(UTXO_WITNESSED_2 - 10, &address),
+					(UTXO_WITNESSED_2, &address),
 				]),
 				None,
 			),
 		];
 
 		let deposit_witnesses =
-			deposit_witnesses(&txs, &map_script_addresses(vec![fake_details(btc_deposit_script)]));
+			deposit_witnesses(&txs, &map_script_addresses(vec![fake_details(address)]));
 		assert_eq!(deposit_witnesses.len(), 2);
 		assert_eq!(deposit_witnesses[0].amount, UTXO_WITNESSED_1);
 		assert_eq!(deposit_witnesses[1].amount, UTXO_WITNESSED_2);

--- a/engine/src/witness/btc/smart_contract.rs
+++ b/engine/src/witness/btc/smart_contract.rs
@@ -270,10 +270,10 @@ mod tests {
 				deposit_amount: DEPOSIT_AMOUNT,
 				destination_address: MOCK_SWAP_PARAMS.output_address.clone(),
 				tx_hash: tx.hash.to_byte_array(),
-				deposit_details: BtcDepositDetails {
+				deposit_details: Box::new(BtcDepositDetails {
 					utxo_id: UtxoId { tx_id: tx.txid.to_byte_array().into(), vout: 0 },
 					deposit_address: vault_deposit_address,
-				},
+				}),
 				refund_params: Some(ChannelRefundParameters {
 					retry_duration: MOCK_SWAP_PARAMS.parameters.retry_duration as u32,
 					refund_address: ForeignChainAddress::Btc(refund_pubkey),

--- a/engine/src/witness/btc/smart_contract.rs
+++ b/engine/src/witness/btc/smart_contract.rs
@@ -134,11 +134,11 @@ pub fn try_extract_contract_call(
 		deposit_amount,
 		destination_address: data.output_address,
 		tx_hash: tx_id,
-		deposit_details: BtcDepositDetails {
+		deposit_details: Box::new(BtcDepositDetails {
 			// we require the deposit to be the first UTXO
 			utxo_id: UtxoId { tx_id: tx_id.into(), vout: 0 },
 			deposit_address: vault_address.clone(),
-		},
+		}),
 		refund_params: Some(ChannelRefundParameters {
 			retry_duration: data.parameters.retry_duration as u32,
 			refund_address: ForeignChainAddress::Btc(refund_address),

--- a/engine/src/witness/btc/smart_contract.rs
+++ b/engine/src/witness/btc/smart_contract.rs
@@ -1,34 +1,22 @@
 use bitcoin::{opcodes::all::OP_RETURN, ScriptBuf};
 use cf_amm::common::{bounded_sqrt_price, sqrt_price_to_price};
 use cf_chains::{
-	address::EncodedAddress,
-	btc::{smart_contract_encoding::UtxoEncodedData, ScriptPubkey},
+	btc::{
+		deposit_address::DepositAddress, smart_contract_encoding::UtxoEncodedData,
+		BtcDepositDetails, ScriptPubkey, UtxoId,
+	},
+	ChannelRefundParameters, ForeignChainAddress,
 };
-use cf_primitives::{Asset, AssetAmount, Price};
+use cf_primitives::{Asset, DcaParameters};
 use codec::Decode;
 use itertools::Itertools;
+use state_chain_runtime::BitcoinInstance;
 use utilities::SliceToArray;
 
 use crate::btc::rpc::VerboseTransaction;
 
 const OP_PUSHBYTES_75: u8 = 0x4b;
 const OP_PUSHDATA1: u8 = 0x4c;
-
-#[derive(PartialEq, Debug)]
-pub struct BtcContractCall {
-	output_asset: Asset,
-	deposit_amount: AssetAmount,
-	output_address: EncodedAddress,
-	// --- FoK ---
-	retry_duration: u16,
-	refund_address: ScriptPubkey,
-	min_price: Price,
-	// --- DCA ---
-	number_of_chunks: u16,
-	chunk_interval: u16,
-	// --- Boost ---
-	boost_fee: u8,
-}
 
 fn try_extract_utxo_encoded_data(script: &bitcoin::ScriptBuf) -> Option<&[u8]> {
 	let bytes = script.as_script().as_bytes();
@@ -86,19 +74,21 @@ fn script_buf_to_script_pubkey(script: &ScriptBuf) -> Option<ScriptPubkey> {
 	Some(pubkey)
 }
 
+type BtcIngressEgressCall =
+	pallet_cf_ingress_egress::Call<state_chain_runtime::Runtime, BitcoinInstance>;
+
 // Currently unused, but will be used by the deposit wintesser:
-#[allow(dead_code)]
 pub fn try_extract_contract_call(
 	tx: &VerboseTransaction,
-	vault_address: ScriptPubkey,
-) -> Option<BtcContractCall> {
+	vault_address: &DepositAddress,
+) -> Option<BtcIngressEgressCall> {
 	// A correctly constructed transaction carrying CF swap parameters must have at least 3 outputs:
 	let [utxo_to_vault, nulldata_utxo, change_utxo, ..] = &tx.vout[..] else {
 		return None;
 	};
 
 	// First output must be a deposit into our vault:
-	if utxo_to_vault.script_pubkey.as_bytes() != vault_address.bytes() {
+	if utxo_to_vault.script_pubkey.as_bytes() != vault_address.script_pubkey().bytes() {
 		return None;
 	}
 
@@ -135,16 +125,32 @@ pub fn try_extract_contract_call(
 		deposit_amount.into(),
 	));
 
-	Some(BtcContractCall {
-		output_asset: data.output_asset,
-		deposit_amount: deposit_amount as AssetAmount,
-		output_address: data.output_address,
-		retry_duration: data.parameters.retry_duration,
-		refund_address,
-		min_price,
-		number_of_chunks: data.parameters.number_of_chunks,
-		chunk_interval: data.parameters.chunk_interval,
-		boost_fee: data.parameters.boost_fee,
+	use secp256k1::hashes::Hash as secp256k1Hash;
+
+	let tx_id: [u8; 32] = tx.txid.to_byte_array();
+
+	Some(BtcIngressEgressCall::contract_swap_request {
+		from: Asset::Btc,
+		to: data.output_asset,
+		deposit_amount,
+		destination_address: data.output_address,
+		tx_hash: tx_id,
+		deposit_details: BtcDepositDetails {
+			// we require the deposit to be the first UTXO
+			utxo_id: UtxoId { tx_id: tx_id.into(), vout: 0 },
+			deposit_address: vault_address.clone(),
+		},
+		refund_params: Some(ChannelRefundParameters {
+			retry_duration: data.parameters.retry_duration as u32,
+			refund_address: ForeignChainAddress::Btc(refund_address),
+			min_price,
+		}),
+		dca_params: Some(DcaParameters {
+			number_of_chunks: data.parameters.number_of_chunks as u32,
+			chunk_interval: data.parameters.chunk_interval as u32,
+		}),
+		// This is only to be checked in the pre-witnessed version
+		boost_fee: data.parameters.boost_fee as u16,
 	})
 }
 
@@ -220,13 +226,12 @@ mod tests {
 	fn test_extract_contract_call_from_tx() {
 		use bitcoin::Amount;
 
-		const VAULT_PK_HASH: [u8; 20] = [7; 20];
 		const REFUND_PK_HASH: [u8; 20] = [8; 20];
+		const DEPOSIT_AMOUNT: u64 = 1000;
 
-		// Addresses represented in both `ScriptPubkey` and `ScriptBuf` to satisfy interfaces:
-		let vault_pubkey = ScriptPubkey::P2PKH(VAULT_PK_HASH);
-		let vault_script = ScriptBuf::new_p2pkh(&PubkeyHash::from_byte_array(VAULT_PK_HASH));
-		assert_eq!(vault_pubkey.bytes(), vault_script.to_bytes());
+		// Addresses have different representations to satisfy interfaces:
+		let vault_deposit_address = DepositAddress::new([7; 32], 0);
+		let vault_script = ScriptBuf::from_bytes(vault_deposit_address.script_pubkey().bytes());
 
 		let refund_pubkey = ScriptPubkey::P2PKH(REFUND_PK_HASH);
 		let refund_script = ScriptBuf::new_p2pkh(&PubkeyHash::from_byte_array(REFUND_PK_HASH));
@@ -236,7 +241,7 @@ mod tests {
 			vec![
 				// A UTXO spending into our vault;
 				VerboseTxOut {
-					value: Amount::from_sat(1000),
+					value: Amount::from_sat(DEPOSIT_AMOUNT),
 					n: 0,
 					script_pubkey: vault_script.clone(),
 				},
@@ -259,21 +264,31 @@ mod tests {
 		);
 
 		assert_eq!(
-			try_extract_contract_call(&tx, vault_pubkey).unwrap(),
-			BtcContractCall {
-				output_asset: MOCK_SWAP_PARAMS.output_asset,
-				deposit_amount: 1000,
-				output_address: MOCK_SWAP_PARAMS.output_address.clone(),
-				retry_duration: MOCK_SWAP_PARAMS.parameters.retry_duration,
-				refund_address: refund_pubkey,
-				min_price: sqrt_price_to_price(bounded_sqrt_price(
-					MOCK_SWAP_PARAMS.parameters.min_output_amount.into(),
-					1000.into(),
-				)),
-				number_of_chunks: MOCK_SWAP_PARAMS.parameters.number_of_chunks,
-				chunk_interval: MOCK_SWAP_PARAMS.parameters.chunk_interval,
-				boost_fee: MOCK_SWAP_PARAMS.parameters.boost_fee,
-			}
+			try_extract_contract_call(&tx, &vault_deposit_address),
+			Some(BtcIngressEgressCall::contract_swap_request {
+				from: Asset::Btc,
+				to: MOCK_SWAP_PARAMS.output_asset,
+				deposit_amount: DEPOSIT_AMOUNT,
+				destination_address: MOCK_SWAP_PARAMS.output_address.clone(),
+				tx_hash: tx.hash.to_byte_array(),
+				deposit_details: BtcDepositDetails {
+					utxo_id: UtxoId { tx_id: tx.txid.to_byte_array().into(), vout: 0 },
+					deposit_address: vault_deposit_address,
+				},
+				refund_params: Some(ChannelRefundParameters {
+					retry_duration: MOCK_SWAP_PARAMS.parameters.retry_duration as u32,
+					refund_address: ForeignChainAddress::Btc(refund_pubkey),
+					min_price: sqrt_price_to_price(bounded_sqrt_price(
+						MOCK_SWAP_PARAMS.parameters.min_output_amount.into(),
+						DEPOSIT_AMOUNT.into(),
+					)),
+				}),
+				dca_params: Some(DcaParameters {
+					number_of_chunks: MOCK_SWAP_PARAMS.parameters.number_of_chunks as u32,
+					chunk_interval: MOCK_SWAP_PARAMS.parameters.chunk_interval as u32,
+				}),
+				boost_fee: MOCK_SWAP_PARAMS.parameters.boost_fee as u16,
+			})
 		);
 	}
 

--- a/engine/src/witness/btc/smart_contract.rs
+++ b/engine/src/witness/btc/smart_contract.rs
@@ -77,7 +77,6 @@ fn script_buf_to_script_pubkey(script: &ScriptBuf) -> Option<ScriptPubkey> {
 type BtcIngressEgressCall =
 	pallet_cf_ingress_egress::Call<state_chain_runtime::Runtime, BitcoinInstance>;
 
-// Currently unused, but will be used by the deposit wintesser:
 pub fn try_extract_contract_call(
 	tx: &VerboseTransaction,
 	vault_address: &DepositAddress,

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -252,7 +252,9 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 					deposit_amount,
 					destination_address,
 					tx_hash,
-					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_hash.into()]) },
+					deposit_details: Box::new(DepositDetails {
+						tx_hashes: Some(vec![tx_hash.into()]),
+					}),
 					// TODO: use real parameters when we can decode them
 					boost_fee: 0,
 					dca_params: None,

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -3,7 +3,7 @@ mod state_chain_gateway;
 
 use std::{collections::HashMap, sync::Arc};
 
-use cf_chains::Ethereum;
+use cf_chains::{evm::DepositDetails, Ethereum};
 use cf_primitives::{chains::assets::eth, EpochIndex};
 use futures_core::Future;
 use sp_core::H160;
@@ -252,6 +252,11 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 					deposit_amount,
 					destination_address,
 					tx_hash,
+					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_hash.into()]) },
+					// TODO: use real parameters when we can decode them
+					boost_fee: 0,
+					dca_params: None,
+					refund_params: None,
 				}
 			},
 		)

--- a/engine/src/witness/evm/evm_deposits.rs
+++ b/engine/src/witness/evm/evm_deposits.rs
@@ -179,7 +179,7 @@ where
 }
 
 /// To ensure we don't double witness deposits, we use the following pseudo-code, implemented by
-/// `eth_ingresses_at_block`.
+/// [eth_ingresses_at_block].
 ///
 /// if !address.hasContract:
 ///    swap = address.balanceAtCurrentBlock - address.balanceAtPreviousBlock

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -623,7 +623,7 @@ fn failed_swaps_are_rolled_back() {
 				deposit_amount: 10_000 * DECIMALS,
 				destination_address: EncodedAddress::Eth(Default::default()),
 				tx_hash: Default::default(),
-				deposit_details: DepositDetails { tx_hashes: None },
+				deposit_details: Box::new(DepositDetails { tx_hashes: None }),
 				refund_params: None,
 				dca_params: None,
 				boost_fee: 0,

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -17,6 +17,7 @@ use cf_chains::{
 	address::{AddressConverter, AddressDerivationApi, EncodedAddress},
 	assets::eth::Asset as EthAsset,
 	eth::{api::EthereumApi, EthereumTrackedData},
+	evm::DepositDetails,
 	CcmChannelMetadata, CcmDepositMetadata, Chain, ChainState, DefaultRetryPolicy, Ethereum,
 	ExecutexSwapAndCall, ForeignChain, ForeignChainAddress, RetryPolicy, SwapOrigin,
 	TransactionBuilder, TransferAssetParams,
@@ -622,6 +623,10 @@ fn failed_swaps_are_rolled_back() {
 				deposit_amount: 10_000 * DECIMALS,
 				destination_address: EncodedAddress::Eth(Default::default()),
 				tx_hash: Default::default(),
+				deposit_details: DepositDetails { tx_hashes: None },
+				refund_params: None,
+				dca_params: None,
+				boost_fee: 0,
 			},
 		));
 

--- a/state-chain/chains/src/benchmarking_value.rs
+++ b/state-chain/chains/src/benchmarking_value.rs
@@ -15,6 +15,7 @@ use sp_std::vec;
 #[cfg(feature = "runtime-benchmarks")]
 use crate::{
 	address::{EncodedAddress, ForeignChainAddress},
+	btc::{BtcDepositDetails, UtxoId},
 	dot::PolkadotTransactionId,
 	evm::{DepositDetails, EvmFetchId, EvmTransactionMetadata},
 };
@@ -220,6 +221,16 @@ impl BenchmarkValue for DepositDetails {
 	fn benchmark_value() -> Self {
 		use sp_core::H256;
 		Self { tx_hashes: Some(vec![H256::default()]) }
+	}
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+impl BenchmarkValue for BtcDepositDetails {
+	fn benchmark_value() -> Self {
+		BtcDepositDetails {
+			utxo_id: UtxoId::benchmark_value(),
+			deposit_address: crate::btc::deposit_address::DepositAddress::new([0; 32], 0),
+		}
 	}
 }
 

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -227,6 +227,12 @@ impl BitcoinFeeInfo {
 	}
 }
 
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, PartialEq, Eq, MaxEncodedLen)]
+pub struct BtcDepositDetails {
+	pub utxo_id: UtxoId,
+	pub deposit_address: DepositAddress,
+}
+
 impl Chain for Bitcoin {
 	const NAME: &'static str = "Bitcoin";
 	const GAS_ASSET: Self::ChainAsset = assets::btc::Asset::Btc;
@@ -244,7 +250,7 @@ impl Chain for Bitcoin {
 	type ChainAccount = ScriptPubkey;
 	type DepositFetchId = BitcoinFetchId;
 	type DepositChannelState = DepositAddress;
-	type DepositDetails = UtxoId;
+	type DepositDetails = BtcDepositDetails;
 	type Transaction = BitcoinTransactionData;
 	type TransactionMetadata = ();
 	type TransactionRef = Hash;

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -297,7 +297,7 @@ mod benchmarks {
 			deposit_amount: deposit_amount.into(),
 			destination_address: EncodedAddress::benchmark_value(),
 			tx_hash: [0; 32],
-			deposit_details: BenchmarkValue::benchmark_value(),
+			deposit_details: Box::new(BenchmarkValue::benchmark_value()),
 			refund_params: None,
 			dca_params: None,
 			boost_fee: 0,

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -288,15 +288,19 @@ mod benchmarks {
 
 	#[benchmark]
 	fn contract_swap_request() {
-		let deposit_amount = 1_000;
+		let deposit_amount = 1_000u32;
 
 		let witness_origin = T::EnsureWitnessed::try_successful_origin().unwrap();
 		let call = Call::<T, I>::contract_swap_request {
 			from: Asset::Usdc,
 			to: Asset::Eth,
-			deposit_amount,
+			deposit_amount: deposit_amount.into(),
 			destination_address: EncodedAddress::benchmark_value(),
 			tx_hash: [0; 32],
+			deposit_details: BenchmarkValue::benchmark_value(),
+			refund_params: None,
+			dca_params: None,
+			boost_fee: 0,
 		};
 
 		#[block]

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -57,6 +57,7 @@ use scale_info::{
 };
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{
+	boxed::Box,
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	marker::PhantomData,
 	vec,
@@ -1103,7 +1104,7 @@ pub mod pallet {
 			deposit_amount: <T::TargetChain as Chain>::ChainAmount,
 			destination_address: EncodedAddress,
 			tx_hash: TransactionHash,
-			deposit_details: <T::TargetChain as Chain>::DepositDetails,
+			deposit_details: Box<<T::TargetChain as Chain>::DepositDetails>,
 			refund_params: Option<ChannelRefundParameters>,
 			dca_params: Option<DcaParameters>,
 			// This is only to be checked in the pre-witnessed version (not implemented yet)
@@ -1123,7 +1124,7 @@ pub mod pallet {
 					},
 				};
 
-			T::DepositHandler::on_deposit_made(deposit_details, deposit_amount);
+			T::DepositHandler::on_deposit_made(*deposit_details, deposit_amount);
 
 			// TODO: ensure minimum deposit?
 

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1100,9 +1100,14 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			from: Asset,
 			to: Asset,
-			deposit_amount: AssetAmount,
+			deposit_amount: <T::TargetChain as Chain>::ChainAmount,
 			destination_address: EncodedAddress,
 			tx_hash: TransactionHash,
+			deposit_details: <T::TargetChain as Chain>::DepositDetails,
+			refund_params: Option<ChannelRefundParameters>,
+			dca_params: Option<DcaParameters>,
+			// This is only to be checked in the pre-witnessed version (not implemented yet)
+			_boost_fee: BasisPoints,
 		) -> DispatchResult {
 			T::EnsureWitnessed::ensure_origin(origin)?;
 
@@ -1118,16 +1123,20 @@ pub mod pallet {
 					},
 				};
 
+			T::DepositHandler::on_deposit_made(deposit_details, deposit_amount);
+
+			// TODO: ensure minimum deposit?
+
+			// TODO: validate dca_params and refund_params
+
 			T::SwapRequestHandler::init_swap_request(
 				from,
-				deposit_amount,
+				deposit_amount.into(),
 				to,
 				SwapRequestType::Regular { output_address: destination_address_internal.clone() },
 				Default::default(),
-				// NOTE: FoK not yet supported for swaps from the contract
-				None,
-				// NOTE: DCA not yet supported for swaps from the contract
-				None,
+				refund_params,
+				dca_params,
 				SwapOrigin::Vault { tx_hash },
 			);
 
@@ -1819,11 +1828,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::deposit_event(Event::<T, I>::DepositFetchesScheduled { channel_id, asset });
 
 		// Add the deposit to the balance.
-		T::DepositHandler::on_deposit_made(
-			deposit_details.clone(),
-			deposit_amount,
-			&deposit_channel_details.deposit_channel,
-		);
+		T::DepositHandler::on_deposit_made(deposit_details.clone(), deposit_amount);
 
 		// We received a deposit on a channel. If channel has been boosted earlier
 		// (i.e. awaiting finalisation), *and* the boosted amount matches the amount

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1851,6 +1851,10 @@ fn can_request_swap_via_extrinsic() {
 			INPUT_AMOUNT,
 			MockAddressConverter::to_encoded_address(output_address.clone()),
 			TX_HASH,
+			DepositDetails { tx_hashes: None },
+			None,
+			None,
+			0,
 		));
 
 		assert_eq!(
@@ -1935,18 +1939,27 @@ fn rejects_invalid_swap_by_witnesser() {
 			10000,
 			btc_encoded_address,
 			Default::default(),
+			DepositDetails { tx_hashes: None },
+			None,
+			None,
+			0
 		),);
 
 		// No swap request created -> the call was ignored
 		assert!(MockSwapRequestHandler::<Test>::get_swap_requests().is_empty());
 
+		// Invalid BTC address:
 		assert_ok!(IngressEgress::contract_swap_request(
 			RuntimeOrigin::root(),
 			Asset::Eth,
 			Asset::Btc,
 			10000,
 			EncodedAddress::Btc(vec![0x41, 0x80, 0x41]),
-			Default::default()
+			Default::default(),
+			DepositDetails { tx_hashes: None },
+			None,
+			None,
+			0
 		),);
 
 		assert!(MockSwapRequestHandler::<Test>::get_swap_requests().is_empty());

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1851,7 +1851,7 @@ fn can_request_swap_via_extrinsic() {
 			INPUT_AMOUNT,
 			MockAddressConverter::to_encoded_address(output_address.clone()),
 			TX_HASH,
-			DepositDetails { tx_hashes: None },
+			Box::new(DepositDetails { tx_hashes: None }),
 			None,
 			None,
 			0,
@@ -1939,7 +1939,7 @@ fn rejects_invalid_swap_by_witnesser() {
 			10000,
 			btc_encoded_address,
 			Default::default(),
-			DepositDetails { tx_hashes: None },
+			Box::new(DepositDetails { tx_hashes: None }),
 			None,
 			None,
 			0
@@ -1956,7 +1956,7 @@ fn rejects_invalid_swap_by_witnesser() {
 			10000,
 			EncodedAddress::Btc(vec![0x41, 0x80, 0x41]),
 			Default::default(),
-			DepositDetails { tx_hashes: None },
+			Box::new(DepositDetails { tx_hashes: None }),
 			None,
 			None,
 			0

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -31,7 +31,7 @@ use cf_chains::{
 	assets::any::ForeignChainAndAsset,
 	btc::{
 		api::{BitcoinApi, SelectedUtxosAndChangeAmount, UtxoSelectionType},
-		Bitcoin, BitcoinCrypto, BitcoinFeeInfo, BitcoinTransactionData, UtxoId,
+		Bitcoin, BitcoinCrypto, BitcoinFeeInfo, BitcoinTransactionData, BtcDepositDetails, UtxoId,
 	},
 	dot::{
 		api::PolkadotApi, Polkadot, PolkadotAccountId, PolkadotCrypto, PolkadotReplayProtection,
@@ -55,9 +55,9 @@ use cf_chains::{
 		SolAddress, SolAmount, SolApiEnvironment, SolanaCrypto, SolanaTransactionData,
 	},
 	AnyChain, ApiCall, Arbitrum, CcmChannelMetadata, CcmDepositMetadata, Chain, ChainCrypto,
-	ChainEnvironment, ChainState, ChannelRefundParameters, DepositChannel, ForeignChain,
-	ReplayProtectionProvider, RequiresSignatureRefresh, SetCommKeyWithAggKey, SetGovKeyWithAggKey,
-	Solana, TransactionBuilder,
+	ChainEnvironment, ChainState, ChannelRefundParameters, ForeignChain, ReplayProtectionProvider,
+	RequiresSignatureRefresh, SetCommKeyWithAggKey, SetGovKeyWithAggKey, Solana,
+	TransactionBuilder,
 };
 use cf_primitives::{
 	chains::assets, AccountRole, Asset, BasisPoints, Beneficiaries, ChannelId, DcaParameters,
@@ -766,11 +766,14 @@ impl OnDeposit<Ethereum> for DepositHandler {}
 impl OnDeposit<Polkadot> for DepositHandler {}
 impl OnDeposit<Bitcoin> for DepositHandler {
 	fn on_deposit_made(
-		utxo_id: <Bitcoin as Chain>::DepositDetails,
+		deposit_details: BtcDepositDetails,
 		amount: <Bitcoin as Chain>::ChainAmount,
-		channel: &DepositChannel<Bitcoin>,
 	) {
-		Environment::add_bitcoin_utxo_to_list(amount, utxo_id, channel.state.clone())
+		Environment::add_bitcoin_utxo_to_list(
+			amount,
+			deposit_details.utxo_id,
+			deposit_details.deposit_address,
+		)
 	}
 }
 impl OnDeposit<Arbitrum> for DepositHandler {}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -23,7 +23,7 @@ use cf_chains::{
 	assets::any::AssetMap,
 	sol::{SolAddress, SolHash},
 	ApiCall, CcmChannelMetadata, CcmDepositMetadata, Chain, ChainCrypto, ChannelRefundParameters,
-	DepositChannel, Ethereum,
+	Ethereum,
 };
 use cf_primitives::{
 	AccountRole, Asset, AssetAmount, AuthorityCount, BasisPoints, Beneficiaries, BlockNumber,
@@ -897,12 +897,7 @@ pub trait FlipBurnInfo {
 
 /// The trait implementation is intentionally no-op by default
 pub trait OnDeposit<C: Chain> {
-	fn on_deposit_made(
-		_deposit_details: C::DepositDetails,
-		_amount: C::ChainAmount,
-		_channel: &DepositChannel<C>,
-	) {
-	}
+	fn on_deposit_made(_deposit_details: C::DepositDetails, _amount: C::ChainAmount) {}
 }
 
 pub trait NetworkEnvironmentProvider {


### PR DESCRIPTION
# Pull Request

Closes: PRO-1695, PRO-1644, PRO-1643

## Summary

- `OnDeposit::on_deposit_made` no longer takes `DepositChannel` as a parameter (in case of smart contract swaps, there is no channel). It was only used by bitcoin to pass deposit address. Instead, now engines submit deposit address as part of `DepositDetails` (next to the existing `UtxoId`).
- Added `deposit_details` as a parameter to `contract_swap_request`.
- Added FoK/DCA/Boost parameters to `contract_swap_request`. FoK and DCA should already by handled correctly on the SC side, however Boost is currently ignored as it will require some potentially non-trivial refactoring. For now the engine uses default parameters for these in case of EVM smart contracts (i.e. they are still effectively disabled).
- On every BTC block the engine checks contract calls into our vault’s change addresses (current and previous), and calls `contract_swaps_request` with the decoded parameters.

## Limitations

- DCA and FoK parameters aren't yet validated (might be worth waiting for https://github.com/chainflip-io/chainflip-backend/pull/5329)
- Boost parameter is currently ignored in contract swaps (needs a potentially non-trivial refactor, so I'd rather we do it in a separate PR)
- No support for "special smart contract" channels yet. Only deposits directly into the vault's change address are witnessed.

FYI @albert-llimos 
