### PR TITLE
refactor: invert the hash check conditions

### DIFF
--- a/engine/src/sol/rpc.rs
+++ b/engine/src/sol/rpc.rs
@@ -39,27 +39,30 @@ impl SolRpcClient {
 			let mut poll_interval = make_periodic_tick(RPC_RETRY_CONNECTION_INTERVAL, true);
 			loop {
 				poll_interval.tick().await;
-				match get_genesis_hash(&client, &endpoint).await {
-					Ok(genesis_hash) => match expected_genesis_hash {
-						None => {
-							warn!("Skipping Solana genesis hash check");
-							break;
-						},
-						Some(expected_hash) if expected_hash == genesis_hash => {
-							break;
-						},
-						Some(_) => {
-							error!(
-                                        "Connected to Solana node at {0} but the genesis hash {genesis_hash} does not match the expected genesis hash. Please check your CFE configuration file.", endpoint
-                                    )
+				match expected_genesis_hash {
+					None => {
+						warn!("Skipping Solana genesis hash check");
+						break;
+					},
+					Some(expected_hash) => match get_genesis_hash(&client, &endpoint).await {
+						Ok(genesis_hash) =>
+							if expected_hash == genesis_hash {
+								break;
+							} else {
+								error!(
+								"Connected to Solana node at {0} but the genesis hash {genesis_hash} does not match the expected genesis hash. Please check your CFE configuration file.",
+								endpoint
+							)
+							},
+						Err(e) => {
+							tracing::error!(
+								"Cannot connect to Solana node at {1} with error: {e}. \
+											Please check your CFE configuration file. Retrying in {:?}...",
+								poll_interval.period(),
+								endpoint
+							)
 						},
 					},
-					Err(e) => tracing::error!(
-						"Cannot connect to Solana node at {1} with error: {e}. \
-                                Please check your CFE configuration file. Retrying in {:?}...",
-						poll_interval.period(),
-						endpoint
-					),
 				}
 			}
 			Self { client, endpoint }


### PR DESCRIPTION
# Pull Request
## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Minor thing I noticed when reading this code, we can invert the condition which means we don't need to do an RPC query before realising it's not required. This means it's possible to instantiate a client without needing the genesis hash rpc endpoint - which is apparently not available for some Solana RPC providers.