### PR TITLE
chore: better not contributing error message

### DIFF
--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -240,7 +240,9 @@ where
 							}
 						}
 					} else {
-						return Err(anyhow!("Validator as been unexpectedly set as not contributing."));
+						// We expect this to happen when a validator joins the set, since they won't be contributing, but will be a validator.
+						// Therefore they get Some() from `electoral_data` but `contributing` is false, until we reset the voting by throwing an error here.
+						return Err(anyhow!("Validator has just joined the authority set, or has been unexpectedly set as not contributing."));
 					}
 				} else {
 					info!("Not voting as not an authority.");


### PR DESCRIPTION
# Pull Request

Closes: PRO-1614

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

It turns out the ticket was incorrect, the error occurs when a validator *becomes* an authority, not when they drop out. There's not really an issue here, it's just because the engines only "find out" they are an authority via the electoral_data rpc, by design, so there's no engine logic required to handle epochs etc. So, just making the error message clearer and adding a clarifying comment.