### PR TITLE
fix: expire previous epochs and rename epoch duration

### DIFF
--- a/state-chain/cf-integration-tests/src/authorities.rs
+++ b/state-chain/cf-integration-tests/src/authorities.rs
@@ -59,10 +59,10 @@ pub fn fund_authorities_and_join_auction(
 /// by going through the correct sequence in sync.
 #[test]
 fn authority_rotates_with_correct_sequence() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -162,7 +162,7 @@ fn authorities_earn_rewards_for_authoring_blocks() {
 	// set
 	const MAX_AUTHORITIES: AuthorityCount = 3;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -206,7 +206,7 @@ fn genesis_nodes_rotated_out_accumulate_rewards_correctly() {
 	// set
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -273,7 +273,7 @@ fn authority_rotation_can_succeed_after_aborted_by_safe_mode() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -328,7 +328,7 @@ fn authority_rotation_cannot_be_aborted_after_key_handover_and_completes_even_on
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -371,7 +371,7 @@ fn authority_rotation_can_recover_after_keygen_fails() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -424,7 +424,7 @@ fn authority_rotation_can_recover_after_key_handover_fails() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -502,7 +502,7 @@ fn can_move_through_multiple_epochs() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -524,7 +524,7 @@ fn cant_rotate_if_previous_rotation_is_pending() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -559,7 +559,7 @@ fn waits_for_governance_when_apicall_fails() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/broadcasting.rs
+++ b/state-chain/cf-integration-tests/src/broadcasting.rs
@@ -12,10 +12,10 @@ use state_chain_runtime::{
 
 #[test]
 fn bitcoin_broadcast_delay_works() {
-	const EPOCH_BLOCKS: u32 = 200;
+	const EPOCH_DURATION_BLOCKS: u32 = 200;
 	const MAX_AUTHORITIES: AuthorityCount = 150;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -22,10 +22,10 @@ use state_chain_runtime::{
 // We have a set of nodes that are funded and can redeem in the redeeming period and
 // not redeem when out of the period
 fn cannot_redeem_funds_out_of_redemption_period() {
-	const EPOCH_BLOCKS: u32 = 100;
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 3;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -68,7 +68,7 @@ fn cannot_redeem_funds_out_of_redemption_period() {
 			}
 
 			let end_of_redemption_period =
-				EPOCH_BLOCKS * REDEMPTION_PERIOD_AS_PERCENTAGE as u32 / 100;
+				EPOCH_DURATION_BLOCKS * REDEMPTION_PERIOD_AS_PERCENTAGE as u32 / 100;
 			// Move to end of the redemption period
 			System::set_block_number(end_of_redemption_period + 1);
 			// We will try to redeem
@@ -125,7 +125,7 @@ fn cannot_redeem_funds_out_of_redemption_period() {
 fn funded_node_is_added_to_backups() {
 	const EPOCH_BLOCKS: u32 = 10_000_000;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		// As we run a rotation at genesis we will need accounts to support
 		// having 5 authorities as the default is 3 (Alice, Bob and Charlie)
 		.accounts(vec![
@@ -149,7 +149,7 @@ fn backup_reward_is_calculated_linearly() {
 	const MAX_AUTHORITIES: u32 = 10;
 	const NUM_BACKUPS: u32 = 20;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -194,7 +194,7 @@ fn can_calculate_account_apy() {
 	const MAX_AUTHORITIES: u32 = 10;
 	const NUM_BACKUPS: u32 = 20;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -246,7 +246,7 @@ fn apy_can_be_above_100_percent() {
 	const MAX_AUTHORITIES: u32 = 2;
 	const NUM_BACKUPS: u32 = 2;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -282,7 +282,7 @@ fn backup_rewards_event_gets_emitted_on_heartbeat_interval() {
 	const NUM_BACKUPS: u32 = 20;
 	const MAX_AUTHORITIES: u32 = 100;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.accounts(
 			(0..MAX_AUTHORITIES as u8)
 				.map(|i| (AccountId32::from([i; 32]), AccountRole::Validator, GENESIS_BALANCE))

--- a/state-chain/cf-integration-tests/src/genesis.rs
+++ b/state-chain/cf-integration-tests/src/genesis.rs
@@ -14,7 +14,7 @@ use state_chain_runtime::{
 };
 pub const GENESIS_BALANCE: FlipBalance = TOTAL_ISSUANCE / 100;
 
-const BLOCKS_PER_EPOCH: u32 = 1000;
+const EPOCH_DURATION: u32 = 1000;
 
 pub fn with_test_defaults() -> ExtBuilder {
 	ExtBuilder::default()
@@ -26,7 +26,7 @@ pub fn with_test_defaults() -> ExtBuilder {
 			(AccountId::from(LIQUIDITY_PROVIDER), AccountRole::LiquidityProvider, GENESIS_BALANCE),
 		])
 		.root(AccountId::from(ERIN))
-		.blocks_per_epoch(BLOCKS_PER_EPOCH)
+		.epoch_duration(EPOCH_DURATION)
 }
 
 #[test]
@@ -62,8 +62,8 @@ fn state_of_genesis_is_as_expected() {
 		}
 
 		assert_eq!(
-			Validator::blocks_per_epoch(),
-			BLOCKS_PER_EPOCH,
+			Validator::epoch_duration(),
+			EPOCH_DURATION,
 			"epochs will not rotate automatically from genesis"
 		);
 

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -69,7 +69,7 @@ use cf_primitives::{
 pub struct ExtBuilder {
 	pub genesis_accounts: Vec<(AccountId, AccountRole, FlipBalance)>,
 	root: Option<AccountId>,
-	blocks_per_epoch: BlockNumber,
+	epoch_duration: BlockNumber,
 	max_authorities: AuthorityCount,
 	min_authorities: AuthorityCount,
 }
@@ -81,7 +81,7 @@ impl Default for ExtBuilder {
 			min_authorities: 1,
 			genesis_accounts: Default::default(),
 			root: Default::default(),
-			blocks_per_epoch: Default::default(),
+			epoch_duration: Default::default(),
 		}
 	}
 }
@@ -105,8 +105,8 @@ impl ExtBuilder {
 		self
 	}
 
-	pub fn blocks_per_epoch(mut self, blocks_per_epoch: BlockNumber) -> Self {
-		self.blocks_per_epoch = blocks_per_epoch;
+	pub fn epoch_duration(mut self, epoch_duration: BlockNumber) -> Self {
+		self.epoch_duration = epoch_duration;
 		self
 	}
 
@@ -186,7 +186,7 @@ impl ExtBuilder {
 					})
 					.collect(),
 				genesis_backups: Default::default(),
-				blocks_per_epoch: self.blocks_per_epoch,
+				epoch_duration: self.epoch_duration,
 				bond: self
 					.genesis_accounts
 					.iter()

--- a/state-chain/cf-integration-tests/src/network.rs
+++ b/state-chain/cf-integration-tests/src/network.rs
@@ -691,7 +691,7 @@ impl Network {
 	/// Move to the last block of the epoch - next block will start Authority rotation
 	pub fn move_to_the_end_of_epoch(&mut self) {
 		let current_block = System::block_number();
-		let target = Validator::current_epoch_started_at() + Validator::blocks_per_epoch();
+		let target = Validator::current_epoch_started_at() + Validator::epoch_duration();
 		if target > current_block {
 			self.move_forward_blocks(target - current_block - 1)
 		}

--- a/state-chain/cf-integration-tests/src/new_epoch.rs
+++ b/state-chain/cf-integration-tests/src/new_epoch.rs
@@ -17,9 +17,9 @@ use state_chain_runtime::{
 
 #[test]
 fn auction_repeats_after_failure_because_of_liveness() {
-	const EPOCH_BLOCKS: BlockNumber = 1000;
+	const EPOCH_DURATION_BLOCKS: BlockNumber = 1000;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		// As we run a rotation at genesis we will need accounts to support
 		// having 5 authorities as the default is 3 (Alice, Bob and Charlie)
 		.accounts(vec![
@@ -107,7 +107,7 @@ fn epoch_rotates() {
 	const EPOCH_BLOCKS: BlockNumber = 1000;
 	const MAX_SET_SIZE: AuthorityCount = 5;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.min_authorities(MAX_SET_SIZE)
 		.build()
 		.execute_with(|| {
@@ -247,7 +247,7 @@ fn can_consolidate_bitcoin_utxos() {
 	const MAX_AUTHORITIES: AuthorityCount = 5;
 	const CONSOLIDATION_SIZE: u32 = 2;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.build()
 		.execute_with(|| {
 			let (mut testnet, _, _) =

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -230,10 +230,10 @@ fn witness_solana_state(state: SolanaState) {
 
 #[test]
 fn can_build_solana_batch_all() {
-	const EPOCH_BLOCKS: u32 = 100;
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -306,7 +306,7 @@ fn can_rotate_solana_vault() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -365,7 +365,7 @@ fn can_send_solana_ccm() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -468,7 +468,7 @@ fn solana_ccm_fails_with_invalid_input() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -615,7 +615,7 @@ fn failed_ccm_does_not_consume_durable_nonce() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -677,7 +677,7 @@ fn solana_resigning() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),
@@ -753,7 +753,7 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -838,7 +838,7 @@ fn solana_can_recycle_deposit_channels() {
 	const EPOCH_BLOCKS: u32 = 100;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.with_additional_accounts(&[
 			(DORIS, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP),

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -705,10 +705,10 @@ fn ethereum_ccm_can_calculate_gas_limits() {
 
 #[test]
 fn can_resign_failed_ccm() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -811,7 +811,7 @@ fn can_handle_failed_vault_transfer() {
 	const EPOCH_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 10;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {

--- a/state-chain/cf-integration-tests/src/witnessing.rs
+++ b/state-chain/cf-integration-tests/src/witnessing.rs
@@ -16,10 +16,10 @@ use pallet_cf_witnesser::{CallHash, CallHashExecuted, WitnessDeadline};
 
 #[test]
 fn can_punish_failed_witnesser() {
-	const EPOCH_BLOCKS: u32 = 1000;
+	const EPOCH_DURATION_BLOCKS: u32 = 1000;
 	const MAX_AUTHORITIES: AuthorityCount = 50;
 	super::genesis::with_test_defaults()
-		.blocks_per_epoch(EPOCH_BLOCKS)
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
 		.max_authorities(MAX_AUTHORITIES)
 		.build()
 		.execute_with(|| {
@@ -46,7 +46,7 @@ fn can_punish_failed_witnesser() {
 			assert_ok!(Reputation::set_penalty(
 				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
 				Offence::FailedToWitnessInTime,
-				Penalty { reputation: -100, suspension: EPOCH_BLOCKS },
+				Penalty { reputation: -100, suspension: EPOCH_DURATION_BLOCKS },
 			));
 
 			// Before the deadline is set, no one has been reported.

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::boost_pool_rpc::BoostPoolFeesRpc;
+use crate::{boost_pool_rpc::BoostPoolFeesRpc, monitoring::RpcEpochStateV2};
 use boost_pool_rpc::BoostPoolDetailsRpc;
 use cf_amm::{
 	common::{PoolPairsMap, Side},
@@ -79,25 +79,6 @@ pub mod monitoring;
 pub mod order_fills;
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct RpcEpochState {
-	pub blocks_per_epoch: u32,
-	pub current_epoch_started_at: u32,
-	pub current_epoch_index: u32,
-	pub min_active_bid: Option<NumberOrHex>,
-	pub rotation_phase: String,
-}
-impl From<EpochState> for RpcEpochState {
-	fn from(rotation_state: EpochState) -> Self {
-		Self {
-			blocks_per_epoch: rotation_state.blocks_per_epoch,
-			current_epoch_started_at: rotation_state.current_epoch_started_at,
-			current_epoch_index: rotation_state.current_epoch_index,
-			rotation_phase: rotation_state.rotation_phase,
-			min_active_bid: rotation_state.min_active_bid.map(Into::into),
-		}
-	}
-}
-#[derive(Serialize, Deserialize, Clone)]
 pub struct RpcRedemptionsInfo {
 	pub total_balance: NumberOrHex,
 	pub count: u32,
@@ -128,7 +109,7 @@ impl From<FlipSupply> for RpcFlipSupply {
 pub struct RpcMonitoringData {
 	pub external_chains_height: ExternalChainsBlockHeight,
 	pub btc_utxos: BtcUtxos,
-	pub epoch: RpcEpochState,
+	pub epoch: RpcEpochStateV2,
 	pub pending_redemptions: RpcRedemptionsInfo,
 	pub pending_broadcasts: PendingBroadcasts,
 	pub pending_tss: PendingTssCeremonies,
@@ -379,7 +360,7 @@ type RpcSuspensions = Vec<(Offence, Vec<(u32, state_chain_runtime::AccountId)>)>
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RpcAuctionState {
-	blocks_per_epoch: u32,
+	epoch_duration: u32,
 	current_epoch_started_at: u32,
 	redemption_period_as_percentage: u8,
 	min_funding: NumberOrHex,
@@ -390,7 +371,7 @@ pub struct RpcAuctionState {
 impl From<AuctionState> for RpcAuctionState {
 	fn from(auction_state: AuctionState) -> Self {
 		Self {
-			blocks_per_epoch: auction_state.blocks_per_epoch,
+			epoch_duration: auction_state.epoch_duration,
 			current_epoch_started_at: auction_state.current_epoch_started_at,
 			redemption_period_as_percentage: auction_state.redemption_period_as_percentage,
 			min_funding: auction_state.min_funding.into(),

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -56,7 +56,7 @@ use state_chain_runtime::{
 	chainflip::{BlockUpdate, Offence},
 	constants::common::TX_FEE_MULTIPLIER,
 	monitoring_apis::{
-		ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, EpochState, ExternalChainsBlockHeight,
+		ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, ExternalChainsBlockHeight,
 		FeeImbalance, FlipSupply, LastRuntimeUpgradeInfo, MonitoringDataV2, OpenDepositChannels,
 		PendingBroadcasts, PendingTssCeremonies, RedemptionsInfo, SolanaNonces,
 	},

--- a/state-chain/custom-rpc/src/monitoring.rs
+++ b/state-chain/custom-rpc/src/monitoring.rs
@@ -1,8 +1,10 @@
 use super::pass_through;
 use crate::{BlockT, CustomRpc, RpcAccountInfoV2, RpcFeeImbalance, RpcMonitoringData, RpcResult};
 use cf_chains::{dot::PolkadotAccountId, sol::SolAddress};
+use cf_utilities::rpc::NumberOrHex;
 use jsonrpsee::proc_macros::rpc;
 use sc_client_api::{BlockchainEvents, HeaderBackend};
+use serde::{Deserialize, Serialize};
 use sp_api::ApiExt;
 use sp_core::{bounded_vec::BoundedVec, ConstU32};
 use state_chain_runtime::{
@@ -15,6 +17,44 @@ use state_chain_runtime::{
 	},
 	Block,
 };
+impl From<EpochState> for RpcEpochState {
+	fn from(rotation_state: EpochState) -> Self {
+		Self {
+			epoch_duration: rotation_state.epoch_duration,
+			current_epoch_started_at: rotation_state.current_epoch_started_at,
+			current_epoch_index: rotation_state.current_epoch_index,
+			rotation_phase: rotation_state.rotation_phase,
+			min_active_bid: rotation_state.min_active_bid.map(Into::into),
+		}
+	}
+}
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RpcEpochState {
+	pub epoch_duration: u32,
+	pub current_epoch_started_at: u32,
+	pub current_epoch_index: u32,
+	pub min_active_bid: Option<NumberOrHex>,
+	pub rotation_phase: String,
+}
+
+// Temporary struct to hold the deprecated blocks_per_epoch field.
+// Can be deleted after v1.7 is released (meaning: after the version is bumped to 1.8).
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RpcEpochStateV2 {
+	#[deprecated(
+		since = "1.8.0",
+		note = "This field is deprecated and will be removed in v1.8. Use blocks_per_epoch instead."
+	)]
+	blocks_per_epoch: u32,
+	#[serde(flatten)]
+	epoch_state: RpcEpochState,
+}
+
+impl From<EpochState> for RpcEpochStateV2 {
+	fn from(epoch_state: EpochState) -> Self {
+		Self { blocks_per_epoch: epoch_state.epoch_duration, epoch_state: epoch_state.into() }
+	}
+}
 
 #[rpc(server, client, namespace = "cf_monitoring")]
 pub trait MonitoringApi {
@@ -35,7 +75,7 @@ pub trait MonitoringApi {
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<(Offence, u32)>>;
 	#[method(name = "epoch_state")]
-	fn cf_epoch_state(&self, at: Option<state_chain_runtime::Hash>) -> RpcResult<EpochState>;
+	fn cf_epoch_state(&self, at: Option<state_chain_runtime::Hash>) -> RpcResult<RpcEpochStateV2>;
 	#[method(name = "redemptions")]
 	fn cf_redemptions(&self, at: Option<state_chain_runtime::Hash>) -> RpcResult<RedemptionsInfo>;
 	#[method(name = "pending_broadcasts")]
@@ -105,7 +145,7 @@ where
 		cf_btc_utxos() -> BtcUtxos,
 		cf_dot_aggkey() -> PolkadotAccountId,
 		cf_suspended_validators() -> Vec<(Offence, u32)>,
-		cf_epoch_state() -> EpochState,
+		cf_epoch_state() -> RpcEpochStateV2 [map: RpcEpochStateV2::from],
 		cf_redemptions() -> RedemptionsInfo,
 		cf_pending_broadcasts_count() -> PendingBroadcasts,
 		cf_pending_tss_ceremonies_count() -> PendingTssCeremonies,

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -568,7 +568,7 @@ fn testnet_genesis(
 	genesis_funding_amount: u128,
 	minimum_funding: u128,
 	redemption_tax: u128,
-	blocks_per_epoch: BlockNumber,
+	epoch_duration: BlockNumber,
 	redemption_ttl_secs: u64,
 	current_authority_emission_inflation_perbill: u32,
 	backup_node_emission_inflation_perbill: u32,
@@ -680,7 +680,7 @@ fn testnet_genesis(
 					}
 				})
 				.collect::<_>(),
-			blocks_per_epoch,
+			epoch_duration,
 			redemption_period_as_percentage,
 			backup_reward_node_percentage: Percent::from_percent(33),
 			bond: all_accounts

--- a/state-chain/pallets/cf-pools/src/migrations.rs
+++ b/state-chain/pallets/cf-pools/src/migrations.rs
@@ -2,16 +2,3 @@ use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
 
 pub type PalletMigration<T> = PlaceholderMigration<5, Pallet<T>>;
-
-#[cfg(feature = "try-runtime")]
-pub mod old {
-	use crate::*;
-	use frame_support::pallet_prelude::ValueQuery;
-	use frame_system::pallet_prelude::BlockNumberFor;
-
-	// Migration 4->5 is in the runtime/src/lib.rs `NetworkFeesMigration`
-	#[frame_support::storage_alias]
-	pub type FlipBuyInterval<T: Config> = StorageValue<Pallet<T>, BlockNumberFor<T>, ValueQuery>;
-	#[frame_support::storage_alias]
-	pub type CollectedNetworkFee<T: Config> = StorageValue<Pallet<T>, AssetAmount, ValueQuery>;
-}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1042,9 +1042,18 @@ impl<T: Config> Pallet<T> {
 					HistoricalAuthorities::<T>::decode_len(epoch).unwrap_or_default() as u32,
 				);
 				if remaining_weight.all_gte(weight_used.saturating_add(required_weight)) {
+					log::info!(target: "cf-validator", "🚮 Expiring epoch {}.", epoch);
 					Self::expire_epoch(epoch);
 					weight_used.saturating_accrue(required_weight);
 					*last_expired_epoch = epoch;
+				} else {
+					log::info!(
+						target: "cf-validator",
+						"🚮 Postponing expiry of epoch {}. Required/Available weights: {}/{}.",
+						epoch,
+						required_weight.ref_time(),
+						remaining_weight.ref_time(),
+					);
 				}
 			}
 		});

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -69,7 +69,7 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(4);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(5);
 
 // Might be better to add the enum inside a struct rather than struct inside enum
 #[derive(Clone, PartialEq, Eq, Default, Encode, Decode, TypeInfo, RuntimeDebugNoBound)]
@@ -174,10 +174,10 @@ pub mod pallet {
 	#[pallet::getter(fn current_epoch_started_at)]
 	pub type CurrentEpochStartedAt<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
-	/// The duration of an epoch in blocks.
+	/// The amount of blocks in an epoch.
 	#[pallet::storage]
-	#[pallet::getter(fn blocks_per_epoch)]
-	pub type BlocksPerEpoch<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
+	#[pallet::getter(fn epoch_duration)]
+	pub type EpochDuration<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
 	/// Current epoch index.
 	#[pallet::storage]
@@ -379,8 +379,8 @@ pub mod pallet {
 			let mut weight = Weight::zero();
 
 			// Check expiry of epoch and store last expired.
-			if let Some(epoch_index) = EpochExpiries::<T>::take(block_number) {
-				weight.saturating_accrue(Self::expire_epoch(epoch_index));
+			if let Some(epoch_to_expire) = EpochExpiries::<T>::take(block_number) {
+				Self::expire_epochs_up_to(epoch_to_expire);
 			}
 
 			weight.saturating_accrue(Self::punish_missed_authorship_slots());
@@ -389,7 +389,7 @@ pub mod pallet {
 			weight.saturating_accrue(match CurrentRotationPhase::<T>::get() {
 				RotationPhase::Idle => {
 					if block_number.saturating_sub(CurrentEpochStartedAt::<T>::get()) >=
-						BlocksPerEpoch::<T>::get() {
+						EpochDuration::<T>::get() {
 						if T::RotationBroadcastsPending::rotation_broadcasts_pending() {
 							Self::deposit_event(Event::PreviousRotationStillPending);
 							T::ValidatorWeightInfo::rotation_phase_idle()
@@ -536,7 +536,7 @@ pub mod pallet {
 				},
 				PalletConfigUpdate::EpochDuration { blocks } => {
 					ensure!(blocks > 0, Error::<T>::InvalidEpochDuration);
-					BlocksPerEpoch::<T>::set(blocks.into());
+					EpochDuration::<T>::set(blocks.into());
 				},
 				PalletConfigUpdate::AuctionParameters { parameters } => {
 					Self::try_update_auction_parameters(parameters)?;
@@ -820,7 +820,7 @@ pub mod pallet {
 	pub struct GenesisConfig<T: Config> {
 		pub genesis_authorities: BTreeSet<ValidatorIdOf<T>>,
 		pub genesis_backups: BackupMap<T>,
-		pub blocks_per_epoch: BlockNumberFor<T>,
+		pub epoch_duration: BlockNumberFor<T>,
 		pub bond: T::Amount,
 		pub redemption_period_as_percentage: Percent,
 		pub backup_reward_node_percentage: Percent,
@@ -835,7 +835,7 @@ pub mod pallet {
 			Self {
 				genesis_authorities: Default::default(),
 				genesis_backups: Default::default(),
-				blocks_per_epoch: Zero::zero(),
+				epoch_duration: Zero::zero(),
 				bond: Default::default(),
 				redemption_period_as_percentage: Zero::zero(),
 				backup_reward_node_percentage: Zero::zero(),
@@ -856,7 +856,7 @@ pub mod pallet {
 		fn build(&self) {
 			use cf_primitives::GENESIS_EPOCH;
 			LastExpiredEpoch::<T>::set(Default::default());
-			BlocksPerEpoch::<T>::set(self.blocks_per_epoch);
+			EpochDuration::<T>::set(self.epoch_duration);
 			CurrentRotationPhase::<T>::set(RotationPhase::Idle);
 			RedemptionPeriodAsPercentage::<T>::set(self.redemption_period_as_percentage);
 			BackupRewardNodePercentage::<T>::set(self.backup_reward_node_percentage);
@@ -988,7 +988,7 @@ impl<T: Config> Pallet<T> {
 
 		// Set the expiry block number for the old epoch.
 		EpochExpiries::<T>::insert(
-			frame_system::Pallet::<T>::current_block_number() + BlocksPerEpoch::<T>::get(),
+			frame_system::Pallet::<T>::current_block_number() + EpochDuration::<T>::get(),
 			old_epoch,
 		);
 
@@ -1013,7 +1013,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn expire_epoch(epoch: EpochIndex) -> Weight {
-		LastExpiredEpoch::<T>::set(epoch);
 		let mut num_expired_authorities = 0;
 		for authority in EpochHistory::<T>::epoch_authorities(epoch).iter() {
 			num_expired_authorities += 1;
@@ -1032,6 +1031,18 @@ impl<T: Config> Pallet<T> {
 		HistoricalBonds::<T>::remove(epoch);
 
 		T::ValidatorWeightInfo::expire_epoch(num_expired_authorities)
+	}
+
+	fn expire_epochs_up_to(latest_epoch_to_expire: EpochIndex) -> Weight {
+		let mut weight = Weight::zero();
+		LastExpiredEpoch::<T>::mutate(|last_expired_epoch| {
+			let first_unexpired_epoch = *last_expired_epoch + 1;
+			for epoch in first_unexpired_epoch..=latest_epoch_to_expire {
+				weight.saturating_accrue(Self::expire_epoch(epoch));
+			}
+			*last_expired_epoch = latest_epoch_to_expire;
+		});
+		weight
 	}
 
 	/// Does all state updates related to the *new* epoch. Is also called at genesis to initialise
@@ -1318,7 +1329,7 @@ impl<T: Config> Pallet<T> {
 
 		// current_block > start + ((epoch * epoch%_can_redeem))
 		CurrentEpochStartedAt::<T>::get()
-			.saturating_add(RedemptionPeriodAsPercentage::<T>::get() * BlocksPerEpoch::<T>::get()) <=
+			.saturating_add(RedemptionPeriodAsPercentage::<T>::get() * EpochDuration::<T>::get()) <=
 			frame_system::Pallet::<T>::current_block_number()
 	}
 }
@@ -1423,14 +1434,14 @@ impl<T: Config> pallet_session::SessionManager<ValidatorIdOf<T>> for Pallet<T> {
 
 impl<T: Config> EstimateNextSessionRotation<BlockNumberFor<T>> for Pallet<T> {
 	fn average_session_length() -> BlockNumberFor<T> {
-		Self::blocks_per_epoch()
+		Self::epoch_duration()
 	}
 
 	fn estimate_current_session_progress(now: BlockNumberFor<T>) -> (Option<Permill>, Weight) {
 		(
 			Some(Permill::from_rational(
 				now.saturating_sub(CurrentEpochStartedAt::<T>::get()),
-				BlocksPerEpoch::<T>::get(),
+				EpochDuration::<T>::get(),
 			)),
 			T::DbWeight::get().reads(2),
 		)
@@ -1440,7 +1451,7 @@ impl<T: Config> EstimateNextSessionRotation<BlockNumberFor<T>> for Pallet<T> {
 		_now: BlockNumberFor<T>,
 	) -> (Option<BlockNumberFor<T>>, Weight) {
 		(
-			Some(CurrentEpochStartedAt::<T>::get() + BlocksPerEpoch::<T>::get()),
+			Some(CurrentEpochStartedAt::<T>::get() + EpochDuration::<T>::get()),
 			T::DbWeight::get().reads(2),
 		)
 	}

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -1,8 +1,16 @@
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
+
 mod rename_blocks_per_epoch;
 
 pub type PalletMigration<T> = (
-	VersionedMigration<Pallet<T>, rename_blocks_per_epoch::BlocksPerEpochMigration<T>, 4, 5>,
-	PlaceholderMigration<Pallet<T>, 5>,
+	VersionedMigration<
+		4,
+		5,
+		rename_blocks_per_epoch::BlocksPerEpochMigration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<5, Pallet<T>>,
 );

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -1,4 +1,8 @@
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
+mod rename_blocks_per_epoch;
 
-pub type PalletMigration<T> = (PlaceholderMigration<4, Pallet<T>>,);
+pub type PalletMigration<T> = (
+	VersionedMigration<Pallet<T>, rename_blocks_per_epoch::BlocksPerEpochMigration<T>, 4, 5>,
+	PlaceholderMigration<Pallet<T>, 5>,
+);

--- a/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
@@ -1,0 +1,66 @@
+use crate::*;
+use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::sp_runtime::DispatchError;
+
+pub mod old {
+	use super::*;
+
+	#[frame_support::storage_alias]
+	pub type BlocksPerEpoch<T: Config> = StorageValue<Config, BlockNumberFor<T>, ValueQuery>;
+}
+
+pub struct BlocksPerEpochMigration<T: Config>(sp_std::marker::PhantomData<T>);
+
+// Rename BlocksPerEpoch -> EpochDuration
+impl<T: Config> OnRuntimeUpgrade for BlocksPerEpochMigration<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok(old::BlocksPerEpoch::<T>::get().encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		EpochDuration::<T>::put(old::BlocksPerEpoch::<T>::take());
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		assert_eq!(
+			EpochDuration::<T>::get(),
+			BlockNumberFor::<T>::decode(&mut &state[..]).unwrap()
+		);
+		assert!(!old::BlocksPerEpoch::<T>::exists());
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod migration_tests {
+	use crate::mock::Test;
+
+	use self::mock::new_test_ext;
+
+	use super::*;
+
+	#[test]
+	fn test_migration() {
+		new_test_ext().execute_with(|| {
+			old::BlocksPerEpoch::<Test>::put(100);
+			assert_ne!(EpochDuration::<Test>::get(), 100);
+
+			#[cfg(feature = "try-runtime")]
+			let state: Vec<u8> = BlocksPerEpochMigration::<Test>::pre_upgrade().unwrap();
+
+			BlocksPerEpochMigration::<Test>::on_runtime_upgrade();
+
+			#[cfg(feature = "try-runtime")]
+			BlocksPerEpochMigration::<Test>::post_upgrade(state).unwrap();
+
+			assert_eq!(EpochDuration::<Test>::get(), 100);
+		});
+	}
+}

--- a/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+use frame_support::{pallet_prelude::Weight, traits::UncheckedOnRuntimeUpgrade};
 
 #[cfg(feature = "try-runtime")]
 use codec::{Decode, Encode};
@@ -16,7 +16,7 @@ pub mod old {
 pub struct BlocksPerEpochMigration<T: Config>(sp_std::marker::PhantomData<T>);
 
 // Rename BlocksPerEpoch -> EpochDuration
-impl<T: Config> OnRuntimeUpgrade for BlocksPerEpochMigration<T> {
+impl<T: Config> UncheckedOnRuntimeUpgrade for BlocksPerEpochMigration<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
 		Ok(old::BlocksPerEpoch::<T>::get().encode())

--- a/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/rename_blocks_per_epoch.rs
@@ -10,7 +10,7 @@ pub mod old {
 	use super::*;
 
 	#[frame_support::storage_alias]
-	pub type BlocksPerEpoch<T: Config> = StorageValue<Config, BlockNumberFor<T>, ValueQuery>;
+	pub type BlocksPerEpoch<T: Config> = StorageValue<Pallet<T>, BlockNumberFor<T>, ValueQuery>;
 }
 
 pub struct BlocksPerEpochMigration<T: Config>(sp_std::marker::PhantomData<T>);

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -173,7 +173,7 @@ cf_test_utilities::impl_test_helpers! {
 		validator_pallet: ValidatorPalletConfig {
 			genesis_authorities: BTreeSet::from(GENESIS_AUTHORITIES),
 			genesis_backups: Default::default(),
-			blocks_per_epoch: EPOCH_DURATION,
+			epoch_duration: EPOCH_DURATION,
 			bond: GENESIS_BOND,
 			redemption_period_as_percentage: REDEMPTION_PERCENTAGE_AT_GENESIS,
 			backup_reward_node_percentage: Percent::from_percent(34),

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1283,7 +1283,10 @@ fn validator_deregistration_after_expired_epoch() {
 		ValidatorPallet::transition_to_next_epoch(REMAINING_AUTHORITIES.to_vec(), BOND);
 		ValidatorPallet::transition_to_next_epoch(REMAINING_AUTHORITIES.to_vec(), BOND);
 
-		ValidatorPallet::expire_epochs_up_to(ValidatorPallet::current_epoch() - 1);
+		ValidatorPallet::expire_epochs_up_to(
+			ValidatorPallet::current_epoch() - 1,
+			Weight::from_all(u64::MAX),
+		);
 
 		// Now you can deregister
 		assert_ok!(ValidatorPallet::deregister_as_validator(RuntimeOrigin::signed(
@@ -1540,7 +1543,7 @@ fn should_expire_all_previous_epochs() {
 			vec![first_epoch, second_epoch, third_epoch]
 		);
 
-		ValidatorPallet::expire_epochs_up_to(second_epoch);
+		ValidatorPallet::expire_epochs_up_to(second_epoch, Weight::from_all(u64::MAX));
 
 		assert_eq!(HistoricalActiveEpochs::<Test>::get(ID), vec![third_epoch]);
 	});

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -632,7 +632,7 @@ impl pallet_aura::Config for Runtime {
 }
 
 parameter_types! {
-	pub storage BlocksPerEpoch: u64 = Validator::blocks_per_epoch().into();
+	pub storage BlocksPerEpoch: u64 = Validator::epoch_duration().into();
 }
 
 type KeyOwnerIdentification<T, Id> =
@@ -1463,7 +1463,7 @@ impl_runtime_apis! {
 			Environment::current_release_version()
 		}
 		fn cf_epoch_duration() -> u32 {
-			Validator::blocks_per_epoch()
+			Validator::epoch_duration()
 		}
 		fn cf_current_epoch_started_at() -> u32 {
 			Validator::current_epoch_started_at()
@@ -1567,7 +1567,7 @@ impl_runtime_apis! {
 			.ok()
 			.map(|auction_outcome| auction_outcome.bond);
 			AuctionState {
-				blocks_per_epoch: Validator::blocks_per_epoch(),
+				epoch_duration: Validator::epoch_duration(),
 				current_epoch_started_at: Validator::current_epoch_started_at(),
 				redemption_period_as_percentage: Validator::redemption_period_as_percentage().deconstruct(),
 				min_funding: MinimumFunding::<Runtime>::get().unique_saturated_into(),
@@ -2499,7 +2499,7 @@ impl_runtime_apis! {
 			.ok()
 			.map(|auction_outcome| auction_outcome.bond);
 			EpochState {
-				blocks_per_epoch: Validator::blocks_per_epoch(),
+				epoch_duration: Validator::epoch_duration(),
 				current_epoch_started_at: Validator::current_epoch_started_at(),
 				current_epoch_index: Validator::current_epoch(),
 				min_active_bid,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -631,10 +631,6 @@ impl pallet_aura::Config for Runtime {
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
-parameter_types! {
-	pub storage BlocksPerEpoch: u64 = Validator::epoch_duration().into();
-}
-
 type KeyOwnerIdentification<T, Id> =
 	<T as KeyOwnerProofSystem<(KeyTypeId, Id)>>::IdentificationTuple;
 type GrandpaOffenceReporter<T> = pallet_cf_reputation::ChainflipOffenceReportingAdapter<

--- a/state-chain/runtime/src/monitoring_apis.rs
+++ b/state-chain/runtime/src/monitoring_apis.rs
@@ -30,7 +30,7 @@ pub struct BtcUtxos {
 
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
 pub struct EpochState {
-	pub blocks_per_epoch: u32,
+	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
 	pub current_epoch_index: u32,
 	pub min_active_bid: Option<u128>,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -172,7 +172,7 @@ pub struct RuntimeApiPenalty {
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct AuctionState {
-	pub blocks_per_epoch: u32,
+	pub epoch_duration: u32,
 	pub current_epoch_started_at: u32,
 	pub redemption_period_as_percentage: u8,
 	pub min_funding: u128,


### PR DESCRIPTION
~~TEMP: opening this PR to investigate recent issues.~~

Appears to be solved. There were a couple of issues:

- It looks like the migration was incorrect.
- Doing the expiry in the on_initialsed hook was causing the block to be filled up with expiry weight. Expiry has now been moved to the on_idle hook and only runs if there is enough remaining weight in the block. 