### PR TITLE
feat: engine-runner verifies gpg signature of old dylib when downloaded

### DIFF
--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -5,7 +5,7 @@ on:
         default: release
         description: Profile to build
         type: string
-      is_mainnet:
+      is-mainnet:
         default: false
         description: Whether to build for mainnet (currently just for verifying dylibs)
         type: boolean
@@ -41,13 +41,13 @@ jobs:
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Import GPG key from Ubuntu key server 🔑
-        if: inputs.is_mainnet
+        if: inputs.is-mainnet
         run: |
           gpg --keyserver keyserver.ubuntu.com --recv-keys $CF_MAINNET_GPG_KEY_ID
           gpg --list-keys
 
       - name: Verify GPG key import ✅
-        if: inputs.is_mainnet
+        if: inputs.is-mainnet
         run: |
           gpg --list-keys | grep -q "$CF_MAINNET_GPG_KEY_ID"
           if [ $? -eq 0 ]; then
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build chainflip binaries 🏗️
         run: |
-          if [ "${{ inputs.is_mainnet }}" = "true" ]; then
+          if [ "${{ inputs.is-mainnet }}" = "true" ]; then
             export IS_MAINNET=true
           fi
           cargo cf-build-${{ inputs.profile }} --locked

--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -5,6 +5,10 @@ on:
         default: release
         description: Profile to build
         type: string
+      is_mainnet:
+        default: false
+        description: Whether to build for mainnet (currently just for verifying dylibs)
+        type: boolean
       upload-name:
         default: chainflip-backend-bin
         description: Name of the folder to upload the binaries to
@@ -17,6 +21,7 @@ on:
 env:
   FORCE_COLOR: 1
   COMMIT_HASH: ${{ github.sha }}
+  CF_MAINNET_GPG_KEY_ID: "4E506212E4EF4E0D3E37E568596FBDCACBBCDD37"
 
 jobs:
   compile:
@@ -35,9 +40,30 @@ jobs:
       - name: Configure Git 🛠️
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Import GPG key from Ubuntu key server 🔑
+        if: inputs.is_mainnet
+        run: |
+          gpg --keyserver keyserver.ubuntu.com --recv-keys $CF_MAINNET_GPG_KEY_ID
+          gpg --list-keys
+
+      - name: Verify GPG key import ✅
+        if: inputs.is_mainnet
+        run: |
+          gpg --list-keys | grep -q "$CF_MAINNET_GPG_KEY_ID"
+          if [ $? -eq 0 ]; then
+            echo "GPG key successfully imported"
+          else
+            echo "Failed to import GPG key"
+            exit 1
+          fi
+
       - name: Build chainflip binaries 🏗️
         run: |
+          if [ "${{ inputs.is_mainnet }}" = "true" ]; then
+            export IS_MAINNET=true
+          fi
           cargo cf-build-${{ inputs.profile }} --locked
+
 
       - name: ls directory
         run: |

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -3,7 +3,7 @@ name: Post build checks
 on:
   workflow_call:
     inputs:
-      full_bouncer:
+      full-bouncer:
         type: boolean
         default: false
       timeout-minutes:
@@ -122,7 +122,7 @@ jobs:
         run: python3 ./ci/scripts/get_ngrok_urls.py
 
       - name: Run HeuteLeiderNicht.voll.exe 🙅‍♂️
-        if: inputs.full_bouncer
+        if: inputs.full-bouncer
         working-directory: bouncer
         run: |
           ./full_bouncer.sh
@@ -130,7 +130,7 @@ jobs:
           ./commands/run_test.ts ./tests/delta_based_ingress.ts ./../ ./../localnet/init
 
       - name: Run HeuteLeiderNicht.einfach.exe 🦺
-        if: ${{ ! inputs.full_bouncer }}
+        if: ${{ ! inputs.full-bouncer }}
         working-directory: bouncer
         run: |
           ./run.sh

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full_bouncer: false
+      full-bouncer: false
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]

