### PR TITLE
fix: various small fixes for 1.7.7 to help with reliability and scalability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [1.7.7] - 2025-01-22
+
+### Fixes
+
+- Search full tx history for get_signature_statuses
+- Retry submission on StateDiscarded error ([#5575](https://github.com/chainflip-io/chainflip-backend/issues/5575))
+- Only submit liveness when haven't yet submitted
+- Solana witnessing efficiency improvements ([#5580](https://github.com/chainflip-io/chainflip-backend/issues/5580))
+
 ## [1.7.6] - 2025-01-18
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3224,7 +3224,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -13058,7 +13058,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.7.6"
+version = "1.7.7"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.7.6"
+version = "1.7.7"
 
 [lints]
 workspace = true

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.7.6"
+version = "1.7.7"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.7.6"
+version = "1.7.7"
 edition = "2021"
 
 [lints]

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.7.6"
+version = "1.7.7"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_7_6"
+name = "chainflip_engine_v1_7_7"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.7.6"
+version = "1.7.7"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.7.6"
+version = "1.7.7"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_7_6.so",
+        "target/release/libchainflip_engine_v1_7_7.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_7_6.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_7_7.so",
         "755",
     ],
     # The old version gets put into target/release by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -13,7 +13,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.7.6")]
+	#[engine_proc_macros::link_engine_library_version("1.7.7")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -11,7 +11,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.6.8";
-pub const NEW_VERSION: &str = "1.7.6";
+pub const NEW_VERSION: &str = "1.7.7";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.7.6"
+version = "1.7.7"
 
 [lib]
 crate-type = ["lib"]

--- a/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/src/state_chain_observer/client/extrinsic_api/signed/submission_watcher.rs
@@ -154,6 +154,7 @@ pub struct SubmissionWatcher<
 
 pub enum SubmissionLogicError {
 	NonceTooLow,
+	StateDiscarded,
 }
 
 impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
@@ -281,6 +282,15 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 
 							self.runtime_version = new_runtime_version;
 						},
+						ClientError::Call(obj)
+							if obj.code() == 1002 &&
+								obj.message()
+									.to_lowercase()
+									.contains("state already discarded") =>
+						{
+							warn!(target: "state_chain_client", request_id = request.id, "Submission failed as the state is stale: {obj:?}");
+							break Ok(Err(SubmissionLogicError::StateDiscarded))
+						},
 						err =>
 							break Err(anyhow!(
 								"Unhandled error while submitting signed extrinsic {:?}: {}",
@@ -299,7 +309,9 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				self.base_rpc_client.next_account_nonce(self.signer.account_id.clone()).await?;
 			match self.submit_extrinsic_at_nonce(request, nonce).await? {
 				Ok(tx_hash) => break tx_hash,
-				Err(SubmissionLogicError::NonceTooLow) => {},
+				Err(SubmissionLogicError::NonceTooLow | SubmissionLogicError::StateDiscarded) => {
+					// In either of these cases we want to refresh the account nonce and try again.
+				},
 			}
 		})
 	}

--- a/engine/src/witness/sol/egress_witnessing.rs
+++ b/engine/src/witness/sol/egress_witnessing.rs
@@ -15,7 +15,7 @@ pub async fn get_finalized_fee_and_success_status(
 	signature: SolSignature,
 ) -> Result<(u64, bool)> {
 	match sol_client
-		.get_signature_statuses(&[signature], false)
+		.get_signature_statuses(&[signature], true)
 		.await
 		.value
 		.iter()

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "<TODO>"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.7.6"
+version = "1.7.7"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -53,6 +53,7 @@ where
 	Sink: IngressSink<DepositDetails = ()> + 'static,
 	Settings: Parameter + Member + MaybeSerializeDeserialize + Eq,
 	<Sink as IngressSink>::Account: Ord,
+	<Sink as IngressSink>::Amount: Default,
 	ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 {
 	pub fn open_channel<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
@@ -96,11 +97,13 @@ where
 		Ok(())
 	}
 }
+
 impl<Sink, Settings, ValidatorId> ElectoralSystem for DeltaBasedIngress<Sink, Settings, ValidatorId>
 where
 	Sink: IngressSink<DepositDetails = ()> + 'static,
 	Settings: Parameter + Member + MaybeSerializeDeserialize + Eq,
 	<Sink as IngressSink>::Account: Ord,
+	<Sink as IngressSink>::Amount: Default,
 	ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 {
 	type ValidatorId = ValidatorId;
@@ -147,17 +150,17 @@ where
 	}
 
 	fn is_vote_needed(
-		(_, current_partial_vote, _): (
+		(_, _, _): (
 			VotePropertiesOf<Self>,
 			<Self::Vote as VoteStorage>::PartialVote,
 			AuthorityVoteOf<Self>,
 		),
-		(proposed_partial_vote, _): (
+		(_, proposed_vote): (
 			<Self::Vote as VoteStorage>::PartialVote,
 			<Self::Vote as VoteStorage>::Vote,
 		),
 	) -> bool {
-		current_partial_vote != proposed_partial_vote
+		!proposed_vote.is_empty()
 	}
 
 	fn generate_vote_properties(
@@ -184,13 +187,21 @@ where
 			};
 
 			let mut closed_channels = Vec::new();
-			for (account, (details, _)) in &channels {
+			let mut new_properties: Self::ElectionProperties = BTreeMap::new();
+			let old_properties = channels.clone();
+			for (account, (details, old_consensus_ingress_total)) in &channels {
 				let (
 					option_ingress_total_before_chain_tracking,
 					option_ingress_total_after_chain_tracking,
 				) = match option_consensus.as_ref().and_then(|consensus| consensus.get(account)) {
-					None => (None, None),
+					None => {
+						new_properties
+							.insert(account.clone(), (*details, *old_consensus_ingress_total));
+						(None, None)
+					},
 					Some(consensus_ingress_total) => {
+						new_properties
+							.insert(account.clone(), (*details, *consensus_ingress_total));
 						if consensus_ingress_total.block_number <= *chain_tracking {
 							(Some(*consensus_ingress_total), None)
 						} else {
@@ -240,11 +251,7 @@ where
 							)?;
 						},
 						Ordering::Greater => {
-							Sink::on_ingress_reverted(
-								account.clone(),
-								details.asset,
-								ingress_total.amount - previous_amount,
-							);
+							log::warn!("Deposit channels on Solana chain has reverted! Account: {:?}, Asset: {:?}, Previous ingressed total: {:?}, new ingressed total: {:?}", account, details.asset, previous_amount, ingress_total.amount);
 						},
 						Ordering::Equal => (),
 					}
@@ -261,29 +268,32 @@ where
 				}
 			}
 
-			let mut election_access = electoral_access.election_mut(election_identifier)?;
-			if !closed_channels.is_empty() {
-				for closed_channel in closed_channels {
-					pending_ingress_totals.remove(&closed_channel);
-					channels.remove(&closed_channel);
-				}
+			for closed_channel in closed_channels {
+				pending_ingress_totals.remove(&closed_channel);
+				channels.remove(&closed_channel);
+				new_properties.remove(&closed_channel);
+			}
 
-				if channels.is_empty() {
-					election_access.delete();
-				} else {
-					election_access.set_state(pending_ingress_totals)?;
-					election_access.refresh(
-						// This value is meaningless. We increment as it is required to use a new
-						// higher value to refresh the election.
-						election_identifier
-							.extra()
-							.checked_add(1)
-							.ok_or_else(CorruptStorageError::new)?,
-						channels,
-					)?;
-				}
+			let mut election_access = electoral_access.election_mut(election_identifier)?;
+
+			if channels.is_empty() {
+				election_access.delete();
 			} else {
-				election_access.set_state(pending_ingress_totals)?;
+				election_access.set_state(pending_ingress_totals.clone())?;
+
+				// recreate this election if the properties changed
+				if new_properties != old_properties {
+					log::debug!("recreate election: recreate since properties changed from: {old_properties:?}, to: {new_properties:?}");
+
+					election_access.delete();
+					electoral_access.new_election(
+						Default::default(),
+						new_properties,
+						pending_ingress_totals,
+					)?;
+				} else {
+					log::debug!("recreate election: keeping old because properties didn't change: {old_properties:?}");
+				}
 			}
 		}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
@@ -78,9 +78,9 @@ impl<
 	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
 		_election_identifier: ElectionIdentifierOf<Self>,
 		_election_access: &ElectionAccess,
-		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
 	) -> Result<bool, CorruptStorageError> {
-		Ok(true)
+		Ok(current_vote.is_none())
 	}
 
 	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -376,6 +376,8 @@ pub mod pallet {
 		/// Not all vote data was cleared. *You should continue clearing votes until you receive
 		/// the AllVotesCleared event*.
 		AllVotesNotCleared,
+		/// Received vote for an unknown election
+		UnknownElection(ElectionIdentifierOf<T::ElectoralSystem>),
 	}
 
 	#[derive(CloneNoBound, PartialEqNoBound, EqNoBound)]
@@ -1259,8 +1261,16 @@ pub mod pallet {
 			);
 
 			for (election_identifier, authority_vote) in authority_votes {
-				let unique_monotonic_identifier =
-					Self::ensure_election_exists(election_identifier)?;
+				// if an identifier refers to a non existent election, skip this vote,
+				// but continue processing others.
+				let unique_monotonic_identifier = if let Ok(unique_monotonic_identifier) =
+					Self::ensure_election_exists(election_identifier)
+				{
+					unique_monotonic_identifier
+				} else {
+					Self::deposit_event(Event::UnknownElection(election_identifier));
+					continue;
+				};
 
 				let (partial_vote, option_vote) = match authority_vote {
 					AuthorityVote::PartialVote(partial_vote) => {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -505,7 +505,7 @@ pub mod pallet {
 
 	/// Stores address ready for use.
 	#[pallet::storage]
-	pub(crate) type DepositChannelPool<T: Config<I>, I: 'static = ()> =
+	pub type DepositChannelPool<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Twox64Concat, ChannelId, DepositChannel<T::TargetChain>>;
 
 	/// Defines the minimum amount of Deposit allowed for each asset.

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.7.6"
+version = "1.7.7"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -206,7 +206,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 176,
+	spec_version: 177,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 12,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -59,6 +59,7 @@ use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, DummyEgressSuccessWitnesser,
 	DummyIngressSource, GetBlockHeight, NoLimit, SwapLimits, SwapLimitsProvider,
 };
+use cf_utilities::bs58_array;
 use codec::{alloc::string::ToString, Decode, Encode};
 use core::ops::Range;
 use frame_support::{derive_impl, instances::*};
@@ -1283,6 +1284,122 @@ type PalletMigrations = (
 	pallet_cf_cfe_interface::migrations::PalletMigration<Runtime>,
 );
 
+// v-- START: DO NOT MERGE TO MAIN --v //
+use cf_primitives::chains::assets::sol::Asset as SolAsset;
+use cf_traits::DepositApi;
+use sp_runtime::AccountId32;
+#[cfg(feature = "try-runtime")]
+use sp_std::collections::btree_set::BTreeSet;
+
+pub struct IngressMigration;
+
+const CHANNEL_ADDRESS: SolAddress =
+	SolAddress(bs58_array("9rwJYe6GpwpRDjNKCoxxwRwXhtTJa7Pecqo375CmeHqZ"));
+const CHANNEL_ACCOUNT: [u8; 32] =
+	hex_literal::hex!("a846a1d39894d3fdb63ec07ef9aed03e2632f508480fbeb047e902371250f46c");
+const CHANNEL_ID: u64 = 14716;
+
+pub fn should_run() -> bool {
+	cf_runtime_upgrade_utilities::genesis_hashes::genesis_hash::<Runtime>() ==
+		cf_runtime_upgrade_utilities::genesis_hashes::BERGHAIN &&
+		!pallet_cf_ingress_egress::DepositChannelLookup::<Runtime, SolanaInstance>::contains_key(
+			CHANNEL_ADDRESS,
+		)
+}
+
+pub fn reopen<T: pallet_cf_ingress_egress::Config<I, AccountId = AccountId32>, I: 'static>(
+	channel_id: u64,
+	asset: <T::TargetChain as cf_chains::Chain>::ChainAsset,
+) -> Result<(), DispatchError> {
+	let channel =
+		cf_chains::DepositChannel::<T::TargetChain>::generate_new::<T::AddressDerivation>(
+			channel_id, asset,
+		)
+		.map_err(|_| DispatchError::Other("Failed to generate new deposit channel"))?;
+	pallet_cf_ingress_egress::DepositChannelPool::<T, I>::insert(
+		channel.channel_id,
+		channel.clone(),
+	);
+
+	let (channel_id, address, ..) =
+		pallet_cf_ingress_egress::Pallet::<T, I>::request_liquidity_deposit_address(
+			AccountId32::new(CHANNEL_ACCOUNT),
+			asset,
+			Default::default(),
+			cf_chains::ForeignChainAddress::Sol(SolAddress(bs58_array(
+				"Hqn5iCLXYm2pP2iqzVAsvsNAFw1kuvEGXxG3JAqwfsEq",
+			))),
+		)?;
+
+	frame_support::ensure!(channel_id == channel.channel_id, "Channel IDs don't match");
+	frame_support::ensure!(
+		<<T::TargetChain as cf_chains::Chain>::ChainAccount>::try_from(address)
+			.map_err(|_| "Failed to convert address")? ==
+			channel.address,
+		"Addresses don't match"
+	);
+
+	Ok(())
+}
+
+impl frame_support::traits::OnRuntimeUpgrade for IngressMigration {
+	fn on_runtime_upgrade() -> Weight {
+		if should_run() {
+			let previous_safe_mode =
+				pallet_cf_environment::RuntimeSafeMode::<Runtime>::mutate(|safe_mode| {
+					core::mem::replace(&mut safe_mode.ingress_egress_solana.deposits_enabled, true)
+				});
+			let _ = reopen::<Runtime, SolanaInstance>(CHANNEL_ID, SolAsset::Sol).map_err(|e| {
+				log::warn!("⛔️ Failed to reopen channel: {:?}", e);
+			});
+			let _ = pallet_cf_environment::RuntimeSafeMode::<Runtime>::mutate(|safe_mode| {
+				core::mem::replace(
+					&mut safe_mode.ingress_egress_solana.deposits_enabled,
+					previous_safe_mode,
+				)
+			});
+		}
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let open_channels_pre_upgrade =
+			pallet_cf_ingress_egress::DepositChannelLookup::<Runtime, SolanaInstance>::iter()
+				.map(|(addr, details)| (addr.0, details.deposit_channel.channel_id))
+				.collect::<BTreeSet<_>>();
+		Ok((
+			should_run(),
+			open_channels_pre_upgrade,
+			pallet_cf_environment::RuntimeSafeMode::<Runtime>::get(),
+		)
+			.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let (should_have_run, open_channels_pre_upgrade, safe_mode) =
+			<(bool, BTreeSet<([u8; 32], u64)>, RuntimeSafeMode)>::decode(&mut &state[..])
+				.map_err(|_| "Failed to decode pre-upgrade state")?;
+		assert_eq!(pallet_cf_environment::RuntimeSafeMode::<Runtime>::get(), safe_mode);
+		let open_channels_post_upgrade =
+			pallet_cf_ingress_egress::DepositChannelLookup::<Runtime, SolanaInstance>::iter()
+				.map(|(addr, details)| (addr.0, details.deposit_channel.channel_id))
+				.collect::<BTreeSet<_>>();
+		let diff = open_channels_post_upgrade
+			.difference(&open_channels_pre_upgrade)
+			.collect::<Vec<_>>();
+		if should_have_run {
+			assert!(diff.len() == 1);
+			assert_eq!(diff[0].clone(), (CHANNEL_ADDRESS.0, CHANNEL_ID));
+		} else {
+			assert!(diff.is_empty());
+		}
+		Ok(())
+	}
+}
+// ^-- END: DO NOT MERGE TO MAIN --^ //
+
 type MigrationsForV1_7 = (
 	// Only the Solana Transaction type has changed
 	VersionedMigration<
@@ -1310,6 +1427,8 @@ type MigrationsForV1_7 = (
 		1,
 	>,
 	VersionedMigration<SolanaElections, chainflip::solana_elections::old::Migration, 1, 2>,
+	// DO NOT MERGE TO MAIN:
+	IngressMigration,
 );
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/runtime/src/migrations/housekeeping.rs
+++ b/state-chain/runtime/src/migrations/housekeeping.rs
@@ -1,11 +1,5 @@
-use core::str::FromStr as _;
-
-use crate::{Runtime, SolEnvironment};
-use cf_chains::{
-	instances::{ArbitrumInstance, EthereumInstance, PolkadotInstance, SolanaInstance},
-	sol::{api::SolanaApi, SolAddress, SolAsset},
-	ForeignChain, Solana, TransferAssetParams,
-};
+use crate::Runtime;
+use cf_chains::instances::{ArbitrumInstance, EthereumInstance, PolkadotInstance};
 use cf_runtime_upgrade_utilities::genesis_hashes;
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
 use pallet_cf_broadcast::migrations::remove_aborted_broadcasts;
@@ -27,36 +21,6 @@ impl OnRuntimeUpgrade for Migration {
 				remove_aborted_broadcasts::remove_stale_and_all_older::<Runtime, ArbitrumInstance>(
 					remove_aborted_broadcasts::ARBITRUM_MAX_ABORTED_BROADCAST_BERGHAIN,
 				);
-				if crate::VERSION.spec_version == 175 {
-					log::info!("🧹 Housekeeping, bumping Solana refund");
-					if let Ok(to) =
-						SolAddress::from_str("9RbaLSDtScGDur9UGAiBQFYPiKK9xDZLuD39xkEqa5Zw")
-					{
-						if let Ok(mut calls) =
-							SolanaApi::<SolEnvironment>::transfer(sp_std::vec![(
-								TransferAssetParams::<Solana> {
-									asset: SolAsset::SolUsdc,
-									amount: 162740593954,
-									to,
-								},
-								(ForeignChain::Solana, 0)
-							)]) {
-							if calls.len() == 1 {
-								let _ = <pallet_cf_broadcast::Pallet<Runtime, SolanaInstance> as cf_traits::Broadcaster<
-											Solana,
-										>>::threshold_sign_and_broadcast(
-											calls.pop().expect("Checked for 1 call.").0,
-										);
-							} else {
-								log::error!("Expected 1 call, got {}", calls.len());
-							}
-						} else {
-							log::error!("Failed to build Solana transaction");
-						}
-					} else {
-						log::error!("Invalid Solana address");
-					}
-				}
 			},
 			genesis_hashes::PERSEVERANCE => {
 				log::info!("🧹 Housekeeping, removing stale aborted broadcasts");


### PR DESCRIPTION
- Set search transaction history to true. This ensures the engines will witness Solana broadcast success even if the broadcast was a while ago. 
- Catch state discarded error that can occur when the SC has a reorg. This was previously causing some engines that saw the reorg to shutdown. 
- Fix Solana deposit vote filtering by refreshing the election properties with latest channel balances
- Filter out duplicate liveness votes
- Bump version 1.7.7