### PR TITLE
Feat: Network Fee from Boost

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -49,7 +49,7 @@ use sp_api::{ApiError, ApiExt, CallApiAt};
 use sp_core::U256;
 use sp_runtime::{
 	traits::{Block as BlockT, Header as HeaderT, UniqueSaturatedInto},
-	Permill,
+	Percent, Permill,
 };
 use sp_state_machine::InspectState;
 use state_chain_runtime::{
@@ -565,6 +565,7 @@ mod boost_pool_rpc {
 		available_amounts: Vec<AccountAndAmount>,
 		deposits_pending_finalization: Vec<PendingBoost>,
 		pending_withdrawals: Vec<PendingWithdrawal>,
+		network_fee_deduction_percents: Percent,
 	}
 
 	impl BoostPoolDetailsRpc {
@@ -602,6 +603,7 @@ mod boost_pool_rpc {
 						pending_deposits,
 					})
 					.collect(),
+				network_fee_deduction_percents: details.network_fee_deduction_percents,
 			}
 		}
 	}
@@ -2422,6 +2424,7 @@ mod test {
 				(1, BTreeMap::from([(ID_1.clone(), OwedAmount { total: 1_000, fee: 50 })])),
 			]),
 			pending_withdrawals: Default::default(),
+			network_fee_deduction_percents: Percent::from_percent(40),
 		}
 	}
 
@@ -2439,6 +2442,7 @@ mod test {
 				(ID_1.clone(), BTreeSet::from([0])),
 				(ID_2.clone(), BTreeSet::from([0])),
 			]),
+			network_fee_deduction_percents: Percent::from_percent(0),
 		}
 	}
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -565,7 +565,7 @@ mod boost_pool_rpc {
 		available_amounts: Vec<AccountAndAmount>,
 		deposits_pending_finalization: Vec<PendingBoost>,
 		pending_withdrawals: Vec<PendingWithdrawal>,
-		network_fee_deduction_percents: Percent,
+		network_fee_deduction_percent: Percent,
 	}
 
 	impl BoostPoolDetailsRpc {
@@ -603,7 +603,7 @@ mod boost_pool_rpc {
 						pending_deposits,
 					})
 					.collect(),
-				network_fee_deduction_percents: details.network_fee_deduction_percents,
+				network_fee_deduction_percent: details.network_fee_deduction_percent,
 			}
 		}
 	}
@@ -2424,7 +2424,7 @@ mod test {
 				(1, BTreeMap::from([(ID_1.clone(), OwedAmount { total: 1_000, fee: 50 })])),
 			]),
 			pending_withdrawals: Default::default(),
-			network_fee_deduction_percents: Percent::from_percent(40),
+			network_fee_deduction_percent: Percent::from_percent(40),
 		}
 	}
 
@@ -2442,7 +2442,7 @@ mod test {
 				(ID_1.clone(), BTreeSet::from([0])),
 				(ID_2.clone(), BTreeSet::from([0])),
 			]),
-			network_fee_deduction_percents: Percent::from_percent(0),
+			network_fee_deduction_percent: Percent::from_percent(0),
 		}
 	}
 

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
@@ -37,7 +37,8 @@ expression: val
         ]
       }
     ],
-    "pending_withdrawals": []
+    "pending_withdrawals": [],
+    "network_fee_deduction_percents": 40
   },
   {
     "fee_tier": 30,
@@ -72,6 +73,7 @@ expression: val
           0
         ]
       }
-    ]
+    ],
+    "network_fee_deduction_percents": 0
   }
 ]

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__boost_details_serialization.snap
@@ -38,7 +38,7 @@ expression: val
       }
     ],
     "pending_withdrawals": [],
-    "network_fee_deduction_percents": 40
+    "network_fee_deduction_percent": 40
   },
   {
     "fee_tier": 30,
@@ -74,6 +74,6 @@ expression: val
         ]
       }
     ],
-    "network_fee_deduction_percents": 0
+    "network_fee_deduction_percent": 0
   }
 ]

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -152,7 +152,7 @@ where
 	AccountId: PartialEq + core::fmt::Debug,
 {
 	pub unlocked_funds: Vec<(AccountId, C::ChainAmount)>,
-	pub amount_credited: C::ChainAmount,
+	pub amount_credited_to_boosters: C::ChainAmount,
 }
 
 impl<AccountId, C: Chain> BoostPool<AccountId, C>
@@ -250,8 +250,8 @@ where
 			(provided_amount, fee)
 		};
 
