### PR TITLE
feat: update custom_rpc, runtime_api and broker api for broker level screening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,12 +1617,14 @@ name = "chainflip-broker-api"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "cf-chains",
  "chainflip-api",
  "clap",
  "custom-rpc",
  "futures",
  "hex",
  "jsonrpsee 0.23.2",
+ "sc-rpc",
  "serde",
  "sp-core 34.0.0",
  "sp-rpc",
@@ -2547,6 +2549,7 @@ dependencies = [
  "jsonrpsee 0.23.2",
  "log",
  "pallet-cf-governance",
+ "pallet-cf-ingress-egress",
  "pallet-cf-pools",
  "pallet-cf-swapping",
  "pallet-cf-witnesser",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 
 [dependencies]
 chainflip-api = { workspace = true }
+cf-chains = { workspace = true, default-features = true }
 cf-utilities = { workspace = true, default-features = true }
 custom-rpc = { workspace = true }
 
@@ -34,6 +35,7 @@ jsonrpsee = { workspace = true, features = ["full"] }
 serde = { workspace = true, default-features = true, features = ["derive"] }
 sp-core = { workspace = true }
 sp-rpc = { workspace = true }
+sc-rpc = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -33,8 +33,8 @@ futures = { workspace = true }
 hex = { workspace = true, default-features = true }
 jsonrpsee = { workspace = true, features = ["full"] }
 serde = { workspace = true, default-features = true, features = ["derive"] }
-sp-core = { workspace = true }
-sp-rpc = { workspace = true }
+sp-core = { workspace = true, default-features = true }
+sp-rpc = { workspace = true, default-features = true }
 sc-rpc = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -12,8 +12,8 @@ use chainflip_api::{
 	},
 	settings::StateChain,
 	AccountId32, AddressString, BlockUpdate, BrokerApi, ChainApi, DepositMonitorApi, OperatorApi,
-	RefundParameters, SignedExtrinsicApi, StateChainApi, SwapDepositAddress,
-	SwapPayload, TransactionInId, WithdrawFeesDetail,
+	RefundParameters, SignedExtrinsicApi, StateChainApi, SwapDepositAddress, SwapPayload,
+	TransactionInId, WithdrawFeesDetail,
 };
 use clap::Parser;
 use custom_rpc::CustomApiClient;
@@ -269,7 +269,7 @@ impl RpcServer for RpcServerImpl {
 						// We only want to send a notification if there have been events.
 						// If other chains are added, they have to be considered here as
 						// well.
-						if events.btc_events.len() == 0 {
+						if events.btc_events.is_empty() {
 							continue;
 						}
 

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -10,8 +10,8 @@ use cf_chains::{
 	dot::PolkadotAccountId,
 	evm::to_evm_address,
 	sol::SolAddress,
-	CcmChannelMetadata, ChannelRefundParametersEncoded, ChannelRefundParametersGeneric,
-	ForeignChain, ForeignChainAddress,
+	CcmChannelMetadata, Chain, ChainCrypto, ChannelRefundParametersEncoded,
+	ChannelRefundParametersGeneric, ForeignChain, ForeignChainAddress,
 };
 pub use cf_primitives::{AccountRole, Affiliates, Asset, BasisPoints, ChannelId, SemVer};
 use cf_primitives::{AssetAmount, BlockNumber, DcaParameters, NetworkEnvironment};
@@ -32,7 +32,7 @@ pub mod primitives {
 	pub type RedemptionAmount = pallet_cf_funding::RedemptionAmount<FlipBalance>;
 	pub use cf_chains::{
 		address::{EncodedAddress, ForeignChainAddress},
-		CcmChannelMetadata, CcmDepositMetadata,
+		CcmChannelMetadata, CcmDepositMetadata, Chain, ChainCrypto,
 	};
 }
 pub use cf_chains::eth::Address as EthereumAddress;
@@ -621,17 +621,28 @@ pub fn clean_foreign_chain_address(chain: ForeignChain, address: &str) -> Result
 	})
 }
 
