### PR TITLE
feature: Added affiliates to cf_account_info rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -2192,7 +2192,7 @@ mod test {
 				btc_vault_deposit_address: Some(
 					ScriptPubkey::Taproot([1u8; 32]).to_address(&BitcoinNetwork::Testnet),
 				),
-                affiliates: vec![(cf_primitives::AffiliateShortId(1), AccountId32::new([1; 32]))],
+				affiliates: vec![(cf_primitives::AffiliateShortId(1), AccountId32::new([1; 32]))],
 			},
 			0,
 		);

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -14,9 +14,9 @@ use cf_chains::{
 };
 use cf_primitives::{
 	chains::assets::any::{self, AssetMap},
-	AccountRole, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints, BlockNumber,
-	BroadcastId, DcaParameters, EpochIndex, ForeignChain, NetworkEnvironment, SemVer, SwapId,
-	SwapRequestId,
+	AccountId, AccountRole, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
+	BlockNumber, BroadcastId, DcaParameters, EpochIndex, ForeignChain, NetworkEnvironment, SemVer,
+	SwapId, SwapRequestId,
 };
 use cf_utilities::rpc::NumberOrHex;
 use core::ops::Range;
@@ -259,6 +259,7 @@ pub enum RpcAccountInfo {
 	Broker {
 		flip_balance: NumberOrHex,
 		earned_fees: any::AssetMap<NumberOrHex>,
+		affiliates: Vec<(AffiliateShortId, AccountId)>,
 		btc_vault_deposit_address: Option<String>,
 	},
 	LiquidityProvider {
@@ -300,6 +301,7 @@ impl RpcAccountInfo {
 					.iter()
 					.map(|(asset, balance)| (*asset, (*balance).into())),
 			),
+			affiliates: broker_info.affiliates,
 		}
 	}
 
@@ -2190,10 +2192,10 @@ mod test {
 				btc_vault_deposit_address: Some(
 					ScriptPubkey::Taproot([1u8; 32]).to_address(&BitcoinNetwork::Testnet),
 				),
+                affiliates: vec![(cf_primitives::AffiliateShortId(1), AccountId32::new([1; 32]))],
 			},
 			0,
 		);
-
 		insta::assert_snapshot!(serde_json::to_value(broker).unwrap());
 	}
 

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -3,4 +3,4 @@ source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
 snapshot_kind: text
 ---
-{"btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT"]],"btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1912,6 +1912,7 @@ impl_runtime_apis! {
 				).collect(),
 				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
 					.map(derive_btc_vault_deposit_address),
+                affiliates: pallet_cf_swapping::AffiliateIdMapping::<Runtime>::iter_prefix(&account_id).collect(),
 			}
 		}
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1912,7 +1912,7 @@ impl_runtime_apis! {
 				).collect(),
 				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
 					.map(derive_btc_vault_deposit_address),
-                affiliates: pallet_cf_swapping::AffiliateIdMapping::<Runtime>::iter_prefix(&account_id).collect(),
+				affiliates: pallet_cf_swapping::AffiliateIdMapping::<Runtime>::iter_prefix(&account_id).collect(),
 			}
 		}
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -162,6 +162,7 @@ pub struct LiquidityProviderInfo {
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
 	pub btc_vault_deposit_address: Option<String>,
+	pub affiliates: Vec<(AffiliateShortId, AccountId32)>,
 }
 
 /// Struct that represents the estimated output of a Swap.


### PR DESCRIPTION
# Pull Request

Closes: PRO-1884

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Adds the associated affiliates of a broker account to the response of the cf_account_info rpc.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
