### PR TITLE
Feat: Boost Support for Vault Swaps

### DIFF
--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -8,11 +8,12 @@ use cf_chains::{
 	Arbitrum, CcmDepositMetadata,
 };
 use cf_primitives::{
-	chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, Beneficiary, EpochIndex,
+	chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, Beneficiary, ChannelId, EpochIndex,
 };
 use cf_utilities::task_scope::Scope;
 use futures_core::Future;
 use itertools::Itertools;
+use pallet_cf_ingress_egress::VaultDepositWitness;
 use sp_core::H160;
 
 use crate::{
@@ -185,7 +186,10 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 	type Chain = Arbitrum;
 
 	fn vault_swap_request(
+		block_height: u64,
 		source_asset: Asset,
+		deposit_address: cf_chains::eth::Address,
+		channel_id: ChannelId,
 		deposit_amount: AssetAmount,
 		destination_asset: Asset,
 		destination_address: EncodedAddress,
@@ -195,24 +199,29 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 	) -> state_chain_runtime::RuntimeCall {
 		state_chain_runtime::RuntimeCall::ArbitrumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
-				input_asset: source_asset.try_into().expect("invalid asset for chain"),
-				output_asset: destination_asset,
-				deposit_amount,
-				destination_address,
-				deposit_metadata,
-				tx_id,
-				deposit_details: Box::new(DepositDetails { tx_hashes: Some(vec![tx_id]) }),
-				broker_fee: vault_swap_parameters.broker_fee,
-				affiliate_fees: vault_swap_parameters
-					.affiliate_fees
-					.into_iter()
-					.map(|entry| Beneficiary { account: entry.affiliate, bps: entry.fee.into() })
-					.collect_vec()
-					.try_into()
-					.expect("runtime supports at least as many affiliates as we allow in cf_parameters encoding"),
-				boost_fee: vault_swap_parameters.boost_fee.into(),
-				dca_params: vault_swap_parameters.dca_params,
-				refund_params: Box::new(vault_swap_parameters.refund_params),
+				block_height,
+				deposits: vec![VaultDepositWitness {
+					input_asset: source_asset.try_into().expect("invalid asset for chain"),
+					output_asset: destination_asset,
+					deposit_amount,
+					destination_address,
+					deposit_metadata,
+					tx_id,
+					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_id]) },
+					broker_fee: vault_swap_parameters.broker_fee,
+					affiliate_fees: vault_swap_parameters
+						.affiliate_fees
+						.into_iter()
+						.map(|entry| Beneficiary { account: entry.affiliate, bps: entry.fee.into() })
+						.collect_vec()
+						.try_into()
+						.expect("runtime supports at least as many affiliates as we allow in cf_parameters encoding"),
+					boost_fee: vault_swap_parameters.boost_fee.into(),
+					dca_params: vault_swap_parameters.dca_params,
+					refund_params: vault_swap_parameters.refund_params,
+					channel_id,
+					deposit_address,
+				}],
 			},
 		)
 	}

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -7,9 +7,7 @@ use cf_chains::{
 	evm::{DepositDetails, H256},
 	Arbitrum, CcmDepositMetadata,
 };
-use cf_primitives::{
-	chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, Beneficiary, EpochIndex,
-};
+use cf_primitives::{chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, EpochIndex};
 use cf_utilities::task_scope::Scope;
 use futures_core::Future;
 use itertools::Itertools;
@@ -208,7 +206,7 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 		state_chain_runtime::RuntimeCall::ArbitrumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
 				block_height,
-				deposits: vec![deposit],
+				deposit: Box::new(deposit),
 			},
 		)
 	}

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -8,7 +8,7 @@ use cf_chains::{
 	Arbitrum, CcmDepositMetadata,
 };
 use cf_primitives::{
-	chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, Beneficiary, ChannelId, EpochIndex,
+	chains::assets::arb::Asset as ArbAsset, Asset, AssetAmount, Beneficiary, EpochIndex,
 };
 use cf_utilities::task_scope::Scope;
 use futures_core::Future;
@@ -188,8 +188,6 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 	fn vault_swap_request(
 		block_height: u64,
 		source_asset: Asset,
-		deposit_address: cf_chains::eth::Address,
-		channel_id: ChannelId,
 		deposit_amount: AssetAmount,
 		destination_asset: Asset,
 		destination_address: EncodedAddress,
@@ -219,8 +217,8 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 					boost_fee: vault_swap_parameters.boost_fee.into(),
 					dca_params: vault_swap_parameters.dca_params,
 					refund_params: vault_swap_parameters.refund_params,
-					channel_id,
-					deposit_address,
+					channel_id: None,
+					deposit_address: None,
 				}],
 			},
 		)

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -96,7 +96,7 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 							process_call(
 								BtcIngressEgressCall::vault_swap_request {
 									block_height: header.index,
-									deposits: vec![deposit],
+									deposit: Box::new(deposit),
 								}
 								.into(),
 								epoch.index,

--- a/engine/src/witness/btc/vault_swaps.rs
+++ b/engine/src/witness/btc/vault_swaps.rs
@@ -170,8 +170,8 @@ pub fn try_extract_vault_swap_witness(
 		}),
 		// This is only to be checked in the pre-witnessed version
 		boost_fee: data.parameters.boost_fee.into(),
-		channel_id,
-		deposit_address: vault_address.script_pubkey(),
+		channel_id: Some(channel_id),
+		deposit_address: Some(vault_address.script_pubkey()),
 	})
 }
 
@@ -328,8 +328,8 @@ mod tests {
 					chunk_interval: MOCK_SWAP_PARAMS.parameters.chunk_interval.into(),
 				}),
 				boost_fee: MOCK_SWAP_PARAMS.parameters.boost_fee.into(),
-				deposit_address: vault_deposit_address.script_pubkey(),
-				channel_id: CHANNEL_ID,
+				deposit_address: Some(vault_deposit_address.script_pubkey()),
+				channel_id: Some(CHANNEL_ID),
 			})
 		);
 	}

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -257,7 +257,7 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 		state_chain_runtime::RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
 				block_height,
-				deposits: vec![deposit],
+				deposit: Box::new(deposit),
 			},
 		)
 	}

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -31,7 +31,10 @@ use crate::{
 	},
 };
 
-use super::{common::epoch_source::EpochSourceBuilder, evm::source::EvmSource};
+use super::{
+	common::epoch_source::EpochSourceBuilder,
+	evm::{source::EvmSource, vault::vault_deposit_witness},
+};
 use crate::witness::common::chain_source::extension::ChainSourceExt;
 
 use anyhow::{Context, Result};
@@ -242,32 +245,19 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 		tx_id: H256,
 		vault_swap_parameters: VaultSwapParameters,
 	) -> state_chain_runtime::RuntimeCall {
+		let deposit = vault_deposit_witness!(
+			source_asset,
+			deposit_amount,
+			destination_asset,
+			destination_address,
+			deposit_metadata,
+			tx_id,
+			vault_swap_parameters
+		);
 		state_chain_runtime::RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
 				block_height,
-				deposits: vec![ VaultDepositWitness {
-					input_asset: source_asset.try_into().expect("invalid asset for chain"),
-					output_asset: destination_asset,
-					deposit_amount,
-					destination_address,
-					deposit_metadata,
-					tx_id,
-					deposit_details: DepositDetails { tx_hashes: Some(vec![tx_id]) },
-					broker_fee: vault_swap_parameters.broker_fee,
-					affiliate_fees: vault_swap_parameters
-						.affiliate_fees
-						.into_iter()
-						.map(Into::into)
-						.collect_vec()
-						.try_into()
-						.expect("runtime supports at least as many affiliates as we allow in cf_parameters encoding"),
-					boost_fee: vault_swap_parameters.boost_fee.into(),
-					dca_params: vault_swap_parameters.dca_params,
-					refund_params: vault_swap_parameters.refund_params,
-					channel_id: None,
-					deposit_address: None,
-				}
-				],
+				deposits: vec![deposit],
 			},
 		)
 	}

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -8,9 +8,7 @@ use cf_chains::{
 	evm::{DepositDetails, H256},
 	CcmDepositMetadata, Ethereum,
 };
-use cf_primitives::{
-	chains::assets::eth::Asset as EthAsset, Asset, AssetAmount, ChannelId, EpochIndex,
-};
+use cf_primitives::{chains::assets::eth::Asset as EthAsset, Asset, AssetAmount, EpochIndex};
 use cf_utilities::task_scope::Scope;
 use futures_core::Future;
 use itertools::Itertools;
@@ -237,8 +235,6 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 	fn vault_swap_request(
 		block_height: u64,
 		source_asset: Asset,
-		deposit_address: cf_chains::eth::Address,
-		channel_id: ChannelId,
 		deposit_amount: AssetAmount,
 		destination_asset: Asset,
 		destination_address: EncodedAddress,
@@ -268,8 +264,8 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 					boost_fee: vault_swap_parameters.boost_fee.into(),
 					dca_params: vault_swap_parameters.dca_params,
 					refund_params: vault_swap_parameters.refund_params,
-					channel_id,
-					deposit_address,
+					channel_id: None,
+					deposit_address: None,
 				}
 				],
 			},

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -1,7 +1,6 @@
 use crate::evm::retry_rpc::EvmRetryRpcApi;
 use codec::Decode;
 use ethers::types::Bloom;
-use pallet_cf_ingress_egress::VaultDepositWitness;
 use sp_core::H256;
 use std::collections::HashMap;
 

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -34,7 +34,7 @@ use pallet_cf_elections::{
 	vote_storage::{composite::tuple_7_impls::CompositeVote, AuthorityVote},
 	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
-use pallet_cf_ingress_egress::{DepositWitness, FetchOrTransfer};
+use pallet_cf_ingress_egress::{DepositWitness, FetchOrTransfer, VaultDepositWitness};
 use pallet_cf_validator::RotationPhase;
 use sp_core::ConstU32;
 use sp_runtime::BoundedBTreeMap;
@@ -437,6 +437,30 @@ fn can_send_solana_ccm() {
 		});
 }
 