--- a/.github/workflows/ci-main-merge-queue.yml
+++ b/.github/workflows/ci-main-merge-queue.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full_bouncer: true
+      full-bouncer: true
 
   upgrade-check:
     needs: [build-try-runtime]

--- a/.github/workflows/release-berghain.yml
+++ b/.github/workflows/release-berghain.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       profile: "production"
       binary-subdir: "production"
+      is_mainnet: true
   build-m2:
     uses: ./.github/workflows/_21_build_m2.yml
     secrets: inherit

--- a/.github/workflows/release-berghain.yml
+++ b/.github/workflows/release-berghain.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       profile: "production"
       binary-subdir: "production"
-      is_mainnet: true
+      is-mainnet: true
   build-m2:
     uses: ./.github/workflows/_21_build_m2.yml
     secrets: inherit

--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full_bouncer: true
+      full-bouncer: true
   test-benchmarks:
     needs: [build-benchmarks]
     uses: ./.github/workflows/_41_test_benchmarks.yml

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -10,7 +10,6 @@ import { compileBinaries } from './utils/compile_binaries';
 import { submitRuntimeUpgradeWithRestrictions } from './submit_runtime_upgrade';
 import { execWithLog } from './utils/exec_with_log';
 import { submitGovernanceExtrinsic } from './cf_governance';
-import { setupLpAccount } from './setup_lp_account';
 
 async function readPackageTomlVersion(projectRoot: string): Promise<string> {
   const data = await fs.readFile(path.join(projectRoot, '/state-chain/runtime/Cargo.toml'), 'utf8');

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -351,9 +351,5 @@ export async function upgradeNetworkPrebuilt(
     await incompatibleUpgradeNoBuild(localnetInitPath, binariesPath, runtimePath, numberOfNodes);
   }
 
-  if (cleanOldVersion.startsWith('1.6')) {
-    await setupLpAccount('//LP_3');
-  }
-
   console.log('Upgrade complete.');
 }

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -31,10 +31,10 @@ assets = [
     # The old version gets put into target/release by the package github actions workflow.
     # It downloads the correct version from the releases page.
     [
-        "target/release/libchainflip_engine_v1_6_7.so",
+        "target/release/libchainflip_engine_v1_6_8.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_7.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_6_8.so",
         "755",
     ],
 ]

--- a/engine-runner-bin/build.rs
+++ b/engine-runner-bin/build.rs
@@ -1,13 +1,31 @@
-use std::{env, error::Error, fs::File, io::BufWriter, path::Path};
+#![feature(path_add_extension)]
+use std::{
+	env,
+	error::Error,
+	fs::File,
+	io::BufWriter,
+	path::{Path, PathBuf},
+	process::{Command, Stdio},
+};
 
 use engine_upgrade_utils::{
 	build_helpers::toml_with_package_version, ENGINE_LIB_PREFIX, NEW_VERSION, OLD_VERSION,
 };
 use reqwest::blocking::get;
 
