### PR TITLE
feat: add expires_at field to request swap parameter encoding

### DIFF
--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -78,7 +78,7 @@ async function buildAndSendBtcVaultSwap(
   // Check that expires_at field is correct (within 20 secs drift)
   assert(
     Math.abs(expectedExpiresAt - vaultSwapDetails.expires_at) <= 20 * 1000,
-    `VaultSwapDetails expiry timestamp is not within a 1 minute drift of the expected expiry time.
+    `VaultSwapDetails expiry timestamp is not within a 20 secs drift of the expected expiry time.
       expectedExpiresAt = ${expectedExpiresAt} and actualExpiresAt = ${vaultSwapDetails.expires_at}`,
   );
 

--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -68,7 +68,17 @@ async function buildAndSendBtcVaultSwap(
   testBtcVaultSwap.debugLog('nulldata_payload:', vaultSwapDetails.nulldata_payload);
   testBtcVaultSwap.debugLog('deposit_address:', vaultSwapDetails.deposit_address);
   testBtcVaultSwap.debugLog('expires_at:', vaultSwapDetails.expires_at);
-  console.log("vaultSwapDetails", vaultSwapDetails);
+
+  // Calculate expiry time assuming block time is 6 secs, vault address expires in 2 rotations adjusted by factor of 2
+  const epochDuration = await chainflip.rpc(`cf_epoch_duration`) as number;
+  const epochStartedAt = await chainflip.rpc(`cf_current_epoch_started_at`) as number;
+  const currentBlockNumber = (await chainflip.rpc.chain.getHeader()).number.toNumber();
+  const blocksUntilNextRotation = epochDuration + epochStartedAt - currentBlockNumber
+  const expectedExpiresAt = Date.now() + ((blocksUntilNextRotation + epochDuration) * 6000 / 2);
+  // Check that expires_at field is correct (within 20 secs drift)
+  assert(Math.abs(expectedExpiresAt - vaultSwapDetails.expires_at) <= 20 * 1000,
+      `VaultSwapDetails expiry timestamp is not within a 1 minute drift of the expected expiry time.
+      expectedExpiresAt = ${expectedExpiresAt} and estimatedExpiresAt = ${vaultSwapDetails.expires_at}` );
 
   const txid = await sendVaultTransaction(
     vaultSwapDetails.nulldata_payload,

--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -24,7 +24,7 @@ interface VaultSwapDetails {
   chain: string;
   nulldata_payload: string;
   deposit_address: string;
-  expires_at: number;
+  estimated_expires_at: number;
 }
 
 interface Beneficiary {
@@ -67,18 +67,20 @@ async function buildAndSendBtcVaultSwap(
   assert.strictEqual(vaultSwapDetails.chain, 'Bitcoin');
   testBtcVaultSwap.debugLog('nulldata_payload:', vaultSwapDetails.nulldata_payload);
   testBtcVaultSwap.debugLog('deposit_address:', vaultSwapDetails.deposit_address);
-  testBtcVaultSwap.debugLog('expires_at:', vaultSwapDetails.expires_at);
+  testBtcVaultSwap.debugLog('estimated_expires_at:', vaultSwapDetails.estimated_expires_at);
 
   // Calculate expiry time assuming block time is 6 secs, vault address expires in 2 rotations adjusted by factor of 2
-  const epochDuration = await chainflip.rpc(`cf_epoch_duration`) as number;
-  const epochStartedAt = await chainflip.rpc(`cf_current_epoch_started_at`) as number;
+  const epochDuration = (await chainflip.rpc(`cf_epoch_duration`)) as number;
+  const epochStartedAt = (await chainflip.rpc(`cf_current_epoch_started_at`)) as number;
   const currentBlockNumber = (await chainflip.rpc.chain.getHeader()).number.toNumber();
-  const blocksUntilNextRotation = epochDuration + epochStartedAt - currentBlockNumber
-  const expectedExpiresAt = Date.now() + ((blocksUntilNextRotation + epochDuration) * 6000 / 2);
+  const blocksUntilNextRotation = epochDuration + epochStartedAt - currentBlockNumber;
+  const expectedExpiresAt = Date.now() + ((blocksUntilNextRotation + epochDuration) * 6000) / 2;
   // Check that expires_at field is correct (within 20 secs drift)
-  assert(Math.abs(expectedExpiresAt - vaultSwapDetails.expires_at) <= 20 * 1000,
-      `VaultSwapDetails expiry timestamp is not within a 1 minute drift of the expected expiry time.
-      expectedExpiresAt = ${expectedExpiresAt} and estimatedExpiresAt = ${vaultSwapDetails.expires_at}` );
+  assert(
+    Math.abs(expectedExpiresAt - vaultSwapDetails.estimated_expires_at) <= 20 * 1000,
+    `VaultSwapDetails expiry timestamp is not within a 1 minute drift of the expected expiry time.
+      expectedExpiresAt = ${expectedExpiresAt} and estimatedExpiresAt = ${vaultSwapDetails.estimated_expires_at}`,
+  );
 
   const txid = await sendVaultTransaction(
     vaultSwapDetails.nulldata_payload,

--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -24,6 +24,7 @@ interface VaultSwapDetails {
   chain: string;
   nulldata_payload: string;
   deposit_address: string;
+  expires_at: number;
 }
 
 interface Beneficiary {
@@ -66,6 +67,8 @@ async function buildAndSendBtcVaultSwap(
   assert.strictEqual(vaultSwapDetails.chain, 'Bitcoin');
   testBtcVaultSwap.debugLog('nulldata_payload:', vaultSwapDetails.nulldata_payload);
   testBtcVaultSwap.debugLog('deposit_address:', vaultSwapDetails.deposit_address);
+  testBtcVaultSwap.debugLog('expires_at:', vaultSwapDetails.expires_at);
+  console.log("vaultSwapDetails", vaultSwapDetails);
 
   const txid = await sendVaultTransaction(
     vaultSwapDetails.nulldata_payload,

--- a/state-chain/runtime/src/constants.rs
+++ b/state-chain/runtime/src/constants.rs
@@ -72,6 +72,10 @@ pub mod common {
 	pub const BLOCKS_PER_MINUTE_ARBITRUM: u64 = 60000 / MILLISECONDS_PER_BLOCK_ARBITRUM;
 	pub const BLOCKS_PER_MINUTE_SOLANA: u64 = 60000 / MILLISECONDS_PER_BLOCK_SOLANA;
 
+	/// Defines a multiplier that is used to adjust the expiry time of the returned vault swap
+	/// payload details.
+	pub const VAULT_SWAP_DETAILS_EXPIRY_TIME_PERCENTAGE: u8 = 50;
+
 	/// Percent of the epoch we are allowed to redeem
 	pub const REDEMPTION_PERIOD_AS_PERCENTAGE: u8 = 50;
 

--- a/state-chain/runtime/src/constants.rs
+++ b/state-chain/runtime/src/constants.rs
@@ -72,10 +72,6 @@ pub mod common {
 	pub const BLOCKS_PER_MINUTE_ARBITRUM: u64 = 60000 / MILLISECONDS_PER_BLOCK_ARBITRUM;
 	pub const BLOCKS_PER_MINUTE_SOLANA: u64 = 60000 / MILLISECONDS_PER_BLOCK_SOLANA;
 
-	/// Defines a multiplier that is used to adjust the expiry time of the returned vault swap
-	/// payload details.
-	pub const VAULT_SWAP_DETAILS_EXPIRY_TIME_PERCENTAGE: u8 = 50;
-
 	/// Percent of the epoch we are allowed to redeem
 	pub const REDEMPTION_PERIOD_AS_PERCENTAGE: u8 = 50;
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2305,7 +2305,7 @@ impl_runtime_apis! {
 					Ok(VaultSwapDetails::Bitcoin {
 						nulldata_payload: encode_swap_params_in_nulldata_payload(params),
 						deposit_address: derive_btc_vault_deposit_address(private_channel_id),
-						expires_at: Timestamp::now() + expires_in
+						estimated_expires_at: Timestamp::now() + expires_in
 					})
 				},
 				_ => Err(pallet_cf_swapping::Error::<Runtime>::UnsupportedSourceAsset.into()),

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2246,10 +2246,10 @@ impl_runtime_apis! {
 
 			// Payload expiry time is set to time left to next rotation.
 			// 	* For BTC: the actual expiry time is 2 rotations, but we deliberately set expires_at to be the time left to next
-			//    rotation to cater for the case when a forced rotation happens between when the payload was requested and before expires_at.
-			//    BTC funds can be lost in 3 cases:
-			// 		* If the user makes the vault transaction after expires_at, and it happens that we did a forced rotation in between
-			//      * User submits the vault transaction 3 days (1 epoch) after expires_at, and with forced rotations in between
+			//    rotation to cater for the case when a forced rotation happens between when the payload was requested and
+			//    before expires_at. BTC funds can be lost in 3 cases:
+			// 		* User makes the vault transaction after expires_at, and it happens that we did a forced rotation in between
+			//      * User submits the vault transaction 3 days (1 epoch) after expires_at, and with no forced rotations in between
 			//      * We do 2 forced rotations in between payload request and expires_at
 			//  * For SOLANA: The actual expiry time is indeed time left to next rotation. If a forced rotation
 			//    happens in between as explained before, it is actually not a problem as the user won't lose any funds.

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -44,7 +44,7 @@ pub enum VaultSwapDetails<BtcAddress> {
 		nulldata_payload: Vec<u8>,
 		deposit_address: BtcAddress,
 		/// Payload expiry time, expressed as timestamp since the UNIX_EPOCH in milliseconds
-		estimated_expires_at: u64,
+		expires_at: u64,
 	},
 }
 
@@ -54,15 +54,12 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 		F: FnOnce(BtcAddress) -> T,
 	{
 		match self {
-			VaultSwapDetails::Bitcoin {
-				nulldata_payload,
-				deposit_address,
-				estimated_expires_at,
-			} => VaultSwapDetails::Bitcoin {
-				nulldata_payload,
-				deposit_address: f(deposit_address),
-				estimated_expires_at,
-			},
+			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address, expires_at } =>
+				VaultSwapDetails::Bitcoin {
+					nulldata_payload,
+					deposit_address: f(deposit_address),
+					expires_at,
+				},
 		}
 	}
 }

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -43,6 +43,8 @@ pub enum VaultSwapDetails<BtcAddress> {
 		#[serde(with = "sp_core::bytes")]
 		nulldata_payload: Vec<u8>,
 		deposit_address: BtcAddress,
+		/// Payload expiry time, expressed as timestamp since the UNIX_EPOCH in milliseconds
+		expires_at: u64,
 	},
 }
 
@@ -52,8 +54,12 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 		F: FnOnce(BtcAddress) -> T,
 	{
 		match self {
-			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address } =>
-				VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address: f(deposit_address) },
+			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address, expires_at } =>
+				VaultSwapDetails::Bitcoin {
+					nulldata_payload,
+					deposit_address: f(deposit_address),
+					expires_at,
+				},
 		}
 	}
 }

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -44,7 +44,7 @@ pub enum VaultSwapDetails<BtcAddress> {
 		nulldata_payload: Vec<u8>,
 		deposit_address: BtcAddress,
 		/// Payload expiry time, expressed as timestamp since the UNIX_EPOCH in milliseconds
-		expires_at: u64,
+		estimated_expires_at: u64,
 	},
 }
 
@@ -54,12 +54,15 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 		F: FnOnce(BtcAddress) -> T,
 	{
 		match self {
-			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address, expires_at } =>
-				VaultSwapDetails::Bitcoin {
-					nulldata_payload,
-					deposit_address: f(deposit_address),
-					expires_at,
-				},
+			VaultSwapDetails::Bitcoin {
+				nulldata_payload,
+				deposit_address,
+				estimated_expires_at,
+			} => VaultSwapDetails::Bitcoin {
+				nulldata_payload,
+				deposit_address: f(deposit_address),
+				estimated_expires_at,
+			},
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1851

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

* Return `expires_at` field determining when the payload is considered expired.
* Only implemented for Bitcoin for now, Solana implementation should be straightforward when Solana vault swapping is in main
* Updated bouncer btc_vault_swap test to validate `expires_at`
