### PR TITLE
feat: allow for providing params to ElectoralSystem test checks

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -1,9 +1,10 @@
 use sp_std::collections::btree_set::BTreeSet;
 
-use super::{mocks::*, register_checks};
+use super::mocks::*;
 use crate::{
 	electoral_system::{ConsensusVote, ConsensusVotes},
 	electoral_systems::liveness::*,
+	register_checks,
 };
 
 pub type ChainBlockHash = u64;
@@ -37,18 +38,8 @@ register_checks! {
 		only_one_election(_pre, post) {
 			assert_eq!(post.election_identifiers.len(), 1, "Only one election should exist.");
 		},
-		hook_called_once(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 1, "Hook should have been called once so far!");
-		},
-		hook_called_twice(_pre, _post) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), 2, "Hook should have been called twice so far!");
-		},
-		hook_not_called(_pre, _post) {
-			assert_eq!(
-				HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()),
-				0,
-				"Hook should not have been called!"
-			);
+		hook_called_n_times(_pre, _post, n: u8) {
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), n, "Hook should have been called n so far!");
 		},
 	}
 }
@@ -134,7 +125,7 @@ fn on_finalize() {
 			|_| assert_eq!(MockHook::called(), 0, "Hook should not have been called!"),
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_not_called(),
+				Check::<SimpleLiveness>::hook_called_n_times(0),
 			],
 		)
 		.expect_consensus(
@@ -147,7 +138,7 @@ fn on_finalize() {
 			|_| {},
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_not_called(),
+				Check::<SimpleLiveness>::hook_called_n_times(0),
 			],
 		)
 		.test_on_finalize(
@@ -155,7 +146,7 @@ fn on_finalize() {
 			|_| {},
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_called_once(),
+				Check::<SimpleLiveness>::hook_called_n_times(1),
 			],
 		)
 		.test_on_finalize(
@@ -165,7 +156,7 @@ fn on_finalize() {
 			|_| {},
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_called_once(),
+				Check::<SimpleLiveness>::hook_called_n_times(1),
 			],
 		)
 		// there have been no votes, so still only called once
@@ -176,7 +167,7 @@ fn on_finalize() {
 			|_| {},
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_called_once(),
+				Check::<SimpleLiveness>::hook_called_n_times(1),
 			],
 		)
 		.expect_consensus(
@@ -189,7 +180,7 @@ fn on_finalize() {
 			|_| {},
 			vec![
 				Check::<SimpleLiveness>::only_one_election(),
-				Check::<SimpleLiveness>::hook_called_twice(),
+				Check::<SimpleLiveness>::hook_called_n_times(2),
 			],
 		);
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -39,7 +39,7 @@ register_checks! {
 			assert_eq!(post.election_identifiers.len(), 1, "Only one election should exist.");
 		},
 		hook_called_n_times(_pre, _post, n: u8) {
-			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), n, "Hook should have been called n so far!");
+			assert_eq!(HOOK_CALLED_COUNT.with(|hook_called| hook_called.get()), n, "Hook should have been called {n} times so far!");
 		},
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/monotonic_median.rs
@@ -54,6 +54,10 @@ register_checks! {
 				"Hook should not have been called!"
 			);
 		},
+		pre_and_post_unsynchronised_state(pre, post, expected_pre_post: (u64, u64)) {
+			assert_eq!(pre.unsynchronised_state, expected_pre_post.0);
+			assert_eq!(post.unsynchronised_state, expected_pre_post.1);
+		},
 	}
 }
 
@@ -107,10 +111,7 @@ fn finalize_election_with_incremented_state() {
 		vec![
 			Check::monotonically_increasing_state(),
 			Check::<MonotonicMedianTest>::hook_called(),
-			Check::new(move |pre, post| {
-				assert_eq!(pre.unsynchronised_state, initial_state);
-				assert_eq!(post.unsynchronised_state, new_unsynchronised_state);
-			}),
+			Check::pre_and_post_unsynchronised_state((initial_state, new_unsynchronised_state)),
 			Check::last_election_deleted(),
 			Check::election_id_incremented(),
 		],
@@ -146,10 +147,7 @@ fn finalize_election_state_can_not_decrease() {
 					Check::monotonically_increasing_state(),
 					// The hook should not be called if the state is not updated.
 					Check::<MonotonicMedianTest>::hook_not_called(),
-					Check::new(|pre, post| {
-						assert_eq!(pre.unsynchronised_state, INTITIAL_STATE);
-						assert_eq!(post.unsynchronised_state, INTITIAL_STATE);
-					}),
+					Check::pre_and_post_unsynchronised_state((INTITIAL_STATE, INTITIAL_STATE)),
 					Check::last_election_deleted(),
 					Check::election_id_incremented(),
 				],


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Allows us to avoid duplicating the "hook_called" etc. I'm also going to need to this to, for example, check how many elections are open at any one time, and would rather not write a hook specific to the number of times I expect, as it will change throughout the test.
