### PR TITLE
feat: min network fee

### DIFF
--- a/state-chain/pallets/cf-swapping/src/migrations.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations.rs
@@ -2,13 +2,13 @@ use cf_runtime_utilities::PlaceholderMigration;
 use frame_support::migrations::VersionedMigration;
 
 use crate::Pallet;
-pub mod swap_request_migration;
+pub mod swap_and_swap_request_migration;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<
 		6,
 		7,
-		swap_request_migration::SwapRequestMigration<T>,
+		swap_and_swap_request_migration::Migration<T>,
 		Pallet<T>,
 		<T as frame_system::Config>::DbWeight,
 	>,

--- a/state-chain/pallets/cf-swapping/src/migrations/swap_and_swap_request_migration.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations/swap_and_swap_request_migration.rs
@@ -54,14 +54,38 @@ pub mod old {
 	#[frame_support::storage_alias]
 	pub type SwapRequests<T: Config> =
 		StorageMap<Pallet<T>, Twox64Concat, SwapRequestId, SwapRequest<T>>;
+
+	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+	pub enum FeeType<T: Config> {
+		NetworkFee,
+		BrokerFee(Beneficiaries<T::AccountId>),
+	}
+
+	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+	pub struct Swap<T: Config> {
+		pub swap_id: SwapId,
+		pub swap_request_id: SwapRequestId,
+		pub from: Asset,
+		pub to: Asset,
+		pub input_amount: AssetAmount,
+		pub fees: Vec<FeeType<T>>,
+		pub refund_params: Option<SwapRefundParameters>,
+	}
+
+	#[frame_support::storage_alias]
+	pub type SwapQueue<T: Config> =
+		StorageMap<Pallet<T>, Twox64Concat, BlockNumberFor<T>, Vec<Swap<T>>, ValueQuery>;
 }
 
-pub struct SwapRequestMigration<T: Config>(PhantomData<T>);
+pub struct Migration<T: Config>(PhantomData<T>);
 
-impl<T: Config> UncheckedOnRuntimeUpgrade for SwapRequestMigration<T> {
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
-		Ok((old::SwapRequests::<T>::iter().count() as u64).encode())
+		let swap_request_count = old::SwapRequests::<T>::iter().count() as u64;
+		let scheduled_swaps_count: u64 =
+			old::SwapQueue::<T>::iter().map(|(_, swaps)| swaps.len() as u64).sum();
+		Ok((swap_request_count, scheduled_swaps_count).encode())
 	}
 
 	fn on_runtime_upgrade() -> Weight {
@@ -90,17 +114,47 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for SwapRequestMigration<T> {
 			})
 		});
 
+		crate::SwapQueue::<T>::translate_values::<Vec<old::Swap<T>>, _>(|old_swaps| {
+			Some(
+				old_swaps
+					.into_iter()
+					.map(|swap| Swap {
+						swap_id: swap.swap_id,
+						swap_request_id: swap.swap_request_id,
+						from: swap.from,
+						to: swap.to,
+						input_amount: swap.input_amount,
+						fees: swap
+							.fees
+							.into_iter()
+							.map(|fee| match fee {
+								old::FeeType::NetworkFee =>
+									FeeType::NetworkFee { min_fee_enforced: false },
+								old::FeeType::BrokerFee(beneficiaries) =>
+									FeeType::BrokerFee(beneficiaries),
+							})
+							.collect(),
+						refund_params: swap.refund_params,
+					})
+					.collect(),
+			)
+		});
+
 		Weight::zero()
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
-		let pre_swap_request_count = <u64>::decode(&mut state.as_slice())
-			.map_err(|_| DispatchError::from("Failed to decode state"))?;
+		let (pre_swap_request_count, pre_scheduled_swap_count) =
+			<(u64, u64)>::decode(&mut state.as_slice())
+				.map_err(|_| DispatchError::from("Failed to decode state"))?;
 
 		let post_swap_request_count = crate::SwapRequests::<T>::iter().count() as u64;
+		let post_scheduled_swaps_count: u64 =
+			SwapQueue::<T>::iter().map(|(_, swaps)| swaps.len() as u64).sum();
 
 		assert_eq!(pre_swap_request_count, post_swap_request_count);
+		assert_eq!(pre_scheduled_swap_count, post_scheduled_swaps_count);
 		Ok(())
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -759,7 +759,15 @@ fn swap_excess_are_confiscated() {
 
 		assert_eq!(
 			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS)),
-			vec![Swap::new(1.into(), 1.into(), from, to, MAX_SWAP, None, [FeeType::NetworkFee { min_fee_enforced: true }])]
+			vec![Swap::new(
+				1.into(),
+				1.into(),
+				from,
+				to,
+				MAX_SWAP,
+				None,
+				[FeeType::NetworkFee { min_fee_enforced: true }]
+			)]
 		);
 		assert_eq!(CollectedRejectedFunds::<Test>::get(from), 900);
 	});

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -119,7 +119,7 @@ fn can_process_ccms_via_swap_deposit_address() {
 					Asset::Eth,
 					DEPOSIT_AMOUNT,
 					None,
-					[FeeType::NetworkFee],
+					[FeeType::NetworkFee { min_fee_enforced: true }],
 				),]
 			);
 		})
@@ -163,7 +163,7 @@ fn ccm_principal_swap_only() {
 					OUTPUT_ASSET,
 					SWAP_AMOUNT,
 					None,
-					[FeeType::NetworkFee],
+					[FeeType::NetworkFee { min_fee_enforced: true }],
 				),]
 			);
 		})

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1697,7 +1697,7 @@ impl_runtime_apis! {
 			let mut fees_vec = vec![];
 
 			if include_fee(FeeTypes::Network) {
-				fees_vec.push(FeeType::NetworkFee);
+				fees_vec.push(FeeType::NetworkFee { min_fee_enforced: true });
 			}
 
 			if broker_commission > 0 {


### PR DESCRIPTION
# Pull Request

Closes: PRO-1701

## Summary

- New `MinimumNetworkFeePerChunk` storage item, set to 0 by default, but can be updated via governance extrinsic. In practice "min fee per chunk" should effectively be "min fee per swap request" since we also enforce min chunk size (which should be sufficiently large). I considered adding checks ensuring that we never update parameters such that this doesn't hold, but it is a bit tricky since chunk size is in target chain asset amount and we don't know the exchange rate... The best we can do it check it against the min chunk limit for USDC and rely on other limits being in line with that. However, I dicussed this with @kylezs and we agreed that this shouldn't really matter considering that the new min network fee will already be incorporated into the price estimation that's used for quotes (i.e. if the user sets a small chunk size and the protocol somehow allows it, they should see the higher network fee).

- Min fee only applies to "regular" swaps, i.e. it doesn't not apply to swaps for ingress/egress fees (which are expected to be tiny). For this I updated FeeType::NetworkFee to include a boolean `min_fee_enforced`, and added a migration to update storage any already queued swaps.