-		// NOTE: only a portion of the boost fee goes to the boost pool,
-		// the rest is charged as network fee:
+		// NOTE: before the boost fee is credited to the boost pool, a portion
+		// of it is deducted as network fee:
 		let network_fee = network_fee_deduction * u128::from(fee_amount);
 		let boost_pool_fee = fee_amount.saturating_sub(ScaledAmount::from(network_fee));
 
@@ -393,7 +393,7 @@ where
 
 		DepositFinalisationOutcomeForPool {
 			unlocked_funds,
-			amount_credited: amount_credited.into_chain_amount(),
+			amount_credited_to_boosters: amount_credited.into_chain_amount(),
 		}
 	}
 

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -3,7 +3,7 @@ mod tests;
 
 use frame_support::DefaultNoBound;
 use sp_runtime::{
-	helpers_128bit::multiply_by_rational_with_rounding, Rounding, SaturatedConversion,
+	helpers_128bit::multiply_by_rational_with_rounding, Percent, Rounding, SaturatedConversion,
 };
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 
@@ -146,6 +146,15 @@ pub struct BoostPool<AccountId, C: Chain> {
 	pending_withdrawals: BTreeMap<AccountId, BTreeSet<PrewitnessedDepositId>>,
 }
 
+#[derive(DefaultNoBound, DebugNoBound, PartialEqNoBound)]
+pub struct DepositFinalisationOutcomeForPool<AccountId, C: Chain>
+where
+	AccountId: PartialEq + core::fmt::Debug,
+{
+	pub unlocked_funds: Vec<(AccountId, C::ChainAmount)>,
+	pub amount_credited: C::ChainAmount,
+}
+
 impl<AccountId, C: Chain> BoostPool<AccountId, C>
 where
 	AccountId: PartialEq + Ord + Clone + core::fmt::Debug,
@@ -225,6 +234,7 @@ where
 		&mut self,
 		prewitnessed_deposit_id: PrewitnessedDepositId,
 		amount_to_boost: C::ChainAmount,
+		network_fee_deduction: Percent,
 	) -> Result<(C::ChainAmount, C::ChainAmount), &'static str> {
 		let amount_to_boost = ScaledAmount::<C>::from_chain_amount(amount_to_boost);
 		let full_amount_fee = fee_from_boosted_amount(amount_to_boost, self.fee_bps);
@@ -240,7 +250,12 @@ where
 			(provided_amount, fee)
 		};
 
