### PR TITLE
Feat: Private Broker Channel Witnessing

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/btc.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/btc.rs
@@ -60,6 +60,8 @@ where
 		.chunk_by_vault(vaults, scope)
 		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
 		.await
+		.private_deposit_channels(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.await
 		.btc_deposits(witness_call.clone())
 		.egress_items(scope, state_chain_stream, state_chain_client)
 		.await

--- a/engine/src/state_chain_observer/client/storage_api.rs
+++ b/engine/src/state_chain_observer/client/storage_api.rs
@@ -180,6 +180,13 @@ pub trait StorageApi {
 			.map(|(_k, v)| v)
 			.collect())
 	}
+
+	async fn storage_map_entries<StorageMap: StorageMapAssociatedTypes + 'static>(
+		&self,
+		block_hash: state_chain_runtime::Hash,
+	) -> RpcResult<Vec<(StorageMap::Key, StorageMap::Value)>> {
+		Ok(self.storage_map::<StorageMap, Vec<_>>(block_hash).await?.into_iter().collect())
+	}
 }
 
 #[async_trait]

--- a/engine/src/state_chain_observer/client/storage_api.rs
+++ b/engine/src/state_chain_observer/client/storage_api.rs
@@ -180,13 +180,6 @@ pub trait StorageApi {
 			.map(|(_k, v)| v)
 			.collect())
 	}
-
-	async fn storage_map_entries<StorageMap: StorageMapAssociatedTypes + 'static>(
-		&self,
-		block_hash: state_chain_runtime::Hash,
-	) -> RpcResult<Vec<(StorageMap::Key, StorageMap::Value)>> {
-		Ok(self.storage_map::<StorageMap, Vec<_>>(block_hash).await?.into_iter().collect())
-	}
 }
 
 #[async_trait]

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -128,6 +128,8 @@ where
 		.chunk_by_vault(vaults.clone(), scope)
 		.deposit_addresses(scope, unfinalised_state_chain_stream, state_chain_client.clone())
 		.await
+		.private_deposit_channels(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.await
 		.btc_deposits(prewitness_call)
 		.logging("pre-witnessing")
 		.spawn(scope);
@@ -163,6 +165,8 @@ where
 		.logging("safe block produced")
 		.chunk_by_vault(vaults, scope)
 		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.await
+		.private_deposit_channels(scope, state_chain_stream.clone(), state_chain_client.clone())
 		.await
 		.btc_deposits(process_call.clone())
 		.egress_items(scope, state_chain_stream, state_chain_client.clone())

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -78,7 +78,7 @@ pub async fn start<
 	prewitness_call: PrewitnessCall,
 	state_chain_client: Arc<StateChainClient>,
 	state_chain_stream: StateChainStream,
-	unfinalised_state_chain_stream: impl StreamApi<UNFINALIZED>,
+	unfinalised_state_chain_stream: impl StreamApi<UNFINALIZED> + Clone,
 	epoch_source: EpochSourceBuilder<'_, '_, StateChainClient, (), ()>,
 	db: Arc<PersistentKeyDB>,
 ) -> Result<()>
@@ -126,9 +126,13 @@ where
 	block_source
 		.clone()
 		.chunk_by_vault(vaults.clone(), scope)
-		.deposit_addresses(scope, unfinalised_state_chain_stream, state_chain_client.clone())
+		.deposit_addresses(
+			scope,
+			unfinalised_state_chain_stream.clone(),
+			state_chain_client.clone(),
+		)
 		.await
-		.private_deposit_channels(scope, state_chain_stream.clone(), state_chain_client.clone())
+		.private_deposit_channels(scope, unfinalised_state_chain_stream, state_chain_client.clone())
 		.await
 		.btc_deposits(prewitness_call)
 		.logging("pre-witnessing")

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -65,6 +65,11 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 
 					let key: &AggKey = &epoch.info.0;
 
