### PR TITLE
fix: expose error detail when swap simulation fails

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1182,7 +1182,7 @@ impl From<CfApiError> for ErrorObjectOwned {
 			},
 			CfApiError::DispatchError(dispatch_error) => match dispatch_error {
 				DispatchErrorWithMessage::Module(message) |
-				DispatchErrorWithMessage::AdHoc(message) => match std::str::from_utf8(&message) {
+				DispatchErrorWithMessage::RawMessage(message) => match std::str::from_utf8(&message) {
 					Ok(message) => call_error(std::format!("DispatchError: {message}")),
 					Err(error) =>
 						internal_error(format!("Unable to decode Module Error Message: {error}")),

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1181,10 +1181,11 @@ impl From<CfApiError> for ErrorObjectOwned {
 				other => internal_error(other),
 			},
 			CfApiError::DispatchError(dispatch_error) => match dispatch_error {
-				DispatchErrorWithMessage::Module(message) => match std::str::from_utf8(&message) {
+				DispatchErrorWithMessage::Module(message) |
+				DispatchErrorWithMessage::AdHoc(message) => match std::str::from_utf8(&message) {
 					Ok(message) => call_error(std::format!("DispatchError: {message}")),
 					Err(error) =>
-						internal_error(format!("Unable to decode DispatchError: {error}")),
+						internal_error(format!("Unable to decode Module Error Message: {error}")),
 				},
 				DispatchErrorWithMessage::Other(error) =>
 					internal_error(format!("Unable to decode DispatchError: {error:?}")),

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1675,11 +1675,11 @@ impl_runtime_apis! {
 						],
 					)
 				],
-			).map_err(|e| DispatchErrorWithMessage::Other(match e {
+			).map_err(|e| match e {
 				BatchExecutionError::SwapLegFailed { .. } => DispatchError::Other("Swap leg failed."),
 				BatchExecutionError::PriceViolation { .. } => DispatchError::Other("Price Violation: Some swaps failed due to Price Impact Limitations."),
 				BatchExecutionError::DispatchError { error } => error,
-			}))?;
+			})?;
 
 			let (
 				network_fee,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -196,6 +196,7 @@ impl From<SimulatedSwapInformation!["1.0.0"]> for SimulatedSwapInformation {
 #[derive(Debug, Decode, Encode, TypeInfo)]
 pub enum DispatchErrorWithMessage {
 	Module(Vec<u8>),
+	AdHoc(Vec<u8>),
 	Other(DispatchError),
 }
 impl<E: Into<DispatchError>> From<E> for DispatchErrorWithMessage {
@@ -203,6 +204,8 @@ impl<E: Into<DispatchError>> From<E> for DispatchErrorWithMessage {
 		match error.into() {
 			DispatchError::Module(sp_runtime::ModuleError { message: Some(message), .. }) =>
 				DispatchErrorWithMessage::Module(message.as_bytes().to_vec()),
+			DispatchError::Other(message) =>
+				DispatchErrorWithMessage::AdHoc(message.as_bytes().to_vec()),
 			error => DispatchErrorWithMessage::Other(error),
 		}
 	}
@@ -212,7 +215,8 @@ impl<E: Into<DispatchError>> From<E> for DispatchErrorWithMessage {
 impl core::fmt::Display for DispatchErrorWithMessage {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
 		match self {
-			DispatchErrorWithMessage::Module(message) => write!(
+			DispatchErrorWithMessage::Module(message) |
+			DispatchErrorWithMessage::AdHoc(message) => write!(
 				f,
 				"{}",
 				str::from_utf8(message).unwrap_or("<Error message is not valid UTF-8>")

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -196,7 +196,7 @@ impl From<SimulatedSwapInformation!["1.0.0"]> for SimulatedSwapInformation {
 #[derive(Debug, Decode, Encode, TypeInfo)]
 pub enum DispatchErrorWithMessage {
 	Module(Vec<u8>),
-	AdHoc(Vec<u8>),
+	RawMessage(Vec<u8>),
 	Other(DispatchError),
 }
 impl<E: Into<DispatchError>> From<E> for DispatchErrorWithMessage {
@@ -205,7 +205,7 @@ impl<E: Into<DispatchError>> From<E> for DispatchErrorWithMessage {
 			DispatchError::Module(sp_runtime::ModuleError { message: Some(message), .. }) =>
 				DispatchErrorWithMessage::Module(message.as_bytes().to_vec()),
 			DispatchError::Other(message) =>
-				DispatchErrorWithMessage::AdHoc(message.as_bytes().to_vec()),
+				DispatchErrorWithMessage::RawMessage(message.as_bytes().to_vec()),
 			error => DispatchErrorWithMessage::Other(error),
 		}
 	}
@@ -216,7 +216,7 @@ impl core::fmt::Display for DispatchErrorWithMessage {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
 		match self {
 			DispatchErrorWithMessage::Module(message) |
-			DispatchErrorWithMessage::AdHoc(message) => write!(
+			DispatchErrorWithMessage::RawMessage(message) => write!(
 				f,
 				"{}",
 				str::from_utf8(message).unwrap_or("<Error message is not valid UTF-8>")


### PR DESCRIPTION
This fixes an issue observed during the recent upgrade, when liquidity is low. Error messages were being erased due to the implementation of DispatchError. 