### PR TITLE
chore: improve ES Check type inference

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -277,18 +277,18 @@ pub struct Check<ES: ElectoralSystem> {
 
 #[macro_export]
 macro_rules! single_check_new {
-	($arg_pre:ident, $arg_post:ident, $check_body:block, $param:ident) => {
+	($state_type:ty, $arg_pre:ident, $arg_post:ident, $check_body:block, $param:ident) => {
 		$crate::electoral_systems::mocks::SingleCheck::new(
 			$param,
 			#[track_caller]
-			|$arg_pre, $arg_post, $param| $check_body,
+			|$arg_pre: $state_type, $arg_post: $state_type, $param| $check_body,
 		)
 	};
-	($arg_pre:ident, $arg_post:ident, $check_body:block) => {
+	($state_type:ty, $arg_pre:ident, $arg_post:ident, $check_body:block) => {
 		$crate::electoral_systems::mocks::SingleCheck::new(
 			(),
 			#[track_caller]
-			|$arg_pre, $arg_post, ()| $check_body,
+			|$arg_pre: $state_type, $arg_post: $state_type, ()| $check_body,
 		)
 	};
 }
@@ -347,7 +347,7 @@ macro_rules! register_checks {
         impl Check<$system> {
             $(
                 pub fn $check_name($($param: $param_type)?) -> Box<dyn $crate::electoral_systems::mocks::Checkable<$system> + 'static> {
-					Box::new($crate::single_check_new!($arg_1, $arg_2, $check_body $(, $param)? ))
+					Box::new($crate::single_check_new!(&$crate::electoral_systems::mocks::ElectoralSystemState<$system>, $arg_1, $arg_2, $check_body $(, $param)? ))
 				}
             )*
         }
@@ -365,7 +365,7 @@ macro_rules! register_checks {
 		{
 			$(
 				pub fn $check_name($($param: $param_type)?) -> Box<dyn $crate::electoral_systems::mocks::Checkable<ES> + 'static> {
-					Box::new($crate::single_check_new!($arg_1, $arg_2, $check_body $(, $param)? ))
+					Box::new($crate::single_check_new!(&$crate::electoral_systems::mocks::ElectoralSystemState<ES>, $arg_1, $arg_2, $check_body $(, $param)? ))
 				}
 			)+
 		}


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

I hit an issue when writing a check like so on my PR:
```rust
number_of_open_elections_is(_pre, post, n: ElectionCount) {
	assert_eq!(post.unsynchronised_state.open_elections, n, "Number of open elections should be {}", n);
},
```

and it was because without explicitly comparing the whole post-state as is currently done on some Checks, it can't infer the rest of the state. Fixing this by explicitly providing the type in the closure, writing checks should remain just as clean.