### PR TITLE
chore: rename Solana CCM remaining accounts

### DIFF
--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -22,11 +22,11 @@ export function newSolanaCcmAdditionalData(maxAccounts: number) {
 
   const fallbackAddress = Keypair.generate().publicKey.toBytes();
 
-  const remainingAccounts = [];
-  const numRemainingAccounts = Math.floor(Math.random() * maxAccounts);
+  const additionalAccounts = [];
+  const numAdditionalAccounts = Math.floor(Math.random() * maxAccounts);
 
-  for (let i = 0; i < numRemainingAccounts; i++) {
-    remainingAccounts.push({
+  for (let i = 0; i < numAdditionalAccounts; i++) {
+    additionalAccounts.push({
       pubkey: Keypair.generate().publicKey.toBytes(),
       is_writable: Math.random() < 0.5,
     });
@@ -37,7 +37,7 @@ export function newSolanaCcmAdditionalData(maxAccounts: number) {
       pubkey: new PublicKey(cfReceiverAddress).toBytes(),
       is_writable: false,
     },
-    remaining_accounts: remainingAccounts,
+    additional_accounts: additionalAccounts,
     fallback_address: fallbackAddress,
   };
 

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -815,34 +815,34 @@ export async function observeSolanaCcmEvent(
               solVersionedCcmAdditionalDataCodec.dec(messageMetadata.ccmAdditionalData!).value;
 
             if (
-              expectedAdditionalAccounts.length !== event.data.additional_is_writable.length ||
-              expectedAdditionalAccounts.length !== event.data.additional_pubkeys.length
+              expectedAdditionalAccounts.length !== event.data.remaining_is_writable.length ||
+              expectedAdditionalAccounts.length !== event.data.remaining_pubkeys.length
             ) {
               throw new Error(
-                `Unexpected additional accounts length: ${expectedAdditionalAccounts.length}, expecting ${event.data.additional_is_writable.length}, ${event.data.additional_pubkeys.length}`,
+                `Unexpected additional accounts length: ${expectedAdditionalAccounts.length}, expecting ${event.data.remaining_is_writable.length}, ${event.data.remaining_pubkeys.length}`,
               );
             }
 
             for (let index = 0; index < expectedAdditionalAccounts.length; index++) {
               if (
                 expectedAdditionalAccounts[index].is_writable.toString() !==
-                event.data.additional_is_writable[index].toString()
+                event.data.remaining_is_writable[index].toString()
               ) {
                 throw new Error(
-                  `Unexpected additional account is_writable: ${event.data.additional_is_writable[index]}, expecting ${expectedAdditionalAccounts[index].is_writable}`,
+                  `Unexpected additional account is_writable: ${event.data.remaining_is_writable[index]}, expecting ${expectedAdditionalAccounts[index].is_writable}`,
                 );
               }
               const expectedPubkey = new PublicKey(
                 expectedAdditionalAccounts[index].pubkey,
               ).toString();
-              if (expectedPubkey !== event.data.additional_pubkeys[index].toString()) {
+              if (expectedPubkey !== event.data.remaining_pubkeys[index].toString()) {
                 throw new Error(
-                  `Unexpected additional account pubkey: ${event.data.additional_pubkeys[index].toString()}, expecting ${expectedPubkey}`,
+                  `Unexpected additional account pubkey: ${event.data.remaining_pubkeys[index].toString()}, expecting ${expectedPubkey}`,
                 );
               }
             }
 
-            if (event.data.additional_is_signer.some((value: boolean) => value === true)) {
+            if (event.data.remaining_is_signer.some((value: boolean) => value === true)) {
               throw new Error(`Expected all additional accounts to be read-only`);
             }
 

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -68,7 +68,7 @@ const solCcmAccountsCodec = Struct({
     pubkey: TsBytes(32),
     is_writable: bool,
   }),
-  remaining_accounts: Vector(
+  additional_accounts: Vector(
     Struct({
       pubkey: TsBytes(32),
       is_writable: bool,
@@ -811,39 +811,39 @@ export async function observeSolanaCcmEvent(
 
           // The message is being used as the main discriminator
           if (matchEventName && matchSourceChain && matchMessage) {
-            const { remaining_accounts: expectedRemainingAccounts } =
+            const { additional_accounts: expectedAdditionalAccounts } =
               solVersionedCcmAdditionalDataCodec.dec(messageMetadata.ccmAdditionalData!).value;
 
             if (
-              expectedRemainingAccounts.length !== event.data.remaining_is_writable.length ||
-              expectedRemainingAccounts.length !== event.data.remaining_pubkeys.length
+              expectedAdditionalAccounts.length !== event.data.additional_is_writable.length ||
+              expectedAdditionalAccounts.length !== event.data.additional_pubkeys.length
             ) {
               throw new Error(
-                `Unexpected remaining accounts length: ${expectedRemainingAccounts.length}, expecting ${event.data.remaining_is_writable.length}, ${event.data.remaining_pubkeys.length}`,
+                `Unexpected additional accounts length: ${expectedAdditionalAccounts.length}, expecting ${event.data.additional_is_writable.length}, ${event.data.additional_pubkeys.length}`,
               );
             }
 
-            for (let index = 0; index < expectedRemainingAccounts.length; index++) {
+            for (let index = 0; index < expectedAdditionalAccounts.length; index++) {
               if (
-                expectedRemainingAccounts[index].is_writable.toString() !==
-                event.data.remaining_is_writable[index].toString()
+                expectedAdditionalAccounts[index].is_writable.toString() !==
+                event.data.additional_is_writable[index].toString()
               ) {
                 throw new Error(
-                  `Unexpected remaining account is_writable: ${event.data.remaining_is_writable[index]}, expecting ${expectedRemainingAccounts[index].is_writable}`,
+                  `Unexpected additional account is_writable: ${event.data.additional_is_writable[index]}, expecting ${expectedAdditionalAccounts[index].is_writable}`,
                 );
               }
               const expectedPubkey = new PublicKey(
-                expectedRemainingAccounts[index].pubkey,
+                expectedAdditionalAccounts[index].pubkey,
               ).toString();
-              if (expectedPubkey !== event.data.remaining_pubkeys[index].toString()) {
+              if (expectedPubkey !== event.data.additional_pubkeys[index].toString()) {
                 throw new Error(
-                  `Unexpected remaining account pubkey: ${event.data.remaining_pubkeys[index].toString()}, expecting ${expectedPubkey}`,
+                  `Unexpected additional account pubkey: ${event.data.additional_pubkeys[index].toString()}, expecting ${expectedPubkey}`,
                 );
               }
             }
 
-            if (event.data.remaining_is_signer.some((value: boolean) => value === true)) {
-              throw new Error(`Expected all remaining accounts to be read-only`);
+            if (event.data.additional_is_signer.some((value: boolean) => value === true)) {
+              throw new Error(`Expected all additional accounts to be read-only`);
             }
 
             if (sourceAddress !== null) {

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -492,7 +492,7 @@ fn solana_ccm_fails_with_invalid_input() {
 					gas_budget: 0u128,
 					ccm_additional_data: VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 						cf_receiver: SolCcmAddress { pubkey: receiver.into(), is_writable: true },
-						remaining_accounts: vec![
+						additional_accounts: vec![
 							SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: false },
 							SolCcmAddress { pubkey: SolPubkey([0x02; 32]), is_writable: false },
 						],
@@ -708,7 +708,7 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 					gas_budget: 1_000_000_000u128,
 					ccm_additional_data: VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 						cf_receiver: SolCcmAddress { pubkey: SolPubkey([0x10; 32]), is_writable: true },
-						remaining_accounts: vec![
+						additional_accounts: vec![
 							SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: false },
 							SolCcmAddress { pubkey: SolPubkey([0x02; 32]), is_writable: false },
 						],

--- a/state-chain/chains/src/ccm_checker.rs
+++ b/state-chain/chains/src/ccm_checker.rs
@@ -74,9 +74,9 @@ impl CcmValidityCheck for CcmValidityChecker {
 			.map_err(|_| CcmValidityError::CannotDecodeCcmAdditionalData)?
 			{
 				VersionedSolanaCcmAdditionalData::V0(ccm_accounts) => {
-					// Length of CCM = length of message + total no. remaining_accounts * constant;
+					// Length of CCM = length of message + total no. additional_accounts * constant;
 					let ccm_length = ccm.message.len() +
-						ccm_accounts.remaining_accounts.len() * CCM_BYTES_PER_ACCOUNT;
+						ccm_accounts.additional_accounts.len() * CCM_BYTES_PER_ACCOUNT;
 					if ccm_length >
 						match asset {
 							SolAsset::Sol => MAX_CCM_BYTES_SOL,
@@ -106,7 +106,7 @@ pub fn check_ccm_for_blacklisted_accounts(
 	blacklisted_accounts.into_iter().try_for_each(|blacklisted_account| {
 		(ccm_accounts.cf_receiver.pubkey != blacklisted_account &&
 			!ccm_accounts
-				.remaining_accounts
+				.additional_accounts
 				.iter()
 				.any(|acc| acc.pubkey == blacklisted_account))
 		.then_some(())
@@ -155,7 +155,7 @@ mod test {
 			gas_budget: 0,
 			ccm_additional_data: VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 				cf_receiver: SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: true },
-				remaining_accounts: vec![],
+				additional_accounts: vec![],
 				fallback_address: SolPubkey([0xf0; 32]),
 			})
 			.encode()
@@ -175,7 +175,7 @@ mod test {
 		let mut invalid_ccm = ccm();
 		invalid_ccm.ccm_additional_data = VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 			cf_receiver: SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: true },
-			remaining_accounts: vec![SolCcmAddress {
+			additional_accounts: vec![SolCcmAddress {
 				pubkey: SolPubkey([0x01; 32]),
 				is_writable: true,
 			}],
@@ -198,7 +198,7 @@ mod test {
 			ccm_additional_data: VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 				cf_receiver: SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: true },
 				fallback_address: SolPubkey([0xf0; 32]),
-				remaining_accounts: vec![],
+				additional_accounts: vec![],
 			})
 			.encode()
 			.try_into()
@@ -217,7 +217,7 @@ mod test {
 		let mut invalid_ccm = ccm();
 		invalid_ccm.ccm_additional_data = VersionedSolanaCcmAdditionalData::V0(SolCcmAccounts {
 			cf_receiver: SolCcmAddress { pubkey: SolPubkey([0x01; 32]), is_writable: true },
-			remaining_accounts: vec![SolCcmAddress {
+			additional_accounts: vec![SolCcmAddress {
 				pubkey: SolPubkey([0x01; 32]),
 				is_writable: true,
 			}],
@@ -318,7 +318,7 @@ mod test {
 				pubkey: sol_test_values::TOKEN_VAULT_PDA_ACCOUNT.into(),
 				is_writable: true,
 			},
-			remaining_accounts: vec![
+			additional_accounts: vec![
 				SolCcmAddress { pubkey: crate::sol::SolPubkey([0x01; 32]), is_writable: false },
 				SolCcmAddress { pubkey: crate::sol::SolPubkey([0x02; 32]), is_writable: false },
 			],
@@ -334,7 +334,7 @@ mod test {
 				pubkey: crate::sol::SolPubkey([0x01; 32]),
 				is_writable: true,
 			},
-			remaining_accounts: vec![
+			additional_accounts: vec![
 				SolCcmAddress {
 					pubkey: sol_test_values::TOKEN_VAULT_PDA_ACCOUNT.into(),
 					is_writable: false,
@@ -354,7 +354,7 @@ mod test {
 				pubkey: sol_test_values::agg_key().into(),
 				is_writable: true,
 			},
-			remaining_accounts: vec![
+			additional_accounts: vec![
 				SolCcmAddress { pubkey: crate::sol::SolPubkey([0x01; 32]), is_writable: false },
 				SolCcmAddress { pubkey: crate::sol::SolPubkey([0x02; 32]), is_writable: false },
 			],
@@ -370,7 +370,7 @@ mod test {
 				pubkey: crate::sol::SolPubkey([0x01; 32]),
 				is_writable: true,
 			},
-			remaining_accounts: vec![
+			additional_accounts: vec![
 				SolCcmAddress { pubkey: sol_test_values::agg_key().into(), is_writable: false },
 				SolCcmAddress { pubkey: crate::sol::SolPubkey([0x02; 32]), is_writable: false },
 			],

--- a/state-chain/chains/src/sol/sol_tx_core.rs
+++ b/state-chain/chains/src/sol/sol_tx_core.rs
@@ -848,13 +848,13 @@ impl From<CcmAddress> for AccountMeta {
 #[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CcmAccounts {
 	pub cf_receiver: CcmAddress,
-	pub remaining_accounts: Vec<CcmAddress>,
+	pub additional_accounts: Vec<CcmAddress>,
 	pub fallback_address: Pubkey,
 }
 
 impl CcmAccounts {
-	pub fn remaining_account_metas(self) -> Vec<AccountMeta> {
-		self.remaining_accounts.into_iter().map(|acc| acc.into()).collect::<Vec<_>>()
+	pub fn additional_account_metas(self) -> Vec<AccountMeta> {
+		self.additional_accounts.into_iter().map(|acc| acc.into()).collect::<Vec<_>>()
 	}
 }
 
@@ -912,7 +912,7 @@ pub mod rpc_types {
 fn ccm_extra_accounts_encoding() {
 	let extra_accounts = CcmAccounts {
 		cf_receiver: CcmAddress { pubkey: Pubkey([0x11; 32]), is_writable: false },
-		remaining_accounts: vec![
+		additional_accounts: vec![
 			CcmAddress { pubkey: Pubkey([0x22; 32]), is_writable: true },
 			CcmAddress { pubkey: Pubkey([0x33; 32]), is_writable: true },
 		],
@@ -923,7 +923,7 @@ fn ccm_extra_accounts_encoding() {
 
 	// Scale encoding format:
 	// cf_receiver(32 bytes, bool),
-	// size_of_vec(compact encoding), remaining_accounts_0(32 bytes, bool), remaining_accounts_1,
+	// size_of_vec(compact encoding), additional_accounts_0(32 bytes, bool), additional_accounts_1,
 	// etc..
 	assert_eq!(
 		encoded,
@@ -1112,7 +1112,7 @@ pub mod sol_test_values {
 				pubkey: const_address("8pBPaVfTAcjLeNfC187Fkvi9b1XEFhRNJ95BQXXVksmH").into(),
 				is_writable: true,
 			},
-			remaining_accounts: vec![SolCcmAddress {
+			additional_accounts: vec![SolCcmAddress {
 				pubkey: const_address("CFp37nEY6E9byYHiuxQZg6vMCnzwNrgiF9nFGT6Zwcnx").into(),
 				is_writable: false,
 			}],
@@ -1669,7 +1669,7 @@ mod tests {
 					SYSTEM_PROGRAM_ID,
 					SYS_VAR_INSTRUCTIONS,
 				)
-				.with_remaining_accounts(extra_accounts.remaining_account_metas()),
+				.with_additional_accounts(extra_accounts.additional_account_metas()),
 		];
 		let message =
 			Message::new_with_blockhash(&instructions, Some(&agg_key_pubkey), &durable_nonce);
@@ -1732,7 +1732,7 @@ mod tests {
 				TOKEN_PROGRAM_ID,
 				USDC_TOKEN_MINT_PUB_KEY,
 				SYS_VAR_INSTRUCTIONS,
-			).with_remaining_accounts(extra_accounts.remaining_account_metas()),
+			).with_additional_accounts(extra_accounts.additional_account_metas()),
 		];
 		let message =
 			Message::new_with_blockhash(&instructions, Some(&agg_key_pubkey), &durable_nonce);

--- a/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
+++ b/state-chain/chains/src/sol/sol_tx_core/program_instructions.rs
@@ -251,11 +251,11 @@ pub trait ProgramInstruction: BorshSerialize {
 }
 
 pub trait InstructionExt {
-	fn with_remaining_accounts(self, accounts: Vec<AccountMeta>) -> Self;
+	fn with_additional_accounts(self, accounts: Vec<AccountMeta>) -> Self;
 }
 
 impl InstructionExt for Instruction {
-	fn with_remaining_accounts(mut self, accounts: Vec<AccountMeta>) -> Self {
+	fn with_additional_accounts(mut self, accounts: Vec<AccountMeta>) -> Self {
 		self.accounts.extend(accounts);
 		self
 	}

--- a/state-chain/chains/src/sol/transaction_builder.rs
+++ b/state-chain/chains/src/sol/transaction_builder.rs
@@ -321,7 +321,7 @@ impl SolanaTransactionBuilder {
 					system_program_id(),
 					sys_var_instructions(),
 				)
-				.with_remaining_accounts(ccm_accounts.remaining_account_metas()),
+				.with_additional_accounts(ccm_accounts.additional_account_metas()),
 		];
 
 		Self::build(instructions, durable_nonce, agg_key.into(), compute_price, compute_limit)
@@ -376,7 +376,7 @@ impl SolanaTransactionBuilder {
 			token_program_id(),
 			token_mint_pubkey,
 			sys_var_instructions(),
-		).with_remaining_accounts(ccm_accounts.remaining_account_metas())];
+		).with_additional_accounts(ccm_accounts.additional_account_metas())];
 
 		Self::build(instructions, durable_nonce, agg_key.into(), compute_price, compute_limit)
 	}
@@ -430,7 +430,7 @@ impl SolanaTransactionBuilder {
 
 		let instructions = vec![SwapEndpointProgram::with_id(swap_endpoint_program)
 			.close_event_accounts(vault_program_data_account, agg_key, swap_endpoint_data_account)
-			.with_remaining_accounts(swap_and_sender_vec)];
+			.with_additional_accounts(swap_and_sender_vec)];
 
 		Self::build(
 			instructions,


### PR DESCRIPTION
# Pull Request


## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Renaming `remaining_accounts` to `additional_accounts`. `remaining_accounts` is Anchor's naming to those extra accounts, which is clear in the context or a Solana program but unclear here.
Solana CCM is not really being used yet by anyone and we are anyway versioning the `ccmAdditionalData` so I'd rather also get this into 1.8 before the overhead of changing it is too large.