+					// Take all current private broker chanenls and use them to build a list of all
+					// deposit addresses that we should check for vault swaps. Note that we
+					// monitor previous epoch key (if exists) in addition to the current one, which
+					// means we get up to two deposit addresses per broker. A special case is the
+					// "change address" that doesn't have a broker associated with it.
 					[key.current].into_iter().chain(key.previous).flat_map(|key| {
 						[(None, CHANGE_ADDRESS_SALT)]
 							.into_iter()

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault.rs
@@ -3,6 +3,7 @@ pub mod continuous;
 pub mod deposit_addresses;
 pub mod egress_items;
 pub mod monitored_items;
+pub mod private_deposit_channels;
 
 use cf_chains::{Chain, ChainCrypto};
 use futures_util::StreamExt;

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/private_deposit_channels.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/private_deposit_channels.rs
@@ -55,16 +55,19 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 					let state_chain_client = state_chain_client_c.clone();
 					async move {
 						state_chain_client
-							.storage_map_entries::<pallet_cf_swapping::BrokerPrivateBtcChannels<
+							.storage_map::<pallet_cf_swapping::BrokerPrivateBtcChannels<
 								state_chain_runtime::Runtime,
-							>>(block_hash)
+							>, Vec<_>>(block_hash)
 							.await
 							.expect(STATE_CHAIN_CONNECTION)
 					}
 				},
 				// Private channels are not reusable (at least at the moment), so we
 				// don't need to check for their expiration:
-				|_index, addresses: &BrokerPrivateChannels| addresses.clone(),
+				|index, addresses: &BrokerPrivateChannels| {
+					assert!(<Inner::Chain as Chain>::is_block_witness_root(index));
+					addresses.clone()
+				},
 			)
 			.await,
 			self.parameters,

--- a/engine/src/witness/common/chunked_chain_source/chunked_by_vault/private_deposit_channels.rs
+++ b/engine/src/witness/common/chunked_chain_source/chunked_by_vault/private_deposit_channels.rs
@@ -1,0 +1,73 @@
+use super::{builder::ChunkedByVaultBuilder, monitored_items::MonitoredSCItems, ChunkedByVault};
+use cf_chains::Chain;
+use cf_primitives::{AccountId, ChannelId};
+use cf_utilities::task_scope::Scope;
+use std::sync::Arc;
+
+pub type BrokerPrivateChannels = Vec<(AccountId, ChannelId)>;
+
+use crate::{
+	state_chain_observer::client::{
+		storage_api::StorageApi, stream_api::StreamApi, STATE_CHAIN_CONNECTION,
+	},
+	witness::common::RuntimeHasChain,
+};
+
+impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
+	pub async fn private_deposit_channels<
+		'env,
+		StateChainStream,
+		StateChainClient,
+		const IS_FINALIZED: bool,
+	>(
+		self,
+		scope: &Scope<'env, anyhow::Error>,
+		state_chain_stream: StateChainStream,
+		state_chain_client: Arc<StateChainClient>,
+	) -> ChunkedByVaultBuilder<
+		MonitoredSCItems<
+			Inner,
+			BrokerPrivateChannels,
+			impl Fn(
+					<Inner::Chain as Chain>::ChainBlockNumber,
+					&BrokerPrivateChannels,
+				) -> BrokerPrivateChannels
+				+ Send
+				+ Sync
+				+ Clone
+				+ 'static,
+		>,
+	>
+	where
+		state_chain_runtime::Runtime: RuntimeHasChain<Inner::Chain>,
+		StateChainStream: StreamApi<IS_FINALIZED>,
+		StateChainClient: StorageApi + Send + Sync + 'static,
+	{
+		let state_chain_client_c = state_chain_client.clone();
+
+		ChunkedByVaultBuilder::new(
+			MonitoredSCItems::new(
+				self.source,
+				scope,
+				state_chain_stream,
+				state_chain_client,
+				move |block_hash| {
+					let state_chain_client = state_chain_client_c.clone();
+					async move {
+						state_chain_client
+							.storage_map_entries::<pallet_cf_swapping::BrokerPrivateBtcChannels<
+								state_chain_runtime::Runtime,
+							>>(block_hash)
+							.await
+							.expect(STATE_CHAIN_CONNECTION)
+					}
+				},
+				// Private channels are not reusable (at least at the moment), so we
+				// don't need to check for their expiration:
+				|_index, addresses: &BrokerPrivateChannels| addresses.clone(),
+			)
+			.await,
+			self.parameters,
+		)
+	}
+}

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -517,7 +517,7 @@ pub mod pallet {
 		StorageMap<_, Twox64Concat, Asset, AssetAmount, ValueQuery>;
 
 	#[pallet::storage]
-	pub(crate) type BrokerPrivateBtcChannels<T: Config> =
+	pub type BrokerPrivateBtcChannels<T: Config> =
 		StorageMap<_, Identity, T::AccountId, ChannelId, OptionQuery>;
 
 	#[pallet::event]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1749

## Summary

- Added a new adapter (similar to the existing `deposit_addresses`) which monitors the new storage for private channels `BrokerPrivateBtcChannels` on every block.
- `btc_deposits` now has access to private channel ids which it uses to derive deposit addresses (based on the current and previous epoch keys) and checks transactions for vault deposits into them (similarly to how it is already done for channel_id = 0 aka "change address").
- Based on #5361, will need to rebase after that one is merged.

### Discussion

- Do we still want to allow vault deposits directly into the "change address" skipping the broker?
