### PR TITLE
feat: add bond to private broker channel events

### DIFF
--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -441,8 +441,12 @@ impl<T: Config> Bonding for Bonder<T> {
 	type AccountId = T::AccountId;
 	type Amount = T::Balance;
 
-	fn update_bond(authority: &Self::AccountId, bond: Self::Amount) {
-		Account::<T>::mutate_exists(authority, |maybe_account| {
+	fn get_bond(account_id: &Self::AccountId) -> Self::Amount {
+		Account::<T>::get(account_id).bond
+	}
+
+	fn update_bond(account_id: &Self::AccountId, bond: Self::Amount) {
+		Account::<T>::mutate_exists(account_id, |maybe_account| {
 			if let Some(account) = maybe_account.as_mut() {
 				account.bond = bond
 			}

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1650,6 +1650,7 @@ mod private_channels {
 				Event::<Test>::PrivateBrokerChannelOpened {
 					broker_id: BROKER,
 					channel_id: FIRST_CHANNEL_ID,
+					bond: DefaultBrokerBond::<Test>::get(),
 				},
 			));
 
@@ -1710,6 +1711,7 @@ mod private_channels {
 				Event::<Test>::PrivateBrokerChannelClosed {
 					broker_id: BROKER,
 					channel_id: CHANNEL_ID,
+					bond: DefaultBrokerBond::<Test>::get(),
 				},
 			));
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -686,7 +686,10 @@ pub trait HistoricalEpoch {
 /// Handles the bonding logic
 pub trait Bonding {
 	type AccountId;
-	type Amount;
+	type Amount: Default;
+
+	/// Get the bond of an authority
+	fn get_bond(account_id: &Self::AccountId) -> Self::Amount;
 	/// Update the bond of an authority
 	fn update_bond(authority: &Self::AccountId, bond: Self::Amount);
 }

--- a/state-chain/traits/src/mocks/bonding.rs
+++ b/state-chain/traits/src/mocks/bonding.rs
@@ -13,15 +13,13 @@ impl<Id, Amount> MockPallet for MockBonder<Id, Amount> {
 
 const BOND: &[u8] = b"BOND";
 
-impl<Id: Encode, Amount: Decode + Default> MockBonder<Id, Amount> {
-	pub fn get_bond(account_id: &Id) -> Amount {
-		Self::get_storage(BOND, account_id).unwrap_or_default()
-	}
-}
-
-impl<Id: Encode, Amount: Encode> Bonding for MockBonder<Id, Amount> {
+impl<Id: Encode, Amount: Encode + Decode + Default> Bonding for MockBonder<Id, Amount> {
 	type AccountId = Id;
 	type Amount = Amount;
+
+	fn get_bond(account_id: &Id) -> Amount {
+		Self::get_storage(BOND, account_id).unwrap_or_default()
+	}
 
 	fn update_bond(account_id: &Self::AccountId, bond: Amount) {
 		Self::put_storage(BOND, account_id, bond);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1910

## Summary

- Added `get_bond` to the Bonder trait (until now it only existed in the mock)
- added bond to `PrivateBrokerChannelOpened` and `PrivateBrokerChannelClosed`

fyi @niklasnatter 