### PR TITLE
chore: reduce data needed for sol get block

### DIFF
--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -8,7 +8,7 @@ use crate::{
 	sol::{
 		commitment_config::CommitmentConfig,
 		retry_rpc::{SolRetryRpcApi, SolRetryRpcClient},
-		rpc_client_api::RpcBlockConfig,
+		rpc_client_api::{RpcBlockConfig, TransactionDetails},
 	},
 	state_chain_observer::client::{
 		chain_api::ChainApi, electoral_api::ElectoralApi,
@@ -174,6 +174,8 @@ impl VoterApi<SolanaLiveness> for SolanaLivenessVoter {
 				.get_block(
 					slot,
 					RpcBlockConfig {
+						transaction_details: Some(TransactionDetails::None),
+						rewards: Some(false),
 						max_supported_transaction_version: Some(0),
 						..Default::default()
 					},


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

According to the docs when not passing those parameters (Rust's None) it doesn't default to those. Setting them prevents the call to get the rewards and more importantly the transaction data which we don't need.
