### PR TITLE
refactor: split out composite electoral system trait

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full-bouncer: true
+      full-bouncer: false
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/upgrade-test.yml
     secrets: inherit
     with:
-      run-job: true
+      run-job: false
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full-bouncer: false
+      full_bouncer: true
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/upgrade-test.yml
     secrets: inherit
     with:
-      run-job: false
+      run-job: true
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full_bouncer: true
+      full-bouncer: true
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -23,7 +23,6 @@ use std::{
 	sync::Arc,
 };
 use tracing::{error, info, warn};
-use utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
 use voter_api::CompositeVoterApi;
 
 const MAXIMUM_CONCURRENT_FILTER_REQUESTS: usize = 16;

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -13,9 +13,9 @@ use cf_primitives::MILLISECONDS_PER_BLOCK;
 use cf_utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
 use futures::{stream, StreamExt, TryStreamExt};
 use pallet_cf_elections::{
-	electoral_system::{ElectionIdentifierOf, ElectoralSystem},
 	vote_storage::{AuthorityVote, VoteStorage},
-	SharedDataHash, MAXIMUM_VOTES_PER_EXTRINSIC,
+	CompositeElectionIdentifierOf, ElectoralSystemRunner, SharedDataHash,
+	MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use rand::Rng;
 use std::{
@@ -23,7 +23,8 @@ use std::{
 	sync::Arc,
 };
 use tracing::{error, info, warn};
-use voter_api::VoterApi;
+use utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
+use voter_api::CompositeVoterApi;
 
 const MAXIMUM_CONCURRENT_FILTER_REQUESTS: usize = 16;
 const LIFETIME_OF_SHARED_DATA_IN_CACHE: std::time::Duration = std::time::Duration::from_secs(90);
@@ -34,7 +35,7 @@ const INITIAL_VOTER_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::
 pub struct Voter<
 	Instance: 'static,
 	StateChainClient: ElectoralApi<Instance> + SignedExtrinsicApi + ChainApi,
-	VoterClient: VoterApi<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem> + Send + Sync + 'static,
+	VoterClient: CompositeVoterApi<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner> + Send + Sync + 'static,
 > where
 	state_chain_runtime::Runtime:
 		pallet_cf_elections::Config<Instance>,
@@ -47,7 +48,7 @@ pub struct Voter<
 impl<
 		Instance: Send + Sync + 'static,
 		StateChainClient: ElectoralApi<Instance> + SignedExtrinsicApi + ChainApi,
-		VoterClient: VoterApi<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem> + Clone + Send + Sync + 'static,
+		VoterClient: CompositeVoterApi<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner> + Clone + Send + Sync + 'static,
 	> Voter<Instance, StateChainClient, VoterClient>
 where
 	state_chain_runtime::Runtime:
@@ -111,17 +112,17 @@ where
 			std::time::Duration::from_millis(MILLISECONDS_PER_BLOCK);
 		let mut submit_interval = tokio::time::interval(BLOCK_TIME);
 		let mut pending_submissions = BTreeMap::<
-			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem>,
+			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
 			(
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::PartialVote,
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::Vote,
+				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::PartialVote,
+				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
 			)
 		>::default();
 		let mut vote_tasks = FutureMap::default();
 		let mut shared_data_cache = HashMap::<
 			SharedDataHash,
 			(
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData,
+				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData,
 				std::time::Instant,
 			)
 		>::default();
@@ -163,7 +164,7 @@ where
 					Ok(vote) => {
 						info!("Voting task for election: '{:?}' succeeded.", election_identifier);
 						// Create the partial_vote early so that SharedData can be provided as soon as the vote has been generated, rather than only after it is submitted.
-						let partial_vote = <<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::vote_into_partial_vote(&vote, |shared_data| {
+						let partial_vote = <<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::vote_into_partial_vote(&vote, |shared_data| {
 							let shared_data_hash = SharedDataHash::of(&shared_data);
 							if shared_data_cache.len() > MAXIMUM_SHARED_DATA_CACHE_ITEMS {
 								for shared_data_hash in shared_data_cache.keys().cloned().take(shared_data_cache.len() - MAXIMUM_SHARED_DATA_CACHE_ITEMS).collect::<Vec<_>>() {

--- a/engine/src/elections/voter_api.rs
+++ b/engine/src/elections/voter_api.rs
@@ -4,8 +4,10 @@ use frame_support::{
 };
 use pallet_cf_elections::{
 	electoral_system::ElectoralSystem,
-	electoral_systems::composite::{self, Composite},
+	electoral_system_runner::RunnerStorageAccessTrait,
+	electoral_systems::composite::{self, CompositeRunner},
 	vote_storage::{self, VoteStorage},
+	ElectoralSystemRunner,
 };
 
 #[async_trait::async_trait]
@@ -17,33 +19,43 @@ pub trait VoterApi<E: ElectoralSystem> {
 	) -> Result<<<E as ElectoralSystem>::Vote as VoteStorage>::Vote, anyhow::Error>;
 }
 
-pub struct CompositeVoter<ElectoralSystem, Voters> {
+pub struct CompositeVoter<ElectoralSystemRunner, Voters> {
 	voters: Voters,
-	_phantom: core::marker::PhantomData<ElectoralSystem>,
+	_phantom: core::marker::PhantomData<ElectoralSystemRunner>,
 }
-impl<ElectoralSystem, Voters: Clone> Clone for CompositeVoter<ElectoralSystem, Voters> {
+impl<ElectoralSystemRunner, Voters: Clone> Clone for CompositeVoter<ElectoralSystemRunner, Voters> {
 	fn clone(&self) -> Self {
 		Self { voters: self.voters.clone(), _phantom: Default::default() }
 	}
 }
 
-impl<ElectoralSystem, Voters> CompositeVoter<ElectoralSystem, Voters> {
+impl<ElectoralSystemRunner, Voters> CompositeVoter<ElectoralSystemRunner, Voters> {
 	pub fn new(voters: Voters) -> Self {
 		Self { voters, _phantom: Default::default() }
 	}
 }
 
+#[async_trait::async_trait]
+pub trait CompositeVoterApi<E: ElectoralSystemRunner> {
+	async fn vote(
+		&self,
+		settings: <E as ElectoralSystemRunner>::ElectoralSettings,
+		properties: <E as ElectoralSystemRunner>::ElectionProperties,
+	) -> Result<<<E as ElectoralSystemRunner>::Vote as VoteStorage>::Vote, anyhow::Error>;
+}
+
+// TODO Combine this into the composite macro PRO-1736
 macro_rules! generate_voter_api_tuple_impls {
     ($module:ident: ($(($electoral_system:ident, $voter:ident)),*$(,)?)) => {
         #[allow(non_snake_case)]
         #[async_trait::async_trait]
-        impl<$($voter: VoterApi<$electoral_system> + Send + Sync),*, $($electoral_system : ElectoralSystem<ValidatorId = ValidatorId> + Send + Sync + 'static),*, ValidatorId: MaybeSerializeDeserialize + Member + Parameter, Hooks: Send + Sync + 'static + composite::$module::Hooks<$($electoral_system,)*>> VoterApi<Composite<($($electoral_system,)*), ValidatorId, Hooks>> for CompositeVoter<Composite<($($electoral_system,)*), ValidatorId, Hooks>, ($($voter,)*)> {
+        impl<$($voter: VoterApi<$electoral_system> + Send + Sync),*, $($electoral_system : ElectoralSystem<ValidatorId = ValidatorId> + Send + Sync + 'static),*, ValidatorId: MaybeSerializeDeserialize + Member + Parameter, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>> + Send + Sync + 'static, Hooks: Send + Sync + 'static + composite::$module::Hooks<$($electoral_system,)*>> CompositeVoterApi<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>> for CompositeVoter<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>, ($($voter,)*)> {
             async fn vote(
                 &self,
-                settings: <Composite<($($electoral_system,)*), ValidatorId, Hooks> as ElectoralSystem>::ElectoralSettings,
-                properties: <Composite<($($electoral_system,)*), ValidatorId, Hooks> as ElectoralSystem>::ElectionProperties,
+                settings: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::ElectoralSettings,
+                properties: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::ElectionProperties,
             ) -> Result<
-                <<Composite<($($electoral_system,)*), ValidatorId, Hooks> as ElectoralSystem>::Vote as VoteStorage>::Vote,
+                <<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
                 anyhow::Error,
             > {
                 use vote_storage::composite::$module::CompositeVote;

--- a/engine/src/state_chain_observer/client/electoral_api.rs
+++ b/engine/src/state_chain_observer/client/electoral_api.rs
@@ -4,9 +4,8 @@ use crate::state_chain_observer::client::{
 };
 use codec::{Decode, Encode};
 use pallet_cf_elections::{
-	electoral_system::{ElectionIdentifierOf, ElectoralSystem},
-	vote_storage::VoteStorage,
-	ElectoralDataFor,
+	electoral_system_runner::CompositeElectionIdentifierOf, vote_storage::VoteStorage,
+	ElectoralDataFor, ElectoralSystemRunner,
 };
 use state_chain_runtime::SolanaInstance;
 use std::collections::{BTreeMap, BTreeSet};
@@ -29,10 +28,10 @@ where
 	fn filter_votes(
 		&self,
 		proposed_votes: BTreeMap<
-			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem>,
-			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::Vote,
+			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
+			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
 		>,
-	) -> impl std::future::Future<Output = BTreeSet<ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystem>>> + Send + 'static;
+	) -> impl std::future::Future<Output = BTreeSet<CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>>> + Send + 'static;
 }
 
 impl<
@@ -68,10 +67,10 @@ impl<
 	fn filter_votes(
 		&self,
 		proposed_votes: BTreeMap<
-			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem>,
-			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::Vote,
+			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>,
+			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
 		>,
-	) -> impl std::future::Future<Output = BTreeSet<ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem>>> + Send + 'static{
+	) -> impl std::future::Future<Output = BTreeSet<CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>>> + Send + 'static{
 		let base_rpc_client = self.base_rpc_client.clone();
 		let account_id = self.signed_extrinsic_client.account_id();
 		async move {
@@ -82,10 +81,10 @@ impl<
 				.map_err(anyhow::Error::from)
 				.and_then(|electoral_data| {
 					<BTreeSet<
-						ElectionIdentifierOf<
+						CompositeElectionIdentifierOf<
 							<state_chain_runtime::Runtime as pallet_cf_elections::Config<
 								SolanaInstance,
-							>>::ElectoralSystem,
+							>>::ElectoralSystemRunner,
 						>,
 					> as Decode>::decode(&mut &electoral_data[..])
 					.map_err(Into::into)

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -21,7 +21,7 @@ use futures::FutureExt;
 use pallet_cf_elections::{electoral_system::ElectoralSystem, vote_storage::VoteStorage};
 use state_chain_runtime::{
 	chainflip::solana_elections::{
-		SolanaBlockHeightTracking, SolanaEgressWitnessing, SolanaElectoralSystem,
+		SolanaBlockHeightTracking, SolanaEgressWitnessing, SolanaElectoralSystemRunner,
 		SolanaFeeTracking, SolanaIngressTracking, SolanaLiveness, SolanaNonceTracking,
 		TransactionSuccessDetails,
 	},
@@ -195,7 +195,7 @@ where
 				crate::elections::Voter::new(
 					scope,
 					state_chain_client,
-					CompositeVoter::<SolanaElectoralSystem, _>::new((
+					CompositeVoter::<SolanaElectoralSystemRunner, _>::new((
 						SolanaBlockHeightTrackingVoter { client: client.clone() },
 						SolanaFeeTrackingVoter { client: client.clone() },
 						SolanaIngressTrackingVoter { client: client.clone() },

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -29,7 +29,7 @@ use frame_support::{
 use pallet_cf_elections::{
 	electoral_system::{ElectionIdentifierOf, ElectoralSystem},
 	vote_storage::{composite::tuple_6_impls::CompositeVote, AuthorityVote, VoteStorage},
-	MAXIMUM_VOTES_PER_EXTRINSIC,
+	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use pallet_cf_ingress_egress::{DepositWitness, FetchOrTransfer};
 use pallet_cf_validator::RotationPhase;
@@ -58,11 +58,12 @@ const BOB: AccountId = AccountId::new([0x44; 32]);
 const DEPOSIT_AMOUNT: u64 = 5_000_000_000u64; // 5 Sol
 const FALLBACK_ADDRESS: SolAddress = SolAddress([0xf0; 32]);
 
-type SolanaElectionVote = BoundedBTreeMap::<
-	ElectionIdentifierOf<<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem>,
-	AuthorityVote<
-		<<<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::PartialVote,
-		<<<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::Vote,
+type SolanaElectionVote = BoundedBTreeMap<
+	CompositeElectionIdentifierOf<
+		<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner,
+	>,
+	CompositeAuthorityVoteOf<
+		<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner,
 	>,
 	ConstU32<MAXIMUM_VOTES_PER_EXTRINSIC>,
 >;
@@ -729,8 +730,8 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 			let ccm_broadcast_id = pallet_cf_broadcast::PendingBroadcasts::<Runtime, SolanaInstance>::get().into_iter().next().unwrap();
 
 			// Get the election identifier of the Solana egress.
-			let election_id = SolanaElections::with_electoral_access_and_identifiers(
-				|_, election_identifiers| {
+			let election_id = SolanaElections::with_election_identifiers(
+				|election_identifiers| {
 					Ok(election_identifiers.last().cloned().unwrap())
 				},
 			).unwrap();

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -27,8 +27,7 @@ use frame_support::{
 	traits::{OnFinalize, UnfilteredDispatchable},
 };
 use pallet_cf_elections::{
-	electoral_system::{ElectionIdentifierOf, ElectoralSystem},
-	vote_storage::{composite::tuple_6_impls::CompositeVote, AuthorityVote, VoteStorage},
+	vote_storage::{composite::tuple_6_impls::CompositeVote, AuthorityVote},
 	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use pallet_cf_ingress_egress::{DepositWitness, FetchOrTransfer};

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -379,7 +379,7 @@ mod access {
 			value: Option<
 				<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapValue,
 			>,
-		) -> Result<(), CorruptStorageError>;
+		);
 
 		/// Allows you to mutate the unsynchronised state. This is more efficient than a read
 		/// (`unsynchronised_state`) and then a write (`set_unsynchronised_state`) in the case of

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -214,9 +214,12 @@ mod access {
 
 	use super::{CorruptStorageError, ElectionIdentifierOf, ElectoralSystem};
 
+	#[cfg(test)]
+	use codec::{Decode, Encode};
+
 	/// Represents the current consensus, and how it has changed since it was last checked (i.e.
 	/// 'check_consensus' was called).
-	#[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
+	#[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq, Encode, Decode))]
 	pub enum ConsensusStatus<Consensus> {
 		/// You did not have consensus when previously checked, but now consensus has been gained.
 		Gained {

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -1,0 +1,309 @@
+use frame_support::{
+	pallet_prelude::{MaybeSerializeDeserialize, Member},
+	Parameter,
+};
+use sp_std::vec::Vec;
+
+use crate::{
+	vote_storage::{AuthorityVote, VoteStorage},
+	CorruptStorageError, ElectionIdentifier,
+};
+
+use crate::electoral_system::ConsensusStatus;
+
+#[allow(type_alias_bounds)]
+pub type CompositeElectionIdentifierOf<E: ElectoralSystemRunner> =
+	ElectionIdentifier<<E as ElectoralSystemRunner>::ElectionIdentifierExtra>;
+
+#[allow(type_alias_bounds)]
+pub type AuthorityVoteOf<E: ElectoralSystemRunner> = AuthorityVote<
+	<<E as ElectoralSystemRunner>::Vote as VoteStorage>::PartialVote,
+	<<E as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+>;
+#[allow(type_alias_bounds)]
+pub type IndividualComponentOf<E: ElectoralSystemRunner> =
+	<<E as ElectoralSystemRunner>::Vote as VoteStorage>::IndividualComponent;
+#[allow(type_alias_bounds)]
+pub type BitmapComponentOf<E: ElectoralSystemRunner> =
+	<<E as ElectoralSystemRunner>::Vote as VoteStorage>::BitmapComponent;
+#[allow(type_alias_bounds)]
+pub type VotePropertiesOf<E: ElectoralSystemRunner> =
+	<<E as ElectoralSystemRunner>::Vote as VoteStorage>::Properties;
+
+pub struct CompositeConsensusVote<ES: ElectoralSystemRunner> {
+	// If the validator hasn't voted, they will get a None.
+	pub vote: Option<(VotePropertiesOf<ES>, <ES::Vote as VoteStorage>::Vote)>,
+	pub validator_id: ES::ValidatorId,
+}
+
+pub struct CompositeConsensusVotes<ES: ElectoralSystemRunner> {
+	pub votes: Vec<CompositeConsensusVote<ES>>,
+}
+
+pub trait ElectoralSystemRunner: 'static + Sized {
+	type ValidatorId: Parameter + Member + MaybeSerializeDeserialize;
+
+	/// This is intended for storing any internal state of the ElectoralSystem. It is not
+	/// synchronised and therefore should only be used by the ElectoralSystem, and not be consumed
+	/// by the engine.
+	///
+	/// Also note that if this state is changed that will not cause election's consensus to be
+	/// retested.
+	type ElectoralUnsynchronisedState: Parameter + Member + MaybeSerializeDeserialize;
+	/// This is intended for storing any internal state of the ElectoralSystem. It is not
+	/// synchronised and therefore should only be used by the ElectoralSystem, and not be consumed
+	/// by the engine.
+	///
+	/// Also note that if this state is changed that will not cause election's consensus to be
+	/// retested.
+	type ElectoralUnsynchronisedStateMapKey: Parameter + Member;
+	/// This is intended for storing any internal state of the ElectoralSystem. It is not
+	/// synchronised and therefore should only be used by the ElectoralSystem, and not be consumed
+	/// by the engine.
+	///
+	/// Also note that if this state is changed that will not cause election's consensus to be
+	/// retested.
+	type ElectoralUnsynchronisedStateMapValue: Parameter + Member;
+
+	/// Settings of the electoral system. These can be changed at any time by governance, and
+	/// are not synchronised with elections, and therefore there is not a universal mapping from
+	/// elections to these settings values. Therefore it should only be used for internal
+	/// state, i.e. the engines should not consume this data.
+	///
+	/// Also note that if these settings are changed that will not cause election's consensus to be
+	/// retested.
+	type ElectoralUnsynchronisedSettings: Parameter + Member + MaybeSerializeDeserialize;
+
+	/// Settings of the electoral system. These settings are synchronised with
+	/// elections, so all engines will have a consistent view of the electoral settings to use for a
+	/// given election.
+	type ElectoralSettings: Parameter + Member + MaybeSerializeDeserialize + Eq;
+
+	/// Extra data stored along with the UniqueMonotonicIdentifier as part of the
+	/// ElectionIdentifier. This is used by composite electoral systems to identify which variant of
+	/// election it is working with, without needing to reading in further election
+	/// state/properties/etc.
+	type ElectionIdentifierExtra: Parameter + Member + Copy + Eq + Ord;
+
+	/// The properties of a single election, for example this could describe which block of the
+	/// external chain the election is associated with and what needs to be witnessed.
+	type ElectionProperties: Parameter + Member;
+
+	/// Per-election state needed by the ElectoralSystem. This state is not synchronised across
+	/// engines, and may change during the lifetime of a election.
+	type ElectionState: Parameter + Member;
+
+	/// A description of the validator's view of the election's topic. For example a list of all
+	/// ingresses the validator has observed in the block the election is about.
+	type Vote: VoteStorage;
+
+	/// This is the information that results from consensus. Typically this will be the same as the
+	/// `Vote` type, but with more complex consensus models the result of an election may not be
+	/// sensibly represented in the same form as a single vote.
+	type Consensus: Parameter + Member + Eq;
+
+	/// This is not used by the pallet, but is used to tell a validator that it should attempt
+	/// to vote in a given Election. Validators are expected to call this indirectly via RPC once
+	/// per state-chain block, for each active election.
+	fn is_vote_desired(
+		_election_identifier_with_extra: CompositeElectionIdentifierOf<Self>,
+		current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+	) -> Result<bool, CorruptStorageError> {
+		Ok(current_vote.is_none())
+	}
+
+	/// This is not used by the pallet, but is used to tell a validator if they should submit vote.
+	/// This is a way to decrease the amount of extrinsics a validator needs to send.
+	fn is_vote_needed(
+		_current_vote: (
+			VotePropertiesOf<Self>,
+			<Self::Vote as VoteStorage>::PartialVote,
+			AuthorityVoteOf<Self>,
+		),
+		_proposed_vote: (
+			<Self::Vote as VoteStorage>::PartialVote,
+			<Self::Vote as VoteStorage>::Vote,
+		),
+	) -> bool {
+		true
+	}
+
+	/// This is used in the vote extrinsic to disallow a validator from providing votes that do not
+	/// pass this check. It is guaranteed that any vote values provided to
+	/// `generate_vote_properties`, or `check_consensus` have past this check.
+	///
+	/// We only pass the `PartialVote` into the validity check, instead of the `AuthorityVote` or
+	/// `Vote`, to ensure the check's logic is consistent regardless of if the authority provides a
+	/// `Vote` or `PartialVote`. If the check was different depending on if the authority voted with
+	/// a `PartialVote` or `Vote`, then check only guarantees of the intersection of the two
+	/// variations.
+	///
+	/// You should *NEVER* update the epoch during this call. And in general updating any other
+	/// state of any pallet is ill advised, and should instead be done in the 'on_finalize'
+	/// function.
+	fn is_vote_valid(
+		_election_identifier: CompositeElectionIdentifierOf<Self>,
+		_partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
+	) -> Result<bool, CorruptStorageError> {
+		Ok(true)
+	}
+
+	/// This is called every time a vote occurs. It associates the vote with a `Properties`
+	/// value.
+	///
+	/// You should *NEVER* update the epoch during this call. And in general updating any other
+	/// state of any pallet is ill advised, and should instead be done in the 'on_finalize'
+	/// function.
+	fn generate_vote_properties(
+		election_identifier: CompositeElectionIdentifierOf<Self>,
+		previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		vote: &<Self::Vote as VoteStorage>::PartialVote,
+	) -> Result<VotePropertiesOf<Self>, CorruptStorageError>;
+
+	/// This is called during the pallet's `on_finalize` callback, if elections aren't paused and
+	/// the CorruptStorage error hasn't occurred.
+	fn on_finalize(
+		election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
+	) -> Result<(), CorruptStorageError>;
+
+	/// This function determines if the votes we have received form a consensus. It is called as
+	/// part of the Election pallet's `on_finalize` callback when the Election's votes or state have
+	/// changed since the previous call.
+	///
+	/// You should *NEVER* update the epoch during this call. And in general updating any other
+	/// state of any pallet is ill advised, and should instead be done in the 'on_finalize'
+	/// function.
+	#[allow(clippy::type_complexity)]
+	fn check_consensus(
+		election_identifier: CompositeElectionIdentifierOf<Self>,
+		// This is the consensus as of the last time the consensus was checked. Note this is *NOT*
+		// the "last" consensus, i.e. this can be `None` even if on some previous check we had
+		// consensus, but it was subsequently lost.
+		previous_consensus: Option<&Self::Consensus>,
+		votes: CompositeConsensusVotes<Self>,
+	) -> Result<Option<Self::Consensus>, CorruptStorageError>;
+}
+
+use crate::UniqueMonotonicIdentifier;
+
+/// A trait allowing access to a storage layer for electoral sytem runners.
+// TODO: rename
+pub trait RunnerStorageAccessTrait {
+	type ElectoralSystemRunner: ElectoralSystemRunner;
+
+	fn electoral_settings_for_election(
+		unique_monotonic_identifier: UniqueMonotonicIdentifier,
+	) -> Result<
+		<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
+		CorruptStorageError,
+	>;
+	fn election_properties(
+		election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
+	) -> Result<
+		<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+		CorruptStorageError,
+	>;
+	fn election_state(
+		unique_monotonic_identifier: UniqueMonotonicIdentifier,
+	) -> Result<
+		<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+		CorruptStorageError,
+	>;
+
+	/// Sets a new `state` value for the election. This will invalid the current Consensus, and
+	/// thereby force it to be recalculated, when `check_consensus` is next called. We do this
+	/// to ensure that in situations where `check_consensus` depends on the `state` that we will
+	/// correctly recalculate the consensus if needed.
+	fn set_election_state(
+		unique_monotonic_identifier: UniqueMonotonicIdentifier,
+		state: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+	) -> Result<(), CorruptStorageError>;
+
+	// Clear the votes of a particular election
+	fn clear_election_votes(unique_monotonic_identifier: UniqueMonotonicIdentifier);
+
+	fn delete_election(
+		composite_election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
+	);
+	/// This will change the `ElectionIdentifierExtra` value of the election, and allows you to
+	/// optionally change the properties. Note the `extra` must be strictly greater than the
+	/// previous value of this election, this function will return `Err` if it is not. This
+	/// ensures that all `Self::ElectoralSystemRunner::ElectionIdentifierExtra` ever used by a
+	/// particular election are unique. The purpose of this function to in effect allow the
+	/// deletion and recreation of an election so you can change its `Properties`, while
+	/// efficiently transferring the existing election's votes to the new election. The only
+	/// difference is that here the elections `Settings` will not be updated to the latest. This
+	/// could create a problem if you never delete elections, as old `Settings` values will be
+	/// stored until any elections referencing them are deleted. Any in-flight authority votes
+	/// will be invalidated by this.
+	fn refresh_election(
+		election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
+		new_extra: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionIdentifierExtra,
+		properties: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+	) -> Result<(), CorruptStorageError>;
+
+	/// This returns the current consensus which will always be up to date with the latest
+	/// votes/state. This also returns information about the difference in the consensus between
+	/// the last call to `check_consensus`.
+	fn check_election_consensus(
+		election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
+	) -> Result<
+		ConsensusStatus<<Self::ElectoralSystemRunner as ElectoralSystemRunner>::Consensus>,
+		CorruptStorageError,
+	>;
+
+	fn unsynchronised_settings() -> Result<
+		<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings,
+		CorruptStorageError,
+	>;
+	fn unsynchronised_state() -> Result<
+		<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+		CorruptStorageError,
+	>;
+	fn unsynchronised_state_map(
+			key: &<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
+		) -> Result<
+			Option<
+				<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
+			>,
+			CorruptStorageError,
+		>;
+
+	fn new_election(
+		extra: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionIdentifierExtra,
+		properties: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+		state: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+	) -> Result<CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>, CorruptStorageError>;
+
+	fn set_unsynchronised_state(
+		unsynchronised_state: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+	) -> Result<(), CorruptStorageError>;
+
+	/// Inserts or removes a value from the unsynchronised state map of the electoral system.
+	fn set_unsynchronised_state_map(
+		key: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
+		value: Option<
+				<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
+			>,
+	) -> Result<(), CorruptStorageError>;
+
+	/// Allows you to mutate the unsynchronised state. This is more efficient than a read
+	/// (`unsynchronised_state`) and then a write (`set_unsynchronised_state`) in the case of
+	/// composite ElectoralSystems, as a write from one of the sub-ElectoralSystems internally
+	/// will require an additional read. Therefore this function should be preferred.
+	fn mutate_unsynchronised_state<
+		T,
+		F: for<'a> FnOnce(
+			&Self,
+			&'a <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+		) -> Result<T, CorruptStorageError>,
+	>(
+		&self,
+		f: F,
+	) -> Result<T, CorruptStorageError> {
+		let mut unsynchronised_state = Self::unsynchronised_state()?;
+		let t = f(self, &mut unsynchronised_state)?;
+		Self::set_unsynchronised_state(unsynchronised_state)?;
+		Ok(t)
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -279,12 +279,9 @@ pub trait RunnerStorageAccessTrait {
 	>;
 	fn unsynchronised_state_map(
 			key: &<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
-		) -> Result<
-			Option<
+		) -> Option<
 				<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
-			>,
-			CorruptStorageError,
-		>;
+			>;
 
 	fn new_election(
 		extra: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionIdentifierExtra,
@@ -294,7 +291,7 @@ pub trait RunnerStorageAccessTrait {
 
 	fn set_unsynchronised_state(
 		unsynchronised_state: <Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
-	) -> Result<(), CorruptStorageError>;
+	);
 
 	/// Inserts or removes a value from the unsynchronised state map of the electoral system.
 	fn set_unsynchronised_state_map(
@@ -302,7 +299,7 @@ pub trait RunnerStorageAccessTrait {
 		value: Option<
 				<Self::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
 			>,
-	) -> Result<(), CorruptStorageError>;
+	);
 
 	/// Allows you to mutate the unsynchronised state. This is more efficient than a read
 	/// (`unsynchronised_state`) and then a write (`set_unsynchronised_state`) in the case of
@@ -320,7 +317,7 @@ pub trait RunnerStorageAccessTrait {
 	) -> Result<T, CorruptStorageError> {
 		let mut unsynchronised_state = Self::unsynchronised_state()?;
 		let t = f(self, &mut unsynchronised_state)?;
-		Self::set_unsynchronised_state(unsynchronised_state)?;
+		Self::set_unsynchronised_state(unsynchronised_state);
 		Ok(t)
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -50,6 +50,13 @@ impl<ES: ElectoralSystemRunner> CompositeConsensusVotes<ES> {
 	}
 }
 
+/// A trait used to define a runner of electoral systems. An object implementing this trait is
+/// injected into an elections pallet, which then executes the necessary logic to run each electoral
+/// system's logic.
+/// The primary implementation of this trait is the `CompositeRunner`. This should be the *only*
+/// implementation of this trait. This ensures that the storage and access is consistent across all
+/// electoral systems. i.e. we always wrap the storage types. Which leads to consistent and
+/// therefore simpler migration logic.
 pub trait ElectoralSystemRunner: 'static + Sized {
 	type ValidatorId: Parameter + Member + MaybeSerializeDeserialize;
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -55,23 +55,22 @@ where
 	<Sink as IngressSink>::Account: Ord,
 	ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 {
-	pub fn open_channel<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
+	pub fn open_channel<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(
 		election_identifiers: Vec<
 			ElectionIdentifier<<Self as ElectoralSystem>::ElectionIdentifierExtra>,
 		>,
-		electoral_access: &mut ElectoralAccess,
 		channel: Sink::Account,
 		asset: Sink::Asset,
 		close_block: Sink::BlockNumber,
 	) -> Result<(), CorruptStorageError> {
 		let channel_details = (
 			OpenChannelDetails { asset, close_block },
-			electoral_access.unsynchronised_state_map(&(channel.clone(), asset))?.unwrap_or(
+			ElectoralAccess::unsynchronised_state_map(&(channel.clone(), asset))?.unwrap_or(
 				ChannelTotalIngressed { block_number: Zero::zero(), amount: Zero::zero() },
 			),
 		);
 		if let Some(election_identifier) = election_identifiers.last() {
-			let mut election_access = electoral_access.election_mut(*election_identifier)?;
+			let mut election_access = ElectoralAccess::election_mut(*election_identifier);
 			let mut channels = election_access.properties()?;
 			if channels.len() < MAXIMUM_CHANNELS_PER_ELECTION as usize {
 				channels.insert(channel, channel_details);
@@ -86,7 +85,7 @@ where
 			}
 		}
 
-		electoral_access.new_election(
+		ElectoralAccess::new_election(
 			Default::default(), /* We use the lowest value, so we can refresh the elections the
 			                     * maximum number of times */
 			[(channel, channel_details)].into_iter().collect(),
@@ -139,7 +138,6 @@ where
 	type OnFinalizeReturn = ();
 
 	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
-		_election_identifier_with_extra: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_election_access: &ElectionAccess,
 		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
 	) -> Result<bool, CorruptStorageError> {
@@ -168,14 +166,13 @@ where
 		Ok(())
 	}
 
-	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
-		electoral_access: &mut ElectoralAccess,
+	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(
 		election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
 		chain_tracking: &Self::OnFinalizeContext,
 	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
 		for election_identifier in election_identifiers {
 			let (mut channels, mut pending_ingress_totals, option_consensus) = {
-				let mut election_access = electoral_access.election_mut(election_identifier)?;
+				let election_access = ElectoralAccess::election_mut(election_identifier);
 				(
 					election_access.properties()?,
 					election_access.state()?,
@@ -220,11 +217,13 @@ where
 				};
 
 				if let Some(ingress_total) = option_ingress_total_before_chain_tracking {
-					let previous_amount = electoral_access
-						.unsynchronised_state_map(&(account.clone(), details.asset))?
-						.map_or(Zero::zero(), |previous_total_ingressed| {
-							previous_total_ingressed.amount
-						});
+					let previous_amount = ElectoralAccess::unsynchronised_state_map(&(
+						account.clone(),
+						details.asset,
+					))?
+					.map_or(Zero::zero(), |previous_total_ingressed| {
+						previous_total_ingressed.amount
+					});
 					match previous_amount.cmp(&ingress_total.amount) {
 						Ordering::Less => {
 							Sink::on_ingress(
@@ -234,7 +233,7 @@ where
 								ingress_total.block_number,
 								(),
 							);
-							electoral_access.set_unsynchronised_state_map(
+							ElectoralAccess::set_unsynchronised_state_map(
 								(account.clone(), details.asset),
 								Some(ingress_total),
 							)?;
@@ -261,7 +260,7 @@ where
 				}
 			}
 
-			let mut election_access = electoral_access.election_mut(election_identifier)?;
+			let mut election_access = ElectoralAccess::election_mut(election_identifier);
 			if !closed_channels.is_empty() {
 				for closed_channel in closed_channels {
 					pending_ingress_totals.remove(&closed_channel);
@@ -291,7 +290,6 @@ where
 	}
 
 	fn check_consensus<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
-		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		election_access: &ElectionAccess,
 		_previous_consensus: Option<&Self::Consensus>,
 		consensus_votes: ConsensusVotes<Self>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -236,7 +236,7 @@ where
 							ElectoralAccess::set_unsynchronised_state_map(
 								(account.clone(), details.asset),
 								Some(ingress_total),
-							)?;
+							);
 						},
 						Ordering::Greater => {
 							Sink::on_ingress_reverted(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -393,7 +393,7 @@ macro_rules! generate_electoral_system_tuple_impls {
             fn unsynchronised_state_map(
                 key: &$current::ElectoralUnsynchronisedStateMapKey,
             ) -> Result<Option<$current::ElectoralUnsynchronisedStateMapValue>, CorruptStorageError> {
-                match StorageAccess::unsynchronised_state_map(&CompositeElectoralUnsynchronisedStateMapKey::$current(key.clone()))? {
+                match StorageAccess::unsynchronised_state_map(&CompositeElectoralUnsynchronisedStateMapKey::$current(key.clone())) {
                     Some(CompositeElectoralUnsynchronisedStateMapValue::$current(value)) => Ok(Some(value)),
                     None => Ok(None),
                     _ => Err(CorruptStorageError::new()),
@@ -423,17 +423,18 @@ macro_rules! generate_electoral_system_tuple_impls {
                 unsynchronised_state: $current::ElectoralUnsynchronisedState,
             ) -> Result<(), CorruptStorageError> {
                 let ($($previous,)* _, $($remaining,)*) = StorageAccess::unsynchronised_state()?;
-                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))
+                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*));
+                Ok(())
             }
 
             fn set_unsynchronised_state_map(
                 key: $current::ElectoralUnsynchronisedStateMapKey,
                 value: Option<$current::ElectoralUnsynchronisedStateMapValue>,
-            ) -> Result<(), CorruptStorageError> {
+            ) {
                 StorageAccess::set_unsynchronised_state_map(
                     CompositeElectoralUnsynchronisedStateMapKey::$current(key),
                     value.map(CompositeElectoralUnsynchronisedStateMapValue::$current),
-                )
+                );
             }
 
             fn mutate_unsynchronised_state<
@@ -446,7 +447,7 @@ macro_rules! generate_electoral_system_tuple_impls {
             ) -> Result<T, CorruptStorageError> {
                 let ($($previous,)* mut unsynchronised_state, $($remaining,)*) = StorageAccess::unsynchronised_state()?;
                 let t = f( &mut unsynchronised_state)?;
-                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))?;
+                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*));
                 Ok(t)
             }
         }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -1,31 +1,12 @@
-use crate::electoral_system::{ElectoralSystem, ElectoralWriteAccess};
-
 /// Allows the composition of multiple ElectoralSystems while allowing the ability to configure the
 /// `on_finalize` behaviour without exposing the internal composite types.
-pub struct Composite<T, ValidatorId, H = DefaultHooks<()>> {
-	_phantom: core::marker::PhantomData<(T, ValidatorId, H)>,
-}
-
-pub struct DefaultHooks<OnFinalizeContext> {
-	_phantom: core::marker::PhantomData<OnFinalizeContext>,
-}
-
-pub trait Translator<GenericElectoralAccess> {
-	type ElectoralSystem: ElectoralSystem;
-	type ElectionAccess<'a>: ElectoralWriteAccess<ElectoralSystem = Self::ElectoralSystem>
-	where
-		Self: 'a,
-		GenericElectoralAccess: 'a;
-
-	fn translate_electoral_access<'a>(
-		&'a self,
-		generic_electoral_access: &'a mut GenericElectoralAccess,
-	) -> Self::ElectionAccess<'a>;
+pub struct CompositeRunner<T, ValidatorId, StorageAccess, H> {
+	_phantom: core::marker::PhantomData<(T, ValidatorId, StorageAccess, H)>,
 }
 
 /// The access wrappers need to impl the access traits once for each variant,
 /// these tags ensure these trait impls don't overlap.
-mod tags {
+pub mod tags {
 	pub struct A;
 	pub struct B;
 	pub struct C;
@@ -45,9 +26,7 @@ macro_rules! generate_electoral_system_tuple_impls {
         #[allow(unused_variables)]
         pub mod $module {
             use super::{
-                Translator,
-                Composite,
-                DefaultHooks,
+                CompositeRunner,
                 tags,
             };
 
@@ -55,17 +34,17 @@ macro_rules! generate_electoral_system_tuple_impls {
                 CorruptStorageError,
                 electoral_system::{
                     ElectoralSystem,
-                    ConsensusStatus,
                     ConsensusVote,
                     ElectionReadAccess,
                     ElectionWriteAccess,
                     ElectoralReadAccess,
                     ElectoralWriteAccess,
-                    AuthorityVoteOf,
-                    VotePropertiesOf,
-                    ElectionIdentifierOf,
                     ConsensusVotes,
+                    ElectionIdentifierOf,
+                    ConsensusStatus,
                 },
+                electoral_system_runner::{ElectoralSystemRunner, AuthorityVoteOf, RunnerStorageAccessTrait,
+                    VotePropertiesOf, CompositeConsensusVotes, CompositeElectionIdentifierOf, CompositeConsensusVote},
                 vote_storage::{
                     AuthorityVote,
                     VoteStorage
@@ -78,44 +57,13 @@ macro_rules! generate_electoral_system_tuple_impls {
 
             use codec::{Encode, Decode};
             use scale_info::TypeInfo;
-            use core::borrow::Borrow;
             use sp_std::vec::Vec;
 
-            /// This trait specifies the behaviour of the composite's `ElectoralSystem::on_finalize` without that code being exposed to the internals of the composite by using the Translator trait to obtain ElectoralAccess objects that abstract those details.
+            /// This trait specifies the behaviour of the composite's `ElectoralSystem::on_finalize` function.
             pub trait Hooks<$($electoral_system: ElectoralSystem,)*> {
-                /// The `OnFinalizeContext` of the composite's ElectoralSystem implementation.
-                type OnFinalizeContext;
-
-                /// The 'OnFinalizeReturn' of the composite's ElectoralSystem implementation.
-                type OnFinalizeReturn;
-
-                fn on_finalize<GenericElectoralAccess, $($electoral_system_alt_name_0: Translator<GenericElectoralAccess, ElectoralSystem = $electoral_system>),*>(
-                    generic_electoral_access: &mut GenericElectoralAccess,
-                    electoral_access_translators: ($($electoral_system_alt_name_0,)*),
+                fn on_finalize(
                     election_identifiers: ($(Vec<ElectionIdentifierOf<$electoral_system>>,)*),
-                    context: &Self::OnFinalizeContext,
-                ) -> Result<Self::OnFinalizeReturn, CorruptStorageError>;
-            }
-
-            impl<OnFinalizeContext, $($electoral_system: ElectoralSystem<OnFinalizeContext = OnFinalizeContext>,)*> Hooks<$($electoral_system,)*> for DefaultHooks<OnFinalizeContext> {
-                type OnFinalizeContext = OnFinalizeContext;
-                type OnFinalizeReturn = ();
-
-                fn on_finalize<GenericElectoralAccess, $($electoral_system_alt_name_0: Translator<GenericElectoralAccess, ElectoralSystem = $electoral_system>),*>(
-                    generic_electoral_access: &mut GenericElectoralAccess,
-                    electoral_access_translators: ($($electoral_system_alt_name_0,)*),
-                    election_identifiers: ($(Vec<ElectionIdentifier<$electoral_system::ElectionIdentifierExtra>>,)*),
-                    context: &Self::OnFinalizeContext,
-                ) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
-                    let ($($electoral_system,)*) = electoral_access_translators;
-                    let ($($electoral_system_alt_name_0,)*) = election_identifiers;
-
-                    $(
-                        $electoral_system::on_finalize(&mut $electoral_system.translate_electoral_access(generic_electoral_access), $electoral_system_alt_name_0, &context)?;
-                    )*
-
-                    Ok(())
-                }
+                ) -> Result<(), CorruptStorageError>;
             }
 
             #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, TypeInfo)]
@@ -143,13 +91,13 @@ macro_rules! generate_electoral_system_tuple_impls {
                 $($electoral_system($electoral_system),)*
             }
 
-            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static> Composite<($($electoral_system,)*), ValidatorId, H> {
+            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = Self> + 'static, H: Hooks<$($electoral_system),*> + 'static> CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H> {
                 pub fn with_identifiers<R, F: for<'a> FnOnce(
                     ($(
                         Vec<ElectionIdentifierOf<$electoral_system>>,
                     )*)
                 ) -> R>(
-                    election_identifiers: Vec<ElectionIdentifierOf<Self>>,
+                    election_identifiers: Vec<CompositeElectionIdentifierOf<Self>>,
                     f: F,
                 ) -> R {
                     $(let mut $electoral_system_alt_name_0 = Vec::new();)*
@@ -166,21 +114,9 @@ macro_rules! generate_electoral_system_tuple_impls {
                         $($electoral_system_alt_name_0,)*
                     ))
                 }
-
-                pub fn with_access_translators<R, F: for<'a> FnOnce(
-                    ($(
-                        ElectoralAccessTranslator<tags::$electoral_system, Self>,
-                    )*)
-                ) -> R>(
-                    f: F,
-                ) -> R {
-                    f((
-                        $(ElectoralAccessTranslator::<tags::$electoral_system, Self>::new(),)*
-                    ))
-                }
             }
 
-            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static> ElectoralSystem for Composite<($($electoral_system,)*), ValidatorId, H> {
+            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = Self> + 'static, H: Hooks<$($electoral_system),*> + 'static> ElectoralSystemRunner for CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H> {
                 type ValidatorId = ValidatorId;
                 type ElectoralUnsynchronisedState = ($(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedState,)*);
                 type ElectoralUnsynchronisedStateMapKey = CompositeElectoralUnsynchronisedStateMapKey<$(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedStateMapKey,)*>;
@@ -194,12 +130,8 @@ macro_rules! generate_electoral_system_tuple_impls {
                 type Vote = ($(<$electoral_system as ElectoralSystem>::Vote,)*);
                 type Consensus = CompositeConsensus<$(<$electoral_system as ElectoralSystem>::Consensus,)*>;
 
-                type OnFinalizeContext = H::OnFinalizeContext;
-                type OnFinalizeReturn = H::OnFinalizeReturn;
-
-                fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+                fn is_vote_desired(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
-                    election_access: &ElectionAccess,
                     current_vote: Option<(
                         VotePropertiesOf<Self>,
                         AuthorityVoteOf<Self>,
@@ -208,8 +140,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                     match *election_identifier.extra() {
                         $(CompositeElectionIdentifierExtra::$electoral_system(extra) => {
                             <$electoral_system as ElectoralSystem>::is_vote_desired(
-                                election_identifier.with_extra(extra),
-                                &CompositeElectionAccess::<tags::$electoral_system, _, ElectionAccess>::new(election_access),
+                                &CompositeElectionAccess::<tags::$electoral_system, $electoral_system, StorageAccess>::new(election_identifier.with_extra(extra)),
                                 current_vote.map(|(properties, vote)| {
                                     Ok((
                                         match properties {
@@ -295,34 +226,25 @@ macro_rules! generate_electoral_system_tuple_impls {
                     }
                 }
 
-                fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
-                    electoral_access: &mut ElectoralAccess,
+                fn on_finalize(
                     election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
-                    context: &Self::OnFinalizeContext,
-                ) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
-                    Self::with_access_translators(|access_translators| {
-                        Self::with_identifiers(election_identifiers, |election_identifiers| {
-                            H::on_finalize(
-                                electoral_access,
-                                access_translators,
-                                election_identifiers,
-                                context
-                            )
-                        })
+                ) -> Result<(), CorruptStorageError> {
+                    Self::with_identifiers(election_identifiers, |election_identifiers| {
+                        H::on_finalize(
+                            election_identifiers,
+                        )
                     })
                 }
 
-                fn check_consensus<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
+                fn check_consensus(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
-                    election_access: &ElectionAccess,
                     previous_consensus: Option<&Self::Consensus>,
-                    consensus_votes: ConsensusVotes<Self>,
+                    consensus_votes: CompositeConsensusVotes<Self>,
                 ) -> Result<Option<Self::Consensus>, CorruptStorageError> {
                     Ok(match *election_identifier.extra() {
                         $(CompositeElectionIdentifierExtra::$electoral_system(extra) => {
                             <$electoral_system as ElectoralSystem>::check_consensus(
-                                election_identifier.with_extra(extra),
-                                &CompositeElectionAccess::<tags::$electoral_system, _, ElectionAccess>::new(election_access),
+                                &CompositeElectionAccess::<tags::$electoral_system, _, StorageAccess>::new(election_identifier.with_extra(extra)),
                                 previous_consensus.map(|previous_consensus| {
                                     match previous_consensus {
                                         CompositeConsensus::$electoral_system(previous_consensus) => Ok(previous_consensus),
@@ -330,7 +252,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                                     }
                                 }).transpose()?,
                                 ConsensusVotes {
-                                    votes: consensus_votes.votes.into_iter().map(|ConsensusVote { vote, validator_id }| {
+                                    votes: consensus_votes.votes.into_iter().map(|CompositeConsensusVote { vote, validator_id }| {
                                         if let Some((properties, vote)) = vote {
                                             match (properties, vote) {
                                                 (
@@ -357,40 +279,21 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
             }
 
-            pub struct CompositeElectionAccess<Tag, BorrowEA, EA> {
-                ea: BorrowEA,
-                _phantom: core::marker::PhantomData<(Tag, EA)>,
-            }
-            impl<Tag, $($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*>, BorrowEA: Borrow<EA>, EA: ElectionReadAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> CompositeElectionAccess<Tag, BorrowEA, EA> {
-                fn new(ea: BorrowEA) -> Self {
-                    Self {
-                        ea,
-                        _phantom: Default::default(),
-                    }
-                }
-            }
-            pub struct CompositeElectoralAccess<'a, Tag, EA> {
-                ea: &'a mut EA,
-                _phantom: core::marker::PhantomData<Tag>,
-            }
-            impl<'a, Tag, EA> CompositeElectoralAccess<'a, Tag, EA> {
-                fn new(ea: &'a mut EA) -> Self {
-                    Self {
-                        ea,
-                        _phantom: Default::default(),
-                    }
-                }
+            pub struct CompositeElectionAccess<Tag, ES: ElectoralSystem, StorageAccess> {
+                id: ElectionIdentifierOf<ES>,
+                _phantom: core::marker::PhantomData<(Tag, ES, StorageAccess)>,
             }
 
-            pub struct ElectoralAccessTranslator<Tag, EA> {
-                _phantom: core::marker::PhantomData<(Tag, EA)>,
-            }
-            impl<Tag, EA> ElectoralAccessTranslator<Tag, EA> {
-                fn new() -> Self {
+            impl<Tag, ES: ElectoralSystem, StorageAccess: RunnerStorageAccessTrait> CompositeElectionAccess<Tag, ES, StorageAccess> {
+                fn new(id: ElectionIdentifierOf<ES>) -> Self {
                     Self {
+                        id,
                         _phantom: Default::default(),
                     }
                 }
+            }
+            pub struct CompositeElectoralAccess<Tag, ES, StorageAccess> {
+                _phantom: core::marker::PhantomData<(Tag, ES, StorageAccess)>,
             }
 
             // This macro solves the problem of taking a repeating argument and generating the
@@ -401,15 +304,16 @@ macro_rules! generate_electoral_system_tuple_impls {
     };
     (@ $($previous:ident,)*;: $($electoral_system:ident,)*) => {};
     (@ $($previous:ident,)*; $current:ident, $($remaining:ident,)*: $($electoral_system:ident,)*) => {
-        impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, BorrowEA: Borrow<EA>, EA: ElectionReadAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> ElectionReadAccess for CompositeElectionAccess<tags::$current, BorrowEA, EA> {
+
+        impl<'a, $($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H>> + 'static> ElectionReadAccess for CompositeElectionAccess<tags::$current, $current, StorageAccess> {
             type ElectoralSystem = $current;
 
             fn settings(&self) -> Result<$current::ElectoralSettings, CorruptStorageError> {
-                let ($($previous,)* settings, $($remaining,)*) =self.ea.borrow().settings()?;
+                let ($($previous,)* settings, $($remaining,)*) = StorageAccess::electoral_settings_for_election(*self.id.unique_monotonic())?;
                 Ok(settings)
             }
             fn properties(&self) -> Result<$current::ElectionProperties, CorruptStorageError> {
-                match self.ea.borrow().properties()? {
+                match StorageAccess::election_properties(self.id.with_extra(CompositeElectionIdentifierExtra::$current(*self.id.extra())))? {
                     CompositeElectionProperties::$current(properties) => {
                         Ok(properties)
                     },
@@ -417,7 +321,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
             }
             fn state(&self) -> Result<$current::ElectionState, CorruptStorageError> {
-                match self.ea.borrow().state()? {
+                match StorageAccess::election_state(*self.id.unique_monotonic())? {
                     CompositeElectionState::$current(state) => {
                         Ok(state)
                     },
@@ -425,81 +329,71 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
             }
 
-            #[cfg(test)]
-            fn election_identifier(&self) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
-                let composite_identifier = self.ea.borrow().election_identifier()?;
-                let extra = match composite_identifier.extra() {
-                    CompositeElectionIdentifierExtra::$current(extra) => Ok(extra),
-                    _ => Err(CorruptStorageError::new()),
-                }?;
-                Ok(composite_identifier.with_extra(*extra))
+            fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
+                self.id
             }
         }
-        impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static,  EA: ElectionWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> ElectionWriteAccess for CompositeElectionAccess<tags::$current, EA, EA> {
-            fn set_state(&mut self, state: $current::ElectionState) -> Result<(), CorruptStorageError> {
-                self.ea.set_state(CompositeElectionState::$current(state))
+
+        impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H>> + 'static> ElectionWriteAccess for CompositeElectionAccess<tags::$current, $current, StorageAccess> {
+            fn set_state(&self, state: $current::ElectionState) -> Result<(), CorruptStorageError> {
+                StorageAccess::set_election_state(*self.id.unique_monotonic(), CompositeElectionState::$current(state))
             }
-            fn clear_votes(&mut self) {
-                self.ea.clear_votes()
+            fn clear_votes(&self) {
+                StorageAccess::clear_election_votes(*self.id.unique_monotonic());
             }
             fn delete(self) {
-                self.ea.delete();
+                StorageAccess::delete_election(self.id.with_extra(CompositeElectionIdentifierExtra::$current(*self.id.extra())));
             }
             fn refresh(
                 &mut self,
-                extra: $current::ElectionIdentifierExtra,
+                new_extra: $current::ElectionIdentifierExtra,
                 properties: $current::ElectionProperties,
             ) -> Result<(), CorruptStorageError> {
-                self.ea.refresh(
-                    CompositeElectionIdentifierExtra::$current(extra),
+                StorageAccess::refresh_election(
+                    self.id.with_extra(CompositeElectionIdentifierExtra::$current(*self.id.extra())),
+                    CompositeElectionIdentifierExtra::$current(new_extra),
                     CompositeElectionProperties::$current(properties),
-                )
+                )?;
+                self.id = self.id.with_extra(new_extra);
+                Ok(())
             }
             fn check_consensus(
-                &mut self,
+                &self,
             ) -> Result<ConsensusStatus<$current::Consensus>, CorruptStorageError> {
-                self.ea.check_consensus().and_then(|consensus_status| {
+                StorageAccess::check_election_consensus(self.id.with_extra(CompositeElectionIdentifierExtra::$current(*self.id.extra()))).and_then(|consensus_status| {
                     consensus_status.try_map(|consensus| {
                         match consensus {
                             CompositeConsensus::$current(consensus) => Ok(consensus),
                             _ => Err(CorruptStorageError::new()),
                         }
                     })
-
                 })
             }
         }
-        impl<'a, $($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, EA: ElectoralReadAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> ElectoralReadAccess for CompositeElectoralAccess<'a, tags::$current, EA> {
+
+        impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H>> + 'static> ElectoralReadAccess for CompositeElectoralAccess<tags::$current, $current, StorageAccess> {
             type ElectoralSystem = $current;
-            type ElectionReadAccess<'b> = CompositeElectionAccess<tags::$current, <EA as ElectoralReadAccess>::ElectionReadAccess<'b>, <EA as ElectoralReadAccess>::ElectionReadAccess<'b>>
-            where
-                Self: 'b;
+            type ElectionReadAccess = CompositeElectionAccess<tags::$current, $current, StorageAccess>;
 
             fn election(
-                &self,
                 id: ElectionIdentifier<<$current as ElectoralSystem>::ElectionIdentifierExtra>,
-            ) -> Result<Self::ElectionReadAccess<'_>, CorruptStorageError> {
-                self.ea.election(id.with_extra(CompositeElectionIdentifierExtra::$current(*id.extra()))).map(|election_access| {
-                    CompositeElectionAccess::<tags::$current, _, <EA as ElectoralReadAccess>::ElectionReadAccess<'_>>::new(election_access)
-                })
+            ) -> Self::ElectionReadAccess {
+                CompositeElectionAccess::<tags::$current, _, StorageAccess>::new(id)
             }
             fn unsynchronised_settings(
-                &self,
             ) -> Result<$current::ElectoralUnsynchronisedSettings, CorruptStorageError> {
-                let ($($previous,)* unsynchronised_settings, $($remaining,)*) = self.ea.unsynchronised_settings()?;
+                let ($($previous,)* unsynchronised_settings, $($remaining,)*) = StorageAccess::unsynchronised_settings()?;
                 Ok(unsynchronised_settings)
             }
             fn unsynchronised_state(
-                &self,
             ) -> Result<$current::ElectoralUnsynchronisedState, CorruptStorageError> {
-                let ($($previous,)* unsynchronised_state, $($remaining,)*) = self.ea.unsynchronised_state()?;
+                let ($($previous,)* unsynchronised_state, $($remaining,)*) = StorageAccess::unsynchronised_state()?;
                 Ok(unsynchronised_state)
             }
             fn unsynchronised_state_map(
-                &self,
                 key: &$current::ElectoralUnsynchronisedStateMapKey,
             ) -> Result<Option<$current::ElectoralUnsynchronisedStateMapValue>, CorruptStorageError> {
-                match self.ea.unsynchronised_state_map(&CompositeElectoralUnsynchronisedStateMapKey::$current(key.clone()))? {
+                match StorageAccess::unsynchronised_state_map(&CompositeElectoralUnsynchronisedStateMapKey::$current(key.clone()))? {
                     Some(CompositeElectoralUnsynchronisedStateMapValue::$current(value)) => Ok(Some(value)),
                     None => Ok(None),
                     _ => Err(CorruptStorageError::new()),
@@ -507,43 +401,36 @@ macro_rules! generate_electoral_system_tuple_impls {
             }
         }
 
-        impl<'a, $($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, EA: ElectoralWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> ElectoralWriteAccess for CompositeElectoralAccess<'a, tags::$current, EA> {
-            type ElectionWriteAccess<'b> = CompositeElectionAccess<tags::$current, <EA as ElectoralWriteAccess>::ElectionWriteAccess<'b>, <EA as ElectoralWriteAccess>::ElectionWriteAccess<'b>>
-            where
-                Self: 'b;
+        impl<'a, $($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H>> + 'static> ElectoralWriteAccess for CompositeElectoralAccess<tags::$current, $current, StorageAccess> {
+            type ElectionWriteAccess = CompositeElectionAccess<tags::$current, $current, StorageAccess>;
 
             fn new_election(
-                &mut self,
                 extra: $current::ElectionIdentifierExtra,
                 properties: $current::ElectionProperties,
                 state: $current::ElectionState,
-            ) -> Result<Self::ElectionWriteAccess<'_>, CorruptStorageError> {
-                self.ea.new_election(CompositeElectionIdentifierExtra::$current(extra), CompositeElectionProperties::$current(properties), CompositeElectionState::$current(state)).map(|election_access| {
-                    CompositeElectionAccess::new(election_access)
-                })
+            ) -> Result<Self::ElectionWriteAccess, CorruptStorageError> {
+                let election_identifier = StorageAccess::new_election(CompositeElectionIdentifierExtra::$current(extra), CompositeElectionProperties::$current(properties), CompositeElectionState::$current(state))?;
+                Ok(Self::ElectionWriteAccess::new(election_identifier.with_extra(extra)))
             }
+
             fn election_mut(
-                &mut self,
                 id: ElectionIdentifier<$current::ElectionIdentifierExtra>,
-            ) -> Result<Self::ElectionWriteAccess<'_>, CorruptStorageError> {
-                self.ea.election_mut(id.with_extra(CompositeElectionIdentifierExtra::$current(*id.extra()))).map(|election_access| {
-                    CompositeElectionAccess::new(election_access)
-                })
+            ) -> Self::ElectionWriteAccess {
+                Self::ElectionWriteAccess::new(id)
             }
+
             fn set_unsynchronised_state(
-                &mut self,
                 unsynchronised_state: $current::ElectoralUnsynchronisedState,
             ) -> Result<(), CorruptStorageError> {
-                let ($($previous,)* _, $($remaining,)*) = self.ea.unsynchronised_state()?;
-                self.ea.set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))
+                let ($($previous,)* _, $($remaining,)*) = StorageAccess::unsynchronised_state()?;
+                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))
             }
 
             fn set_unsynchronised_state_map(
-                &mut self,
                 key: $current::ElectoralUnsynchronisedStateMapKey,
                 value: Option<$current::ElectoralUnsynchronisedStateMapValue>,
             ) -> Result<(), CorruptStorageError> {
-                self.ea.set_unsynchronised_state_map(
+                StorageAccess::set_unsynchronised_state_map(
                     CompositeElectoralUnsynchronisedStateMapKey::$current(key),
                     value.map(CompositeElectoralUnsynchronisedStateMapValue::$current),
                 )
@@ -552,28 +439,15 @@ macro_rules! generate_electoral_system_tuple_impls {
             fn mutate_unsynchronised_state<
                 T,
                 F: for<'b> FnOnce(
-                    &mut Self,
                     &'b mut $current::ElectoralUnsynchronisedState,
                 ) -> Result<T, CorruptStorageError>,
             >(
-                &mut self,
                 f: F,
             ) -> Result<T, CorruptStorageError> {
-                let ($($previous,)* mut unsynchronised_state, $($remaining,)*) = self.ea.unsynchronised_state()?;
-                let t = f(self, &mut unsynchronised_state)?;
-                self.ea.set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))?;
+                let ($($previous,)* mut unsynchronised_state, $($remaining,)*) = StorageAccess::unsynchronised_state()?;
+                let t = f( &mut unsynchronised_state)?;
+                StorageAccess::set_unsynchronised_state(($($previous,)* unsynchronised_state, $($remaining,)*))?;
                 Ok(t)
-            }
-        }
-
-        impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, H: Hooks<$($electoral_system),*> + 'static, EA: ElectoralWriteAccess<ElectoralSystem = Composite<($($electoral_system,)*), ValidatorId, H>>> Translator<EA> for ElectoralAccessTranslator<tags::$current, Composite<($($electoral_system,)*), ValidatorId, H>> {
-            type ElectoralSystem = $current;
-            type ElectionAccess<'a> = CompositeElectoralAccess<'a, tags::$current, EA>
-            where
-                Self: 'a, EA: 'a;
-
-            fn translate_electoral_access<'a>(&'a self, generic_electoral_access: &'a mut EA) -> Self::ElectionAccess<'a> {
-                Self::ElectionAccess::<'a>::new(generic_electoral_access)
             }
         }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -350,7 +350,9 @@ macro_rules! generate_electoral_system_tuple_impls {
                 properties: $current::ElectionProperties,
             ) -> Result<(), CorruptStorageError> {
                 StorageAccess::refresh_election(
+                    // The current election id + extra that we want to refresh.
                     self.id.with_extra(CompositeElectionIdentifierExtra::$current(*self.id.extra())),
+                    // The new extra we want to use.
                     CompositeElectionIdentifierExtra::$current(new_extra),
                     CompositeElectionProperties::$current(properties),
                 )?;
@@ -410,7 +412,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 state: $current::ElectionState,
             ) -> Result<Self::ElectionWriteAccess, CorruptStorageError> {
                 let election_identifier = StorageAccess::new_election(CompositeElectionIdentifierExtra::$current(extra), CompositeElectionProperties::$current(properties), CompositeElectionState::$current(state))?;
-                Ok(Self::ElectionWriteAccess::new(election_identifier.with_extra(extra)))
+                Ok(Self::election_mut(election_identifier.with_extra(extra)))
             }
 
             fn election_mut(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -1,14 +1,10 @@
 use crate::{
-	electoral_system::{
-		ConsensusStatus, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralWriteAccess,
-	},
+	electoral_system::ConsensusStatus,
 	electoral_system_runner::{CompositeConsensusVotes, RunnerStorageAccessTrait},
 	mock::Test,
 	vote_storage::{self, VoteStorage},
 	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, CompositeVotePropertiesOf,
-	CorruptStorageError, ElectionIdentifier, ElectoralSystemRunner, RunnerStorageAccess,
-	UniqueMonotonicIdentifier,
+	CorruptStorageError, ElectoralSystemRunner, RunnerStorageAccess, UniqueMonotonicIdentifier,
 };
 use cf_primitives::AuthorityCount;
 use cf_traits::Chainflip;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -104,11 +104,6 @@ where
 		)
 		.unwrap();
 
-		println!(
-			"Election identifier in with initial election: {:?}",
-			election.election_identifier()
-		);
-
 		// A new election should not have consensus at any authority count.
 		assert_eq!(election.check_consensus(None, ConsensusVotes { votes: vec![] }).unwrap(), None);
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -1,6 +1,11 @@
-use crate::electoral_system::{
-	ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectoralReadAccess, ElectoralSystem,
-	ElectoralWriteAccess,
+use std::collections::BTreeMap;
+
+use crate::{
+	electoral_system::{
+		ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
+		ElectoralReadAccess, ElectoralSystem, ElectoralWriteAccess,
+	},
+	UniqueMonotonicIdentifier,
 };
 use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 
@@ -37,7 +42,6 @@ where
 #[derive(CloneNoBound, DebugNoBound, PartialEqNoBound, EqNoBound)]
 pub struct TestContext<ES: ElectoralSystem> {
 	setup: TestSetup<ES>,
-	electoral_access: MockAccess<ES>,
 }
 
 impl<ES: ElectoralSystem> TestSetup<ES>
@@ -79,36 +83,48 @@ where
 	// Useful for testing check_consensus since we already have an election.
 	pub fn build_with_initial_election(self) -> TestContext<ES> {
 		let setup = self.clone();
-		let mut electoral_access = MockAccess::<ES>::new(
-			self.unsynchronised_state,
-			self.unsynchronised_settings,
-			self.electoral_settings,
-		);
+
+		// We need to clear the storage at every build so if there are multiple test contexts used
+		// within a single test they do not conflict.
+		MockStorageAccess::clear_storage();
 
 		let (election_identifier_extra, election_properties, election_state) =
 			self.initial_election_state.unwrap_or_default();
 
-		let election = electoral_access
-			.new_election(election_identifier_extra, election_properties, election_state)
-			.unwrap();
+		// These are synchronised with respect to an election, so for simplicity in the tests
+		// we just assign them to an election.
+		MockStorageAccess::set_electoral_settings::<ES>(setup.electoral_settings.clone());
+		MockStorageAccess::set_unsynchronised_state::<ES>(setup.unsynchronised_state.clone());
+		MockStorageAccess::set_unsynchronised_settings::<ES>(setup.unsynchronised_settings.clone());
+
+		let election = MockAccess::<ES>::new_election(
+			election_identifier_extra,
+			election_properties,
+			election_state,
+		)
+		.unwrap();
+
+		println!(
+			"Election identifier in with initial election: {:?}",
+			election.election_identifier()
+		);
 
 		// A new election should not have consensus at any authority count.
 		assert_eq!(election.check_consensus(None, ConsensusVotes { votes: vec![] }).unwrap(), None);
 
-		TestContext { setup, electoral_access }
+		TestContext { setup }
 	}
 
 	// We may want to test initialisation of elections within on finalise, so *don't* want to
 	// initialise an election in the utilities.
 	pub fn build(self) -> TestContext<ES> {
-		TestContext {
-			setup: self.clone(),
-			electoral_access: MockAccess::<ES>::new(
-				self.unsynchronised_state,
-				self.unsynchronised_settings,
-				self.electoral_settings,
-			),
-		}
+		// We need to clear the storage at every build so if there are multiple test contexts used
+		// within a single test they do not conflict.
+		MockStorageAccess::clear_storage();
+
+		MockStorageAccess::set_electoral_settings::<ES>(self.electoral_settings.clone());
+
+		TestContext { setup: self.clone() }
 	}
 }
 
@@ -129,10 +145,7 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 		// Expect only one election.
 		let current_election_id = self.only_election_id();
 
-		let new_consensus = self
-			.electoral_access
-			.election(current_election_id)
-			.unwrap()
+		let new_consensus = MockAccess::<ES>::election(current_election_id)
 			.check_consensus(None, consensus_votes)
 			.unwrap();
 
@@ -157,7 +170,7 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 	}
 
 	pub fn all_election_ids(&self) -> Vec<ElectionIdentifierOf<ES>> {
-		self.electoral_access.election_identifiers()
+		MockStorageAccess::election_identifiers::<ES>()
 	}
 
 	/// Update the current consensus without processing any votes.
@@ -166,27 +179,15 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 		self.inner_force_consensus_update(id, new_consensus)
 	}
 
-	pub fn access(&self) -> &MockAccess<ES> {
-		&self.electoral_access
-	}
-
-	pub fn mut_access(&mut self) -> &mut MockAccess<ES> {
-		&mut self.electoral_access
-	}
-
 	#[track_caller]
 	fn inner_force_consensus_update(
 		self,
 		election_id: ElectionIdentifierOf<ES>,
 		new_consensus: ConsensusStatus<ES::Consensus>,
 	) -> Self {
-		let mut electoral_access = self.electoral_access.clone();
-		electoral_access
-			.election_mut(election_id)
-			.unwrap()
-			.set_consensus_status(new_consensus);
+		MockStorageAccess::set_consensus_status::<ES>(election_id, new_consensus);
 
-		Self { electoral_access, ..self }
+		self
 	}
 
 	/// Test the finalization of the election.
@@ -199,18 +200,22 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 	/// See [register_checks] and
 	#[track_caller]
 	pub fn test_on_finalize(
-		mut self,
+		self,
 		on_finalize_context: &ES::OnFinalizeContext,
-		pre_finalize_checks: impl FnOnce(&MockAccess<ES>),
+		pre_finalize_checks: impl FnOnce(&ElectoralSystemState<ES>),
 		post_finalize_checks: impl IntoIterator<Item = Check<ES>>,
 	) -> Self {
-		let pre_finalize = self.electoral_access.clone();
-		// TODO: Move 'hook' static local checks into MockAccess so we can remove this.
+		let pre_finalize = ElectoralSystemState::<ES>::load_state();
+		// TODO: Move 'hook' static local checks into ElectoralSystemState so we can remove this.
 		pre_finalize_checks(&pre_finalize);
 
-		self.electoral_access.finalize_elections(on_finalize_context).unwrap();
+		ES::on_finalize::<MockAccess<ES>>(
+			MockStorageAccess::election_identifiers::<ES>(),
+			on_finalize_context,
+		)
+		.unwrap();
 
-		let post_finalize = self.electoral_access.clone();
+		let post_finalize = ElectoralSystemState::<ES>::load_state();
 		for check in post_finalize_checks {
 			check.check(&pre_finalize, &post_finalize);
 		}
@@ -294,36 +299,55 @@ register_checks! {
 	assert_unchanged(pre_finalize, post_finalize) {
 		assert_eq!(pre_finalize, post_finalize);
 	},
+	// check state is deleted, rather than can't construct election
 	last_election_deleted(pre_finalize, post_finalize) {
-		let last_election_id = *pre_finalize.election_identifiers().last().expect("Expected an election before finalization.");
+		let last_election_id = pre_finalize.election_identifiers.last().expect("Expected an election before finalization");
 		assert!(
-			post_finalize.election(last_election_id).is_err(),
-			"Expected election {:?} to be deleted. Elections before: {:?}. After: {:?}",
-			last_election_id,
-			pre_finalize.election_identifiers(),
-			post_finalize.election_identifiers(),
+			!post_finalize.election_identifiers.contains(last_election_id),
+			"Last election should have been deleted.",
 		);
 	},
 	election_id_incremented(pre_finalize, post_finalize) {
 		assert_eq!(
-			pre_finalize.next_umi().next_identifier().unwrap(),
-			post_finalize.next_umi(),
+			pre_finalize.next_umi.next_identifier().unwrap(),
+			post_finalize.next_umi,
 			"Expected the election id to be incremented.",
 		);
 	},
 	all_elections_deleted(pre_finalize, post_finalize) {
 		assert!(
-			!pre_finalize.election_identifiers().is_empty(),
+			!pre_finalize.election_identifiers.is_empty(),
 			"Expected elections before finalization. This check makes no sense otherwise.",
 		);
 		assert!(
-			post_finalize.election_identifiers().is_empty(),
+			post_finalize.election_identifiers.is_empty(),
 			"Expected no elections after finalization.",
 		);
 	},
 }
 
-type CheckFn<ES> = Box<dyn Fn(&MockAccess<ES>, &MockAccess<ES>)>;
+#[derive(CloneNoBound, DebugNoBound, PartialEqNoBound, EqNoBound)]
+pub struct ElectoralSystemState<ES: ElectoralSystem> {
+	pub unsynchronised_state: ES::ElectoralUnsynchronisedState,
+	pub unsynchronised_state_map: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+	pub unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
+	pub election_identifiers: Vec<ElectionIdentifierOf<ES>>,
+	pub next_umi: UniqueMonotonicIdentifier,
+}
+
+impl<ES: ElectoralSystem> ElectoralSystemState<ES> {
+	pub fn load_state() -> Self {
+		Self {
+			unsynchronised_settings: MockStorageAccess::unsynchronised_settings::<ES>(),
+			unsynchronised_state: MockStorageAccess::unsynchronised_state::<ES>(),
+			unsynchronised_state_map: MockStorageAccess::raw_unsynchronised_state_map::<ES>(),
+			election_identifiers: MockStorageAccess::election_identifiers::<ES>(),
+			next_umi: MockStorageAccess::next_umi(),
+		}
+	}
+}
+
+type CheckFn<ES> = Box<dyn Fn(&ElectoralSystemState<ES>, &ElectoralSystemState<ES>)>;
 
 /// Checks that can be applied post-finalization.
 pub struct Check<ES: ElectoralSystem> {
@@ -331,11 +355,17 @@ pub struct Check<ES: ElectoralSystem> {
 }
 
 impl<ES: ElectoralSystem> Check<ES> {
-	pub fn new(check_fn: impl Fn(&MockAccess<ES>, &MockAccess<ES>) + 'static) -> Self {
+	pub fn new(
+		check_fn: impl Fn(&ElectoralSystemState<ES>, &ElectoralSystemState<ES>) + 'static,
+	) -> Self {
 		Self { check_fn: Box::new(check_fn) }
 	}
 
-	pub fn check(&self, pre_finalize: &MockAccess<ES>, post_finalize: &MockAccess<ES>) {
+	pub fn check(
+		&self,
+		pre_finalize: &ElectoralSystemState<ES>,
+		post_finalize: &ElectoralSystemState<ES>,
+	) {
 		(self.check_fn)(pre_finalize, post_finalize)
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -91,9 +91,13 @@ where
 		let (election_identifier_extra, election_properties, election_state) =
 			self.initial_election_state.unwrap_or_default();
 
-		// These are synchronised with respect to an election, so for simplicity in the tests
-		// we just assign them to an election.
+		// The ElectoralSettings are synchronised with an election, by election identifier in the
+		// actual implementation. Here we simplify by storing the settings in the electoral
+		// system, and upon the creation of new election, we store the ElectoralSettings that were
+		// in storage with the election directly. This duplicates the settings, but is fine for
+		// testing.
 		MockStorageAccess::set_electoral_settings::<ES>(setup.electoral_settings.clone());
+
 		MockStorageAccess::set_unsynchronised_state::<ES>(setup.unsynchronised_state.clone());
 		MockStorageAccess::set_unsynchronised_settings::<ES>(setup.unsynchronised_settings.clone());
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use crate::{
 	electoral_system::{
-		ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
-		ElectoralReadAccess, ElectoralSystem, ElectoralWriteAccess,
+		ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectoralReadAccess,
+		ElectoralSystem, ElectoralWriteAccess,
 	},
 	UniqueMonotonicIdentifier,
 };

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -299,7 +299,6 @@ register_checks! {
 	assert_unchanged(pre_finalize, post_finalize) {
 		assert_eq!(pre_finalize, post_finalize);
 	},
-	// check state is deleted, rather than can't construct election
 	last_election_deleted(pre_finalize, post_finalize) {
 		let last_election_id = pre_finalize.election_identifiers.last().expect("Expected an election before finalization");
 		assert!(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -339,7 +339,7 @@ impl<ES: ElectoralSystem> ElectoralSystemState<ES> {
 		Self {
 			unsynchronised_settings: MockStorageAccess::unsynchronised_settings::<ES>(),
 			unsynchronised_state: MockStorageAccess::unsynchronised_state::<ES>(),
-			unsynchronised_state_map: MockStorageAccess::raw_unsynchronised_state_map::<ES>(),
+			unsynchronised_state_map: MockStorageAccess::raw_unsynchronised_state_map(),
 			election_identifiers: MockStorageAccess::election_identifiers::<ES>(),
 			next_umi: MockStorageAccess::next_umi(),
 		}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -181,9 +181,8 @@ impl<ES: ElectoralSystem> ElectoralWriteAccess for MockAccess<ES> {
 		value: Option<
 			<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapValue,
 		>,
-	) -> Result<(), CorruptStorageError> {
+	) {
 		MockStorageAccess::set_unsynchronised_state_map::<ES>(key, value);
-		Ok(())
 	}
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -230,7 +230,7 @@ impl MockStorageAccess {
 	}
 
 	pub fn next_umi() -> UniqueMonotonicIdentifier {
-		NEXT_ELECTION_ID.with(|next_id| next_id.borrow().clone())
+		NEXT_ELECTION_ID.with(|next_id| *next_id.borrow())
 	}
 
 	pub fn increment_next_umi() {
@@ -273,7 +273,6 @@ impl MockStorageAccess {
 			let settings_ref = settings.borrow();
 			settings_ref
 				.get(&identifier.encode())
-				.clone()
 				.map(|v| ES::ElectoralSettings::decode(&mut &v[..]).unwrap())
 				.unwrap()
 		})
@@ -382,8 +381,7 @@ impl MockStorageAccess {
 		})
 	}
 
-	pub fn raw_unsynchronised_state_map<ES: ElectoralSystem>() -> BTreeMap<Vec<u8>, Option<Vec<u8>>>
-	{
+	pub fn raw_unsynchronised_state_map() -> BTreeMap<Vec<u8>, Option<Vec<u8>>> {
 		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|old_state_map| {
 			let state_map_ref = old_state_map.borrow();
 			state_map_ref.clone()

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -7,10 +7,9 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use core::cell::RefCell;
-use frame_support::{ensure, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
+use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 use std::collections::BTreeMap;
 
-// TODO: Create a new() so no need to pass mock storage access in each time. same below.
 pub struct MockReadAccess<ES: ElectoralSystem> {
 	election_identifier: ElectionIdentifierOf<ES>,
 }
@@ -199,6 +198,10 @@ impl MockStorageAccess {
 		ELECTION_PROPERTIES.with(|properties| {
 			let mut properties_ref = properties.borrow_mut();
 			properties_ref.clear();
+		});
+		ELECTORAL_SETTINGS.with(|settings| {
+			let mut settings_ref = settings.borrow_mut();
+			settings_ref.clear();
 		});
 		ELECTION_SETTINGS.with(|settings| {
 			let mut settings_ref = settings.borrow_mut();

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -69,7 +69,6 @@ macro_rules! impl_read_access {
 				previous_consensus: Option<&ES::Consensus>,
 				votes: ConsensusVotes<ES>,
 			) -> Result<Option<ES::Consensus>, CorruptStorageError> {
-				println!("Calling check consensus on the electoral system struct");
 				ES::check_consensus(self, previous_consensus, votes)
 			}
 		}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -5,55 +5,23 @@ use crate::{
 	},
 	CorruptStorageError, ElectionIdentifier, UniqueMonotonicIdentifier,
 };
-use codec::Encode;
-use frame_support::{
-	ensure, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound, StorageHasher, Twox64Concat,
-};
+use codec::{Decode, Encode};
+use core::cell::RefCell;
+use frame_support::{ensure, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 use std::collections::BTreeMap;
 
-pub struct MockReadAccess<'es, ES: ElectoralSystem> {
+// TODO: Create a new() so no need to pass mock storage access in each time. same below.
+pub struct MockReadAccess<ES: ElectoralSystem> {
 	election_identifier: ElectionIdentifierOf<ES>,
-	electoral_system: &'es MockAccess<ES>,
-}
-pub struct MockWriteAccess<'es, ES: ElectoralSystem> {
-	election_identifier: ElectionIdentifierOf<ES>,
-	electoral_system: &'es mut MockAccess<ES>,
 }
 
-#[derive(CloneNoBound, DebugNoBound, PartialEqNoBound, EqNoBound)]
-pub struct MockElection<ES: ElectoralSystem> {
-	properties: ES::ElectionProperties,
-	state: ES::ElectionState,
-	settings: ES::ElectoralSettings,
-	consensus_status: ConsensusStatus<ES::Consensus>,
+pub struct MockWriteAccess<ES: ElectoralSystem> {
+	election_identifier: ElectionIdentifierOf<ES>,
 }
 
 #[derive(CloneNoBound, DebugNoBound, PartialEqNoBound, EqNoBound)]
 pub struct MockAccess<ES: ElectoralSystem> {
-	electoral_settings: ES::ElectoralSettings,
-	unsynchronised_state: ES::ElectoralUnsynchronisedState,
-	unsynchronised_state_map: BTreeMap<Vec<u8>, Option<ES::ElectoralUnsynchronisedStateMapValue>>,
-	elections: BTreeMap<ElectionIdentifierOf<ES>, MockElection<ES>>,
-	unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
-	next_election_id: UniqueMonotonicIdentifier,
-}
-
-impl<ES: ElectoralSystem> MockAccess<ES> {
-	fn election_read_access(
-		&self,
-		id: ElectionIdentifierOf<ES>,
-	) -> Result<MockReadAccess<'_, ES>, CorruptStorageError> {
-		ensure!(self.elections.contains_key(&id), CorruptStorageError::new());
-		Ok(MockReadAccess { election_identifier: id, electoral_system: self })
-	}
-
-	fn election_write_access(
-		&mut self,
-		id: ElectionIdentifierOf<ES>,
-	) -> Result<MockWriteAccess<'_, ES>, CorruptStorageError> {
-		ensure!(self.elections.contains_key(&id), CorruptStorageError::new());
-		Ok(MockWriteAccess { election_identifier: id, electoral_system: self })
-	}
+	_phantom: core::marker::PhantomData<ES>,
 }
 
 macro_rules! impl_read_access {
@@ -67,7 +35,7 @@ macro_rules! impl_read_access {
 				<Self::ElectoralSystem as ElectoralSystem>::ElectoralSettings,
 				CorruptStorageError,
 			> {
-				self.with_election(|e| e.settings.clone())
+				Ok(MockStorageAccess::electoral_settings_for_election::<ES>(self.identifier()))
 			}
 
 			fn properties(
@@ -76,7 +44,7 @@ macro_rules! impl_read_access {
 				<Self::ElectoralSystem as ElectoralSystem>::ElectionProperties,
 				CorruptStorageError,
 			> {
-				self.with_election(|e| e.properties.clone())
+				Ok(MockStorageAccess::election_properties::<ES>(self.identifier()))
 			}
 
 			fn state(
@@ -85,27 +53,15 @@ macro_rules! impl_read_access {
 				<Self::ElectoralSystem as ElectoralSystem>::ElectionState,
 				CorruptStorageError,
 			> {
-				self.with_election(|e| e.state.clone())
+				Ok(MockStorageAccess::election_state::<ES>(self.identifier()))
 			}
 
-			fn election_identifier(
-				&self,
-			) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
-				Ok(self.identifier())
+			fn election_identifier(&self) -> ElectionIdentifierOf<Self::ElectoralSystem> {
+				self.identifier()
 			}
 		}
 
 		impl<ES: ElectoralSystem> $t {
-			fn with_election<F: FnOnce(&MockElection<ES>) -> R, R>(
-				&self,
-				f: F,
-			) -> Result<R, CorruptStorageError> {
-				self.electoral_system
-					.elections
-					.get(&self.identifier())
-					.map(f)
-					.ok_or_else(CorruptStorageError::new)
-			}
 			pub fn identifier(&self) -> ElectionIdentifierOf<ES> {
 				self.election_identifier
 			}
@@ -114,183 +70,386 @@ macro_rules! impl_read_access {
 				previous_consensus: Option<&ES::Consensus>,
 				votes: ConsensusVotes<ES>,
 			) -> Result<Option<ES::Consensus>, CorruptStorageError> {
-				ES::check_consensus(self.identifier(), self, previous_consensus, votes)
+				println!("Calling check consensus on the electoral system struct");
+				ES::check_consensus(self, previous_consensus, votes)
 			}
 		}
 	};
 }
 
-impl_read_access!(MockReadAccess<'_, ES>);
-impl_read_access!(MockWriteAccess<'_, ES>);
+impl_read_access!(MockReadAccess<ES>);
+impl_read_access!(MockWriteAccess<ES>);
 
-impl<ES: ElectoralSystem> MockWriteAccess<'_, ES> {
-	fn with_election_mut<F: FnOnce(&mut MockElection<ES>) -> R, R>(
-		&mut self,
-		f: F,
-	) -> Result<R, CorruptStorageError> {
-		self.electoral_system
-			.elections
-			.get_mut(&self.identifier())
-			.map(f)
-			.ok_or_else(CorruptStorageError::new)
-	}
-	pub fn set_consensus_status(&mut self, consensus_status: ConsensusStatus<ES::Consensus>) {
-		self.with_election_mut(|e| e.consensus_status = consensus_status)
-			.expect("Cannot set consensus status for non-existent election");
-	}
+thread_local! {
+	pub static ELECTION_STATE: RefCell<BTreeMap<Vec<u8>, Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
+	pub static ELECTION_PROPERTIES: RefCell<BTreeMap<Vec<u8>, Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
+	pub static ELECTORAL_SETTINGS: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+	// The electoral settings for a particular election
+	pub static ELECTION_SETTINGS: RefCell<BTreeMap<Vec<u8>, Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
+	pub static ELECTORAL_UNSYNCHRONISED_SETTINGS: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+	pub static ELECTORAL_UNSYNCHRONISED_STATE: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+	pub static ELECTORAL_UNSYNCHRONISED_STATE_MAP: RefCell<BTreeMap<Vec<u8>, Option<Vec<u8>>>> = const { RefCell::new(BTreeMap::new()) };
+	pub static CONSENSUS_STATUS: RefCell<BTreeMap<Vec<u8>, Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
+	pub static NEXT_ELECTION_ID: RefCell<UniqueMonotonicIdentifier> = const { RefCell::new(UniqueMonotonicIdentifier::from_u64(0)) };
 }
 
-impl<ES: ElectoralSystem> ElectionWriteAccess for MockWriteAccess<'_, ES> {
+impl<ES: ElectoralSystem> ElectionWriteAccess for MockWriteAccess<ES> {
 	fn set_state(
-		&mut self,
+		&self,
 		state: <Self::ElectoralSystem as ElectoralSystem>::ElectionState,
 	) -> Result<(), CorruptStorageError> {
-		self.with_election_mut(|e| e.state = state)?;
+		MockStorageAccess::set_state::<ES>(self.identifier(), state);
 		Ok(())
 	}
-	fn clear_votes(&mut self) {
+	fn clear_votes(&self) {
 		// nothing
 	}
 	fn delete(self) {
-		self.electoral_system.elections.remove(&self.identifier());
+		MockStorageAccess::delete_election::<ES>(self.identifier());
 	}
 	fn refresh(
 		&mut self,
-		_extra: <Self::ElectoralSystem as ElectoralSystem>::ElectionIdentifierExtra,
+		new_extra: <Self::ElectoralSystem as ElectoralSystem>::ElectionIdentifierExtra,
 		properties: <Self::ElectoralSystem as ElectoralSystem>::ElectionProperties,
 	) -> Result<(), CorruptStorageError> {
-		self.with_election_mut(|e| e.properties = properties)?;
+		self.election_identifier = self.election_identifier.with_extra(new_extra);
+		MockStorageAccess::set_election_properties::<ES>(self.identifier(), properties);
 		Ok(())
 	}
 
 	fn check_consensus(
-		&mut self,
+		&self,
 	) -> Result<
 		ConsensusStatus<<Self::ElectoralSystem as ElectoralSystem>::Consensus>,
 		CorruptStorageError,
 	> {
-		self.with_election_mut(|e| e.consensus_status.clone())
-	}
-}
-
-impl<ES: ElectoralSystem> MockAccess<ES> {
-	pub fn new(
-		unsynchronised_state: ES::ElectoralUnsynchronisedState,
-		unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
-		electoral_settings: ES::ElectoralSettings,
-	) -> Self {
-		Self {
-			electoral_settings,
-			unsynchronised_state,
-			unsynchronised_settings,
-			unsynchronised_state_map: Default::default(),
-			elections: Default::default(),
-			next_election_id: Default::default(),
-		}
-	}
-
-	pub fn finalize_elections(
-		&mut self,
-		context: &ES::OnFinalizeContext,
-	) -> Result<ES::OnFinalizeReturn, CorruptStorageError> {
-		ES::on_finalize(self, self.elections.keys().cloned().collect(), context)
-	}
-
-	pub fn election_identifiers(&self) -> Vec<ElectionIdentifierOf<ES>> {
-		self.elections.keys().cloned().collect()
-	}
-
-	pub fn next_umi(&self) -> UniqueMonotonicIdentifier {
-		self.next_election_id
+		Ok(MockStorageAccess::consensus_status::<ES>(self.identifier()))
 	}
 }
 
 impl<ES: ElectoralSystem> ElectoralReadAccess for MockAccess<ES> {
 	type ElectoralSystem = ES;
-	type ElectionReadAccess<'es> = MockReadAccess<'es, ES>;
+	type ElectionReadAccess = MockReadAccess<ES>;
 
-	fn election(
-		&self,
-		id: ElectionIdentifierOf<Self::ElectoralSystem>,
-	) -> Result<Self::ElectionReadAccess<'_>, CorruptStorageError> {
-		self.election_read_access(id)
+	fn election(id: ElectionIdentifierOf<Self::ElectoralSystem>) -> Self::ElectionReadAccess {
+		MockReadAccess { election_identifier: id }
 	}
-	fn unsynchronised_settings(
-		&self,
-	) -> Result<
+	fn unsynchronised_settings() -> Result<
 		<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedSettings,
 		CorruptStorageError,
 	> {
-		Ok(self.unsynchronised_settings.clone())
+		Ok(MockStorageAccess::unsynchronised_settings::<ES>())
 	}
-	fn unsynchronised_state(
-		&self,
-	) -> Result<
+	fn unsynchronised_state() -> Result<
 		<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedState,
 		CorruptStorageError,
 	> {
-		Ok(self.unsynchronised_state.clone())
+		Ok(MockStorageAccess::unsynchronised_state::<ES>())
 	}
 	fn unsynchronised_state_map(
-		&self,
 		key: &<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapKey,
 	) -> Result<
 		Option<<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapValue>,
 		CorruptStorageError,
 	> {
-		self.unsynchronised_state_map
-			.get(&key.using_encoded(Twox64Concat::hash))
-			.ok_or_else(CorruptStorageError::new)
-			.cloned()
+		Ok(MockStorageAccess::unsynchronised_state_map::<ES>(key))
 	}
 }
 
 impl<ES: ElectoralSystem> ElectoralWriteAccess for MockAccess<ES> {
-	type ElectionWriteAccess<'a> = MockWriteAccess<'a, ES>;
+	type ElectionWriteAccess = MockWriteAccess<ES>;
 
 	fn new_election(
-		&mut self,
 		extra: <Self::ElectoralSystem as ElectoralSystem>::ElectionIdentifierExtra,
 		properties: <Self::ElectoralSystem as ElectoralSystem>::ElectionProperties,
 		state: <Self::ElectoralSystem as ElectoralSystem>::ElectionState,
-	) -> Result<Self::ElectionWriteAccess<'_>, CorruptStorageError> {
-		let election_identifier = ElectionIdentifier::new(self.next_election_id, extra);
-		self.next_election_id = self.next_election_id.next_identifier().unwrap();
-		self.elections.insert(
-			election_identifier,
-			MockElection {
-				properties,
-				state,
-				settings: self.electoral_settings.clone(),
-				consensus_status: ConsensusStatus::None,
-			},
-		);
-		self.election_write_access(election_identifier)
+	) -> Result<Self::ElectionWriteAccess, CorruptStorageError> {
+		Ok(Self::election_mut(MockStorageAccess::new_election::<ES>(extra, properties, state)))
 	}
-	fn election_mut(
-		&mut self,
-		id: ElectionIdentifierOf<Self::ElectoralSystem>,
-	) -> Result<Self::ElectionWriteAccess<'_>, CorruptStorageError> {
-		self.election_write_access(id)
+	fn election_mut(id: ElectionIdentifierOf<Self::ElectoralSystem>) -> Self::ElectionWriteAccess {
+		MockWriteAccess { election_identifier: id }
 	}
 	fn set_unsynchronised_state(
-		&mut self,
 		unsynchronised_state: <Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedState,
 	) -> Result<(), CorruptStorageError> {
-		self.unsynchronised_state = unsynchronised_state;
+		MockStorageAccess::set_unsynchronised_state::<ES>(unsynchronised_state);
 		Ok(())
 	}
 
 	/// Inserts or removes a value from the unsynchronised state map of the electoral system.
 	fn set_unsynchronised_state_map(
-		&mut self,
 		key: <Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapKey,
 		value: Option<
 			<Self::ElectoralSystem as ElectoralSystem>::ElectoralUnsynchronisedStateMapValue,
 		>,
 	) -> Result<(), CorruptStorageError> {
-		self.unsynchronised_state_map
-			.insert(key.using_encoded(Twox64Concat::hash), value);
+		MockStorageAccess::set_unsynchronised_state_map::<ES>(key, value);
 		Ok(())
+	}
+}
+
+pub struct MockStorageAccess;
+
+impl MockStorageAccess {
+	pub fn clear_storage() {
+		ELECTION_STATE.with(|state| {
+			let mut state_ref = state.borrow_mut();
+			state_ref.clear();
+		});
+		ELECTION_PROPERTIES.with(|properties| {
+			let mut properties_ref = properties.borrow_mut();
+			properties_ref.clear();
+		});
+		ELECTION_SETTINGS.with(|settings| {
+			let mut settings_ref = settings.borrow_mut();
+			settings_ref.clear();
+		});
+		ELECTORAL_UNSYNCHRONISED_SETTINGS.with(|settings| {
+			let mut settings_ref = settings.borrow_mut();
+			settings_ref.clear();
+		});
+		ELECTORAL_UNSYNCHRONISED_STATE.with(|state| {
+			let mut state_ref = state.borrow_mut();
+			state_ref.clear();
+		});
+		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|state_map| {
+			let mut state_map_ref = state_map.borrow_mut();
+			state_map_ref.clear();
+		});
+		CONSENSUS_STATUS.with(|consensus| {
+			let mut consensus_ref = consensus.borrow_mut();
+			consensus_ref.clear();
+		});
+		NEXT_ELECTION_ID.with(|next_id| {
+			let mut next_id_ref = next_id.borrow_mut();
+			*next_id_ref = UniqueMonotonicIdentifier::from_u64(0);
+		});
+	}
+
+	pub fn next_umi() -> UniqueMonotonicIdentifier {
+		NEXT_ELECTION_ID.with(|next_id| next_id.borrow().clone())
+	}
+
+	pub fn increment_next_umi() {
+		NEXT_ELECTION_ID.with(|next_id| {
+			let mut next_id_ref = next_id.borrow_mut();
+			*next_id_ref = next_id_ref.next_identifier().unwrap();
+		});
+	}
+
+	pub fn set_electoral_settings<ES: ElectoralSystem>(
+		settings: <ES as ElectoralSystem>::ElectoralSettings,
+	) {
+		ELECTORAL_SETTINGS.with(|old_settings| {
+			let mut settings_ref = old_settings.borrow_mut();
+			*settings_ref = settings.encode();
+		});
+	}
+
+	pub fn electoral_settings<ES: ElectoralSystem>() -> ES::ElectoralSettings {
+		ELECTORAL_SETTINGS.with(|settings| {
+			let settings_ref = settings.borrow();
+			ES::ElectoralSettings::decode(&mut &settings_ref[..]).unwrap()
+		})
+	}
+
+	pub fn set_electoral_settings_for_election<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+		settings: <ES as ElectoralSystem>::ElectoralSettings,
+	) {
+		ELECTION_SETTINGS.with(|old_settings| {
+			let mut settings_ref = old_settings.borrow_mut();
+			settings_ref.insert(identifier.encode(), settings.encode());
+		});
+	}
+
+	pub fn electoral_settings_for_election<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+	) -> <ES as ElectoralSystem>::ElectoralSettings {
+		ELECTION_SETTINGS.with(|settings| {
+			let settings_ref = settings.borrow();
+			settings_ref
+				.get(&identifier.encode())
+				.clone()
+				.map(|v| ES::ElectoralSettings::decode(&mut &v[..]).unwrap())
+				.unwrap()
+		})
+	}
+
+	pub fn delete_election<ES: ElectoralSystem>(identifier: ElectionIdentifierOf<ES>) {
+		ELECTION_PROPERTIES.with(|properties| {
+			let mut properties_ref = properties.borrow_mut();
+			properties_ref.remove(&identifier.encode());
+		});
+		ELECTION_STATE.with(|state| {
+			let mut state_ref = state.borrow_mut();
+			state_ref.remove(&identifier.encode());
+		});
+	}
+
+	pub fn set_state<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+		state: ES::ElectionState,
+	) {
+		println!("Setting election state for identifier: {:?}", identifier);
+		ELECTION_STATE.with(|old_state| {
+			let mut state_ref = old_state.borrow_mut();
+			state_ref.insert(identifier.encode(), state.encode());
+		});
+	}
+
+	pub fn election_state<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+	) -> ES::ElectionState {
+		ELECTION_STATE.with(|old_state| {
+			let state_ref = old_state.borrow();
+			state_ref
+				.get(&identifier.encode())
+				.map(|v| ES::ElectionState::decode(&mut &v[..]).unwrap())
+				.unwrap()
+		})
+	}
+
+	pub fn set_election_properties<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+		properties: ES::ElectionProperties,
+	) {
+		ELECTION_PROPERTIES.with(|old_properties| {
+			let mut properties_ref = old_properties.borrow_mut();
+			properties_ref.insert(identifier.encode(), properties.encode());
+		});
+	}
+
+	pub fn election_properties<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+	) -> ES::ElectionProperties {
+		ELECTION_PROPERTIES.with(|old_properties| {
+			let properties_ref = old_properties.borrow();
+			properties_ref
+				.get(&identifier.encode())
+				.map(|v| ES::ElectionProperties::decode(&mut &v[..]).unwrap())
+				.unwrap()
+		})
+	}
+
+	pub fn set_unsynchronised_state<ES: ElectoralSystem>(
+		unsynchronised_state: ES::ElectoralUnsynchronisedState,
+	) {
+		ELECTORAL_UNSYNCHRONISED_STATE.with(|old_state| {
+			let mut state_ref = old_state.borrow_mut();
+			state_ref.clear();
+			state_ref.extend_from_slice(&unsynchronised_state.encode());
+		});
+	}
+
+	pub fn set_unsynchronised_settings<ES: ElectoralSystem>(
+		unsynchronised_settings: ES::ElectoralUnsynchronisedSettings,
+	) {
+		ELECTORAL_UNSYNCHRONISED_SETTINGS.with(|old_settings| {
+			let mut settings_ref = old_settings.borrow_mut();
+			settings_ref.clear();
+			settings_ref.extend_from_slice(&unsynchronised_settings.encode());
+		});
+	}
+
+	pub fn unsynchronised_settings<ES: ElectoralSystem>() -> ES::ElectoralUnsynchronisedSettings {
+		ELECTORAL_UNSYNCHRONISED_SETTINGS.with(|old_settings| {
+			let settings_ref = old_settings.borrow();
+			ES::ElectoralUnsynchronisedSettings::decode(&mut &settings_ref[..]).unwrap()
+		})
+	}
+
+	pub fn unsynchronised_state<ES: ElectoralSystem>() -> ES::ElectoralUnsynchronisedState {
+		ELECTORAL_UNSYNCHRONISED_STATE.with(|old_state| {
+			let state_ref = old_state.borrow();
+			ES::ElectoralUnsynchronisedState::decode(&mut &state_ref[..]).unwrap()
+		})
+	}
+
+	pub fn unsynchronised_state_map<ES: ElectoralSystem>(
+		key: &ES::ElectoralUnsynchronisedStateMapKey,
+	) -> Option<ES::ElectoralUnsynchronisedStateMapValue> {
+		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|old_state_map| {
+			let state_map_ref = old_state_map.borrow();
+			state_map_ref
+				.get(&key.encode())
+				.expect("Key should exist")
+				.clone()
+				.map(|v| ES::ElectoralUnsynchronisedStateMapValue::decode(&mut &v[..]).unwrap())
+		})
+	}
+
+	pub fn raw_unsynchronised_state_map<ES: ElectoralSystem>() -> BTreeMap<Vec<u8>, Option<Vec<u8>>>
+	{
+		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|old_state_map| {
+			let state_map_ref = old_state_map.borrow();
+			state_map_ref.clone()
+		})
+	}
+
+	pub fn set_unsynchronised_state_map<ES: ElectoralSystem>(
+		key: ES::ElectoralUnsynchronisedStateMapKey,
+		value: Option<ES::ElectoralUnsynchronisedStateMapValue>,
+	) {
+		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|old_state_map| {
+			let mut state_map_ref = old_state_map.borrow_mut();
+			state_map_ref.insert(key.encode(), value.map(|v| v.encode()));
+		});
+	}
+
+	pub fn election_identifiers<ES: ElectoralSystem>() -> Vec<ElectionIdentifierOf<ES>> {
+		ELECTION_PROPERTIES.with(|properties| {
+			let properties_ref = properties.borrow();
+			properties_ref
+				.keys()
+				.map(|k| ElectionIdentifierOf::<ES>::decode(&mut &k[..]).unwrap())
+				.collect()
+		})
+	}
+
+	pub fn set_consensus_status<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+		status: ConsensusStatus<ES::Consensus>,
+	) {
+		println!("Setting consensus status to {:?} for {:?}", status, identifier);
+		CONSENSUS_STATUS.with(|old_consensus| {
+			let mut consensus_ref = old_consensus.borrow_mut();
+			consensus_ref.insert(identifier.encode(), status.encode());
+		});
+	}
+
+	pub fn consensus_status<ES: ElectoralSystem>(
+		identifier: ElectionIdentifierOf<ES>,
+	) -> ConsensusStatus<ES::Consensus> {
+		CONSENSUS_STATUS
+			.with(|old_consensus| {
+				let consensus_ref = old_consensus.borrow();
+				consensus_ref
+					.get(&identifier.encode())
+					.map(|v| ConsensusStatus::<ES::Consensus>::decode(&mut &v[..]).unwrap())
+			})
+			.unwrap_or(ConsensusStatus::None)
+	}
+
+	pub fn new_election<ES: ElectoralSystem>(
+		extra: <ES as ElectoralSystem>::ElectionIdentifierExtra,
+		properties: <ES as ElectoralSystem>::ElectionProperties,
+		state: <ES as ElectoralSystem>::ElectionState,
+	) -> ElectionIdentifierOf<ES> {
+		let next_umi = Self::next_umi();
+		let election_identifier = ElectionIdentifier::new(next_umi, extra);
+		Self::increment_next_umi();
+
+		Self::set_election_properties::<ES>(election_identifier, properties);
+		Self::set_state::<ES>(election_identifier, state);
+		// These are normally stored once and synchronised by election identifier. In the tests we
+		// simplify this by just storing the electoral settings (that would be fetched by
+		// resolving the synchronisation) alongside the election.
+		Self::set_electoral_settings_for_election::<ES>(
+			election_identifier,
+			Self::electoral_settings::<ES>(),
+		);
+
+		election_identifier
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
@@ -125,7 +125,7 @@ impl<
 				if previous_value != value && block_height > previous_block_height {
 					election_access.delete();
 					Hook::on_change(identifier.clone(), value);
-					ElectoralAccess::set_unsynchronised_state_map(identifier, Some(block_height))?;
+					ElectoralAccess::set_unsynchronised_state_map(identifier, Some(block_height));
 				} else {
 					// We don't expect this to be hit, since we should have filtered out any votes
 					// that would cause this in check_consensus.

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -63,8 +63,7 @@ impl<
 		Ok(())
 	}
 
-	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
-		electoral_access: &mut ElectoralAccess,
+	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(
 		election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
 		_context: &Self::OnFinalizeContext,
 	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
@@ -73,30 +72,27 @@ impl<
 			.at_most_one()
 			.map_err(|_| CorruptStorageError::new())?
 		{
-			let mut election_access = electoral_access.election_mut(election_identifier)?;
+			let election_access = ElectoralAccess::election_mut(election_identifier);
 			if let Some(consensus) = election_access.check_consensus()?.has_consensus() {
 				election_access.delete();
-				electoral_access.new_election((), (), ())?;
-				electoral_access.mutate_unsynchronised_state(
-					|_electoral_access, unsynchronised_state| {
-						if consensus > *unsynchronised_state {
-							*unsynchronised_state = consensus.clone();
-							Hook::on_change(consensus);
-						}
+				ElectoralAccess::new_election((), (), ())?;
+				ElectoralAccess::mutate_unsynchronised_state(|unsynchronised_state| {
+					if consensus > *unsynchronised_state {
+						*unsynchronised_state = consensus.clone();
+						Hook::on_change(consensus);
+					}
 
-						Ok(())
-					},
-				)?;
+					Ok(())
+				})?;
 			}
 		} else {
-			electoral_access.new_election((), (), ())?;
+			ElectoralAccess::new_election((), (), ())?;
 		}
 
-		electoral_access.unsynchronised_state()
+		ElectoralAccess::unsynchronised_state()
 	}
 
 	fn check_consensus<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
-		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_election_access: &ElectionAccess,
 		_previous_consensus: Option<&Self::Consensus>,
 		consensus_votes: ConsensusVotes<Self>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -38,9 +38,11 @@ register_checks! {
 			assert_eq!(post.election_identifiers.len(), 1, "Only one election should exist.");
 		},
 		hook_called_once(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!"); 		},
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!");
+		},
 		hook_called_twice(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!"); 		},
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!");
+		},
 		hook_not_called(_pre, _post) {
 			assert_eq!(
 				HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -35,15 +35,12 @@ type SimpleLiveness =
 register_checks! {
 	SimpleLiveness {
 		only_one_election(_pre, post) {
-			let election_ids = post.election_identifiers();
-			assert_eq!(election_ids.len(), 1, "Only one election should exist.");
+			assert_eq!(post.election_identifiers.len(), 1, "Only one election should exist.");
 		},
 		hook_called_once(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!");
-		},
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!"); 		},
 		hook_called_twice(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!");
-		},
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!"); 		},
 		hook_not_called(_pre, _post) {
 			assert_eq!(
 				HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
@@ -2,7 +2,7 @@ use cf_primitives::AuthorityCount;
 
 use super::{mocks::*, register_checks};
 use crate::{
-	electoral_system::{ConsensusStatus, ElectoralReadAccess},
+	electoral_system::ConsensusStatus,
 	electoral_systems::{tests::utils::generate_votes, unsafe_median::*},
 };
 
@@ -21,23 +21,23 @@ fn with_default_context() -> TestContext<SimpleUnsafeMedian> {
 
 register_checks! {
 	SimpleUnsafeMedian {
-		started_at_initial_state(pre_finalize, _post) {
+		started_at_initial_state(pre_finalize, _a) {
 			assert_eq!(
-				pre_finalize.unsynchronised_state().unwrap(),
+				pre_finalize.unsynchronised_state,
 				INIT_UNSYNCHRONISED_STATE,
 				"Expected initial state pre-finalization."
 			);
 		},
 		ended_at_initial_state(_pre, post_finalize) {
 			assert_eq!(
-				post_finalize.unsynchronised_state().unwrap(),
+				post_finalize.unsynchronised_state,
 				INIT_UNSYNCHRONISED_STATE,
 				"Expected initial state post-finalization."
 			);
 		},
 		ended_at_new_state(_pre, post_finalize) {
 			assert_eq!(
-				post_finalize.unsynchronised_state().unwrap(),
+				post_finalize.unsynchronised_state,
 				NEW_UNSYNCHRONISED_STATE,
 				"Expected new state post-finalization."
 			);

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -886,20 +886,17 @@ pub mod pallet {
 
 			fn unsynchronised_state_map(
 				key: &<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
-			) -> Result<
+			) ->
 				Option<
 					<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
-				>,
-				CorruptStorageError,
 			>{
-				Ok(ElectoralUnsynchronisedStateMap::<T, I>::get(key))
+				ElectoralUnsynchronisedStateMap::<T, I>::get(key)
 			}
 
 			fn set_unsynchronised_state(
 				unsynchronised_state: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
-			) -> Result<(), CorruptStorageError> {
+			) {
 				ElectoralUnsynchronisedState::<T, I>::put(unsynchronised_state);
-				Ok(())
 			}
 
 			fn set_unsynchronised_state_map(
@@ -907,9 +904,8 @@ pub mod pallet {
 				value: Option<
 					<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
 				>,
-			) -> Result<(), CorruptStorageError> {
+			) {
 				ElectoralUnsynchronisedStateMap::<T, I>::set(key, value);
-				Ok(())
 			}
 		}
 	}

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -145,8 +145,8 @@ pub mod pallet {
 	};
 	use bitmap_components::ElectionBitmapComponents;
 	pub use electoral_system_runner::{
-		AuthorityVoteOf, CompositeElectionIdentifierOf, ElectoralSystemRunner,
-		IndividualComponentOf, VotePropertiesOf,
+		CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, CompositeIndividualComponentOf,
+		CompositeVotePropertiesOf, ElectoralSystemRunner,
 	};
 
 	use frame_support::{
@@ -192,7 +192,7 @@ pub mod pallet {
 		CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
 		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
 		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
-		AuthorityVoteOf<T::ElectoralSystemRunner>,
+		CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
 		BlockNumberFor<T>,
 	>;
 
@@ -208,8 +208,8 @@ pub mod pallet {
 			self.0.checked_add(1).map(Self)
 		}
 
-		#[cfg(feature = "runtime-benchmarks")]
-		pub fn from_u64(value: u64) -> Self {
+		#[cfg(any(feature = "runtime-benchmarks", test))]
+		pub const fn from_u64(value: u64) -> Self {
 			Self(value)
 		}
 	}
@@ -469,8 +469,8 @@ pub mod pallet {
 		Identity,
 		T::ValidatorId,
 		(
-			VotePropertiesOf<T::ElectoralSystemRunner>,
-			IndividualComponentOf<T::ElectoralSystemRunner>,
+			CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
+			CompositeIndividualComponentOf<T::ElectoralSystemRunner>,
 		),
 		OptionQuery,
 	>;
@@ -1223,7 +1223,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			authority_votes: BoundedBTreeMap<
 				CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
-				AuthorityVoteOf<T::ElectoralSystemRunner>,
+				CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
 				ConstU32<MAXIMUM_VOTES_PER_EXTRINSIC>,
 			>,
 		) -> DispatchResult {
@@ -1675,12 +1675,8 @@ pub mod pallet {
 			}
 		}
 
-		/// Provides access into the ElectoralSystem's storage, and also all the current election
+		/// Provides access into the ElectoralSystem's current election
 		/// identifiers.
-		///
-		/// Ideally we would avoid introducing re-entrance (also with `with_storage_access`), so
-		/// the ElectoralAccess object can internally cache storage which is possibly helpful
-		/// particularly in the case of composites.
 		pub fn with_election_identifiers<
 			R,
 			F: FnOnce(
@@ -1922,8 +1918,8 @@ pub mod pallet {
 			R,
 			F: for<'a> FnOnce(
 				Option<(
-					VotePropertiesOf<T::ElectoralSystemRunner>,
-					AuthorityVoteOf<T::ElectoralSystemRunner>,
+					CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
+					CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
 				)>,
 				&'a mut ElectionBitmapComponents<T, I>,
 			) -> Result<R, CorruptStorageError>,
@@ -1981,8 +1977,8 @@ pub mod pallet {
 			mut visit_unprovided_shared_data: VisitUnprovidedSharedData,
 		) -> Result<
 			Option<(
-				VotePropertiesOf<T::ElectoralSystemRunner>,
-				AuthorityVoteOf<T::ElectoralSystemRunner>,
+				CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
+				CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
 			)>,
 			CorruptStorageError,
 		> {

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -706,7 +706,10 @@ pub mod pallet {
 				} else {
 					ElectionProperties::<T, I>::remove(election_identifier);
 					let new_election_identifier =
-						ElectionIdentifier::new(*election_identifier.unique_monotonic(), new_extra);
+						CompositeElectionIdentifierOf::<Self::ElectoralSystemRunner>::new(
+							*election_identifier.unique_monotonic(),
+							new_extra,
+						);
 					ElectionProperties::<T, I>::insert(new_election_identifier, properties);
 					Ok(())
 				}
@@ -774,8 +777,8 @@ pub mod pallet {
 									Ok(SharedData::<T, I>::get(shared_data_hash))
 								}) {
 									// Only a full vote can count towards consensus.
-									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties,
-				vote))), 					Ok(Some((_properties, AuthorityVote::PartialVote(_)))) => Ok(None),
+									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))),
+									Ok(Some((_properties, AuthorityVote::PartialVote(_)))) => Ok(None),
 									Ok(None) => Ok(None),
 									Err(e) => Err(e),
 								}
@@ -1223,8 +1226,6 @@ pub mod pallet {
 				ConstU32<MAXIMUM_VOTES_PER_EXTRINSIC>,
 			>,
 		) -> DispatchResult {
-			Self::ensure_initialized()?;
-
 			let (epoch_index, authority, authority_index) = Self::ensure_can_vote(origin)?;
 
 			ensure!(!authority_votes.is_empty(), Error::<T, I>::NoVotesSpecified);
@@ -1660,10 +1661,6 @@ pub mod pallet {
 			);
 			Status::<T, I>::put(ElectionPalletStatus::Running);
 			Ok(())
-		}
-
-		pub fn ensure_initialized() -> Result<(), DispatchError> {
-			Self::with_status_check(|| Ok(()))
 		}
 
 		/// Provides access into the ElectoralSystem's current election

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -1688,7 +1688,6 @@ pub mod pallet {
 			})
 		}
 
-		// TODO: make handle_corrupt storage private
 		pub fn with_status_check<R, F: FnOnce() -> Result<R, CorruptStorageError>>(
 			f: F,
 		) -> Result<R, DispatchError> {

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -590,7 +590,7 @@ pub mod pallet {
 
 	// ---------------------------------------------------------------------------------------- //
 
-	pub(crate) mod access_impls {
+	pub mod access_impls {
 		use electoral_system_runner::RunnerStorageAccessTrait;
 
 		use super::*;

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -24,7 +24,7 @@ impl pallet_cf_elections::Config<Instance1> for Test {
 	type RuntimeEvent = RuntimeEvent;
 
 	// TODO: Use Settings?
-	type ElectoralSystemRunner = crate::electoral_systems::mock::MockElectoralSystem;
+	type ElectoralSystemRunner = crate::electoral_systems::mock::MockElectoralSystemRunner;
 
 	type WeightInfo = ();
 }

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -24,7 +24,7 @@ impl pallet_cf_elections::Config<Instance1> for Test {
 	type RuntimeEvent = RuntimeEvent;
 
 	// TODO: Use Settings?
-	type ElectoralSystem = crate::electoral_systems::mock::MockElectoralSystem;
+	type ElectoralSystemRunner = crate::electoral_systems::mock::MockElectoralSystem;
 
 	type WeightInfo = ();
 }

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -143,7 +143,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 			#[track_caller]
 			|mut ctx| {
 				let unique_monotonic_identifier =
-					*Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
+					*Pallet::<Test, Instance1>::with_storage_access(|electoral_access| {
 						electoral_access.new_election((), (), ())
 					})
 					.expect("New election should not corrupt storage.")
@@ -153,7 +153,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 
 				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectionPalletStatus::Running));
 
-				Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
+				Pallet::<Test, Instance1>::with_storage_access(|electoral_access| {
 					electoral_access
 						.election(ElectionIdentifier::new(unique_monotonic_identifier, ()))
 				})

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -4,7 +4,11 @@ use cf_primitives::AuthorityCount;
 use electoral_system::{
 	AuthorityVoteOf, ConsensusStatus, ElectionReadAccess, ElectoralReadAccess, ElectoralWriteAccess,
 };
-use electoral_systems::mock::{BehaviourUpdate, MockElectoralSystem};
+use electoral_system_runner::RunnerStorageAccessTrait;
+use electoral_systems::{
+	mock::{BehaviourUpdate, MockElectoralSystemRunner},
+	mocks::MockStorageAccess,
+};
 use frame_support::traits::OriginTrait;
 use mock::Test;
 use std::collections::BTreeMap;
@@ -117,7 +121,7 @@ fn ensure_can_vote() {
 	});
 }
 
-pub trait ElectoralSystemTestExt: Sized {
+pub trait ElectoralSystemRunnerTestExt: Sized {
 	fn update_settings(self, updates: &[BehaviourUpdate]) -> Self;
 	fn expect_consensus_after_next_block(self, expected: ConsensusStatus<AuthorityCount>) -> Self;
 	fn assume_consensus(self) -> Self;
@@ -127,39 +131,28 @@ pub trait ElectoralSystemTestExt: Sized {
 	fn submit_votes<I: 'static>(
 		self,
 		validator_ids: &[u64],
-		vote: AuthorityVoteOf<MockElectoralSystem>,
+		vote: CompositeAuthorityVoteOf<MockElectoralSystemRunner>,
 		expected_outcome: Result<(), Error<Test, I>>,
 	) -> Self
 	where
-		Test: Config<I, ElectoralSystem = MockElectoralSystem>,
+		Test: Config<I, ElectoralSystemRunner = MockElectoralSystemRunner>,
 		<Test as frame_system::Config>::RuntimeCall: From<Call<Test, I>>;
 }
 
-impl ElectoralSystemTestExt for TestRunner<TestContext> {
+impl ElectoralSystemRunnerTestExt for TestRunner<TestContext> {
 	/// Starts a new election, adding its unique monotonic identifier to the test context.
 	#[track_caller]
 	fn new_election(self) -> Self {
 		self.then_execute_with(
 			#[track_caller]
 			|mut ctx| {
-				let unique_monotonic_identifier =
-					*Pallet::<Test, Instance1>::with_storage_access(|electoral_access| {
-						electoral_access.new_election((), (), ())
-					})
-					.expect("New election should not corrupt storage.")
-					.election_identifier()
-					.expect("New election should have an identifier.")
-					.unique_monotonic();
+				let identifier =
+					RunnerStorageAccess::<Test, Instance1>::new_election((), (), ()).unwrap();
+				let unique_monotonic_identifier = identifier.unique_monotonic();
 
 				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectionPalletStatus::Running));
 
-				Pallet::<Test, Instance1>::with_storage_access(|electoral_access| {
-					electoral_access
-						.election(ElectionIdentifier::new(unique_monotonic_identifier, ()))
-				})
-				.expect("Expected an initial election.");
-
-				ctx.umis.push(unique_monotonic_identifier);
+				ctx.umis.push(*unique_monotonic_identifier);
 
 				ctx
 			},
@@ -167,7 +160,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 	}
 
 	fn update_settings(self, updates: &[BehaviourUpdate]) -> Self {
-		MockElectoralSystem::update(updates);
+		MockElectoralSystemRunner::update(updates);
 		self
 	}
 
@@ -185,11 +178,11 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 	fn submit_votes<I: 'static>(
 		self,
 		validator_ids: &[u64],
-		vote: AuthorityVoteOf<MockElectoralSystem>,
+		vote: CompositeAuthorityVoteOf<MockElectoralSystemRunner>,
 		expected_outcome: Result<(), Error<Test, I>>,
 	) -> Self
 	where
-		Test: Config<I, ElectoralSystem = MockElectoralSystem>,
+		Test: Config<I, ElectoralSystemRunner = MockElectoralSystemRunner>,
 		<Test as frame_system::Config>::RuntimeCall: From<Call<Test, I>>,
 	{
 		self.then_apply_extrinsics(
@@ -204,7 +197,9 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 								Call::<Test, I>::vote {
 									authority_votes: BoundedBTreeMap::try_from(
 										sp_std::iter::once((
-											ElectionIdentifier::new(*umi, ()),
+											CompositeElectionIdentifierOf::<
+												MockElectoralSystemRunner,
+											>::new(*umi, ()),
 											vote.clone(),
 										))
 										.collect::<BTreeMap<_, _>>(),
@@ -228,7 +223,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 				assert!(!umis.is_empty(), "Asserted consensus on empty election set.");
 
 				for umi in umis {
-					let actual = MockElectoralSystem::consensus_status(*umi);
+					let actual = MockElectoralSystemRunner::consensus_status(*umi);
 					assert_eq!(
 					actual,
 					expected,
@@ -249,7 +244,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 
 #[test]
 fn consensus_state_transitions() {
-	const VOTE: AuthorityVoteOf<MockElectoralSystem> = AuthorityVote::Vote(());
+	const VOTE: CompositeAuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
 
 	election_test_ext(TestSetup { num_non_contributing_authorities: 2, ..Default::default() })
 		.new_election()
@@ -301,7 +296,7 @@ fn consensus_state_transitions() {
 
 #[test]
 fn authority_removes_and_re_adds_itself_from_contributing_set() {
-	const VOTE: AuthorityVoteOf<MockElectoralSystem> = AuthorityVote::Vote(());
+	const VOTE: CompositeAuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
 
 	election_test_ext(Default::default())
 		.new_election()

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -1,14 +1,9 @@
 #![cfg(test)]
 use crate::{mock::*, *};
 use cf_primitives::AuthorityCount;
-use electoral_system::{
-	AuthorityVoteOf, ConsensusStatus, ElectionReadAccess, ElectoralReadAccess, ElectoralWriteAccess,
-};
+use electoral_system::ConsensusStatus;
 use electoral_system_runner::RunnerStorageAccessTrait;
-use electoral_systems::{
-	mock::{BehaviourUpdate, MockElectoralSystemRunner},
-	mocks::MockStorageAccess,
-};
+use electoral_systems::mock::{BehaviourUpdate, MockElectoralSystemRunner};
 use frame_support::traits::OriginTrait;
 use mock::Test;
 use std::collections::BTreeMap;

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -441,18 +441,15 @@ impl SolanaNonceWatch for SolanaNonceTrackingTrigger {
 		nonce_account: SolAddress,
 		previous_nonce_value: SolHash,
 	) -> DispatchResult {
-		// TODO: Check if safe. We are not checking if initialised or not here - we were before in
-		// with_electoral_access
-		// TODO: Look at handling the corrupt storage elsewhere.
-		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
+		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
 			SolanaNonceTracking::watch_for_change::<
 				DerivedElectoralAccess<
 					_,
 					SolanaNonceTracking,
 					RunnerStorageAccess<Runtime, SolanaInstance>,
 				>,
-			>(nonce_account, previous_nonce_value),
-		)?)
+			>(nonce_account, previous_nonce_value)
+		})?)
 	}
 }
 
@@ -462,16 +459,14 @@ impl ElectionEgressWitnesser for SolanaEgressWitnessingTrigger {
 	type Chain = SolanaCrypto;
 
 	fn watch_for_egress_success(signature: SolSignature) -> DispatchResult {
-		// TODO: Check if safe. We are not checking if initialised or not here - we were before in
-		// with_electoral_access
-		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
+		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
 			SolanaEgressWitnessing::watch_for_egress::<
 				DerivedElectoralAccess<
 					_,
 					SolanaEgressWitnessing,
 					RunnerStorageAccess<Runtime, SolanaInstance>,
 				>,
-			>(signature),
-		)?)
+			>(signature)
+		})?)
 	}
 }

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -3,8 +3,11 @@ use crate::{
 	SolanaIngressEgress, SolanaThresholdSigner,
 };
 use cf_chains::{
-	instances::ChainInstanceAlias,
-	sol::{api::SolanaTransactionType, SolAddress, SolAmount, SolHash, SolSignature, SolTrackedData, SolanaCrypto},
+	instances::{ChainInstanceAlias, SolanaInstance},
+	sol::{
+		api::SolanaTransactionType, SolAddress, SolAmount, SolHash, SolSignature, SolTrackedData,
+		SolanaCrypto,
+	},
 	Chain, FeeEstimationApi, ForeignChain, Solana,
 };
 use cf_runtime_utilities::log_or_panic;
@@ -19,7 +22,6 @@ use pallet_cf_elections::{
 	electoral_system::{ElectoralReadAccess, ElectoralSystem},
 	electoral_systems::{
 		self,
-		change::OnChangeHook,
 		composite::{tuple_6_impls::Hooks, CompositeRunner},
 		egress_success::OnEgressSuccess,
 		liveness::OnCheckComplete,

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -4,10 +4,7 @@ use crate::{
 };
 use cf_chains::{
 	instances::ChainInstanceAlias,
-	sol::{
-		api::SolanaTransactionType, SolAddress, SolAmount, SolHash, SolSignature, SolTrackedData,
-		SolanaCrypto,
-	},
+	sol::{api::SolanaTransactionType, SolAddress, SolAmount, SolHash, SolSignature, SolTrackedData, SolanaCrypto},
 	Chain, FeeEstimationApi, ForeignChain, Solana,
 };
 use cf_runtime_utilities::log_or_panic;
@@ -22,13 +19,14 @@ use pallet_cf_elections::{
 	electoral_system::{ElectoralReadAccess, ElectoralSystem},
 	electoral_systems::{
 		self,
-		composite::{tuple_6_impls::Hooks, Composite, Translator},
+		change::OnChangeHook,
+		composite::{tuple_6_impls::Hooks, CompositeRunner},
 		egress_success::OnEgressSuccess,
 		liveness::OnCheckComplete,
 		monotonic_change::OnChangeHook,
 		monotonic_median::MedianChangeHook,
 	},
-	CorruptStorageError, ElectionIdentifier, InitialState, InitialStateOf,
+	CorruptStorageError, ElectionIdentifier, InitialState, InitialStateOf, RunnerStorageAccess,
 };
 
 use scale_info::TypeInfo;
@@ -42,7 +40,7 @@ use sol_prim::SlotNumber;
 
 type Instance = <Solana as ChainInstanceAlias>::Instance;
 
-pub type SolanaElectoralSystem = Composite<
+pub type SolanaElectoralSystemRunner = CompositeRunner<
 	(
 		SolanaBlockHeightTracking,
 		SolanaFeeTracking,
@@ -52,6 +50,7 @@ pub type SolanaElectoralSystem = Composite<
 		SolanaLiveness,
 	),
 	<Runtime as Chainflip>::ValidatorId,
+	RunnerStorageAccess<Runtime, SolanaInstance>,
 	SolanaElectionHooks,
 >;
 
@@ -228,34 +227,7 @@ impl
 		SolanaLiveness,
 	> for SolanaElectionHooks
 {
-	type OnFinalizeContext = ();
-	type OnFinalizeReturn = ();
-
-	fn on_finalize<
-		GenericElectoralAccess,
-		BlockHeightTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaBlockHeightTracking>,
-		FeeTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaFeeTracking>,
-		IngressTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaIngressTracking>,
-		NonceTrackingTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaNonceTracking>,
-		EgressWitnessingTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaEgressWitnessing>,
-		LivenessTranslator: Translator<GenericElectoralAccess, ElectoralSystem = SolanaLiveness>,
-	>(
-		generic_electoral_access: &mut GenericElectoralAccess,
-		(
-			block_height_translator,
-			fee_translator,
-			ingress_translator,
-			nonce_tracking_translator,
-			egress_witnessing_translator,
-			liveness_translator,
-		): (
-			BlockHeightTranslator,
-			FeeTranslator,
-			IngressTranslator,
-			NonceTrackingTranslator,
-			EgressWitnessingTranslator,
-			LivenessTranslator,
-		),
+	fn on_finalize(
 		(
 			block_height_identifiers,
 			fee_identifiers,
@@ -289,38 +261,49 @@ impl
 			>,
 			Vec<ElectionIdentifier<<SolanaLiveness as ElectoralSystem>::ElectionIdentifierExtra>>,
 		),
-		_context: &Self::OnFinalizeContext,
-	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
-		let block_height = SolanaBlockHeightTracking::on_finalize(
-			&mut block_height_translator.translate_electoral_access(generic_electoral_access),
-			block_height_identifiers,
-			&(),
-		)?;
-		SolanaLiveness::on_finalize(
-			&mut liveness_translator.translate_electoral_access(generic_electoral_access),
-			liveness_identifiers,
-			&(crate::System::block_number(), block_height),
-		)?;
-		SolanaFeeTracking::on_finalize(
-			&mut fee_translator.translate_electoral_access(generic_electoral_access),
-			fee_identifiers,
-			&(),
-		)?;
-		SolanaNonceTracking::on_finalize(
-			&mut nonce_tracking_translator.translate_electoral_access(generic_electoral_access),
-			nonce_tracking_identifiers,
-			&(),
-		)?;
-		SolanaEgressWitnessing::on_finalize(
-			&mut egress_witnessing_translator.translate_electoral_access(generic_electoral_access),
-			egress_witnessing_identifiers,
-			&(),
-		)?;
-		SolanaIngressTracking::on_finalize(
-			&mut ingress_translator.translate_electoral_access(generic_electoral_access),
-			ingress_identifiers,
-			&block_height,
-		)?;
+	) -> Result<(), CorruptStorageError> {
+		let block_height = SolanaBlockHeightTracking::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaBlockHeightTracking,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(block_height_identifiers, &())?;
+		SolanaLiveness::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaLiveness,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(liveness_identifiers, &(crate::System::block_number(), block_height))?;
+		SolanaFeeTracking::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaFeeTracking,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(fee_identifiers, &())?;
+		SolanaNonceTracking::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaNonceTracking,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(nonce_tracking_identifiers, &())?;
+		SolanaEgressWitnessing::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaEgressWitnessing,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(egress_witnessing_identifiers, &())?;
+		SolanaIngressTracking::on_finalize::<
+			CompositeElectoralAccess<
+				_,
+				SolanaIngressTracking,
+				RunnerStorageAccess<Runtime, SolanaInstance>,
+			>,
+		>(ingress_identifiers, &block_height)?;
 		Ok(())
 	}
 }
@@ -353,19 +336,16 @@ impl BenchmarkValue for SolanaIngressSettings {
 	}
 }
 
+use pallet_cf_elections::electoral_systems::composite::tuple_6_impls::CompositeElectoralAccess;
+
 pub struct SolanaChainTrackingProvider;
 impl GetBlockHeight<Solana> for SolanaChainTrackingProvider {
 	fn get_block_height() -> <Solana as Chain>::ChainBlockNumber {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access(
-			|electoral_access| {
-				SolanaElectoralSystem::with_access_translators(|access_translators| {
-					let (access_translator, ..) = &access_translators;
-					access_translator
-						.translate_electoral_access(electoral_access)
-						.unsynchronised_state()
-				})
-			},
-		)
+		CompositeElectoralAccess::<
+			_,
+			SolanaBlockHeightTracking,
+			RunnerStorageAccess<Runtime, SolanaInstance>,
+		>::unsynchronised_state()
 		.unwrap_or_else(|err| {
 			log_or_panic!("Failed to obtain Solana block height: '{err:?}'.");
 			// We use default in error case as it is preferable to panicking, and in
@@ -375,19 +355,15 @@ impl GetBlockHeight<Solana> for SolanaChainTrackingProvider {
 		})
 	}
 }
+
 impl SolanaChainTrackingProvider {
 	pub fn priority_fee() -> Option<<Solana as Chain>::ChainAmount> {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access(
-			|electoral_access| {
-				SolanaElectoralSystem::with_access_translators(|access_translators| {
-					let (_, access_translator, ..) = &access_translators;
-					let electoral_access =
-						access_translator.translate_electoral_access(electoral_access);
-					electoral_access.unsynchronised_state()
-				})
-			},
-		)
-		.ok()
+		CompositeElectoralAccess::<
+			_,
+			SolanaFeeTracking,
+			RunnerStorageAccess<Runtime, SolanaInstance>,
+			>::unsynchronised_state()
+			.ok()
 	}
 
 	fn with_tracked_data_then_apply_fee_multiplier<
@@ -395,25 +371,26 @@ impl SolanaChainTrackingProvider {
 	>(
 		f: F,
 	) -> <Solana as Chain>::ChainAmount {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access(
-			|electoral_access| {
-				SolanaElectoralSystem::with_access_translators(|access_translators| {
-					let (_, access_translator, ..) = &access_translators;
-					let electoral_access =
-						access_translator.translate_electoral_access(electoral_access);
-					Ok(electoral_access
-						.unsynchronised_settings()?
-						.fee_multiplier
-						.saturating_mul_int(f(SolTrackedData {
-							priority_fee: electoral_access.unsynchronised_state()?,
-						})))
+		CompositeElectoralAccess::<
+			_,
+			SolanaFeeTracking,
+			RunnerStorageAccess<Runtime, SolanaInstance>,
+		>::unsynchronised_state()
+			.and_then(|priority_fee| {
+				CompositeElectoralAccess::<
+			_,
+			SolanaFeeTracking,
+			RunnerStorageAccess<Runtime, SolanaInstance>,
+		>::unsynchronised_settings().map(|fees| {
+					{
+						fees.fee_multiplier.saturating_mul_int(f(SolTrackedData { priority_fee }))
+					}
 				})
-			},
-		)
-		.unwrap_or_else(|err| {
-			log_or_panic!("Failed to obtain Solana fee: '{err:?}'.");
-			Default::default()
-		})
+			})
+			.unwrap_or_else(|err| {
+				log_or_panic!("Failed to obtain Solana fee: '{err:?}'.");
+				Default::default()
+			})
 	}
 }
 impl AdjustedFeeEstimationApi<Solana> for SolanaChainTrackingProvider {
@@ -441,22 +418,19 @@ impl IngressSource for SolanaIngress {
 		asset: <Self::Chain as Chain>::ChainAsset,
 		close_block: <Self::Chain as Chain>::ChainBlockNumber,
 	) -> DispatchResult {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access_and_identifiers(
-			|electoral_access, election_identifiers| {
-				SolanaElectoralSystem::with_identifiers(
-					election_identifiers,
-					|election_identifiers| {
-						SolanaElectoralSystem::with_access_translators(|access_translators| {
-							let (_, _, access_translator, ..) = &access_translators;
-							let (_, _, election_identifiers, ..) = election_identifiers;
-							SolanaIngressTracking::open_channel(
-								election_identifiers,
-								&mut access_translator.translate_electoral_access(electoral_access),
-								channel,
-								asset,
-								close_block,
-							)
-						})
+		pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_election_identifiers(
+			|composite_election_identifiers| {
+				SolanaElectoralSystemRunner::with_identifiers(
+					composite_election_identifiers,
+					|grouped_election_identifiers| {
+						let (_, _, election_identifiers, ..) = grouped_election_identifiers;
+						SolanaIngressTracking::open_channel::<
+							CompositeElectoralAccess<
+								_,
+								SolanaIngressTracking,
+								RunnerStorageAccess<Runtime, SolanaInstance>,
+							>,
+						>(election_identifiers, channel, asset, close_block)
 					},
 				)
 			},
@@ -471,20 +445,18 @@ impl SolanaNonceWatch for SolanaNonceTrackingTrigger {
 		nonce_account: SolAddress,
 		previous_nonce_value: SolHash,
 	) -> DispatchResult {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access(
-			|electoral_access| {
-				SolanaElectoralSystem::with_access_translators(|access_translators| {
-					let (_, _, _, access_translator, ..) = &access_translators;
-					let mut electoral_access =
-						access_translator.translate_electoral_access(electoral_access);
-					SolanaNonceTracking::watch_for_change(
-						&mut electoral_access,
-						nonce_account,
-						previous_nonce_value,
-					)
-				})
-			},
-		)
+		// TODO: Check if safe. We are not checking if initialised or not here - we were before in
+		// with_electoral_access
+		// TODO: Look at handling the corrupt storage elsewhere.
+		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
+			SolanaNonceTracking::watch_for_change::<
+				CompositeElectoralAccess<
+					_,
+					SolanaNonceTracking,
+					RunnerStorageAccess<Runtime, SolanaInstance>,
+				>,
+			>(nonce_account, previous_nonce_value),
+		)?)
 	}
 }
 
@@ -494,16 +466,16 @@ impl ElectionEgressWitnesser for SolanaEgressWitnessingTrigger {
 	type Chain = SolanaCrypto;
 
 	fn watch_for_egress_success(signature: SolSignature) -> DispatchResult {
-		pallet_cf_elections::Pallet::<Runtime, Instance>::with_electoral_access(
-			|electoral_access| {
-				SolanaElectoralSystem::with_access_translators(|access_translators| {
-					let (_, _, _, _, access_translator, ..) = &access_translators;
-					let mut electoral_access =
-						access_translator.translate_electoral_access(electoral_access);
-
-					SolanaEgressWitnessing::watch_for_egress(&mut electoral_access, signature)
-				})
-			},
-		)
+		// TODO: Check if safe. We are not checking if initialised or not here - we were before in
+		// with_electoral_access
+		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
+			SolanaEgressWitnessing::watch_for_egress::<
+				CompositeElectoralAccess<
+					_,
+					SolanaEgressWitnessing,
+					RunnerStorageAccess<Runtime, SolanaInstance>,
+				>,
+			>(signature),
+		)?)
 	}
 }

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -443,7 +443,7 @@ impl SolanaNonceWatch for SolanaNonceTrackingTrigger {
 		nonce_account: SolAddress,
 		previous_nonce_value: SolHash,
 	) -> DispatchResult {
-		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
+		pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
 			SolanaNonceTracking::watch_for_change::<
 				DerivedElectoralAccess<
 					_,
@@ -451,7 +451,7 @@ impl SolanaNonceWatch for SolanaNonceTrackingTrigger {
 					RunnerStorageAccess<Runtime, SolanaInstance>,
 				>,
 			>(nonce_account, previous_nonce_value)
-		})?)
+		})
 	}
 }
 
@@ -461,7 +461,7 @@ impl ElectionEgressWitnesser for SolanaEgressWitnessingTrigger {
 	type Chain = SolanaCrypto;
 
 	fn watch_for_egress_success(signature: SolSignature) -> DispatchResult {
-		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
+		pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::with_status_check(|| {
 			SolanaEgressWitnessing::watch_for_egress::<
 				DerivedElectoralAccess<
 					_,
@@ -469,6 +469,6 @@ impl ElectionEgressWitnesser for SolanaEgressWitnessingTrigger {
 					RunnerStorageAccess<Runtime, SolanaInstance>,
 				>,
 			>(signature)
-		})?)
+		})
 	}
 }

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -263,42 +263,38 @@ impl
 		),
 	) -> Result<(), CorruptStorageError> {
 		let block_height = SolanaBlockHeightTracking::on_finalize::<
-			CompositeElectoralAccess<
+			DerivedElectoralAccess<
 				_,
 				SolanaBlockHeightTracking,
 				RunnerStorageAccess<Runtime, SolanaInstance>,
 			>,
 		>(block_height_identifiers, &())?;
 		SolanaLiveness::on_finalize::<
-			CompositeElectoralAccess<
-				_,
-				SolanaLiveness,
-				RunnerStorageAccess<Runtime, SolanaInstance>,
-			>,
+			DerivedElectoralAccess<_, SolanaLiveness, RunnerStorageAccess<Runtime, SolanaInstance>>,
 		>(liveness_identifiers, &(crate::System::block_number(), block_height))?;
 		SolanaFeeTracking::on_finalize::<
-			CompositeElectoralAccess<
+			DerivedElectoralAccess<
 				_,
 				SolanaFeeTracking,
 				RunnerStorageAccess<Runtime, SolanaInstance>,
 			>,
 		>(fee_identifiers, &())?;
 		SolanaNonceTracking::on_finalize::<
-			CompositeElectoralAccess<
+			DerivedElectoralAccess<
 				_,
 				SolanaNonceTracking,
 				RunnerStorageAccess<Runtime, SolanaInstance>,
 			>,
 		>(nonce_tracking_identifiers, &())?;
 		SolanaEgressWitnessing::on_finalize::<
-			CompositeElectoralAccess<
+			DerivedElectoralAccess<
 				_,
 				SolanaEgressWitnessing,
 				RunnerStorageAccess<Runtime, SolanaInstance>,
 			>,
 		>(egress_witnessing_identifiers, &())?;
 		SolanaIngressTracking::on_finalize::<
-			CompositeElectoralAccess<
+			DerivedElectoralAccess<
 				_,
 				SolanaIngressTracking,
 				RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -336,12 +332,12 @@ impl BenchmarkValue for SolanaIngressSettings {
 	}
 }
 
-use pallet_cf_elections::electoral_systems::composite::tuple_6_impls::CompositeElectoralAccess;
+use pallet_cf_elections::electoral_systems::composite::tuple_6_impls::DerivedElectoralAccess;
 
 pub struct SolanaChainTrackingProvider;
 impl GetBlockHeight<Solana> for SolanaChainTrackingProvider {
 	fn get_block_height() -> <Solana as Chain>::ChainBlockNumber {
-		CompositeElectoralAccess::<
+		DerivedElectoralAccess::<
 			_,
 			SolanaBlockHeightTracking,
 			RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -358,7 +354,7 @@ impl GetBlockHeight<Solana> for SolanaChainTrackingProvider {
 
 impl SolanaChainTrackingProvider {
 	pub fn priority_fee() -> Option<<Solana as Chain>::ChainAmount> {
-		CompositeElectoralAccess::<
+		DerivedElectoralAccess::<
 			_,
 			SolanaFeeTracking,
 			RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -371,13 +367,13 @@ impl SolanaChainTrackingProvider {
 	>(
 		f: F,
 	) -> <Solana as Chain>::ChainAmount {
-		CompositeElectoralAccess::<
+		DerivedElectoralAccess::<
 			_,
 			SolanaFeeTracking,
 			RunnerStorageAccess<Runtime, SolanaInstance>,
 		>::unsynchronised_state()
 			.and_then(|priority_fee| {
-				CompositeElectoralAccess::<
+				DerivedElectoralAccess::<
 			_,
 			SolanaFeeTracking,
 			RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -425,7 +421,7 @@ impl IngressSource for SolanaIngress {
 					|grouped_election_identifiers| {
 						let (_, _, election_identifiers, ..) = grouped_election_identifiers;
 						SolanaIngressTracking::open_channel::<
-							CompositeElectoralAccess<
+							DerivedElectoralAccess<
 								_,
 								SolanaIngressTracking,
 								RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -450,7 +446,7 @@ impl SolanaNonceWatch for SolanaNonceTrackingTrigger {
 		// TODO: Look at handling the corrupt storage elsewhere.
 		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
 			SolanaNonceTracking::watch_for_change::<
-				CompositeElectoralAccess<
+				DerivedElectoralAccess<
 					_,
 					SolanaNonceTracking,
 					RunnerStorageAccess<Runtime, SolanaInstance>,
@@ -470,7 +466,7 @@ impl ElectionEgressWitnesser for SolanaEgressWitnessingTrigger {
 		// with_electoral_access
 		Ok(pallet_cf_elections::Pallet::<Runtime, SolanaInstance>::handle_corrupt_storage(
 			SolanaEgressWitnessing::watch_for_egress::<
-				CompositeElectoralAccess<
+				DerivedElectoralAccess<
 					_,
 					SolanaEgressWitnessing,
 					RunnerStorageAccess<Runtime, SolanaInstance>,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1000,7 +1000,7 @@ impl pallet_cf_chain_tracking::Config<Instance5> for Runtime {
 
 impl pallet_cf_elections::Config<Instance5> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type ElectoralSystem = chainflip::solana_elections::SolanaElectoralSystem;
+	type ElectoralSystemRunner = chainflip::solana_elections::SolanaElectoralSystemRunner;
 	type WeightInfo = pallet_cf_elections::weights::PalletWeight<Runtime>;
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1675

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Rather than have a composite "electoral system" impl Electoral system, we now have a new `ElectoralSystemRunner` trait for the composite, which is then used by the elections pallet directly. This removes some prior hacks that were required to get the traits to work for both a single and composite electoral system.

It also makes it easier to write migration utilities in the future, since storage will *always* be enum wrapped, as a composite, and we don't need to consider the individual electoral system case.

As a consequence there were other simplifications that fell out:
- Simpler Composite electoral system macro
- Some trait methods now have simpler signatures (e.g. no Result necessary in some cases, fewer params).
- Removes unnecessary complex borrowing in macros by simply using the traits and associated functions directly - which also maps better to how substrate works, data is written into a static storage layer.
- Removes translators 🙌  - much clearer what's happening here now, as we can directly use a CompositeElectoralSystem and provide it with the ElectoralSystem we want to access.
- For the tests I just took the approach of most flexibility for now, the model in the tests also maps nicely to how it actually works with respect to the storage, so can save building a separate mental model. 