### PR TITLE
refactor: move broker api subscription to custom-rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -898,6 +898,9 @@ pub trait CustomApi {
 	#[subscription(name = "subscribe_lp_order_fills", item = BlockUpdate<OrderFills>)]
 	async fn cf_subscribe_lp_order_fills(&self);
 
+	#[subscription(name = "subscribe_transaction_screening_events", item = BlockUpdate<TransactionScreeningEvents>)]
+	async fn cf_subscribe_transaction_screening_events(&self);
+
 	#[method(name = "scheduled_swaps")]
 	fn cf_scheduled_swaps(
 		&self,
@@ -1667,6 +1670,25 @@ where
 			},
 		)
 		.await
+	}
+
+	async fn cf_subscribe_transaction_screening_events(
+		&self,
+		pending_sink: PendingSubscriptionSink,
+	) {
+		self.new_subscription(
+			NotificationBehaviour::Finalized, /* only_finalized */
+			false, /* only_on_changes */
+			true,  /* end_on_error */
+			pending_sink,
+			move |client, hash| {
+				Ok(
+					(*client.runtime_api())
+						.cf_transaction_screening_events(hash)?
+				)
+			},
+		)
+			.await;
 	}
 
 	async fn cf_subscribe_scheduled_swaps(

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1678,17 +1678,12 @@ where
 	) {
 		self.new_subscription(
 			NotificationBehaviour::Finalized, /* only_finalized */
-			false, /* only_on_changes */
-			true,  /* end_on_error */
+			false,                            /* only_on_changes */
+			true,                             /* end_on_error */
 			pending_sink,
-			move |client, hash| {
-				Ok(
-					(*client.runtime_api())
-						.cf_transaction_screening_events(hash)?
-				)
-			},
+			move |client, hash| Ok((*client.runtime_api()).cf_transaction_screening_events(hash)?),
 		)
-			.await;
+		.await;
 	}
 
 	async fn cf_subscribe_scheduled_swaps(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1886

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* Added cf_subscribe_transaction_screening_events to custom_rpc that uses the new finalized notification behavior
* Modified broker-api subscribe_transaction_screening_events to use the custom-rpc equivalent function
* Also, changed the logic slightly so that it returns an empty events vector if there are no events detected, making it consistent with other custom-rpc subscriptions
