### PR TITLE
update localnet polkadot node to version 1.3.4

### DIFF
--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     command:
       - --alice
       - --blocks-pruning=archive
-      - --chain=/chainspecs/polkadot-dev.chainspec.v1.3.3.json
+      - --chain=/chainspecs/polkadot-dev.chainspec.v1.3.4.json
       - --force-authoring
       - --name=PolkaDocker
       - --rpc-cors=all


### PR DESCRIPTION
# Pull Request
Updates the localnet chainspec for polkadot to the latest version 1.3.4