### PR TITLE
feat: Support backwards compatible vault_swap_requests

### DIFF
--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Check workflow files 📝
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.4/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=
         shell: bash
 

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -289,7 +289,7 @@ where
 				.collect::<Vec<Beneficiary<AccountId32>>>()
 				.try_into()
 				.expect("We collect into the same Affiliates type we started with, so the Vec bound is the same."),
-			refund_params: self.refund_params.and_then(|params| Some(params.map_address(|a| a.to_encoded_address(network)))).or(None),
+			refund_params: self.refund_params.map(|params| params.map_address(|a| a.to_encoded_address(network))),
 			dca_params: self.dca_params,
 			max_boost_fee: self.boost_fee,
 		}

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -289,7 +289,7 @@ where
 				.collect::<Vec<Beneficiary<AccountId32>>>()
 				.try_into()
 				.expect("We collect into the same Affiliates type we started with, so the Vec bound is the same."),
-			refund_params: self.refund_params.map_address(|a| a.to_encoded_address(network)),
+			refund_params: self.refund_params.expect("To be an option").map_address(|a| a.to_encoded_address(network)),
 			dca_params: self.dca_params,
 			max_boost_fee: self.boost_fee,
 		}
@@ -642,7 +642,7 @@ mod tests {
 		dot::PolkadotAccountId,
 		evm::{EvmTransactionMetadata, TransactionFee},
 		instances::ChainInstanceFor,
-		CcmChannelMetadata, Chain, ChannelRefundParameters, ForeignChainAddress,
+		CcmChannelMetadata, Chain, ForeignChainAddress,
 	};
 	use cf_utilities::assert_ok;
 	use chainflip_api::primitives::AffiliateShortId;
@@ -874,6 +874,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_handle_vault_deposit_calls() {
+		use cf_chains::ChannelRefundParametersDecoded;
 		chainflip_api::use_chainflip_account_id_encoding();
 		let (eth_address, _) = parse_eth_address("0x541f563237A309B3A61E33BDf07a8930Bdba8D99");
 		let affiliate_short_id = AffiliateShortId::from(69);
@@ -925,11 +926,11 @@ mod tests {
 						bps: 10
 					}])
 					.unwrap(),
-					refund_params: ChannelRefundParameters {
+					refund_params: Some(ChannelRefundParametersDecoded {
 						refund_address: ForeignChainAddress::Eth(eth_address),
 						retry_duration: Default::default(),
 						min_price: Default::default(),
-					},
+					}),
 					dca_params: Some(DcaParameters { number_of_chunks: 5, chunk_interval: 100 }),
 					boost_fee: 5,
 				},

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -133,7 +133,7 @@ enum WitnessInformation {
 		deposit_details: Option<DepositDetails>,
 		broker_fee: Beneficiary<AccountId32>,
 		affiliate_fees: Affiliates<AccountId32>,
-		refund_params: ChannelRefundParametersEncoded,
+		refund_params: Option<ChannelRefundParametersEncoded>,
 		dca_params: Option<DcaParameters>,
 		max_boost_fee: BasisPoints,
 	},
@@ -289,7 +289,7 @@ where
 				.collect::<Vec<Beneficiary<AccountId32>>>()
 				.try_into()
 				.expect("We collect into the same Affiliates type we started with, so the Vec bound is the same."),
