### PR TITLE
chore: bouncer EVM & BTC Vault Swaps to use Broker API

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/upgrade-test.yml
     secrets: inherit
     with:
-      run-job: true
+      run-job: false
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/upgrade-test.yml
     secrets: inherit
     with:
-      run-job: false
+      run-job: true
   publish:
     needs: [package]
     uses: ./.github/workflows/_30_publish.yml

--- a/bouncer/shared/contract_interfaces.ts
+++ b/bouncer/shared/contract_interfaces.ts
@@ -26,6 +26,9 @@ export const getCFTesterAbi = loadContractCached(
 export const getKeyManagerAbi = loadContractCached(
   `../contract-interfaces/eth-contract-abis/${CF_ETH_CONTRACT_ABI_TAG}/IKeyManager.json`,
 );
+export const getEvmVaultAbi = loadContractCached(
+  `../contract-interfaces/eth-contract-abis/${CF_ETH_CONTRACT_ABI_TAG}/IVault.json`,
+);
 export const getSolanaVaultIdl = loadContractCached(
   `../contract-interfaces/sol-program-idls/${CF_SOL_PROGRAM_IDL_TAG}/vault.json`,
 );

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -140,7 +140,7 @@ export async function executeEvmVaultSwap(
   const refundParams: ChannelRefundParameters = {
     retry_duration: fokParams.retryDurationBlocks,
     refund_address: fokParams.refundAddress,
-    min_price: fokParams.minPriceX128,
+    min_price: '0x' + new BigNumber(fokParams.minPriceX128).toString(16),
   };
 
   const extraParameters: EvmVaultSwapExtraParameters = {

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -130,7 +130,6 @@ export async function executeEvmVaultSwap(
     );
     return receipt.hash;
   }
-  console.log('Using the broker API');
 
   // Use the broker API
   await using chainflip = await getChainflipApi();

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -177,7 +177,7 @@ export async function executeEvmVaultSwap(
     to: vaultSwapDetails.to,
     data: vaultSwapDetails.calldata,
     value: new BigNumber(vaultSwapDetails.value.slice(2), 16).toString(),
-    gas: srcChain === 'Arbitrum' ? 20000000 : 1000000,
+    gas: srcChain === 'Arbitrum' ? 32000000 : 5000000,
   };
 
   const signedTx = await web3.eth.accounts.signTransaction(tx, evmWallet.privateKey);

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -32,7 +32,7 @@ import { ChannelRefundParameters } from './sol_vault_swap';
 const erc20Assets: Asset[] = ['Flip', 'Usdc', 'Usdt', 'ArbUsdc'];
 
 interface EvmVaultSwapDetails {
-  chain: string;
+  chain: 'Ethereum' | 'Arbitrum';
   calldata: string;
   value: string;
   to: string;

--- a/bouncer/shared/evm_vault_swap.ts
+++ b/bouncer/shared/evm_vault_swap.ts
@@ -9,6 +9,8 @@ import {
 } from '@chainflip/cli';
 import { HDNodeWallet } from 'ethers';
 import { randomBytes } from 'crypto';
+import BigNumber from 'bignumber.js';
+import Web3 from 'web3';
 import Keyring from '../polkadot/keyring';
 import {
   getContractAddress,
@@ -19,10 +21,28 @@ import {
   stateChainAssetFromAsset,
   createEvmWalletAndFund,
   newAddress,
+  createStateChainKeypair,
+  decodeDotAddressForContract,
+  getEvmEndpoint,
 } from './utils';
 import { CcmDepositMetadata, DcaParams, FillOrKillParamsX128 } from './new_swap';
+import { getChainflipApi } from './utils/substrate';
+import { ChannelRefundParameters } from './sol_vault_swap';
 
 const erc20Assets: Asset[] = ['Flip', 'Usdc', 'Usdt', 'ArbUsdc'];
+
+interface EvmVaultSwapDetails {
+  chain: string;
+  calldata: string;
+  value: string;
+  to: string;
+}
+
+interface EvmVaultSwapExtraParameters {
+  chain: 'Ethereum' | 'Arbitrum';
+  input_amount: string;
+  refund_parameters: ChannelRefundParameters;
+}
 
 export async function executeEvmVaultSwap(
   sourceAsset: Asset,
@@ -38,7 +58,7 @@ export async function executeEvmVaultSwap(
     account: string;
     commissionBps: number;
   },
-): ReturnType<typeof executeSwap> {
+): Promise<string> {
   const srcChain = chainFromAsset(sourceAsset);
   const destChain = chainFromAsset(destAsset);
   const amountToSwap = amount ?? defaultAssetAmounts(sourceAsset);
@@ -67,45 +87,104 @@ export async function executeEvmVaultSwap(
     );
   }
 
-  const networkOptions = {
-    signer: evmWallet,
-    network: 'localnet',
-    vaultContractAddress: getContractAddress(srcChain, 'VAULT'),
-    srcTokenContractAddress: getContractAddress(srcChain, sourceAsset),
-  } as const;
-  const txOptions = {
-    // This is run with fresh addresses to prevent nonce issues. Will be 1 for ERC20s.
-    gasLimit: srcChain === Chains.Arbitrum ? 32000000n : 5000000n,
-  } as const;
+  const fineAmount = amountToFineAmount(amountToSwap, assetDecimals(sourceAsset));
 
-  const receipt = await executeSwap(
-    {
-      destChain,
-      destAsset: stateChainAssetFromAsset(destAsset),
-      // It is important that this is large enough to result in
-      // an amount larger than existential (e.g. on Polkadot):
-      amount: amountToFineAmount(amountToSwap, assetDecimals(sourceAsset)),
-      destAddress,
-      srcAsset: stateChainAssetFromAsset(sourceAsset),
-      srcChain,
-      ccmParams: messageMetadata && {
-        gasBudget: messageMetadata.gasBudget.toString(),
-        message: messageMetadata.message,
-        ccmAdditionalData: messageMetadata.ccmAdditionalData,
-      },
-      brokerFees: brokerComission,
-      // The SDK will encode these parameters and the ccmAdditionalData
-      // into the `cfParameters` field for the vault swap.
-      boostFeeBps,
-      fillOrKillParams: fokParams,
-      dcaParams,
-      affiliateFees: undefined,
-    } as ExecuteSwapParams,
-    networkOptions,
-    txOptions,
-  );
+  if (Math.random() > 0.5) {
+    // Use SDK
+    const networkOptions = {
+      signer: evmWallet,
+      network: 'localnet',
+      vaultContractAddress: getContractAddress(srcChain, 'VAULT'),
+      srcTokenContractAddress: getContractAddress(srcChain, sourceAsset),
+    } as const;
+    const txOptions = {
+      // This is run with fresh addresses to prevent nonce issues. Will be 1 for ERC20s.
+      gasLimit: srcChain === Chains.Arbitrum ? 32000000n : 5000000n,
+    } as const;
 
-  return receipt;
+    const receipt = await executeSwap(
+      {
+        destChain,
+        destAsset: stateChainAssetFromAsset(destAsset),
+        // It is important that this is large enough to result in
+        // an amount larger than existential (e.g. on Polkadot):
+        amount: fineAmount,
+        destAddress,
+        srcAsset: stateChainAssetFromAsset(sourceAsset),
+        srcChain,
+        ccmParams: messageMetadata && {
+          gasBudget: messageMetadata.gasBudget.toString(),
+          message: messageMetadata.message,
+          ccmAdditionalData: messageMetadata.ccmAdditionalData,
+        },
+        brokerFees: brokerComission,
+        // The SDK will encode these parameters and the ccmAdditionalData
+        // into the `cfParameters` field for the vault swap.
+        boostFeeBps,
+        fillOrKillParams: fokParams,
+        dcaParams,
+        affiliateFees: undefined,
+      } as ExecuteSwapParams,
+      networkOptions,
+      txOptions,
+    );
+    return receipt.hash;
+  }
+  console.log('Using the broker API');
+
+  // Use the broker API
+  await using chainflip = await getChainflipApi();
+  const brokerUri = '//BROKER_1';
+  const broker = createStateChainKeypair(brokerUri);
+
+  const refundParams: ChannelRefundParameters = {
+    retry_duration: fokParams.retryDurationBlocks,
+    refund_address: fokParams.refundAddress,
+    min_price: fokParams.minPriceX128,
+  };
+
+  const extraParameters: EvmVaultSwapExtraParameters = {
+    chain: srcChain as 'Ethereum' | 'Arbitrum',
+    input_amount: '0x' + new BigNumber(fineAmount).toString(16),
+    refund_parameters: refundParams,
+  };
+
+  const vaultSwapDetails = (await chainflip.rpc(
+    `cf_get_vault_swap_details`,
+    broker.address,
+    { chain: chainFromAsset(sourceAsset), asset: stateChainAssetFromAsset(sourceAsset) },
+    { chain: chainFromAsset(destAsset), asset: stateChainAssetFromAsset(destAsset) },
+    chainFromAsset(destAsset) === Chains.Polkadot
+      ? decodeDotAddressForContract(destAddress)
+      : destAddress,
+    0, // broker_commission
+    extraParameters, // extra_parameters
+    // channel_metadata
+    messageMetadata && {
+      message: messageMetadata.message as `0x${string}`,
+      gas_budget: messageMetadata.gasBudget,
+      ccm_additional_data: messageMetadata.ccmAdditionalData,
+    },
+    boostFeeBps ?? 0, // boost_fee
+    null, // affiliates
+    dcaParams && {
+      number_of_chunks: dcaParams.numberOfChunks,
+      chunk_interval: dcaParams.chunkIntervalBlocks,
+    },
+  )) as unknown as EvmVaultSwapDetails;
+
+  const web3 = new Web3(getEvmEndpoint(srcChain));
+  const tx = {
+    to: vaultSwapDetails.to,
+    data: vaultSwapDetails.calldata,
+    value: new BigNumber(vaultSwapDetails.value.slice(2), 16).toString(),
+    gas: srcChain === 'Arbitrum' ? 20000000 : 1000000,
+  };
+
+  const signedTx = await web3.eth.accounts.signTransaction(tx, evmWallet.privateKey);
+  const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction as string);
+
+  return receipt.transactionHash;
 }
 
 export async function approveEvmTokenVault(

--- a/bouncer/shared/fund_flip.ts
+++ b/bouncer/shared/fund_flip.ts
@@ -15,7 +15,12 @@ import { approveErc20 } from './approve_erc20';
 import { observeEvent } from './utils/substrate';
 
 export async function fundFlip(scAddress: string, flipAmount: string) {
-  await approveErc20('Flip', getContractAddress('Ethereum', 'GATEWAY'), flipAmount);
+  // Doing effectively infinite approvals to prevent race conditions between tests
+  await approveErc20(
+    'Flip',
+    getContractAddress('Ethereum', 'GATEWAY'),
+    '100000000000000000000000000',
+  );
 
   const flipperinoAmount = amountToFineAmount(flipAmount, assetDecimals('Flip'));
 

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -243,7 +243,7 @@ export async function performAndTrackSwap(
 
   if (broadcastId) await observeBroadcastSuccess(broadcastId, tag);
   else throw new Error('Failed to retrieve broadcastId!');
-  console.log(`${tag} broadcast executed succesfully, swap is complete!`);
+  console.log(`${tag} broadcast executed successfully, swap is complete!`);
 }
 
 export async function executeVaultSwap(

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -267,7 +267,7 @@ export async function executeVaultSwap(
     // To uniquely identify the VaultSwap, we need to use the TX hash. This is only known
     // after sending the transaction, so we send it first and observe the events afterwards.
     // There are still multiple blocks of safety margin inbetween before the event is emitted
-    const receipt = await executeEvmVaultSwap(
+    const txHash = await executeEvmVaultSwap(
       sourceAsset,
       destAsset,
       destAddress,
@@ -278,7 +278,7 @@ export async function executeVaultSwap(
       dcaParams,
       wallet,
     );
-    transactionId = { type: TransactionOrigin.VaultSwapEvm, txHash: receipt.hash };
+    transactionId = { type: TransactionOrigin.VaultSwapEvm, txHash };
     sourceAddress = wallet.address.toLowerCase();
   } else {
     const { slot, accountAddress } = await executeSolVaultSwap(

--- a/bouncer/shared/sol_vault_swap.ts
+++ b/bouncer/shared/sol_vault_swap.ts
@@ -55,14 +55,6 @@ interface SolanaVaultSwapExtraParameters {
   from_token_account?: string;
 }
 
-// TODO: Unify this with BTC & EVM vault swaps.
-// interface BitcoinVaultSwapExtraParameters {
-//   chain: 'Bitcoin';
-//   min_output_amount: number;
-//   retry_duration: number;
-// }
-// type VaultSwapExtraParameters = BitcoinVaultSwapExtraParameters | SolanaVaultSwapExtraParameters;
-
 export type ChannelRefundParameters = {
   retry_duration: number;
   refund_address: string;

--- a/bouncer/shared/sol_vault_swap.ts
+++ b/bouncer/shared/sol_vault_swap.ts
@@ -10,6 +10,7 @@ import {
   AccountMeta,
 } from '@solana/web3.js';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
+import BigNumber from 'bignumber.js';
 import {
   getContractAddress,
   amountToFineAmount,
@@ -62,7 +63,7 @@ interface SolanaVaultSwapExtraParameters {
 // }
 // type VaultSwapExtraParameters = BitcoinVaultSwapExtraParameters | SolanaVaultSwapExtraParameters;
 
-type ChannelRefundParameters = {
+export type ChannelRefundParameters = {
   retry_duration: number;
   refund_address: string;
   min_price: string;
@@ -106,7 +107,7 @@ export async function executeSolVaultSwap(
     chain: 'Solana',
     from: decodeSolAddress(whaleKeypair.publicKey.toBase58()),
     event_data_account: decodeSolAddress(newEventAccountKeypair.publicKey.toBase58()),
-    input_amount: amountToSwap,
+    input_amount: '0x' + new BigNumber(amountToSwap).toString(16),
     refund_parameters: refundParams,
     from_token_account:
       srcAsset === 'Sol'

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -63,7 +63,7 @@ const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 5;
 // that when construction the call the Solana length is not exceeded. Technically the
 // check should be tx lenght (dstAsset, srcAsset, ccmData, cf_parameters...) < 1232
 const MAX_SOL_VAULT_SWAP_CCM_MESSAGE_LENGTH = 300;
-const MAX_SOL_VAULT_SWAP_ADDITIONAL_METADATA_LENGTH = 200;
+const MAX_SOL_VAULT_SWAP_ADDITIONAL_METADATA_LENGTH = 150;
 
 // Solana CCM-related parameters. These are limits in the protocol.
 const MAX_CCM_BYTES_SOL = 705;

--- a/bouncer/test_commands/legacy_vault_swap_test.ts
+++ b/bouncer/test_commands/legacy_vault_swap_test.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S pnpm tsx
+import { legacyEvmVaultSwaps } from '../tests/legacy_vault_swap';
+
+await legacyEvmVaultSwaps.runAndExit();

--- a/bouncer/tests/all_concurrent_tests.ts
+++ b/bouncer/tests/all_concurrent_tests.ts
@@ -16,6 +16,7 @@ import { depositChannelCreation } from './request_swap_deposit_address_with_affi
 import { testDCASwaps } from './DCA_test';
 import { testBrokerLevelScreening } from './broker_level_screening';
 import { checkSolEventAccountsClosure } from '../shared/sol_vault_swap';
+import { legacyEvmVaultSwaps } from './legacy_vault_swap';
 
 async function runAllConcurrentTests() {
   // Specify the number of nodes via providing an argument to this script.
@@ -46,6 +47,7 @@ async function runAllConcurrentTests() {
     testCancelOrdersBatch.run(),
     depositChannelCreation.run(),
     testBrokerLevelScreening.run(),
+    legacyEvmVaultSwaps.run(),
   ];
 
   // Tests that only work if there is more than one node

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -70,7 +70,8 @@ async function main() {
           // Vault Swaps
           appendSwap(sourceAsset, destAsset, testVaultSwap);
 
-          if (ccmSupportedChains.includes(destChain)) {
+          // Bitcoin doesn't support CCM Vault swaps due to transaction length limits
+          if (ccmSupportedChains.includes(destChain) && sourceChain !== 'Bitcoin') {
             // CCM Vault swaps
             appendSwap(sourceAsset, destAsset, testVaultSwap, true);
           }

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -14,6 +14,7 @@ import {
   VaultSwapParams,
   vaultSwapSupportedChains,
 } from '../shared/utils';
+import { openPrivateBtcChannel } from './btc_vault_swap';
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
 export const testAllSwaps = new ExecutableTest('All-Swaps', main, 3000);
@@ -47,6 +48,9 @@ export async function initiateSwap(
 
 async function main() {
   const allSwaps: Promise<SwapParams | VaultSwapParams>[] = [];
+
+  // Open a private BTC channel to be used for btc vault swaps
+  await openPrivateBtcChannel('//BROKER_1');
 
   function appendSwap(
     sourceAsset: Asset,

--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -179,9 +179,16 @@ export async function openPrivateBtcChannel(brokerUri: string) {
   try {
     await brokerApiRpc('broker_open_private_btc_channel', []);
     testBtcVaultSwap.log('Private Btc channel opened');
-  } catch (error) {
-    // We expect this to fail if the channel already exists from a previous run
-    testBtcVaultSwap.debugLog('Failed to open private Btc channel', error);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    // We expect this to fail if the channel already exists
+    if (error.message.includes('PrivateChannelExistsForBroker')) {
+      testBtcVaultSwap.debugLog('Failed to open private Btc channel', error);
+    } else {
+      // Any other error is unexpected, ie InsufficientFunds
+      testBtcVaultSwap.log(`Failed to open private Btc channel for ${brokerUri}`);
+      throw error;
+    }
   }
 }
 

--- a/bouncer/tests/legacy_vault_swap.ts
+++ b/bouncer/tests/legacy_vault_swap.ts
@@ -1,0 +1,161 @@
+import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
+import { randomBytes } from 'crypto';
+import Web3 from 'web3';
+import assert from 'assert';
+import {
+  amountToFineAmount,
+  assetContractId,
+  assetDecimals,
+  ccmSupportedChains,
+  chainContractId,
+  chainFromAsset,
+  chainGasAsset,
+  createEvmWalletAndFund,
+  defaultAssetAmounts,
+  getContractAddress,
+  getEvmEndpoint,
+  newAddress,
+  observeBalanceIncrease,
+  observeSwapRequested,
+  SwapRequestType,
+  TransactionOrigin,
+} from '../shared/utils';
+import { observeEvent } from '../shared/utils/substrate';
+import { getBalance } from '../shared/get_balance';
+import { ExecutableTest } from '../shared/executable_test';
+import { newVaultSwapCcmMetadata } from '../shared/swapping';
+import { getEvmVaultAbi } from '../shared/contract_interfaces';
+import { approveEvmTokenVault } from '../shared/evm_vault_swap';
+
+/* eslint-disable @typescript-eslint/no-use-before-define */
+export const legacyEvmVaultSwaps = new ExecutableTest('Legacy-EVM-Vault-Swaps', main, 300);
+
+async function legacyEvmVaultSwap(sourceAsset: Asset, destAsset: Asset, ccmSwap: boolean = false) {
+  const destAddress = ccmSwap
+    ? getContractAddress(chainFromAsset(destAsset), 'CFTESTER')
+    : await newAddress(destAsset, randomBytes(32).toString('hex'));
+  const destBalanceBefore = await getBalance(destAsset, destAddress);
+  const sourceChain = chainFromAsset(sourceAsset);
+  const destChain = chainFromAsset(destAsset);
+  const amount = amountToFineAmount(defaultAssetAmounts(sourceAsset), assetDecimals(sourceAsset));
+
+  // Only EVM have legacy vault swaps
+  assert(ccmSupportedChains.includes(sourceChain));
+
+  const web3 = new Web3(getEvmEndpoint(sourceChain));
+  const vaultAddress = getContractAddress(sourceChain, 'VAULT');
+  const vaultContract = new web3.eth.Contract(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (await getEvmVaultAbi()) as any,
+    vaultAddress,
+  );
+  const evmWallet = await createEvmWalletAndFund(sourceAsset);
+
+  const cfParametersList = ['', '0x', 'deadbeef', '0xdeadbeef', 'deadc0de', '0xdeadc0de'];
+  const cfParameters = Math.floor(Math.random() * cfParametersList.length);
+
+  if (chainGasAsset(sourceChain) !== sourceAsset) {
+    // Doing effectively infinite approvals to make sure it doesn't fail.
+    await approveEvmTokenVault(sourceAsset, (BigInt(amount) * 100n).toString(), evmWallet);
+  }
+
+  let data;
+  if (!ccmSwap) {
+    if (chainGasAsset(sourceChain) === sourceAsset) {
+      data = vaultContract.methods
+        .xSwapNative(
+          chainContractId(destChain),
+          destAddress,
+          assetContractId(destAsset),
+          cfParameters,
+        )
+        .encodeABI();
+    } else {
+      data = vaultContract.methods
+        .xSwapToken(
+          chainContractId(destChain),
+          destAddress,
+          assetContractId(destAsset),
+          getContractAddress(sourceChain, sourceAsset),
+          Number(amount),
+          cfParameters,
+        )
+        .encodeABI();
+    }
+  } else {
+    const ccmSwapMetadata = await newVaultSwapCcmMetadata(sourceAsset, destAsset);
+    if (chainGasAsset(sourceChain) === sourceAsset) {
+      data = vaultContract.methods
+        .xCallNative(
+          chainContractId(destChain),
+          destAddress,
+          assetContractId(destAsset),
+          ccmSwapMetadata.message,
+          ccmSwapMetadata.gasBudget,
+          cfParameters,
+        )
+        .encodeABI();
+    } else {
+      data = vaultContract.methods
+        .xCallToken(
+          chainContractId(destChain),
+          destAddress,
+          assetContractId(destAsset),
+          ccmSwapMetadata.message,
+          ccmSwapMetadata.gasBudget,
+          getContractAddress(sourceChain, sourceAsset),
+          amount,
+          cfParameters,
+        )
+        .encodeABI();
+    }
+  }
+
+  const tx = {
+    to: vaultAddress,
+    data,
+    gas: sourceChain === 'Arbitrum' ? 5000000 : 200000,
+    value: chainGasAsset(sourceChain) === sourceAsset ? amount : '0',
+  };
+
+  const signedTx = await web3.eth.accounts.signTransaction(tx, evmWallet.privateKey);
+  const receipt = await web3.eth.sendSignedTransaction(signedTx.rawTransaction as string);
+
+  legacyEvmVaultSwaps.log(`Vault swap executed, tx hash: ${receipt.transactionHash}`);
+
+  // Look after Swap Requested of data.origin.Vault.tx_hash
+  const swapRequestedHandle = observeSwapRequested(
+    sourceAsset,
+    destAsset,
+    { type: TransactionOrigin.VaultSwapEvm, txHash: receipt.transactionHash },
+    SwapRequestType.Regular,
+  );
+
+  const swapRequestId = Number((await swapRequestedHandle).data.swapRequestId.replaceAll(',', ''));
+  legacyEvmVaultSwaps.debugLog(`${sourceAsset} swap via vault, swapRequestId: ${swapRequestId}`);
+
+  // Wait for the swap to complete
+  await observeEvent(`swapping:SwapRequestCompleted`, {
+    test: (event) => Number(event.data.swapRequestId.replaceAll(',', '')) === swapRequestId,
+  }).event;
+
+  await observeEvent(`swapping:SwapExecuted`, {
+    test: (event) => Number(event.data.swapRequestId.replaceAll(',', '')) === swapRequestId,
+    historicalCheckBlocks: 10,
+  }).event;
+
+  legacyEvmVaultSwaps.debugLog(
+    `swapRequestId: ${swapRequestId} executed. Waiting for balance to increase.`,
+  );
+  await observeBalanceIncrease(destAsset, destAddress, destBalanceBefore);
+  legacyEvmVaultSwaps.debugLog(`swapRequestId: ${swapRequestId} - swap success`);
+}
+
+export async function main() {
+  await Promise.all([
+    legacyEvmVaultSwap(Assets.Eth, Assets.ArbUsdc),
+    legacyEvmVaultSwap(Assets.ArbEth, Assets.Eth, true),
+    legacyEvmVaultSwap(Assets.ArbUsdc, Assets.Usdt),
+    legacyEvmVaultSwap(Assets.Usdc, Assets.Eth, true),
+  ]);
+}

--- a/bouncer/tests/legacy_vault_swap.ts
+++ b/bouncer/tests/legacy_vault_swap.ts
@@ -114,7 +114,7 @@ async function legacyEvmVaultSwap(sourceAsset: Asset, destAsset: Asset, ccmSwap:
   const tx = {
     to: vaultAddress,
     data,
-    gas: sourceChain === 'Arbitrum' ? 5000000 : 200000,
+    gas: sourceChain === 'Arbitrum' ? 32000000 : 5000000,
     value: chainGasAsset(sourceChain) === sourceAsset ? amount : '0',
   };
 

--- a/state-chain/runtime/src/chainflip/vault_swaps.rs
+++ b/state-chain/runtime/src/chainflip/vault_swaps.rs
@@ -202,7 +202,7 @@ pub fn evm_vault_swap<A>(
 			calldata,
 			// Only return `amount` for native currently. 0 for Tokens
 			value: (source_asset == Asset::Eth).then_some(U256::from(amount)).unwrap_or_default(),
-			to: Environment::key_manager_address(),
+			to: Environment::eth_vault_address(),
 		})),
 		ForeignChain::Arbitrum => Ok(VaultSwapDetails::arbitrum(EvmVaultSwapDetails {
 			calldata,
@@ -210,7 +210,7 @@ pub fn evm_vault_swap<A>(
 			value: (source_asset == Asset::ArbEth)
 				.then_some(U256::from(amount))
 				.unwrap_or_default(),
-			to: Environment::arb_key_manager_address(),
+			to: Environment::arb_vault_address(),
 		})),
 		_ => Err(DispatchErrorWithMessage::from(
 			"Only EVM chains should execute this branch of logic. This error should never happen",


### PR DESCRIPTION
# Pull Request

Closes: PRO-1912, PRO-1854

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Use broker APi for EVM vault swaps
- Add test for legacy vault swaps (undecodable cfParameters) to make sure it doesn't break backwards compatibility. This is to test the logic in #5514 .
- Add BTC Vault swap test to the regular swapping flow. Affiliate fee testing shall be done separately. I've opened a ticket for that: https://linear.app/chainflip/issue/PRO-1927/add-bouncer-affiliate-test-for-vault-swaps
- Fix bug in broker API - it was using the keyManager address.