### PR TITLE
fix: Solana get_block transaction version

### DIFF
--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -173,7 +173,10 @@ impl VoterApi<SolanaLiveness> for SolanaLivenessVoter {
 				.client
 				.get_block(
 					slot,
-					RpcBlockConfig { max_supported_transaction_version: 0, ..Default::default() },
+					RpcBlockConfig {
+						max_supported_transaction_version: Some(0),
+						..Default::default()
+					},
 				)
 				.await
 				.blockhash,


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

When getting block in Solana use `max_supported_transaction_version` zero instead of defaulting to None.