+pub type TransactionInIdFor<C> = <<C as Chain>::ChainCrypto as ChainCrypto>::TransactionInId;
+
+#[derive(Serialize, Deserialize)]
+pub enum TransactionInId {
+	Bitcoin(TransactionInIdFor<cf_chains::Bitcoin>),
+	// other variants reserved for other chains.
+}
+
 #[async_trait]
 pub trait DepositMonitorApi:
 	SignedExtrinsicApi + StorageApi + Sized + Send + Sync + 'static
 {
-	async fn mark_btc_transaction_as_tainted(&self, tx_id: cf_chains::btc::Hash) -> Result<()> {
-		let _ = self
-			.submit_signed_extrinsic(state_chain_runtime::RuntimeCall::BitcoinIngressEgress(
-				pallet_cf_ingress_egress::Call::mark_transaction_as_tainted { tx_id },
-			))
-			.await;
-		Ok(())
+	async fn mark_transaction_as_tainted(&self, tx_id: TransactionInId) -> Result<H256> {
+		match tx_id {
+			TransactionInId::Bitcoin(tx_id) =>
+				self.simple_submission_with_dry_run(
+					state_chain_runtime::RuntimeCall::BitcoinIngressEgress(
+						pallet_cf_ingress_egress::Call::mark_transaction_as_tainted { tx_id },
+					),
+				)
+				.await,
+		}
 	}
 }
 

--- a/state-chain/custom-rpc/Cargo.toml
+++ b/state-chain/custom-rpc/Cargo.toml
@@ -29,6 +29,7 @@ pallet-cf-governance = { workspace = true, default-features = true }
 pallet-cf-pools = { workspace = true, default-features = true }
 pallet-cf-witnesser = { workspace = true, default-features = true }
 pallet-cf-swapping = { workspace = true, default-features = true }
+pallet-cf-ingress-egress = { workspace = true, default-features = true }
 
 sp-api = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -964,6 +964,12 @@ pub trait CustomApi {
 
 	#[subscription(name = "subscribe_tainted_transaction_events", item = BlockUpdate<TaintedTransactionEvents>)]
 	async fn cf_subscribe_tainted_transaction_events(&self);
+
+	#[method(name = "get_tainted_transaction_events")]
+	fn cf_get_tainted_transaction_events(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<TaintedTransactionEvents>;
 }
 
 /// An RPC extension for the state chain node.
@@ -1766,6 +1772,13 @@ where
 			|client, hash| Ok(client.runtime_api().cf_tainted_transaction_events(hash)?),
 		)
 		.await
+	}
+
+	fn cf_get_tainted_transaction_events(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<TaintedTransactionEvents> {
+		self.with_runtime_api(at, |api, hash| api.cf_tainted_transaction_events(hash))
 	}
 }
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -962,9 +962,6 @@ pub trait CustomApi {
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<ChainAccounts>;
 
-	#[subscription(name = "subscribe_tainted_transaction_events", item = BlockUpdate<TaintedTransactionEvents>)]
-	async fn cf_subscribe_tainted_transaction_events(&self);
-
 	#[method(name = "get_tainted_transaction_events")]
 	fn cf_get_tainted_transaction_events(
 		&self,
@@ -1759,19 +1756,6 @@ where
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<u8>> {
 		self.with_runtime_api(at, |api, hash| api.cf_filter_votes(hash, validator, proposed_votes))
-	}
-
-	async fn cf_subscribe_tainted_transaction_events(
-		&self,
-		sink: jsonrpsee::PendingSubscriptionSink,
-	) {
-		self.new_subscription(
-			true, /* only_on_changes */
-			true, /* end_on_error */
-			sink,
-			|client, hash| Ok(client.runtime_api().cf_tainted_transaction_events(hash)?),
-		)
-		.await
 	}
 
 	fn cf_get_tainted_transaction_events(

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2104,8 +2104,7 @@ impl_runtime_apis! {
 		}
 
 		fn cf_get_open_deposit_channels(account_id: Option<AccountId>) -> ChainAccounts {
-			let btc_chain_accounts = pallet_cf_ingress_egress::DepositChannelLookup::<Runtime,BitcoinInstance>::iter()
-				.map(|(_, value)| value)
+			let btc_chain_accounts = pallet_cf_ingress_egress::DepositChannelLookup::<Runtime,BitcoinInstance>::iter_values()
 				.filter(|channel_details| account_id.is_none() || Some(&channel_details.owner) == account_id.as_ref())
 				.map(|channel_details| channel_details.deposit_channel.address)
 				.collect::<Vec<_>>();
@@ -2124,7 +2123,7 @@ impl_runtime_apis! {
 						pallet_cf_ingress_egress::Event::TaintedTransactionReportReceived{ account_id, tx_id, expires_at: _ } =>
 							Some(TaintedTransactionEvent::TaintedTransactionReportReceived{account_id, tx_id }),
 						pallet_cf_ingress_egress::Event::TaintedTransactionRejected{ broadcast_id, tx_id } =>
-							Some(TaintedTransactionEvent::TaintedTransactionRejected{ broadcast_id, tx_id: tx_id.id.tx_id }),
+							Some(TaintedTransactionEvent::TaintedTransactionRejected{ refund_broadcast_id: broadcast_id, tx_id: tx_id.id.tx_id }),
 						_ => None,
 					}
 				} else {

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2107,11 +2107,6 @@ impl_runtime_apis! {
 			let btc_chain_accounts = pallet_cf_ingress_egress::DepositChannelLookup::<Runtime,BitcoinInstance>::iter()
 				.map(|(_, value)| value)
 				.filter(|channel_details| account_id.is_none() || Some(&channel_details.owner) == account_id.as_ref())
-				.filter(|channel_details| match channel_details.action {
-					ChannelAction::Swap {..} => true,
-					ChannelAction::CcmTransfer {..} => true,
-					ChannelAction::LiquidityProvision {..} => false,
-				})
 				.map(|channel_details| channel_details.deposit_channel.address)
 				.collect::<Vec<_>>();
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -4,7 +4,8 @@ use cf_amm::{
 	range_orders::Liquidity,
 };
 use cf_chains::{
-	assets::any::AssetMap, eth::Address as EthereumAddress, Chain, ForeignChainAddress,
+	self, assets::any::AssetMap, eth::Address as EthereumAddress, Chain, ChainCrypto,
+	ForeignChainAddress,
 };
 use cf_primitives::{
 	AccountRole, Asset, AssetAmount, BlockNumber, BroadcastId, EpochIndex, FlipBalance,
@@ -183,22 +184,37 @@ pub struct FailingWitnessValidators {
 	pub validators: Vec<(cf_primitives::AccountId, String, bool)>,
 }
 
+type ChainAccountFor<C> = <C as Chain>::ChainAccount;
+
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
-pub enum TaintedBtcTransactionEvent {
+pub struct ChainAccounts {
+	pub btc_chain_accounts: Vec<ChainAccountFor<cf_chains::Bitcoin>>,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
+pub enum TaintedTransactionEvent<TxId> {
 	TaintedTransactionReportReceived {
 		account_id: <Runtime as frame_system::Config>::AccountId,
-		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+		tx_id: TxId,
 	},
 
 	TaintedTransactionReportExpired {
 		account_id: <Runtime as frame_system::Config>::AccountId,
-		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+		tx_id: TxId,
 	},
 
 	TaintedTransactionRejected {
 		broadcast_id: BroadcastId,
-		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+		tx_id: TxId,
 	},
+}
+
+type TaintedTransactionEventFor<C> =
+	TaintedTransactionEvent<<<C as Chain>::ChainCrypto as ChainCrypto>::TransactionInId>;
+
+#[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
+pub struct TaintedTransactionEvents {
+	pub btc_events: Vec<TaintedTransactionEventFor<cf_chains::Bitcoin>>,
 }
 
 decl_runtime_apis!(
@@ -324,13 +340,8 @@ decl_runtime_apis!(
 			chunk_interval: u32,
 		) -> Result<(), DispatchErrorWithMessage>;
 		fn cf_validate_refund_params(retry_duration: u32) -> Result<(), DispatchErrorWithMessage>;
-		fn cf_open_btc_deposit_channels(
-			account_id: AccountId32,
-		) -> Result<
-			Vec<<cf_chains::Bitcoin as cf_chains::Chain>::ChainAccount>,
-			DispatchErrorWithMessage,
-		>;
-		fn cf_tainted_btc_transaction_events() -> Vec<TaintedBtcTransactionEvent>;
+		fn cf_get_open_deposit_channels(account_id: Option<AccountId32>) -> ChainAccounts;
+		fn cf_tainted_transaction_events() -> TaintedTransactionEvents;
 	}
 );
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -183,6 +183,24 @@ pub struct FailingWitnessValidators {
 	pub validators: Vec<(cf_primitives::AccountId, String, bool)>,
 }
 
+#[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
+pub enum TaintedBtcTransactionEvent {
+	TaintedTransactionReportReceived {
+		account_id: <Runtime as frame_system::Config>::AccountId,
+		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+	},
+
+	TaintedTransactionReportExpired {
+		account_id: <Runtime as frame_system::Config>::AccountId,
+		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+	},
+
+	TaintedTransactionRejected {
+		broadcast_id: BroadcastId,
+		tx_id: <<cf_chains::Bitcoin as cf_chains::Chain>::ChainCrypto as cf_chains::ChainCrypto>::TransactionInId,
+	},
+}
+
 decl_runtime_apis!(
 	/// Definition for all runtime API interfaces.
 	pub trait CustomRuntimeApi {
@@ -306,6 +324,13 @@ decl_runtime_apis!(
 			chunk_interval: u32,
 		) -> Result<(), DispatchErrorWithMessage>;
 		fn cf_validate_refund_params(retry_duration: u32) -> Result<(), DispatchErrorWithMessage>;
+		fn cf_open_btc_deposit_channels(
+			account_id: AccountId32,
+		) -> Result<
+			Vec<<cf_chains::Bitcoin as cf_chains::Chain>::ChainAccount>,
+			DispatchErrorWithMessage,
+		>;
+		fn cf_tainted_btc_transaction_events() -> Vec<TaintedBtcTransactionEvent>;
 	}
 );
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -204,7 +204,7 @@ pub enum TaintedTransactionEvent<TxId> {
 	},
 
 	TaintedTransactionRejected {
-		broadcast_id: BroadcastId,
+		refund_broadcast_id: BroadcastId,
 		tx_id: TxId,
 	},
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1706

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

In this PR all changes to the broker API which are required for broker level screening are going to be merged. Currently based on @Janislav 's PR ~~(https://github.com/chainflip-io/chainflip-backend/pull/5310)~~ (https://github.com/chainflip-io/chainflip-backend/pull/5332) which implements the extrinsic for rejecting transactions.

Once that PR is merged, rebase this on main.

This PR includes the following changes:
 - Add new methods to `custom_rpc`:
     - `cf_get_tainted_transaction_events` which gets all events (for a given block) related with tainted transactions occuring in the ingress egress pallet.
     - `cf_get_open_deposit_channels` which returns all open channel addresses for a given account id.
 - These methods forward to corresponding implementations in the runtime api.
 - Changes to the broker API:
     - Add `mark_transaction_as_tainted` endpoint which submits the corresponding extrinsic.
     - Add `get_open_deposit_channels` method. 
     - Add `subscribe_tainted_btc_transaction_events` method which creates a subscription for calling the `cf_get_tainted_transaction_events` custom rpc method.
#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
