### PR TITLE
feat: add ability to configure DepositChannelLifetime via governance

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -198,6 +198,9 @@ pub enum PalletConfigUpdate<T: Config<I>, I: 'static> {
 	ChannelOpeningFee { fee: T::Amount },
 	/// Set the minimum deposit allowed for a particular asset.
 	SetMinimumDeposit { asset: TargetChainAsset<T, I>, minimum_deposit: TargetChainAmount<T, I> },
+	/// Set the deposit channel lifetime. The time before the engines stop witnessing a channel.
+	/// This is configurable primarily to allow for unpredictable block times in testnets.
+	SetDepositChannelLifetime { lifetime: TargetChainBlockNumber<T, I> },
 }
 
 macro_rules! append_chain_to_name {
@@ -627,6 +630,9 @@ pub mod pallet {
 		MinimumDepositSet {
 			asset: TargetChainAsset<T, I>,
 			minimum_deposit: TargetChainAmount<T, I>,
+		},
+		DepositChannelLifetimeSet {
+			lifetime: TargetChainBlockNumber<T, I>,
 		},
 		/// The deposits was rejected because the amount was below the minimum allowed.
 		DepositIgnored {
@@ -1135,6 +1141,10 @@ pub mod pallet {
 							asset,
 							minimum_deposit,
 						});
+					},
+					PalletConfigUpdate::<T, I>::SetDepositChannelLifetime { lifetime } => {
+						DepositChannelLifetime::<T, I>::set(lifetime);
+						Self::deposit_event(Event::<T, I>::DepositChannelLifetimeSet { lifetime });
 					},
 				}
 			}

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3,11 +3,12 @@ mod screening;
 
 use crate::{
 	mock_eth::*, BoostStatus, Call as PalletCall, ChannelAction, ChannelIdCounter,
-	ChannelOpeningFee, CrossChainMessage, DepositAction, DepositChannelLookup, DepositChannelPool,
-	DepositIgnoredReason, DepositWitness, DisabledEgressAssets, EgressDustLimit,
-	Event as PalletEvent, FailedForeignChainCall, FailedForeignChainCalls, FetchOrTransfer,
-	MinimumDeposit, Pallet, PalletConfigUpdate, PalletSafeMode, PrewitnessedDepositIdCounter,
-	ScheduledEgressCcm, ScheduledEgressFetchOrTransfer,
+	ChannelOpeningFee, CrossChainMessage, DepositAction, DepositChannelLifetime,
+	DepositChannelLookup, DepositChannelPool, DepositIgnoredReason, DepositWitness,
+	DisabledEgressAssets, EgressDustLimit, Event as PalletEvent, FailedForeignChainCall,
+	FailedForeignChainCalls, FetchOrTransfer, MinimumDeposit, Pallet, PalletConfigUpdate,
+	PalletSafeMode, PrewitnessedDepositIdCounter, ScheduledEgressCcm,
+	ScheduledEgressFetchOrTransfer,
 };
 use cf_chains::{
 	address::{AddressConverter, EncodedAddress},
@@ -1451,11 +1452,13 @@ fn can_update_all_config_items() {
 		const NEW_OPENING_FEE: u128 = 300;
 		const NEW_MIN_DEPOSIT_FLIP: u128 = 100;
 		const NEW_MIN_DEPOSIT_ETH: u128 = 200;
+		const NEW_DEPOSIT_CHANNEL_LIFETIME: u64 = 99;
 
 		// Check that the default values are different from the new ones
 		assert_eq!(ChannelOpeningFee::<Test, _>::get(), 0);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Flip), 0);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Eth), 0);
+		assert_ne!(DepositChannelLifetime::<Test, _>::get(), NEW_DEPOSIT_CHANNEL_LIFETIME);
 
 		// Update all config items at the same time, and updates 2 separate min deposit amounts.
 		assert_ok!(IngressEgress::update_pallet_config(
@@ -1470,6 +1473,9 @@ fn can_update_all_config_items() {
 					asset: EthAsset::Eth,
 					minimum_deposit: NEW_MIN_DEPOSIT_ETH
 				},
+				PalletConfigUpdate::SetDepositChannelLifetime {
+					lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
+				}
 			]
 			.try_into()
 			.unwrap()
@@ -1479,6 +1485,7 @@ fn can_update_all_config_items() {
 		assert_eq!(ChannelOpeningFee::<Test, _>::get(), NEW_OPENING_FEE);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Flip), NEW_MIN_DEPOSIT_FLIP);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Eth), NEW_MIN_DEPOSIT_ETH);
+		assert_eq!(DepositChannelLifetime::<Test, _>::get(), NEW_DEPOSIT_CHANNEL_LIFETIME);
 
 		// Check that the events were emitted
 		assert_events_eq!(
@@ -1493,6 +1500,9 @@ fn can_update_all_config_items() {
 			RuntimeEvent::IngressEgress(crate::Event::<Test, _>::MinimumDepositSet {
 				asset: EthAsset::Eth,
 				minimum_deposit: NEW_MIN_DEPOSIT_ETH
+			}),
+			RuntimeEvent::IngressEgress(crate::Event::<Test, _>::DepositChannelLifetimeSet {
+				lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
 			}),
 		);
 


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Added here #5394 to deal with unpredictable block times on testnets. In particular bitcoin testnet block times can move extremely fast at times.
