### PR TITLE
Feat: add boost_fee and broker_fees to events

### DIFF
--- a/state-chain/pallets/cf-asset-balances/src/tests.rs
+++ b/state-chain/pallets/cf-asset-balances/src/tests.rs
@@ -4,7 +4,7 @@ use cf_traits::{
 	mocks::egress_handler::MockEgressParameter, AssetWithholding, LiabilityTracker, SetSafeMode,
 };
 
-use crate::FreeBalances;
+use crate::{Event, FreeBalances};
 use cf_chains::AnyChain;
 use cf_test_utilities::assert_has_event;
 use cf_traits::{mocks::egress_handler::MockEgressHandler, BalanceApi, SafeMode};
@@ -86,12 +86,12 @@ pub fn not_enough_withheld_fees() {
 
 		Pallet::<Test>::trigger_reconciliation();
 
-		System::assert_has_event(RuntimeEvent::AssetBalances(crate::Event::VaultDeficitDetected {
+		System::assert_has_event(RuntimeEvent::AssetBalances(Event::VaultDeficitDetected {
 			chain: ForeignChain::Bitcoin,
 			amount_owed: BTC_OWED,
 			available: BTC_AVAILABLE,
 		}));
-		System::assert_has_event(RuntimeEvent::AssetBalances(crate::Event::VaultDeficitDetected {
+		System::assert_has_event(RuntimeEvent::AssetBalances(Event::VaultDeficitDetected {
 			chain: ForeignChain::Ethereum,
 			amount_owed: ETH_OWED,
 			available: ETH_AVAILABLE,
@@ -123,7 +123,7 @@ pub fn do_not_refund_if_amount_is_too_low() {
 		Pallet::<Test>::trigger_reconciliation();
 
 		assert_has_event::<Test>(
-			crate::Event::RefundSkipped {
+			Event::RefundSkipped {
 				reason: crate::Error::<Test>::RefundAmountTooLow.into(),
 				chain: ForeignChain::Ethereum,
 				address: ETH_ADDR_1,
@@ -290,7 +290,7 @@ pub mod balance_api {
 			const DELTA: u128 = 10;
 			Pallet::<Test>::credit_account(&alice, ForeignChain::Ethereum.gas_asset(), AMOUNT);
 			assert_has_event::<Test>(
-				crate::Event::AccountCredited {
+				Event::AccountCredited {
 					account_id: alice.clone(),
 					asset: ForeignChain::Ethereum.gas_asset(),
 					amount_credited: AMOUNT,
@@ -323,7 +323,7 @@ pub mod balance_api {
 				DELTA
 			);
 			assert_has_event::<Test>(
-				crate::Event::AccountDebited {
+				Event::AccountDebited {
 					account_id: alice.clone(),
 					asset: ForeignChain::Ethereum.gas_asset(),
 					amount_debited: AMOUNT - DELTA,

--- a/state-chain/pallets/cf-emissions/src/tests.rs
+++ b/state-chain/pallets/cf-emissions/src/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{mock::*, BlockEmissions, LastSupplyUpdateBlock, Pallet, BURN_FEE_MULTIPLE};
+use crate::{mock::*, BlockEmissions, Event, LastSupplyUpdateBlock, Pallet, BURN_FEE_MULTIPLE};
 use cf_primitives::SECONDS_PER_BLOCK;
 use cf_test_utilities::{assert_has_event, assert_has_matching_event};
 use cf_traits::{
@@ -192,7 +192,7 @@ fn burn_flip() {
 		assert_eq!(egresses.first().expect("should exist").amount(), FLIP_TO_BURN);
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::Emissions(crate::Event::NetworkFeeBurned { amount: FLIP_TO_BURN, .. }),
+			RuntimeEvent::Emissions(Event::NetworkFeeBurned { amount: FLIP_TO_BURN, .. }),
 		);
 	});
 }
@@ -206,7 +206,7 @@ fn dont_burn_flip_below_threshold() {
 		MockEgressHandler::<Ethereum>::set_fee(FLIP_TO_BURN / BURN_FEE_MULTIPLE);
 		Pallet::<Test>::burn_flip_network_fee();
 		assert_has_event::<Test>(
-			crate::Event::FlipBurnSkipped {
+			Event::FlipBurnSkipped {
 				reason: crate::Error::<Test>::FlipBalanceBelowBurnThreshold.into(),
 			}
 			.into(),
@@ -230,7 +230,7 @@ fn dont_burn_flip_below_threshold() {
 		Pallet::<Test>::burn_flip_network_fee();
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::Emissions(crate::Event::NetworkFeeBurned {
+			RuntimeEvent::Emissions(Event::NetworkFeeBurned {
 				amount,
 				..
 			}) if *amount == FLIP_TO_BURN - LOW_FEE,

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -302,12 +302,10 @@ impl FlipOperation {
 					return false
 				}
 				if expected_slash > 0 {
-					System::assert_last_event(RuntimeEvent::Flip(
-						crate::Event::<Test>::SlashingPerformed {
-							who: *account_id,
-							amount: expected_slash,
-						},
-					));
+					System::assert_last_event(RuntimeEvent::Flip(Event::SlashingPerformed {
+						who: *account_id,
+						amount: expected_slash,
+					}));
 				}
 			},
 			// Account to account transfer

--- a/state-chain/pallets/cf-governance/src/tests.rs
+++ b/state-chain/pallets/cf-governance/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-	mock::*, ActiveProposals, Error, ExecutionMode, ExecutionPipeline, ExpiryTime, Members,
+	mock::*, ActiveProposals, Error, Event, ExecutionMode, ExecutionPipeline, ExpiryTime, Members,
 	PreAuthorisedGovCalls, ProposalIdCounter,
 };
 use cf_primitives::SemVer;
@@ -67,7 +67,7 @@ fn propose_a_governance_extrinsic_and_expect_execution() {
 			));
 			assert_eq!(
 				last_event::<Test>(),
-				crate::mock::RuntimeEvent::Governance(crate::Event::Approved(1)),
+				crate::mock::RuntimeEvent::Governance(Event::Approved(1)),
 			);
 			// Make sure only a governance member can approve
 			assert_noop!(
@@ -81,7 +81,7 @@ fn propose_a_governance_extrinsic_and_expect_execution() {
 			// Expect the Executed event was fired
 			assert_eq!(
 				last_event::<Test>(),
-				crate::mock::RuntimeEvent::Governance(crate::Event::Executed(1)),
+				crate::mock::RuntimeEvent::Governance(Event::Executed(1)),
 			);
 			// Check the new governance set
 			let genesis_members = Members::<Test>::get();
@@ -103,10 +103,7 @@ fn already_executed() {
 			ExecutionMode::Automatic,
 		));
 		// Assert the proposed event was fired
-		assert_eq!(
-			last_event::<Test>(),
-			crate::mock::RuntimeEvent::Governance(crate::Event::Approved(1)),
-		);
+		assert_eq!(last_event::<Test>(), crate::mock::RuntimeEvent::Governance(Event::Approved(1)),);
 		// Do the second approval to reach majority
 		assert_ok!(Governance::approve(RuntimeOrigin::signed(BOB), 1));
 		// The third attempt in this block has to fail because the
@@ -154,7 +151,7 @@ fn propose_a_governance_extrinsic_and_expect_it_to_expire() {
 			// Expect the Expired event to be fired
 			assert_eq!(
 				last_event::<Test>(),
-				crate::mock::RuntimeEvent::Governance(crate::Event::Expired(1)),
+				crate::mock::RuntimeEvent::Governance(Event::Expired(1)),
 			);
 			assert_eq!(ActiveProposals::<Test>::get().len(), 0);
 		});
@@ -185,19 +182,13 @@ fn several_open_proposals() {
 			mock_extrinsic(),
 			ExecutionMode::Automatic,
 		));
-		assert_eq!(
-			last_event::<Test>(),
-			crate::mock::RuntimeEvent::Governance(crate::Event::Approved(1)),
-		);
+		assert_eq!(last_event::<Test>(), crate::mock::RuntimeEvent::Governance(Event::Approved(1)),);
 		assert_ok!(Governance::propose_governance_extrinsic(
 			RuntimeOrigin::signed(BOB),
 			mock_extrinsic(),
 			ExecutionMode::Automatic,
 		));
-		assert_eq!(
-			last_event::<Test>(),
-			crate::mock::RuntimeEvent::Governance(crate::Event::Approved(2)),
-		);
+		assert_eq!(last_event::<Test>(), crate::mock::RuntimeEvent::Governance(Event::Approved(2)),);
 		assert_eq!(ProposalIdCounter::<Test>::get(), 2);
 	});
 }
@@ -227,7 +218,7 @@ fn sudo_extrinsic() {
 			));
 			assert_eq!(
 				last_event::<Test>(),
-				crate::mock::RuntimeEvent::Governance(crate::Event::Approved(1)),
+				crate::mock::RuntimeEvent::Governance(Event::Approved(1)),
 			);
 			// Do the second necessary approval
 			assert_ok!(Governance::approve(RuntimeOrigin::signed(BOB), 1));
@@ -236,7 +227,7 @@ fn sudo_extrinsic() {
 			// Expect the sudo extrinsic to be executed successfully
 			assert_eq!(
 				last_event::<Test>(),
-				crate::mock::RuntimeEvent::Governance(crate::Event::Executed(1)),
+				crate::mock::RuntimeEvent::Governance(Event::Executed(1)),
 			);
 		});
 }

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -714,6 +714,7 @@ pub mod pallet {
 			// Ingress fee in the deposit asset. i.e. *NOT* the gas asset, if the deposit asset is
 			// a non-gas asset.
 			ingress_fee: TargetChainAmount<T, I>,
+			max_boost_fee_bps: BasisPoints,
 			action: DepositAction<T::AccountId>,
 			channel_id: Option<ChannelId>,
 			origin_type: DepositOriginType,
@@ -801,6 +802,7 @@ pub mod pallet {
 			// Ingress fee in the deposit asset. i.e. *NOT* the gas asset, if the deposit asset is
 			// a non-gas asset. The ingress fee is taken *after* the boost fee.
 			ingress_fee: TargetChainAmount<T, I>,
+			max_boost_fee_bps: BasisPoints,
 			// Total fee the user paid for their deposit to be boosted.
 			boost_fee: TargetChainAmount<T, I>,
 			action: DepositAction<T::AccountId>,
@@ -1952,6 +1954,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				None, // source address is unknown
 				&deposit_channel_details.owner,
 				deposit_channel_details.boost_status,
+				deposit_channel_details.boost_fee,
 				Some(channel_id),
 				deposit_channel_details.action,
 				block_height,
@@ -2089,6 +2092,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						channel_id,
 						deposit_details: deposit_details.clone(),
 						ingress_fee,
+						max_boost_fee_bps: boost_fee,
 						boost_fee: boost_fee_amount,
 						action,
 						origin_type: origin.into(),
@@ -2206,6 +2210,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		source_address: Option<ForeignChainAddress>,
 		broker: &T::AccountId,
 		boost_status: BoostStatus<TargetChainAmount<T, I>>,
+		max_boost_fee_bps: BasisPoints,
 		channel_id: Option<u64>,
 		action: ChannelAction<T::AccountId>,
 		block_height: TargetChainBlockNumber<T, I>,
@@ -2323,6 +2328,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				deposit_details,
 				// no ingress fee as it was already charged at the time of boosting
 				ingress_fee: 0u32.into(),
+				max_boost_fee_bps,
 				action: DepositAction::BoostersCredited { prewitnessed_deposit_id },
 				channel_id,
 				origin_type: origin.into(),
@@ -2359,6 +2365,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					block_height,
 					deposit_details,
 					ingress_fee: fees_withheld,
+					max_boost_fee_bps,
 					action,
 					channel_id,
 					origin_type: origin.into(),
@@ -2385,8 +2392,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			affiliate_fees,
 			refund_params,
 			dca_params,
-			// Boost fee is only relevant for prewitnessing
-			boost_fee: _,
+			boost_fee,
 		}: VaultDepositWitness<T, I>,
 	) {
 		let boost_status =
@@ -2486,6 +2492,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				source_address,
 				&broker,
 				boost_status,
+				boost_fee,
 				channel_id,
 				action,
 				block_height,

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -856,6 +856,7 @@ fn deposits_below_minimum_are_rejected() {
 				block_height: Default::default(),
 				deposit_details: Default::default(),
 				ingress_fee: 0,
+				max_boost_fee_bps: 0,
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
 				channel_id: Some(channel_id),
 				origin_type: DepositOriginType::DepositChannel,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -199,7 +199,9 @@ fn basic_passive_boosting() {
 
 		// ==== LP sends funds to liquidity deposit address, which gets pre-witnessed ====
 		assert_eq!(get_lp_eth_balance(&LP_ACCOUNT), INIT_LP_BALANCE);
-		let (channel_id, deposit_address) = request_deposit_address_eth(LP_ACCOUNT, 30);
+		const MAX_BOOST_FEE_BPS: u16 = 30;
+		let (channel_id, deposit_address) =
+			request_deposit_address_eth(LP_ACCOUNT, MAX_BOOST_FEE_BPS);
 		let prewitnessed_deposit_id = prewitness_deposit(deposit_address, ASSET, DEPOSIT_AMOUNT);
 		// All of BOOSTER_AMOUNT_1 should be used:
 		const POOL_1_FEE: AssetAmount =
@@ -225,6 +227,7 @@ fn basic_passive_boosting() {
 				prewitnessed_deposit_id,
 				deposit_details: Default::default(),
 				ingress_fee: INGRESS_FEE,
+				max_boost_fee_bps: MAX_BOOST_FEE_BPS,
 				boost_fee: POOL_1_FEE + POOL_2_FEE,
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
 				origin_type: DepositOriginType::DepositChannel,
@@ -253,6 +256,7 @@ fn basic_passive_boosting() {
 				block_height: Default::default(),
 				deposit_details: Default::default(),
 				ingress_fee: 0,
+				max_boost_fee_bps: MAX_BOOST_FEE_BPS,
 				action: DepositAction::BoostersCredited { prewitnessed_deposit_id },
 				channel_id: Some(channel_id),
 				origin_type: DepositOriginType::DepositChannel,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -1,9 +1,9 @@
 use crate::{
 	mock_btc::*,
 	tests::{ALICE, BROKER},
-	BoostPoolId, DepositChannelLookup, DepositIgnoredReason, DepositWitness, ReportExpiresAt,
-	ScheduledTxForReject, TransactionPrewitnessedStatus, TransactionRejectionDetails,
-	TransactionsMarkedForRejection, MARKED_TX_EXPIRATION_BLOCKS,
+	BoostPoolId, DepositChannelLookup, DepositIgnoredReason, DepositWitness, Event,
+	ReportExpiresAt, ScheduledTxForReject, TransactionPrewitnessedStatus,
+	TransactionRejectionDetails, TransactionsMarkedForRejection, MARKED_TX_EXPIRATION_BLOCKS,
 };
 
 use frame_support::{
@@ -135,7 +135,7 @@ fn process_marked_transaction_and_expect_refund() {
 
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::IngressEgress(crate::Event::<Test, ()>::DepositIgnored {
+			RuntimeEvent::IngressEgress(Event::DepositIgnored {
 				deposit_address: _address,
 				asset: btc::Asset::Btc,
 				amount: DEFAULT_DEPOSIT_AMOUNT,
@@ -189,7 +189,7 @@ fn finalize_boosted_tx_if_marked_after_prewitness() {
 
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::IngressEgress(crate::Event::DepositFinalised {
+			RuntimeEvent::IngressEgress(Event::DepositFinalised {
 				deposit_address: _,
 				asset: btc::Asset::Btc,
 				..
@@ -238,7 +238,7 @@ fn reject_tx_if_marked_before_prewitness() {
 
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::IngressEgress(crate::Event::DepositIgnored {
+			RuntimeEvent::IngressEgress(Event::DepositIgnored {
 				deposit_address: _,
 				asset: btc::Asset::Btc,
 				amount: DEFAULT_DEPOSIT_AMOUNT,
@@ -276,7 +276,7 @@ fn marked_transactions_expire_if_not_witnessed() {
 		assert!(!TransactionsMarkedForRejection::<Test, ()>::contains_key(BROKER, tx_id));
 
 		assert_has_event::<Test>(RuntimeEvent::IngressEgress(
-			crate::Event::TransactionRejectionRequestExpired { account_id: BROKER, tx_id },
+			Event::TransactionRejectionRequestExpired { account_id: BROKER, tx_id },
 		));
 	});
 }
@@ -381,7 +381,7 @@ fn send_funds_back_after_they_have_been_rejected() {
 
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::IngressEgress(crate::Event::TransactionRejectedByBroker {
+			RuntimeEvent::IngressEgress(Event::TransactionRejectedByBroker {
 				broadcast_id: _,
 				tx_id: _,
 			})
@@ -428,7 +428,7 @@ fn can_report_between_prewitness_and_witness_if_tx_was_not_boosted() {
 
 		assert_has_matching_event!(
 			Test,
-			RuntimeEvent::IngressEgress(crate::Event::DepositIgnored {
+			RuntimeEvent::IngressEgress(Event::DepositIgnored {
 				deposit_address: _,
 				asset: btc::Asset::Btc,
 				amount: DEFAULT_DEPOSIT_AMOUNT,

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -672,7 +672,7 @@ fn can_execute_scheduled_limit_order() {
 		));
 		assert_eq!(
 			last_event::<Test>(),
-			RuntimeEvent::LiquidityPools(crate::Event::LimitOrderSetOrUpdateScheduled {
+			RuntimeEvent::LiquidityPools(Event::LimitOrderSetOrUpdateScheduled {
 				lp: ALICE,
 				order_id,
 				dispatch_at: 6,
@@ -687,7 +687,7 @@ fn can_execute_scheduled_limit_order() {
 		);
 		assert_eq!(
 			last_event::<Test>(),
-			RuntimeEvent::LiquidityPools(crate::Event::ScheduledLimitOrderUpdateDispatchSuccess {
+			RuntimeEvent::LiquidityPools(Event::ScheduledLimitOrderUpdateDispatchSuccess {
 				lp: ALICE,
 				order_id,
 			})
@@ -965,12 +965,10 @@ fn test_maximum_slippage_limits() {
 			RuntimeOrigin::root(),
 			bounded_vec![(OTHER_ASSET, Some(1))],
 		));
-		System::assert_last_event(RuntimeEvent::LiquidityPools(
-			crate::Event::<Test>::PriceImpactLimitSet {
-				asset_pair: AssetPair::new(OTHER_ASSET, STABLE_ASSET).unwrap(),
-				limit: Some(1),
-			},
-		));
+		System::assert_last_event(RuntimeEvent::LiquidityPools(Event::PriceImpactLimitSet {
+			asset_pair: AssetPair::new(OTHER_ASSET, STABLE_ASSET).unwrap(),
+			limit: Some(1),
+		}));
 
 		let test_swaps = |size_limit_when_slippage_limit_is_hit| {
 			for (size, expected_output) in [

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2153,7 +2153,6 @@ pub mod pallet {
 				dca_params
 			});
 
-			// MAXIM: explose: broker/affiliate fees, boost_fee_bps
 			Self::deposit_event(Event::<T>::SwapRequested {
 				swap_request_id: request_id,
 				input_asset,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -564,6 +564,7 @@ pub mod pallet {
 			output_asset: Asset,
 			origin: SwapOrigin,
 			request_type: SwapRequestTypeEncoded,
+			broker_fees: Beneficiaries<T::AccountId>,
 			refund_parameters: Option<ChannelRefundParametersEncoded>,
 			dca_parameters: Option<DcaParameters>,
 		},
@@ -2152,6 +2153,7 @@ pub mod pallet {
 				dca_params
 			});
 
+			// MAXIM: explose: broker/affiliate fees, boost_fee_bps
 			Self::deposit_event(Event::<T>::SwapRequested {
 				swap_request_id: request_id,
 				input_asset,
@@ -2177,6 +2179,7 @@ pub mod pallet {
 						},
 				},
 				origin: origin.clone(),
+				broker_fees: broker_fees.clone(),
 				refund_parameters: refund_params
 					.clone()
 					.map(|params| params.map_address(T::AddressConverter::to_encoded_address)),

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -37,6 +37,7 @@ fn init_ccm_swap_request(input_asset: Asset, output_asset: Asset, input_amount: 
 		},
 		dca_parameters: None,
 		refund_parameters: None,
+		broker_fees: Default::default(),
 		origin,
 	}));
 }

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -57,27 +57,25 @@ fn can_update_all_config_items() {
 		// Check that the events were emitted
 		assert_events_eq!(
 			Test,
-			RuntimeEvent::Swapping(crate::Event::MaximumSwapAmountSet {
+			RuntimeEvent::Swapping(Event::MaximumSwapAmountSet {
 				asset: Asset::Btc,
 				amount: NEW_MAX_SWAP_AMOUNT_BTC,
 			}),
-			RuntimeEvent::Swapping(crate::Event::MaximumSwapAmountSet {
+			RuntimeEvent::Swapping(Event::MaximumSwapAmountSet {
 				asset: Asset::Dot,
 				amount: NEW_MAX_SWAP_AMOUNT_DOT,
 			}),
-			RuntimeEvent::Swapping(crate::Event::SwapRetryDelaySet {
+			RuntimeEvent::Swapping(Event::SwapRetryDelaySet {
 				swap_retry_delay: new_swap_retry_delay
 			}),
-			RuntimeEvent::Swapping(crate::Event::BuyIntervalSet {
-				buy_interval: new_flip_buy_interval
-			}),
-			RuntimeEvent::Swapping(crate::Event::MaxSwapRetryDurationSet {
+			RuntimeEvent::Swapping(Event::BuyIntervalSet { buy_interval: new_flip_buy_interval }),
+			RuntimeEvent::Swapping(Event::MaxSwapRetryDurationSet {
 				blocks: NEW_MAX_SWAP_RETRY_DURATION
 			}),
-			RuntimeEvent::Swapping(crate::Event::MaxSwapRequestDurationSet {
+			RuntimeEvent::Swapping(Event::MaxSwapRequestDurationSet {
 				blocks: MAX_SWAP_REQUEST_DURATION
 			}),
-			RuntimeEvent::Swapping(crate::Event::MinimumChunkSizeSet {
+			RuntimeEvent::Swapping(Event::MinimumChunkSizeSet {
 				asset: Asset::Eth,
 				amount: NEW_MINIMUM_CHUNK_SIZE
 			}),

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -204,16 +204,24 @@ fn network_fee_swap_gets_burnt() {
 
 			assert!(SwapRequests::<Test>::get(SWAP_REQUEST_ID).is_some());
 
-			System::assert_has_event(RuntimeEvent::Swapping(Event::SwapRequested {
-				swap_request_id: SWAP_REQUEST_ID,
-				input_asset: INPUT_ASSET,
-				input_amount: AMOUNT,
-				output_asset: OUTPUT_ASSET,
-				request_type: SwapRequestTypeEncoded::NetworkFee,
-				refund_parameters: None,
-				dca_parameters: None,
-				origin: SwapOrigin::Internal,
-			}));
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRequested {
+					swap_request_id: SWAP_REQUEST_ID,
+					input_asset: INPUT_ASSET,
+					input_amount: AMOUNT,
+					output_asset: OUTPUT_ASSET,
+					request_type: SwapRequestTypeEncoded::NetworkFee,
+					origin: SwapOrigin::Internal,
+					..
+				}),
+			);
+
+			// System::assert_has_event(RuntimeEvent::Swapping(Event::SwapRequested {
+			// 	refund_parameters: None,
+			// 	dca_parameters: None,
+			// 	origin: SwapOrigin::Internal,
+			// }));
 			assert_has_matching_event!(Test, RuntimeEvent::Swapping(Event::SwapScheduled { .. }),);
 		})
 		.then_process_blocks_until_block(SWAP_BLOCK)
@@ -246,16 +254,18 @@ fn transaction_fees_are_collected() {
 				SwapOrigin::Internal,
 			);
 
-			System::assert_has_event(RuntimeEvent::Swapping(Event::SwapRequested {
-				swap_request_id: SWAP_REQUEST_ID,
-				input_asset: INPUT_ASSET,
-				input_amount: AMOUNT,
-				output_asset: OUTPUT_ASSET,
-				request_type: SwapRequestTypeEncoded::IngressEgressFee,
-				refund_parameters: None,
-				dca_parameters: None,
-				origin: SwapOrigin::Internal,
-			}));
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRequested {
+					swap_request_id: SWAP_REQUEST_ID,
+					input_asset: INPUT_ASSET,
+					input_amount: AMOUNT,
+					output_asset: OUTPUT_ASSET,
+					request_type: SwapRequestTypeEncoded::IngressEgressFee,
+					origin: SwapOrigin::Internal,
+					..
+				}),
+			);
 
 			assert_has_matching_event!(Test, RuntimeEvent::Swapping(Event::SwapScheduled { .. }),);
 

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -217,11 +217,6 @@ fn network_fee_swap_gets_burnt() {
 				}),
 			);
 
-			// System::assert_has_event(RuntimeEvent::Swapping(Event::SwapRequested {
-			// 	refund_parameters: None,
-			// 	dca_parameters: None,
-			// 	origin: SwapOrigin::Internal,
-			// }));
 			assert_has_matching_event!(Test, RuntimeEvent::Swapping(Event::SwapScheduled { .. }),);
 		})
 		.then_process_blocks_until_block(SWAP_BLOCK)

--- a/state-chain/pallets/cf-tokenholder-governance/src/tests.rs
+++ b/state-chain/pallets/cf-tokenholder-governance/src/tests.rs
@@ -21,7 +21,7 @@ fn submit_and_pass_proposal(proposal: Proposal) {
 	));
 	assert_eq!(
 		last_event::<Test>(),
-		mock::RuntimeEvent::TokenholderGovernance(crate::Event::ProposalSubmitted {
+		mock::RuntimeEvent::TokenholderGovernance(Event::ProposalSubmitted {
 			proposal: proposal.clone()
 		}),
 	);
@@ -41,7 +41,7 @@ fn submit_and_pass_proposal(proposal: Proposal) {
 	assert!(!Proposals::<Test>::contains_key(proposal_decision_block));
 	assert_eq!(
 		last_event::<Test>(),
-		mock::RuntimeEvent::TokenholderGovernance(crate::Event::ProposalPassed {
+		mock::RuntimeEvent::TokenholderGovernance(Event::ProposalPassed {
 			proposal: proposal.clone()
 		}),
 	);
@@ -66,7 +66,7 @@ fn update_gov_key_via_onchain_proposal() {
 		assert!(GovKeyUpdateAwaitingEnactment::<Test>::get().is_none());
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::TokenholderGovernance(crate::Event::ProposalEnacted { proposal }),
+			mock::RuntimeEvent::TokenholderGovernance(Event::ProposalEnacted { proposal }),
 		);
 
 		// The key should now be set
@@ -88,7 +88,7 @@ fn update_community_key_via_onchain_proposal() {
 		assert!(CommKeyUpdateAwaitingEnactment::<Test>::get().is_none());
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::TokenholderGovernance(crate::Event::ProposalEnacted { proposal }),
+			mock::RuntimeEvent::TokenholderGovernance(Event::ProposalEnacted { proposal }),
 		);
 	});
 }
@@ -180,7 +180,7 @@ fn not_enough_backed_liquidity_for_proposal_enactment() {
 		assert!(GovKeyUpdateAwaitingEnactment::<Test>::get().is_none());
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::TokenholderGovernance(crate::Event::ProposalRejected { proposal }),
+			mock::RuntimeEvent::TokenholderGovernance(Event::ProposalRejected { proposal }),
 		);
 	});
 }

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -107,9 +107,7 @@ fn changing_epoch_block_size() {
 		assert_ok!(ValidatorPallet::update_pallet_config(RuntimeOrigin::root(), UPDATE));
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PalletConfigUpdated {
-				update: UPDATE
-			}),
+			mock::RuntimeEvent::ValidatorPallet(Event::PalletConfigUpdated { update: UPDATE }),
 		);
 	});
 }
@@ -249,7 +247,7 @@ fn send_cfe_version() {
 
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::CFEVersionUpdated {
+			mock::RuntimeEvent::ValidatorPallet(Event::CFEVersionUpdated {
 				account_id: authority,
 				old_version: SemVer::default(),
 				new_version: version,
@@ -269,7 +267,7 @@ fn send_cfe_version() {
 
 		assert_eq!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::CFEVersionUpdated {
+			mock::RuntimeEvent::ValidatorPallet(Event::CFEVersionUpdated {
 				account_id: authority,
 				old_version: version,
 				new_version,
@@ -725,7 +723,7 @@ fn auction_params_must_be_valid_when_set() {
 		// Confirm we have an event
 		assert!(matches!(
 			last_event::<Test>(),
-			mock::RuntimeEvent::ValidatorPallet(crate::Event::PalletConfigUpdated { .. }),
+			mock::RuntimeEvent::ValidatorPallet(Event::PalletConfigUpdated { .. }),
 		));
 	});
 }
@@ -1336,8 +1334,8 @@ fn test_start_and_stop_bidding() {
 
 		assert_event_sequence!(
 			Test,
-			RuntimeEvent::ValidatorPallet(crate::Event::StartedBidding { account_id: ALICE }),
-			RuntimeEvent::ValidatorPallet(crate::Event::StoppedBidding { account_id: ALICE })
+			RuntimeEvent::ValidatorPallet(Event::StartedBidding { account_id: ALICE }),
+			RuntimeEvent::ValidatorPallet(Event::StoppedBidding { account_id: ALICE })
 		);
 	});
 }
@@ -1482,9 +1480,9 @@ fn can_update_all_config_items() {
 		for update in updates {
 			assert_ok!(ValidatorPallet::update_pallet_config(OriginTrait::root(), update.clone()));
 			// Check that the events were emitted
-			System::assert_has_event(RuntimeEvent::ValidatorPallet(
-				crate::Event::PalletConfigUpdated { update },
-			));
+			System::assert_has_event(RuntimeEvent::ValidatorPallet(Event::PalletConfigUpdated {
+				update,
+			}));
 		}
 
 		// Check that the new values were set

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 
-use crate::{mock::*, PendingVaultActivation, VaultActivationStatus, VaultStartBlockNumbers};
+use crate::{
+	mock::*, Event, PendingVaultActivation, VaultActivationStatus, VaultStartBlockNumbers,
+};
 use cf_chains::mocks::{MockAggKey, MockEthereum};
 use cf_test_utilities::last_event;
 use cf_traits::{
@@ -28,7 +30,7 @@ fn key_unavailable_on_activate_returns_governance_event() {
 	new_test_ext_no_key().execute_with(|| {
 		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, None);
 
-		assert_last_event!(crate::Event::AwaitingGovernanceActivation { .. });
+		assert_last_event!(Event::AwaitingGovernanceActivation { .. });
 
 		// we're awaiting the governance action, so we are pending from
 		// perspective of an outside observer (e.g. the validator pallet)
@@ -68,7 +70,7 @@ fn vault_start_block_number_is_set_correctly() {
 			PendingVaultActivation::<Test, _>::get().unwrap(),
 			VaultActivationStatus::Complete
 		));
-		assert_last_event!(crate::Event::VaultActivationCompleted);
+		assert_last_event!(Event::VaultActivationCompleted);
 	});
 }
 

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -3,7 +3,7 @@
 use crate::{
 	mock::{dummy::pallet as pallet_dummy, *},
 	weights::WeightInfo,
-	CallHash, CallHashExecuted, Config, EpochsToCull, Error, ExtraCallData, PalletOffence,
+	CallHash, CallHashExecuted, Config, EpochsToCull, Error, Event, ExtraCallData, PalletOffence,
 	PalletSafeMode, VoteMask, Votes, WitnessDeadline, WitnessedCallsScheduledForDispatch,
 };
 use cf_test_utilities::assert_event_sequence;
@@ -549,9 +549,7 @@ fn can_punish_failed_witnesser() {
 
 			assert!(CallHashExecuted::<Test>::contains_key(epoch, call_hash));
 			assert_eq!(WitnessDeadline::<Test>::get(target), vec![(epoch, call_hash)]);
-			System::assert_has_event(RuntimeEvent::Witnesser(
-				crate::Event::<Test>::CallDispatched { call_hash },
-			));
+			System::assert_has_event(RuntimeEvent::Witnesser(Event::CallDispatched { call_hash }));
 
 			// Before the deadline is set, no one has been reported.
 			OffenceReporter::assert_reported(PalletOffence::FailedToWitnessInTime, vec![]);
@@ -565,13 +563,11 @@ fn can_punish_failed_witnesser() {
 				success_threshold..100u64,
 			);
 
-			System::assert_has_event(RuntimeEvent::Witnesser(
-				crate::Event::<Test>::ReportedWitnessingFailures {
-					call_hash,
-					block_number: System::block_number() - GracePeriod::get(),
-					accounts: (success_threshold..100u64).collect(),
-				},
-			));
+			System::assert_has_event(RuntimeEvent::Witnesser(Event::ReportedWitnessingFailures {
+				call_hash,
+				block_number: System::block_number() - GracePeriod::get(),
+				accounts: (success_threshold..100u64).collect(),
+			}));
 
 			// storage is cleaned up.
 			assert_eq!(WitnessDeadline::<Test>::decode_len(target), None);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1824

## Summary

- Added `max_boost_fee_bps` field to both `DepositFinalised` and `DepositBoosted` events

- Added `broker_fees` field to the `SwapRequested` event FYI @niklasnatter 

- While updating tests, I noticed some tests used unnecessary annotations like `crate::Event::<Test, Instance1>` where `Event` would suffice, so I cleaned up the tests where this applies. This change is done in a separate commit.