-		self.use_funds_for_boosting(prewitnessed_deposit_id, provided_amount, fee_amount)?;
+		// NOTE: only a portion of the boost fee goes to the boost pool,
+		// the rest is charged as network fee:
+		let network_fee = network_fee_deduction * u128::from(fee_amount);
+		let boost_pool_fee = fee_amount.saturating_sub(ScaledAmount::from(network_fee));
+
+		self.use_funds_for_boosting(prewitnessed_deposit_id, provided_amount, boost_pool_fee)?;
 
 		Ok((
 			provided_amount.saturating_add(fee_amount).into_chain_amount(),
@@ -254,7 +269,7 @@ where
 		&mut self,
 		prewitnessed_deposit_id: PrewitnessedDepositId,
 		required_amount: ScaledAmount<C>,
-		boost_fee: ScaledAmount<C>,
+		boost_pool_fee: ScaledAmount<C>,
 	) -> Result<(), &'static str> {
 		let current_total_available_amount = self.available_amount;
 
@@ -266,7 +281,7 @@ where
 		let mut total_contributed = ScaledAmount::<C>::default();
 		let mut to_receive_recorded = ScaledAmount::default();
 
-		let amount_to_receive = required_amount.saturating_add(boost_fee);
+		let amount_to_receive = required_amount.saturating_add(boost_pool_fee);
 
 		let mut boosters_to_receive: BTreeMap<_, _> = self
 			.amounts
@@ -347,13 +362,14 @@ where
 	pub(crate) fn process_deposit_as_finalised(
 		&mut self,
 		prewitnessed_deposit_id: PrewitnessedDepositId,
-	) -> Vec<(AccountId, C::ChainAmount)> {
+	) -> DepositFinalisationOutcomeForPool<AccountId, C> {
 		let Some(boost_contributions) = self.pending_boosts.remove(&prewitnessed_deposit_id) else {
 			// The deposit hadn't been boosted
-			return vec![];
+			return Default::default();
 		};
 
 		let mut unlocked_funds = vec![];
+		let mut amount_credited: ScaledAmount<C> = 0.into();
 
 		for (booster_id, amount) in boost_contributions {
 			// Depending on whether the booster is withdrawing, add deposits to
@@ -371,9 +387,14 @@ where
 			} else {
 				self.add_funds_inner(booster_id, amount.total);
 			}
+
+			amount_credited = amount_credited.saturating_add(amount.total);
 		}
 
-		unlocked_funds
+		DepositFinalisationOutcomeForPool {
+			unlocked_funds,
+			amount_credited: amount_credited.into_chain_amount(),
+		}
 	}
 
 	// Returns the number of boosters affected

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool/tests.rs
@@ -193,11 +193,9 @@ fn boosting_with_max_network_fee_deduction() {
 
 	check_pool(&pool, [(BOOSTER_1, INIT_BOOSTER_AMOUNT)]);
 
-	const PROVIDED_AMOUNT: u128 = 1000;
-	const FULL_BOOST_FEE: u128 =
-		(PROVIDED_AMOUNT * BOOST_FEE_BPS as u128) / MAX_BASIS_POINTS as u128;
-
-	const DEPOSIT_AMOUNT: u128 = PROVIDED_AMOUNT + FULL_BOOST_FEE;
+	const DEPOSIT_AMOUNT: u128 = 2000;
+	const FULL_BOOST_FEE: u128 = DEPOSIT_AMOUNT * BOOST_FEE_BPS as u128 / MAX_BASIS_POINTS as u128;
+	const PROVIDED_AMOUNT: u128 = DEPOSIT_AMOUNT - FULL_BOOST_FEE;
 
 	// NOTE: Full 1% boost fee is charged from the deposit
 	assert_eq!(
@@ -210,12 +208,12 @@ fn boosting_with_max_network_fee_deduction() {
 	);
 
 	// Booster's contribution is recorded, but they earn 0 fees:
-	check_pending_boosts(&pool, [(BOOST_1, vec![(BOOSTER_1, 1000, 0)])]);
+	check_pending_boosts(&pool, [(BOOST_1, vec![(BOOSTER_1, PROVIDED_AMOUNT, 0)])]);
 
 	assert_eq!(
 		pool.process_deposit_as_finalised(BOOST_1),
 		DepositFinalisationOutcomeForPool {
-			amount_credited_to_boosters: 0,
+			amount_credited_to_boosters: PROVIDED_AMOUNT,
 			unlocked_funds: vec![]
 		}
 	);

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -6,8 +6,8 @@ use crate::{
 	ChannelOpeningFee, CrossChainMessage, DepositAction, DepositChannelLifetime,
 	DepositChannelLookup, DepositChannelPool, DepositIgnoredReason, DepositWitness,
 	DisabledEgressAssets, EgressDustLimit, Event as PalletEvent, Event, FailedForeignChainCall,
-	FailedForeignChainCalls, FetchOrTransfer, MinimumDeposit, Pallet, PalletConfigUpdate,
-	PalletSafeMode, PrewitnessedDepositIdCounter, ScheduledEgressCcm,
+	FailedForeignChainCalls, FetchOrTransfer, MinimumDeposit, NetworkFeeDeductionFromBoostPercents,
+	Pallet, PalletConfigUpdate, PalletSafeMode, PrewitnessedDepositIdCounter, ScheduledEgressCcm,
 	ScheduledEgressFetchOrTransfer, VaultDepositWitness,
 };
 use cf_chains::{
@@ -48,7 +48,7 @@ use frame_support::{
 	weights::Weight,
 };
 use sp_core::{bounded_vec, H160};
-use sp_runtime::{DispatchError, DispatchResult};
+use sp_runtime::{DispatchError, DispatchResult, Percent};
 
 const ALICE_ETH_ADDRESS: EthereumAddress = H160([100u8; 20]);
 const BOB_ETH_ADDRESS: EthereumAddress = H160([101u8; 20]);
@@ -1456,6 +1456,7 @@ fn can_update_all_config_items() {
 		const NEW_MIN_DEPOSIT_FLIP: u128 = 100;
 		const NEW_MIN_DEPOSIT_ETH: u128 = 200;
 		const NEW_DEPOSIT_CHANNEL_LIFETIME: u64 = 99;
+		const NETWORK_FEE_DEDUCTION: Percent = Percent::from_parts(50);
 
 		// Check that the default values are different from the new ones
 		assert_eq!(ChannelOpeningFee::<Test, _>::get(), 0);
@@ -1478,6 +1479,9 @@ fn can_update_all_config_items() {
 				},
 				PalletConfigUpdate::SetDepositChannelLifetime {
 					lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
+				},
+				PalletConfigUpdate::SetNetworkFeeDeductionFromBoost {
+					deduction_percents: NETWORK_FEE_DEDUCTION
 				}
 			]
 			.try_into()
@@ -1489,6 +1493,7 @@ fn can_update_all_config_items() {
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Flip), NEW_MIN_DEPOSIT_FLIP);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Eth), NEW_MIN_DEPOSIT_ETH);
 		assert_eq!(DepositChannelLifetime::<Test, _>::get(), NEW_DEPOSIT_CHANNEL_LIFETIME);
