### PR TITLE
chore: removed cf_pool_simulate_swap_v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7650,27 +7650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "obake"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c016d34f5be5713bfcaa23668b736865921606c2ddff17e158f0815e4cde091b"
-dependencies = [
- "obake_macros",
-]
-
-[[package]]
-name = "obake_macros"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47056b8eb01b867a9fdc29f69c05799b9eafb50f73e440cafe624949e27cc7dc"
-dependencies = [
- "proc-macro2",
- "quote",
- "semver 1.0.23",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13281,7 +13260,6 @@ dependencies = [
  "hex-literal",
  "log",
  "nanorand",
- "obake",
  "pallet-aura",
  "pallet-authorship",
  "pallet-cf-account-roles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ web3 = { version = "0.19" }
 x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
-obake = { version = "1.0.5" }
 
 # PolkadotSdk Pallets
 pallet-aura = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.15.2+2", default-features = false }

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -24,7 +24,6 @@ nanorand = { workspace = true, features = ["wyrand"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 ethabi = { workspace = true }
 bitvec = { workspace = true }
-obake = { workspace = true }
 
 # Chainflip local dependencies
 cf-amm = { workspace = true }

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -167,9 +167,6 @@ pub struct BrokerInfo {
 }
 
 /// Struct that represents the estimated output of a Swap.
-#[obake::versioned]
-#[obake(version("1.0.0"))]
-#[obake(version("2.0.0"))]
 #[derive(Encode, Decode, TypeInfo)]
 pub struct SimulatedSwapInformation {
 	pub intermediary: Option<AssetAmount>,
@@ -177,21 +174,7 @@ pub struct SimulatedSwapInformation {
 	pub network_fee: AssetAmount,
 	pub ingress_fee: AssetAmount,
 	pub egress_fee: AssetAmount,
-	#[obake(cfg(">=2.0"))]
 	pub broker_fee: AssetAmount,
-}
-
-impl From<SimulatedSwapInformation!["1.0.0"]> for SimulatedSwapInformation {
-	fn from(value: SimulatedSwapInformation!["1.0.0"]) -> Self {
-		Self {
-			intermediary: value.intermediary,
-			output: value.output,
-			network_fee: value.network_fee,
-			ingress_fee: value.ingress_fee,
-			egress_fee: value.egress_fee,
-			broker_fee: Default::default(),
-		}
-	}
 }
 
 #[derive(Debug, Decode, Encode, TypeInfo)]

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -318,13 +318,6 @@ decl_runtime_apis!(
 			base_asset: Asset,
 			quote_asset: Asset,
 		) -> Result<PoolPriceV2, DispatchErrorWithMessage>;
-		#[changed_in(2)]
-		fn cf_pool_simulate_swap(
-			from: Asset,
-			to: Asset,
-			amount: AssetAmount,
-			additional_limit_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
-		) -> Result<SimulatedSwapInformation!["1.0.0"], DispatchErrorWithMessage>;
 		fn cf_pool_simulate_swap(
 			from: Asset,
 			to: Asset,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1776

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Removes deprecated V1 RPC for cf_pool_simulate_swap. Since this is only a runtime API that is called over cf_pool_swap_rate, there is no actual RPC that is changing. The only thing that is changing is the fact that calling the cf_pool_swap_rate on "old" blocks will potentially fail, but since this is not needed any more it should be fine to remove it.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
