### PR TITLE
fix: use correct trait object

### DIFF
--- a/state-chain/custom-rpc/src/monitoring.rs
+++ b/state-chain/custom-rpc/src/monitoring.rs
@@ -3,7 +3,7 @@ use crate::{BlockT, CustomRpc, RpcAccountInfoV2, RpcFeeImbalance, RpcMonitoringD
 use cf_chains::{dot::PolkadotAccountId, sol::SolAddress};
 use jsonrpsee::proc_macros::rpc;
 use sc_client_api::{BlockchainEvents, HeaderBackend};
-use sp_api::{ApiExt, Core};
+use sp_api::ApiExt;
 use sp_core::{bounded_vec::BoundedVec, ConstU32};
 use state_chain_runtime::{
 	self,
@@ -130,7 +130,7 @@ where
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcMonitoringData> {
 		self.with_runtime_api(at, |api, hash| {
-			if api.api_version::<dyn Core<Block>>(hash).unwrap().unwrap() < 2 {
+			if api.api_version::<dyn MonitoringRuntimeApi<Block>>(hash).unwrap().unwrap() < 2 {
 				let old_result = api.cf_monitoring_data_before_version_2(hash)?;
 				Ok(old_result.into())
 			} else {


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Use correct trait object to access the runtime api version.
