### PR TITLE
fix: use ccm params in a partial refund

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1472,7 +1472,7 @@ pub mod pallet {
 
 			match &mut request.state {
 				SwapRequestState::UserSwap {
-					ccm_deposit_metadata: _,
+					ccm_deposit_metadata,
 					output_address,
 					dca_state: DcaState { remaining_input_amount, accumulated_output_amount, .. },
 					broker_fees: _,
@@ -1494,7 +1494,7 @@ pub mod pallet {
 							*accumulated_output_amount,
 							request.output_asset,
 							output_address.clone(),
-							None,  /* ccm */
+							ccm_deposit_metadata.clone(),
 							false, /* refund */
 						);
 					}

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -366,6 +366,10 @@ fn dca_with_fok_partial_refund(is_ccm: bool) {
 			// already executed amount.
 			assert_eq!(SwapRequests::<Test>::get(SWAP_REQUEST_ID), None);
 
+			if is_ccm {
+				ccm::assert_ccm_egressed(Asset::Eth, CHUNK_OUTPUT, GAS_BUDGET);
+			}
+
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {


### PR DESCRIPTION
# Pull Request

## Summary

I noticed that in the case of a partial refund we don't use the CCM parameters for the swapped portion of the funds. (Looks like this was introduced in the recent CCM refactor, so this is currently working correctly on 1.7.) I changed the code to use the parameters and updated the relevant test to catch this.

