### PR TITLE
fix: rpc error message displaying as "{error}" (#5399)

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1090,7 +1090,7 @@ fn internal_error(error: impl core::fmt::Debug) -> ErrorObjectOwned {
 fn call_error(error: impl Into<Box<dyn core::error::Error + Sync + Send>>) -> ErrorObjectOwned {
 	let error = error.into();
 	log::debug!(target: "cf_rpc", "Call error: {}", error);
-	ErrorObject::owned(ErrorCode::InternalError.code(), "{error}", None::<()>)
+	ErrorObject::owned(ErrorCode::InternalError.code(), format!("{error}"), None::<()>)
 }
 
 impl From<CfApiError> for ErrorObjectOwned {


### PR DESCRIPTION
Picked from #5399 