### PR TITLE
fix: solana elections efficiency improvements

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -315,6 +315,9 @@ where
 						},
 						Ordering::Equal => (),
 					}
+					// Note: we only check for close in this branch to guarantee that both the
+					// channel state and chain tracking have caught up to the close block, and all
+					// confirmed deposits have been ingressed.
 					if ready_total.block_number >= details.close_block {
 						Sink::on_channel_closed(account.clone());
 						new_properties.remove(account);
@@ -336,7 +339,7 @@ where
 				// open indeifitely by streaming small deposits.
 				election_access.delete();
 			} else if new_properties != properties {
-				log::debug!("recreate election: recreate since properties changed from: {properties:?}, to: {new_properties:?}");
+				log::debug!("recreate delta based ingress election: recreate since properties changed from: {properties:?}, to: {new_properties:?}");
 				election_access.delete();
 				ElectoralAccess::new_election(
 					Default::default(),
@@ -344,7 +347,7 @@ where
 					new_pending_ingress_totals,
 				)?;
 			} else {
-				log::debug!("recreate election: keeping old because properties didn't change: {properties:?}");
+				log::debug!("recreate delta based ingress election: keeping old because properties didn't change: {properties:?}");
 				election_access.set_state(new_pending_ingress_totals)?;
 			}
 		}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -303,7 +303,7 @@ where
 					log::debug!("recreate election: recreate since properties changed from: {old_properties:?}, to: {new_properties:?}");
 
 					election_access.delete();
-					electoral_access.new_election(
+					ElectoralAccess::new_election(
 						Default::default(),
 						new_properties,
 						pending_ingress_totals,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -325,19 +325,17 @@ where
 				debug_assert!(pending_ingress_totals.is_empty());
 				log::debug!("recreate election: deleting since no channels are left");
 				election_access.delete();
+			} else if new_properties != properties {
+				log::debug!("recreate election: recreate since properties changed from: {properties:?}, to: {new_properties:?}");
+				election_access.delete();
+				ElectoralAccess::new_election(
+					Default::default(),
+					new_properties,
+					pending_ingress_totals,
+				)?;
 			} else {
-				if new_properties != properties {
-					log::debug!("recreate election: recreate since properties changed from: {properties:?}, to: {new_properties:?}");
-					election_access.delete();
-					ElectoralAccess::new_election(
-						Default::default(),
-						new_properties,
-						pending_ingress_totals,
-					)?;
-				} else {
-					log::debug!("recreate election: keeping old because properties didn't change: {properties:?}");
-					election_access.set_state(pending_ingress_totals)?;
-				}
+				log::debug!("recreate election: keeping old because properties didn't change: {properties:?}");
+				election_access.set_state(pending_ingress_totals)?;
 			}
 		}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
@@ -93,9 +93,9 @@ impl<
 
 	fn is_vote_desired<ElectionAccess: ElectionReadAccess<ElectoralSystem = Self>>(
 		_election_access: &ElectionAccess,
-		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
 	) -> Result<bool, CorruptStorageError> {
-		Ok(true)
+		Ok(current_vote.is_none())
 	}
 
 	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -420,7 +420,8 @@ register_checks! {
 		);
 		assert!(
 			post_finalize.election_identifiers.is_empty(),
-			"Expected no elections after finalization.",
+			"Expected no elections after finalization, got: {:?}.",
+			post_finalize.election_identifiers,
 		);
 	},
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
@@ -432,7 +432,9 @@ mod channel_closure {
 		let _test_ctx = check_closure(test_ctx, channels[1]);
 	}
 
-	fn setup_close_after_deposits(lagging: bool) -> TestContext<SimpleDeltaBasedIngress> {
+	fn setup_close_after_deposits(
+		chain_tracking_lagging: bool,
+	) -> TestContext<SimpleDeltaBasedIngress> {
 		let setup = with_default_setup()
 			.build()
 			.then(|| DEFAULT_CHANNEL.open())
@@ -446,7 +448,7 @@ mod channel_closure {
 				.collect(),
 			});
 
-		if lagging {
+		if chain_tracking_lagging {
 			setup
 				// Chain tracking is lagging, nothing should be ingressed.
 				.test_on_finalize(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
@@ -6,7 +6,6 @@ use crate::{
 use cf_primitives::Asset;
 use cf_traits::IngressSink;
 use codec::{Decode, Encode};
-use core::u64;
 use frame_support::assert_ok;
 use sp_std::collections::btree_map::BTreeMap;
 use std::cell::RefCell;
@@ -199,8 +198,8 @@ fn with_default_setup() -> TestSetup<SimpleDeltaBasedIngress> {
 	TestSetup::<_>::default()
 		.with_initial_election_state(
 			1u32,
-			to_properties(INITIAL_CHANNEL_STATE.clone()),
-			to_state(INITIAL_CHANNEL_STATE.clone()),
+			to_properties(INITIAL_CHANNEL_STATE),
+			to_state(INITIAL_CHANNEL_STATE),
 		)
 		.with_initial_state_map(to_state_map(INITIAL_CHANNEL_STATE).into_iter().collect::<Vec<_>>())
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
@@ -222,6 +222,7 @@ fn with_default_setup() -> TestSetup<SimpleDeltaBasedIngress> {
 }
 
 impl TestContext<SimpleDeltaBasedIngress> {
+	#[track_caller]
 	fn assert_state_update(
 		self,
 		chain_tracking: &BlockNumber,


### PR DESCRIPTION
This is effectively a rewrite of the delta based ingress logic. Mostly this just makes things (subjectively speaking) more readable. 

Elections are recreated if properties change (ie. if there are any ingresses or channel closures). State (ie. 'pending ingresses') is preserved across elections. 

~~The only behavioural change is in the case where there is (a) a pending deposit in the state and (b) consensus on a higher deposit, with chain tracking lagging behind both:~~
- ~~before, the pending amount was never updated, ie. when chain tracking caught up to the pending amount, the 'first' ingress would always be processed, then the rest.~~
- ~~now, the pending amount is updated with the latest consensus value, even if chain tracking is lagging. This way, once it catches up, everything is processed at once.~~

~~I don't mind changing the behaviour back to what it was before. I don't think either option is actively exploitable in any way, unless it's possible to influence chain tracking.~~

Update: changed it back to previous behaviour.