### PR TITLE
fix: solana efficiency with old delta based ingress

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -288,7 +288,7 @@ where
 				//  - taking the consensus amount from either:
 				//     - the unsynchronized state map
 				//     - the election state
-				//    where we use the one which refers to a higher block number.
+				//    where we use the one which is higher.
 				let new_properties = channels
 					.iter()
 					.map(|(account, (channel_details, _))| {
@@ -301,13 +301,12 @@ where
 							.copied()
 							.unwrap_or_else(|| properties.get(account).unwrap().1);
 
-						let last_consensus_amount = if ingressed_amount.block_number >=
-							pending_ingressed_amount.block_number
-						{
-							ingressed_amount
-						} else {
-							pending_ingressed_amount
-						};
+						let last_consensus_amount =
+							if ingressed_amount.amount >= pending_ingressed_amount.amount {
+								ingressed_amount
+							} else {
+								pending_ingressed_amount
+							};
 
 						(account.clone(), (*channel_details, last_consensus_amount))
 					})

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -294,12 +294,12 @@ where
 				if new_properties != properties {
 					log::info!("recreate election: recreate since properties changed from: {properties:?}, to: {new_properties:?}");
 
+					electoral_access.election_mut(election_identifier)?.delete();
 					electoral_access.new_election(
 						Default::default(),
 						new_properties,
 						pending_ingress_totals,
 					)?;
-					electoral_access.election_mut(election_identifier)?.delete();
 				} else {
 					log::info!("recreate election: keeping old because properties didn't change: {properties:?}");
 				}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -53,6 +53,7 @@ where
 	Sink: IngressSink<DepositDetails = ()> + 'static,
 	Settings: Parameter + Member + MaybeSerializeDeserialize + Eq,
 	<Sink as IngressSink>::Account: Ord,
+	<Sink as IngressSink>::Amount: Default,
 	ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 {
 	pub fn open_channel<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self>>(
@@ -101,6 +102,7 @@ where
 	Sink: IngressSink<DepositDetails = ()> + 'static,
 	Settings: Parameter + Member + MaybeSerializeDeserialize + Eq,
 	<Sink as IngressSink>::Account: Ord,
+	<Sink as IngressSink>::Amount: Default,
 	ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 {
 	type ValidatorId = ValidatorId;
@@ -157,7 +159,10 @@ where
 			<Self::Vote as VoteStorage>::Vote,
 		),
 	) -> bool {
-		current_partial_vote != proposed_partial_vote
+		proposed_partial_vote.into_iter().any(|(account, new_balance)| {
+			new_balance.amount !=
+				current_partial_vote.get(&account).map(|total| total.amount).unwrap_or_default()
+		})
 	}
 
 	fn generate_vote_properties(

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -376,6 +376,8 @@ pub mod pallet {
 		/// Not all vote data was cleared. *You should continue clearing votes until you receive
 		/// the AllVotesCleared event*.
 		AllVotesNotCleared,
+		/// Received vote for an unknown election
+		UnknownElection(ElectionIdentifierOf<T::ElectoralSystem>),
 	}
 
 	#[derive(CloneNoBound, PartialEqNoBound, EqNoBound)]
@@ -1259,8 +1261,16 @@ pub mod pallet {
 			);
 
 			for (election_identifier, authority_vote) in authority_votes {
-				let unique_monotonic_identifier =
-					Self::ensure_election_exists(election_identifier)?;
+				// if an identifier refers to a non existent election, skip this vote,
+				// but continue processing others.
+				let unique_monotonic_identifier = if let Ok(unique_monotonic_identifier) =
+					Self::ensure_election_exists(election_identifier)
+				{
+					unique_monotonic_identifier
+				} else {
+					Self::deposit_event(Event::UnknownElection(election_identifier));
+					continue;
+				};
 
 				let (partial_vote, option_vote) = match authority_vote {
 					AuthorityVote::PartialVote(partial_vote) => {


### PR DESCRIPTION
This PR keeps the old delta based ingress structure, while adding:

 - filter votes for nonexistent elections (e.g. if identifier_extra was updated in-flight)
 - recreate elections if ingress amount on a channel updated