### PR TITLE
feat: try-state hook for elections pallet

### DIFF
--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -38,7 +38,7 @@ function tryRuntimeCommand(runtimePath: string, blockHash: 'latest' | string, ne
     `try-runtime \
         --runtime ${runtimePath} on-runtime-upgrade \
         --disable-spec-version-check \
-        --checks pre-and-post ${blockParam} \
+        --checks all ${blockParam} \
         --uri ${networkUrl}`,
     `try-runtime-${blockHash}`,
     'runtime::executive=debug',

--- a/state-chain/TROUBLESHOOTING.md
+++ b/state-chain/TROUBLESHOOTING.md
@@ -10,10 +10,10 @@ As of yet there is no real structure - this isn't intended to be a document to r
 
 ## Runtime upgrades / Try-runtime
 
-First, download and install the [`try-runtime-cli`](https://paritytech.github.io/try-runtime-cli/try_runtime/):
+First, download and install the [`try-runtime-cli`](https://paritytech.github.io/try-runtime-cli/try_runtime/). This guide was written against try-runtime-cli v0.7.0:
 
 ```bash copy
-cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+cargo +stable install --git https://github.com/paritytech/try-runtime-cli --tag v0.7.0
 ```
 
 You need to build the runtime with `try-runtime` enabled.
@@ -28,7 +28,19 @@ To test against Perseverance (Our canary testnet):
 ```bash copy
 try-runtime \
     --runtime ./target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm \
-    on-runtime-upgrade live --uri wss://perseverance.chainflip.xyz:443
+    on-runtime-upgrade --checks all live --uri wss://archive.perseverance.chainflip.io:443
+```
+
+For fatser executions, you can create a snapshot of a live node state:
+```bash copy
+try-runtime create-snapshot --uri wss://archive.perseverance.chainflip.io:443 /tmp/perseverance_state.snap
+```
+
+then run try-runtime against the sanpshot:
+```bash copy
+try-runtime \
+    --runtime ./target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm \
+    on-runtime-upgrade --checks all snap --path /tmp/perseverance_state.snap
 ```
 
 To test try-runtime against Berghain (Our Mainnet):
@@ -36,7 +48,7 @@ To test try-runtime against Berghain (Our Mainnet):
 ```bash copy
 try-runtime \
     --runtime ./target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm \
-    on-runtime-upgrade live --uri wss://mainnet-rpc.chainflip.io:443
+    on-runtime-upgrade --checks all live --uri wss://mainnet-rpc.chainflip.io:443
 ```
 
 If you have trouble connecting to the remote rpc node, you can run a local rpc node and connect to that instead. First connect a local node to the network with some rpc optimisations:
@@ -56,7 +68,7 @@ Once the node has synced, in another terminal window, run the checks as above:
 ```bash copy
 try-runtime \
     --runtime ./target/release/wbuild/state-chain-runtime/state_chain_runtime.wasm \
-    on-runtime-upgrade live --uri ws://localhost:9944
+    on-runtime-upgrade --checks all live --uri ws://localhost:9944
 ```
 
 ### General tips and guidelines

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -2159,7 +2159,7 @@ pub mod pallet {
 			let shared_ref_count_keys =
 				SharedDataReferenceCount::<T, I>::iter_keys().collect::<Vec<_>>();
 			for shared_data_key in SharedData::<T, I>::iter_keys() {
-				if shared_ref_count_keys.iter().find(|(h, _)| *h == shared_data_key).is_none() {
+				if !shared_ref_count_keys.iter().any(|(h, _)| *h == shared_data_key) {
 					Err(DispatchError::Other(
 						"All keys in SharedData should have an entry in SharedDataReferenceCount",
 					))?;

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -2150,42 +2150,47 @@ pub mod pallet {
 				.map(|id| *id.unique_monotonic())
 				.collect::<BTreeSet<_>>();
 
-			if properties_keys != ElectionState::<T, I>::iter_keys().collect::<BTreeSet<_>>() {
-				Err(DispatchError::Other(
+			ensure!(
+				properties_keys == ElectionState::<T, I>::iter_keys().collect::<BTreeSet<_>>(),
+				DispatchError::Other(
 					"All keys in ElectionProperties and ElectionState should match",
-				))?;
-			}
+				)
+			);
 
 			let shared_ref_count_keys =
 				SharedDataReferenceCount::<T, I>::iter_keys().collect::<Vec<_>>();
 			for shared_data_key in SharedData::<T, I>::iter_keys() {
-				if !shared_ref_count_keys.iter().any(|(h, _)| *h == shared_data_key) {
-					Err(DispatchError::Other(
+				ensure!(
+					shared_ref_count_keys.iter().any(|(h, _)| *h == shared_data_key),
+					DispatchError::Other(
 						"All keys in SharedData should have an entry in SharedDataReferenceCount",
-					))?;
-				}
+					)
+				)
 			}
 
 			for election_id in ElectionConsensusHistoryUpToDate::<T, I>::iter_keys() {
-				if !properties_keys.contains(&election_id) {
-					Err(DispatchError::Other(
+				ensure!(
+					properties_keys.contains(&election_id),
+					DispatchError::Other(
 						"ElectionConsensusHistoryUpToDate should have a corresponding entry in ElectionProperties"
-					))?;
-				}
+					)
+				)
 			}
 			for election_id in BitmapComponents::<T, I>::iter_keys() {
-				if !properties_keys.contains(&election_id) {
-					Err(DispatchError::Other(
-						"BitmapComponents should have a corresponding entry in ElectionProperties",
-					))?;
-				}
+				ensure!(
+					properties_keys.contains(&election_id),
+					DispatchError::Other(
+						"BitmapComponents should have a corresponding entry in ElectionProperties"
+					)
+				)
 			}
 			for (election_id, _) in IndividualComponents::<T, I>::iter_keys() {
-				if !properties_keys.contains(&election_id) {
-					Err(DispatchError::Other(
-						"BitmapComponents should have a corresponding entry in ElectionProperties",
-					))?;
-				}
+				ensure!(
+					properties_keys.contains(&election_id),
+					DispatchError::Other(
+						"IndividualComponents should have a corresponding entry in ElectionProperties",
+					)
+				)
 			}
 
 			Ok(())

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -102,8 +102,7 @@ pub fn election_test_ext(test_setup: TestSetup) -> TestRunner<TestContext> {
 			}
 			MockEpochInfo::next_epoch(test_setup.all_authorities());
 
-			Pallet::<Test, _>::do_try_state()
-				.expect("All try-state variants must hold");
+			Pallet::<Test, _>::do_try_state().expect("All try-state variants must hold");
 
 			test_setup
 		})

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -103,7 +103,7 @@ pub fn election_test_ext(test_setup: TestSetup) -> TestRunner<TestContext> {
 			MockEpochInfo::next_epoch(test_setup.all_authorities());
 
 			Pallet::<Test, _>::do_try_state()
-				.expect("All try-state variants must hold after a test");
+				.expect("All try-state variants must hold");
 
 			test_setup
 		})

--- a/state-chain/pallets/cf-elections/src/mock.rs
+++ b/state-chain/pallets/cf-elections/src/mock.rs
@@ -102,6 +102,9 @@ pub fn election_test_ext(test_setup: TestSetup) -> TestRunner<TestContext> {
 			}
 			MockEpochInfo::next_epoch(test_setup.all_authorities());
 
+			Pallet::<Test, _>::do_try_state()
+				.expect("All try-state variants must hold after a test");
+
 			test_setup
 		})
 		.then_apply_extrinsics(|test_setup| {


### PR DESCRIPTION
# Pull Request

Closes: PRO-1726

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

This PR adds try-state hook checks to the Elections pallet. For these hooks to be fired up, the try-runtime-cli must be called with --checks all (or at- least try-state). The ci and troubleshooting guide were updated accordingly.

This PR implemented try-state hook only for the Elections pallet, but it was agreed that another issue will be raised to handle try-state hooks in a more generic way and enable it for all other pallets.

