### PR TITLE
feat: check if node is bonded before deregistering

### DIFF
--- a/state-chain/pallets/cf-account-roles/src/mock.rs
+++ b/state-chain/pallets/cf-account-roles/src/mock.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use crate::{self as pallet_cf_account_roles, Config};
+use cf_traits::mocks::deregistration_check::MockDeregistrationCheck;
 use frame_support::derive_impl;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -24,6 +25,7 @@ impl frame_system::Config for Test {
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureGovernance = frame_system::EnsureRoot<<Self as frame_system::Config>::AccountId>;
+	type DeregistrationCheck = MockDeregistrationCheck<Self::AccountId>;
 	type WeightInfo = ();
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -535,6 +535,7 @@ impl pallet_cf_lp::Config for Runtime {
 impl pallet_cf_account_roles::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type EnsureGovernance = pallet_cf_governance::EnsureGovernance;
+	type DeregistrationCheck = Bonder<Self>;
 	type WeightInfo = ();
 }
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -833,6 +833,25 @@ pub trait AccountRoleRegistry<T: frame_system::Config> {
 	}
 }
 
+pub trait DeregistrationCheck {
+	type AccountId;
+	type Error: Into<DispatchError>;
+	fn check(account_id: &Self::AccountId) -> Result<(), Self::Error>;
+}
+
+impl<A: DeregistrationCheck, B: DeregistrationCheck<AccountId = A::AccountId>> DeregistrationCheck
+	for (A, B)
+{
+	type AccountId = A::AccountId;
+	type Error = DispatchError;
+
+	fn check(account_id: &Self::AccountId) -> Result<(), DispatchError> {
+		A::check(account_id)
+			.map_err(Into::into)
+			.and_then(|()| B::check(account_id).map_err(Into::into))
+	}
+}
+
 #[derive(
 	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, TypeInfo, MaxEncodedLen, RuntimeDebug,
 )]

--- a/state-chain/traits/src/mocks.rs
+++ b/state-chain/traits/src/mocks.rs
@@ -17,6 +17,7 @@ pub mod ceremony_id_provider;
 pub mod cfe_interface_mock;
 pub mod chain_tracking;
 pub mod deposit_handler;
+pub mod deregistration_check;
 pub mod egress_handler;
 pub mod ensure_origin_mock;
 pub mod epoch_info;

--- a/state-chain/traits/src/mocks/deregistration_check.rs
+++ b/state-chain/traits/src/mocks/deregistration_check.rs
@@ -1,0 +1,40 @@
+use crate::DeregistrationCheck;
+use codec::{Decode, Encode};
+use sp_std::marker::PhantomData;
+
+use super::{MockPallet, MockPalletStorage};
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct MockDeregistrationCheck<Id>(PhantomData<Id>);
+
+impl<Id> MockPallet for MockDeregistrationCheck<Id> {
+	const PREFIX: &'static [u8] = b"cf-mocks//DeregistrationCheck";
+}
+
+const SHOULD_FAIL: &[u8] = b"SHOULD_FAIL";
+
+impl<Id: Encode + Decode> MockDeregistrationCheck<Id> {
+	pub fn set_should_fail(account_id: &Id, should_fail: bool) {
+		if should_fail {
+			<Self as MockPalletStorage>::put_storage(SHOULD_FAIL, account_id, ());
+		} else {
+			Self::take_storage::<_, Id>(SHOULD_FAIL, account_id);
+		}
+	}
+	fn should_fail(account_id: &Id) -> bool {
+		<Self as MockPalletStorage>::get_storage::<_, ()>(SHOULD_FAIL, account_id).is_some()
+	}
+}
+
+impl<Id: Encode + Decode> DeregistrationCheck for MockDeregistrationCheck<Id> {
+	type AccountId = Id;
+	type Error = &'static str;
+
+	fn check(account_id: &Self::AccountId) -> Result<(), Self::Error> {
+		if Self::should_fail(account_id) {
+			Err("Cannot deregister.")
+		} else {
+			Ok(())
+		}
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1831

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Adds a check to ensure accounts are unbonded before allowing deregistration. We already implicitly required this but it seemed to good to have an explicit check. 
