### PR TITLE
fix: don't remove while iterating

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -259,8 +259,9 @@ impl<T: Config<I>, I: 'static> VaultKeyWitnessedHandler<T::Chain> for Pallet<T, 
 
 impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
 	fn on_expired_epoch(expired_epoch: EpochIndex) {
-		for epoch in
-			VaultStartBlockNumbers::<T, I>::iter_keys().filter(|epoch| *epoch <= expired_epoch)
+		for epoch in VaultStartBlockNumbers::<T, I>::iter_keys()
+			.filter(|epoch| *epoch <= expired_epoch)
+			.collect::<Vec<EpochIndex>>()
 		{
 			VaultStartBlockNumbers::<T, I>::remove(epoch);
 		}


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

The docs here: https://paritytech.github.io/polkadot-sdk/master/frame_support/storage/trait.IterableStorageMap.html#tymethod.iter_keys say you shouldn't remove when iterating, so even though it's probably ok, best not to.