-			refund_params: self.refund_params.expect("To be an option").map_address(|a| a.to_encoded_address(network)),
+			refund_params: self.refund_params.and_then(|params| Some(params.map_address(|a| a.to_encoded_address(network)))).or(None),
 			dca_params: self.dca_params,
 			max_boost_fee: self.boost_fee,
 		}

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -80,20 +80,20 @@ async function main() {
   // We observed this values in the wild and want to ensure that the engine can handle them gracefully.
   allSwaps.push(
     testVaultSwap(
-      "ArbEth",
-      "Eth",
+      'ArbEth',
+      'Eth',
       undefined,
-      newCcmMetadata("Eth", undefined, undefined, "0xdeadbeef"),
+      newCcmMetadata('Eth', undefined, undefined, '0xdeadbeef'),
       testAllSwaps.swapContext,
     ),
   );
 
   allSwaps.push(
     testVaultSwap(
-      "Eth",
-      "ArbEth",
+      'Eth',
+      'ArbEth',
       undefined,
-      newCcmMetadata("ArbEth", undefined, undefined, "0xdeadC0de"),
+      newCcmMetadata('ArbEth', undefined, undefined, '0xdeadC0de'),
       testAllSwaps.swapContext,
     ),
   );
@@ -101,10 +101,10 @@ async function main() {
   // Invalid refund params: passing no params
   allSwaps.push(
     testVaultSwap(
-      "ArbEth",
-      "Eth",
+      'ArbEth',
+      'Eth',
       undefined,
-      newCcmMetadata("Eth", undefined, undefined, "0x"),
+      newCcmMetadata('Eth', undefined, undefined, '0x'),
       testAllSwaps.swapContext,
     ),
   );

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -76,38 +76,5 @@ async function main() {
   appendSwap('SolUsdc', 'Eth', testVaultSwap);
   appendSwap('SolUsdc', 'Flip', testVaultSwap, true);
 
-  // Note: Test vault swap with invalid refund params to ensure the engine decoding fallback works.
-  // We observed this values in the wild and want to ensure that the engine can handle them gracefully.
-  allSwaps.push(
-    testVaultSwap(
-      'ArbEth',
-      'Eth',
-      undefined,
-      newCcmMetadata('Eth', undefined, undefined, '0xdeadbeef'),
-      testAllSwaps.swapContext,
-    ),
-  );
-
-  allSwaps.push(
-    testVaultSwap(
-      'Eth',
-      'ArbEth',
-      undefined,
-      newCcmMetadata('ArbEth', undefined, undefined, '0xdeadC0de'),
-      testAllSwaps.swapContext,
-    ),
-  );
-
-  // Invalid refund params: passing no params
-  allSwaps.push(
-    testVaultSwap(
-      'ArbEth',
-      'Eth',
-      undefined,
-      newCcmMetadata('Eth', undefined, undefined, '0x'),
-      testAllSwaps.swapContext,
-    ),
-  );
-
   await Promise.all(allSwaps);
 }

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -76,5 +76,38 @@ async function main() {
   appendSwap('SolUsdc', 'Eth', testVaultSwap);
   appendSwap('SolUsdc', 'Flip', testVaultSwap, true);
 
+  // Note: Test vault swap with invalid refund params to ensure the engine decoding fallback works.
+  // We observed this values in the wild and want to ensure that the engine can handle them gracefully.
+  allSwaps.push(
+    testVaultSwap(
+      "ArbEth",
+      "Eth",
+      undefined,
+      newCcmMetadata("Eth", undefined, undefined, "0xdeadbeef"),
+      testAllSwaps.swapContext,
+    ),
+  );
+
+  allSwaps.push(
+    testVaultSwap(
+      "Eth",
+      "ArbEth",
+      undefined,
+      newCcmMetadata("ArbEth", undefined, undefined, "0xdeadC0de"),
+      testAllSwaps.swapContext,
+    ),
+  );
+
+  // Invalid refund params: passing no params
+  allSwaps.push(
+    testVaultSwap(
+      "ArbEth",
+      "Eth",
+      undefined,
+      newCcmMetadata("Eth", undefined, undefined, "0x"),
+      testAllSwaps.swapContext,
+    ),
+  );
+
   await Promise.all(allSwaps);
 }

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -192,7 +192,7 @@ impl super::evm::vault::IngressCallBuilder for ArbCallBuilder {
 		destination_address: EncodedAddress,
 		deposit_metadata: Option<CcmDepositMetadata>,
 		tx_id: H256,
-		vault_swap_parameters: VaultSwapParameters,
+		vault_swap_parameters: Option<VaultSwapParameters>,
 	) -> state_chain_runtime::RuntimeCall {
 		let deposit = vault_deposit_witness!(
 			source_asset,

--- a/engine/src/witness/btc/vault_swaps.rs
+++ b/engine/src/witness/btc/vault_swaps.rs
@@ -159,11 +159,11 @@ pub fn try_extract_vault_swap_witness(
 			.collect_vec()
 			.try_into()
 			.expect("runtime supports at least as many affiliates as we allow in UTXO encoding"),
-		refund_params: ChannelRefundParametersDecoded {
+		refund_params: Some(ChannelRefundParametersDecoded {
 			retry_duration: data.parameters.retry_duration.into(),
 			refund_address: ForeignChainAddress::Btc(refund_address),
 			min_price,
-		},
+		}),
 		dca_params: Some(DcaParameters {
 			number_of_chunks: data.parameters.number_of_chunks.into(),
 			chunk_interval: data.parameters.chunk_interval.into(),
@@ -327,14 +327,14 @@ mod tests {
 				},
 				affiliate_fees: bounded_vec![MOCK_SWAP_PARAMS.parameters.affiliates[0].into()],
 				deposit_metadata: None,
-				refund_params: ChannelRefundParametersDecoded {
+				refund_params: Some(ChannelRefundParametersDecoded {
 					retry_duration: MOCK_SWAP_PARAMS.parameters.retry_duration.into(),
 					refund_address: ForeignChainAddress::Btc(refund_pubkey),
 					min_price: sqrt_price_to_price(bounded_sqrt_price(
 						MOCK_SWAP_PARAMS.parameters.min_output_amount.into(),
 						DEPOSIT_AMOUNT.into(),
 					)),
-				},
+				}),
 				dca_params: Some(DcaParameters {
 					number_of_chunks: MOCK_SWAP_PARAMS.parameters.number_of_chunks.into(),
 					chunk_interval: MOCK_SWAP_PARAMS.parameters.chunk_interval.into(),

--- a/engine/src/witness/eth.rs
+++ b/engine/src/witness/eth.rs
@@ -241,7 +241,7 @@ impl super::evm::vault::IngressCallBuilder for EthCallBuilder {
 		destination_address: EncodedAddress,
 		deposit_metadata: Option<CcmDepositMetadata>,
 		tx_id: H256,
-		vault_swap_parameters: VaultSwapParameters,
+		vault_swap_parameters: Option<VaultSwapParameters>,
 	) -> state_chain_runtime::RuntimeCall {
 		let deposit = vault_deposit_witness!(
 			source_asset,

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -251,8 +251,7 @@ where
 
 macro_rules! vault_deposit_witness {
 	($source_asset: expr, $deposit_amount: expr, $dest_asset: expr, $dest_address: expr, $metadata: expr, $tx_id: expr, $params: expr) => {
-		if $params.is_some() {
-			let params = $params.unwrap();
+		if let Some(params) = $params {
 			VaultDepositWitness {
 				input_asset: $source_asset.try_into().expect("invalid asset for chain"),
 				output_asset: $dest_asset,

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -66,16 +66,17 @@ where
 			sender: _,
 			cf_parameters,
 		}) => {
-			let vault_swap_parameters =
+			let (vault_swap_parameters, _) =
 				if let Ok(decoded) = VersionedCfParameters::decode(&mut &cf_parameters[..]) {
 					match decoded {
 						VersionedCfParameters::V0(CfParameters {
 							ccm_additional_data: (),
 							vault_swap_parameters,
-						}) => Some(vault_swap_parameters),
+						}) => (Some(vault_swap_parameters), ()),
 					}
 				} else {
-					None
+					tracing::warn!("Failed to decode cf_parameters!");
+					(None, ())
 				};
 
 			Some(CallBuilder::vault_swap_request(
@@ -98,16 +99,17 @@ where
 			sender: _,
 			cf_parameters,
 		}) => {
-			let vault_swap_parameters =
+			let (vault_swap_parameters, _) =
 				if let Ok(decoded) = VersionedCfParameters::decode(&mut &cf_parameters[..]) {
 					match decoded {
 						VersionedCfParameters::V0(CfParameters {
 							ccm_additional_data: (),
 							vault_swap_parameters,
-						}) => Some(vault_swap_parameters),
+						}) => (Some(vault_swap_parameters), ()),
 					}
 				} else {
-					None
+					tracing::warn!("Failed to decode cf_parameters!");
+					(None, ())
 				};
 
 			Some(CallBuilder::vault_swap_request(
@@ -142,6 +144,7 @@ where
 						}) => (Some(vault_swap_parameters), ccm_additional_data),
 					}
 				} else {
+					tracing::warn!("Failed to decode cf_parameters!");
 					(None, Default::default())
 				};
 
@@ -191,6 +194,7 @@ where
 						}) => (Some(vault_swap_parameters), ccm_additional_data),
 					}
 				} else {
+					tracing::warn!("Failed to decode cf_parameters!");
 					(None, Default::default())
 				};
 

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -156,11 +156,7 @@ where
 				try_into_encoded_address(try_into_primitive(dst_chain)?, dst_address.to_vec())?,
 				Some(CcmDepositMetadata {
 					source_chain,
-					source_address: Some(
-						<EthereumAddress as IntoForeignChainAddress<C>>::into_foreign_chain_address(
-							sender,
-						),
-					),
+					source_address: Some(sender.into_foreign_chain_address()),
 					channel_metadata: CcmChannelMetadata {
 						message: message
 							.to_vec()
@@ -208,11 +204,7 @@ where
 				try_into_encoded_address(try_into_primitive(dst_chain)?, dst_address.to_vec())?,
 				Some(CcmDepositMetadata {
 					source_chain,
-					source_address: Some(
-						<EthereumAddress as IntoForeignChainAddress<C>>::into_foreign_chain_address(
-							sender,
-						),
-					),
+					source_address: Some(sender.into_foreign_chain_address()),
 					channel_metadata: CcmChannelMetadata {
 						message: message
 							.to_vec()

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -66,17 +66,17 @@ where
 			sender: _,
 			cf_parameters,
 		}) => {
-			let (vault_swap_parameters, _) =
+			let vault_swap_parameters =
 				if let Ok(decoded) = VersionedCfParameters::decode(&mut &cf_parameters[..]) {
 					match decoded {
 						VersionedCfParameters::V0(CfParameters {
 							ccm_additional_data: (),
 							vault_swap_parameters,
-						}) => (Some(vault_swap_parameters), ()),
+						}) => Some(vault_swap_parameters),
 					}
 				} else {
 					tracing::warn!("Failed to decode cf_parameters!");
-					(None, ())
+					None
 				};
 
 			Some(CallBuilder::vault_swap_request(
@@ -99,17 +99,17 @@ where
 			sender: _,
 			cf_parameters,
 		}) => {
-			let (vault_swap_parameters, _) =
+			let vault_swap_parameters =
 				if let Ok(decoded) = VersionedCfParameters::decode(&mut &cf_parameters[..]) {
 					match decoded {
 						VersionedCfParameters::V0(CfParameters {
 							ccm_additional_data: (),
 							vault_swap_parameters,
-						}) => (Some(vault_swap_parameters), ()),
+						}) => Some(vault_swap_parameters),
 					}
 				} else {
 					tracing::warn!("Failed to decode cf_parameters!");
-					(None, ())
+					None
 				};
 
 			Some(CallBuilder::vault_swap_request(

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -455,7 +455,7 @@ fn vault_swap_deposit_witness(
 			bps: 0,
 		},
 		affiliate_fees: Default::default(),
-		refund_params: REFUND_PARAMS,
+		refund_params: Some(REFUND_PARAMS),
 		dca_params: None,
 		boost_fee: 0,
 		deposit_address: Some(SolAddress([2u8; 32])),

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -535,7 +535,7 @@ fn vault_swap_deposit_witness(
 			bps: 0,
 		},
 		affiliate_fees: Default::default(),
-		refund_params: ETH_REFUND_PARAMS,
+		refund_params: Some(ETH_REFUND_PARAMS),
 		dca_params: None,
 		boost_fee: 0,
 		deposit_address: Some(H160::from([0x03; 20])),

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -316,11 +316,11 @@ mod benchmarks {
 				deposit_details: BenchmarkValue::benchmark_value(),
 				broker_fee: cf_primitives::Beneficiary { account: account("broker", 0, 0), bps: 0 },
 				affiliate_fees: Default::default(),
-				refund_params: ChannelRefundParametersDecoded {
+				refund_params: Some(ChannelRefundParametersDecoded {
 					retry_duration: Default::default(),
 					refund_address: ForeignChainAddress::Eth(Default::default()),
 					min_price: Default::default(),
-				},
+				}),
 				dca_params: None,
 				boost_fee: 0,
 				channel_id: None,

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1827,7 +1827,7 @@ fn submit_vault_swap_request(
 			tx_id,
 			broker_fee,
 			affiliate_fees,
-			refund_params,
+			refund_params: Some(refund_params),
 			dca_params,
 			boost_fee,
 		}),

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1199,11 +1199,11 @@ mod vault_swaps {
 				tx_id,
 				broker_fee: Beneficiary { account: BROKER, bps: 5 },
 				affiliate_fees: Default::default(),
-				refund_params: ChannelRefundParametersDecoded {
+				refund_params: Some(ChannelRefundParametersDecoded {
 					retry_duration: 2,
 					refund_address: ForeignChainAddress::Eth([2; 20].into()),
 					min_price: Default::default(),
-				},
+				}),
 				dca_params: None,
 				boost_fee: 5,
 			};

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -593,7 +593,7 @@ impl
 				broker_fee: swap_details.broker_fee,
 				affiliate_fees: swap_details.affiliate_fees,
 				dca_params: swap_details.dca_params,
-				refund_params: swap_details.refund_params,
+				refund_params: Some(swap_details.refund_params),
 				boost_fee: swap_details.boost_fee.into(),
 			},
 		);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1906

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Catches decoding errors of cf-parameters
- Provides default parameters
- Handles the case if no refund parameters are available on the protocol side

Defaults values

If we can not decode the cf_parameters we use these default vaules:

- broker_fee = broker_account with 0 address, and 0 bps
- affilate_fees = Default / which should just be an empty Vector
- dca_parameters = None
- refund_params = None 

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
