### PR TITLE
feat: cleanup VaultStartBlockNumbers upon epoch expiry

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -6,8 +6,8 @@ use cf_chains::{Chain, ChainCrypto, SetAggKeyWithAggKey};
 use cf_primitives::EpochIndex;
 use cf_runtime_utilities::EnumVariant;
 use cf_traits::{
-	AsyncResult, Broadcaster, CfeMultisigRequest, Chainflip, CurrentEpochIndex, GetBlockHeight,
-	SafeMode, SetSafeMode, VaultKeyWitnessedHandler,
+	AsyncResult, Broadcaster, CfeMultisigRequest, Chainflip, CurrentEpochIndex,
+	EpochTransitionHandler, GetBlockHeight, SafeMode, SetSafeMode, VaultKeyWitnessedHandler,
 };
 use frame_support::{pallet_prelude::*, traits::StorageVersion};
 use frame_system::pallet_prelude::*;
@@ -254,6 +254,16 @@ impl<T: Config<I>, I: 'static> VaultKeyWitnessedHandler<T::Chain> for Pallet<T, 
 		Self::activate_new_key_for_chain(block_number);
 
 		Ok(())
+	}
+}
+
+impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
+	fn on_expired_epoch(expired_epoch: EpochIndex) {
+		let epochs_to_cull =
+			VaultStartBlockNumbers::<T, I>::iter_keys().filter(|epoch| *epoch <= expired_epoch);
+		for epoch in epochs_to_cull {
+			VaultStartBlockNumbers::<T, I>::remove(epoch);
+		}
 	}
 }
 

--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -259,9 +259,9 @@ impl<T: Config<I>, I: 'static> VaultKeyWitnessedHandler<T::Chain> for Pallet<T, 
 
 impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
 	fn on_expired_epoch(expired_epoch: EpochIndex) {
-		let epochs_to_cull =
-			VaultStartBlockNumbers::<T, I>::iter_keys().filter(|epoch| *epoch <= expired_epoch);
-		for epoch in epochs_to_cull {
+		for epoch in
+			VaultStartBlockNumbers::<T, I>::iter_keys().filter(|epoch| *epoch <= expired_epoch)
+		{
 			VaultStartBlockNumbers::<T, I>::remove(epoch);
 		}
 	}

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -2,13 +2,18 @@ use crate::AssetBalances;
 use cf_primitives::EpochIndex;
 use cf_traits::EpochTransitionHandler;
 
-use crate::Witnesser;
+use crate::{ArbitrumVault, BitcoinVault, EthereumVault, PolkadotVault, SolanaVault, Witnesser};
 
 pub struct ChainflipEpochTransitions;
 
 impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_expired_epoch(expired: EpochIndex) {
 		<Witnesser as EpochTransitionHandler>::on_expired_epoch(expired);
+		<EthereumVault as EpochTransitionHandler>::on_expired_epoch(expired);
+		<PolkadotVault as EpochTransitionHandler>::on_expired_epoch(expired);
+		<BitcoinVault as EpochTransitionHandler>::on_expired_epoch(expired);
+		<ArbitrumVault as EpochTransitionHandler>::on_expired_epoch(expired);
+		<SolanaVault as EpochTransitionHandler>::on_expired_epoch(expired);
 	}
 	fn on_new_epoch(_new: EpochIndex) {
 		AssetBalances::trigger_reconciliation();


### PR DESCRIPTION
# Pull Request

Closes: PRO-1699

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

* Implemented cleaning VaultStartBlockNumbers upon epoch expiry
* It's implemented in a simple way where it removes all epochs <= expired_epoch. This means that it would be expensive the first time we run this. 
