### PR TITLE
feat: Btc vault swap bouncer test can open a private channel

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -14,9 +14,9 @@ use chainflip_api::{
 		DcaParameters,
 	},
 	settings::StateChain,
-	AccountId32, AddressString, BlockUpdate, BrokerApi, ChainApi, DepositMonitorApi, OperatorApi,
-	RefundParameters, SignedExtrinsicApi, StateChainApi, SwapDepositAddress, TransactionInId,
-	WithdrawFeesDetail,
+	AccountId32, AddressString, BlockUpdate, BrokerApi, ChainApi, ChannelId, DepositMonitorApi,
+	OperatorApi, RefundParameters, SignedExtrinsicApi, StateChainApi, SwapDepositAddress,
+	TransactionInId, WithdrawFeesDetail,
 };
 use clap::Parser;
 use custom_rpc::CustomApiClient;
@@ -128,6 +128,12 @@ pub trait Rpc {
 
 	#[subscription(name = "subscribe_tainted_transaction_events", item = BlockUpdate<TaintedTransactionEvents>)]
 	async fn subscribe_tainted_transaction_events(&self) -> SubscriptionResult;
+
+	#[method(name = "open_private_btc_channel", aliases = ["broker_openPrivateBtcChannel"])]
+	async fn open_private_btc_channel(&self) -> RpcResult<ChannelId>;
+
+	#[method(name = "close_private_btc_channel", aliases = ["broker_closePrivateBtcChannel"])]
+	async fn close_private_btc_channel(&self) -> RpcResult<ChannelId>;
 }
 
 pub struct RpcServerImpl {
@@ -297,6 +303,14 @@ impl RpcServer for RpcServerImpl {
 			}
 		});
 		Ok(())
