### PR TITLE
feat: bouncer test timeout diagnosis

### DIFF
--- a/bouncer/shared/executable_test_task_tracker.ts
+++ b/bouncer/shared/executable_test_task_tracker.ts
@@ -4,16 +4,13 @@ export const runningTests = new Set<ExecutableTest>();
 
 // Look at the call stack and find a known test file, matching against the list of all running test. Returns the test and the location of the call.
 function getTestFromStack(): { test: ExecutableTest; location: string } | undefined {
-  const originalFunc = Error.prepareStackTrace;
-
   try {
     const fakeError = new Error();
 
     if (fakeError.stack !== undefined) {
       const stack = fakeError.stack.split('\n');
       for (let i = 1; i < stack.length; i++) {
-        const fileName = stack[i].split(':')[0];
-        const lineNumber = stack[i].split(':')[1];
+        const [fileName, lineNumber] = stack[i].split(':');
         for (const test of runningTests) {
           if (fileName?.includes(test.fileName)) {
             return { test, location: `${test.filePath}:${lineNumber}` };
@@ -22,11 +19,9 @@ function getTestFromStack(): { test: ExecutableTest; location: string } | undefi
       }
     }
   } catch (e) {
-    Error.prepareStackTrace = originalFunc;
     console.error(e);
   }
 
-  Error.prepareStackTrace = originalFunc;
   return undefined;
 }
 

--- a/bouncer/shared/executable_test_task_tracker.ts
+++ b/bouncer/shared/executable_test_task_tracker.ts
@@ -1,0 +1,57 @@
+import { ExecutableTest } from './executable_test';
+
+export const runningTests = new Set<ExecutableTest>();
+
+// Look at the call stack and find a known test file, matching against the list of all running test. Returns the test and the location of the call.
+function getTestFromStack(): { test: ExecutableTest; location: string } | undefined {
+  const originalFunc = Error.prepareStackTrace;
+
+  try {
+    const fakeError = new Error();
+
+    if (fakeError.stack !== undefined) {
+      const stack = fakeError.stack.split('\n');
+      for (let i = 1; i < stack.length; i++) {
+        const fileName = stack[i].split(':')[0];
+        const lineNumber = stack[i].split(':')[1];
+        for (const test of runningTests) {
+          if (fileName?.includes(test.fileName)) {
+            return { test, location: `${test.filePath}:${lineNumber}` };
+          }
+        }
+      }
+    }
+  } catch (e) {
+    Error.prepareStackTrace = originalFunc;
+    console.error(e);
+  }
+
+  Error.prepareStackTrace = originalFunc;
+  return undefined;
+}
+
+export class TaskTracker {
+  private test: ExecutableTest | undefined;
+
+  private taskId: number | undefined;
+
+  constructor(name: string) {
+    const testDetails = getTestFromStack();
+    if (testDetails !== undefined) {
+      this.test = testDetails.test;
+      this.taskId = testDetails.test.startAwaiting(name, testDetails.location);
+    }
+  }
+
+  stopAwaiting() {
+    this.test?.stopAwaiting(this.taskId);
+  }
+}
+
+// Use to detect where timeouts are happening in tests.
+// Call at the start of any utility function that is expected to take some time to compete.
+// It returns a TaskTracker object that can be use to stop the tracking when the task is completed.
+// Please remember to stop the tracker at all places the function stops.
+export function startAwaitTask(name: string): TaskTracker {
+  return new TaskTracker(name);
+}

--- a/bouncer/tests/boost.ts
+++ b/bouncer/tests/boost.ts
@@ -38,16 +38,6 @@ export async function stopBoosting<T = any>(
 
   assert(boostTier > 0, 'Boost tier must be greater than 0');
 
-  const observeStoppedBoosting = observeEvent(
-    `${chainFromAsset(asset).toLowerCase()}IngressEgress:StoppedBoosting`,
-    {
-      test: (event) =>
-        event.data.boosterId === lp.address &&
-        event.data.boostPool.asset === asset &&
-        event.data.boostPool.tier === boostTier.toString(),
-    },
-  ).event;
-
   const extrinsicResult: any = await extrinsicSubmitter.submit(
     chainflip.tx[ingressEgressPalletForChain(chainFromAsset(asset))].stopBoosting(
       shortChainFromAsset(asset).toUpperCase(),
@@ -57,6 +47,16 @@ export async function stopBoosting<T = any>(
   );
   if (!extrinsicResult?.dispatchError) {
     console.log('waiting for stop boosting event');
+    const observeStoppedBoosting = observeEvent(
+      `${chainFromAsset(asset).toLowerCase()}IngressEgress:StoppedBoosting`,
+      {
+        test: (event) =>
+          event.data.boosterId === lp.address &&
+          event.data.boostPool.asset === asset &&
+          event.data.boostPool.tier === boostTier.toString(),
+        historicalCheckBlocks: 10,
+      },
+    ).event;
     return observeStoppedBoosting;
   }
   console.log('Already stopped boosting');

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -10,222 +10,222 @@ import { getChainflipApi } from '../shared/utils/substrate';
 import { deferredPromise, handleSubstrateError, shortChainFromAsset } from '../shared/utils';
 import { ExecutableTest } from '../shared/executable_test';
 
-const keyring = new Keyring({ type: 'sr25519' });
-keyring.setSS58Format(2112);
+async function main() {
+  const keyring = new Keyring({ type: 'sr25519' });
+  keyring.setSS58Format(2112);
 
-const account = keyring.addFromUri('//BROKER_2');
-const account2 = keyring.addFromUri('//BROKER_1');
-type NewSwapRequest = Parameters<(typeof broker)['buildExtrinsicPayload']>[0];
+  const account = keyring.addFromUri('//BROKER_2');
+  const account2 = keyring.addFromUri('//BROKER_1');
+  type NewSwapRequest = Parameters<(typeof broker)['buildExtrinsicPayload']>[0];
 
-const numberSchema = z.string().transform((n) => Number(n.replace(/,/g, '')));
-const bigintSchema = z.string().transform((n) => BigInt(n.replace(/,/g, '')));
+  const numberSchema = z.string().transform((n) => Number(n.replace(/,/g, '')));
+  const bigintSchema = z.string().transform((n) => BigInt(n.replace(/,/g, '')));
 
-const shortChainSchema = z.enum(['Btc', 'Eth', 'Arb', 'Dot', 'Sol']);
+  const shortChainSchema = z.enum(['Btc', 'Eth', 'Arb', 'Dot', 'Sol']);
 
-const addressTransforms = {
-  Btc: (address: string) => address,
-  Eth: (address: string) => address.toLowerCase(),
-  Arb: (address: string) => address.toLowerCase(),
-  Dot: (address: string) =>
-    isHex(address) ? ss58.encode({ data: address, ss58Format: 0 }) : address,
-  Sol: (address: string) => (isHex(address) ? base58.encode(hexToBytes(address)) : address),
-} as const;
+  const addressTransforms = {
+    Btc: (address: string) => address,
+    Eth: (address: string) => address.toLowerCase(),
+    Arb: (address: string) => address.toLowerCase(),
+    Dot: (address: string) =>
+      isHex(address) ? ss58.encode({ data: address, ss58Format: 0 }) : address,
+    Sol: (address: string) => (isHex(address) ? base58.encode(hexToBytes(address)) : address),
+  } as const;
 
-const eventSchema = z
-  .object({
-    event: z.object({
-      data: z.object({
-        destinationAddress: z.record(shortChainSchema, z.string()),
-        sourceAsset: z.string(),
-        destinationAsset: z.string(),
-        brokerCommissionRate: numberSchema,
-        channelMetadata: z
-          .object({ message: z.string(), gasBudget: bigintSchema, ccmAdditionalData: z.string() })
-          .nullable(),
-        boostFee: numberSchema,
-        affiliateFees: z.array(z.object({ account: z.string(), bps: numberSchema })),
-        refundParameters: z
-          .object({
-            retryDuration: numberSchema,
-            refundAddress: z.record(shortChainSchema, z.string()),
-            minPrice: bigintSchema,
-          })
-          .nullable(),
-        dcaParameters: z
-          .object({ numberOfChunks: numberSchema, chunkInterval: numberSchema })
-          .nullable(),
+  const eventSchema = z
+    .object({
+      event: z.object({
+        data: z.object({
+          destinationAddress: z.record(shortChainSchema, z.string()),
+          sourceAsset: z.string(),
+          destinationAsset: z.string(),
+          brokerCommissionRate: numberSchema,
+          channelMetadata: z
+            .object({ message: z.string(), gasBudget: bigintSchema, ccmAdditionalData: z.string() })
+            .nullable(),
+          boostFee: numberSchema,
+          affiliateFees: z.array(z.object({ account: z.string(), bps: numberSchema })),
+          refundParameters: z
+            .object({
+              retryDuration: numberSchema,
+              refundAddress: z.record(shortChainSchema, z.string()),
+              minPrice: bigintSchema,
+            })
+            .nullable(),
+          dcaParameters: z
+            .object({ numberOfChunks: numberSchema, chunkInterval: numberSchema })
+            .nullable(),
+        }),
       }),
-    }),
-  })
-  .transform((event) => event.event.data);
+    })
+    .transform((event) => event.event.data);
 
-const requestSwapDepositAddress = async (
-  chainflip: ApiPromise,
-  params: NewSwapRequest,
-  getNonce: () => number,
-) => {
-  const deferred = deferredPromise<z.output<typeof eventSchema>>();
-  const { promise, resolve, reject } = deferred;
+  const requestSwapDepositAddress = async (
+    chainflip: ApiPromise,
+    params: NewSwapRequest,
+    getNonce: () => number,
+  ) => {
+    const deferred = deferredPromise<z.output<typeof eventSchema>>();
+    const { promise, resolve, reject } = deferred;
 
-  const eventMatcher = chainflip.events.swapping.SwapDepositAddressReady;
+    const eventMatcher = chainflip.events.swapping.SwapDepositAddressReady;
 
-  const unsubscribe = await chainflip.tx.swapping
-    .requestSwapDepositAddressWithAffiliates(...broker.buildExtrinsicPayload(params))
-    .signAndSend(account, { nonce: getNonce() }, (result) => {
-      if (!result.isInBlock) return;
+    const unsubscribe = await chainflip.tx.swapping
+      .requestSwapDepositAddressWithAffiliates(...broker.buildExtrinsicPayload(params))
+      .signAndSend(account, { nonce: getNonce() }, (result) => {
+        if (!result.isInBlock) return;
 
-      if (result.dispatchError) {
-        try {
-          handleSubstrateError(chainflip, false)(result);
-        } catch (e) {
-          reject(e as Error);
-          return;
+        if (result.dispatchError) {
+          try {
+            handleSubstrateError(chainflip, false)(result);
+          } catch (e) {
+            reject(e as Error);
+            return;
+          }
         }
-      }
 
-      const event = result.events.find((record) => eventMatcher.is(record.event));
-      assert(event, 'SwapDepositAddressReady event not found');
-      resolve(eventSchema.parse(event.toHuman()));
-    });
+        const event = result.events.find((record) => eventMatcher.is(record.event));
+        assert(event, 'SwapDepositAddressReady event not found');
+        resolve(eventSchema.parse(event.toHuman()));
+      });
 
-  const event = await promise.finally(unsubscribe);
+    const event = await promise.finally(unsubscribe);
 
-  const sourceAsset = getInternalAsset({ chain: params.srcChain, asset: params.srcAsset });
-  const destinationAsset = getInternalAsset({ chain: params.destChain, asset: params.destAsset });
+    const sourceAsset = getInternalAsset({ chain: params.srcChain, asset: params.srcAsset });
+    const destinationAsset = getInternalAsset({ chain: params.destChain, asset: params.destAsset });
 
-  assert.strictEqual(event.sourceAsset, sourceAsset, 'source asset is wrong');
-  assert.strictEqual(event.destinationAsset, destinationAsset, 'destination asset is wrong');
+    assert.strictEqual(event.sourceAsset, sourceAsset, 'source asset is wrong');
+    assert.strictEqual(event.destinationAsset, destinationAsset, 'destination asset is wrong');
 
-  const destChain = shortChainFromAsset(destinationAsset);
-  const transformDestAddress = addressTransforms[destChain];
+    const destChain = shortChainFromAsset(destinationAsset);
+    const transformDestAddress = addressTransforms[destChain];
 
-  assert.strictEqual(
-    transformDestAddress(event.destinationAddress[destChain]!),
-    transformDestAddress(params.destAddress),
-    'destination address is wrong',
+    assert.strictEqual(
+      transformDestAddress(event.destinationAddress[destChain]!),
+      transformDestAddress(params.destAddress),
+      'destination address is wrong',
+    );
+    assert.strictEqual(event.brokerCommissionRate, params.commissionBps ?? 0);
+    assert.strictEqual(event.boostFee, params.maxBoostFeeBps ?? 0);
+
+    if (params.fillOrKillParams) {
+      assert.strictEqual(
+        event.refundParameters?.minPrice,
+        BigInt(params.fillOrKillParams.minPriceX128),
+      );
+      assert.strictEqual(
+        event.refundParameters?.retryDuration,
+        params.fillOrKillParams.retryDurationBlocks,
+      );
+      const sourceChain = shortChainFromAsset(sourceAsset);
+      const transformRefundAddress = addressTransforms[sourceChain];
+      assert.strictEqual(
+        transformRefundAddress(event.refundParameters!.refundAddress[sourceChain]!),
+        transformRefundAddress(params.fillOrKillParams.refundAddress),
+      );
+    }
+
+    if (params.affiliates) {
+      assert.deepStrictEqual(
+        params.affiliates
+          .toSorted((a, b) => a.account.localeCompare(b.account))
+          .map((aff) => ({ account: aff.account, bps: aff.commissionBps })),
+        event.affiliateFees.toSorted((a, b) => a.account.localeCompare(b.account)),
+      );
+    }
+
+    if (params.dcaParams) {
+      assert.strictEqual(event.dcaParameters?.numberOfChunks, params.dcaParams.numberOfChunks);
+      assert.strictEqual(event.dcaParameters.chunkInterval, params.dcaParams.chunkIntervalBlocks);
+    }
+
+    if (params.ccmParams) {
+      assert.strictEqual(
+        event.channelMetadata?.message,
+        params.ccmParams.message === '0x' ? '' : params.ccmParams.message,
+      );
+      assert.strictEqual(event.channelMetadata.gasBudget, BigInt(params.ccmParams.gasBudget));
+      assert.strictEqual(
+        event.channelMetadata.ccmAdditionalData,
+        params.ccmParams.ccmAdditionalData === '0x' ? '' : params.ccmParams.ccmAdditionalData,
+      );
+    }
+  };
+
+  const addresses = {
+    Bitcoin: [
+      'n37AcBDN48pKxBR5DK1fSDFnzFuMhGq9wy', // P2PKH
+      '2MuBZJLi7VdTJgdTkeBfWFMMVvGUJYW9aAt', // P2SH
+      'bcrt1qzhzr5p67ukjyzfmxsh53a8rv3p06nqq0m3md3q', // P2WPKH
+      'bcrt1qqazrtdsvdnl8pv6ypz4jv9h7ud0fs5u4tullapvan2amku7eyujsum5wt8', // P2WSH
+      'bcrt1plrgeugjy6vsehsythzxy4jg5ga2zdvuf4zwjchynd78ldklacs4q52p6g5', // Taproot
+    ],
+    Ethereum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+    Arbitrum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+    Polkadot: ['1yMmfLti1k3huRQM2c47WugwonQMqTvQ2GUFxnU7Pcs7xPo'],
+    Solana: ['3yKDHJgzS2GbZB9qruoadRYtq8597HZifnRju7fHpdRC'],
+  } as const;
+
+  const entries = Object.entries as <T>(o: T) => [keyof T, T[keyof T]][];
+
+  const baseCases = entries(addresses).flatMap(([destChain, addrs]) =>
+    addrs.map(
+      (destAddress) =>
+        ({
+          srcAsset: 'FLIP',
+          srcChain: 'Ethereum',
+          destChain,
+          destAsset: chainConstants[destChain].assets[0],
+          destAddress,
+        }) as NewSwapRequest,
+    ),
   );
-  assert.strictEqual(event.brokerCommissionRate, params.commissionBps ?? 0);
-  assert.strictEqual(event.boostFee, params.maxBoostFeeBps ?? 0);
 
-  if (params.fillOrKillParams) {
-    assert.strictEqual(
-      event.refundParameters?.minPrice,
-      BigInt(params.fillOrKillParams.minPriceX128),
-    );
-    assert.strictEqual(
-      event.refundParameters?.retryDuration,
-      params.fillOrKillParams.retryDurationBlocks,
-    );
-    const sourceChain = shortChainFromAsset(sourceAsset);
-    const transformRefundAddress = addressTransforms[sourceChain];
-    assert.strictEqual(
-      transformRefundAddress(event.refundParameters!.refundAddress[sourceChain]!),
-      transformRefundAddress(params.fillOrKillParams.refundAddress),
-    );
-  }
+  const refundCases = entries(addresses).flatMap(([srcChain, addrs]) =>
+    addrs.map(
+      (refundAddress) =>
+        ({
+          destAsset: 'FLIP',
+          destChain: 'Ethereum',
+          destAddress: addresses.Ethereum[0],
+          srcChain,
+          srcAsset: chainConstants[srcChain].assets[0],
+          fillOrKillParams: {
+            refundAddress,
+            minPriceX128: '1',
+            retryDurationBlocks: 100,
+          },
+        }) as NewSwapRequest,
+    ),
+  );
 
-  if (params.affiliates) {
-    assert.deepStrictEqual(
-      params.affiliates
-        .toSorted((a, b) => a.account.localeCompare(b.account))
-        .map((aff) => ({ account: aff.account, bps: aff.commissionBps })),
-      event.affiliateFees.toSorted((a, b) => a.account.localeCompare(b.account)),
-    );
-  }
+  const withDca: NewSwapRequest = {
+    ...refundCases[0],
+    dcaParams: {
+      numberOfChunks: 7200,
+      chunkIntervalBlocks: 2,
+    },
+  };
 
-  if (params.dcaParams) {
-    assert.strictEqual(event.dcaParameters?.numberOfChunks, params.dcaParams.numberOfChunks);
-    assert.strictEqual(event.dcaParameters.chunkInterval, params.dcaParams.chunkIntervalBlocks);
-  }
+  const withCommission: NewSwapRequest = {
+    ...baseCases[0],
+    commissionBps: 100,
+  };
 
-  if (params.ccmParams) {
-    assert.strictEqual(
-      event.channelMetadata?.message,
-      params.ccmParams.message === '0x' ? '' : params.ccmParams.message,
-    );
-    assert.strictEqual(event.channelMetadata.gasBudget, BigInt(params.ccmParams.gasBudget));
-    assert.strictEqual(
-      event.channelMetadata.ccmAdditionalData,
-      params.ccmParams.ccmAdditionalData === '0x' ? '' : params.ccmParams.ccmAdditionalData,
-    );
-  }
-};
+  const withAffiliates: NewSwapRequest = {
+    ...baseCases[0],
+    affiliates: [{ account: account2.address, commissionBps: 100 }],
+  };
 
-const addresses = {
-  Bitcoin: [
-    'n37AcBDN48pKxBR5DK1fSDFnzFuMhGq9wy', // P2PKH
-    '2MuBZJLi7VdTJgdTkeBfWFMMVvGUJYW9aAt', // P2SH
-    'bcrt1qzhzr5p67ukjyzfmxsh53a8rv3p06nqq0m3md3q', // P2WPKH
-    'bcrt1qqazrtdsvdnl8pv6ypz4jv9h7ud0fs5u4tullapvan2amku7eyujsum5wt8', // P2WSH
-    'bcrt1plrgeugjy6vsehsythzxy4jg5ga2zdvuf4zwjchynd78ldklacs4q52p6g5', // Taproot
-  ],
-  Ethereum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
-  Arbitrum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
-  Polkadot: ['1yMmfLti1k3huRQM2c47WugwonQMqTvQ2GUFxnU7Pcs7xPo'],
-  Solana: ['3yKDHJgzS2GbZB9qruoadRYtq8597HZifnRju7fHpdRC'],
-} as const;
+  const withCcm: NewSwapRequest = {
+    ...baseCases.find((c) => c.destChain === 'Arbitrum')!,
+    ccmParams: {
+      message: '0xcafebabe',
+      gasBudget: '1000000',
+      ccmAdditionalData: '0x',
+    },
+  };
 
-const entries = Object.entries as <T>(o: T) => [keyof T, T[keyof T]][];
-
-const baseCases = entries(addresses).flatMap(([destChain, addrs]) =>
-  addrs.map(
-    (destAddress) =>
-      ({
-        srcAsset: 'FLIP',
-        srcChain: 'Ethereum',
-        destChain,
-        destAsset: chainConstants[destChain].assets[0],
-        destAddress,
-      }) as NewSwapRequest,
-  ),
-);
-
-const refundCases = entries(addresses).flatMap(([srcChain, addrs]) =>
-  addrs.map(
-    (refundAddress) =>
-      ({
-        destAsset: 'FLIP',
-        destChain: 'Ethereum',
-        destAddress: addresses.Ethereum[0],
-        srcChain,
-        srcAsset: chainConstants[srcChain].assets[0],
-        fillOrKillParams: {
-          refundAddress,
-          minPriceX128: '1',
-          retryDurationBlocks: 100,
-        },
-      }) as NewSwapRequest,
-  ),
-);
-
-const withDca: NewSwapRequest = {
-  ...refundCases[0],
-  dcaParams: {
-    numberOfChunks: 7200,
-    chunkIntervalBlocks: 2,
-  },
-};
-
-const withCommission: NewSwapRequest = {
-  ...baseCases[0],
-  commissionBps: 100,
-};
-
-const withAffiliates: NewSwapRequest = {
-  ...baseCases[0],
-  affiliates: [{ account: account2.address, commissionBps: 100 }],
-};
-
-const withCcm: NewSwapRequest = {
-  ...baseCases.find((c) => c.destChain === 'Arbitrum')!,
-  ccmParams: {
-    message: '0xcafebabe',
-    gasBudget: '1000000',
-    ccmAdditionalData: '0x',
-  },
-};
-
-const main = async () => {
   await using api = await getChainflipApi();
   let nonce = (await api.rpc.system.accountNextIndex(account.address)).toJSON() as number;
 
@@ -256,6 +256,6 @@ const main = async () => {
     console.error('Some tests failed');
     process.exit(1);
   }
-};
+}
 
 export const depositChannelCreation = new ExecutableTest('Deposit-Channel-Creation', main, 360);


### PR DESCRIPTION
# Pull Request

Help solve: PRO-1950

## Checklist

- [x] I am confident that the code works.
- [x] I have written sufficient tests.

## Summary

The problem is that when a timeout happens in the bouncer, we don't know why. Thanks to the executable test class, we know what test timed out, but not where in that test it was up to. until now....

I added a new class that allows us to instrument the any functions that a test often waits for. The code will look at the call stack and match it against a list of currently running tests, then add the task to that test as a tracked task. If a timeout happens on a test, it will see if it had any tasks that it was waiting on and print a message with the name and location of the task.

```sh
=== Boosting-For-Asset test failed (13:59:11) ===
Timeout waiting for:
  Observing Event assetBalances:AccountCredited at file:///Users/jamieford/alt-chainflip-backend/bouncer/tests/boost.ts:126
Error: Timed out after 12s.
```    
```sh
=== Boosting-For-Asset test failed (14:00:55) ===
Timeout waiting for:
  Balance Increase Btc at file:///Users/jamieford/alt-chainflip-backend/bouncer/tests/boost.ts:198
Error: Timed out after 12s.
```

I added this task tracker to the main utility functions that I expect timeouts to happen on, eg `observeEvent`, `observeBalanceIncrease`, etc. This will enable diagnosing of timeouts in all tests, without any change to the individual test code.
It's not a perfect solution, but should cover 90% of timeouts.