### PR TITLE
fix: vault swap - solana improvements

### DIFF
--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -37,9 +37,9 @@ pub use sol_prim::{
 	Signature as SolSignature, SlotNumber as SolBlockNumber,
 };
 pub use sol_tx_core::{
-	AccountMeta as SolAccountMeta, CcmAccounts as SolCcmAccounts, CcmAddress as SolCcmAddress,
-	Hash as RawSolHash, Instruction as SolInstruction, Message as SolMessage, Pubkey as SolPubkey,
-	Transaction as SolTransaction,
+	rpc_types, AccountMeta as SolAccountMeta, CcmAccounts as SolCcmAccounts,
+	CcmAddress as SolCcmAddress, Hash as RawSolHash, Instruction as SolInstruction,
+	Message as SolMessage, Pubkey as SolPubkey, Transaction as SolTransaction,
 };
 
 // Due to transaction size limit in Solana, we have a limit on number of fetches in a solana fetch

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -37,8 +37,8 @@ pub use sol_prim::{
 	Signature as SolSignature, SlotNumber as SolBlockNumber,
 };
 pub use sol_tx_core::{
-	rpc_types, AccountMeta as SolAccountMeta, CcmAccounts as SolCcmAccounts,
-	CcmAddress as SolCcmAddress, Hash as RawSolHash, Instruction as SolInstruction,
+	AccountMeta as SolAccountMeta, CcmAccounts as SolCcmAccounts, CcmAddress as SolCcmAddress,
+	Hash as RawSolHash, Instruction as SolInstruction, InstructionRpc as SolInstructionRpc,
 	Message as SolMessage, Pubkey as SolPubkey, Transaction as SolTransaction,
 };
 

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -36,6 +36,8 @@ pub struct AllNonceAccounts;
 pub struct ApiEnvironment;
 #[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo)]
 pub struct CurrentAggKey;
+#[derive(Clone, Encode, Decode, PartialEq, Debug, TypeInfo)]
+pub struct CurrentOnChainKey;
 
 pub type DurableNonceAndAccount = (SolAddress, SolHash);
 
