### PR TITLE
fix: revert adding expires_at to vault swap details

### DIFF
--- a/bouncer/tests/btc_vault_swap.ts
+++ b/bouncer/tests/btc_vault_swap.ts
@@ -30,7 +30,6 @@ interface BtcVaultSwapDetails {
   chain: string;
   nulldata_payload: string;
   deposit_address: string;
-  expires_at: number;
 }
 
 interface BtcVaultSwapExtraParameters {
@@ -88,20 +87,6 @@ export async function buildAndSendBtcVaultSwap(
   assert.strictEqual(BtcVaultSwapDetails.chain, 'Bitcoin');
   testBtcVaultSwap.debugLog('nulldata_payload:', BtcVaultSwapDetails.nulldata_payload);
   testBtcVaultSwap.debugLog('deposit_address:', BtcVaultSwapDetails.deposit_address);
-  testBtcVaultSwap.debugLog('expires_at:', BtcVaultSwapDetails.expires_at);
-
-  // Calculate expected expiry time assuming block time is 6 secs, expires_at = time left to next rotation
-  const epochDuration = (await chainflip.rpc(`cf_epoch_duration`)) as number;
-  const epochStartedAt = (await chainflip.rpc(`cf_current_epoch_started_at`)) as number;
-  const currentBlockNumber = (await chainflip.rpc.chain.getHeader()).number.toNumber();
-  const blocksUntilNextRotation = epochDuration + epochStartedAt - currentBlockNumber;
-  const expectedExpiresAt = Date.now() + blocksUntilNextRotation * 6000;
-  // Check that expires_at field is correct (within 20 secs drift)
-  assert(
-    Math.abs(expectedExpiresAt - BtcVaultSwapDetails.expires_at) <= 20 * 1000,
-    `BtcVaultSwapDetails expiry timestamp is not within a 20 secs drift of the expected expiry time.
-      expectedExpiresAt = ${expectedExpiresAt} and actualExpiresAt = ${BtcVaultSwapDetails.expires_at}`,
-  );
 
   const txid = await sendVaultTransaction(
     BtcVaultSwapDetails.nulldata_payload,

--- a/state-chain/runtime/src/chainflip/vault_swaps.rs
+++ b/state-chain/runtime/src/chainflip/vault_swaps.rs
@@ -58,7 +58,6 @@ pub fn bitcoin_vault_swap(
 	boost_fee: u8,
 	affiliate_fees: Affiliates<AccountId>,
 	dca_parameters: Option<DcaParameters>,
-	expires_at: u64,
 ) -> Result<VaultSwapDetails<String>, DispatchErrorWithMessage> {
 	let private_channel_id =
 		pallet_cf_swapping::BrokerPrivateBtcChannels::<Runtime>::get(&broker_id)
@@ -96,7 +95,6 @@ pub fn bitcoin_vault_swap(
 	Ok(VaultSwapDetails::Bitcoin {
 		nulldata_payload: encode_swap_params_in_nulldata_payload(params),
 		deposit_address: derive_btc_vault_deposit_address(private_channel_id),
-		expires_at,
 	})
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2302,23 +2302,6 @@ impl_runtime_apis! {
 				) => {
 					pallet_cf_swapping::Pallet::<Runtime>::validate_refund_params(retry_duration)?;
 
-					// Payload expiry time is set to time left to next rotation.
-					// 	* For BTC: the actual expiry time is 2 rotations, but we deliberately set expires_at to be the time left to next
-					//    rotation to cater for the case when a forced rotation happens between when the payload was requested and
-					//    before expires_at. BTC funds can be lost in 3 cases:
-					// 		* User makes the vault transaction after expires_at, and it happens that we did a forced rotation in between
-					//      * User submits the vault transaction 3 days (1 epoch) after expires_at, and with no forced rotations in between
-					//      * We do 2 forced rotations in between payload request and expires_at
-					//  * For SOLANA: The actual expiry time is indeed time left to next rotation. If a forced rotation
-					//    happens in between as explained before, it is actually not a problem as the user won't lose any funds.
-					//  * For ETH: payload never expires hence we don't send expires_at
-					let current_block = System::block_number();
-					let (Some(next_rotation_block), _) = Validator::estimate_next_session_rotation(current_block) else {
-						Err(pallet_cf_validator::Error::<Runtime>::InvalidEpochDuration)?
-					};
-					let blocks_until_next_rotation = next_rotation_block.saturating_sub(current_block);
-					let expires_at = Timestamp::now() + blocks_until_next_rotation as u64 * SLOT_DURATION;
-
 					crate::chainflip::vault_swaps::bitcoin_vault_swap(
 						broker_id,
 						destination_asset,
@@ -2329,7 +2312,6 @@ impl_runtime_apis! {
 						boost_fee,
 						affiliate_fees,
 						dca_parameters,
-						expires_at,
 					)
 				},
 				(

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -123,10 +123,7 @@ use sp_runtime::{
 	BoundedVec,
 };
 
-use frame_support::{
-	genesis_builder_helper::build_state,
-	traits::{EstimateNextSessionRotation, Time},
-};
+use frame_support::genesis_builder_helper::build_state;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -44,8 +44,6 @@ pub enum VaultSwapDetails<BtcAddress> {
 		#[serde(with = "sp_core::bytes")]
 		nulldata_payload: Vec<u8>,
 		deposit_address: BtcAddress,
-		/// Payload expiry time, expressed as timestamp since the UNIX_EPOCH in milliseconds
-		expires_at: u64,
 	},
 	Ethereum {
 		#[serde(flatten)]
@@ -83,12 +81,8 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 		F: FnOnce(BtcAddress) -> T,
 	{
 		match self {
-			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address, expires_at } =>
-				VaultSwapDetails::Bitcoin {
-					nulldata_payload,
-					deposit_address: f(deposit_address),
-					expires_at,
-				},
+			VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address } =>
+				VaultSwapDetails::Bitcoin { nulldata_payload, deposit_address: f(deposit_address) },
 			VaultSwapDetails::Solana { instruction } => VaultSwapDetails::Solana { instruction },
 			VaultSwapDetails::Ethereum { details } => VaultSwapDetails::Ethereum { details },
 			VaultSwapDetails::Arbitrum { details } => VaultSwapDetails::Arbitrum { details },


### PR DESCRIPTION
# Pull Request

Closes: PRO-1851

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* This PR removes the logic for adding expires_at field to BTC. 
* Also corresponding bouncer test logic is also removed
