### PR TITLE
refactor: vault swap refund instead of ignoring the deposit

### DIFF
--- a/bouncer/tests/evm_deposits.ts
+++ b/bouncer/tests/evm_deposits.ts
@@ -106,6 +106,7 @@ async function testTxMultipleVaultSwaps(
   const amount = BigInt(
     amountToFineAmount(defaultAssetAmounts(sourceAsset), assetDecimals(sourceAsset)),
   );
+
   const numSwaps = 2;
   const txData = cfTesterContract.methods
     .multipleContractSwap(
@@ -114,8 +115,8 @@ async function testTxMultipleVaultSwaps(
       assetContractId(destAsset),
       getContractAddress(chainFromAsset(sourceAsset), sourceAsset),
       amount,
-      // Dummy encoded data containing a refund address and a broker accountId.
-      '0x000001000000000202020202020202020202020202020202020202000000000000000000000000000000000000000000000000000000000000000000000303030303030303030303030303030303030303030303030303030303030303040000',
+      // Dummy encoded data containing a refund address and th broker accountId `5FKyTaAoazbwkQ7CHFNJfhWV5sVnRw23HWdPUeQ2tTp3gryJ`.
+      '0x00010000000002020202020202020202020202020202020202020000000000000000000000000000000000000000000000000000000000000000009059e6d854b769a505d01148af212bf8cb7f8469a7153edce8dcaedd9d299125010000',
       numSwaps,
     )
     .encodeABI();

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -39,7 +39,7 @@ describe('ConcurrentTests', () => {
   concurrentTest('CancelOrdersBatch', testCancelOrdersBatch, 240);
   concurrentTest('DepositChannelCreation', depositChannelCreation, 360);
   concurrentTest('BrokerLevelScreening', testBrokerLevelScreening, 800);
-  concurrentTest('VaultSwapFeeCollection', testVaultSwapFeeCollection, 800);
+  concurrentTest('VaultSwapFeeCollection', testVaultSwap, 800);
 
   // Tests that only work if there is more than one node
   if (numberOfNodes > 1) {

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'vitest';
 import { testBoostingSwap } from './boost';
-import { testVaultSwapFeeCollection } from './vault_swap_fee_collection';
+import { testVaultSwap } from './vault_swap_tests';
 import { testPolkadotRuntimeUpdate } from './polkadot_runtime_update';
 import { checkSolEventAccountsClosure } from '../shared/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from '../shared/utils';

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -245,7 +245,7 @@ pub mod tests {
 				asset: btc::Asset::Btc,
 				state: deposit_address,
 			},
-			action: ChannelAction::<AccountId32>::LiquidityProvision {
+			action: ChannelAction::<AccountId32, Bitcoin>::LiquidityProvision {
 				lp_account: AccountId32::new([0xab; 32]),
 				refund_address: ForeignChainAddress::Btc(ScriptPubkey::P2PKH([0; 20])),
 			},

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -23,7 +23,7 @@ use crate::{
 		fund_authorities_and_join_auction, new_account, register_refund_addresses,
 		setup_account_and_peer_mapping, Cli, Network,
 	},
-	witness_call, witness_ethereum_rotation_broadcast, witness_rotation_broadcasts,
+	witness_call, witness_ethereum_rotation_broadcast, witness_rotation_broadcasts, BROKER,
 };
 use cf_amm::{
 	math::{price_at_tick, Price, Tick},
@@ -39,8 +39,8 @@ use cf_chains::{
 	RetryPolicy, SwapOrigin, TransactionBuilder, TransferAssetParams,
 };
 use cf_primitives::{
-	chains, AccountId, AccountRole, Asset, AssetAmount, AuthorityCount, EgressId, SwapId,
-	FLIPPERINOS_PER_FLIP, GENESIS_EPOCH, STABLE_ASSET, SWAP_DELAY_BLOCKS,
+	chains, AccountId, AccountRole, Asset, AssetAmount, AuthorityCount, Beneficiary, EgressId,
+	SwapId, FLIPPERINOS_PER_FLIP, GENESIS_EPOCH, STABLE_ASSET, SWAP_DELAY_BLOCKS,
 };
 use cf_test_utilities::{assert_events_eq, assert_events_match, assert_has_matching_event};
 use cf_traits::{
@@ -607,7 +607,7 @@ fn vault_swap_deposit_witness(
 		deposit_metadata: Some(ccm_deposit_metadata_mock()),
 		tx_id: Default::default(),
 		deposit_details: DepositDetails { tx_hashes: None },
-		broker_fee: None,
+		broker_fee: Some(Beneficiary { account: BROKER.into(), bps: 0 }),
 		affiliate_fees: Default::default(),
 		refund_params: ETH_REFUND_PARAMS,
 		dca_params: None,

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -86,7 +86,7 @@ mod benchmarks {
 						source_asset,
 					)
 					.unwrap(),
-				action: ChannelAction::<T::AccountId>::LiquidityProvision {
+				action: ChannelAction::<T::AccountId, T::TargetChain>::LiquidityProvision {
 					lp_account: account("doogle", 0, 0),
 					refund_address: ForeignChainAddress::benchmark_value(),
 				},
@@ -129,7 +129,7 @@ mod benchmarks {
 						<T as Config<I>>::AddressDerivation,
 					>(1, source_asset)
 					.unwrap(),
-					action: ChannelAction::<T::AccountId>::LiquidityProvision {
+					action: ChannelAction::<T::AccountId, T::TargetChain>::LiquidityProvision {
 						lp_account: account("doogle", 0, 0),
 						refund_address: ForeignChainAddress::benchmark_value(),
 					},

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/mandatory_refund_params.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/mandatory_refund_params.rs
@@ -54,9 +54,9 @@ mod old {
 		},
 	}
 
-	impl<A> TryFrom<ChannelAction<A>> for crate::ChannelAction<A> {
+	impl<A, C: cf_chains::Chain> TryFrom<ChannelAction<A>> for crate::ChannelAction<A, C> {
 		type Error = ();
-		fn try_from(action: ChannelAction<A>) -> Result<crate::ChannelAction<A>, Self::Error> {
+		fn try_from(action: ChannelAction<A>) -> Result<crate::ChannelAction<A, C>, Self::Error> {
 			Ok(match action {
 				ChannelAction::Swap {
 					destination_asset,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -315,13 +315,15 @@ pub struct ChainAccounts {
 pub enum ChannelActionType {
 	Swap,
 	LiquidityProvision,
+	Refund,
 }
 
-impl<AccountId> From<ChannelAction<AccountId>> for ChannelActionType {
-	fn from(action: ChannelAction<AccountId>) -> Self {
+impl<AccountId, C: Chain> From<ChannelAction<AccountId, C>> for ChannelActionType {
+	fn from(action: ChannelAction<AccountId, C>) -> Self {
 		match action {
 			ChannelAction::Swap { .. } => ChannelActionType::Swap,
 			ChannelAction::LiquidityProvision { .. } => ChannelActionType::LiquidityProvision,
+			ChannelAction::Refund { .. } => ChannelActionType::Refund,
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-1804, PRO-2139

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Adding refund functionality if there is no broker provided in the vault swap. If we identify on the prewitness stage that there is no broker provided or the account provided is no broker, we mark the tx as aborted. When the deposit gets eventually fully witnessed, we check if it was identified as aborted and directly try to refund it. If the refund should not be possible (failing to create the API call for e.x) we push the details of the tx to another storage item to remember the tx.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a refund mechanism for vault swaps to ensure users receive prompt recovery for aborted transactions.
  - Added stage tracking to provide clearer insight into the progress of vault swap processes.
- **Enhancements**
  - Improved fee processing by assigning a dedicated fee recipient for more accurate fee management.
- **Tests**
  - Updated automation to validate the new refund and fee handling capabilities, ensuring reliable swap transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->