### PR TITLE
chore: make broker id explicitly optional for vault swaps

### DIFF
--- a/engine/src/witness/btc/vault_swaps.rs
+++ b/engine/src/witness/btc/vault_swaps.rs
@@ -147,10 +147,10 @@ pub fn try_extract_vault_swap_witness(
 			deposit_address: vault_address.clone(),
 		},
 		deposit_metadata: None, // No ccm for BTC (yet?)
-		broker_fee: Beneficiary {
+		broker_fee: Some(Beneficiary {
 			account: broker_id.clone(),
 			bps: data.parameters.broker_fee.into(),
-		},
+		}),
 		affiliate_fees: data
 			.parameters
 			.affiliates
@@ -320,10 +320,10 @@ mod tests {
 					amount: DEPOSIT_AMOUNT,
 					deposit_address: vault_deposit_address.clone(),
 				},
-				broker_fee: Beneficiary {
+				broker_fee: Some(Beneficiary {
 					account: BROKER,
 					bps: MOCK_SWAP_PARAMS.parameters.broker_fee.into()
-				},
+				}),
 				affiliate_fees: bounded_vec![MOCK_SWAP_PARAMS.parameters.affiliates[0].into()],
 				deposit_metadata: None,
 				refund_params: Some(ChannelRefundParametersDecoded {

--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -254,7 +254,6 @@ macro_rules! vault_deposit_witness {
 				deposit_address: None,
 			}
 		} else {
-			use cf_primitives::Beneficiary;
 			VaultDepositWitness {
 				input_asset: $source_asset.try_into().expect("invalid asset for chain"),
 				output_asset: $dest_asset,
@@ -263,10 +262,7 @@ macro_rules! vault_deposit_witness {
 				deposit_metadata: $metadata,
 				tx_id: $tx_id,
 				deposit_details: DepositDetails { tx_hashes: Some(vec![$tx_id]) },
-				broker_fee: Beneficiary {
-					account: sp_runtime::AccountId32::new([0; 32]),
-					bps: 0,
-				},
+				broker_fee: None,
 				affiliate_fees: Default::default(),
 				boost_fee: 0,
 				dca_params: None,

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -378,10 +378,7 @@ fn vault_swap_deposit_witness(
 		deposit_metadata,
 		tx_id: Default::default(),
 		deposit_details: (),
-		broker_fee: cf_primitives::Beneficiary {
-			account: sp_runtime::AccountId32::new([0; 32]),
-			bps: 0,
-		},
+		broker_fee: None,
 		affiliate_fees: Default::default(),
 		refund_params: Some(REFUND_PARAMS),
 		dca_params: None,

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -530,10 +530,7 @@ fn vault_swap_deposit_witness(
 		deposit_metadata: Some(ccm_deposit_metadata_mock()),
 		tx_id: Default::default(),
 		deposit_details: DepositDetails { tx_hashes: None },
-		broker_fee: cf_primitives::Beneficiary {
-			account: sp_runtime::AccountId32::new([0; 32]),
-			bps: 0,
-		},
+		broker_fee: None,
 		affiliate_fees: Default::default(),
 		refund_params: Some(ETH_REFUND_PARAMS),
 		dca_params: None,

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -679,9 +679,19 @@ pub enum SwapOrigin<AccountId> {
 	},
 	Vault {
 		tx_id: TransactionInIdForAnyChain,
-		broker_id: AccountId,
+		broker_id: Option<AccountId>,
 	},
 	Internal,
+}
+
+impl<AccountId> SwapOrigin<AccountId> {
+	pub fn broker_id(&self) -> Option<&AccountId> {
+		match self {
+			Self::DepositChannel { ref broker_id, .. } => Some(broker_id),
+			Self::Vault { ref broker_id, .. } => broker_id.as_ref(),
+			Self::Internal => None,
+		}
+	}
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -314,7 +314,7 @@ mod benchmarks {
 				deposit_metadata: Some(deposit_metadata),
 				tx_id: TransactionInIdFor::<T, I>::benchmark_value(),
 				deposit_details: BenchmarkValue::benchmark_value(),
-				broker_fee: cf_primitives::Beneficiary { account: account("broker", 0, 0), bps: 0 },
+				broker_fee: None,
 				affiliate_fees: Default::default(),
 				refund_params: Some(ChannelRefundParametersDecoded {
 					retry_duration: Default::default(),

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -164,12 +164,12 @@ mod deposit_origin {
 		},
 		Vault {
 			tx_id: TransactionInIdFor<T, I>,
-			broker_id: T::AccountId,
+			broker_id: Option<T::AccountId>,
 		},
 	}
 
 	impl<T: Config<I>, I: 'static> DepositOrigin<T, I> {
-		pub(super) fn deposit_channel(
+		pub fn deposit_channel(
 			deposit_address: <T::TargetChain as Chain>::ChainAccount,
 			channel_id: ChannelId,
 			deposit_block_height: <T::TargetChain as Chain>::ChainBlockNumber,
@@ -183,8 +183,15 @@ mod deposit_origin {
 			}
 		}
 
-		pub(super) fn vault(tx_id: TransactionInIdFor<T, I>, broker_id: T::AccountId) -> Self {
+		pub fn vault(tx_id: TransactionInIdFor<T, I>, broker_id: Option<T::AccountId>) -> Self {
 			DepositOrigin::Vault { tx_id, broker_id }
+		}
+
+		pub fn broker_id(&self) -> Option<&T::AccountId> {
+			match self {
+				Self::DepositChannel { ref broker_id, .. } => Some(broker_id),
+				Self::Vault { ref broker_id, .. } => broker_id.as_ref(),
+			}
 		}
 	}
 
@@ -391,7 +398,7 @@ pub mod pallet {
 		pub destination_address: EncodedAddress,
 		pub deposit_metadata: Option<CcmDepositMetadata>,
 		pub tx_id: TransactionInIdFor<T, I>,
-		pub broker_fee: Beneficiary<T::AccountId>,
+		pub broker_fee: Option<Beneficiary<T::AccountId>>,
 		pub affiliate_fees: Affiliates<AffiliateShortId>,
 		pub refund_params: Option<ChannelRefundParametersDecoded>,
 		pub dca_params: Option<DcaParameters>,
@@ -1840,7 +1847,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Some(deposit_address.clone()),
 			None, // source address is unknown
 			action,
-			&owner,
 			boost_fee,
 			boost_status,
 			Some(deposit_channel.channel_id),
@@ -1962,7 +1968,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			*amount,
 			deposit_details.clone(),
 			None, // source address is unknown
-			&deposit_channel_details.owner,
 			deposit_channel_details.boost_status,
 			deposit_channel_details.boost_fee,
 			Some(channel_id),
@@ -1999,14 +2004,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	fn assemble_broker_fees(
-		broker_fee: Beneficiary<T::AccountId>,
+		broker_fee: Option<Beneficiary<T::AccountId>>,
 		affiliate_fees: Affiliates<AffiliateShortId>,
 	) -> Beneficiaries<T::AccountId> {
-		let primary_broker = broker_fee.account.clone();
-
-		if T::AccountRoleRegistry::has_account_role(&primary_broker, AccountRole::Broker) {
-			[broker_fee]
-				.into_iter()
+		broker_fee
+			.as_ref()
+			.filter(|Beneficiary { account, .. }| {
+				if T::AccountRoleRegistry::has_account_role(account, AccountRole::Broker) {
+					true
+				} else {
+					Self::deposit_event(Event::<T, I>::UnknownBroker {
+						broker_id: account.clone(),
+					});
+					false
+				}
+			})
+			.map(|primary_broker_fee| {
+				let primary_broker = primary_broker_fee.account.clone();
+				core::iter::once(primary_broker_fee.clone())
 				.chain(affiliate_fees.into_iter().filter_map(
 					|Beneficiary { account: short_affiliate_id, bps }| {
 						if let Some(affiliate_id) = T::AffiliateRegistry::get_account_id(
@@ -2031,10 +2046,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				.expect(
 					"must fit since affiliates are limited to 1 fewer element than beneficiaries",
 				)
-		} else {
-			Self::deposit_event(Event::<T, I>::UnknownBroker { broker_id: primary_broker });
-			Default::default()
-		}
+			})
+			.unwrap_or_default()
 	}
 
 	fn process_prewitness_deposit_inner(
@@ -2044,7 +2057,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		deposit_address: Option<TargetChainAccount<T, I>>,
 		source_address: Option<ForeignChainAddress>,
 		action: ChannelAction<T::AccountId>,
-		broker: &T::AccountId,
 		boost_fee: u16,
 		boost_status: BoostStatus<TargetChainAmount<T, I>>,
 		channel_id: Option<u64>,
@@ -2057,8 +2069,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			return None;
 		}
 
-		if let Some(tx_id) = deposit_details.deposit_id() {
-			if TransactionsMarkedForRejection::<T, I>::mutate(broker, &tx_id, |opt| {
+		if let (Some(tx_id), Some(broker_id)) = (deposit_details.deposit_id(), origin.broker_id()) {
+			if TransactionsMarkedForRejection::<T, I>::mutate(broker_id, &tx_id, |opt| {
 				match opt.as_mut() {
 					// Transaction has been reported, mark it as pre-witnessed.
 					Some(status @ TransactionPrewitnessedStatus::Unseen) => {
@@ -2194,8 +2206,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 		}
 
-		let broker = broker_fee.account.clone();
-
+		let origin = DepositOrigin::vault(
+			tx_id.clone(),
+			broker_fee.as_ref().map(|Beneficiary { account, .. }| account.clone()),
+		);
 		let broker_fees = Self::assemble_broker_fees(broker_fee, affiliate_fees);
 
 		let (channel_metadata, source_address) = match deposit_metadata {
@@ -2215,8 +2229,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let boost_status =
 			BoostedVaultTransactions::<T, I>::get(&tx_id).unwrap_or(BoostStatus::NotBoosted);
 
-		let origin = DepositOrigin::vault(tx_id.clone(), broker.clone());
-
 		if let Some(new_boost_status) = Self::process_prewitness_deposit_inner(
 			amount,
 			asset,
@@ -2224,7 +2236,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_address,
 			source_address,
 			action,
-			&broker,
 			boost_fee,
 			boost_status,
 			channel_id,
@@ -2241,7 +2252,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		deposit_amount: TargetChainAmount<T, I>,
 		deposit_details: <T::TargetChain as Chain>::DepositDetails,
 		source_address: Option<ForeignChainAddress>,
-		broker: &T::AccountId,
 		boost_status: BoostStatus<TargetChainAmount<T, I>>,
 		max_boost_fee_bps: BasisPoints,
 		channel_id: Option<u64>,
@@ -2255,10 +2265,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				// TODO: track these funds somewhere, for example add them to the withheld fees.
 				return Err(DepositFailedReason::BelowMinimumDeposit);
 			}
-			if let Some(tx_id) = deposit_details.deposit_id() {
+			if let (Some(tx_id), Some(broker_id)) =
+				(deposit_details.deposit_id(), origin.broker_id())
+			{
 				// Only consider rejecting a transaction if we haven't already boosted it,
 				// since by boosting the protocol is committing to accept the deposit.
-				if TransactionsMarkedForRejection::<T, I>::take(broker, &tx_id).is_some() {
+				if TransactionsMarkedForRejection::<T, I>::take(broker_id, &tx_id).is_some() {
 					let refund_address = match &action {
 						ChannelAction::Swap { refund_params, .. } => refund_params
 							.as_ref()
@@ -2462,10 +2474,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				},
 			};
 
-		let broker = broker_fee.account.clone();
+		let deposit_origin = DepositOrigin::vault(
+			tx_id.clone(),
+			broker_fee.as_ref().map(|Beneficiary { account, .. }| account.clone()),
+		);
 		let broker_fees = Self::assemble_broker_fees(broker_fee.clone(), affiliate_fees.clone());
-
-		let deposit_origin = DepositOrigin::vault(tx_id.clone(), broker.clone());
 
 		if T::SwapLimitsProvider::validate_broker_fees(&broker_fees).is_err() {
 			emit_deposit_failed_event(DepositFailedReason::InvalidBrokerFees);
@@ -2527,7 +2540,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_amount,
 			deposit_details.clone(),
 			source_address,
-			&broker,
 			boost_status,
 			boost_fee,
 			channel_id,

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1825,7 +1825,7 @@ fn submit_vault_swap_request(
 			destination_address,
 			deposit_metadata,
 			tx_id,
-			broker_fee,
+			broker_fee: Some(broker_fee),
 			affiliate_fees,
 			refund_params: Some(refund_params),
 			dca_params,
@@ -1869,7 +1869,7 @@ fn can_request_swap_via_extrinsic() {
 				broker_fees: bounded_vec![Beneficiary { account: BROKER, bps: 0 }],
 				origin: SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			},]
 		);
@@ -1934,7 +1934,7 @@ fn vault_swaps_support_affiliate_fees() {
 				],
 				origin: SwapOrigin::Vault {
 					tx_id: cf_chains::TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			},]
 		);
@@ -1986,7 +1986,7 @@ fn charge_no_broker_fees_on_unknown_primary_broker() {
 				broker_fees: Default::default(),
 				origin: SwapOrigin::Vault {
 					tx_id: cf_chains::TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: NOT_A_BROKER,
+					broker_id: Some(NOT_A_BROKER),
 				},
 			},]
 		);
@@ -2046,7 +2046,7 @@ fn can_request_ccm_swap_via_extrinsic() {
 				broker_fees: bounded_vec![Beneficiary { account: BROKER, bps: 0 }],
 				origin: SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			},]
 		);
@@ -2231,7 +2231,7 @@ fn assembling_broker_fees() {
 			Beneficiary { account: 50, bps: 5 },
 		];
 
-		assert_eq!(IngressEgress::assemble_broker_fees(broker_fee, affiliate_fees), expected);
+		assert_eq!(IngressEgress::assemble_broker_fees(Some(broker_fee), affiliate_fees), expected);
 	});
 }
 
@@ -2250,13 +2250,12 @@ fn ignore_change_of_minimum_deposit_if_deposit_is_not_boosted() {
 				DEPOSIT_AMOUNT,
 				Default::default(),
 				None,
-				&BROKER,
 				BoostStatus::NotBoosted,
 				0,
 				None,
 				ChannelAction::LiquidityProvision { lp_account: 0, refund_address: None },
 				0,
-				DepositOrigin::Vault { tx_id: H256::default(), broker_id: BROKER },
+				DepositOrigin::Vault { tx_id: H256::default(), broker_id: Some(BROKER) },
 			)
 			.err(),
 			Some(DepositFailedReason::BelowMinimumDeposit)
@@ -2268,7 +2267,6 @@ fn ignore_change_of_minimum_deposit_if_deposit_is_not_boosted() {
 			DEPOSIT_AMOUNT,
 			Default::default(),
 			None,
-			&BROKER,
 			BoostStatus::Boosted {
 				prewitnessed_deposit_id: 0,
 				pools: vec![],
@@ -2278,7 +2276,7 @@ fn ignore_change_of_minimum_deposit_if_deposit_is_not_boosted() {
 			None,
 			ChannelAction::LiquidityProvision { lp_account: 0, refund_address: None },
 			0,
-			DepositOrigin::Vault { tx_id: H256::default(), broker_id: BROKER },
+			DepositOrigin::Vault { tx_id: H256::default(), broker_id: Some(BROKER) },
 		)
 		.is_ok());
 	});

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1197,7 +1197,7 @@ mod vault_swaps {
 				),
 				deposit_metadata: None,
 				tx_id,
-				broker_fee: Beneficiary { account: BROKER, bps: 5 },
+				broker_fee: Some(Beneficiary { account: BROKER, bps: 5 }),
 				affiliate_fees: Default::default(),
 				refund_params: Some(ChannelRefundParametersDecoded {
 					retry_duration: 2,
@@ -1235,7 +1235,7 @@ mod vault_swaps {
 						broker_fees: bounded_vec![Beneficiary { account: BROKER, bps: 5 }],
 						origin: SwapOrigin::Vault {
 							tx_id: TransactionInIdForAnyChain::Evm(tx_id),
-							broker_id: BROKER
+							broker_id: Some(BROKER)
 						},
 					},]
 				);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -213,7 +213,7 @@ fn insert_swaps(swaps: &[TestSwapParams]) {
 			swap.dca_params.clone(),
 			SwapOrigin::Vault {
 				tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-				broker_id: BROKER,
+				broker_id: Some(BROKER),
 			},
 		);
 	}
@@ -348,7 +348,7 @@ fn cannot_swap_with_incorrect_destination_address_type() {
 			None,
 			SwapOrigin::Vault {
 				tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-				broker_id: BROKER,
+				broker_id: Some(BROKER),
 			},
 		);
 
@@ -525,7 +525,7 @@ fn process_all_into_stable_swaps_first() {
 					None,
 					SwapOrigin::Vault {
 						tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-						broker_id: BROKER,
+						broker_id: Some(BROKER),
 					},
 				);
 			});
@@ -663,7 +663,7 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 
@@ -1322,7 +1322,7 @@ fn swap_output_amounts_correctly_account_for_fees() {
 					None,
 					SwapOrigin::Vault {
 						tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-						broker_id: BROKER,
+						broker_id: Some(BROKER),
 					},
 				);
 

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -9,7 +9,7 @@ fn init_ccm_swap_request(input_asset: Asset, output_asset: Asset, input_amount: 
 	let encoded_output_address = MockAddressConverter::to_encoded_address(output_address.clone());
 	let origin = SwapOrigin::Vault {
 		tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-		broker_id: BROKER,
+		broker_id: Some(BROKER),
 	};
 
 	Swapping::init_swap_request(
@@ -111,7 +111,7 @@ fn can_process_ccms_via_swap_deposit_address() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -125,7 +125,7 @@ fn max_swap_amount_can_be_removed() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 		};
@@ -226,7 +226,7 @@ fn can_swap_below_max_amount() {
 			None,
 			SwapOrigin::Vault {
 				tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-				broker_id: BROKER,
+				broker_id: Some(BROKER),
 			},
 		);
 

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -687,7 +687,7 @@ fn test_minimum_chunk_size() {
 			Some(dca_params),
 			SwapOrigin::Vault {
 				tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-				broker_id: BROKER,
+				broker_id: Some(BROKER),
 			},
 		);
 

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -42,7 +42,7 @@ fn swap_output_amounts_correctly_account_for_fees() {
 					None,
 					SwapOrigin::Vault {
 						tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-						broker_id: BROKER,
+						broker_id: Some(BROKER),
 					},
 				);
 
@@ -373,7 +373,7 @@ fn input_amount_excludes_network_fee() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 		})
@@ -579,7 +579,7 @@ fn min_network_fee_is_enforced_in_regular_swaps() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 
@@ -600,7 +600,7 @@ fn min_network_fee_is_enforced_in_regular_swaps() {
 				None,
 				SwapOrigin::Vault {
 					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-					broker_id: BROKER,
+					broker_id: Some(BROKER),
 				},
 			);
 		})

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -590,7 +590,7 @@ impl
 				destination_address: swap_details.destination_address,
 				deposit_metadata: swap_details.deposit_metadata,
 				tx_id: (swap_details.swap_account, swap_details.creation_slot),
-				broker_fee: swap_details.broker_fee,
+				broker_fee: Some(swap_details.broker_fee),
 				affiliate_fees: swap_details.affiliate_fees,
 				dca_params: swap_details.dca_params,
 				refund_params: Some(swap_details.refund_params),


### PR DESCRIPTION
# Pull Request

We were previously defaulting it to [0u8; 32] which is an invalid address and somewhat misleading as to the intent. 
