### PR TITLE
feat: add bond to broker cf_account_info

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -239,6 +239,7 @@ pub enum RpcAccountInfo {
 	},
 	Broker {
 		flip_balance: NumberOrHex,
+		bond: NumberOrHex,
 		earned_fees: any::AssetMap<NumberOrHex>,
 		affiliates: Vec<(AffiliateShortId, AccountId)>,
 		btc_vault_deposit_address: Option<String>,
@@ -275,6 +276,7 @@ impl RpcAccountInfo {
 	fn broker(broker_info: BrokerInfo, balance: u128) -> Self {
 		Self::Broker {
 			flip_balance: balance.into(),
+			bond: broker_info.bond.into(),
 			btc_vault_deposit_address: broker_info.btc_vault_deposit_address,
 			earned_fees: cf_chains::assets::any::AssetMap::from_iter_or_default(
 				broker_info
@@ -2180,6 +2182,7 @@ mod test {
 					ScriptPubkey::Taproot([1u8; 32]).to_address(&BitcoinNetwork::Testnet),
 				),
 				affiliates: vec![(cf_primitives::AffiliateShortId(1), AccountId32::new([1; 32]))],
+				bond: 0,
 			},
 			0,
 		);

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -3,4 +3,4 @@ source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
 snapshot_kind: text
 ---
-{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT"]],"btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT"]],"bond":"0x0","btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1966,6 +1966,7 @@ impl_runtime_apis! {
 		fn cf_broker_info(
 			account_id: AccountId,
 		) -> BrokerInfo {
+			let account_info = pallet_cf_flip::Account::<Runtime>::get(&account_id);
 			BrokerInfo {
 				earned_fees: Asset::all().map(|asset|
 					(asset, AssetBalances::get_balance(&account_id, asset))
@@ -1973,6 +1974,7 @@ impl_runtime_apis! {
 				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
 					.map(derive_btc_vault_deposit_address),
 				affiliates: pallet_cf_swapping::AffiliateIdMapping::<Runtime>::iter_prefix(&account_id).collect(),
+				bond: account_info.bond()
 			}
 		}
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -111,8 +111,8 @@ pub enum ChainflipAccountStateWithPassive {
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]
 pub struct ValidatorInfo {
-	pub balance: u128,
-	pub bond: u128,
+	pub balance: AssetAmount,
+	pub bond: AssetAmount,
 	pub last_heartbeat: u32, // can *maybe* remove this - check with Andrew
 	pub reputation_points: i32,
 	pub keyholder_epochs: Vec<EpochIndex>,
@@ -123,7 +123,7 @@ pub struct ValidatorInfo {
 	pub is_bidding: bool,
 	pub bound_redeem_address: Option<EthereumAddress>,
 	pub apy_bp: Option<u32>, // APY for validator/back only. In Basis points.
-	pub restricted_balances: BTreeMap<EthereumAddress, u128>,
+	pub restricted_balances: BTreeMap<EthereumAddress, AssetAmount>,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Clone)]
@@ -202,7 +202,7 @@ pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
 	pub btc_vault_deposit_address: Option<String>,
 	pub affiliates: Vec<(AffiliateShortId, AccountId32)>,
-	pub bond: u128,
+	pub bond: AssetAmount,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -202,6 +202,7 @@ pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
 	pub btc_vault_deposit_address: Option<String>,
 	pub affiliates: Vec<(AffiliateShortId, AccountId32)>,
+	pub bond: u128,
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1911

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Just added the bond to the `RpcAccountInfo` Broker variant. So now the `cf_account_info` RPC will show the bond.
Updated the snapshot for the RPC, but  I'm pretty sure this will not break anything because its just adding a field.