+	}
+
+	async fn open_private_btc_channel(&self) -> RpcResult<ChannelId> {
+		Ok(self.api.broker_api().open_private_btc_channel().await?)
+	}
+
+	async fn close_private_btc_channel(&self) -> RpcResult<ChannelId> {
+		Ok(self.api.broker_api().close_private_btc_channel().await?)
 	}
 }
 

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -477,10 +477,10 @@ pub trait BrokerApi: SignedExtrinsicApi + StorageApi + Sized + Send + Sync + 'st
 
 	async fn open_private_btc_channel(&self) -> Result<ChannelId> {
 		let (_, events, ..) = self
-			.submit_signed_extrinsic(RuntimeCall::from(
+			.submit_signed_extrinsic_with_dry_run(RuntimeCall::from(
 				pallet_cf_swapping::Call::open_private_btc_channel {},
 			))
-			.await
+			.await?
 			.until_in_block()
 			.await?;
 
@@ -502,10 +502,10 @@ pub trait BrokerApi: SignedExtrinsicApi + StorageApi + Sized + Send + Sync + 'st
 
 	async fn close_private_btc_channel(&self) -> Result<ChannelId> {
 		let (_, events, ..) = self
-			.submit_signed_extrinsic(RuntimeCall::from(
+			.submit_signed_extrinsic_with_dry_run(RuntimeCall::from(
 				pallet_cf_swapping::Call::close_private_btc_channel {},
 			))
-			.await
+			.await?
 			.until_in_block()
 			.await?;
 

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -474,6 +474,56 @@ pub trait BrokerApi: SignedExtrinsicApi + StorageApi + Sized + Send + Sync + 'st
 		self.simple_submission_with_dry_run(pallet_cf_swapping::Call::deregister_as_broker {})
 			.await
 	}
+
+	async fn open_private_btc_channel(&self) -> Result<ChannelId> {
+		let (_, events, ..) = self
+			.submit_signed_extrinsic(RuntimeCall::from(
+				pallet_cf_swapping::Call::open_private_btc_channel {},
+			))
+			.await
+			.until_in_block()
+			.await?;
+
+		if let Some(state_chain_runtime::RuntimeEvent::Swapping(
+			pallet_cf_swapping::Event::PrivateBrokerChannelOpened { channel_id, .. },
+		)) = events.iter().find(|event| {
+			matches!(
+				event,
+				state_chain_runtime::RuntimeEvent::Swapping(
+					pallet_cf_swapping::Event::PrivateBrokerChannelOpened { .. }
+				)
+			)
+		}) {
+			Ok(*channel_id)
+		} else {
+			bail!("No PrivateBrokerChannelOpened event was found");
+		}
+	}
+
+	async fn close_private_btc_channel(&self) -> Result<ChannelId> {
+		let (_, events, ..) = self
+			.submit_signed_extrinsic(RuntimeCall::from(
+				pallet_cf_swapping::Call::close_private_btc_channel {},
+			))
+			.await
+			.until_in_block()
+			.await?;
+
+		if let Some(state_chain_runtime::RuntimeEvent::Swapping(
+			pallet_cf_swapping::Event::PrivateBrokerChannelClosed { channel_id, .. },
+		)) = events.iter().find(|event| {
+			matches!(
+				event,
+				state_chain_runtime::RuntimeEvent::Swapping(
+					pallet_cf_swapping::Event::PrivateBrokerChannelClosed { .. }
+				)
+			)
+		}) {
+			Ok(*channel_id)
+		} else {
+			bail!("No PrivateBrokerChannelClosed event was found");
+		}
+	}
 }
 
 #[async_trait]

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -15,6 +15,7 @@ import { testAllSwaps } from './all_swaps';
 import { depositChannelCreation } from './request_swap_deposit_address_with_affiliates';
 import { testDCASwaps } from './DCA_test';
 import { testBrokerLevelScreening } from './broker_level_screening';
+import { testBtcVaultSwap } from './btc_vault_swap';
 
 async function runAllConcurrentTests() {
   // Specify the number of nodes via providing an argument to this script.
@@ -46,6 +47,7 @@ async function runAllConcurrentTests() {
     testDCASwaps.run(),
     testCancelOrdersBatch.run(),
     depositChannelCreation.run(),
+    testBtcVaultSwap.run(),
   ];
 
   // Tests that only work if there is more than one node

--- a/engine/src/state_chain_observer/client/base_rpc_api.rs
+++ b/engine/src/state_chain_observer/client/base_rpc_api.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use cf_primitives::BlockNumber;
 use jsonrpsee::core::client::{ClientT, Subscription, SubscriptionClientT};
 use sc_transaction_pool_api::TransactionStatus;
 use sp_core::{
@@ -168,19 +167,6 @@ pub trait BaseRpcApi {
 		params: Option<Box<RawValue>>,
 		unsub: &str,
 	) -> RpcResult<Subscription<Box<RawValue>>>;
-
-	async fn validate_refund_params(
-		&self,
-		retry_duration: BlockNumber,
-		block_hash: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<()>;
-
-	async fn validate_dca_params(
-		&self,
-		number_of_chunks: u32,
-		chunk_interval: u32,
-		block_hash: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<()>;
 }
 
 pub struct BaseRpcClient<RawRpcClient> {
@@ -317,25 +303,6 @@ impl<RawRpcClient: RawRpcApi + Send + Sync> BaseRpcApi for BaseRpcClient<RawRpcC
 		unsub: &str,
 	) -> RpcResult<Subscription<Box<RawValue>>> {
 		self.raw_rpc_client.subscribe(sub, Params(params), unsub).await
-	}
-
-	async fn validate_refund_params(
-		&self,
-		retry_duration: BlockNumber,
-		block_hash: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<()> {
-		self.raw_rpc_client.cf_validate_refund_params(retry_duration, block_hash).await
-	}
-
-	async fn validate_dca_params(
-		&self,
-		number_of_chunks: u32,
-		chunk_interval: u32,
-		block_hash: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<()> {
-		self.raw_rpc_client
-			.cf_validate_dca_params(number_of_chunks, chunk_interval, block_hash)
-			.await
 	}
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2132,8 +2132,7 @@ impl_runtime_apis! {
 						Ok(())
 					}
 				})
-				.map_err(|()| pallet_cf_swapping::Error::<Runtime>::InvalidDestinationAddress)?;
-
+				.map_err(|_| pallet_cf_swapping::Error::<Runtime>::InvalidDestinationAddress)?;
 
 			// Encode swap
 			match ForeignChain::from(source_asset) {


### PR DESCRIPTION
# Pull Request

Closes: PRO-1752

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Added RPC's to the broker to open and close private btc channels.
- The Btc vault swap now opens a private channel
- Added the btc vault swap bouncer test to the concurrent tests