### PR TITLE
fix: rpc error message displaying as "{error}"

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1105,7 +1105,7 @@ fn internal_error(error: impl core::fmt::Debug) -> ErrorObjectOwned {
 fn call_error(error: impl Into<Box<dyn core::error::Error + Sync + Send>>) -> ErrorObjectOwned {
 	let error = error.into();
 	log::debug!(target: "cf_rpc", "Call error: {}", error);
-	ErrorObject::owned(ErrorCode::InternalError.code(), "{error}", None::<()>)
+	ErrorObject::owned(ErrorCode::InternalError.code(), format!("{error}"), None::<()>)
 }
 
 impl From<CfApiError> for ErrorObjectOwned {


### PR DESCRIPTION
# Pull Request


## Summary

Simple fix. now the rpc's show the error message:
`{"jsonrpc":"2.0","error":{"code":-32603,"message":"DispatchError: PoolDoesNotExist"},"id":1}%   `