+		assert_eq!(NetworkFeeDeductionFromBoostPercents::<Test, _>::get(), NETWORK_FEE_DEDUCTION);
 
 		// Check that the events were emitted
 		assert_events_eq!(
@@ -1504,6 +1509,9 @@ fn can_update_all_config_items() {
 			}),
 			RuntimeEvent::IngressEgress(Event::DepositChannelLifetimeSet {
 				lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
+			}),
+			RuntimeEvent::IngressEgress(Event::NetworkFeeDeductionFromBoostSet {
+				deduction_percents: NETWORK_FEE_DEDUCTION
 			}),
 		);
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 	ChannelOpeningFee, CrossChainMessage, DepositAction, DepositChannelLifetime,
 	DepositChannelLookup, DepositChannelPool, DepositIgnoredReason, DepositWitness,
 	DisabledEgressAssets, EgressDustLimit, Event as PalletEvent, Event, FailedForeignChainCall,
-	FailedForeignChainCalls, FetchOrTransfer, MinimumDeposit, NetworkFeeDeductionFromBoostPercents,
+	FailedForeignChainCalls, FetchOrTransfer, MinimumDeposit, NetworkFeeDeductionFromBoostPercent,
 	Pallet, PalletConfigUpdate, PalletSafeMode, PrewitnessedDepositIdCounter, ScheduledEgressCcm,
 	ScheduledEgressFetchOrTransfer, VaultDepositWitness,
 };
@@ -1481,7 +1481,7 @@ fn can_update_all_config_items() {
 					lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
 				},
 				PalletConfigUpdate::SetNetworkFeeDeductionFromBoost {
-					deduction_percents: NETWORK_FEE_DEDUCTION
+					deduction_percent: NETWORK_FEE_DEDUCTION
 				}
 			]
 			.try_into()
@@ -1493,7 +1493,7 @@ fn can_update_all_config_items() {
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Flip), NEW_MIN_DEPOSIT_FLIP);
 		assert_eq!(MinimumDeposit::<Test, _>::get(EthAsset::Eth), NEW_MIN_DEPOSIT_ETH);
 		assert_eq!(DepositChannelLifetime::<Test, _>::get(), NEW_DEPOSIT_CHANNEL_LIFETIME);
