### PR TITLE
fix: remove is_vote_valid

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -7,7 +7,7 @@ use sp_std::vec::Vec;
 
 use crate::{
 	vote_storage::{AuthorityVote, VoteStorage},
-	CorruptStorageError, ElectionIdentifier,
+	CorruptStorageError, ElectionIdentifier, SharedDataHash,
 };
 
 pub struct ConsensusVote<ES: ElectoralSystem> {
@@ -238,6 +238,7 @@ mod access {
 	//! correct ElectoralSystem implementation.
 
 	use super::{CorruptStorageError, ElectionIdentifierOf, ElectoralSystem};
+	use crate::{vote_storage::VoteStorage, SharedDataHash};
 
 	/// Represents the current consensus, and how it has changed since it was last checked (i.e.
 	/// 'check_consensus' was called).
@@ -311,6 +312,12 @@ mod access {
 		fn state(
 			&self,
 		) -> Result<<Self::ElectoralSystem as ElectoralSystem>::ElectionState, CorruptStorageError>;
+
+		fn shared_data_hash_of(
+			&self,
+			data: <<Self::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData,
+		) -> SharedDataHash;
+
 		#[cfg(test)]
 		fn election_identifier(
 			&self,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -52,6 +52,7 @@ macro_rules! generate_electoral_system_tuple_impls {
             };
 
             use crate::{
+                SharedDataHash,
                 CorruptStorageError,
                 electoral_system::{
                     ElectoralSystem,
@@ -72,7 +73,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 },
                 ElectionIdentifier,
             };
-            use crate::vote_storage::composite::$module::{CompositeVoteProperties, CompositeVote, CompositePartialVote};
+            use crate::vote_storage::composite::$module::{CompositeVoteProperties, CompositeVote, CompositePartialVote, CompositeSharedData};
 
             use frame_support::{Parameter, pallet_prelude::{Member, MaybeSerializeDeserialize}};
 
@@ -440,6 +441,12 @@ macro_rules! generate_electoral_system_tuple_impls {
                     _ => Err(CorruptStorageError::new())
                 }
             }
+
+            // TODO: Push this into lower level
+            fn shared_data_hash_of(&self, data: <<Self::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData) -> SharedDataHash {
+                SharedDataHash::of(&CompositeSharedData::<$(<<$electoral_system as ElectoralSystem>::Vote as VoteStorage>::SharedData),*>::$current(data))
+            }
+
             #[cfg(test)]
             fn election_identifier(&self) -> Result<ElectionIdentifierOf<Self::ElectoralSystem>, CorruptStorageError> {
                 let composite_identifier = self.ea.borrow().election_identifier()?;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -52,7 +52,6 @@ macro_rules! generate_electoral_system_tuple_impls {
             };
 
             use crate::{
-                SharedDataHash,
                 CorruptStorageError,
                 electoral_system::{
                     ElectoralSystem,
@@ -73,7 +72,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 },
                 ElectionIdentifier,
             };
-            use crate::vote_storage::composite::$module::{CompositeVoteProperties, CompositeVote, CompositePartialVote, CompositeSharedData};
+            use crate::vote_storage::composite::$module::{CompositeVoteProperties, CompositeVote, CompositePartialVote};
 
             use frame_support::{Parameter, pallet_prelude::{Member, MaybeSerializeDeserialize}};
 
@@ -264,22 +263,6 @@ macro_rules! generate_electoral_system_tuple_impls {
                     }
                 }
 
-
-                fn is_vote_valid<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
-                    election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
-                    election_access: &ElectionAccess,
-                    partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
-                ) -> Result<bool, CorruptStorageError> {
-                    Ok(match (*election_identifier.extra(), partial_vote) {
-                        $((CompositeElectionIdentifierExtra::$electoral_system(extra), CompositePartialVote::$electoral_system(partial_vote)) => <$electoral_system as ElectoralSystem>::is_vote_valid(
-                            election_identifier.with_extra(extra),
-                            &CompositeElectionAccess::<tags::$electoral_system, _, ElectionAccess>::new(election_access),
-                            partial_vote,
-                        )?,)*
-                        _ => false,
-                    })
-                }
-
                 fn generate_vote_properties(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
                     previous_vote: Option<(
@@ -440,11 +423,6 @@ macro_rules! generate_electoral_system_tuple_impls {
                     },
                     _ => Err(CorruptStorageError::new())
                 }
-            }
-
-            // TODO: Push this into lower level
-            fn shared_data_hash_of(&self, data: <<Self::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData) -> SharedDataHash {
-                SharedDataHash::of(&CompositeSharedData::<$(<<$electoral_system as ElectoralSystem>::Vote as VoteStorage>::SharedData),*>::$current(data))
             }
 
             #[cfg(test)]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -193,12 +193,4 @@ impl ElectoralSystem for MockElectoralSystem {
 	) -> bool {
 		Self::vote_needed()
 	}
-
-	fn is_vote_valid<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
-		_election_identifier: crate::electoral_system::ElectionIdentifierOf<Self>,
-		_election_access: &ElectionAccess,
-		_partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
-	) -> Result<bool, CorruptStorageError> {
-		Ok(Self::vote_valid())
-	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -6,7 +6,6 @@ use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 
 pub mod access;
 
-use crate::{vote_storage::VoteStorage, CorruptStorageError};
 pub use access::*;
 use itertools::Itertools;
 
@@ -216,13 +215,6 @@ impl<ES: ElectoralSystem> TestContext<ES> {
 			check.check(&pre_finalize, &post_finalize);
 		}
 		self
-	}
-
-	pub fn is_vote_valid(
-		&self,
-		partial_vote: &<ES::Vote as VoteStorage>::PartialVote,
-	) -> Result<bool, CorruptStorageError> {
-		self.electoral_access.is_vote_valid(self.only_election_id(), partial_vote)
 	}
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -3,7 +3,6 @@ use crate::{
 		ConsensusStatus, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
 		ElectionWriteAccess, ElectoralReadAccess, ElectoralSystem, ElectoralWriteAccess,
 	},
