### PR TITLE
chore: bump redis dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9475,9 +9475,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6baebe319ef5e4b470f248335620098d1c2e9261e995be05f56f719ca4bdb2"
+checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -11375,7 +11375,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "rand",
  "secp256k1-sys 0.10.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ quickcheck_macros = { version = "1" }
 quote = { version = "1.0.35" }
 rayon = { version = "1.7.0" }
 rand = { version = "0.8.5", default-features = false }
-redis = { version = "0.27.2" }
+redis = { version = "0.27.5" }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.11.4" }
 rlp = { version = "0.5.2", default-features = false }


### PR DESCRIPTION
# Pull Request

## Summary

Redis 0.27.4 has been yanked, which makes cargo audit sad. Bumping to 0.27.5 should make it happy again.