### PR TITLE
chore: consistent naming prewitnessed

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -769,7 +769,7 @@ pub mod pallet {
 		/// Unsupported chain
 		UnsupportedChain,
 		/// Transaction cannot be reported after being pre-witnessed or boosted.
-		TransactionAlreadyPreWitnessed,
+		TransactionAlreadyPrewitnessed,
 	}
 
 	#[pallet::hooks]
@@ -1372,7 +1372,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			const UNSEEN: TaintedTransactionStatus = TaintedTransactionStatus::Unseen;
 			ensure!(
 				opt.replace(UNSEEN).unwrap_or_default() == UNSEEN,
-				Error::<T, I>::TransactionAlreadyPreWitnessed
+				Error::<T, I>::TransactionAlreadyPrewitnessed
 			);
 			Ok::<_, DispatchError>(())
 		})?;

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -2121,7 +2121,7 @@ fn finalize_boosted_tx_if_tainted_after_prewitness() {
 
 		assert_noop!(
 			IngressEgress::mark_transaction_as_tainted(OriginTrait::signed(BROKER), tx_id.clone(),),
-			crate::Error::<Test, ()>::TransactionAlreadyPreWitnessed
+			crate::Error::<Test, ()>::TransactionAlreadyPrewitnessed
 		);
 
 		assert_ok!(IngressEgress::process_single_deposit(
@@ -2242,11 +2242,11 @@ fn can_not_report_transaction_after_witnessing() {
 		);
 		assert_noop!(
 			IngressEgress::mark_transaction_as_tainted(OriginTrait::signed(BROKER), prewitnessed,),
-			crate::Error::<Test, ()>::TransactionAlreadyPreWitnessed
+			crate::Error::<Test, ()>::TransactionAlreadyPrewitnessed
 		);
 		assert_noop!(
 			IngressEgress::mark_transaction_as_tainted(OriginTrait::signed(BROKER), boosted,),
-			crate::Error::<Test, ()>::TransactionAlreadyPreWitnessed
+			crate::Error::<Test, ()>::TransactionAlreadyPrewitnessed
 		);
 	});
 }


### PR DESCRIPTION
Everywhere else we treat "prewitnessed as one word" so making it consistent.