-		assert_eq!(NetworkFeeDeductionFromBoostPercents::<Test, _>::get(), NETWORK_FEE_DEDUCTION);
+		assert_eq!(NetworkFeeDeductionFromBoostPercent::<Test, _>::get(), NETWORK_FEE_DEDUCTION);
 
 		// Check that the events were emitted
 		assert_events_eq!(
@@ -1511,7 +1511,7 @@ fn can_update_all_config_items() {
 				lifetime: NEW_DEPOSIT_CHANNEL_LIFETIME
 			}),
 			RuntimeEvent::IngressEgress(Event::NetworkFeeDeductionFromBoostSet {
-				deduction_percents: NETWORK_FEE_DEDUCTION
+				deduction_percent: NETWORK_FEE_DEDUCTION
 			}),
 		);
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1055,7 +1055,7 @@ fn taking_network_fee_from_boost_fee() {
 	// we get a non-zero amount of the input asset, and we schedule a swap to FLIP as
 	// network fee.
 
-	use crate::NetworkFeeDeductionFromBoostPercents;
+	use crate::NetworkFeeDeductionFromBoostPercent;
 
 	new_test_ext().execute_with(|| {
 		const ASSET: EthAsset = EthAsset::Eth;
@@ -1077,7 +1077,7 @@ fn taking_network_fee_from_boost_fee() {
 		// First check that with a zero network fee portion, no network fee is collected:
 		{
 			assert_eq!(
-				NetworkFeeDeductionFromBoostPercents::<Test, ()>::get(),
+				NetworkFeeDeductionFromBoostPercent::<Test, ()>::get(),
 				Percent::from_percent(0)
 			);
 			let _ = prewitness_deposit(deposit_address, ASSET, DEPOSIT_AMOUNT);
@@ -1108,11 +1108,11 @@ fn taking_network_fee_from_boost_fee() {
 			assert_ok!(Pallet::<Test, ()>::update_pallet_config(
 				RuntimeOrigin::root(),
 				bounded_vec![PalletConfigUpdate::SetNetworkFeeDeductionFromBoost {
-					deduction_percents: Percent::from_percent(20)
+					deduction_percent: Percent::from_percent(20)
 				}]
 			));
 			assert_eq!(
-				NetworkFeeDeductionFromBoostPercents::<Test, ()>::get(),
+				NetworkFeeDeductionFromBoostPercent::<Test, ()>::get(),
 				Percent::from_percent(20)
 			);
 			let _ = prewitness_deposit(deposit_address, ASSET, DEPOSIT_AMOUNT);

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2100,7 +2100,7 @@ impl_runtime_apis! {
 			fn boost_pools_details<I: 'static>(asset: TargetChainAsset::<Runtime, I>) -> BTreeMap<u16, BoostPoolDetails>
 				where Runtime: pallet_cf_ingress_egress::Config<I> {
 
-				let network_fee_deduction_percents = pallet_cf_ingress_egress::NetworkFeeDeductionFromBoostPercents::<Runtime, I>::get();
+				let network_fee_deduction_percent = pallet_cf_ingress_egress::NetworkFeeDeductionFromBoostPercent::<Runtime, I>::get();
 
 				pallet_cf_ingress_egress::BoostPools::<Runtime, I>::iter_prefix(asset).map(|(tier, pool)| {
 					(
@@ -2114,7 +2114,7 @@ impl_runtime_apis! {
 								)
 							}).collect(),
 							pending_withdrawals: pool.get_pending_withdrawals().clone(),
-							network_fee_deduction_percents,
+							network_fee_deduction_percent,
 						}
 					)
 				}).collect()

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2100,6 +2100,8 @@ impl_runtime_apis! {
 			fn boost_pools_details<I: 'static>(asset: TargetChainAsset::<Runtime, I>) -> BTreeMap<u16, BoostPoolDetails>
 				where Runtime: pallet_cf_ingress_egress::Config<I> {
 
+				let network_fee_deduction_percents = pallet_cf_ingress_egress::NetworkFeeDeductionFromBoostPercents::<Runtime, I>::get();
+
 				pallet_cf_ingress_egress::BoostPools::<Runtime, I>::iter_prefix(asset).map(|(tier, pool)| {
 					(
 						tier,
@@ -2112,6 +2114,7 @@ impl_runtime_apis! {
 								)
 							}).collect(),
 							pending_withdrawals: pool.get_pending_withdrawals().clone(),
+							network_fee_deduction_percents,
 						}
 					)
 				}).collect()

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -123,7 +123,7 @@ pub struct BoostPoolDetails {
 	pub pending_boosts:
 		BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId32, OwedAmount<AssetAmount>>>,
 	pub pending_withdrawals: BTreeMap<AccountId32, BTreeSet<PrewitnessedDepositId>>,
-	pub network_fee_deduction_percents: Percent,
+	pub network_fee_deduction_percent: Percent,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -28,7 +28,7 @@ use pallet_cf_witnesser::CallHash;
 use scale_info::{prelude::string::String, TypeInfo};
 use serde::{Deserialize, Serialize};
 use sp_api::decl_runtime_apis;
-use sp_runtime::DispatchError;
+use sp_runtime::{DispatchError, Percent};
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	vec::Vec,
@@ -123,6 +123,7 @@ pub struct BoostPoolDetails {
 	pub pending_boosts:
 		BTreeMap<PrewitnessedDepositId, BTreeMap<AccountId32, OwedAmount<AssetAmount>>>,
 	pub pending_withdrawals: BTreeMap<AccountId32, BTreeSet<PrewitnessedDepositId>>,
+	pub network_fee_deduction_percents: Percent,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1778

## Summary

- New storage item: `NetworkFeeDeductionFromBoostPercents` representing the % of boost fee to be taken as network fee. Its value is initially 0, and can be updated via `update_pallet_config` governance extrinsic.
- When a deposit is boosted, the full boost fee is "deducted" from the deposit, but we now apply network fee reduction when recording the amounts to be credited to boosters upon finalisation.
- When a boosted deposit is finalised, we add up all funds credited to boosters, and any non-zero excees amount is swaped into FLIP as network fee. (The swap request's type being NetworkFee takes care of the resulting flip being scheduled for burning later.)
- `DepositFinalised` (when action is `BoostersCredited`) now additionally exposes `network_fee_swap_request_id` (of the network fee swap), and `network_fee_from_boost` (the amount of input asset to be swapped).
- Added `network_fee_deduction` to `cf_boost_pool_details` rpc.
- Added tests that should cover all new behaviour.

I haven't added network_fee_decution to `DepositBoosted` (there still seems to be an ongoing discussion whether this should be necessary), but it shouldn't be too difficult to add if needed (though maybe with a name indicating that it is not confirmed?).