### PR TITLE
Fix: pool orderbook panic

### DIFF
--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -232,16 +232,19 @@ impl SwapDirection for QuoteToBase {
 }
 
 /// Takes a Q128 fixed point number and raises it to the nth power, and returns it as a Q128 fixed
-/// point number. If the result is larger than the maximum U384 this function will panic.
-///
-/// The result will be equal or less than the true value.
+/// point number. If the result is larger than the maximum U384 this function will return None.
 fn fixed_point_to_power_as_fixed_point(x: U256, n: u32) -> Option<U512> {
 	let x = U512::from(x);
 	let mut result = U512::from(1) << 128;
+
+	// Iterate over bits of the exponent (n) from most to least significant
+	// (starting with the first non-zero bit):
 	for bit_idx in (0..(32 - n.leading_zeros())).rev() {
 		let bit = (n & (0x1 << bit_idx)) >> bit_idx;
 
+		// Square the intermediate result on each iteration:
 		result = result.checked_mul(result)? >> 128;
+		// Additionally multiply by `x` if the bit is set:
 		if bit == 0x1 {
 			result = result.checked_mul(x)? >> 128;
 		}

--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -333,12 +333,12 @@ mod fast_tests {
 		);
 
 		assert_eq!(
-			U512::from(1) << 127,
-			fixed_point_to_power_as_fixed_point(U256::from(2) << 128, 127).unwrap() >> 128
+			U512::from(1) << 128,
+			fixed_point_to_power_as_fixed_point(U256::from(2) << 128, 128).unwrap() >> 128
 		);
 
 		// Expected to overflow
-		assert_eq!(fixed_point_to_power_as_fixed_point(U256::from(2) << 128, 128), None);
+		assert_eq!(fixed_point_to_power_as_fixed_point(U256::from(2) << 128, 256), None);
 	}
 
 	#[test]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1711

## Summary

1. `fixed_point_to_power_as_fixed_point` now returns `None` (instead of panicking) whenever the result would overflow, to achieve which rewrote the algorithm in a more procedural style (which looks way simpler IMO).

2. To address the overflow/panic in `nth_root_of_integer_as_fixed_point` I initially tried saturating some values at `U256::MAX` where it made sense (like when computing the "error"), but I noticed that for some inputs while the panic no longer occurred, we were getting incorrect results, even after increasing the max number of iterations. My guess is that the algorithm isn't guaranteed to converge on the answer due to how "step" is computed (If I remember my math, we should be computing the first derivative in this case, but the derivative of nth root contains nth root itself, so that's not very helpful), and we end up oscillating around the correct answer instead.

- I figured a much more straightforward way of computing the root would be to do a binary search (which we can do since the function is strictly monotonically increasing). Given good initial lower/upper bounds (we can start with the value that previous implementation was using for its initiall guess as a good upper bound) its performance is actually not too bad, and the new implementation needs about 20-40 iterations to converge. Previous implementaion on some inputs needed only 5-10 iterations, but it was also inconsistent and for some inputs required significantly more iterations, and on some other inputs (added to the unit tests) it was maxing out 128 iterations giving incorrect result in the end. It would be interesting to know what the typical inputs to that function look like to better understand the performance implications of this change, but I think it is fast enough, and it is more important that the algorithm is more reliable/consistent (and its simplicity gives us more confidence that it is correct).

- All existing tests still pass (including the "slow" onces), plus I added additional test cases which would trigger a panic or give an incorrect result previously.

(thanks @j4m1ef0rd for some initial investigation of this, narrowing down the cause of the failure)