### PR TITLE
chore: localnet recreate script can use defaults

### DIFF
--- a/localnet/create.sh
+++ b/localnet/create.sh
@@ -5,8 +5,6 @@
 ## Usage ./localnet/create.sh -b <BINARY_ROOT_PATH> -n <NODE_COUNT> -t <START_TRACKER>
 ## Example ./localnet/create.sh -b ./target/debug -n 1 -s y
 
-source ./localnet/common.sh
-
 # Parse command-line arguments
 while getopts "b:n:t:h" opt; do
   case $opt in
@@ -14,7 +12,7 @@ while getopts "b:n:t:h" opt; do
     n) NODE_COUNT=$OPTARG ;;
     t) START_TRACKER=$OPTARG ;;
     h) echo "Usage: ./localnet/create.sh -b <BINARY_ROOT_PATH> -n <NODE_COUNT> -t <START_TRACKER>"; exit 0 ;;
-    \?) echo "Invalid option -$OPTARG" >&2 ;;
+    \?) echo "Invalid option -$OPTARG" >&2 ; exit 0 ;;
   esac
 done
 if [[ -n "$NODE_COUNT" && "$NODE_COUNT" != "1" && "$NODE_COUNT" != "3" ]]; then
@@ -25,6 +23,8 @@ if [[ -n "$START_TRACKER" && "$START_TRACKER" != "y" && "$START_TRACKER" != "" ]
   echo "❌ Invalid START_TRACKER value: $START_TRACKER"
   exit 1
 fi
+
+source ./localnet/common.sh
 
 # Set default values if not provided
 export BINARY_ROOT_PATH=${BINARY_ROOT_PATH:-"./target/debug"}

--- a/localnet/recreate.sh
+++ b/localnet/recreate.sh
@@ -1,17 +1,40 @@
 #!/bin/bash
-## Stops the existing localnet and starts a new one using the same settings. 
-## The settings are saved in the settings.sh file in the tmp directory.
+## Stops the existing localnet (if running) and starts a new one using the same settings. 
+## The settings are saved in the settings.sh file in the tmp directory on creation of a localnet.
+## Use the -d flag to use default values if no settings file is found.
+
+# Parse arguments
+USE_DEFAULTS=false
+while getopts "dh" opt; do
+  case $opt in
+    d) USE_DEFAULTS=true;;
+    h) echo "Use -d to create with deafult values if no settings file is found"; exit 0;;
+    \?) echo "Invalid option -$OPTARG" >&2 ; exit 0 ;;
+  esac
+done
 
 source ./localnet/common.sh
 
-# Load the env vars that the last network used
+# Load the env vars that the last localnet used
 load_settings
+
+# Use default values or error if no settings file was found
 if [ -z "$NODE_COUNT" ] || [ -z "$BINARY_ROOT_PATH" ]; then
-  echo "❌ Error: no existing network to recreate. Please run the manage script first to build a network."
-  exit 1
+  if [ "$USE_DEFAULTS" = true ]; then
+    export BINARY_ROOT_PATH="./target/debug"
+    export NODE_COUNT="1-node"
+    export START_TRACKER="NO"
+    echo "No settings file found. Using default values:"
+    echo "BINARY_ROOT_PATH: $BINARY_ROOT_PATH"
+    echo "NODE_COUNT: $NODE_COUNT"
+    echo "START_TRACKER: $START_TRACKER"
+  else
+    echo "❌ Error: no settings file found. Use -d to create one with defaults, or you can create one using the create/manage scripts."
+    exit 1
+  fi
 fi
 
-# Destroy and start a new network
+# Destroy and start a new localnet
 destroy
 sleep 5
 build-localnet


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Added a "-d" option to the recreate localnet script that will cause it to use defaults if no settings file is found.
