### PR TITLE
chore: increase ccm message max to 15k

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full-bouncer: true
+      full-bouncer: false
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/_40_post_check.yml
     secrets: inherit
     with:
-      full-bouncer: false
+      full-bouncer: true
       ngrok: true
   test-benchmarks:
     needs: [build-benchmarks]

--- a/bouncer/package.json
+++ b/bouncer/package.json
@@ -6,7 +6,7 @@
     "prettier:write": "prettier --write ."
   },
   "dependencies": {
-    "@chainflip/cli": "1.8.0-rc.6",
+    "@chainflip/cli": "1.8.0-rc.7",
     "@chainflip/utils": "^0.4.0",
     "@coral-xyz/anchor": "^0.30.1",
     "@iarna/toml": "^2.2.5",

--- a/bouncer/pnpm-lock.yaml
+++ b/bouncer/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@chainflip/cli':
-        specifier: 1.8.0-rc.6
-        version: 1.8.0-rc.6(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)
+        specifier: 1.8.0-rc.7
+        version: 1.8.0-rc.7(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
         specifier: ^0.4.0
         version: 0.4.0
@@ -145,8 +145,8 @@ packages:
   '@chainflip/bitcoin@1.1.1':
     resolution: {integrity: sha512-Jr6X/0QTSFYpTp23ZPhyioL6wL9x3Xpj6OGjadQKZyhobRN4BZkhLogv20HDYTJcRzVphzrTJArbEaNie04XVA==}
 
-  '@chainflip/cli@1.8.0-rc.6':
-    resolution: {integrity: sha512-3YtEFJNeDcwELcSk23gkJcoxcjAYuvcc+YyQsazYO7VHTMmWg910Md/RXlbTjE6BrBwW5l2Nlbzl6822qy88Kg==}
+  '@chainflip/cli@1.8.0-rc.7':
+    resolution: {integrity: sha512-EgVvibGesRM773utHiWVb6tHoelasZJP64m6cBVy2/srVHMqTh+KPLRPPJsi6whhTWYhUPS80Qev8NSycX84kA==}
     hasBin: true
     peerDependencies:
       axios: ^1.x
@@ -3166,7 +3166,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@chainflip/cli@1.8.0-rc.6(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)':
+  '@chainflip/cli@1.8.0-rc.7(axios@1.7.2)(bufferutil@4.0.8)(ethers@6.13.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.5.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@chainflip/bitcoin': 1.1.1(typescript@5.5.3)
       '@chainflip/extrinsics': 1.6.1

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -75,7 +75,7 @@ export async function executeEvmVaultSwap(
   } as const;
   const txOptions = {
     // This is run with fresh addresses to prevent nonce issues. Will be 1 for ERC20s.
-    gasLimit: srcChain === Chains.Arbitrum ? 100000000n : 5000000n,
+    gasLimit: srcChain === Chains.Arbitrum ? 32000000n : 5000000n,
   } as const;
 
   const receipt = await executeSwap(

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -75,7 +75,7 @@ export async function executeEvmVaultSwap(
   } as const;
   const txOptions = {
     // This is run with fresh addresses to prevent nonce issues. Will be 1 for ERC20s.
-    gasLimit: srcChain === Chains.Arbitrum ? 10000000n : 200000n,
+    gasLimit: srcChain === Chains.Arbitrum ? 50000000n : 1000000n,
   } as const;
 
   const receipt = await executeSwap(

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -75,7 +75,7 @@ export async function executeEvmVaultSwap(
   } as const;
   const txOptions = {
     // This is run with fresh addresses to prevent nonce issues. Will be 1 for ERC20s.
-    gasLimit: srcChain === Chains.Arbitrum ? 50000000n : 1000000n,
+    gasLimit: srcChain === Chains.Arbitrum ? 100000000n : 5000000n,
   } as const;
 
   const receipt = await executeSwap(

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -53,7 +53,7 @@ function newCcmArbitraryBytes(maxLength: number): string {
 }
 
 // Protocol limits
-const MAX_CCM_MSG_LENGTH = 9_000;
+const MAX_CCM_MSG_LENGTH = 15_000;
 const MAX_CCM_ADDITIONAL_DATA_LENGTH = 1000;
 // Solana transactions have a length of 1232. Cappig it to some reasonable values
 // that when construction the call the Solana length is not exceeded.

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -127,7 +127,9 @@ export function newCcmMetadata(
 ): CcmDepositMetadata {
   const message = ccmMessage ?? newCcmMessage(destAsset);
   const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
-  const gasDiv = gasBudgetFraction ?? 2;
+  // TODO: Update this after PR #5462 is merged. This has been changed because with longer CCM
+  // messages, up to 15k, the gas budget was not enough to cover the fees.
+  const gasDiv = gasBudgetFraction ?? 4 / 3;
 
   const gasBudget = Math.floor(
     Number(amountToFineAmount(defaultAssetAmounts(sourceAsset), assetDecimals(sourceAsset))) /

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -129,20 +129,11 @@ const OVERHEAD_COMPUTE_UNITS = 10000;
 export async function newCcmMetadata(
   destAsset: Asset,
   ccmMessage?: string,
-  gasBudget?: number,
   ccmAdditionalDataArray?: string,
 ): Promise<CcmDepositMetadata> {
   const message = ccmMessage ?? newCcmMessage(destAsset);
   const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
   const destChain = chainFromAsset(destAsset);
-
-  if (gasBudget !== undefined) {
-    return {
-      message,
-      gasBudget: gasBudget.toString(),
-      ccmAdditionalData,
-    };
-  }
 
   let userLogicGasBudget;
   if (destChain === 'Arbitrum' || destChain === 'Ethereum') {
@@ -151,7 +142,7 @@ export async function newCcmMetadata(
     // required for execution is very complicated without using `eth_estimateGas` on the user's side.
     // This is what integrators are expected to do and it''ll give a good estimate of the gas
     // needed for the user logic.
-    userLogicGasBudget = estimateCcmCfTesterGas(destChain, message);
+    userLogicGasBudget = await estimateCcmCfTesterGas(destChain, message);
   } else if (destChain === 'Solana') {
     // We don't bother estimating in Solana since the gas needed doesn't really change upon the message length.
     userLogicGasBudget = OVERHEAD_COMPUTE_UNITS.toString();
@@ -171,7 +162,6 @@ export async function newVaultSwapCcmMetadata(
   sourceAsset: Asset,
   destAsset: Asset,
   ccmMessage?: string,
-  gasBudget?: number,
   ccmAdditionalDataArray?: string,
 ): Promise<CcmDepositMetadata> {
   const sourceChain = chainFromAsset(sourceAsset);
@@ -204,7 +194,7 @@ export async function newVaultSwapCcmMetadata(
   const message = ccmMessage ?? newCcmMessage(destAsset, messageMaxLength);
   const ccmAdditionalData =
     ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, metadataMaxLength);
-  return newCcmMetadata(destAsset, message, gasBudget, ccmAdditionalData);
+  return newCcmMetadata(destAsset, message, ccmAdditionalData);
 }
 
 export async function prepareSwap(

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -59,7 +59,7 @@ const MAX_CCM_ADDITIONAL_DATA_LENGTH = 1000;
 // In Arbitrum's localnet extremely large messages end up with large gas estimations
 // of >70M gas, surpassing our hardcoded gas limit (25M) and Arbitrum's block gas
 // gas limit (32M). We cap it to a lower value than Ethereum to work around that.
-const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 4;
+const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 5;
 
 // Solana transactions have a length of 1232. Cappig it to some reasonable values
 // that when construction the call the Solana length is not exceeded.

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -156,7 +156,7 @@ export function newCcmMetadata(
       // TODO: For payloads larger than like a few hundred bytes we are short ~1M
       // on the gas. Either the user estimation needs to be larger or we need to
       // revisit the SC gas estimation. Difficult to do in localnet.
-      (destChain === 'Arbitrum' ? 1000000 : 0)
+      (destChain === 'Arbitrum' ? 1500000 : 0)
     ).toString();
   } else if (destChain === 'Solana') {
     userLogicGasBudget = OVERHEAD_COMPUTE_UNITS.toString();

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -56,7 +56,7 @@ const MAX_CCM_ADDITIONAL_DATA_LENGTH = 1000;
 // In Arbitrum's localnet extremely large messages end up with large gas estimations
 // of >70M gas, surpassing our hardcoded gas limit (25M) and Arbitrum's block gas
 // gas limit (32M). We cap it to a lower value than Ethereum to work around that.
-const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 5;
+const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 6;
 
 // Solana transactions have a length of 1232. Cappig it to some reasonable values
 // that when construction the call the Solana length is not exceeded.

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -87,8 +87,5 @@ async function main() {
   appendSwap('SolUsdc', 'Eth', testVaultSwap);
   appendSwap('SolUsdc', 'Flip', testVaultSwap, true);
 
-  // await appendSwap('Sol', 'ArbEth', testSwap, true);
-  // await appendSwap('Sol', 'Eth', testSwap, true);
-
   await Promise.all(allSwaps);
 }

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -1,7 +1,12 @@
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
 import { ExecutableTest } from '../shared/executable_test';
 import { SwapParams } from '../shared/perform_swap';
-import { newCcmMetadata, testSwap, testVaultSwap } from '../shared/swapping';
+import {
+  newCcmMetadata,
+  newVaultSwapCcmMetadata,
+  testSwap,
+  testVaultSwap,
+} from '../shared/swapping';
 import { btcAddressTypes } from '../shared/new_btc_address';
 import { ccmSupportedChains, chainFromAsset, VaultSwapParams } from '../shared/utils';
 
@@ -17,6 +22,14 @@ async function main() {
     functionCall: typeof testSwap | typeof testVaultSwap,
     ccmSwap: boolean = false,
   ) {
+    let ccmSwapMetadata;
+    if (ccmSwap) {
+      ccmSwapMetadata =
+        functionCall === testSwap
+          ? newCcmMetadata(sourceAsset, destAsset)
+          : newVaultSwapCcmMetadata(sourceAsset, destAsset);
+    }
+
     if (destAsset === 'Btc') {
       const btcAddressTypesArray = Object.values(btcAddressTypes);
       allSwaps.push(
@@ -24,19 +37,13 @@ async function main() {
           sourceAsset,
           destAsset,
           btcAddressTypesArray[Math.floor(Math.random() * btcAddressTypesArray.length)],
-          ccmSwap ? newCcmMetadata(sourceAsset, destAsset) : undefined,
+          ccmSwapMetadata,
           testAllSwaps.swapContext,
         ),
       );
     } else {
       allSwaps.push(
-        functionCall(
-          sourceAsset,
-          destAsset,
-          undefined,
-          ccmSwap ? newCcmMetadata(sourceAsset, destAsset) : undefined,
-          testAllSwaps.swapContext,
-        ),
+        functionCall(sourceAsset, destAsset, undefined, ccmSwapMetadata, testAllSwaps.swapContext),
       );
     }
   }

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -11,7 +11,7 @@ import { btcAddressTypes } from '../shared/new_btc_address';
 import { ccmSupportedChains, chainFromAsset, VaultSwapParams } from '../shared/utils';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export const testAllSwaps = new ExecutableTest('All-Swaps', main, 3000);
+export const testAllSwaps = new ExecutableTest('All-Swaps', main, 1500);
 
 async function main() {
   const allSwaps: Promise<SwapParams | VaultSwapParams>[] = [];

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -11,7 +11,7 @@ import { btcAddressTypes } from '../shared/new_btc_address';
 import { ccmSupportedChains, chainFromAsset, VaultSwapParams } from '../shared/utils';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
-export const testAllSwaps = new ExecutableTest('All-Swaps', main, 1500);
+export const testAllSwaps = new ExecutableTest('All-Swaps', main, 900);
 
 async function main() {
   const allSwaps: Promise<SwapParams | VaultSwapParams>[] = [];

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -78,7 +78,7 @@ async function testMinPriceRefund(inputAsset: Asset, amount: number, swapViaVaul
     // Randomly use CCM to test different encodings
     let ccmMetadata: CcmDepositMetadata | undefined;
     if (Math.random() < 0.5) {
-      ccmMetadata = newCcmMetadata(destAsset, undefined, 100000);
+      ccmMetadata = await newCcmMetadata(destAsset);
       ccmMetadata.ccmAdditionalData =
         Math.random() < 0.5 ? ccmMetadata.ccmAdditionalData : undefined;
     }

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -166,7 +166,7 @@ async function testGasLimitSwapToSolana(sourceAsset: Asset, destAsset: Asset) {
     throw new Error(`Destination chain ${destChain} is not Solana`);
   }
 
-  const ccmMetadata = newCcmMetadata(destAsset);
+  const ccmMetadata = await newCcmMetadata(destAsset);
 
   const { tag, destAddress } = await executeAndTrackCcmSwap(sourceAsset, destAsset, ccmMetadata);
 
@@ -235,10 +235,9 @@ async function testGasLimitSwapToEvm(
 
   const gasConsumption = getRandomGasConsumption(chainFromAsset(destAsset));
 
-  const ccmMetadata = newCcmMetadata(
+  const ccmMetadata = await newCcmMetadata(
     destAsset,
     web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
-    undefined, // Get the default minimum gas budget
   );
 
   // Adding buffers on both ends to avoid flakiness

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -269,7 +269,7 @@ async function testGasLimitSwapToEvm(
   const gasLimitBudget = Number(txPayload.gasLimit.replace(/,/g, ''));
 
   testGasLimitCcmSwaps.log(
-    `${tag} Expecting broadcast ${abortTest ? 'abort' : 'success'}. Broadcast gas budget: ${gasLimitBudget}, ccmMetadata.gasBudget ${ccmMetadata.gasBudget} gasConsumption ${gasConsumption}`,
+    `${tag} Expecting broadcast ${abortTest ? 'abort' : 'success'}. Broadcast gas budget: ${gasLimitBudget}, user gasBudget ${ccmMetadata.gasBudget} cfTester gasConsumption ${gasConsumption}`,
   );
 
   if (abortTest) {

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -244,7 +244,7 @@ async function testGasLimitSwapToEvm(
   if (abortTest) {
     // newCcmMetadata's gasBudgetis the estimated gas required. Chainflip overestimates
     // the overhead for safety so we use a 25% buffer to ensure the gas budget is too low.
-    ccmMetadata.gasBudget = (Math.round(Number(ccmMetadata.gasBudget) * 0.75)).toString();
+    ccmMetadata.gasBudget = Math.round(Number(ccmMetadata.gasBudget) * 0.75).toString();
   } else {
     // A small buffer should work (10%) as CF should be overestimate, not underestimate
     ccmMetadata.gasBudget = (

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -242,14 +242,11 @@ async function testGasLimitSwapToEvm(
 
   // Adding buffers on both ends to avoid flakiness
   if (abortTest) {
-    // CF might overestimate so we use a 25% buffer. Extra large buffer for Arbitrum
-    // where gas estimations are extremely unreliable in localnet.
-    ccmMetadata.gasBudget = (
-      Number(ccmMetadata.gasBudget) +
-      Math.round(gasConsumption * (destChain !== 'Arbitrum' ? 0.75 : 0.1))
-    ).toString();
+    // newCcmMetadata's gasBudgetis the estimated gas required. Chainflip overestimates
+    // the overhead for safety so we use a 25% buffer to ensure the gas budget is too low.
+    ccmMetadata.gasBudget = (Math.round(Number(ccmMetadata.gasBudget) * 0.75)).toString();
   } else {
-    // A small buffer should work (10%) as CF should be overestimate not underestimate
+    // A small buffer should work (10%) as CF should be overestimate, not underestimate
     ccmMetadata.gasBudget = (
       Number(ccmMetadata.gasBudget) + Math.round(gasConsumption * 1.1)
     ).toString();

--- a/bouncer/tests/gaslimit_ccm.ts
+++ b/bouncer/tests/gaslimit_ccm.ts
@@ -15,7 +15,7 @@ import {
 } from '../shared/utils';
 import { requestNewSwap } from '../shared/perform_swap';
 import { send } from '../shared/send';
-import { spamEvm } from '../shared/send_evm';
+import { estimateCcmCfTesterGas, spamEvm } from '../shared/send_evm';
 import { observeEvent, observeBadEvent, getChainflipApi } from '../shared/utils/substrate';
 import { CcmDepositMetadata } from '../shared/new_swap';
 import { spamSolana } from '../shared/send_sol';
@@ -240,16 +240,19 @@ async function testGasLimitSwapToEvm(
     web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
   );
 
-  // Adding buffers on both ends to avoid flakiness
+  // Estimating gas separately. We can't rely on the default gas estimation in `newCcmMetadata()`
+  // because the CF tester gas consumption depends on the gas limit, making this a circular calculation.
+  // Instead, we get a base calculation with an empty message that doesn't run the gas consumption.
+  const baseCfTesterGas = await estimateCcmCfTesterGas(destChain, '0x');
+
+  // Adding buffers on both ends to avoid flakiness.
   if (abortTest) {
-    // newCcmMetadata's gasBudgetis the estimated gas required. Chainflip overestimates
-    // the overhead for safety so we use a 25% buffer to ensure the gas budget is too low.
-    ccmMetadata.gasBudget = Math.round(Number(ccmMetadata.gasBudget) * 0.75).toString();
+    // Chainflip overestimates the overhead for safety so we use a 25% buffer to ensure that
+    // the gas budget is too low.We also apply a 50% on the baseCfTesterGas since it's highly unreliable.
+    ccmMetadata.gasBudget = Math.round(gasConsumption * 0.75 + baseCfTesterGas * 0.5).toString();
   } else {
     // A small buffer should work (10%) as CF should be overestimate, not underestimate
-    ccmMetadata.gasBudget = (
-      Number(ccmMetadata.gasBudget) + Math.round(gasConsumption * 1.1)
-    ).toString();
+    ccmMetadata.gasBudget = (baseCfTesterGas + Math.round(gasConsumption * 1.1)).toString();
   }
 
   const testTag = abortTest ? `InsufficientGas` : '';
@@ -266,13 +269,11 @@ async function testGasLimitSwapToEvm(
   const gasLimitBudget = Number(txPayload.gasLimit.replace(/,/g, ''));
 
   testGasLimitCcmSwaps.log(
-    `${tag} ccmMetadata.gasBudget ${ccmMetadata.gasBudget} gasConsumption ${gasConsumption}, txGasLimit ${gasLimitBudget}`,
+    `${tag} Expecting broadcast ${abortTest ? 'abort' : 'success'}. Broadcast gas budget: ${gasLimitBudget}, ccmMetadata.gasBudget ${ccmMetadata.gasBudget} gasConsumption ${gasConsumption}`,
   );
 
   if (abortTest) {
-    testGasLimitCcmSwaps.log(
-      `${tag} Gas budget is too low. Expecting BroadcastAborted event. Ensuring CCM event is not emitted`,
-    );
+    // Expect Broadcast Aborted
     let stopObservingCcmReceived = false;
 
     // We run this because we want to ensure that we *don't* get a CCM event.
@@ -290,20 +291,12 @@ async function testGasLimitSwapToEvm(
         throw new Error(`${tag} CCM event emitted. Transaction should not have been broadcasted!`);
       }
     });
-    // Expect Broadcast Aborted
-    testGasLimitCcmSwaps.log(
-      `${tag} Gas budget ${gasLimitBudget} is too low. Expecting BroadcastAborted event.`,
-    );
     await observeEvent(`${destChain.toLowerCase()}Broadcaster:BroadcastAborted`, {
       test: (event) => event.data.broadcastId === broadcastId,
     }).event;
     stopObservingCcmReceived = true;
     testGasLimitCcmSwaps.log(`${tag} Broadcast Aborted found! broadcastId: ${broadcastId}`);
   } else {
-    testGasLimitCcmSwaps.log(
-      `${tag} Gas budget ${gasLimitBudget}. Expecting successful broadcast.`,
-    );
-
     // Check that broadcast is not aborted
     const observeBroadcastFailure = observeBadEvent(
       `${destChain.toLowerCase()}Broadcaster:BroadcastAborted`,

--- a/engine/src/evm/retry_rpc.rs
+++ b/engine/src/evm/retry_rpc.rs
@@ -380,7 +380,9 @@ impl<Rpc: EvmSigningRpcApi> EvmRetrySigningRpcApi for EvmRetryRpcClient<Rpc> {
 							Some(gas_limit) =>
 								if estimated_gas > gas_limit {
 									return Err(anyhow::anyhow!(
-										"Estimated gas is greater than the gas limit"
+										"Estimated gas ({}) is greater than the gas limit ({})",
+										estimated_gas,
+										gas_limit
 									))
 								} else {
 									gas_limit

--- a/state-chain/chains/src/arb.rs
+++ b/state-chain/chains/src/arb.rs
@@ -244,7 +244,7 @@ mod test {
 		};
 
 		let gas_limit = arb_tracked_data.calculate_ccm_gas_limit(true, GAS_BUDGET, MESSAGE_LENGTH);
-		assert_eq!(gas_limit, 2526102u128);
+		assert_eq!(gas_limit, 1858469u128);
 
 		let gas_budget_extra = 1_000_000u128;
 		let gas_limit_extra = arb_tracked_data.calculate_ccm_gas_limit(

--- a/state-chain/chains/src/benchmarking_value.rs
+++ b/state-chain/chains/src/benchmarking_value.rs
@@ -310,7 +310,7 @@ macro_rules! impl_bounded_vec_benchmark_value {
 	};
 }
 
-impl_bounded_vec_benchmark_value!(u8, 10000);
+impl_bounded_vec_benchmark_value!(u8, 15000);
 impl_bounded_vec_benchmark_value!(u8, 1000);
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -671,7 +671,7 @@ pub enum DepositOriginType {
 	Vault,
 }
 
-pub const MAX_CCM_MSG_LENGTH: u32 = 10_000;
+pub const MAX_CCM_MSG_LENGTH: u32 = 15_000;
 pub const MAX_CCM_ADDITIONAL_DATA_LENGTH: u32 = 1_000;
 
 pub type CcmMessage = BoundedVec<u8, ConstU32<MAX_CCM_MSG_LENGTH>>;


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Increase allowed ccm length to 15k.
While testing with higher payloads I've encountered some issues:
- In localnet payloads bigger than several hundred bytes end up with gas limits higher than Arbitrum block gas limit so we need to limit the size. Pretty sure this is due to localnet settings, this won't happen in a real network.
- Vault swaps, particularly in Solana, run into issues due to transaction size limitations. I've added a the corresponding limitations under the `newVaultSwapCcmMetadata` function.
- Arbitrum gas proved extremely unreliable. While this is just a localnet issue, it made me rethink how estimations should be done. Part of the gas estimation that takes into account Arbitrum's gas limit variability should be done for the user so only the CF vault overhead should be taken into consideration when estimating the Arbitrum's gas. Then in the bouncer I have added a gas estimation that is what the integrators should be doing.