### PR TITLE
Feature: bond brokers for private channels

### DIFF
--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -166,19 +166,19 @@ pub fn extra_accounts() -> Vec<(AccountId, AccountRole, FlipBalance, Option<Vec<
 		(
 			get_account_id_from_seed::<sr25519::Public>("BROKER_1"),
 			AccountRole::Broker,
-			100 * FLIPPERINOS_PER_FLIP,
+			200 * FLIPPERINOS_PER_FLIP,
 			Some(b"Chainflip Testnet Broker 1".to_vec()),
 		),
 		(
 			get_account_id_from_seed::<sr25519::Public>("BROKER_2"),
 			AccountRole::Broker,
-			100 * FLIPPERINOS_PER_FLIP,
+			200 * FLIPPERINOS_PER_FLIP,
 			Some(b"Chainflip Testnet Broker 2".to_vec()),
 		),
 		(
 			get_account_id_from_seed::<sr25519::Public>("BROKER_FEE_TEST"),
 			AccountRole::Broker,
-			100 * FLIPPERINOS_PER_FLIP,
+			200 * FLIPPERINOS_PER_FLIP,
 			Some(b"Chainflip Testnet Broker for broker_fee_collection_test".to_vec()),
 		),
 	]

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -143,8 +143,6 @@ pub mod pallet {
 		InsufficientReserves,
 		/// No pending redemption for this ID.
 		NoPendingRedemptionForThisID,
-		/// Account does not exist.
-		AccountDoesNotExist,
 	}
 
 	#[pallet::call]
@@ -447,29 +445,6 @@ impl<T: Config> Bonding for Bonder<T> {
 		Account::<T>::mutate_exists(authority, |maybe_account| {
 			if let Some(account) = maybe_account.as_mut() {
 				account.bond = bond
-			}
-		})
-	}
-
-	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult {
-		Account::<T>::mutate_exists(authority, |maybe_account| {
-			if let Some(account) = maybe_account.as_mut() {
-				if account.balance >= bond {
-					account.bond = bond;
-					Ok(())
-				} else {
-					Err(Error::<T>::InsufficientLiquidity.into())
-				}
-			} else {
-				Err(Error::<T>::AccountDoesNotExist.into())
-			}
-		})
-	}
-
-	fn unbond(authority: &Self::ValidatorId) {
-		Account::<T>::mutate_exists(authority, |maybe_account| {
-			if let Some(account) = maybe_account.as_mut() {
-				account.bond = 0u128.into()
 			}
 		})
 	}

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -448,6 +448,29 @@ impl<T: Config> Bonding for Bonder<T> {
 			}
 		})
 	}
+
+	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> bool {
+		Account::<T>::mutate_exists(authority, |maybe_account| {
+			if let Some(account) = maybe_account.as_mut() {
+				if account.balance >= bond {
+					account.bond = bond;
+					true
+				} else {
+					false
+				}
+			} else {
+				false
+			}
+		})
+	}
+
+	fn kill_bond(authority: &Self::ValidatorId) {
+		Account::<T>::mutate_exists(authority, |maybe_account| {
+			if let Some(account) = maybe_account.as_mut() {
+				account.bond = 0u128.into()
+			}
+		})
+	}
 }
 
 pub struct FlipIssuance<T>(PhantomData<T>);

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -143,6 +143,8 @@ pub mod pallet {
 		InsufficientReserves,
 		/// No pending redemption for this ID.
 		NoPendingRedemptionForThisID,
+		/// Account does not exist.
+		AccountDoesNotExist,
 	}
 
 	#[pallet::call]
@@ -449,22 +451,22 @@ impl<T: Config> Bonding for Bonder<T> {
 		})
 	}
 