+fn vault_swap_deposit_witness(
+	deposit_metadata: Option<CcmDepositMetadata>,
+) -> VaultDepositWitness<Runtime, SolanaInstance> {
+	VaultDepositWitness {
+		input_asset: SolAsset::Sol,
+		output_asset: Asset::SolUsdc,
+		deposit_amount: 1_000_000_000_000u64,
+		destination_address: EncodedAddress::Sol([1u8; 32]),
+		deposit_metadata,
+		tx_id: Default::default(),
+		deposit_details: (),
+		broker_fee: cf_primitives::Beneficiary {
+			account: sp_runtime::AccountId32::new([0; 32]),
+			bps: 0,
+		},
+		affiliate_fees: Default::default(),
+		refund_params: REFUND_PARAMS,
+		dca_params: None,
+		boost_fee: 0,
+		deposit_address: SolAddress([2u8; 32]),
+		channel_id: 0,
+	}
+}
+
 #[test]
 fn solana_ccm_fails_with_invalid_input() {
 	const EPOCH_BLOCKS: u32 = 100;
@@ -507,21 +531,8 @@ fn solana_ccm_fails_with_invalid_input() {
 			// Contract call fails with invalid CCM
 			assert_ok!(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
-					input_asset: SolAsset::Sol,
-					output_asset: Asset::SolUsdc,
-					deposit_amount: 1_000_000_000_000u64,
-					destination_address: EncodedAddress::Sol([1u8; 32]),
-					deposit_metadata: Some(invalid_ccm),
-					tx_id: Default::default(),
-					deposit_details: Box::new(()),
-					broker_fee: cf_primitives::Beneficiary {
-						account: sp_runtime::AccountId32::new([0; 32]),
-						bps: 0,
-					},
-					affiliate_fees: Default::default(),
-					refund_params: Box::new(REFUND_PARAMS),
-					dca_params: None,
-					boost_fee: 0,
+					block_height: 0,
+					deposits: vec![vault_swap_deposit_witness(Some(invalid_ccm))],
 				}
 			)
 			.dispatch_bypass_filter(
@@ -565,21 +576,8 @@ fn solana_ccm_fails_with_invalid_input() {
 
 			witness_call(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
-					input_asset: SolAsset::Sol,
-					output_asset: Asset::SolUsdc,
-					deposit_amount: 1_000_000_000_000u64,
-					destination_address: EncodedAddress::Sol([1u8; 32]),
-					deposit_metadata: Some(ccm),
-					tx_id: Default::default(),
-					deposit_details: Box::new(()),
-					broker_fee: cf_primitives::Beneficiary {
-						account: sp_runtime::AccountId32::new([0; 32]),
-						bps: 0,
-					},
-					affiliate_fees: Default::default(),
-					refund_params: Box::new(REFUND_PARAMS),
-					dca_params: None,
-					boost_fee: 0,
+					block_height: 0,
+					deposits: vec![vault_swap_deposit_witness(Some(ccm))],
 				},
 			));
 			// Setting the current agg key will invalidate the CCM.
@@ -793,23 +791,9 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 			};
 			witness_call(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
-					input_asset: SolAsset::Sol,
-					output_asset: Asset::SolUsdc,
-					deposit_amount: 1_000_000_000_000u64,
-					destination_address: EncodedAddress::Sol([1u8; 32]),
-					deposit_metadata: Some(ccm),
-					tx_id: Default::default(),
-					deposit_details: Box::new(()),
-					broker_fee: cf_primitives::Beneficiary {
-						account: sp_runtime::AccountId32::new([0; 32]),
-						bps: 0,
-					},
-					affiliate_fees: Default::default(),
-					refund_params:  Box::new(REFUND_PARAMS),
-					dca_params: None,
-					boost_fee: 0,
-
-				},
+					block_height: 0,
+					deposits: vec![vault_swap_deposit_witness(Some(ccm))],
+				}
 			));
 
 			// Wait for the swaps to complete and call broadcasted.

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -532,7 +532,7 @@ fn solana_ccm_fails_with_invalid_input() {
 			assert_ok!(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
 					block_height: 0,
-					deposits: vec![vault_swap_deposit_witness(Some(invalid_ccm))],
+					deposit: Box::new(vault_swap_deposit_witness(Some(invalid_ccm))),
 				}
 			)
 			.dispatch_bypass_filter(
@@ -577,7 +577,7 @@ fn solana_ccm_fails_with_invalid_input() {
 			witness_call(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
 					block_height: 0,
-					deposits: vec![vault_swap_deposit_witness(Some(ccm))],
+					deposit: Box::new(vault_swap_deposit_witness(Some(ccm))),
 				},
 			));
 			// Setting the current agg key will invalidate the CCM.