-	vote_storage::VoteStorage,
 	CorruptStorageError, ElectionIdentifier, UniqueMonotonicIdentifier,
 };
 use codec::Encode;
@@ -203,14 +202,6 @@ impl<ES: ElectoralSystem> MockAccess<ES> {
 
 	pub fn next_umi(&self) -> UniqueMonotonicIdentifier {
 		self.next_election_id
-	}
-
-	pub fn is_vote_valid(
-		&self,
-		election_identifier: ElectionIdentifierOf<ES>,
-		partial_vote: &<ES::Vote as VoteStorage>::PartialVote,
-	) -> Result<bool, CorruptStorageError> {
-		ES::is_vote_valid(election_identifier, &self.election(election_identifier)?, partial_vote)
 	}
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
@@ -101,7 +101,8 @@ impl<
 		),
 	) -> bool {
 		match current_vote {
-			AuthorityVoteOf::<Self>::Vote(current_vote) => current_vote != proposed_vote,
+			AuthorityVoteOf::<Self>::Vote(current_vote) =>
+				current_vote.value != proposed_vote.value,
 			// Could argue for either true or false. If the `PartialVote` is never reconstructed and
 			// becomes invalid, then this function will be bypassed and the vote will be considered
 			// needed. So false is safe, and true will likely result in unneeded voting.

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
@@ -167,7 +167,7 @@ impl<
 				monotonic_change_vote.block > previous_block &&
 					previous_value != monotonic_change_vote.value
 			}) {
-				counts.entry(vote.value).or_insert_with(Vec::new).push(vote.block);
+				counts.entry(vote.value).or_default().push(vote.block);
 			}
 
 			counts.iter().find_map(|(vote, blocks_height)| {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
@@ -115,7 +115,7 @@ impl<
 		partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
 	) -> Result<bool, CorruptStorageError> {
 		let (_, previous_value, previous_slot) = election_access.properties()?;
-		Ok(partial_vote.value != SharedDataHash::of(&previous_value) &&
+		Ok(partial_vote.value != election_access.shared_data_hash_of(previous_value) &&
 			partial_vote.block > previous_slot)
 	}
 	fn generate_vote_properties(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_change.rs
@@ -81,7 +81,6 @@ fn generate_votes_with_different_slots(
 	incorrect_value: MonotonicChangeVote<Value, Slot>,
 ) -> ConsensusVotes<SimpleMonotonicChange> {
 	ConsensusVotes {
-		// we start from 1 so don't get a Default::default() conflict on vote validity.
 		votes: (0..correct_voters)
 			.enumerate()
 			.map(|(index, _)| ConsensusVote {

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -637,12 +637,6 @@ pub mod pallet {
 				ElectionState::<T, I>::get(self.unique_monotonic_identifier())
 					.ok_or_else(CorruptStorageError::new)
 			}
-			fn shared_data_hash_of(
-				&self,
-				shared_data: <<T::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData,
-			) -> SharedDataHash {
-				todo!()
-			}
 			#[cfg(test)]
 			fn election_identifier(
 				&self,
@@ -1282,19 +1276,6 @@ pub mod pallet {
 						)
 					},
 				};
-
-				ensure!(
-					Self::with_electoral_access(
-						|electoral_access| -> Result<_, CorruptStorageError> {
-							<T::ElectoralSystem as ElectoralSystem>::is_vote_valid(
-								election_identifier,
-								&electoral_access.election(election_identifier)?,
-								&partial_vote,
-							)
-						}
-					)?,
-					Error::<T, I>::InvalidVote
-				);
 
 				Self::handle_corrupt_storage(Self::take_vote_and_then(
 					epoch_index,

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -637,6 +637,12 @@ pub mod pallet {
 				ElectionState::<T, I>::get(self.unique_monotonic_identifier())
 					.ok_or_else(CorruptStorageError::new)
 			}
+			fn shared_data_hash_of(
+				&self,
+				shared_data: <<T::ElectoralSystem as ElectoralSystem>::Vote as VoteStorage>::SharedData,
+			) -> SharedDataHash {
+				todo!()
+			}
 			#[cfg(test)]
 			fn election_identifier(
 				&self,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1757

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

`is_vote_valid` was only used once, and was used erroneously. Plus, if a single vote within a group is invalid then the whole extrinsic vails, effectively invalidating all the votes. We have is_vote_needed to prevent engines from submitting too many votes. So have removed it, which simplifies things too. No need to hash the data at all, we can compare the values directly in check_consensus.
