### PR TITLE
fix: ignore dust underflows in order fills rpc

### DIFF
--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -66,7 +66,17 @@ fn order_fills_for_pool<'a>(
 						if let Some((previous_collected, _)) = option_previous_order_state {
 							(
 								collected.fees - previous_collected.fees,
-								collected.sold_amount - previous_collected.sold_amount,
+								collected
+									.sold_amount
+									.checked_sub(previous_collected.sold_amount)
+									.unwrap_or_else(|| {
+										log::info!(
+															"Ignored dust sold_amount underflow. Current: {}, Previous: {}",
+															collected.sold_amount,
+															previous_collected.sold_amount
+														);
+										0.into()
+									}),
 								collected.bought_amount - previous_collected.bought_amount,
 							)
 						} else {


### PR DESCRIPTION
chore: more consistent params

This was causing lp apis to crash, we avoid it by saturating the calculation. 