### PR TITLE
fix: broker get affiliates rpc

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -303,7 +303,11 @@ impl RpcServer for RpcServerImpl {
 	}
 
 	async fn get_affiliates(&self) -> RpcResult<Vec<(AffiliateShortId, AccountId32)>> {
-		Ok(self.api.raw_client().get_affiliates().await?)
+		Ok(self
+			.api
+			.raw_client()
+			.cf_get_affiliates(self.api.state_chain_client.account_id(), None)
+			.await?)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix for the `broker_get_affiliates` RPC returning "Method not found".
Not sure why the compiler did not pick this up. I guess I only tested the `cf_get_affiliates` directly and not on the broker api. woops.