@@ -792,7 +792,7 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 			witness_call(RuntimeCall::SolanaIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
 					block_height: 0,
-					deposits: vec![vault_swap_deposit_witness(Some(ccm))],
+					deposit: Box::new(vault_swap_deposit_witness(Some(ccm))),
 				}
 			));
 

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -456,8 +456,8 @@ fn vault_swap_deposit_witness(
 		refund_params: REFUND_PARAMS,
 		dca_params: None,
 		boost_fee: 0,
-		deposit_address: SolAddress([2u8; 32]),
-		channel_id: 0,
+		deposit_address: Some(SolAddress([2u8; 32])),
+		channel_id: Some(0),
 	}
 }
 

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -81,7 +81,7 @@ fn new_pool(unstable_asset: Asset, fee_hundredth_pips: u32, initial_price: Price
 
 fn credit_account(account_id: &AccountId, asset: Asset, amount: AssetAmount) {
 	let original_amount = pallet_cf_asset_balances::FreeBalances::<Runtime>::get(account_id, asset);
-	assert_ok!(AssetBalances::try_credit_account(account_id, asset, amount));
+	AssetBalances::credit_account(account_id, asset, amount);
 	assert_eq!(
 		pallet_cf_asset_balances::FreeBalances::<Runtime>::get(account_id, asset),
 		original_amount + amount

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -37,10 +37,10 @@ use pallet_cf_broadcast::{
 	AwaitingBroadcast, BroadcastIdCounter, PendingApiCalls, RequestFailureCallbacks,
 	RequestSuccessCallbacks,
 };
-use pallet_cf_ingress_egress::{DepositWitness, FailedForeignChainCall};
+use pallet_cf_ingress_egress::{DepositWitness, FailedForeignChainCall, VaultDepositWitness};
 use pallet_cf_pools::{HistoricalEarnedFees, OrderId, RangeOrderSize};
 use pallet_cf_swapping::{SwapRequestIdCounter, SwapRetryDelay};
-use sp_core::U256;
+use sp_core::{H160, U256};
 use state_chain_runtime::{
 	chainflip::{
 		address_derivation::AddressDerivation, ChainAddressConverter, EthTransactionBuilder,
@@ -569,6 +569,31 @@ fn ccm_deposit_metadata_mock() -> CcmDepositMetadata {
 	}
 }
 
+fn vault_swap_deposit_witness(
+	deposit_amount: u128,
+	output_asset: Asset,
+) -> VaultDepositWitness<Runtime, EthereumInstance> {
+	VaultDepositWitness {
+		input_asset: EthAsset::Eth,
+		output_asset,
+		deposit_amount,
+		destination_address: EncodedAddress::Eth([0x02; 20]),
+		deposit_metadata: Some(ccm_deposit_metadata_mock()),
+		tx_id: Default::default(),
+		deposit_details: DepositDetails { tx_hashes: None },
+		broker_fee: cf_primitives::Beneficiary {
+			account: sp_runtime::AccountId32::new([0; 32]),
+			bps: 0,
+		},
+		affiliate_fees: Default::default(),
+		refund_params: ETH_REFUND_PARAMS,
+		dca_params: None,
+		boost_fee: 0,
+		deposit_address: H160::from([0x03; 20]),
+		channel_id: 0,
+	}
+}
+
 #[test]
 fn can_process_ccm_via_direct_deposit() {
 	super::genesis::with_test_defaults().build().execute_with(|| {
@@ -578,21 +603,8 @@ fn can_process_ccm_via_direct_deposit() {
 
 		witness_call(RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
-				input_asset: EthAsset::Flip,
-				output_asset: Asset::Usdc,
-				deposit_amount,
-				destination_address: EncodedAddress::Eth([0x02; 20]),
-				deposit_metadata: Some(ccm_deposit_metadata_mock()),
-				tx_id: Default::default(),
-				deposit_details: Box::new(DepositDetails { tx_hashes: None }),
-				broker_fee: cf_primitives::Beneficiary {
-					account: sp_runtime::AccountId32::new([0; 32]),
-					bps: 0,
-				},
-				affiliate_fees: Default::default(),
-				refund_params: Box::new(ETH_REFUND_PARAMS),
-				dca_params: None,
-				boost_fee: 0,
+				block_height: 0,
+				deposits: vec![vault_swap_deposit_witness(deposit_amount, Asset::Usdc)],
 			},
 		));
 
@@ -632,21 +644,8 @@ fn failed_swaps_are_rolled_back() {
 
 		witness_call(RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
-				input_asset: EthAsset::Eth,
-				output_asset: Asset::Flip,
-				deposit_amount: 10_000 * DECIMALS,
-				destination_address: EncodedAddress::Eth(Default::default()),
-				tx_id: Default::default(),
-				deposit_metadata: None,
-				deposit_details: Box::new(DepositDetails { tx_hashes: None }),
-				broker_fee: cf_primitives::Beneficiary {
-					account: sp_runtime::AccountId32::new([0; 32]),
-					bps: 0,
-				},
-				affiliate_fees: Default::default(),
-				refund_params: Box::new(ETH_REFUND_PARAMS),
-				dca_params: None,
-				boost_fee: 0,
+				block_height: 0,
+				deposits: vec![vault_swap_deposit_witness(10_000 * DECIMALS, Asset::Flip)],
 			},
 		));
 
@@ -798,22 +797,8 @@ fn can_resign_failed_ccm() {
 
 			witness_call(RuntimeCall::EthereumIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
-					input_asset: EthAsset::Flip,
-					output_asset: Asset::Usdc,
-					deposit_amount: 10_000_000_000_000,
-					destination_address: EncodedAddress::Eth([0x02; 20]),
-					deposit_metadata: Some(ccm_deposit_metadata_mock()),
-					tx_id: Default::default(),
-					deposit_details: Box::new(DepositDetails { tx_hashes: None }),
-					broker_fee: cf_primitives::Beneficiary {
-						account: sp_runtime::AccountId32::new([0; 32]),
-						bps: 0,
-					},
-					affiliate_fees: Default::default(),
-
-					refund_params: Box::new(ETH_REFUND_PARAMS),
-					dca_params: None,
-					boost_fee: 0,
+					block_height: 0,
+					deposits: vec![vault_swap_deposit_witness(10_000_000_000_000, Asset::Usdc)],
 				},
 			));
 

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -604,7 +604,7 @@ fn can_process_ccm_via_direct_deposit() {
 		witness_call(RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
 				block_height: 0,
-				deposits: vec![vault_swap_deposit_witness(deposit_amount, Asset::Usdc)],
+				deposit: Box::new(vault_swap_deposit_witness(deposit_amount, Asset::Usdc)),
 			},
 		));
 
@@ -645,7 +645,7 @@ fn failed_swaps_are_rolled_back() {
 		witness_call(RuntimeCall::EthereumIngressEgress(
 			pallet_cf_ingress_egress::Call::vault_swap_request {
 				block_height: 0,
-				deposits: vec![vault_swap_deposit_witness(10_000 * DECIMALS, Asset::Flip)],
+				deposit: Box::new(vault_swap_deposit_witness(10_000 * DECIMALS, Asset::Flip)),
 			},
 		));
 
@@ -798,7 +798,7 @@ fn can_resign_failed_ccm() {
 			witness_call(RuntimeCall::EthereumIngressEgress(
 				pallet_cf_ingress_egress::Call::vault_swap_request {
 					block_height: 0,
-					deposits: vec![vault_swap_deposit_witness(10_000_000_000_000, Asset::Usdc)],
+					deposit: Box::new(vault_swap_deposit_witness(10_000_000_000_000, Asset::Usdc)),
 				},
 			));
 

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -589,8 +589,8 @@ fn vault_swap_deposit_witness(
 		refund_params: ETH_REFUND_PARAMS,
 		dca_params: None,
 		boost_fee: 0,
-		deposit_address: H160::from([0x03; 20]),
-		channel_id: 0,
+		deposit_address: Some(H160::from([0x03; 20])),
+		channel_id: Some(0),
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -665,6 +665,12 @@ pub enum SwapOrigin {
 	Internal,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+pub enum DepositOriginType {
+	DepositChannel,
+	Vault,
+}
+
 pub const MAX_CCM_MSG_LENGTH: u32 = 10_000;
 pub const MAX_CCM_ADDITIONAL_DATA_LENGTH: u32 = 1_000;
 
@@ -785,6 +791,8 @@ impl<Address> CcmDepositMetadataGeneric<Address> {
 
 		let principal_swap_amount = deposit_amount.saturating_sub(gas_budget);
 
+		// TODO: we already check ccm support when opening a channel (and we have to).
+		// If we can also check this in vault swaps, we should be able to remove this here.
 		let destination_chain: ForeignChain = destination_asset.into();
 		if !destination_chain.ccm_support() {
 			return Err(CcmFailReason::UnsupportedForTargetChain)

--- a/state-chain/pallets/cf-asset-balances/src/tests.rs
+++ b/state-chain/pallets/cf-asset-balances/src/tests.rs
@@ -288,11 +288,7 @@ pub mod balance_api {
 			let alice = AccountId::from([1; 32]);
 			const AMOUNT: u128 = 100;
 			const DELTA: u128 = 10;
-			assert_ok!(Pallet::<Test>::try_credit_account(
-				&alice,
-				ForeignChain::Ethereum.gas_asset(),
-				AMOUNT
-			));
+			Pallet::<Test>::credit_account(&alice, ForeignChain::Ethereum.gas_asset(), AMOUNT);
 			assert_has_event::<Test>(
 				crate::Event::AccountCredited {
 					account_id: alice.clone(),

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -49,7 +49,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn process_single_deposit() {
+	fn process_channel_deposit_full_witness() {
 		const CHANNEL_ID: u64 = 1;
 
 		let deposit_address: <<T as Config<I>>::TargetChain as Chain>::ChainAccount =
@@ -82,7 +82,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert_ok!(Pallet::<T, I>::process_single_deposit(
+			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
 				deposit_address,
 				source_asset,
 				deposit_amount,
@@ -478,7 +478,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert_ok!(Pallet::<T, I>::process_single_deposit(
+			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
 				deposit_address,
 				asset,
 				1_000u32.into(),
@@ -544,7 +544,7 @@ mod benchmarks {
 			_finalise_ingress::<Test, ()>(100, true);
 		});
 		new_test_ext().execute_with(|| {
-			_process_single_deposit::<Test, ()>(true);
+			_process_channel_deposit_full_witness::<Test, ()>(true);
 		});
 		new_test_ext().execute_with(|| {
 			_disable_asset_egress::<Test, ()>(true);

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -307,22 +307,27 @@ mod benchmarks {
 			},
 		};
 		let call = Call::<T, I>::vault_swap_request {
-			input_asset: BenchmarkValue::benchmark_value(),
-			deposit_amount: 1_000u32.into(),
-			output_asset: Asset::Eth,
-			destination_address: EncodedAddress::benchmark_value(),
-			deposit_metadata: Some(deposit_metadata),
-			tx_id: TransactionInIdFor::<T, I>::benchmark_value(),
-			deposit_details: Box::new(BenchmarkValue::benchmark_value()),
-			broker_fee: cf_primitives::Beneficiary { account: account("broker", 0, 0), bps: 0 },
-			affiliate_fees: Default::default(),
-			refund_params: Box::new(ChannelRefundParameters {
-				retry_duration: Default::default(),
-				refund_address: ForeignChainAddress::Eth(Default::default()),
-				min_price: Default::default(),
-			}),
-			dca_params: None,
-			boost_fee: 0,
+			block_height: 0u32.into(),
+			deposits: vec![VaultDepositWitness {
+				input_asset: BenchmarkValue::benchmark_value(),
+				output_asset: Asset::Eth,
+				deposit_amount: 1_000u32.into(),
+				destination_address: EncodedAddress::benchmark_value(),
+				deposit_metadata: Some(deposit_metadata),
+				tx_id: TransactionInIdFor::<T, I>::benchmark_value(),
+				deposit_details: BenchmarkValue::benchmark_value(),
+				broker_fee: cf_primitives::Beneficiary { account: account("broker", 0, 0), bps: 0 },
+				affiliate_fees: Default::default(),
+				refund_params: ChannelRefundParameters {
+					retry_duration: Default::default(),
+					refund_address: ForeignChainAddress::Eth(Default::default()),
+					min_price: Default::default(),
+				},
+				dca_params: None,
+				boost_fee: 0,
+				channel_id: 0,
+				deposit_address: BenchmarkValue::benchmark_value(),
+			}],
 		};
 
 		#[block]

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -83,10 +83,12 @@ mod benchmarks {
 		#[block]
 		{
 			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
-				deposit_address,
-				source_asset,
-				deposit_amount,
-				BenchmarkValue::benchmark_value(),
+				&DepositWitness {
+					deposit_address,
+					asset: source_asset,
+					amount: deposit_amount,
+					deposit_details: BenchmarkValue::benchmark_value(),
+				},
 				BenchmarkValue::benchmark_value()
 			));
 		}
@@ -236,15 +238,15 @@ mod benchmarks {
 		)
 		.unwrap();
 
-		assert_ok!(Pallet::<T, I>::add_prewitnessed_deposits(
-			vec![DepositWitness::<T::TargetChain> {
+		assert_ok!(Pallet::<T, I>::process_channel_deposit_prewitness(
+			DepositWitness::<T::TargetChain> {
 				deposit_address: deposit_address.clone(),
 				asset,
 				amount: TargetChainAmount::<T, I>::from(1000u32),
 				deposit_details: BenchmarkValue::benchmark_value()
-			}],
+			},
 			BenchmarkValue::benchmark_value()
-		),);
+		));
 
 		deposit_address
 	}
@@ -304,7 +306,7 @@ mod benchmarks {
 		};
 		let call = Call::<T, I>::vault_swap_request {
 			block_height: 0u32.into(),
-			deposits: vec![VaultDepositWitness {
+			deposit: Box::new(VaultDepositWitness {
 				input_asset: BenchmarkValue::benchmark_value(),
 				output_asset: Asset::Eth,
 				deposit_amount: 1_000u32.into(),
@@ -321,9 +323,9 @@ mod benchmarks {
 				},
 				dca_params: None,
 				boost_fee: 0,
-				channel_id: 0,
-				deposit_address: BenchmarkValue::benchmark_value(),
-			}],
+				channel_id: None,
+				deposit_address: None,
+			}),
 		};
 
 		#[block]
@@ -410,13 +412,13 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert_ok!(Pallet::<T, I>::add_prewitnessed_deposits(
-				vec![DepositWitness::<T::TargetChain> {
+			assert_ok!(Pallet::<T, I>::process_channel_deposit_prewitness(
+				DepositWitness::<T::TargetChain> {
 					deposit_address,
 					asset,
 					amount: TargetChainAmount::<T, I>::from(1000u32),
 					deposit_details: BenchmarkValue::benchmark_value()
-				}],
+				},
 				BenchmarkValue::benchmark_value()
 			),);
 		}
@@ -475,10 +477,12 @@ mod benchmarks {
 		#[block]
 		{
 			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
-				deposit_address,
-				asset,
-				1_000u32.into(),
-				BenchmarkValue::benchmark_value(),
+				&DepositWitness {
+					deposit_address,
+					asset,
+					amount: 1_000u32.into(),
+					deposit_details: BenchmarkValue::benchmark_value(),
+				},
 				BenchmarkValue::benchmark_value()
 			));
 		}

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -183,16 +183,12 @@ mod benchmarks {
 		}
 		<T as frame_system::Config>::OnNewAccount::on_new_account(&caller);
 		assert_ok!(<T as Chainflip>::AccountRoleRegistry::register_as_liquidity_provider(&caller));
-		assert_ok!(T::Balance::try_credit_account(&caller, asset.into(), 1_000_000,));
+		T::Balance::credit_account(&caller, asset.into(), 1_000_000);
 
 		// A non-zero balance is required to pay for the channel opening fee.
 		T::FeePayment::mint_to_account(&caller, u32::MAX.into());
 
-		assert_ok!(T::Balance::try_credit_account(
-			&caller,
-			asset.into(),
-			5_000_000_000_000_000_000u128
-		));
+		T::Balance::credit_account(&caller, asset.into(), 5_000_000_000_000_000_000u128);
 
 		caller
 	}

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -82,7 +82,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
+			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness_inner(
 				&DepositWitness {
 					deposit_address,
 					asset: source_asset,
@@ -476,7 +476,7 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness(
+			assert_ok!(Pallet::<T, I>::process_channel_deposit_full_witness_inner(
 				&DepositWitness {
 					deposit_address,
 					asset,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2038,8 +2038,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					// Pre-witnessing twice is unlikely but possible. Either way we don't want
 					// to change the status and we don't want to allow boosting.
 					Some(TransactionPrewitnessedStatus::Prewitnessed) => true,
-					// Transaction has not been reported, mark it as boosted to prevent further
-					// reports.
+					// Transaction has not been reported
 					None => false,
 				}
 			}) {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -61,6 +61,7 @@ use scale_info::{
 };
 use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{
+	boxed::Box,
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	marker::PhantomData,
 	vec,
@@ -1418,18 +1419,14 @@ pub mod pallet {
 		pub fn vault_swap_request(
 			origin: OriginFor<T>,
 			block_height: TargetChainBlockNumber<T, I>,
-			deposits: Vec<VaultDepositWitness<T, I>>,
+			deposit: Box<VaultDepositWitness<T, I>>,
 		) -> DispatchResult {
 			if T::EnsureWitnessed::ensure_origin(origin.clone()).is_ok() {
-				for deposit in deposits {
-					Self::process_vault_swap_request_full_witness(block_height, deposit);
-				}
+				Self::process_vault_swap_request_full_witness(block_height, *deposit);
 			} else {
 				T::EnsurePrewitnessed::ensure_origin(origin)?;
 
-				for deposit in deposits {
-					Self::process_vault_swap_request_prewitness(block_height, deposit);
-				}
+				Self::process_vault_swap_request_prewitness(block_height, *deposit);
 			}
 
 			Ok(())

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -826,6 +826,7 @@ pub mod pallet {
 			asset: TargetChainAsset<T, I>,
 			amount_attempted: TargetChainAmount<T, I>,
 			channel_id: Option<ChannelId>,
+			origin_type: DepositOriginType,
 		},
 		BoostPoolCreated {
 			boost_pool: BoostPoolId<T::TargetChain>,
@@ -2103,6 +2104,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						asset,
 						amount_attempted: amount,
 						channel_id,
+						origin_type: origin.into(),
 					});
 				},
 			}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1916,7 +1916,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		>,
 		block_height: TargetChainBlockNumber<T, I>,
 	) -> DispatchResult {
-		let deposit_channel_details = DepositChannelLookup::<T, I>::get(&deposit_address)
+		let deposit_channel_details = DepositChannelLookup::<T, I>::get(deposit_address)
 			.ok_or(Error::<T, I>::InvalidDepositAddress)?;
 
 		ensure!(
@@ -1950,7 +1950,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				DepositOrigin::deposit_channel(deposit_address.clone(), channel_id, block_height),
 			) {
 			// This allows the channel to be boosted again:
-			DepositChannelLookup::<T, I>::mutate(&deposit_address, |details| {
+			DepositChannelLookup::<T, I>::mutate(deposit_address, |details| {
 				if let Some(details) = details {
 					details.boost_status = BoostStatus::NotBoosted;
 				}
@@ -2254,9 +2254,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				return Err(());
 			}
 		}
-
-		// Vault deposits don't need to be fetched:
-		if !matches!(origin, DepositOrigin::Vault { .. }) {}
 
 		match &origin {
 			DepositOrigin::DepositChannel { deposit_address, channel_id, .. } => {

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -194,7 +194,7 @@ impl<Ctx: Clone> RequestAddressAndDeposit for TestRunner<Ctx> {
 					.zip(amounts)
 					.map(|((request, channel_id, deposit_address), amount)| {
 						if !amount.is_zero() {
-							IngressEgress::process_channel_deposit_full_witness(
+							IngressEgress::process_channel_deposit_full_witness_inner(
 								&DepositWitness {
 									deposit_address,
 									asset: request.source_asset(),

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -194,16 +194,16 @@ impl<Ctx: Clone> RequestAddressAndDeposit for TestRunner<Ctx> {
 					.zip(amounts)
 					.map(|((request, channel_id, deposit_address), amount)| {
 						if !amount.is_zero() {
-							IngressEgress::process_deposit_witnesses(
-								vec![DepositWitness {
+							IngressEgress::process_channel_deposit_full_witness(
+								&DepositWitness {
 									deposit_address,
 									asset: request.source_asset(),
 									amount,
 									deposit_details: Default::default(),
-								}],
+								},
 								Default::default(),
 							)
-							.unwrap();
+							.unwrap()
 						}
 						(request, channel_id, deposit_address)
 					})

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -47,7 +47,7 @@ use frame_support::{
 	traits::{Hooks, OriginTrait},
 	weights::Weight,
 };
-use sp_core::{bounded_vec, H160, U256};
+use sp_core::{bounded_vec, H160};
 use sp_runtime::{DispatchError, DispatchResult};
 
 const ALICE_ETH_ADDRESS: EthereumAddress = H160([100u8; 20]);
@@ -1817,7 +1817,7 @@ fn submit_vault_swap_request(
 	IngressEgress::vault_swap_request(
 		RuntimeOrigin::root(),
 		0,
-		vec![VaultDepositWitness {
+		Box::new(VaultDepositWitness {
 			input_asset: input_asset.try_into().unwrap(),
 			deposit_address: Some(deposit_address),
 			channel_id: Some(0),
@@ -1832,7 +1832,7 @@ fn submit_vault_swap_request(
 			refund_params,
 			dca_params,
 			boost_fee,
-		}],
+		}),
 	)
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -667,8 +667,8 @@ fn multi_use_deposit_address_different_blocks() {
 		})
 		// The channel should be closed at the next block.
 		.then_execute_at_next_block(|deposit_address| {
-			assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(
-				&DepositWitness {
+			IngressEgress::process_channel_deposit_full_witness(
+				DepositWitness {
 					deposit_address,
 					asset: ETH,
 					amount: 1,
@@ -676,7 +676,7 @@ fn multi_use_deposit_address_different_blocks() {
 				},
 				// block height is purely informative.
 				BlockHeightProvider::<MockEthereum>::get_block_height(),
-			));
+			);
 			deposit_address
 		})
 		.then_process_events(|_, event| match event {

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -618,7 +618,7 @@ fn multi_deposit_includes_deposit_beyond_recycle_height() {
 				crate::Event::DepositFinalised {
 					deposit_address,
 					..
-				}) if deposit_address == expected_accepted_address
+				}) if deposit_address.as_ref() == Some(expected_accepted_address)
 			)),);
 		});
 }
@@ -848,14 +848,14 @@ fn deposits_below_minimum_are_rejected() {
 		let (channel_id, deposit_address) = request_address_and_deposit(LP_ACCOUNT, flip);
 		System::assert_last_event(RuntimeEvent::IngressEgress(
 			crate::Event::<Test, ()>::DepositFinalised {
-				deposit_address,
+				deposit_address: Some(deposit_address),
 				asset: flip,
 				amount: default_deposit_amount,
 				block_height: Default::default(),
 				deposit_details: Default::default(),
 				ingress_fee: 0,
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
-				channel_id,
+				channel_id: Some(channel_id),
 				origin_type: DepositOriginType::DepositChannel,
 			},
 		));
@@ -1812,8 +1812,8 @@ fn submit_vault_swap_request(
 		0,
 		vec![VaultDepositWitness {
 			input_asset: input_asset.try_into().unwrap(),
-			deposit_address,
-			channel_id: 0,
+			deposit_address: Some(deposit_address),
+			channel_id: Some(0),
 			deposit_amount,
 			deposit_details,
 			output_asset,

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -245,7 +245,7 @@ fn request_address_and_deposit(
 	let address: <Ethereum as Chain>::ChainAccount = address.try_into().unwrap();
 	assert_ok!(IngressEgress::process_channel_deposit_full_witness(
 		&DepositWitness {
-			deposit_address: address.clone(),
+			deposit_address: address,
 			asset,
 			amount: DEFAULT_DEPOSIT_AMOUNT,
 			deposit_details: Default::default()

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -63,13 +63,13 @@ fn request_deposit_address_eth(account_id: u64, max_boost_fee: BasisPoints) -> (
 
 #[track_caller]
 fn prewitness_deposit(deposit_address: H160, asset: EthAsset, amount: AssetAmount) -> u64 {
-	assert_ok!(Pallet::<Test, _>::add_prewitnessed_deposits(
-		vec![DepositWitness::<Ethereum> {
+	assert_ok!(IngressEgress::process_channel_deposit_prewitness(
+		DepositWitness::<Ethereum> {
 			deposit_address,
 			asset,
 			amount,
 			deposit_details: Default::default()
-		}],
+		},
 		0
 	),);
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -121,17 +121,17 @@ fn setup() {
 	);
 
 	for asset in EthAsset::all() {
-		assert_ok!(<Test as crate::Config>::Balance::try_credit_account(
+		<Test as crate::Config>::Balance::credit_account(
 			&BOOSTER_1,
 			asset.into(),
 			INIT_BOOSTER_ETH_BALANCE,
-		));
+		);
 
-		assert_ok!(<Test as crate::Config>::Balance::try_credit_account(
+		<Test as crate::Config>::Balance::credit_account(
 			&BOOSTER_2,
 			asset.into(),
 			INIT_BOOSTER_ETH_BALANCE,
-		));
+		);
 	}
 
 	assert_eq!(get_lp_eth_balance(&BOOSTER_1), INIT_BOOSTER_ETH_BALANCE);

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -673,6 +673,7 @@ fn insufficient_funds_for_boost() {
 			asset: EthAsset::Eth,
 			amount_attempted: DEPOSIT_AMOUNT,
 			channel_id: Some(channel_id),
+			origin_type: DepositOriginType::DepositChannel,
 		}));
 
 		// When the deposit is finalised, it is processed as normal:

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -994,7 +994,7 @@ fn test_create_boost_pools() {
 
 mod vault_swaps {
 
-	use crate::BoostedVaultTxs;
+	use crate::BoostedVaultTransactions;
 
 	use super::*;
 
@@ -1027,7 +1027,7 @@ mod vault_swaps {
 			let tx_id = [9u8; 32].into();
 
 			// Initially tx is not recorded as boosted
-			assert!(!BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+			assert!(!BoostedVaultTransactions::<Test, ()>::contains_key(tx_id));
 
 			let deposit = VaultDepositWitness {
 				input_asset: INPUT_ASSET.try_into().unwrap(),
@@ -1089,7 +1089,7 @@ mod vault_swaps {
 				);
 
 				// Now the tx is recorded as boosted
-				assert!(BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+				assert!(BoostedVaultTransactions::<Test, ()>::contains_key(tx_id));
 			}
 
 			// Prewitnessing the same deposit (e.g. due to a reorg) should not result in a second
@@ -1155,7 +1155,7 @@ mod vault_swaps {
 				);
 
 				// Boost record for tx is removed:
-				assert!(!BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+				assert!(!BoostedVaultTransactions::<Test, ()>::contains_key(tx_id));
 			}
 		});
 	}

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -78,7 +78,7 @@ fn prewitness_deposit(deposit_address: H160, asset: EthAsset, amount: AssetAmoun
 
 #[track_caller]
 fn witness_deposit(deposit_address: H160, asset: EthAsset, amount: AssetAmount) {
-	assert_ok!(Pallet::<Test, _>::process_channel_deposit_full_witness(
+	assert_ok!(Pallet::<Test, _>::process_channel_deposit_full_witness_inner(
 		&DepositWitness::<Ethereum> {
 			deposit_address,
 			asset,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -78,14 +78,14 @@ fn prewitness_deposit(deposit_address: H160, asset: EthAsset, amount: AssetAmoun
 
 #[track_caller]
 fn witness_deposit(deposit_address: H160, asset: EthAsset, amount: AssetAmount) {
-	assert_ok!(Pallet::<Test, _>::process_deposit_witnesses(
-		vec![DepositWitness::<Ethereum> {
+	assert_ok!(Pallet::<Test, _>::process_channel_deposit_full_witness(
+		&DepositWitness::<Ethereum> {
 			deposit_address,
 			asset,
 			amount,
-			deposit_details: Default::default()
-		}],
-		Default::default()
+			deposit_details: Default::default(),
+		},
+		Default::default(),
 	));
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use cf_chains::FeeEstimationApi;
+use cf_chains::{DepositOriginType, FeeEstimationApi};
 use cf_primitives::{AssetAmount, BasisPoints, PrewitnessedDepositId};
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{
@@ -227,6 +227,7 @@ fn basic_passive_boosting() {
 				ingress_fee: INGRESS_FEE,
 				boost_fee: POOL_1_FEE + POOL_2_FEE,
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
+				origin_type: DepositOriginType::DepositChannel,
 			}));
 
 			assert_boosted(deposit_address, prewitnessed_deposit_id, [TIER_5_BPS, TIER_10_BPS]);
@@ -254,6 +255,7 @@ fn basic_passive_boosting() {
 				ingress_fee: 0,
 				action: DepositAction::BoostersCredited { prewitnessed_deposit_id },
 				channel_id,
+				origin_type: DepositOriginType::DepositChannel,
 			}));
 
 			assert_eq!(get_available_amount(ASSET, TIER_5_BPS), BOOSTER_AMOUNT_1 + POOL_1_FEE);
@@ -988,4 +990,173 @@ fn test_create_boost_pools() {
 			sp_runtime::traits::BadOrigin
 		);
 	});
+}
+
+mod vault_swaps {
+
+	use crate::BoostedVaultTxs;
+
+	use super::*;
+
+	#[test]
+	fn vault_swap_boosting() {
+		new_test_ext().execute_with(|| {
+			let output_address = ForeignChainAddress::Eth([1; 20].into());
+
+			let block_height = 10;
+			let deposit_address = [1; 20].into();
+
+			const BOOSTER_AMOUNT: AssetAmount = 500_000_000;
+			const DEPOSIT_AMOUNT: AssetAmount = 100_000_000;
+			const INPUT_ASSET: Asset = Asset::Eth;
+			const OUTPUT_ASSET: Asset = Asset::Flip;
+
+			const BOOST_FEE: AssetAmount = DEPOSIT_AMOUNT * TIER_5_BPS as u128 / 10_000;
+			const PREWITNESS_DEPOSIT_ID: PrewitnessedDepositId = 1;
+			const CHANNEL_ID: ChannelId = 1;
+
+			setup();
+
+			assert_ok!(IngressEgress::add_boost_funds(
+				RuntimeOrigin::signed(BOOSTER_1),
+				EthAsset::Eth,
+				BOOSTER_AMOUNT,
+				TIER_5_BPS
+			));
+
+			let tx_id = [9u8; 32].into();
+
+			// Initially tx is not recorded as boosted
+			assert!(!BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+
+			let deposit = VaultDepositWitness {
+				input_asset: INPUT_ASSET.try_into().unwrap(),
+				deposit_address,
+				channel_id: CHANNEL_ID,
+				deposit_amount: DEPOSIT_AMOUNT,
+				deposit_details: Default::default(),
+				output_asset: OUTPUT_ASSET,
+				destination_address: MockAddressConverter::to_encoded_address(
+					output_address.clone(),
+				),
+				deposit_metadata: None,
+				tx_id,
+				broker_fee: Beneficiary { account: BROKER, bps: 5 },
+				affiliate_fees: Default::default(),
+				refund_params: ChannelRefundParameters {
+					retry_duration: 2,
+					refund_address: ForeignChainAddress::Eth([2; 20].into()),
+					min_price: Default::default(),
+				},
+				dca_params: None,
+				boost_fee: 5,
+			};
+
+			// Prewitnessing a deposit for the first time should result in a boost:
+			{
+				IngressEgress::process_vault_swap_request_prewitness(block_height, deposit.clone());
+				assert_eq!(PrewitnessedDepositIdCounter::<Test, _>::get(), PREWITNESS_DEPOSIT_ID);
+
+				assert_eq!(
+					BoostPools::<Test, ()>::get(EthAsset::Eth, TIER_5_BPS)
+						.unwrap()
+						.get_pending_boost_ids()
+						.len(),
+					1
+				);
+
+				assert_eq!(
+					MockSwapRequestHandler::<Test>::get_swap_requests(),
+					vec![MockSwapRequest {
+						input_asset: INPUT_ASSET,
+						output_asset: OUTPUT_ASSET,
+						// Note that ingress fee is not charged:
+						input_amount: DEPOSIT_AMOUNT - BOOST_FEE,
+						swap_type: SwapRequestType::Regular { output_address },
+						broker_fees: bounded_vec![Beneficiary { account: BROKER, bps: 5 }],
+						origin: SwapOrigin::Vault { tx_id: TransactionInIdForAnyChain::Evm(tx_id) },
+					},]
+				);
+
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::IngressEgress(Event::DepositBoosted {
+						prewitnessed_deposit_id: PREWITNESS_DEPOSIT_ID,
+						channel_id: CHANNEL_ID,
+						action: DepositAction::Swap { .. },
+						..
+					})
+				);
+
+				// Now the tx is recorded as boosted
+				assert!(BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+			}
+
+			// Prewitnessing the same deposit (e.g. due to a reorg) should not result in a second
+			// boost:
+			{
+				IngressEgress::process_vault_swap_request_prewitness(block_height, deposit.clone());
+
+				assert_eq!(
+					BoostPools::<Test, ()>::get(EthAsset::Eth, TIER_5_BPS)
+						.unwrap()
+						.get_pending_boost_ids()
+						.len(),
+					1
+				);
+
+				assert_eq!(MockSwapRequestHandler::<Test>::get_swap_requests().len(), 1);
+			}
+
+			// Prewitnessing a different deposit *should* result in a second boost:
+			{
+				let other_deposit =
+					VaultDepositWitness { tx_id: [10u8; 32].into(), ..deposit.clone() };
+				IngressEgress::process_vault_swap_request_prewitness(block_height, other_deposit);
+
+				assert_eq!(
+					BoostPools::<Test, ()>::get(EthAsset::Eth, TIER_5_BPS)
+						.unwrap()
+						.get_pending_boost_ids()
+						.len(),
+					2
+				);
+
+				assert_eq!(MockSwapRequestHandler::<Test>::get_swap_requests().len(), 2);
+			}
+
+			// Fully witnessing a boosted deposit should finalise boost:
+			{
+				IngressEgress::process_vault_swap_request_full_witness(
+					block_height,
+					deposit.clone(),
+				);
+
+				// No new swap is initiated:
+				assert_eq!(MockSwapRequestHandler::<Test>::get_swap_requests().len(), 2);
+
+				assert_eq!(
+					BoostPools::<Test, ()>::get(EthAsset::Eth, TIER_5_BPS)
+						.unwrap()
+						.get_pending_boost_ids()
+						.len(),
+					1
+				);
+
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::IngressEgress(Event::DepositFinalised {
+						channel_id: CHANNEL_ID,
+						action: DepositAction::BoostersCredited {
+							prewitnessed_deposit_id: PREWITNESS_DEPOSIT_ID
+						},
+						..
+					})
+				);
+
+				// Boost record for tx is removed:
+				assert!(!BoostedVaultTxs::<Test, ()>::contains_key(tx_id));
+			}
+		});
+	}
 }

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -214,14 +214,14 @@ fn basic_passive_boosting() {
 			const POOL_2_CONTRIBUTION: AssetAmount = DEPOSIT_AMOUNT - POOL_1_CONTRIBUTION;
 
 			System::assert_last_event(RuntimeEvent::IngressEgress(Event::DepositBoosted {
-				deposit_address,
+				deposit_address: Some(deposit_address),
 				asset: ASSET,
 				amounts: BTreeMap::from_iter(vec![
 					(TIER_5_BPS, POOL_1_CONTRIBUTION),
 					(TIER_10_BPS, POOL_2_CONTRIBUTION),
 				]),
 				block_height: Default::default(),
-				channel_id,
+				channel_id: Some(channel_id),
 				prewitnessed_deposit_id,
 				deposit_details: Default::default(),
 				ingress_fee: INGRESS_FEE,
@@ -247,14 +247,14 @@ fn basic_passive_boosting() {
 			witness_deposit(deposit_address, ASSET, DEPOSIT_AMOUNT);
 
 			System::assert_last_event(RuntimeEvent::IngressEgress(Event::DepositFinalised {
-				deposit_address,
+				deposit_address: Some(deposit_address),
 				asset: ASSET,
 				amount: DEPOSIT_AMOUNT,
 				block_height: Default::default(),
 				deposit_details: Default::default(),
 				ingress_fee: 0,
 				action: DepositAction::BoostersCredited { prewitnessed_deposit_id },
-				channel_id,
+				channel_id: Some(channel_id),
 				origin_type: DepositOriginType::DepositChannel,
 			}));
 
@@ -672,7 +672,7 @@ fn insufficient_funds_for_boost() {
 			prewitnessed_deposit_id: deposit_id,
 			asset: EthAsset::Eth,
 			amount_attempted: DEPOSIT_AMOUNT,
-			channel_id,
+			channel_id: Some(channel_id),
 		}));
 
 		// When the deposit is finalised, it is processed as normal:
@@ -1031,8 +1031,8 @@ mod vault_swaps {
 
 			let deposit = VaultDepositWitness {
 				input_asset: INPUT_ASSET.try_into().unwrap(),
-				deposit_address,
-				channel_id: CHANNEL_ID,
+				deposit_address: Some(deposit_address),
+				channel_id: Some(CHANNEL_ID),
 				deposit_amount: DEPOSIT_AMOUNT,
 				deposit_details: Default::default(),
 				output_asset: OUTPUT_ASSET,
@@ -1082,7 +1082,7 @@ mod vault_swaps {
 					Test,
 					RuntimeEvent::IngressEgress(Event::DepositBoosted {
 						prewitnessed_deposit_id: PREWITNESS_DEPOSIT_ID,
-						channel_id: CHANNEL_ID,
+						channel_id: Some(CHANNEL_ID),
 						action: DepositAction::Swap { .. },
 						..
 					})
@@ -1146,7 +1146,7 @@ mod vault_swaps {
 				assert_has_matching_event!(
 					Test,
 					RuntimeEvent::IngressEgress(Event::DepositFinalised {
-						channel_id: CHANNEL_ID,
+						channel_id: Some(CHANNEL_ID),
 						action: DepositAction::BoostersCredited {
 							prewitnessed_deposit_id: PREWITNESS_DEPOSIT_ID
 						},

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -55,7 +55,7 @@ mod helpers {
 		)
 		.unwrap();
 		let address: <Bitcoin as Chain>::ChainAccount = address.try_into().unwrap();
-		assert_ok!(IngressEgress::process_channel_deposit_full_witness(
+		assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(
 			&DepositWitness {
 				deposit_address: address.clone(),
 				asset,
@@ -123,7 +123,7 @@ fn process_marked_transaction_and_expect_refund() {
 			tx_in_id,
 		));
 
-		assert_ok!(IngressEgress::process_channel_deposit_full_witness(
+		assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(
 			&DepositWitness {
 				deposit_address: address.clone(),
 				asset: btc::Asset::Btc,
@@ -177,7 +177,7 @@ fn finalize_boosted_tx_if_marked_after_prewitness() {
 			tx_id,
 		),);
 
-		assert_ok!(IngressEgress::process_channel_deposit_full_witness(
+		assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(
 			&DepositWitness {
 				deposit_address: address.clone(),
 				asset: btc::Asset::Btc,
@@ -226,7 +226,7 @@ fn reject_tx_if_marked_before_prewitness() {
 			10,
 		));
 
-		assert_ok!(IngressEgress::process_channel_deposit_full_witness(
+		assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(
 			&DepositWitness {
 				deposit_address: address.clone(),
 				asset: btc::Asset::Btc,
@@ -424,7 +424,7 @@ fn can_report_between_prewitness_and_witness_if_tx_was_not_boosted() {
 			OriginTrait::signed(BROKER),
 			tx_id
 		));
-		assert_ok!(IngressEgress::process_channel_deposit_full_witness(&deposit_witness, 10));
+		assert_ok!(IngressEgress::process_channel_deposit_full_witness_inner(&deposit_witness, 10));
 
 		assert_has_matching_event!(
 			Test,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -79,8 +79,7 @@ mod helpers {
 			vec![BoostPoolId { asset: btc::Asset::Btc, tier: 10 }],
 		));
 
-		<Test as crate::Config>::Balance::try_credit_account(&ALICE, btc::Asset::Btc.into(), 1000)
-			.unwrap();
+		<Test as crate::Config>::Balance::credit_account(&ALICE, btc::Asset::Btc.into(), 1000);
 
 		let (_, address, _, _) = IngressEgress::request_swap_deposit_address(
 			btc::Asset::Btc,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -162,13 +162,13 @@ fn finalize_boosted_tx_if_tainted_after_prewitness() {
 		let address: <Bitcoin as Chain>::ChainAccount =
 			helpers::setup_boost_swap().try_into().unwrap();
 
-		let _ = IngressEgress::add_prewitnessed_deposits(
-			vec![DepositWitness {
+		let _ = IngressEgress::process_channel_deposit_prewitness(
+			DepositWitness {
 				deposit_address: address.clone(),
 				asset: btc::Asset::Btc,
 				amount: DEFAULT_DEPOSIT_AMOUNT,
 				deposit_details: deposit_details.clone(),
-			}],
+			},
 			10,
 		);
 
@@ -211,15 +211,15 @@ fn reject_tx_if_tainted_before_prewitness() {
 
 		assert_ok!(IngressEgress::mark_transaction_as_tainted(OriginTrait::signed(BROKER), tx_id,));
 
-		let _ = IngressEgress::add_prewitnessed_deposits(
-			vec![DepositWitness {
+		assert_ok!(IngressEgress::process_channel_deposit_prewitness(
+			DepositWitness {
 				deposit_address: address.clone(),
 				asset: btc::Asset::Btc,
 				amount: DEFAULT_DEPOSIT_AMOUNT,
 				deposit_details: deposit_details.clone(),
-			}],
+			},
 			10,
-		);
+		));
 
 		assert_ok!(IngressEgress::process_channel_deposit_full_witness(
 			&DepositWitness {
@@ -404,7 +404,7 @@ fn can_report_between_prewitness_and_witness_if_tx_was_not_boosted() {
 			deposit_details,
 		};
 
-		assert_ok!(IngressEgress::add_prewitnessed_deposits(vec![deposit_witness.clone()], 10,));
+		assert_ok!(IngressEgress::process_channel_deposit_prewitness(deposit_witness.clone(), 10,));
 		assert_ok!(IngressEgress::mark_transaction_as_tainted(OriginTrait::signed(BROKER), tx_id,));
 		assert_ok!(IngressEgress::process_channel_deposit_full_witness(&deposit_witness, 10));
 

--- a/state-chain/pallets/cf-ingress-egress/src/weights.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/weights.rs
@@ -33,7 +33,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_cf_ingress_egress.
 pub trait WeightInfo {
 	fn disable_asset_egress() -> Weight;
-	fn process_single_deposit() -> Weight;
+	fn process_channel_deposit_full_witness() -> Weight;
 	fn finalise_ingress(a: u32, ) -> Weight;
 	fn vault_transfer_failed() -> Weight;
 	fn ccm_broadcast_failed() -> Weight;
@@ -75,7 +75,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `EthereumChainTracking::CurrentChainState` (`max_values`: Some(1), `max_size`: Some(40), added: 535, mode: `MaxEncodedLen`)
 	/// Storage: `AssetBalances::WithheldAssets` (r:1 w:1)
 	/// Proof: `AssetBalances::WithheldAssets` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn process_single_deposit() -> Weight {
+	fn process_channel_deposit_full_witness() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `624`
 		//  Estimated: `4089`
@@ -325,7 +325,7 @@ impl WeightInfo for () {
 	/// Proof: `EthereumChainTracking::CurrentChainState` (`max_values`: Some(1), `max_size`: Some(40), added: 535, mode: `MaxEncodedLen`)
 	/// Storage: `AssetBalances::WithheldAssets` (r:1 w:1)
 	/// Proof: `AssetBalances::WithheldAssets` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn process_single_deposit() -> Weight {
+	fn process_channel_deposit_full_witness() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `624`
 		//  Estimated: `4089`

--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -38,7 +38,7 @@ mod benchmarks {
 			AccountRole::LiquidityProvider,
 		)
 		.unwrap();
-		assert_ok!(T::BalanceApi::try_credit_account(&caller, Asset::Eth, 1_000_000,));
+		T::BalanceApi::credit_account(&caller, Asset::Eth, 1_000_000);
 
 		#[extrinsic_call]
 		withdraw_asset(

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -364,7 +364,7 @@ impl<T: Config> Pallet<T> {
 					T::BalanceApi::try_debit_account(&account_id, asset, amount)?;
 
 					// Credit the asset to the destination account.
-					T::BalanceApi::try_credit_account(&destination_account, asset, amount)?;
+					T::BalanceApi::credit_account(&destination_account, asset, amount);
 
 					Self::deposit_event(Event::AssetTransferred {
 						from: account_id,

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -78,16 +78,20 @@ pub struct MockBalanceApi;
 impl BalanceApi for MockBalanceApi {
 	type AccountId = AccountId;
 
-	fn try_credit_account(
-		who: &Self::AccountId,
-		_asset: cf_primitives::Asset,
-		amount: cf_primitives::AssetAmount,
-	) -> frame_support::dispatch::DispatchResult {
+	fn credit_account(who: &Self::AccountId, _asset: Asset, amount: AssetAmount) {
 		BALANCE_MAP.with(|balance_map| {
 			let mut balance_map = balance_map.borrow_mut();
 			*balance_map.entry(who.to_owned()).or_default() += amount;
-			Ok(())
-		})
+		});
+	}
+
+	fn try_credit_account(
+		who: &Self::AccountId,
+		asset: cf_primitives::Asset,
+		amount: cf_primitives::AssetAmount,
+	) -> frame_support::dispatch::DispatchResult {
+		Self::credit_account(who, asset, amount);
+		Ok(())
 	}
 
 	fn try_debit_account(

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -320,7 +320,7 @@ fn account_registration_and_deregistration() {
 			EncodedAddress::Eth([0x01; 20])
 		));
 
-		MockBalanceApi::try_credit_account(&LP_ACCOUNT_ID, Asset::Eth, DEPOSIT_AMOUNT).unwrap();
+		MockBalanceApi::credit_account(&LP_ACCOUNT_ID, Asset::Eth, DEPOSIT_AMOUNT);
 
 		assert_noop!(
 			LiquidityProvider::deregister_lp_account(OriginTrait::signed(LP_ACCOUNT_ID)),

--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -61,8 +61,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000));
-		assert_ok!(T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 
 		#[extrinsic_call]
 		update_range_order(

--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -61,8 +61,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		assert_ok!(T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000));
+		assert_ok!(T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000));
 
 		#[extrinsic_call]
 		update_range_order(
@@ -88,8 +88,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 
 		#[extrinsic_call]
 		set_range_order(
@@ -115,8 +115,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 
 		#[extrinsic_call]
 		update_limit_order(
@@ -140,8 +140,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 
 		#[extrinsic_call]
 		set_limit_order(
@@ -165,8 +165,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 		assert_ok!(Pallet::<T>::set_limit_order(
 			RawOrigin::Signed(caller.clone()).into(),
 			Asset::Eth,
@@ -219,8 +219,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000);
 		#[extrinsic_call]
 		schedule_limit_order_update(
 			RawOrigin::Signed(caller.clone()),
@@ -278,8 +278,8 @@ mod benchmarks {
 			0,
 			price_at_tick(0).unwrap()
 		));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Eth, 1_000_000_000,));
-		assert_ok!(T::LpBalance::try_credit_account(&caller, Asset::Usdc, 1_000_000_000,));
+		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000_000);
+		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000_000);
 		let mut orders_to_delete: BoundedVec<CloseOrder, ConstU32<MAX_ORDERS_DELETE>> =
 			vec![].try_into().unwrap();
 		for i in 1..101i32 {

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1472,11 +1472,11 @@ impl<T: Config> Pallet<T> {
 				}?;
 
 				let withdrawn_amount: AssetAmount = sold_amount.try_into()?;
-				T::LpBalance::try_credit_account(
+				T::LpBalance::credit_account(
 					lp,
 					asset_pair.assets()[side.to_sold_pair()],
 					withdrawn_amount,
-				)?;
+				);
 
 				(IncreaseOrDecrease::Decrease(withdrawn_amount), position_info, collected)
 			},
@@ -1584,12 +1584,14 @@ impl<T: Config> Pallet<T> {
 
 				let assets_withdrawn = asset_pair.assets().zip(assets_withdrawn).try_map(
 					|(asset, amount_withdrawn)| {
-						AssetAmount::try_from(amount_withdrawn).map_err(Into::into).and_then(
-							|amount_withdrawn| {
-								T::LpBalance::try_credit_account(lp, asset, amount_withdrawn)
-									.map(|()| amount_withdrawn)
-							},
-						)
+						AssetAmount::try_from(amount_withdrawn)
+							.map_err(Into::<DispatchError>::into)
+							// Use map?
+							.and_then(|amount_withdrawn| {
+								T::LpBalance::credit_account(lp, asset, amount_withdrawn);
+
+								Ok(amount_withdrawn)
+							})
 					},
 				)?;
 

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1586,11 +1586,8 @@ impl<T: Config> Pallet<T> {
 					|(asset, amount_withdrawn)| {
 						AssetAmount::try_from(amount_withdrawn)
 							.map_err(Into::<DispatchError>::into)
-							// Use map?
-							.and_then(|amount_withdrawn| {
+							.inspect(|&amount_withdrawn| {
 								T::LpBalance::credit_account(lp, asset, amount_withdrawn);
-
-								Ok(amount_withdrawn)
 							})
 					},
 				)?;

--- a/state-chain/pallets/cf-pools/src/mock.rs
+++ b/state-chain/pallets/cf-pools/src/mock.rs
@@ -50,11 +50,7 @@ pub struct MockBalance;
 impl BalanceApi for MockBalance {
 	type AccountId = AccountId;
 
-	fn try_credit_account(
-		who: &Self::AccountId,
-		asset: cf_primitives::Asset,
-		amount: cf_primitives::AssetAmount,
-	) -> DispatchResult {
+	fn credit_account(who: &Self::AccountId, asset: Asset, amount: AssetAmount) {
 		match (*who, asset) {
 			(ALICE, Asset::Eth) => AliceCollectedEth::set(AliceCollectedEth::get() + amount),
 			(ALICE, Asset::Usdc) => AliceCollectedUsdc::set(AliceCollectedUsdc::get() + amount),
@@ -62,6 +58,14 @@ impl BalanceApi for MockBalance {
 			(BOB, Asset::Usdc) => BobCollectedUsdc::set(BobCollectedUsdc::get() + amount),
 			_ => (),
 		}
+	}
+
+	fn try_credit_account(
+		who: &Self::AccountId,
+		asset: cf_primitives::Asset,
+		amount: cf_primitives::AssetAmount,
+	) -> DispatchResult {
+		Self::credit_account(who, asset, amount);
 		Ok(())
 	}
 

--- a/state-chain/pallets/cf-swapping/src/benchmarking.rs
+++ b/state-chain/pallets/cf-swapping/src/benchmarking.rs
@@ -94,7 +94,7 @@ mod benchmarks {
 		)
 		.unwrap();
 
-		T::BalanceApi::try_credit_account(&caller, Asset::Eth, 200).unwrap();
+		T::BalanceApi::credit_account(&caller, Asset::Eth, 200);
 
 		#[extrinsic_call]
 		withdraw(RawOrigin::Signed(caller.clone()), Asset::Eth, EncodedAddress::benchmark_value());

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1308,15 +1308,7 @@ pub mod pallet {
 						let fee = Permill::from_parts(*bps as u32 * BASIS_POINTS_PER_MILLION) *
 							stable_amount;
 
-						if let Err(err) =
-							T::BalanceApi::try_credit_account(account, STABLE_ASSET, fee)
-						{
-							log_or_panic!(
-								"Failed to credit broker fee to account {:?} with error: {:?}",
-								account,
-								err
-							);
-						}
+						T::BalanceApi::credit_account(account, STABLE_ASSET, fee);
 
 						fee_accumulator.saturating_add(fee)
 					},

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -235,10 +235,6 @@ fn get_broker_balance<T: Config>(who: &T::AccountId, asset: Asset) -> AssetAmoun
 	T::BalanceApi::get_balance(who, asset)
 }
 
-fn credit_broker_account<T: Config>(who: &T::AccountId, asset: Asset, amount: AssetAmount) {
-	assert_ok!(T::BalanceApi::try_credit_account(who, asset, amount));
-}
-
 #[track_caller]
 fn assert_swaps_queue_is_empty() {
 	assert_eq!(SwapQueue::<Test>::iter_keys().count(), 0);
@@ -1228,7 +1224,7 @@ fn broker_deregistration_checks_earned_fees() {
 		.expect("BROKER was registered in test setup.");
 
 		// Earn some fees.
-		credit_broker_account::<Test>(&BROKER, Asset::Eth, 100);
+		<Test as Config>::BalanceApi::credit_account(&BROKER, Asset::Eth, 100);
 
 		assert_noop!(
 			Swapping::deregister_as_broker(OriginTrait::signed(BROKER)),

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -274,7 +274,7 @@ fn cannot_swap_in_safe_mode() {
 #[test]
 fn cannot_withdraw_in_safe_mode() {
 	new_test_ext().execute_with(|| {
-		credit_broker_account::<Test>(&BROKER, Asset::Eth, 200);
+		<Test as Config>::BalanceApi::credit_account(&BROKER, Asset::Eth, 200);
 
 		// Activate code red
 		<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_red();

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -374,7 +374,8 @@ fn withdraw_broker_fees() {
 			),
 			<Error<Test>>::NoFundsAvailable
 		);
-		credit_broker_account::<Test>(&BROKER, Asset::Eth, 200);
+
+		<Test as Config>::BalanceApi::credit_account(&BROKER, Asset::Eth, 200);
 		assert_ok!(Swapping::withdraw(
 			RuntimeOrigin::signed(BROKER),
 			Asset::Eth,

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -565,8 +565,8 @@ impl
 			block_height,
 			VaultDepositWitness {
 				input_asset: swap_details.from,
-				deposit_address: todo!(),
-				channel_id: todo!(),
+				deposit_address: None,
+				channel_id: None,
 				deposit_amount: swap_details.deposit_amount,
 				deposit_details: (),
 				output_asset: swap_details.to,

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -37,6 +37,7 @@ use pallet_cf_elections::{
 	},
 	CorruptStorageError, ElectionIdentifier, InitialState, InitialStateOf, RunnerStorageAccess,
 };
+use pallet_cf_ingress_egress::VaultDepositWitness;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::{DispatchResult, FixedPointNumber, FixedU128};
@@ -559,19 +560,25 @@ impl
 	> for SolanaVaultSwapsHandler
 {
 	fn initiate_vault_swap(swap_details: SolanaVaultSwapDetails) {
-		SolanaIngressEgress::process_vault_swap_request(
-			swap_details.from,
-			swap_details.deposit_amount,
-			swap_details.to,
-			swap_details.destination_address,
-			swap_details.deposit_metadata,
-			(swap_details.swap_account, swap_details.creation_slot),
-			(),
-			swap_details.broker_fee,
-			swap_details.affiliate_fees,
-			swap_details.refund_params,
-			swap_details.dca_params,
-			swap_details.boost_fee.into(),
+		let block_height = swap_details.creation_slot;
+		SolanaIngressEgress::process_vault_swap_request_full_witness(
+			block_height,
+			VaultDepositWitness {
+				input_asset: swap_details.from,
+				deposit_address: todo!(),
+				channel_id: todo!(),
+				deposit_amount: swap_details.deposit_amount,
+				deposit_details: (),
+				output_asset: swap_details.to,
+				destination_address: swap_details.destination_address,
+				deposit_metadata: swap_details.deposit_metadata,
+				tx_id: (swap_details.swap_account, swap_details.creation_slot),
+				broker_fee: swap_details.broker_fee,
+				affiliate_fees: swap_details.affiliate_fees,
+				dca_params: swap_details.dca_params,
+				refund_params: swap_details.refund_params,
+				boost_fee: swap_details.boost_fee.into(),
+			},
 		);
 	}
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1924,38 +1924,14 @@ impl_runtime_apis! {
 			let current_block_events = System::read_events_no_consensus();
 
 			for event in current_block_events {
+				#[allow(clippy::collapsible_match)]
 				match *event {
 					frame_system::EventRecord::<RuntimeEvent, sp_core::H256> { event: RuntimeEvent::Witnesser(pallet_cf_witnesser::Event::Prewitnessed { call }), ..} => {
 						match call {
-							RuntimeCall::EthereumIngressEgress(pallet_cf_ingress_egress::Call::vault_swap_request {
-								input_asset: swap_from, output_asset: swap_to, deposit_amount, ..
-							}) if from == swap_from.into() && to == swap_to => {
-								all_prewitnessed_swaps.push(deposit_amount);
-							}
-							RuntimeCall::ArbitrumIngressEgress(pallet_cf_ingress_egress::Call::vault_swap_request {
-								input_asset: swap_from, output_asset: swap_to, deposit_amount, ..
-							}) if from == swap_from.into() && to == swap_to => {
-								all_prewitnessed_swaps.push(deposit_amount);
-							}
-							RuntimeCall::EthereumIngressEgress(pallet_cf_ingress_egress::Call::process_deposits::<_, EthereumInstance> {
-								deposit_witnesses, ..
-							}) => {
-								all_prewitnessed_swaps.extend(filter_deposit_swaps::<Ethereum, EthereumInstance>(from, to, deposit_witnesses));
-							},
-							RuntimeCall::ArbitrumIngressEgress(pallet_cf_ingress_egress::Call::process_deposits::<_, ArbitrumInstance> {
-								deposit_witnesses, ..
-							}) => {
-								all_prewitnessed_swaps.extend(filter_deposit_swaps::<Arbitrum, ArbitrumInstance>(from, to, deposit_witnesses));
-							},
 							RuntimeCall::BitcoinIngressEgress(pallet_cf_ingress_egress::Call::process_deposits {
 								deposit_witnesses, ..
 							}) => {
 								all_prewitnessed_swaps.extend(filter_deposit_swaps::<Bitcoin, BitcoinInstance>(from, to, deposit_witnesses));
-							},
-							RuntimeCall::PolkadotIngressEgress(pallet_cf_ingress_egress::Call::process_deposits {
-								deposit_witnesses, ..
-							}) => {
-								all_prewitnessed_swaps.extend(filter_deposit_swaps::<Polkadot, PolkadotInstance>(from, to, deposit_witnesses));
 							},
 							_ => {
 								// ignore, we only care about calls that trigger swaps.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1004,6 +1004,8 @@ pub trait SwapLimitsProvider {
 pub trait BalanceApi {
 	type AccountId;
 
+	fn credit_account(who: &Self::AccountId, asset: Asset, amount: AssetAmount);
+
 	/// Attempt to credit the account with the given asset and amount.
 	fn try_credit_account(
 		who: &Self::AccountId,

--- a/state-chain/traits/src/mocks/balance_api.rs
+++ b/state-chain/traits/src/mocks/balance_api.rs
@@ -33,11 +33,7 @@ const FREE_BALANCES: &[u8] = b"FREE_BALANCES";
 impl BalanceApi for MockBalance {
 	type AccountId = u64;
 
-	fn try_credit_account(
-		who: &Self::AccountId,
-		asset: Asset,
-		amount_to_credit: AssetAmount,
-	) -> DispatchResult {
+	fn credit_account(who: &Self::AccountId, asset: Asset, amount_to_credit: AssetAmount) {
 		Self::mutate_storage::<(u64, cf_primitives::Asset), _, _, _, _>(
 			FREE_BALANCES,
 			&(*who, asset),
@@ -46,6 +42,14 @@ impl BalanceApi for MockBalance {
 				*amount = amount.saturating_add(amount_to_credit);
 			},
 		);
+	}
+
+	fn try_credit_account(
+		who: &Self::AccountId,
+		asset: Asset,
+		amount_to_credit: AssetAmount,
+	) -> DispatchResult {
+		Self::credit_account(who, asset, amount_to_credit);
 		Ok(())
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1753

## Summary

- Added additional fields to `vault_swap_request` (height, deposit_address, channel_id). This is needed for DepositBoosted/DepositFinalised events. I also made it take a vec of deposits (represented as `VaultDepositWitness`) instead to be consistent with "regular" deposits and as a better (compared to box-ing individual fields) solution to the "max call size" problem that occurs when we have too many paramters not on a heap. Right now engines still vote on individual deposits (i.e. vec of size 1), but we can change this in the future and submit batches of deposits like we do for regular deposits (@dandanlen mentions that this might require some discussion, so not done here).

- Added `BoostedVaultTxs` field to track the status of vault deposits (regular deposits use `DepositChannelLookup` for this)

- Added `DepositOrigin` which mimicks `SwapOrigin` but excludes `Internal` variant and makes more sense in contexts where we are not necessarily dealing with swaps, but deposits in general. I considered merging them into one to simplify, but seemed a bit cleaner to have explicit types (but happy to reconsider).

- Factored out `process_prewitness_deposit_inner` and `process_full_witness_deposit_inner` so that the core logic is used regardless of the "origin". Deposit extrinsics now just assemble the parameters for the channel action, perform validation where needed, and read/update the boost status.

- `DepositBoosted/DepositFinalised` events now include `DepositOriginType` so the product knows whether `channel_id` should be used to lookup deposit channel details for example. @niklasnatter 

Edit: I might need to check unit-tests/bouncer tests to see why they fail, but otherwise this PR should be read for review.