-	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> bool {
+	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult {
 		Account::<T>::mutate_exists(authority, |maybe_account| {
 			if let Some(account) = maybe_account.as_mut() {
 				if account.balance >= bond {
 					account.bond = bond;
-					true
+					Ok(())
 				} else {
-					false
+					Err(Error::<T>::InsufficientLiquidity.into())
 				}
 			} else {
-				false
+				Err(Error::<T>::AccountDoesNotExist.into())
 			}
 		})
 	}
 
-	fn kill_bond(authority: &Self::ValidatorId) {
+	fn unbond(authority: &Self::ValidatorId) {
 		Account::<T>::mutate_exists(authority, |maybe_account| {
 			if let Some(account) = maybe_account.as_mut() {
 				account.bond = 0u128.into()

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -438,10 +438,10 @@ impl<T: Config> FeePayment for Pallet<T> {
 pub struct Bonder<T>(PhantomData<T>);
 
 impl<T: Config> Bonding for Bonder<T> {
-	type ValidatorId = T::AccountId;
+	type AccountId = T::AccountId;
 	type Amount = T::Balance;
 
-	fn update_bond(authority: &Self::ValidatorId, bond: Self::Amount) {
+	fn update_bond(authority: &Self::AccountId, bond: Self::Amount) {
 		Account::<T>::mutate_exists(authority, |maybe_account| {
 			if let Some(account) = maybe_account.as_mut() {
 				account.bond = bond

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -465,6 +465,16 @@ fn test_try_debit_from_liquid_funds() {
 	});
 }
 
+#[test]
+fn test_try_bond() {
+	new_test_ext().execute_with(|| {
+		assert_noop!(
+			Bonder::<Test>::try_bond(&ALICE, Flip::total_balance_of(&ALICE) * 2),
+			Error::<Test>::InsufficientLiquidity
+		);
+	});
+}
+
 #[cfg(test)]
 mod test_issuance {
 	use super::*;

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -465,16 +465,6 @@ fn test_try_debit_from_liquid_funds() {
 	});
 }
 
-#[test]
-fn test_try_bond() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			Bonder::<Test>::try_bond(&ALICE, Flip::total_balance_of(&ALICE) * 2),
-			Error::<Test>::InsufficientLiquidity
-		);
-	});
-}
-
 #[cfg(test)]
 mod test_issuance {
 	use super::*;

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -134,6 +134,8 @@ mod benchmarks {
 
 		let caller = OriginFor::<T>::signed(broker_id.clone());
 
+		T::FeePayment::mint_to_account(&broker_id, (200 * FLIPPERINOS_PER_FLIP).into());
+
 		#[block]
 		{
 			assert_ok!(Pallet::<T>::open_private_btc_channel(caller));
@@ -151,6 +153,8 @@ mod benchmarks {
 			T::AccountRoleRegistry::whitelisted_caller_with_role(AccountRole::Broker).unwrap();
 
 		let caller = OriginFor::<T>::signed(broker_id.clone());
+
+		T::FeePayment::mint_to_account(&broker_id, (200 * FLIPPERINOS_PER_FLIP).into());
 
 		assert_ok!(Pallet::<T>::open_private_btc_channel(caller.clone()));
 

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -195,5 +195,12 @@ mod benchmarks {
 		);
 	}
 
+	#[benchmark]
+	fn update_broker_bond() {
+		let caller: T::AccountId = whitelisted_caller();
+		#[extrinsic_call]
+		update_broker_bond(RawOrigin::Signed(caller.clone()), 100_000_000_000_000_000_000.into());
+	}
+
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test,);
 }

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -199,17 +199,5 @@ mod benchmarks {
 		);
 	}
 
-	#[benchmark]
-	fn update_broker_bond() {
-		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
-		#[block]
-		{
-			assert_ok!(Pallet::<T>::update_broker_bond(
-				origin.clone(),
-				(FLIPPERINOS_PER_FLIP * 100).into()
-			));
-		}
-	}
-
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test,);
 }

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -206,7 +206,7 @@ mod benchmarks {
 		{
 			assert_ok!(Pallet::<T>::update_broker_bond(
 				origin.clone(),
-				100_000_000_000_000_000_000.into()
+				(FLIPPERINOS_PER_FLIP * 100).into()
 			));
 		}
 	}

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -197,9 +197,14 @@ mod benchmarks {
 
 	#[benchmark]
 	fn update_broker_bond() {
-		let caller: T::AccountId = whitelisted_caller();
-		#[extrinsic_call]
-		update_broker_bond(RawOrigin::Signed(caller.clone()), 100_000_000_000_000_000_000.into());
+		let origin = T::EnsureGovernance::try_successful_origin().unwrap();
+		#[block]
+		{
+			assert_ok!(Pallet::<T>::update_broker_bond(
+				origin.clone(),
+				100_000_000_000_000_000_000.into()
+			));
+		}
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -11,7 +11,8 @@ use cf_chains::{
 use cf_primitives::{
 	AffiliateShortId, Affiliates, Asset, AssetAmount, Beneficiaries, Beneficiary, BlockNumber,
 	ChannelId, DcaParameters, ForeignChain, SwapId, SwapLeg, SwapRequestId,
-	BASIS_POINTS_PER_MILLION, MAX_BASIS_POINTS, SECONDS_PER_BLOCK, STABLE_ASSET, SWAP_DELAY_BLOCKS,
+	BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP, MAX_BASIS_POINTS, SECONDS_PER_BLOCK,
+	STABLE_ASSET, SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
@@ -170,7 +171,7 @@ pub struct Swap<T: Config> {
 pub struct DefaultBrokerBond<T>(PhantomData<T>);
 impl<T: Config> Get<T::Amount> for DefaultBrokerBond<T> {
 	fn get() -> T::Amount {
-		T::Amount::from(100_000_000_000_000_000_000u128)
+		T::Amount::from(FLIPPERINOS_PER_FLIP * 100)
 	}
 }
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -166,6 +166,14 @@ pub struct Swap<T: Config> {
 	refund_params: Option<SwapRefundParameters>,
 }
 
+// 100 FLIP is our default broker bond
+pub struct DefaultBrokerBond<T>(PhantomData<T>);
+impl<T: Config> Get<T::Amount> for DefaultBrokerBond<T> {
+	fn get() -> T::Amount {
+		T::Amount::from(100_000_000_000_000_000_000u128)
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct SwapLegInfo {
 	pub swap_id: SwapId,
@@ -395,7 +403,6 @@ pub mod pallet {
 	use sp_runtime::SaturatedConversion;
 
 	use super::*;
-
 	#[pallet::config]
 	#[pallet::disable_frame_system_supertrait_check]
 	pub trait Config: Chainflip {
@@ -541,7 +548,7 @@ pub mod pallet {
 
 	/// The bond for a broker to open a private channel.
 	#[pallet::storage]
-	pub type BrokerBond<T: Config> = StorageValue<_, <T as Chainflip>::Amount, ValueQuery>;
+	pub type BrokerBond<T: Config> = StorageValue<_, T::Amount, ValueQuery, DefaultBrokerBond<T>>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -167,7 +167,6 @@ pub struct Swap<T: Config> {
 	refund_params: Option<SwapRefundParameters>,
 }
 
-// 100 FLIP is our default broker bond
 pub struct DefaultBrokerBond<T>(PhantomData<T>);
 impl<T: Config> Get<T::Amount> for DefaultBrokerBond<T> {
 	fn get() -> T::Amount {

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -455,7 +455,7 @@ pub mod pallet {
 		type ChannelIdAllocator: ChannelIdAllocator;
 
 		type Bonder: Bonding<
-			ValidatorId = <Self as frame_system::Config>::AccountId,
+			AccountId = <Self as frame_system::Config>::AccountId,
 			Amount = <Self as Chainflip>::Amount,
 		>;
 	}

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1149,7 +1149,7 @@ pub mod pallet {
 			);
 
 			ensure!(
-				T::FundingInfo::total_balance_of(&broker_id) > BrokerBond::<T>::get(),
+				T::FundingInfo::total_balance_of(&broker_id) >= BrokerBond::<T>::get(),
 				Error::<T>::InsufficientFunds
 			);
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1192,7 +1192,7 @@ pub mod pallet {
 
 		/// Updates the broker's bond to the new amount.
 		#[pallet::call_index(15)]
-		#[pallet::weight(10_000)]
+		#[pallet::weight(T::WeightInfo::update_broker_bond())]
 		pub fn update_broker_bond(origin: OriginFor<T>, new_bond: T::Amount) -> DispatchResult {
 			T::EnsureGovernance::ensure_origin(origin)?;
 			BrokerBond::<T>::set(new_bond);

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -373,7 +373,8 @@ pub enum PalletConfigUpdate<T: Config> {
 	/// Set the minimum chunk size for DCA swaps. The number of chunks of a DCA swap will be
 	/// reduced to meet this requirement.
 	SetMinimumChunkSize { asset: Asset, size: AssetAmount },
-	/// Set the broker bond.
+	/// Set the broker bond. This is the amount of FLIP that must be bonded to open a private
+	/// broker channel. The funds are getting freed when the channel is closed.
 	SetBrokerBond { bond: T::Amount },
 }
 

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -8,7 +8,7 @@ use cf_traits::mocks::fee_payment::MockFeePayment;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
-		address_converter::MockAddressConverter, balance_api::MockBalance, bonding::MockBonder,
+		address_converter::MockAddressConverter, balance_api::MockBalance, bonding::MockBonderFor,
 		deposit_handler::MockDepositHandler, egress_handler::MockEgressHandler,
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
@@ -179,7 +179,7 @@ impl pallet_cf_swapping::Config for Test {
 	type CcmValidityChecker = AlwaysValid;
 	type NetworkFee = NetworkFee;
 	type ChannelIdAllocator = MockChannelIdAllocator;
-	type Bonder = MockBonder;
+	type Bonder = MockBonderFor<Self>;
 }
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -149,10 +149,6 @@ impl WeightInfo for MockWeightInfo {
 	fn register_affiliate() -> Weight {
 		Weight::from_parts(100, 0)
 	}
-
-	fn update_broker_bond() -> Weight {
-		Weight::from_parts(100, 0)
-	}
 }
 
 pub struct AlwaysValid;

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -8,7 +8,7 @@ use cf_traits::mocks::fee_payment::MockFeePayment;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
-		address_converter::MockAddressConverter, balance_api::MockBalance,
+		address_converter::MockAddressConverter, balance_api::MockBalance, bonding::MockBonder,
 		deposit_handler::MockDepositHandler, egress_handler::MockEgressHandler,
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
@@ -179,6 +179,7 @@ impl pallet_cf_swapping::Config for Test {
 	type CcmValidityChecker = AlwaysValid;
 	type NetworkFee = NetworkFee;
 	type ChannelIdAllocator = MockChannelIdAllocator;
+	type Bonder = MockBonder;
 }
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -149,6 +149,10 @@ impl WeightInfo for MockWeightInfo {
 	fn register_affiliate() -> Weight {
 		Weight::from_parts(100, 0)
 	}
+
+	fn update_broker_bond() -> Weight {
+		Weight::from_parts(100, 0)
+	}
 }
 
 pub struct AlwaysValid;

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1803,4 +1803,11 @@ mod private_channels {
 			assert_eq!(BrokerBond::<Test>::get(), BOND);
 		});
 	}
+
+	#[test]
+	fn default_broker_bond() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(BrokerBond::<Test>::get(), 100_000_000_000_000_000_000u128);
+		});
+	}
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1790,4 +1790,17 @@ mod private_channels {
 			}
 		});
 	}
+
+	#[test]
+	fn update_broker_bond() {
+		new_test_ext().execute_with(|| {
+			const BOND: u128 = 100_000_000_000_000_000_000u128;
+			assert_noop!(
+				Swapping::update_broker_bond(OriginTrait::signed(BROKER), BOND),
+				sp_runtime::traits::BadOrigin
+			);
+			assert_ok!(Swapping::update_broker_bond(RuntimeOrigin::root(), BOND));
+			assert_eq!(BrokerBond::<Test>::get(), BOND);
+		});
+	}
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1792,19 +1792,6 @@ mod private_channels {
 	}
 
 	#[test]
-	fn update_broker_bond() {
-		new_test_ext().execute_with(|| {
-			const BOND: u128 = FLIPPERINOS_PER_FLIP * 100;
-			assert_noop!(
-				Swapping::update_broker_bond(OriginTrait::signed(BROKER), BOND),
-				sp_runtime::traits::BadOrigin
-			);
-			assert_ok!(Swapping::update_broker_bond(RuntimeOrigin::root(), BOND));
-			assert_eq!(BrokerBond::<Test>::get(), BOND);
-		});
-	}
-
-	#[test]
 	fn default_broker_bond() {
 		new_test_ext().execute_with(|| {
 			assert_eq!(BrokerBond::<Test>::get(), FLIPPERINOS_PER_FLIP * 100);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -28,6 +28,7 @@ use cf_traits::{
 	mocks::{
 		address_converter::MockAddressConverter,
 		egress_handler::{MockEgressHandler, MockEgressParameter},
+		funding_info::MockFundingInfo,
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 	},
 	AccountRoleRegistry, AssetConverter, Chainflip, SetSafeMode,
@@ -1257,6 +1258,8 @@ fn broker_deregistration_checks_private_channels() {
 		)
 		.expect("BROKER was registered in test setup.");
 
+		MockFundingInfo::<Test>::credit_funds(&BROKER, FLIPPERINOS_PER_FLIP * 200);
+
 		// Create a private broker channel
 		assert_ok!(Swapping::open_private_btc_channel(OriginTrait::signed(BROKER)));
 
@@ -1663,6 +1666,8 @@ mod private_channels {
 			// Only brokers can open private channels
 			assert_noop!(Swapping::open_private_btc_channel(OriginTrait::signed(ALICE)), BadOrigin);
 
+			MockFundingInfo::<Test>::credit_funds(&BROKER, FLIPPERINOS_PER_FLIP * 200);
+
 			assert_eq!(BrokerPrivateBtcChannels::<Test>::get(BROKER), None);
 
 			assert_ok!(Swapping::open_private_btc_channel(OriginTrait::signed(BROKER)));
@@ -1692,6 +1697,8 @@ mod private_channels {
 				)
 				.unwrap();
 
+				MockFundingInfo::<Test>::credit_funds(&BROKER_2, FLIPPERINOS_PER_FLIP * 200);
+
 				assert_ok!(Swapping::open_private_btc_channel(OriginTrait::signed(BROKER_2)));
 
 				assert_eq!(
@@ -1717,6 +1724,8 @@ mod private_channels {
 				Swapping::close_private_btc_channel(OriginTrait::signed(BROKER)),
 				Error::<Test>::NoPrivateChannelExistsForBroker
 			);
+
+			MockFundingInfo::<Test>::credit_funds(&BROKER, FLIPPERINOS_PER_FLIP * 200);
 
 			assert_ok!(Swapping::open_private_btc_channel(OriginTrait::signed(BROKER)));
 			assert_eq!(BrokerPrivateBtcChannels::<Test>::get(BROKER), Some(CHANNEL_ID));

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1794,7 +1794,7 @@ mod private_channels {
 	#[test]
 	fn update_broker_bond() {
 		new_test_ext().execute_with(|| {
-			const BOND: u128 = 100_000_000_000_000_000_000u128;
+			const BOND: u128 = FLIPPERINOS_PER_FLIP * 100;
 			assert_noop!(
 				Swapping::update_broker_bond(OriginTrait::signed(BROKER), BOND),
 				sp_runtime::traits::BadOrigin
@@ -1807,7 +1807,7 @@ mod private_channels {
 	#[test]
 	fn default_broker_bond() {
 		new_test_ext().execute_with(|| {
-			assert_eq!(BrokerBond::<Test>::get(), 100_000_000_000_000_000_000u128);
+			assert_eq!(BrokerBond::<Test>::get(), FLIPPERINOS_PER_FLIP * 100);
 		});
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/weights.rs
+++ b/state-chain/pallets/cf-swapping/src/weights.rs
@@ -40,7 +40,6 @@ pub trait WeightInfo {
 	fn open_private_btc_channel() -> Weight;
 	fn close_private_btc_channel() -> Weight;
 	fn register_affiliate() -> Weight;
-	fn update_broker_bond() -> Weight;
 }
 
 /// Weights for pallet_cf_swapping using the Substrate node and recommended hardware.
@@ -210,16 +209,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Swapping::BrokerBond` (r:0 w:1)
-	/// Proof: `Swapping::BrokerBond` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	fn update_broker_bond() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 1_000_000 picoseconds.
-		Weight::from_parts(2_000_000, 0)
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
 }
 
 // For backwards compatibility and tests
@@ -386,16 +375,6 @@ impl WeightInfo for () {
 		// Minimum execution time: 13_000_000 picoseconds.
 		Weight::from_parts(14_000_000, 4072)
 			.saturating_add(ParityDbWeight::get().reads(2_u64))
-			.saturating_add(ParityDbWeight::get().writes(1_u64))
-	}
-	/// Storage: `Swapping::BrokerBond` (r:0 w:1)
-	/// Proof: `Swapping::BrokerBond` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	fn update_broker_bond() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 1_000_000 picoseconds.
-		Weight::from_parts(2_000_000, 0)
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/weights.rs
+++ b/state-chain/pallets/cf-swapping/src/weights.rs
@@ -40,6 +40,7 @@ pub trait WeightInfo {
 	fn open_private_btc_channel() -> Weight;
 	fn close_private_btc_channel() -> Weight;
 	fn register_affiliate() -> Weight;
+	fn update_broker_bond() -> Weight;
 }
 
 /// Weights for pallet_cf_swapping using the Substrate node and recommended hardware.
@@ -209,7 +210,16 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-
+	/// Storage: `Swapping::BrokerBond` (r:0 w:1)
+	/// Proof: `Swapping::BrokerBond` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn update_broker_bond() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 1_000_000 picoseconds.
+		Weight::from_parts(2_000_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -378,5 +388,14 @@ impl WeightInfo for () {
 			.saturating_add(ParityDbWeight::get().reads(2_u64))
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
-
+	/// Storage: `Swapping::BrokerBond` (r:0 w:1)
+	/// Proof: `Swapping::BrokerBond` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn update_broker_bond() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 1_000_000 picoseconds.
+		Weight::from_parts(2_000_000, 0)
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
+	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -150,7 +150,7 @@ pub mod pallet {
 		>;
 
 		/// Updates the bond of an authority.
-		type Bonder: Bonding<ValidatorId = ValidatorIdOf<Self>, Amount = Self::Amount>;
+		type Bonder: Bonding<AccountId = ValidatorIdOf<Self>, Amount = Self::Amount>;
 
 		/// This is used to reset the validator's reputation
 		type ReputationResetter: ReputationResetter<ValidatorId = ValidatorIdOf<Self>>;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -16,6 +16,8 @@ use frame_support::{construct_runtime, derive_impl};
 use sp_runtime::{impl_opaque_keys, testing::UintAuthorityId, traits::ConvertInto};
 use std::{cell::RefCell, collections::HashMap};
 
+use cf_traits::mocks::bonding::MockBonder;
+
 pub type Amount = u128;
 pub type ValidatorId = u64;
 
@@ -112,24 +114,37 @@ thread_local! {
 	pub static AUTHORITY_BONDS: RefCell<HashMap<ValidatorId, Amount>> = RefCell::new(HashMap::default());
 }
 
-pub struct MockBonder;
+// pub struct MockBonder;
 
-impl MockBonder {
-	pub fn get_bond(account_id: &ValidatorId) -> Amount {
-		AUTHORITY_BONDS.with(|cell| cell.borrow().get(account_id).copied().unwrap_or(0))
-	}
-}
+// impl MockBonder {
+// 	pub fn get_bond(account_id: &ValidatorId) -> Amount {
+// 		AUTHORITY_BONDS.with(|cell| cell.borrow().get(account_id).copied().unwrap_or(0))
+// 	}
+// }
 
-impl Bonding for MockBonder {
-	type ValidatorId = ValidatorId;
-	type Amount = Amount;
+// impl Bonding for MockBonder {
+// 	type ValidatorId = ValidatorId;
+// 	type Amount = Amount;
 
-	fn update_bond(account_id: &Self::ValidatorId, bond: Self::Amount) {
-		AUTHORITY_BONDS.with(|cell| {
-			cell.borrow_mut().insert(*account_id, bond);
-		})
-	}
-}
+// 	fn update_bond(account_id: &Self::ValidatorId, bond: Self::Amount) {
+// 		AUTHORITY_BONDS.with(|cell| {
+// 			cell.borrow_mut().insert(*account_id, bond);
+// 		})
+// 	}
+
+// 	fn try_bond(account_id: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult {
+// 		AUTHORITY_BONDS.with(|cell| {
+// 			cell.borrow_mut().insert(*account_id, bond);
+// 		});
+// 		Ok(())
+// 	}
+
+// 	fn unbond(account_id: &Self::ValidatorId) {
+// 		AUTHORITY_BONDS.with(|cell| {
+// 			cell.borrow_mut().remove(account_id);
+// 		})
+// 	}
+// }
 
 pub type MockOffenceReporter =
 	cf_traits::mocks::offence_reporting::MockOffenceReporter<ValidatorId, PalletOffence>;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -16,7 +16,7 @@ use frame_support::{construct_runtime, derive_impl};
 use sp_runtime::{impl_opaque_keys, testing::UintAuthorityId, traits::ConvertInto};
 use std::{cell::RefCell, collections::HashMap};
 
-use cf_traits::mocks::bonding::MockBonder;
+use cf_traits::mocks::bonding::MockBonderFor;
 
 pub type Amount = u128;
 pub type ValidatorId = u64;
@@ -133,7 +133,7 @@ impl Config for Test {
 	type RotationBroadcastsPending = MockRotationBroadcastsPending;
 	type MissedAuthorshipSlots = MockMissedAuthorshipSlots;
 	type OffenceReporter = MockOffenceReporter;
-	type Bonder = MockBonder;
+	type Bonder = MockBonderFor<Self>;
 	type ReputationResetter = MockReputationResetter<Self>;
 	type KeygenQualification = QualifyAll<ValidatorId>;
 	type SafeMode = MockRuntimeSafeMode;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -114,38 +114,6 @@ thread_local! {
 	pub static AUTHORITY_BONDS: RefCell<HashMap<ValidatorId, Amount>> = RefCell::new(HashMap::default());
 }
 
-// pub struct MockBonder;
-
-// impl MockBonder {
-// 	pub fn get_bond(account_id: &ValidatorId) -> Amount {
-// 		AUTHORITY_BONDS.with(|cell| cell.borrow().get(account_id).copied().unwrap_or(0))
-// 	}
-// }
-
-// impl Bonding for MockBonder {
-// 	type ValidatorId = ValidatorId;
-// 	type Amount = Amount;
-
-// 	fn update_bond(account_id: &Self::ValidatorId, bond: Self::Amount) {
-// 		AUTHORITY_BONDS.with(|cell| {
-// 			cell.borrow_mut().insert(*account_id, bond);
-// 		})
-// 	}
-
-// 	fn try_bond(account_id: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult {
-// 		AUTHORITY_BONDS.with(|cell| {
-// 			cell.borrow_mut().insert(*account_id, bond);
-// 		});
-// 		Ok(())
-// 	}
-
-// 	fn unbond(account_id: &Self::ValidatorId) {
-// 		AUTHORITY_BONDS.with(|cell| {
-// 			cell.borrow_mut().remove(account_id);
-// 		})
-// 	}
-// }
-
 pub type MockOffenceReporter =
 	cf_traits::mocks::offence_reporting::MockOffenceReporter<ValidatorId, PalletOffence>;
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{mock::*, Error, *};
 use cf_test_utilities::{assert_event_sequence, last_event};
 use cf_traits::{
 	mocks::{
-		bonding::MockBonder,
+		bonding::MockBonderFor,
 		cfe_interface_mock::{MockCfeEvent, MockCfeInterface},
 		key_rotator::MockKeyRotatorA,
 		reputation_resetter::MockReputationResetter,
@@ -649,7 +649,7 @@ mod bond_expiry {
 
 			// Ensure the new bond is set for each authority
 			ValidatorPallet::current_authorities().iter().for_each(|account_id| {
-				assert_eq!(MockBonder::get_bond(account_id), BOND);
+				assert_eq!(MockBonderFor::<Test>::get_bond(account_id), BOND);
 			});
 
 			const NEXT_BOND: u128 = BOND + 1;
@@ -657,7 +657,7 @@ mod bond_expiry {
 			assert_eq!(ValidatorPallet::bond(), NEXT_BOND);
 
 			ValidatorPallet::current_authorities().iter().for_each(|account_id| {
-				assert_eq!(MockBonder::get_bond(account_id), NEXT_BOND);
+				assert_eq!(MockBonderFor::<Test>::get_bond(account_id), NEXT_BOND);
 			});
 
 			assert_eq!(EpochHistory::<Test>::active_epochs_for_authority(&1), [initial_epoch + 1]);
@@ -681,16 +681,16 @@ mod bond_expiry {
 			assert_eq!(ValidatorPallet::bond(), 100);
 
 			ValidatorPallet::current_authorities().iter().for_each(|account_id| {
-				assert_eq!(MockBonder::get_bond(account_id), 100);
+				assert_eq!(MockBonderFor::<Test>::get_bond(account_id), 100);
 			});
 
 			ValidatorPallet::transition_to_next_epoch(vec![AUTHORITY_IN_BOTH_EPOCHS, 3], 99);
 			assert_eq!(ValidatorPallet::bond(), 99);
 
 			// Keeps the highest bond of all the epochs it's been active in
-			assert_eq!(MockBonder::get_bond(&AUTHORITY_IN_BOTH_EPOCHS), 100);
+			assert_eq!(MockBonderFor::<Test>::get_bond(&AUTHORITY_IN_BOTH_EPOCHS), 100);
 			// Uses the new bond
-			assert_eq!(MockBonder::get_bond(&3), 99);
+			assert_eq!(MockBonderFor::<Test>::get_bond(&3), 99);
 
 			assert_eq!(EpochHistory::<Test>::active_epochs_for_authority(&1), [initial_epoch + 1]);
 			assert_eq!(EpochHistory::<Test>::active_bond(&1), 100);

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -6,6 +6,7 @@ use crate::{mock::*, Error, *};
 use cf_test_utilities::{assert_event_sequence, last_event};
 use cf_traits::{
 	mocks::{
+		bonding::MockBonder,
 		cfe_interface_mock::{MockCfeEvent, MockCfeInterface},
 		key_rotator::MockKeyRotatorA,
 		reputation_resetter::MockReputationResetter,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -308,6 +308,7 @@ impl pallet_cf_swapping::Config for Runtime {
 	type NetworkFee = NetworkFee;
 	type BalanceApi = AssetBalances;
 	type ChannelIdAllocator = BitcoinIngressEgress;
+	type Bonder = Bonder<Runtime>;
 }
 
 impl pallet_cf_vaults::Config<Instance1> for Runtime {

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -690,13 +690,6 @@ pub trait Bonding {
 	type Amount;
 	/// Update the bond of an authority
 	fn update_bond(authority: &Self::ValidatorId, bond: Self::Amount);
-	/// Try to bond an amount for an account. Checks if the account exists and if the account has
-	/// enough liquidity to bond the amount.
-	/// If not, returns an error.
-	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult;
-	/// Frees the account from its bond.
-	/// Note: Does nothing if the account does not exist.
-	fn unbond(authority: &Self::ValidatorId);
 }
 
 /// Something that is able to provide block authorship slots that were missed.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -686,10 +686,10 @@ pub trait HistoricalEpoch {
 
 /// Handles the bonding logic
 pub trait Bonding {
-	type ValidatorId;
+	type AccountId;
 	type Amount;
 	/// Update the bond of an authority
-	fn update_bond(authority: &Self::ValidatorId, bond: Self::Amount);
+	fn update_bond(authority: &Self::AccountId, bond: Self::Amount);
 }
 
 /// Something that is able to provide block authorship slots that were missed.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -689,11 +689,13 @@ pub trait Bonding {
 	type Amount;
 	/// Update the bond of an authority
 	fn update_bond(authority: &Self::ValidatorId, bond: Self::Amount);
-	/// Try to bond an amount for an account. Returns true if the bond was successful, false
-	/// otherwise.
-	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> bool;
-	/// Kill the bond of an authority.
-	fn kill_bond(authority: &Self::ValidatorId);
+	/// Try to bond an amount for an account. Checks if the account exists and if the account has
+	/// enough liquidity to bond the amount.
+	/// If not, returns an error.
+	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult;
+	/// Frees the account from its bond.
+	/// Note: Does nothing if the account does not exist.
+	fn unbond(authority: &Self::ValidatorId);
 }
 
 /// Something that is able to provide block authorship slots that were missed.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -689,6 +689,11 @@ pub trait Bonding {
 	type Amount;
 	/// Update the bond of an authority
 	fn update_bond(authority: &Self::ValidatorId, bond: Self::Amount);
+	/// Try to bond an amount for an account. Returns true if the bond was successful, false
+	/// otherwise.
+	fn try_bond(authority: &Self::ValidatorId, bond: Self::Amount) -> bool;
+	/// Kill the bond of an authority.
+	fn kill_bond(authority: &Self::ValidatorId);
 }
 
 /// Something that is able to provide block authorship slots that were missed.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -59,6 +59,7 @@ pub trait Chainflip: frame_system::Config {
 		+ FixedPointOperand
 		+ MaybeSerializeDeserialize
 		+ Bounded
+		+ From<u128>
 		+ Sum<Self::Amount>;
 
 	/// An identity for a node

--- a/state-chain/traits/src/mocks.rs
+++ b/state-chain/traits/src/mocks.rs
@@ -11,6 +11,7 @@ pub mod asset_converter;
 pub mod asset_withholding;
 pub mod balance_api;
 pub mod block_height_provider;
+pub mod bonding;
 pub mod broadcaster;
 pub mod ceremony_id_provider;
 pub mod cfe_interface_mock;

--- a/state-chain/traits/src/mocks/bonding.rs
+++ b/state-chain/traits/src/mocks/bonding.rs
@@ -1,0 +1,43 @@
+use crate::Bonding;
+use std::{cell::RefCell, collections::HashMap};
+
+use crate::DispatchResult;
+
+pub type Amount = u128;
+pub type ValidatorId = u64;
+
+thread_local! {
+	pub static AUTHORITY_BONDS: RefCell<HashMap<ValidatorId, Amount>> = RefCell::new(HashMap::default());
+}
+
+pub struct MockBonder;
+
+impl MockBonder {
+	pub fn get_bond(account_id: &ValidatorId) -> Amount {
+		AUTHORITY_BONDS.with(|cell| cell.borrow().get(account_id).copied().unwrap_or(0))
+	}
+}
+
+impl Bonding for MockBonder {
+	type ValidatorId = ValidatorId;
+	type Amount = Amount;
+
+	fn update_bond(account_id: &Self::ValidatorId, bond: Self::Amount) {
+		AUTHORITY_BONDS.with(|cell| {
+			cell.borrow_mut().insert(*account_id, bond);
+		})
+	}
+
+	fn try_bond(account_id: &Self::ValidatorId, bond: Self::Amount) -> DispatchResult {
+		AUTHORITY_BONDS.with(|cell| {
+			cell.borrow_mut().insert(*account_id, bond);
+		});
+		Ok(())
+	}
+
+	fn unbond(account_id: &Self::ValidatorId) {
+		AUTHORITY_BONDS.with(|cell| {
+			cell.borrow_mut().remove(account_id);
+		})
+	}
+}

--- a/state-chain/traits/src/mocks/bonding.rs
+++ b/state-chain/traits/src/mocks/bonding.rs
@@ -25,5 +25,6 @@ impl Bonding for MockBonder {
 	fn update_bond(account_id: &Self::ValidatorId, bond: Self::Amount) {
 		let mut authority_bonds = AuthorityBonds::get();
 		authority_bonds.insert(*account_id, bond);
+		AuthorityBonds::set(&authority_bonds);
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1761

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Bond a broker by a 100 FLIP if he wants to open a private broker channel
- Added an extrinsic to update the required bond
- Extended the Flip pallet to bond an account under the condition of having enough liquid balance in his account
- Added a benchmark and tests
- Increased the amount of FLIP for BROKER accounts in the test net to have enough funds in the bouncer tests

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
