### PR TITLE
fix: only apply minimum deposit check on deposit process if it hasn't been boosted

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1915,7 +1915,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Completes a single deposit request.
 	#[transactional]
-	pub(crate) fn process_channel_deposit_full_witness_inner(
+	fn process_channel_deposit_full_witness_inner(
 		DepositWitness { deposit_address, asset, amount, deposit_details }: &DepositWitness<
 			T::TargetChain,
 		>,
@@ -2024,7 +2024,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	pub(crate) fn process_prewitness_deposit_inner(
+	fn process_prewitness_deposit_inner(
 		amount: TargetChainAmount<T, I>,
 		asset: TargetChainAsset<T, I>,
 		deposit_details: <T::TargetChain as Chain>::DepositDetails,
@@ -2222,7 +2222,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	pub(crate) fn process_full_witness_deposit_inner(
+	fn process_full_witness_deposit_inner(
 		deposit_address: Option<TargetChainAccount<T, I>>,
 		asset: TargetChainAsset<T, I>,
 		deposit_amount: TargetChainAmount<T, I>,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2236,34 +2236,35 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		block_height: TargetChainBlockNumber<T, I>,
 		origin: DepositOrigin<T, I>,
 	) -> Result<FullWitnessDepositOutcome, DepositFailedReason> {
-		let boosted = matches!(boost_status, BoostStatus::Boosted { .. });
+		if !matches!(boost_status, BoostStatus::Boosted { .. }) {
+			if deposit_amount < MinimumDeposit::<T, I>::get(asset) {
+				// If the deposit amount is below the minimum allowed, the deposit is ignored.
+				// TODO: track these funds somewhere, for example add them to the withheld fees.
+				return Err(DepositFailedReason::BelowMinimumDeposit);
+			}
+			if let Some(tx_id) = deposit_details.deposit_id() {
+				// Only consider rejecting a transaction if we haven't already boosted it,
+				// since by boosting the protocol is committing to accept the deposit.
+				if TransactionsMarkedForRejection::<T, I>::take(broker, &tx_id).is_some() {
+					let refund_address = match &action {
+						ChannelAction::Swap { refund_params, .. } => refund_params
+							.as_ref()
+							.map(|refund_params| refund_params.refund_address.clone()),
+						ChannelAction::LiquidityProvision { refund_address, .. } =>
+							refund_address.clone(),
+					};
 
-		if !boosted && deposit_amount < MinimumDeposit::<T, I>::get(asset) {
-			// If the deposit amount is below the minimum allowed, the deposit is ignored.
-			// TODO: track these funds somewhere, for example add them to the withheld fees.
-			return Err(DepositFailedReason::BelowMinimumDeposit);
-		}
+					ScheduledTransactionsForRejection::<T, I>::append(
+						TransactionRejectionDetails {
+							refund_address,
+							amount: deposit_amount,
+							asset,
+							deposit_details: deposit_details.clone(),
+						},
+					);
 
-		if let Some(tx_id) = deposit_details.deposit_id() {
-			// Only consider rejecting a transaction if we haven't already boosted it,
-			// since by boosting the protocol is committing to accept the deposit.
-			if TransactionsMarkedForRejection::<T, I>::take(broker, &tx_id).is_some() && !boosted {
-				let refund_address = match &action {
-					ChannelAction::Swap { refund_params, .. } => refund_params
-						.as_ref()
-						.map(|refund_params| refund_params.refund_address.clone()),
-					ChannelAction::LiquidityProvision { refund_address, .. } =>
-						refund_address.clone(),
-				};
-
-				ScheduledTransactionsForRejection::<T, I>::append(TransactionRejectionDetails {
-					refund_address,
-					amount: deposit_amount,
-					asset,
-					deposit_details: deposit_details.clone(),
-				});
-
-				return Err(DepositFailedReason::TransactionRejectedByBroker);
+					return Err(DepositFailedReason::TransactionRejectedByBroker);
+				}
 			}
 		}
 

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -1,4 +1,3 @@
-
 pub use crate::{self as pallet_cf_ingress_egress};
 use crate::{DepositWitness, PalletSafeMode};
 

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -1,4 +1,5 @@
- pub use crate::{self as pallet_cf_ingress_egress};
+
+pub use crate::{self as pallet_cf_ingress_egress};
 use crate::{DepositWitness, PalletSafeMode};
 
 use cf_chains::eth::EthereumTrackedData;

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -1,4 +1,4 @@
-pub use crate::{self as pallet_cf_ingress_egress};
+ pub use crate::{self as pallet_cf_ingress_egress};
 use crate::{DepositWitness, PalletSafeMode};
 
 use cf_chains::eth::EthereumTrackedData;


### PR DESCRIPTION
# Pull Request

Closes: PRO-1846

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Introduces a check on full deposit that a channel has not been boosted. The reason for this is that we want to catch the edge case where we would ignore the finalization of a boosted channel when the deposit minimum increases between the prewitness and the full witness stage.

#### Non-Breaking changes

If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.