-// TODO: Download from mainnet repo if it exists and verify signature.
-// TODO: If we're doing a release build we should force use mainnet binaries. PRO-1622
-fn download_old_dylib(dest_folder: &Path) -> Result<(), Box<dyn Error>> {
+fn download_file(download_url: String, dest: PathBuf) -> Result<(), Box<dyn Error>> {
+	let mut response: reqwest::blocking::Response = get(&download_url)?;
+
+	if response.status().is_success() {
+		let mut dest: BufWriter<File> = BufWriter::new(File::create(dest)?);
+		response.copy_to(&mut dest)?;
+		Ok(())
+	} else {
+		Err(Box::from(format!("Failed to download from {download_url}: {}", response.status())))
+	}
+}
+
+fn download_old_dylib(dest_folder: &Path, is_mainnet: bool) -> Result<(), Box<dyn Error>> {
 	let target: String = env::var("TARGET").unwrap();
 
 	let prebuilt_supported =
@@ -24,17 +42,30 @@ fn download_old_dylib(dest_folder: &Path) -> Result<(), Box<dyn Error>> {
 	// or added another commit on top then we get the latest build artifacts for a particular
 	// version.
 	if prebuilt_supported {
-		let download_url = format!("https://artifacts.chainflip.io/{OLD_VERSION}/{dylib_name}");
-		let mut response = get(&download_url)?;
+		let download_dylib = format!(
+			"https://{}.chainflip.io/{OLD_VERSION}/{dylib_name}",
+			if is_mainnet {
+				println!("Downloading from pkgs...");
+				"pkgs"
+			} else {
+				println!("Downloading from artifacts...");
+				"artifacts"
+			}
+		);
 
-		if response.status().is_success() {
-			std::fs::create_dir_all(dest_folder)?;
-			let mut dest: BufWriter<File> = BufWriter::new(File::create(dylib_location)?);
-			response.copy_to(&mut dest)?;
-			Ok(())
-		} else {
-			Err(Box::from(format!("Failed to download from {download_url}: {}", response.status())))
+		std::fs::create_dir_all(dest_folder)?;
+		download_file(download_dylib.clone(), dylib_location.clone())?;
+
+		// We want to download the sig file and verify the downloaded dylib only for mainnet.
+		if is_mainnet {
+			let mut dylib_sig_location = dylib_location.clone();
+			dylib_sig_location.add_extension("sig");
+
+			download_file(format!("{download_dylib}.sig"), dylib_sig_location.clone())?;
+			gpg_verify_signature(dylib_location, dylib_sig_location)?;
 		}
+
+		Ok(())
 	} else if dylib_location.exists() {
 		// They've already been built and moved to the correct folder, so we can continue the
 		// build.
@@ -43,6 +74,26 @@ fn download_old_dylib(dest_folder: &Path) -> Result<(), Box<dyn Error>> {
 		Err(Box::from(format!(
 				"Unsupported target {target} for downloading prebuilt shared libraries. You need to build from source and insert the shared libs into the target/debug or target/release folder.",
 			)))
+	}
+}
+
+// This is using the local gpg keystore.
+fn gpg_verify_signature(
+	dylib_location: PathBuf,
+	dylib_sig_location: PathBuf,
+) -> Result<(), Box<dyn Error>> {
+	if Command::new("gpg")
+		.arg("--verify")
+		.arg(dylib_sig_location)
+		.arg(dylib_location)
+		.stdout(Stdio::inherit())
+		.stderr(Stdio::inherit())
+		.status()?
+		.success()
+	{
+		Ok(())
+	} else {
+		Err(Box::from(format!("Failed to verify gpg signature")))
 	}
 }
 
@@ -59,7 +110,14 @@ fn main() {
 		.parent()
 		.unwrap(); // target/debug or target/release
 
-	download_old_dylib(build_dir).unwrap();
+	download_old_dylib(
+		build_dir,
+		match env::var("IS_MAINNET") {
+			Ok(val) => val.to_lowercase() == "true",
+			Err(_) => false, // Default to false
+		},
+	)
+	.unwrap();
 
 	let build_dir_str = build_dir.to_str().unwrap();
 

--- a/engine-runner-bin/build.rs
+++ b/engine-runner-bin/build.rs
@@ -93,7 +93,7 @@ fn gpg_verify_signature(
 	{
 		Ok(())
 	} else {
-		Err(Box::from(format!("Failed to verify gpg signature")))
+		Err(Box::from("Failed to verify gpg signature".to_string()))
 	}
 }
 

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -2,7 +2,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.6.7")]
+	#[engine_proc_macros::link_engine_library_version("1.6.8")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -10,7 +10,7 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.6.7";
+pub const OLD_VERSION: &str = "1.6.8";
 pub const NEW_VERSION: &str = "1.7.0";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";


### PR DESCRIPTION
# Pull Request

Closes: PRO-1622

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works. - I added the is_mainnet flag on ci-development to see it works and it did :). Also manually tested broken signatures and missing files to see that it fails correctly as well.
- [x] I have written sufficient tests. 
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

When the is_mainnet flag is `true` on the build job, the engine-runner will now download from the pgks.chainflip.io - which contain only the binaries built for mainnet. It will also verify the signature of these dylibs to ensure that the chainflip releaser has released them. 