### PR TITLE
chore: unify fallback events

### DIFF
--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -856,6 +856,7 @@ fn can_handle_failed_vault_transfer() {
 					amount,
 					destination_address,
 					broadcast_id,
+					egress_details: None,
 				},
 			));
 			testnet.move_forward_blocks(11);

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1117,6 +1117,7 @@ fn can_store_failed_vault_transfers() {
 				amount,
 				destination_address,
 				broadcast_id,
+				egress_details: None,
 			},
 		));
 		assert_eq!(


### PR DESCRIPTION
# Pull Request

Closes: PRO-1898

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

I added an optional field for the egress details so it's easy for Product to know if we are scheduling the egress or it's for the user to broadcast themselves if they want to.
Adding this field might be a breaking change for Product so I'll let them know.