@@ -63,6 +65,7 @@ pub struct VaultSwapAccountAndSender {
 pub trait SolanaEnvironment:
 	ChainEnvironment<ApiEnvironment, SolApiEnvironment>
 	+ ChainEnvironment<CurrentAggKey, SolAddress>
+	+ ChainEnvironment<CurrentOnChainKey, SolAddress>
 	+ ChainEnvironment<ComputePrice, SolAmount>
 	+ ChainEnvironment<DurableNonce, DurableNonceAndAccount>
 	+ ChainEnvironment<AllNonceAccounts, Vec<DurableNonceAndAccount>>
@@ -83,6 +86,11 @@ pub trait SolanaEnvironment:
 
 	fn current_agg_key() -> Result<SolAddress, SolanaTransactionBuildingError> {
 		<Self as ChainEnvironment<CurrentAggKey, SolAddress>>::lookup(CurrentAggKey)
+			.ok_or(SolanaTransactionBuildingError::CannotLookupCurrentAggKey)
+	}
+
+	fn current_on_chain_key() -> Result<SolAddress, SolanaTransactionBuildingError> {
+		<Self as ChainEnvironment<CurrentOnChainKey, SolAddress>>::lookup(CurrentOnChainKey)
 			.ok_or(SolanaTransactionBuildingError::CannotLookupCurrentAggKey)
 	}
 

--- a/state-chain/chains/src/sol/sol_tx_core.rs
+++ b/state-chain/chains/src/sol/sol_tx_core.rs
@@ -268,21 +268,19 @@ impl From<Transaction> for RawTransaction {
 /// should be specified as signers during `Instruction` construction. The
 /// program must still validate during execution that the account is a signer.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TypeInfo)]
-pub struct InstructionInternal<Address> {
+pub struct Instruction<Address = Pubkey> {
 	/// Pubkey of the program that executes this instruction.
 	pub program_id: Address,
 	/// Metadata describing accounts that should be passed to the program.
-	pub accounts: Vec<AccountMetaInternal<Address>>,
+	pub accounts: Vec<AccountMeta<Address>>,
 	/// Opaque data passed to the program for its own interpretation.
 	#[serde(with = "sp_core::bytes")]
 	pub data: Vec<u8>,
 }
 
-/// Instruction type used to encode a Solana Transaction.
-pub type Instruction = InstructionInternal<Pubkey>;
 /// Instruction type used when being presented to the end user.
 /// Serializes addresses into bs58 format.
-pub type InstructionRpc = InstructionInternal<SolAddress>;
+pub type InstructionRpc = Instruction<SolAddress>;
 
 impl From<Instruction> for InstructionRpc {
 	fn from(value: Instruction) -> Self {
@@ -341,7 +339,7 @@ impl Instruction {
 #[derive(
 	Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TypeInfo,
 )]
-pub struct AccountMetaInternal<Address> {
+pub struct AccountMeta<Address = Pubkey> {
 	/// An account's public key.
 	pub pubkey: Address,
 	/// True if an `Instruction` requires a `Transaction` signature matching `pubkey`.
@@ -350,10 +348,8 @@ pub struct AccountMetaInternal<Address> {
 	pub is_writable: bool,
 }
 
-/// Type used for building Solana Transactions.
-pub type AccountMeta = AccountMetaInternal<Pubkey>;
 /// Type used to be presented to the user. Serializes address into bs58 string.
-pub type AccountMetaRpc = AccountMetaInternal<SolAddress>;
+pub type AccountMetaRpc = AccountMeta<SolAddress>;
 
 impl From<AccountMeta> for AccountMetaRpc {
 	fn from(value: AccountMeta) -> Self {

--- a/state-chain/chains/src/sol/sol_tx_core.rs
+++ b/state-chain/chains/src/sol/sol_tx_core.rs
@@ -830,6 +830,56 @@ impl CcmAccounts {
 	}
 }
 
+/// Provides alternative version of internal types that uses `Address` instead of Pubkey:
+///
+/// |----------------------|
+/// |Type    |   Serialized|
+/// |----------------------|
+/// |Pubkey  |   Byte Array|
+/// |Address |   bs58      |
+/// |----------------------|
+///
+/// When serialized, these types returns Solana addresses in human readable bs58 format.
+/// These are intended to be used for returning data via RPC calls only.
+pub mod rpc_types {
+	use super::*;
+
+	#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TypeInfo)]
+	pub struct SolInstructionRpc {
+		pub program_id: SolAddress,
+		pub accounts: Vec<SolAccountMetaRpc>,
+		#[serde(with = "sp_core::bytes")]
+		pub data: Vec<u8>,
+	}
+
+	impl From<Instruction> for SolInstructionRpc {
+		fn from(value: Instruction) -> Self {
+			SolInstructionRpc {
+				program_id: value.program_id.into(),
+				accounts: value.accounts.into_iter().map(|a| a.into()).collect(),
+				data: value.data,
+			}
+		}
+	}
+
+	#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TypeInfo)]
+	pub struct SolAccountMetaRpc {
+		pub address: SolAddress,
+		pub is_signer: bool,
+		pub is_writable: bool,
+	}
+
+	impl From<AccountMeta> for SolAccountMetaRpc {
+		fn from(value: AccountMeta) -> Self {
+			SolAccountMetaRpc {
+				address: value.pubkey.into(),
+				is_signer: value.is_signer,
+				is_writable: value.is_writable,
+			}
+		}
+	}
+}
+
 #[test]
 fn ccm_extra_accounts_encoding() {
 	let extra_accounts = CcmAccounts {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -50,8 +50,9 @@ use cf_chains::{
 	},
 	sol::{
 		api::{
-			AllNonceAccounts, ApiEnvironment, ComputePrice, CurrentAggKey, DurableNonce,
-			DurableNonceAndAccount, RecoverDurableNonce, SolanaApi, SolanaEnvironment,
+			AllNonceAccounts, ApiEnvironment, ComputePrice, CurrentAggKey, CurrentOnChainKey,
+			DurableNonce, DurableNonceAndAccount, RecoverDurableNonce, SolanaApi,
+			SolanaEnvironment,
 		},
 		SolAddress, SolAmount, SolApiEnvironment, SolanaCrypto, SolanaTransactionData,
 	},
@@ -553,6 +554,12 @@ impl ChainEnvironment<CurrentAggKey, SolAddress> for SolEnvironment {
 	fn lookup(_s: CurrentAggKey) -> Option<SolAddress> {
 		let epoch = SolanaThresholdSigner::current_key_epoch()?;
 		SolanaThresholdSigner::keys(epoch)
+	}
+}
+
+impl ChainEnvironment<CurrentOnChainKey, SolAddress> for SolEnvironment {
+	fn lookup(_s: CurrentOnChainKey) -> Option<SolAddress> {
+		SolanaBroadcaster::current_on_chain_key()
 	}
 }
 

--- a/state-chain/runtime/src/chainflip/vault_swap.rs
+++ b/state-chain/runtime/src/chainflip/vault_swap.rs
@@ -173,7 +173,8 @@ pub fn solana_vault_swap<A>(
 				event_data_account,
 				input_amount,
 				channel_metadata,
-			),
+			)
+			.into(),
 			Asset::SolUsdc => {
 				let token_supported_account =
 						cf_chains::sol::sol_tx_core::address_derivation::derive_token_supported_account(
@@ -204,7 +205,8 @@ pub fn solana_vault_swap<A>(
 					input_amount,
 					channel_metadata,
 				)
-			},
+			}
+			.into(),
 			_ => Err("Invalid source_asset: Not a Solana asset.")?,
 		},
 	})

--- a/state-chain/runtime/src/chainflip/vault_swap.rs
+++ b/state-chain/runtime/src/chainflip/vault_swap.rs
@@ -126,6 +126,10 @@ pub fn solana_vault_swap<A>(
 		.map_err(|_| "Failed to load Solana Agg key")?
 		.into();
 
+	let on_chain_key = SolEnvironment::current_on_chain_key()
+		.map_err(|_| DispatchErrorWithMessage::from("Failed to load Solana On-chain key"))?
+		.into();
+
 	// Ensure CCM message is valid
 	if let Some(ccm) = channel_metadata.as_ref() {
 		if let DecodedCcmAdditionalData::Solana(ccm_accounts) =
@@ -134,7 +138,7 @@ pub fn solana_vault_swap<A>(
 			// Ensure the CCM parameters do not contain blacklisted accounts.
 			check_ccm_for_blacklisted_accounts(
 				&ccm_accounts,
-				vec![api_environment.token_vault_pda_account.into(), agg_key],
+				vec![api_environment.token_vault_pda_account.into(), agg_key, on_chain_key],
 			)
 			.map_err(DispatchError::from)?;
 		} else {
@@ -160,7 +164,7 @@ pub fn solana_vault_swap<A>(
 		instruction: match source_asset {
 			Asset::Sol => SolanaInstructionBuilder::x_swap_native(
 				api_environment,
-				agg_key,
+				on_chain_key,
 				destination_asset,
 				destination_address,
 				broker_id,

--- a/state-chain/runtime/src/chainflip/vault_swap.rs
+++ b/state-chain/runtime/src/chainflip/vault_swap.rs
@@ -177,8 +177,7 @@ pub fn solana_vault_swap<A>(
 				event_data_account,
 				input_amount,
 				channel_metadata,
-			)
-			.into(),
+			),
 			Asset::SolUsdc => {
 				let token_supported_account =
 						cf_chains::sol::sol_tx_core::address_derivation::derive_token_supported_account(
@@ -209,9 +208,9 @@ pub fn solana_vault_swap<A>(
 					input_amount,
 					channel_metadata,
 				)
-			}
-			.into(),
+			},
 			_ => Err("Invalid source_asset: Not a Solana asset.")?,
-		},
+		}
+		.into(),
 	})
 }

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -6,7 +6,7 @@ use cf_amm::{
 };
 use cf_chains::{
 	self, address::EncodedAddress, assets::any::AssetMap, eth::Address as EthereumAddress,
-	sol::rpc_types::SolInstructionRpc, CcmChannelMetadata, Chain, ChainCrypto, ForeignChainAddress,
+	sol::SolInstructionRpc, CcmChannelMetadata, Chain, ChainCrypto, ForeignChainAddress,
 	VaultSwapExtraParametersEncoded,
 };
 use cf_primitives::{

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -6,7 +6,7 @@ use cf_amm::{
 };
 use cf_chains::{
 	self, address::EncodedAddress, assets::any::AssetMap, eth::Address as EthereumAddress,
-	sol::SolInstruction, CcmChannelMetadata, Chain, ChainCrypto, ForeignChainAddress,
+	sol::rpc_types::SolInstructionRpc, CcmChannelMetadata, Chain, ChainCrypto, ForeignChainAddress,
 	VaultSwapExtraParametersEncoded,
 };
 use cf_primitives::{
@@ -46,7 +46,7 @@ pub enum VaultSwapDetails<BtcAddress> {
 		deposit_address: BtcAddress,
 	},
 	Solana {
-		instruction: SolInstruction,
+		instruction: SolInstructionRpc,
 	},
 }
 


### PR DESCRIPTION
## Summary

Per discussion, made some improvements to the Solana version of Vault swap RPC call
* Solana vault swaps uses on-chain-key instead of aggkey
* Added a new SolInstructionRpc type that uses SolAddress so it serializes all addresses into bs58 instead of byte arrays.
