### PR TITLE
chore: rename ElectoralSystemStatus -> ElectionPalletStatus

### DIFF
--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -124,7 +124,7 @@ mod benchmarks {
 
 		T::EpochInfo::add_authority_info_for_epoch(epoch, vec![validator_id.clone()]);
 
-		Status::<T, I>::put(ElectoralSystemStatus::Running);
+		Status::<T, I>::put(ElectionPalletStatus::Running);
 
 		#[extrinsic_call]
 		stop_ignoring_my_votes(RawOrigin::Signed(caller));
@@ -141,7 +141,7 @@ mod benchmarks {
 
 		T::EpochInfo::add_authority_info_for_epoch(epoch, vec![validator_id.clone()]);
 
-		Status::<T, I>::put(ElectoralSystemStatus::Running);
+		Status::<T, I>::put(ElectionPalletStatus::Running);
 
 		assert!(
 			!ContributingAuthorities::<T, I>::contains_key(validator_id.clone()),
@@ -274,7 +274,7 @@ mod benchmarks {
 		assert!(ElectoralUnsynchronisedState::<T, I>::get().is_some());
 		assert!(ElectoralUnsynchronisedSettings::<T, I>::get().is_some());
 		assert!(ElectoralSettings::<T, I>::get(NextElectionIdentifier::<T, I>::get()).is_some());
-		assert_eq!(Status::<T, I>::get(), Some(ElectoralSystemStatus::Running));
+		assert_eq!(Status::<T, I>::get(), Some(ElectionPalletStatus::Running));
 	}
 
 	#[benchmark]
@@ -403,7 +403,7 @@ mod benchmarks {
 		// Ensure elections are paused
 		assert_eq!(
 			Status::<T, I>::get(),
-			Some(ElectoralSystemStatus::Paused { detected_corrupt_storage: false })
+			Some(ElectionPalletStatus::Paused { detected_corrupt_storage: false })
 		);
 	}
 
@@ -416,7 +416,7 @@ mod benchmarks {
 			.dispatch_bypass_filter(T::EnsureGovernance::try_successful_origin().unwrap()));
 		assert_eq!(
 			Status::<T, I>::get(),
-			Some(ElectoralSystemStatus::Paused { detected_corrupt_storage: false })
+			Some(ElectionPalletStatus::Paused { detected_corrupt_storage: false })
 		);
 		assert_ok!(Call::<T, I>::clear_all_votes {
 			limit: 100u32,
@@ -434,7 +434,7 @@ mod benchmarks {
 		}
 
 		// Ensure elections are unpaused
-		assert_eq!(Status::<T, I>::get(), Some(ElectoralSystemStatus::Running));
+		assert_eq!(Status::<T, I>::get(), Some(ElectionPalletStatus::Running));
 	}
 
 	#[benchmark]
@@ -444,7 +444,7 @@ mod benchmarks {
 		// Pause the election, and set corrupt storage to `true`
 		assert_ok!(Call::<T, I>::pause_elections {}
 			.dispatch_bypass_filter(T::EnsureGovernance::try_successful_origin().unwrap()));
-		Status::<T, I>::put(ElectoralSystemStatus::Paused { detected_corrupt_storage: true });
+		Status::<T, I>::put(ElectionPalletStatus::Paused { detected_corrupt_storage: true });
 
 		let call = Call::<T, I>::validate_storage {};
 
@@ -457,7 +457,7 @@ mod benchmarks {
 
 		assert_eq!(
 			Status::<T, I>::get(),
-			Some(ElectoralSystemStatus::Paused { detected_corrupt_storage: false })
+			Some(ElectionPalletStatus::Paused { detected_corrupt_storage: false })
 		);
 	}
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -285,7 +285,7 @@ pub mod pallet {
 	pub use corrupt_storage_error::CorruptStorageError;
 
 	#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, TypeInfo)]
-	pub enum ElectoralSystemStatus {
+	pub enum ElectionPalletStatus {
 		Paused { detected_corrupt_storage: bool },
 		Running,
 	}
@@ -578,7 +578,7 @@ pub mod pallet {
 	/// this is None, the pallet is considered uninitialized.
 	#[pallet::storage]
 	pub type Status<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, ElectoralSystemStatus, OptionQuery>;
+		StorageValue<_, ElectionPalletStatus, OptionQuery>;
 
 	// ---------------------------------------------------------------------------------------- //
 
@@ -1493,9 +1493,9 @@ pub mod pallet {
 			T::EnsureGovernance::ensure_origin(origin)?;
 			match Status::<T, I>::get() {
 				None => Err(Error::<T, I>::Uninitialized.into()),
-				Some(ElectoralSystemStatus::Paused { .. }) => Err(Error::<T, I>::Paused.into()),
+				Some(ElectionPalletStatus::Paused { .. }) => Err(Error::<T, I>::Paused.into()),
 				Some(_) => {
-					Status::<T, I>::put(ElectoralSystemStatus::Paused {
+					Status::<T, I>::put(ElectionPalletStatus::Paused {
 						detected_corrupt_storage: false,
 					});
 					Ok(())
@@ -1512,9 +1512,9 @@ pub mod pallet {
 			T::EnsureGovernance::ensure_origin(origin)?;
 			match Status::<T, I>::get() {
 				None => Err(Error::<T, I>::Uninitialized.into()),
-				Some(ElectoralSystemStatus::Paused { detected_corrupt_storage: true }) =>
+				Some(ElectionPalletStatus::Paused { detected_corrupt_storage: true }) =>
 					Err(Error::<T, I>::CorruptStorage.into()),
-				Some(ElectoralSystemStatus::Paused { .. }) => {
+				Some(ElectionPalletStatus::Paused { .. }) => {
 					ensure!(
 						!require_votes_cleared ||
 							(SharedDataReferenceCount::<T, I>::iter_keys().next().is_none() &&
@@ -1526,7 +1526,7 @@ pub mod pallet {
 									.is_none()),
 						Error::<T, I>::VotesNotCleared
 					);
-					Status::<T, I>::put(ElectoralSystemStatus::Running);
+					Status::<T, I>::put(ElectionPalletStatus::Running);
 					Ok(())
 				},
 				Some(_) => Err(Error::<T, I>::NotPaused.into()),
@@ -1576,8 +1576,8 @@ pub mod pallet {
 			T::EnsureGovernance::ensure_origin(origin)?;
 			match Status::<T, I>::get() {
 				None => Err(Error::<T, I>::Uninitialized.into()),
-				Some(ElectoralSystemStatus::Paused { .. }) => {
-					Status::<T, I>::put(ElectoralSystemStatus::Paused {
+				Some(ElectionPalletStatus::Paused { .. }) => {
+					Status::<T, I>::put(ElectionPalletStatus::Paused {
 						detected_corrupt_storage: false,
 					});
 					Ok(())
@@ -1594,11 +1594,11 @@ pub mod pallet {
 		fn on_finalize(block_number: BlockNumberFor<T>) {
 			if let Some(status) = Status::<T, I>::get() {
 				match status {
-					ElectoralSystemStatus::Paused { detected_corrupt_storage } =>
+					ElectionPalletStatus::Paused { detected_corrupt_storage } =>
 						if detected_corrupt_storage {
 							Self::deposit_event(Event::<T, I>::CorruptStorage);
 						},
-					ElectoralSystemStatus::Running => {
+					ElectionPalletStatus::Running => {
 						let _ = Self::with_electoral_access_and_identifiers(
 							|electoral_access, election_identifiers| {
 								if Into::<sp_core::U256>::into(block_number) %
@@ -1685,7 +1685,7 @@ pub mod pallet {
 				NextElectionIdentifier::<T, I>::get(),
 				initial_state.settings,
 			);
-			Status::<T, I>::put(ElectoralSystemStatus::Running);
+			Status::<T, I>::put(ElectionPalletStatus::Running);
 			Ok(())
 		}
 
@@ -2056,7 +2056,7 @@ pub mod pallet {
 			let authority_index = T::EpochInfo::authority_index(epoch_index, &validator_id);
 			ensure!(authority_index.is_some(), Error::<T, I>::Unauthorised);
 			ensure!(
-				matches!(Status::<T, I>::get(), Some(ElectoralSystemStatus::Running)),
+				matches!(Status::<T, I>::get(), Some(ElectionPalletStatus::Running)),
 				Error::<T, I>::Paused
 			);
 			Ok((epoch_index, validator_id, authority_index.unwrap()))
@@ -2070,7 +2070,7 @@ pub mod pallet {
 				ensure!(
 					!matches!(
 						status,
-						ElectoralSystemStatus::Paused { detected_corrupt_storage: true }
+						ElectionPalletStatus::Paused { detected_corrupt_storage: true }
 					) || matches!(ignore_corrupt_storage, CorruptStorageAdherance::Ignore),
 					Error::<T, I>::CorruptStorage
 				);
@@ -2096,7 +2096,7 @@ pub mod pallet {
 				Ok(ok) => Ok(ok),
 				Err(_) => {
 					Self::deposit_event(Event::<T, I>::CorruptStorage);
-					Status::<T, I>::put(ElectoralSystemStatus::Paused {
+					Status::<T, I>::put(ElectionPalletStatus::Paused {
 						detected_corrupt_storage: true,
 					});
 					Err(Error::<T, I>::CorruptStorage)

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -151,7 +151,7 @@ impl ElectoralSystemTestExt for TestRunner<TestContext> {
 					.expect("New election should have an identifier.")
 					.unique_monotonic();
 
-				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectoralSystemStatus::Running));
+				assert_eq!(Status::<Test, Instance1>::get(), Some(ElectionPalletStatus::Running));
 
 				Pallet::<Test, Instance1>::with_electoral_access(|electoral_access| {
 					electoral_access


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

It's not the ElectoralSystemStatus at all... is a recipe for confusion, so renaming.
