### PR TITLE
feat: Add private channel address to account info rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -252,7 +252,7 @@ pub enum RpcAccountInfo {
 	Broker {
 		flip_balance: NumberOrHex,
 		earned_fees: any::AssetMap<NumberOrHex>,
-		deposit_address: Option<String>,
+		btc_vault_deposit_address: Option<String>,
 	},
 	LiquidityProvider {
 		balances: any::AssetMap<NumberOrHex>,
@@ -286,7 +286,7 @@ impl RpcAccountInfo {
 	fn broker(broker_info: BrokerInfo, balance: u128) -> Self {
 		Self::Broker {
 			flip_balance: balance.into(),
-			deposit_address: broker_info.deposit_address,
+			btc_vault_deposit_address: broker_info.btc_vault_deposit_address,
 			earned_fees: cf_chains::assets::any::AssetMap::from_iter_or_default(
 				broker_info
 					.earned_fees
@@ -2064,7 +2064,7 @@ mod test {
 					(Asset::Sol, 0),
 					(Asset::SolUsdc, 0),
 				],
-				deposit_address: Some(
+				btc_vault_deposit_address: Some(
 					ScriptPubkey::Taproot([1u8; 32]).to_address(&BitcoinNetwork::Testnet),
 				),
 			},

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -252,7 +252,7 @@ pub enum RpcAccountInfo {
 	Broker {
 		flip_balance: NumberOrHex,
 		earned_fees: any::AssetMap<NumberOrHex>,
-		channel_address: Option<String>,
+		deposit_address: Option<String>,
 	},
 	LiquidityProvider {
 		balances: any::AssetMap<NumberOrHex>,
@@ -286,7 +286,7 @@ impl RpcAccountInfo {
 	fn broker(broker_info: BrokerInfo, balance: u128) -> Self {
 		Self::Broker {
 			flip_balance: balance.into(),
-			channel_address: broker_info.channel_address,
+			deposit_address: broker_info.deposit_address,
 			earned_fees: cf_chains::assets::any::AssetMap::from_iter_or_default(
 				broker_info
 					.earned_fees
@@ -2064,7 +2064,7 @@ mod test {
 					(Asset::Sol, 0),
 					(Asset::SolUsdc, 0),
 				],
-				channel_address: Some(
+				deposit_address: Some(
 					ScriptPubkey::Taproot([1u8; 32]).to_address(&BitcoinNetwork::Testnet),
 				),
 			},

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -3,4 +3,4 @@ source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
 snapshot_kind: text
 ---
-{"channel_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -3,4 +3,4 @@ source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
 snapshot_kind: text
 ---
-{"channel_address":null,"earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"channel_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: state-chain/custom-rpc/src/lib.rs
-expression: "serde_json::to_value(RpcAccountInfo::broker(0,\n            BrokerInfo {\n                earned_fees: vec![(Asset::Eth, 0), (Asset::Btc, 0),\n                    (Asset::Flip, 1000000000000000000), (Asset::Usdc, 0),\n                    (Asset::Usdt, 0), (Asset::Dot, 0), (Asset::ArbEth, 0),\n                    (Asset::ArbUsdc, 0), (Asset::Sol, 0), (Asset::SolUsdc, 0),],\n            })).unwrap()"
+expression: "serde_json::to_value(broker).unwrap()"
+snapshot_kind: text
 ---
-{"earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"channel_address":null,"earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -3,4 +3,4 @@ source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
 snapshot_kind: text
 ---
-{"deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/runtime/src/chainflip/address_derivation/btc.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/btc.rs
@@ -44,9 +44,11 @@ impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 	}
 }
 
+/// ONLY FOR USE IN RPC CALLS.
+///
 /// Derives the BTC vault deposit address from the private channel id.
-/// Note: This function will **panic** if the private channel id is out of bounds so use it with
-/// caution...
+/// Note: This function will **panic** if the private channel id is out of bounds or if there is
+/// no active epoch key for Bitcoin.
 pub(crate) fn derive_btc_vault_deposit_address(private_channel_id: u64) -> String {
 	let EpochKey { key, .. } = BitcoinThresholdSigner::active_epoch_key()
 		.expect("We should always have a key for the current epoch.");

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1866,14 +1866,14 @@ impl_runtime_apis! {
 				let EpochKey { key, .. } = BitcoinThresholdSigner::active_epoch_key().expect("We should always have a key for the current epoch.");
 				BrokerInfo {
 					earned_fees,
-					deposit_address: if let Ok(salt) = channel_id.try_into() {
-						let deposit_address = DepositAddress::new(
+					btc_vault_deposit_address: if let Ok(salt) = channel_id.try_into() {
+						let btc_vault_deposit_address = DepositAddress::new(
 							key.current,
 							salt,
 						)
 						.script_pubkey()
 						.to_address(&Environment::network_environment().into());
-						Some(deposit_address)
+						Some(btc_vault_deposit_address)
 					} else {
 						log::error!("Private channel id out of bounds.");
 						None
@@ -1882,7 +1882,7 @@ impl_runtime_apis! {
 			} else {
 				BrokerInfo {
 					earned_fees,
-					deposit_address: None
+					btc_vault_deposit_address: None
 				}
 			}
 		}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -79,7 +79,7 @@ use pallet_cf_pools::{
 	AskBidMap, AssetPair, HistoricalEarnedFees, OrderId, PoolLiquidity, PoolOrderbook, PoolPriceV1,
 	PoolPriceV2, UnidirectionalPoolDepth,
 };
-use pallet_cf_swapping::{BatchExecutionError, FeeType, Swap};
+use pallet_cf_swapping::{BatchExecutionError, BrokerPrivateBtcChannels, FeeType, Swap};
 use runtime_apis::ChainAccounts;
 
 use crate::{chainflip::EvmLimit, runtime_apis::TransactionScreeningEvent};
@@ -1859,19 +1859,12 @@ impl_runtime_apis! {
 		fn cf_broker_info(
 			account_id: AccountId,
 		) -> BrokerInfo {
-			let earned_fees: Vec<_> = Asset::all().map(|asset|
-				(asset, AssetBalances::get_balance(&account_id, asset))
-			).collect();
-			if let Some(channel_id) = pallet_cf_swapping::BrokerPrivateBtcChannels::<Runtime>::get(&account_id) {
-				BrokerInfo {
-					earned_fees,
-					btc_vault_deposit_address: Some(derive_btc_vault_deposit_address(channel_id))
-				}
-			} else {
-				BrokerInfo {
-					earned_fees,
-					btc_vault_deposit_address: None
-				}
+			BrokerInfo {
+				earned_fees: Asset::all().map(|asset|
+					(asset, AssetBalances::get_balance(&account_id, asset))
+				).collect(),
+				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
+					.map(derive_btc_vault_deposit_address),
 			}
 		}
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1866,14 +1866,14 @@ impl_runtime_apis! {
 				let EpochKey { key, .. } = BitcoinThresholdSigner::active_epoch_key().expect("We should always have a key for the current epoch.");
 				BrokerInfo {
 					earned_fees,
-					channel_address: if let Ok(salt) = channel_id.try_into() {
-						let channel_address = DepositAddress::new(
+					deposit_address: if let Ok(salt) = channel_id.try_into() {
+						let deposit_address = DepositAddress::new(
 							key.current,
 							salt,
 						)
 						.script_pubkey()
 						.to_address(&Environment::network_environment().into());
-						Some(channel_address)
+						Some(deposit_address)
 					} else {
 						log::error!("Private channel id out of bounds.");
 						None
@@ -1882,7 +1882,7 @@ impl_runtime_apis! {
 			} else {
 				BrokerInfo {
 					earned_fees,
-					channel_address: None
+					deposit_address: None
 				}
 			}
 		}

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -161,7 +161,7 @@ pub struct LiquidityProviderInfo {
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
-	pub channel_address: Option<String>,
+	pub deposit_address: Option<String>,
 }
 
 /// Struct that represents the estimated output of a Swap.

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -161,7 +161,7 @@ pub struct LiquidityProviderInfo {
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
-	pub deposit_address: Option<String>,
+	pub btc_vault_deposit_address: Option<String>,
 }
 
 /// Struct that represents the estimated output of a Swap.

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -161,6 +161,7 @@ pub struct LiquidityProviderInfo {
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
+	pub channel_address: Option<ForeignChainAddress>,
 }
 
 /// Struct that represents the estimated output of a Swap.

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -161,7 +161,7 @@ pub struct LiquidityProviderInfo {
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
-	pub channel_address: Option<ForeignChainAddress>,
+	pub channel_address: Option<String>,
 }
 
 /// Struct that represents the estimated output of a Swap.


### PR DESCRIPTION
# Pull Request

Closes: PRO-1862

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Adds the deposit address of a private broker channel to the response of cf_account_info.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
