### PR TITLE
fix: bouncer btc client mutex for vault swaps

### DIFF
--- a/bouncer/commands/create_raw_btc_tx.ts
+++ b/bouncer/commands/create_raw_btc_tx.ts
@@ -15,6 +15,7 @@ const createRawTransaction = async (toAddress: string, amountInBtc: number | str
     const fundedTx = (await btcClient.fundRawTransaction(rawTx, {
       changeAddress: await btcClient.getNewAddress(),
       feeRate: 0.00001,
+      lockUnspents: true,
     })) as { hex: string };
 
     // Sign the raw transaction

--- a/bouncer/commands/create_raw_btc_tx.ts
+++ b/bouncer/commands/create_raw_btc_tx.ts
@@ -2,26 +2,23 @@
 // Constructs a very simple Raw BTC transaction. Can be used for manual testing a raw broadcast for example.
 // Usage: ./commands/create_raw_btc_tx.ts <bitcoin_address> <btc_amount>
 
-import { BTC_ENDPOINT, btcClient, selectInputs } from '../shared/send_btc';
+import { BTC_ENDPOINT, btcClient } from '../shared/send_btc';
 
 console.log(`Btc endpoint is set to '${BTC_ENDPOINT}'`);
 
 const createRawTransaction = async (toAddress: string, amountInBtc: number | string) => {
   try {
-    // Inputs and outputs
-    const feeInBtc = 0.00001;
-    const { inputs, change } = await selectInputs(Number(amountInBtc) + feeInBtc);
-    const changeAddress = await btcClient.getNewAddress();
-    const outputs = {
-      [toAddress]: amountInBtc,
-      [changeAddress]: change,
-    };
-
     // Create the raw transaction
-    const rawTx = await btcClient.createRawTransaction(inputs, outputs);
+    const rawTx = await btcClient.createRawTransaction([], {
+      [toAddress]: amountInBtc,
+    });
+    const fundedTx = (await btcClient.fundRawTransaction(rawTx, {
+      changeAddress: await btcClient.getNewAddress(),
+      feeRate: 0.00001,
+    })) as { hex: string };
 
     // Sign the raw transaction
-    const signedTx = await btcClient.signRawTransactionWithWallet(rawTx);
+    const signedTx = await btcClient.signRawTransactionWithWallet(fundedTx);
 
     // Here's your raw signed transaction
     console.log('Raw signed transaction:', signedTx.hex);

--- a/bouncer/shared/send_btc.ts
+++ b/bouncer/shared/send_btc.ts
@@ -21,6 +21,8 @@ export async function fundAndSendTransaction(
     const fundedTx = (await btcClient.fundRawTransaction(rawTx, {
       changeAddress,
       feeRate: feeRate ?? 0.00001,
+      lockUnspents: true,
+      changePosition: 2,
     })) as { hex: string };
     const signedTx = await btcClient.signRawTransactionWithWallet(fundedTx.hex);
     const txId = (await btcClient.sendRawTransaction(signedTx.hex)) as string | undefined;

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -21,7 +21,7 @@ import { getChainflipApi, observeEvent } from '../shared/utils/substrate';
 import { ExecutableTest } from '../shared/executable_test';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export const testLpApi = new ExecutableTest('LP-API', main, 1000);
+export const testLpApi = new ExecutableTest('LP-API', main, 200);
 
 type RpcAsset = {
   asset: string;
@@ -397,27 +397,27 @@ async function main() {
   const registerLiquidityRefundAddress = new ExecutableTest(
     'LP-API::Register-Liquidity-Refund-Address',
     testRegisterLiquidityRefundAddress,
-    500,
+    30,
   );
   const LiquidityDeposit = new ExecutableTest(
     'LP-API::Liquidity-Deposit',
     testLiquidityDeposit,
-    500,
+    60,
   );
-  const WithdrawAsset = new ExecutableTest('LP-API::Withdraw-Asset', testWithdrawAsset, 500);
+  const WithdrawAsset = new ExecutableTest('LP-API::Withdraw-Asset', testWithdrawAsset, 60);
   const RegisterWithExistingLpAccount = new ExecutableTest(
     'LP-API::testRegisterWithExistingLpAccount',
     testRegisterWithExistingLpAccount,
-    500,
+    15,
   );
-  const RangeOrder = new ExecutableTest('LP-API::Range-Order', testRangeOrder, 500);
-  const LimitOrder = new ExecutableTest('LP-API::Limit-Order', testLimitOrder, 500);
+  const RangeOrder = new ExecutableTest('LP-API::Range-Order', testRangeOrder, 60);
+  const LimitOrder = new ExecutableTest('LP-API::Limit-Order', testLimitOrder, 120);
   const GetOpenSwapChannels = new ExecutableTest(
     'LP-API::Get-Open-Swap-Channels',
     testGetOpenSwapChannels,
-    500,
+    15,
   );
-  const TransferAsset = new ExecutableTest('LP-API::TransferAsset', testTransferAsset, 500);
+  const TransferAsset = new ExecutableTest('LP-API::TransferAsset', testTransferAsset, 30);
 
   // Provide the amount of liquidity needed for the tests
   await provideLiquidityAndTestAssetBalances();

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -21,7 +21,7 @@ import { getChainflipApi, observeEvent } from '../shared/utils/substrate';
 import { ExecutableTest } from '../shared/executable_test';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export const testLpApi = new ExecutableTest('LP-API', main, 200);
+export const testLpApi = new ExecutableTest('LP-API', main, 1000);
 
 type RpcAsset = {
   asset: string;


### PR DESCRIPTION
# Pull Request

Closes: PRO-1832

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Using the btc client mutex around selecting inputs and sending transaction to avoid double spending error.
