### PR TITLE
feat: move order fills api to custom rpc

### DIFF
--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -14,21 +14,17 @@ use chainflip_api::{
 	},
 	primitives::{
 		chains::{assets::any::AssetMap, Bitcoin, Ethereum, Polkadot},
-		state_chain_runtime::{Runtime, RuntimeEvent},
 		AccountRole, Asset, ForeignChain, Hash, RedemptionAmount,
 	},
 	settings::StateChain,
-	AccountId32, AddressString, BlockInfo, BlockUpdate, ChainApi, EthereumAddress, OperatorApi,
-	SignedExtrinsicApi, StateChainApi, StorageApi, WaitFor,
+	AccountId32, AddressString, BlockUpdate, ChainApi, EthereumAddress, OperatorApi,
+	SignedExtrinsicApi, StateChainApi, WaitFor,
 };
 use clap::Parser;
-use custom_rpc::{
-	order_fills::{order_fills_from_block_updates, OrderFills},
-	CustomApiClient,
-};
-use futures::{try_join, FutureExt, StreamExt};
+use custom_rpc::{order_fills::OrderFills, CustomApiClient};
+use futures::{stream, FutureExt, StreamExt};
 use jsonrpsee::{
-	core::{async_trait, ClientError, SubscriptionResult},
+	core::{async_trait, ClientError},
 	proc_macros::rpc,
 	server::ServerBuilder,
 	types::{ErrorCode, ErrorObject, ErrorObjectOwned},
@@ -38,7 +34,6 @@ use pallet_cf_pools::{CloseOrder, IncreaseOrDecrease, OrderId, RangeOrderSize, M
 use rpc_types::{OpenSwapChannels, OrderIdJson, RangeOrderSizeJson};
 use sp_core::{bounded::BoundedVec, ConstU32, H256, U256};
 use std::{
-	collections::BTreeMap,
 	ops::Range,
 	path::PathBuf,
 	sync::{atomic::AtomicBool, Arc},
@@ -199,7 +194,7 @@ pub trait Rpc {
 	) -> RpcResult<Hash>;
 
 	#[subscription(name = "subscribe_order_fills", item = BlockUpdate<OrderFills>)]
-	async fn subscribe_order_fills(&self) -> SubscriptionResult;
+	async fn subscribe_order_fills(&self);
 
 	#[method(name = "order_fills")]
 	async fn order_fills(&self, at: Option<Hash>) -> RpcResult<BlockUpdate<OrderFills>>;
@@ -486,45 +481,34 @@ impl RpcServer for RpcServerImpl {
 			.await?)
 	}
 
-	async fn subscribe_order_fills(
-		&self,
-		pending_sink: PendingSubscriptionSink,
-	) -> SubscriptionResult {
-		let state_chain_client = self.api.state_chain_client.clone();
-		let sink = pending_sink.accept().await.map_err(|e| e.to_string())?;
-		tokio::spawn(async move {
-			// Note we construct the subscription here rather than relying on the custom-rpc
-			// subscription. This is because we want to use finalized blocks.
-			// TODO: allow custom rpc subscriptions to use finalized blocks.
-			let mut finalized_block_stream = state_chain_client.finalized_block_stream().await;
-			while let Some(block) = finalized_block_stream.next().await {
-				match order_fills(state_chain_client.clone(), block).await {
-					Ok(order_fills) => {
-						if sink
-							.send(sc_rpc::utils::to_sub_message(&sink, &order_fills))
-							.await
-							.is_err()
-						{
-							break;
-						}
-					},
-					Err(_) => break,
-				}
-			}
-		});
-		Ok(())
+	async fn subscribe_order_fills(&self, pending_sink: PendingSubscriptionSink) {
+		// pipe results from custom-rpc subscription
+		match self.api.raw_client().cf_subscribe_lp_order_fills().await {
+			Ok(subscription) => {
+				let stream = stream::unfold(subscription, move |mut sub| async move {
+					match sub.next().await {
+						Some(Ok(block_update)) => Some((block_update, sub)),
+						_ => None,
+					}
+				})
+				.boxed();
+
+				tokio::spawn(async move {
+					sc_rpc::utils::pipe_from_stream(pending_sink, stream).await;
+				});
+			},
+			Err(e) => {
+				pending_sink.reject(LpApiError::ClientError(e)).await;
+			},
+		}
 	}
 
 	async fn order_fills(&self, at: Option<Hash>) -> RpcResult<BlockUpdate<OrderFills>> {
-		let state_chain_client = &self.api.state_chain_client;
-
-		let block = if let Some(at) = at {
-			state_chain_client.block(at).await?
-		} else {
-			state_chain_client.latest_finalized_block()
-		};
-
-		Ok(order_fills(state_chain_client.clone(), block).await?)
+		self.api
+			.raw_client()
+			.cf_lp_get_order_fills(at)
+			.await
+			.map_err(LpApiError::ClientError)
 	}
 
 	async fn cancel_all_orders(
@@ -610,39 +594,6 @@ impl RpcServer for RpcServerImpl {
 			.cancel_orders_batch(orders, wait_for.unwrap_or_default())
 			.await?)
 	}
-}
-
-async fn order_fills<StateChainClient>(
-	state_chain_client: Arc<StateChainClient>,
-	block: BlockInfo,
-) -> RpcResult<BlockUpdate<OrderFills>>
-where
-	StateChainClient: StorageApi,
-{
-	let (previous_pools, pools, events) = try_join!(
-		state_chain_client
-			.storage_map::<pallet_cf_pools::Pools<Runtime>, BTreeMap<_, _>>(block.parent_hash),
-		state_chain_client
-			.storage_map::<pallet_cf_pools::Pools<Runtime>, BTreeMap<_, _>>(block.hash),
-		state_chain_client.storage_value::<frame_system::Events<Runtime>>(block.hash)
-	)?;
-
-	let lp_events = events
-		.into_iter()
-		.filter_map(|event_record| {
-			if let RuntimeEvent::LiquidityPools(pools_event) = event_record.event {
-				Some(pools_event)
-			} else {
-				None
-			}
-		})
-		.collect();
-
-	Ok(BlockUpdate::<OrderFills> {
-		block_hash: block.hash,
-		block_number: block.number,
-		data: order_fills_from_block_updates(&previous_pools, &pools, lp_events),
-	})
 }
 
 #[derive(Parser, Debug, Clone, Default)]

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -37,6 +37,47 @@ pub enum OrderFilled {
 	},
 }
 
+pub(crate) fn order_fills_for_block<C, B, BE>(
+	client: &C,
+	hash: Hash,
+) -> RpcResult<BlockUpdate<OrderFills>>
+where
+	B: BlockT<Hash = Hash, Header = state_chain_runtime::Header>,
+	B::Header: Unpin,
+	BE: Send + Sync + 'static + Backend<B>,
+	C: sp_api::ProvideRuntimeApi<B>
+		+ Send
+		+ Sync
+		+ 'static
+		+ BlockBackend<B>
+		+ ExecutorProvider<B>
+		+ HeaderBackend<B>
+		+ HeaderMetadata<B, Error = sc_client_api::blockchain::Error>
+		+ BlockchainEvents<B>
+		+ CallApiAt<B>
+		+ StorageProvider<B, BE>,
+	C::Api: CustomRuntimeApi<B>,
+{
+	let header = client
+		.header(hash)
+		.map_err(|e| call_error(e))?
+		.ok_or(internal_error(format!("Could not fetch block header for block {:?}", hash)))?;
+
+	let pools = StorageQueryApi::new(client)
+		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(hash)?;
+
+	let prev_pools = StorageQueryApi::new(client)
+		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(header.parent_hash)?;
+
+	let lp_events = client.runtime_api().cf_lp_events(hash)?;
+
+	Ok(BlockUpdate::<OrderFills> {
+		block_hash: hash,
+		block_number: header.number,
+		data: order_fills_from_block_updates(&prev_pools, &pools, lp_events),
+	})
+}
+
 fn order_fills_for_pool<'a>(
 	asset_pair: &'a AssetPair,
 	pool: &'a Pool<Runtime>,

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -183,7 +183,7 @@ fn order_fills_for_pool<'a>(
 		))
 }
 
-pub fn order_fills_from_block_updates(
+fn order_fills_from_block_updates(
 	previous_pools: &BTreeMap<AssetPair, Pool<Runtime>>,
 	pools: &BTreeMap<AssetPair, Pool<Runtime>>,
 	events: Vec<pallet_cf_pools::Event<Runtime>>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1764

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* Implemented lp_get_order_fills for a certain block in custom-rpc.
* Modified the custom-rpc cf_subscribe_lp_order_fills to subscribe to the finalized block stream.
* Removed and refactored lp_api order-fills calls to use the custom-rpc equivalents. Logic is defined in only one place.
* Performed manual testing 