### PR TITLE
chore: remove non-breaking changes section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,3 @@ Please conduct a thorough self-review before opening the PR.
 ## Summary
 
 *Please include a succinct description of the purpose and content of the PR. What problem does it solve, and how? Link issues, discussions, other PRs, and anything else that will help the reviewer.*
-
-#### Non-Breaking changes
-
-If this PR includes non-breaking changes, select the `non-breaking` label. On merge, CI will automatically cherry-pick the commit to a PR against the release branch.


### PR DESCRIPTION
Removes the non-breaking changes section from the PR template as it's more confusing than useful
