### PR TITLE
refactor: extract commonalities of ElectoralSystem and ElectoralSystemRunner into its own trait

### DIFF
--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -14,8 +14,8 @@ use cf_utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
 use futures::{stream, StreamExt, TryStreamExt};
 use pallet_cf_elections::{
 	vote_storage::{AuthorityVote, VoteStorage},
-	ElectionIdentifierOf, ElectoralSystemRunner, ElectoralSystemTypes, PartialVoteOf,
-	SharedDataHash, VoteOf, VoteStorageOf, MAXIMUM_VOTES_PER_EXTRINSIC,
+	ElectionIdentifierOf, ElectoralSystemTypes, PartialVoteOf, SharedDataHash, VoteOf,
+	VoteStorageOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use rand::Rng;
 use std::{

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -14,8 +14,8 @@ use cf_utilities::{future_map::FutureMap, task_scope::Scope, UnendingStream};
 use futures::{stream, StreamExt, TryStreamExt};
 use pallet_cf_elections::{
 	vote_storage::{AuthorityVote, VoteStorage},
-	CompositeElectionIdentifierOf, ElectoralSystemRunner, SharedDataHash,
-	MAXIMUM_VOTES_PER_EXTRINSIC,
+	ElectionIdentifierOf, ElectoralSystemRunner, ElectoralSystemTypes, PartialVoteOf,
+	SharedDataHash, VoteOf, VoteStorageOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use rand::Rng;
 use std::{
@@ -111,17 +111,17 @@ where
 			std::time::Duration::from_millis(MILLISECONDS_PER_BLOCK);
 		let mut submit_interval = tokio::time::interval(BLOCK_TIME);
 		let mut pending_submissions = BTreeMap::<
-			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
+			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
 			(
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::PartialVote,
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+				PartialVoteOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
+				VoteOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
 			)
 		>::default();
 		let mut vote_tasks = FutureMap::default();
 		let mut shared_data_cache = HashMap::<
 			SharedDataHash,
 			(
-				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData,
+				<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData,
 				std::time::Instant,
 			)
 		>::default();
@@ -163,7 +163,7 @@ where
 					Ok(vote) => {
 						info!("Voting task for election: '{:?}' succeeded.", election_identifier);
 						// Create the partial_vote early so that SharedData can be provided as soon as the vote has been generated, rather than only after it is submitted.
-						let partial_vote = <<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::vote_into_partial_vote(&vote, |shared_data| {
+						let partial_vote = VoteStorageOf::<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>::vote_into_partial_vote(&vote, |shared_data| {
 							let shared_data_hash = SharedDataHash::of(&shared_data);
 							if shared_data_cache.len() > MAXIMUM_SHARED_DATA_CACHE_ITEMS {
 								for shared_data_hash in shared_data_cache.keys().cloned().take(shared_data_cache.len() - MAXIMUM_SHARED_DATA_CACHE_ITEMS).collect::<Vec<_>>() {

--- a/engine/src/elections/voter_api.rs
+++ b/engine/src/elections/voter_api.rs
@@ -4,19 +4,19 @@ use frame_support::{
 };
 use pallet_cf_elections::{
 	electoral_system::ElectoralSystem,
-	electoral_system_runner::RunnerStorageAccessTrait,
+	electoral_system_runner::{ElectoralSystemRunner, RunnerStorageAccessTrait},
 	electoral_systems::composite::{self, CompositeRunner},
 	vote_storage::{self, VoteStorage},
-	ElectoralSystemRunner,
+	ElectoralSystemTypes, VoteOf,
 };
 
 #[async_trait::async_trait]
 pub trait VoterApi<E: ElectoralSystem> {
 	async fn vote(
 		&self,
-		settings: <E as ElectoralSystem>::ElectoralSettings,
-		properties: <E as ElectoralSystem>::ElectionProperties,
-	) -> Result<<<E as ElectoralSystem>::Vote as VoteStorage>::Vote, anyhow::Error>;
+		settings: <E as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <E as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<E>, anyhow::Error>;
 }
 
 pub struct CompositeVoter<ElectoralSystemRunner, Voters> {
@@ -39,9 +39,9 @@ impl<ElectoralSystemRunner, Voters> CompositeVoter<ElectoralSystemRunner, Voters
 pub trait CompositeVoterApi<E: ElectoralSystemRunner> {
 	async fn vote(
 		&self,
-		settings: <E as ElectoralSystemRunner>::ElectoralSettings,
-		properties: <E as ElectoralSystemRunner>::ElectionProperties,
-	) -> Result<<<E as ElectoralSystemRunner>::Vote as VoteStorage>::Vote, anyhow::Error>;
+		settings: <E as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <E as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<E>, anyhow::Error>;
 }
 
 // TODO Combine this into the composite macro PRO-1736
@@ -52,10 +52,10 @@ macro_rules! generate_voter_api_tuple_impls {
         impl<$($voter: VoterApi<$electoral_system> + Send + Sync),*, $($electoral_system : ElectoralSystem<ValidatorId = ValidatorId> + Send + Sync + 'static),*, ValidatorId: MaybeSerializeDeserialize + Member + Parameter, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>> + Send + Sync + 'static, Hooks: Send + Sync + 'static + composite::$module::Hooks<$($electoral_system,)*>> CompositeVoterApi<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>> for CompositeVoter<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks>, ($($voter,)*)> {
             async fn vote(
                 &self,
-                settings: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::ElectoralSettings,
-                properties: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::ElectionProperties,
+                settings: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemTypes>::ElectoralSettings,
+                properties: <CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemTypes>::ElectionProperties,
             ) -> Result<
-                <<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+                <<CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, Hooks> as ElectoralSystemTypes>::VoteStorage as VoteStorage>::Vote,
                 anyhow::Error,
             > {
                 use vote_storage::composite::$module::CompositeVote;

--- a/engine/src/state_chain_observer/client/electoral_api.rs
+++ b/engine/src/state_chain_observer/client/electoral_api.rs
@@ -3,10 +3,7 @@ use crate::state_chain_observer::client::{
 	StateChainClient,
 };
 use codec::{Decode, Encode};
-use pallet_cf_elections::{
-	vote_storage::VoteStorage, ElectionIdentifierOf, ElectoralDataFor, ElectoralSystemRunner,
-	VoteOf,
-};
+use pallet_cf_elections::{ElectionIdentifierOf, ElectoralDataFor, VoteOf};
 use state_chain_runtime::SolanaInstance;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::error;

--- a/engine/src/state_chain_observer/client/electoral_api.rs
+++ b/engine/src/state_chain_observer/client/electoral_api.rs
@@ -4,8 +4,8 @@ use crate::state_chain_observer::client::{
 };
 use codec::{Decode, Encode};
 use pallet_cf_elections::{
-	electoral_system_runner::CompositeElectionIdentifierOf, vote_storage::VoteStorage,
-	ElectoralDataFor, ElectoralSystemRunner,
+	vote_storage::VoteStorage, ElectionIdentifierOf, ElectoralDataFor, ElectoralSystemRunner,
+	VoteOf,
 };
 use state_chain_runtime::SolanaInstance;
 use std::collections::{BTreeMap, BTreeSet};
@@ -28,10 +28,10 @@ where
 	fn filter_votes(
 		&self,
 		proposed_votes: BTreeMap<
-			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
-			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
+			VoteOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>,
 		>,
-	) -> impl std::future::Future<Output = BTreeSet<CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>>> + Send + 'static;
+	) -> impl std::future::Future<Output = BTreeSet<ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>>> + Send + 'static;
 }
 
 impl<
@@ -67,10 +67,10 @@ impl<
 	fn filter_votes(
 		&self,
 		proposed_votes: BTreeMap<
-			CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>,
-			<<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+			ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>,
+			VoteOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>,
 		>,
-	) -> impl std::future::Future<Output = BTreeSet<CompositeElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>>> + Send + 'static{
+	) -> impl std::future::Future<Output = BTreeSet<ElectionIdentifierOf<<state_chain_runtime::Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner>>> + Send + 'static{
 		let base_rpc_client = self.base_rpc_client.clone();
 		let account_id = self.signed_extrinsic_client.account_id();
 		async move {
@@ -81,7 +81,7 @@ impl<
 				.map_err(anyhow::Error::from)
 				.and_then(|electoral_data| {
 					<BTreeSet<
-						CompositeElectionIdentifierOf<
+						ElectionIdentifierOf<
 							<state_chain_runtime::Runtime as pallet_cf_elections::Config<
 								SolanaInstance,
 							>>::ElectoralSystemRunner,

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -24,6 +24,7 @@ use futures::FutureExt;
 use pallet_cf_elections::{
 	electoral_system::ElectoralSystem,
 	electoral_systems::solana_vault_swap_accounts::SolanaVaultSwapsVote, vote_storage::VoteStorage,
+	ElectoralSystemTypes, VoteOf,
 };
 use state_chain_runtime::{
 	chainflip::solana_elections::{
@@ -51,12 +52,9 @@ struct SolanaBlockHeightTrackingVoter {
 impl VoterApi<SolanaBlockHeightTracking> for SolanaBlockHeightTrackingVoter {
 	async fn vote(
 		&self,
-		_settings: <SolanaBlockHeightTracking as ElectoralSystem>::ElectoralSettings,
-		_properties: <SolanaBlockHeightTracking as ElectoralSystem>::ElectionProperties,
-	) -> Result<
-		<<SolanaBlockHeightTracking as ElectoralSystem>::Vote as VoteStorage>::Vote,
-		anyhow::Error,
-	> {
+		_settings: <SolanaBlockHeightTracking as ElectoralSystemTypes>::ElectoralSettings,
+		_properties: <SolanaBlockHeightTracking as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaBlockHeightTracking>, anyhow::Error> {
 		let slot = self.client.get_slot(CommitmentConfig::finalized()).await;
 		CHAIN_TRACKING.set(&[cf_chains::Solana::NAME], Into::<u64>::into(slot));
 		Ok(slot)
@@ -72,10 +70,9 @@ struct SolanaFeeTrackingVoter;
 impl VoterApi<SolanaFeeTracking> for SolanaFeeTrackingVoter {
 	async fn vote(
 		&self,
-		_settings: <SolanaFeeTracking as ElectoralSystem>::ElectoralSettings,
-		_properties: <SolanaFeeTracking as ElectoralSystem>::ElectionProperties,
-	) -> Result<<<SolanaFeeTracking as ElectoralSystem>::Vote as VoteStorage>::Vote, anyhow::Error>
-	{
+		_settings: <SolanaFeeTracking as ElectoralSystemTypes>::ElectoralSettings,
+		_properties: <SolanaFeeTracking as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaFeeTracking>, anyhow::Error> {
 		// Note, this won't actually be submitted, because no elections will be created (they have
 		// been disabled inside the UnsafeMedian electoral system) this is just to provide
 		// something so we compile.
@@ -92,12 +89,9 @@ struct SolanaIngressTrackingVoter {
 impl VoterApi<SolanaIngressTracking> for SolanaIngressTrackingVoter {
 	async fn vote(
 		&self,
-		settings: <SolanaIngressTracking as ElectoralSystem>::ElectoralSettings,
-		properties: <SolanaIngressTracking as ElectoralSystem>::ElectionProperties,
-	) -> Result<
-		<<SolanaIngressTracking as ElectoralSystem>::Vote as VoteStorage>::Vote,
-		anyhow::Error,
-	> {
+		settings: <SolanaIngressTracking as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <SolanaIngressTracking as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaIngressTracking>, anyhow::Error> {
 		sol_deposits::get_channel_ingress_amounts(
 			&self.client,
 			settings.vault_program,
@@ -120,10 +114,9 @@ struct SolanaNonceTrackingVoter {
 impl VoterApi<SolanaNonceTracking> for SolanaNonceTrackingVoter {
 	async fn vote(
 		&self,
-		_settings: <SolanaNonceTracking as ElectoralSystem>::ElectoralSettings,
-		properties: <SolanaNonceTracking as ElectoralSystem>::ElectionProperties,
-	) -> Result<<<SolanaNonceTracking as ElectoralSystem>::Vote as VoteStorage>::Vote, anyhow::Error>
-	{
+		_settings: <SolanaNonceTracking as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <SolanaNonceTracking as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaNonceTracking>, anyhow::Error> {
 		let (nonce_account, previous_nonce, previous_slot) = properties;
 
 		let nonce_and_slot =
@@ -146,12 +139,9 @@ struct SolanaEgressWitnessingVoter {
 impl VoterApi<SolanaEgressWitnessing> for SolanaEgressWitnessingVoter {
 	async fn vote(
 		&self,
-		_settings: <SolanaEgressWitnessing as ElectoralSystem>::ElectoralSettings,
-		signature: <SolanaEgressWitnessing as ElectoralSystem>::ElectionProperties,
-	) -> Result<
-		<<SolanaEgressWitnessing as ElectoralSystem>::Vote as VoteStorage>::Vote,
-		anyhow::Error,
-	> {
+		_settings: <SolanaEgressWitnessing as ElectoralSystemTypes>::ElectoralSettings,
+		signature: <SolanaEgressWitnessing as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaEgressWitnessing>, anyhow::Error> {
 		egress_witnessing::get_finalized_fee_and_success_status(&self.client, signature)
 			.await
 			.map(|(tx_fee, transaction_successful)| TransactionSuccessDetails {
@@ -170,9 +160,9 @@ struct SolanaLivenessVoter {
 impl VoterApi<SolanaLiveness> for SolanaLivenessVoter {
 	async fn vote(
 		&self,
-		_settings: <SolanaLiveness as ElectoralSystem>::ElectoralSettings,
-		slot: <SolanaLiveness as ElectoralSystem>::ElectionProperties,
-	) -> Result<<<SolanaLiveness as ElectoralSystem>::Vote as VoteStorage>::Vote, anyhow::Error> {
+		_settings: <SolanaLiveness as ElectoralSystemTypes>::ElectoralSettings,
+		slot: <SolanaLiveness as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaLiveness>, anyhow::Error> {
 		Ok(SolHash::from_str(
 			&self
 				.client
@@ -201,12 +191,9 @@ struct SolanaVaultSwapsVoter {
 impl VoterApi<SolanaVaultSwapTracking> for SolanaVaultSwapsVoter {
 	async fn vote(
 		&self,
-		settings: <SolanaVaultSwapTracking as ElectoralSystem>::ElectoralSettings,
-		properties: <SolanaVaultSwapTracking as ElectoralSystem>::ElectionProperties,
-	) -> Result<
-		<<SolanaVaultSwapTracking as ElectoralSystem>::Vote as VoteStorage>::Vote,
-		anyhow::Error,
-	> {
+		settings: <SolanaVaultSwapTracking as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <SolanaVaultSwapTracking as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<VoteOf<SolanaVaultSwapTracking>, anyhow::Error> {
 		program_swaps_witnessing::get_program_swaps(
 			&self.client,
 			settings.swap_endpoint_data_account_address,

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -22,9 +22,8 @@ use cf_chains::{
 };
 use futures::FutureExt;
 use pallet_cf_elections::{
-	electoral_system::ElectoralSystem,
-	electoral_systems::solana_vault_swap_accounts::SolanaVaultSwapsVote, vote_storage::VoteStorage,
-	ElectoralSystemTypes, VoteOf,
+	electoral_systems::solana_vault_swap_accounts::SolanaVaultSwapsVote, ElectoralSystemTypes,
+	VoteOf,
 };
 use state_chain_runtime::{
 	chainflip::solana_elections::{

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-01-10"
+channel = "nightly-2025-01-09"
 components = [
 	"cargo",
 	"clippy",

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -28,7 +28,7 @@ use frame_support::{
 };
 use pallet_cf_elections::{
 	vote_storage::{composite::tuple_7_impls::CompositeVote, AuthorityVote},
-	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, MAXIMUM_VOTES_PER_EXTRINSIC,
+	AuthorityVoteOf, ElectionIdentifierOf, MAXIMUM_VOTES_PER_EXTRINSIC,
 };
 use pallet_cf_ingress_egress::{
 	DepositFailedReason, DepositWitness, FetchOrTransfer, VaultDepositWitness,
@@ -65,10 +65,10 @@ const REFUND_PARAMS: ChannelRefundParametersDecoded = ChannelRefundParametersDec
 };
 
 type SolanaElectionVote = BoundedBTreeMap<
-	CompositeElectionIdentifierOf<
+	ElectionIdentifierOf<
 		<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner,
 	>,
-	CompositeAuthorityVoteOf<
+	AuthorityVoteOf<
 		<Runtime as pallet_cf_elections::Config<SolanaInstance>>::ElectoralSystemRunner,
 	>,
 	ConstU32<MAXIMUM_VOTES_PER_EXTRINSIC>,

--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -1,9 +1,7 @@
 use crate::{
 	bitmap_components::ElectionBitmapComponents,
-	electoral_system_runner::{
-		CompositeAuthorityVoteOf, CompositeIndividualComponentOf, CompositeVotePropertiesOf,
-		ElectoralSystemRunner,
-	},
+	electoral_system::{AuthorityVoteOf, IndividualComponentOf, VotePropertiesOf},
+	electoral_system_runner::ElectoralSystemRunner,
 	vote_storage::VoteStorage,
 	*,
 };
@@ -25,13 +23,13 @@ use crate::Call;
 #[allow(clippy::multiple_bound_locations)]
 #[instance_benchmarks(
 	where
-	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote: BenchmarkValue,
-	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData: BenchmarkValue,
-	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Properties: BenchmarkValue,
-	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::IndividualComponent: BenchmarkValue,
+	VoteOf<<T as Config<I>>::ElectoralSystemRunner>: BenchmarkValue,
+	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData: BenchmarkValue,
+	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::Properties: BenchmarkValue,
+	<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::IndividualComponent: BenchmarkValue,
 	InitialStateOf<T, I>: BenchmarkValue,
-	<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings: BenchmarkValue,
-	<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings: BenchmarkValue,
+	<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings: BenchmarkValue,
+	<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings: BenchmarkValue,
 )]
 mod benchmarks {
 	use super::*;
@@ -64,8 +62,8 @@ mod benchmarks {
 
 	fn setup_validators_and_vote<T: crate::pallet::Config<I>, I: 'static>(
 		validator_counts: u32,
-		vote_value: <<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
-	) -> CompositeElectionIdentifierOf<T::ElectoralSystemRunner> {
+		vote_value: VoteOf<<T as Config<I>>::ElectoralSystemRunner>,
+	) -> ElectionIdentifierOf<T::ElectoralSystemRunner> {
 		// Setup a validator set of 150 as in the case of Mainnet.
 		let validators = ready_validator_for_vote::<T, I>(validator_counts);
 		let caller = validators[0].clone();
@@ -82,9 +80,7 @@ mod benchmarks {
 				BoundedBTreeMap::try_from(
 					[(
 						election_identifier,
-						CompositeAuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
-							vote_value.clone()
-						),
+						AuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(vote_value.clone()),
 					)]
 					.into_iter()
 					.collect::<BTreeMap<_, _>>(),
@@ -108,7 +104,7 @@ mod benchmarks {
 			BoundedBTreeMap::try_from(
 				iter::repeat((
 					next_election.0,
-					CompositeAuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
+					AuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
 						BenchmarkValue::benchmark_value(),
 					),
 				))
@@ -170,7 +166,7 @@ mod benchmarks {
 			BoundedBTreeMap::try_from(
 				[(
 					next_election.0,
-					CompositeAuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
+					AuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
 						BenchmarkValue::benchmark_value()
 					),
 				)]
@@ -207,7 +203,7 @@ mod benchmarks {
 			BoundedBTreeMap::try_from(
 				[(
 					next_election.0,
-					CompositeAuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
+					AuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
 						BenchmarkValue::benchmark_value()
 					),
 				)]
@@ -247,7 +243,7 @@ mod benchmarks {
 			BoundedBTreeMap::try_from(
 				[(
 					election_identifier,
-					CompositeAuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
+					AuthorityVoteOf::<T::ElectoralSystemRunner>::Vote(
 						BenchmarkValue::benchmark_value()
 					),
 				)]
@@ -262,7 +258,7 @@ mod benchmarks {
 
 		assert_eq!(
 			SharedData::<T, I>::get(SharedDataHash::of::<
-				<<<T as Config<I>>::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+				VoteOf<<T as Config<I>>::ElectoralSystemRunner>,
 			>(&BenchmarkValue::benchmark_value())),
 			Some(BenchmarkValue::benchmark_value())
 		);
@@ -497,7 +493,7 @@ mod benchmarks {
 		(0..b).for_each(|i| {
 			SharedData::<T, I>::insert(
 				SharedDataHash::of(&i),
-				<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData::benchmark_value());
+				<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData::benchmark_value());
 		});
 
 		(0..c).for_each(|i| {
@@ -514,8 +510,8 @@ mod benchmarks {
 				UniqueMonotonicIdentifier::from_u64(i as u64),
 				T::ValidatorId::from(validators[i as usize].clone()),
 				(
-					CompositeVotePropertiesOf::<T::ElectoralSystemRunner>::benchmark_value(),
-					CompositeIndividualComponentOf::<T::ElectoralSystemRunner>::benchmark_value(),
+					VotePropertiesOf::<T::ElectoralSystemRunner>::benchmark_value(),
+					IndividualComponentOf::<T::ElectoralSystemRunner>::benchmark_value(),
 				),
 			);
 		});

--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -1,7 +1,6 @@
 use crate::{
 	bitmap_components::ElectionBitmapComponents,
 	electoral_system::{AuthorityVoteOf, IndividualComponentOf, VotePropertiesOf},
-	electoral_system_runner::ElectoralSystemRunner,
 	vote_storage::VoteStorage,
 	*,
 };

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -1,7 +1,3 @@
-use frame_support::{
-	pallet_prelude::{MaybeSerializeDeserialize, Member},
-	Parameter,
-};
 use sp_std::vec::Vec;
 
 use crate::{
@@ -9,7 +5,6 @@ use crate::{
 		AuthorityVoteOf, ConsensusVotes, ElectionIdentifierOf, ElectoralSystemTypes, PartialVoteOf,
 		VoteOf, VotePropertiesOf,
 	},
-	vote_storage::{AuthorityVote, VoteStorage},
 	CorruptStorageError, ElectionIdentifier,
 };
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -3,8 +3,7 @@ use crate::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
 		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError, ElectionIdentifier,
+	vote_storage, CorruptStorageError, ElectionIdentifier,
 };
 use cf_traits::IngressSink;
 use cf_utilities::success_threshold_from_share_count;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -49,10 +49,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 },
                 electoral_system_runner::{ElectoralSystemRunner, RunnerStorageAccessTrait},
                 electoral_system::{AuthorityVoteOf, VotePropertiesOf},
-                vote_storage::{
-                    AuthorityVote,
-                    VoteStorage
-                },
+                vote_storage::AuthorityVote,
                 ElectionIdentifier,
             };
             use crate::vote_storage::composite::$module::{CompositeVoteProperties, CompositeVote, CompositePartialVote};

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -35,6 +35,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 CorruptStorageError,
                 electoral_system::{
                     ElectoralSystem,
+                    ElectoralSystemTypes,
                     ConsensusVote,
                     ElectionReadAccess,
                     ElectionWriteAccess,
@@ -42,10 +43,12 @@ macro_rules! generate_electoral_system_tuple_impls {
                     ElectoralWriteAccess,
                     ConsensusVotes,
                     ElectionIdentifierOf,
+                    PartialVoteOf,
+                    VoteOf,
                     ConsensusStatus,
                 },
-                electoral_system_runner::{ElectoralSystemRunner, CompositeAuthorityVoteOf, RunnerStorageAccessTrait,
-                    CompositeVotePropertiesOf, CompositeConsensusVotes, CompositeElectionIdentifierOf, CompositeConsensusVote},
+                electoral_system_runner::{ElectoralSystemRunner, RunnerStorageAccessTrait},
+                electoral_system::{AuthorityVoteOf, VotePropertiesOf},
                 vote_storage::{
                     AuthorityVote,
                     VoteStorage
@@ -98,7 +101,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                         Vec<ElectionIdentifierOf<$electoral_system>>,
                     )*)
                 ) -> R>(
-                    election_identifiers: Vec<CompositeElectionIdentifierOf<Self>>,
+                    election_identifiers: Vec<ElectionIdentifierOf<Self>>,
                     f: F,
                 ) -> R {
                     $(let mut $electoral_system_alt_name_0 = Vec::new();)*
@@ -117,25 +120,29 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
             }
 
-            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = Self> + 'static, H: Hooks<$($electoral_system),*> + 'static> ElectoralSystemRunner for CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H> {
+            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = Self> + 'static, H: Hooks<$($electoral_system),*> + 'static> ElectoralSystemTypes for CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H> {
                 type ValidatorId = ValidatorId;
-                type ElectoralUnsynchronisedState = ($(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedState,)*);
-                type ElectoralUnsynchronisedStateMapKey = CompositeElectoralUnsynchronisedStateMapKey<$(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedStateMapKey,)*>;
-                type ElectoralUnsynchronisedStateMapValue = CompositeElectoralUnsynchronisedStateMapValue<$(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedStateMapValue,)*>;
-                type ElectoralUnsynchronisedSettings = ($(<$electoral_system as ElectoralSystem>::ElectoralUnsynchronisedSettings,)*);
-                type ElectoralSettings = ($(<$electoral_system as ElectoralSystem>::ElectoralSettings,)*);
+                type ElectoralUnsynchronisedState = ($(<$electoral_system as ElectoralSystemTypes>::ElectoralUnsynchronisedState,)*);
+                type ElectoralUnsynchronisedStateMapKey = CompositeElectoralUnsynchronisedStateMapKey<$(<$electoral_system as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,)*>;
+                type ElectoralUnsynchronisedStateMapValue = CompositeElectoralUnsynchronisedStateMapValue<$(<$electoral_system as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue,)*>;
+                type ElectoralUnsynchronisedSettings = ($(<$electoral_system as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,)*);
+                type ElectoralSettings = ($(<$electoral_system as ElectoralSystemTypes>::ElectoralSettings,)*);
 
-                type ElectionIdentifierExtra = CompositeElectionIdentifierExtra<$(<$electoral_system as ElectoralSystem>::ElectionIdentifierExtra,)*>;
-                type ElectionProperties = CompositeElectionProperties<$(<$electoral_system as ElectoralSystem>::ElectionProperties,)*>;
-                type ElectionState = CompositeElectionState<$(<$electoral_system as ElectoralSystem>::ElectionState,)*>;
-                type Vote = ($(<$electoral_system as ElectoralSystem>::Vote,)*);
-                type Consensus = CompositeConsensus<$(<$electoral_system as ElectoralSystem>::Consensus,)*>;
+                type ElectionIdentifierExtra = CompositeElectionIdentifierExtra<$(<$electoral_system as ElectoralSystemTypes>::ElectionIdentifierExtra,)*>;
+                type ElectionProperties = CompositeElectionProperties<$(<$electoral_system as ElectoralSystemTypes>::ElectionProperties,)*>;
+                type ElectionState = CompositeElectionState<$(<$electoral_system as ElectoralSystemTypes>::ElectionState,)*>;
+                type VoteStorage = ($(<$electoral_system as ElectoralSystemTypes>::VoteStorage,)*);
+                type Consensus = CompositeConsensus<$(<$electoral_system as ElectoralSystemTypes>::Consensus,)*>;
+                type OnFinalizeContext = ();
+                type OnFinalizeReturn = ();
+            }
 
+            impl<$($electoral_system: ElectoralSystem<ValidatorId = ValidatorId>,)* ValidatorId: MaybeSerializeDeserialize + Parameter + Member, StorageAccess: RunnerStorageAccessTrait<ElectoralSystemRunner = Self> + 'static, H: Hooks<$($electoral_system),*> + 'static> ElectoralSystemRunner for CompositeRunner<($($electoral_system,)*), ValidatorId, StorageAccess, H> {
                 fn is_vote_desired(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
                     current_vote: Option<(
-                        CompositeVotePropertiesOf<Self>,
-                        CompositeAuthorityVoteOf<Self>,
+                        VotePropertiesOf<Self>,
+                        AuthorityVoteOf<Self>,
                     )>,
                 ) -> Result<bool, CorruptStorageError> {
                     match *election_identifier.extra() {
@@ -161,8 +168,8 @@ macro_rules! generate_electoral_system_tuple_impls {
                 }
 
                 fn is_vote_needed(
-                    (current_vote_properties, current_partial_vote, current_authority_vote): (CompositeVotePropertiesOf<Self>, <Self::Vote as VoteStorage>::PartialVote, CompositeAuthorityVoteOf<Self>),
-                    (proposed_partial_vote, proposed_vote): (<Self::Vote as VoteStorage>::PartialVote, <Self::Vote as VoteStorage>::Vote),
+                    (current_vote_properties, current_partial_vote, current_authority_vote): (VotePropertiesOf<Self>, PartialVoteOf<Self>, AuthorityVoteOf<Self>),
+                    (proposed_partial_vote, proposed_vote): (PartialVoteOf<Self>, VoteOf<Self>),
                 ) -> bool {
                     match (current_vote_properties, current_partial_vote, current_authority_vote, proposed_partial_vote, proposed_vote) {
                         $(
@@ -198,11 +205,11 @@ macro_rules! generate_electoral_system_tuple_impls {
                 fn generate_vote_properties(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
                     previous_vote: Option<(
-                        CompositeVotePropertiesOf<Self>,
-                        CompositeAuthorityVoteOf<Self>,
+                        VotePropertiesOf<Self>,
+                        AuthorityVoteOf<Self>,
                     )>,
-                    partial_vote: &<Self::Vote as VoteStorage>::PartialVote,
-                ) -> Result<CompositeVotePropertiesOf<Self>, CorruptStorageError> {
+                    partial_vote: &PartialVoteOf<Self>,
+                ) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
                     match (*election_identifier.extra(), partial_vote) {
                         $((CompositeElectionIdentifierExtra::$electoral_system(extra), CompositePartialVote::$electoral_system(partial_vote)) => {
                             <$electoral_system as ElectoralSystem>::generate_vote_properties(
@@ -240,7 +247,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                 fn check_consensus(
                     election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
                     previous_consensus: Option<&Self::Consensus>,
-                    consensus_votes: CompositeConsensusVotes<Self>,
+                    consensus_votes: ConsensusVotes<Self>,
                 ) -> Result<Option<Self::Consensus>, CorruptStorageError> {
                     Ok(match *election_identifier.extra() {
                         $(CompositeElectionIdentifierExtra::$electoral_system(extra) => {
@@ -253,7 +260,7 @@ macro_rules! generate_electoral_system_tuple_impls {
                                     }
                                 }).transpose()?,
                                 ConsensusVotes {
-                                    votes: consensus_votes.votes.into_iter().map(|CompositeConsensusVote { vote, validator_id }| {
+                                    votes: consensus_votes.votes.into_iter().map(|ConsensusVote { vote, validator_id }| {
                                         if let Some((properties, vote)) = vote {
                                             match (properties, vote) {
                                                 (
@@ -379,7 +386,7 @@ macro_rules! generate_electoral_system_tuple_impls {
             type ElectionReadAccess = DerivedElectionAccess<tags::$current, $current, StorageAccess>;
 
             fn election(
-                id: ElectionIdentifier<<$current as ElectoralSystem>::ElectionIdentifierExtra>,
+                id: ElectionIdentifier<<$current as ElectoralSystemTypes>::ElectionIdentifierExtra>,
             ) -> Self::ElectionReadAccess {
                 DerivedElectionAccess::<tags::$current, _, StorageAccess>::new(id)
             }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
@@ -4,8 +4,7 @@ use crate::{
 		ElectionWriteAccess, ElectoralSystem, ElectoralSystemTypes, ElectoralWriteAccess,
 		PartialVoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError,
+	vote_storage, CorruptStorageError,
 };
 use cf_utilities::success_threshold_from_share_count;
 use frame_support::{

--- a/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/egress_success.rs
@@ -1,7 +1,8 @@
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
-		ElectionWriteAccess, ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
+		ElectionWriteAccess, ElectoralSystem, ElectoralSystemTypes, ElectoralWriteAccess,
+		PartialVoteOf, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError,
@@ -47,7 +48,7 @@ impl<
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: OnEgressSuccess<Identifier, Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem for EgressSuccess<Identifier, Value, Settings, Hook, ValidatorId>
+	> ElectoralSystemTypes for EgressSuccess<Identifier, Value, Settings, Hook, ValidatorId>
 {
 	type ValidatorId = ValidatorId;
 	type ElectoralUnsynchronisedState = ();
@@ -59,15 +60,24 @@ impl<
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = Identifier;
 	type ElectionState = ();
-	type Vote = vote_storage::bitmap::Bitmap<Value>;
+	type VoteStorage = vote_storage::bitmap::Bitmap<Value>;
 	type Consensus = Value;
 	type OnFinalizeContext = ();
 	type OnFinalizeReturn = ();
+}
 
+impl<
+		Identifier: Member + Parameter + Ord,
+		Value: Member + Parameter + Eq + Ord,
+		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
+		Hook: OnEgressSuccess<Identifier, Value> + 'static,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem for EgressSuccess<Identifier, Value, Settings, Hook, ValidatorId>
+{
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifierOf<Self>,
 		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
 		Ok(())
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
@@ -3,7 +3,8 @@ use sp_std::collections::btree_set::BTreeSet;
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVote, ConsensusVotes, ElectionIdentifierOf, ElectionReadAccess,
-		ElectionWriteAccess, ElectoralSystem, ElectoralWriteAccess, VotePropertiesOf,
+		ElectionWriteAccess, ElectoralSystem, ElectoralSystemTypes, ElectoralWriteAccess,
+		PartialVoteOf, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError,
@@ -44,7 +45,8 @@ impl<
 			+ Copy,
 		Hook: OnCheckComplete<ValidatorId> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem for Liveness<ChainBlockNumber, ChainBlockHash, BlockNumber, Hook, ValidatorId>
+	> ElectoralSystemTypes
+	for Liveness<ChainBlockNumber, ChainBlockHash, BlockNumber, Hook, ValidatorId>
 {
 	type ValidatorId = ValidatorId;
 	type ElectoralUnsynchronisedState = ();
@@ -61,16 +63,31 @@ impl<
 
 	// The SC block number that we started the election at.
 	type ElectionState = BlockNumber;
-	type Vote = vote_storage::bitmap::Bitmap<ChainBlockHash>;
+	type VoteStorage = vote_storage::bitmap::Bitmap<ChainBlockHash>;
 	type Consensus = BTreeSet<Self::ValidatorId>;
 	// The current SC block number, and the current chain tracking height.
 	type OnFinalizeContext = (BlockNumber, ChainBlockNumber);
 	type OnFinalizeReturn = ();
+}
 
+impl<
+		ChainBlockNumber: Member + Parameter + Eq + From<u64> + Into<u64> + Copy,
+		ChainBlockHash: Member + Parameter + Eq + Ord,
+		BlockNumber: Member
+			+ Parameter
+			+ Eq
+			+ MaybeSerializeDeserialize
+			+ frame_support::sp_runtime::Saturating
+			+ Ord
+			+ Copy,
+		Hook: OnCheckComplete<ValidatorId> + 'static,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem for Liveness<ChainBlockNumber, ChainBlockHash, BlockNumber, Hook, ValidatorId>
+{
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifierOf<Self>,
 		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
 		Ok(())
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/liveness.rs
@@ -6,8 +6,7 @@ use crate::{
 		ElectionWriteAccess, ElectoralSystem, ElectoralSystemTypes, ElectoralWriteAccess,
 		PartialVoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError,
+	vote_storage, CorruptStorageError,
 };
 use cf_primitives::AuthorityCount;
 use cf_utilities::success_threshold_from_share_count;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -5,8 +5,7 @@ use crate::{
 	},
 	electoral_system_runner::{ElectoralSystemRunner, RunnerStorageAccessTrait},
 	mock::Test,
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError, RunnerStorageAccess, UniqueMonotonicIdentifier,
+	vote_storage, CorruptStorageError, RunnerStorageAccess, UniqueMonotonicIdentifier,
 };
 use cf_primitives::AuthorityCount;
 use cf_traits::Chainflip;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mock.rs
@@ -1,10 +1,12 @@
 use crate::{
-	electoral_system::ConsensusStatus,
-	electoral_system_runner::{CompositeConsensusVotes, RunnerStorageAccessTrait},
+	electoral_system::{
+		AuthorityVoteOf, ConsensusStatus, ConsensusVotes, ElectionIdentifierOf,
+		ElectoralSystemTypes, PartialVoteOf, VoteOf, VotePropertiesOf,
+	},
+	electoral_system_runner::{ElectoralSystemRunner, RunnerStorageAccessTrait},
 	mock::Test,
 	vote_storage::{self, VoteStorage},
-	CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, CompositeVotePropertiesOf,
-	CorruptStorageError, ElectoralSystemRunner, RunnerStorageAccess, UniqueMonotonicIdentifier,
+	CorruptStorageError, RunnerStorageAccess, UniqueMonotonicIdentifier,
 };
 use cf_primitives::AuthorityCount;
 use cf_traits::Chainflip;
@@ -115,7 +117,7 @@ impl MockElectoralSystemRunner {
 	}
 }
 
-impl ElectoralSystemRunner for MockElectoralSystemRunner {
+impl ElectoralSystemTypes for MockElectoralSystemRunner {
 	type ValidatorId = <Test as Chainflip>::ValidatorId;
 	type ElectoralUnsynchronisedState = ();
 	type ElectoralUnsynchronisedStateMapKey = ();
@@ -127,20 +129,25 @@ impl ElectoralSystemRunner for MockElectoralSystemRunner {
 	type ElectionProperties = ();
 	type ElectionState = ();
 	// TODO: mock the vote storage
-	type Vote =
+	type VoteStorage =
 		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<()>>;
 	type Consensus = AuthorityCount;
 
+	type OnFinalizeContext = ();
+	type OnFinalizeReturn = ();
+}
+
+impl ElectoralSystemRunner for MockElectoralSystemRunner {
 	fn generate_vote_properties(
-		_election_identifier: CompositeElectionIdentifierOf<Self>,
-		_previous_vote: Option<(CompositeVotePropertiesOf<Self>, CompositeAuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_election_identifier: ElectionIdentifierOf<Self>,
+		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<(), CorruptStorageError> {
 		Ok(())
 	}
 
 	fn on_finalize(
-		election_identifiers: Vec<CompositeElectionIdentifierOf<Self>>,
+		election_identifiers: Vec<ElectionIdentifierOf<Self>>,
 	) -> Result<(), CorruptStorageError> {
 		for id in election_identifiers {
 			let consensus =
@@ -155,9 +162,9 @@ impl ElectoralSystemRunner for MockElectoralSystemRunner {
 	}
 
 	fn check_consensus(
-		_election_identifier: CompositeElectionIdentifierOf<Self>,
+		_election_identifier: ElectionIdentifierOf<Self>,
 		_previous_consensus: Option<&Self::Consensus>,
-		consensus_votes: CompositeConsensusVotes<Self>,
+		consensus_votes: ConsensusVotes<Self>,
 	) -> Result<Option<Self::Consensus>, CorruptStorageError> {
 		Ok(if Self::should_assume_consensus() {
 			Some(consensus_votes.active_votes().len() as AuthorityCount)
@@ -167,22 +174,15 @@ impl ElectoralSystemRunner for MockElectoralSystemRunner {
 	}
 
 	fn is_vote_desired(
-		_election_identifier: CompositeElectionIdentifierOf<Self>,
-		_current_vote: Option<(CompositeVotePropertiesOf<Self>, CompositeAuthorityVoteOf<Self>)>,
+		_election_identifier: ElectionIdentifierOf<Self>,
+		_current_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
 	) -> Result<bool, CorruptStorageError> {
 		Ok(Self::vote_desired())
 	}
 
 	fn is_vote_needed(
-		_current_vote: (
-			CompositeVotePropertiesOf<Self>,
-			<Self::Vote as VoteStorage>::PartialVote,
-			CompositeAuthorityVoteOf<Self>,
-		),
-		_proposed_vote: (
-			<Self::Vote as VoteStorage>::PartialVote,
-			<Self::Vote as VoteStorage>::Vote,
-		),
+		_current_vote: (VotePropertiesOf<Self>, PartialVoteOf<Self>, AuthorityVoteOf<Self>),
+		_proposed_vote: (PartialVoteOf<Self>, VoteOf<Self>),
 	) -> bool {
 		Self::vote_needed()
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_change.rs
@@ -4,8 +4,7 @@ use crate::{
 		ElectionWriteAccess, ElectoralSystem, ElectoralSystemTypes, ElectoralWriteAccess,
 		PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError,
+	vote_storage, CorruptStorageError,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_utilities::{success_threshold_from_share_count, threshold_from_share_count};

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -1,10 +1,9 @@
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
+		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError, ElectionIdentifier,
+	vote_storage, CorruptStorageError, ElectionIdentifier,
 };
 use cf_utilities::success_threshold_from_share_count;
 use frame_support::{

--- a/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/monotonic_median.rs
@@ -1,7 +1,7 @@
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralWriteAccess, VotePropertiesOf,
+		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError, ElectionIdentifier,
@@ -37,7 +37,7 @@ impl<
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: MedianChangeHook<Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem for MonotonicMedian<Value, Settings, Hook, ValidatorId>
+	> ElectoralSystemTypes for MonotonicMedian<Value, Settings, Hook, ValidatorId>
 {
 	type ValidatorId = ValidatorId;
 	type ElectoralUnsynchronisedState = Value;
@@ -49,16 +49,23 @@ impl<
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = ();
 	type ElectionState = ();
-	type Vote =
+	type VoteStorage =
 		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<Value>>;
 	type Consensus = Value;
 	type OnFinalizeContext = ();
 	type OnFinalizeReturn = Value;
-
+}
+impl<
+		Value: MaybeSerializeDeserialize + Member + Parameter + Ord,
+		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
+		Hook: MedianChangeHook<Value> + 'static,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem for MonotonicMedian<Value, Settings, Hook, ValidatorId>
+{
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
 		Ok(())
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/solana_vault_swap_accounts.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/solana_vault_swap_accounts.rs
@@ -13,7 +13,7 @@ use cf_chains::sol::api::VaultSwapAccountAndSender;
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralWriteAccess, VotePropertiesOf,
+		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError, ElectionIdentifier,
@@ -113,7 +113,7 @@ impl<
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: SolanaVaultSwapAccountsHook<Account, SwapDetails, E> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem
+	> ElectoralSystemTypes
 	for SolanaVaultSwapAccounts<Account, SwapDetails, BlockNumber, Settings, Hook, ValidatorId, E>
 {
 	type ValidatorId = ValidatorId;
@@ -126,15 +126,27 @@ impl<
 	type ElectionIdentifierExtra = u64;
 	type ElectionProperties = SolanaVaultSwapsKnownAccounts<Account>;
 	type ElectionState = ();
-	type Vote = vote_storage::bitmap::Bitmap<SolanaVaultSwapsVote<Account, SwapDetails>>;
+	type VoteStorage = vote_storage::bitmap::Bitmap<SolanaVaultSwapsVote<Account, SwapDetails>>;
 	type Consensus = SolanaVaultSwapsVote<Account, SwapDetails>;
 	type OnFinalizeContext = BlockNumber;
 	type OnFinalizeReturn = ();
+}
 
+impl<
+		E: sp_std::fmt::Debug + 'static,
+		Account: MaybeSerializeDeserialize + Member + Parameter + Ord,
+		SwapDetails: MaybeSerializeDeserialize + Member + Parameter + Ord + FromSolOrNot,
+		BlockNumber: MaybeSerializeDeserialize + Member + Parameter + Ord + Saturating + Into<u32> + Copy,
+		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
+		Hook: SolanaVaultSwapAccountsHook<Account, SwapDetails, E> + 'static,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem
+	for SolanaVaultSwapAccounts<Account, SwapDetails, BlockNumber, Settings, Hook, ValidatorId, E>
+{
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
 		Ok(())
 	}
@@ -149,13 +161,10 @@ impl<
 	fn is_vote_needed(
 		(_, current_partial_vote, _): (
 			VotePropertiesOf<Self>,
-			<Self::Vote as VoteStorage>::PartialVote,
+			PartialVoteOf<Self>,
 			AuthorityVoteOf<Self>,
 		),
-		(proposed_partial_vote, _): (
-			<Self::Vote as VoteStorage>::PartialVote,
-			<Self::Vote as VoteStorage>::Vote,
-		),
+		(proposed_partial_vote, _): (PartialVoteOf<Self>, VoteOf<Self>),
 	) -> bool {
 		current_partial_vote != proposed_partial_vote
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/solana_vault_swap_accounts.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/solana_vault_swap_accounts.rs
@@ -15,8 +15,7 @@ use crate::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
 		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError, ElectionIdentifier,
+	vote_storage, CorruptStorageError, ElectionIdentifier,
 };
 use cf_chains::sol::{
 	MAX_BATCH_SIZE_OF_VAULT_SWAP_ACCOUNT_CLOSURES,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/utils.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/utils.rs
@@ -12,8 +12,8 @@ pub fn generate_votes<ES>(
 ) -> ConsensusVotes<ES>
 where
 	ES: ElectoralSystem<ValidatorId = ()>,
-	ES::Vote: VoteStorage<Properties = ()>,
-	ES::Vote: VoteStorage<Vote = u64>,
+	ES::VoteStorage: VoteStorage<Properties = ()>,
+	ES::VoteStorage: VoteStorage<Vote = u64>,
 {
 	ConsensusVotes {
 		votes: (0..success_votes)

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -1,10 +1,9 @@
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
+		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VotePropertiesOf,
 	},
-	vote_storage::{self, VoteStorage},
-	CorruptStorageError, ElectionIdentifier,
+	vote_storage, CorruptStorageError, ElectionIdentifier,
 };
 use cf_chains::benchmarking_value::BenchmarkValue;
 use cf_utilities::success_threshold_from_share_count;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -1,7 +1,7 @@
 use crate::{
 	electoral_system::{
 		AuthorityVoteOf, ConsensusVotes, ElectionReadAccess, ElectionWriteAccess, ElectoralSystem,
-		ElectoralWriteAccess, VotePropertiesOf,
+		ElectoralSystemTypes, ElectoralWriteAccess, PartialVoteOf, VoteOf, VotePropertiesOf,
 	},
 	vote_storage::{self, VoteStorage},
 	CorruptStorageError, ElectionIdentifier,
@@ -31,7 +31,7 @@ impl<
 		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem for UnsafeMedian<Value, UnsynchronisedSettings, Settings, ValidatorId>
+	> ElectoralSystemTypes for UnsafeMedian<Value, UnsynchronisedSettings, Settings, ValidatorId>
 {
 	type ValidatorId = ValidatorId;
 
@@ -44,16 +44,24 @@ impl<
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = ();
 	type ElectionState = ();
-	type Vote =
+	type VoteStorage =
 		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<Value>>;
 	type Consensus = Value;
 	type OnFinalizeContext = ();
 	type OnFinalizeReturn = ();
+}
 
+impl<
+		Value: Member + Parameter + MaybeSerializeDeserialize + Ord + BenchmarkValue,
+		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
+		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
+		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
+	> ElectoralSystem for UnsafeMedian<Value, UnsynchronisedSettings, Settings, ValidatorId>
+{
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
 		_previous_vote: Option<(VotePropertiesOf<Self>, AuthorityVoteOf<Self>)>,
-		_vote: &<Self::Vote as VoteStorage>::PartialVote,
+		_vote: &PartialVoteOf<Self>,
 	) -> Result<VotePropertiesOf<Self>, CorruptStorageError> {
 		Ok(())
 	}

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -140,14 +140,13 @@ pub mod pallet {
 	use crate::electoral_system::ConsensusStatus;
 	pub use access_impls::RunnerStorageAccess;
 
-	use crate::electoral_system_runner::{
-		CompositeConsensusVote, CompositeConsensusVotes, RunnerStorageAccessTrait,
-	};
+	use crate::electoral_system_runner::RunnerStorageAccessTrait;
 	use bitmap_components::ElectionBitmapComponents;
-	pub use electoral_system_runner::{
-		CompositeAuthorityVoteOf, CompositeElectionIdentifierOf, CompositeIndividualComponentOf,
-		CompositeVotePropertiesOf, ElectoralSystemRunner,
+	pub use electoral_system::{
+		AuthorityVoteOf, ConsensusVote, ConsensusVotes, ElectionIdentifierOf, ElectoralSystemTypes,
+		IndividualComponentOf, PartialVoteOf, VoteOf, VotePropertiesOf, VoteStorageOf,
 	};
+	pub use electoral_system_runner::ElectoralSystemRunner;
 
 	use frame_support::{
 		sp_runtime::traits::BlockNumberProvider, storage::bounded_btree_map::BoundedBTreeMap,
@@ -189,10 +188,10 @@ pub mod pallet {
 	/// when to vote.
 	#[allow(type_alias_bounds)]
 	pub type ElectoralDataFor<T: Config<I>, I: 'static> = ElectoralData<
-		CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
-		CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
+		ElectionIdentifierOf<T::ElectoralSystemRunner>,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties,
+		AuthorityVoteOf<T::ElectoralSystemRunner>,
 		BlockNumberFor<T>,
 	>;
 
@@ -320,9 +319,9 @@ pub mod pallet {
 
 	#[allow(type_alias_bounds)]
 	pub type InitialStateOf<T: Config<I>, I: 'static> = InitialState<
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings,
 	>;
 
 	#[pallet::genesis_config]
@@ -444,7 +443,7 @@ pub mod pallet {
 		_,
 		Identity,
 		SharedDataHash,
-		<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData,
+		<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData,
 		OptionQuery,
 	>;
 
@@ -468,8 +467,8 @@ pub mod pallet {
 		Identity,
 		T::ValidatorId,
 		(
-			CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
-			CompositeIndividualComponentOf<T::ElectoralSystemRunner>,
+			VotePropertiesOf<T::ElectoralSystemRunner>,
+			IndividualComponentOf<T::ElectoralSystemRunner>,
 		),
 		OptionQuery,
 	>;
@@ -486,7 +485,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(crate) type ElectoralUnsynchronisedSettings<T: Config<I>, I: 'static = ()> = StorageValue<
 		_,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
 		OptionQuery,
 	>;
 
@@ -494,7 +493,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type ElectoralUnsynchronisedState<T: Config<I>, I: 'static = ()> = StorageValue<
 		_,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
 		OptionQuery,
 	>;
 
@@ -503,8 +502,8 @@ pub mod pallet {
 	pub type ElectoralUnsynchronisedStateMap<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Twox64Concat,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue,
 		OptionQuery,
 	>;
 
@@ -515,7 +514,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		UniqueMonotonicIdentifier,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings,
 		OptionQuery,
 	>;
 
@@ -525,8 +524,8 @@ pub mod pallet {
 	type ElectionProperties<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Twox64Concat,
-		CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+		ElectionIdentifierOf<T::ElectoralSystemRunner>,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties,
 		OptionQuery,
 	>;
 
@@ -536,7 +535,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		UniqueMonotonicIdentifier,
-		<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+		<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionState,
 		OptionQuery,
 	>;
 
@@ -548,7 +547,7 @@ pub mod pallet {
 		_,
 		Twox64Concat,
 		UniqueMonotonicIdentifier,
-		ConsensusHistory<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Consensus>,
+		ConsensusHistory<<T::ElectoralSystemRunner as ElectoralSystemTypes>::Consensus>,
 		OptionQuery,
 	>;
 
@@ -603,13 +602,10 @@ pub mod pallet {
 			type ElectoralSystemRunner = T::ElectoralSystemRunner;
 
 			fn new_election(
-				extra: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionIdentifierExtra,
-				properties: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
-				state: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
-			) -> Result<
-				CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
-				CorruptStorageError,
-			> {
+				extra: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionIdentifierExtra,
+				properties: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties,
+				state: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionState,
+			) -> Result<ElectionIdentifierOf<Self::ElectoralSystemRunner>, CorruptStorageError> {
 				let unique_monotonic_identifier = NextElectionIdentifier::<T, I>::get();
 				let election_identifier = ElectionIdentifier(unique_monotonic_identifier, extra);
 				NextElectionIdentifier::<T, I>::set(UniqueMonotonicIdentifier(
@@ -626,7 +622,7 @@ pub mod pallet {
 			fn electoral_settings_for_election(
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
 			) -> Result<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings,
 				CorruptStorageError,
 			> {
 				let mut settings_boundaries =
@@ -641,9 +637,9 @@ pub mod pallet {
 					.ok_or_else(CorruptStorageError::new)
 			}
 			fn election_properties(
-				election_identifier: CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
+				election_identifier: ElectionIdentifierOf<T::ElectoralSystemRunner>,
 			) -> Result<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties,
 				CorruptStorageError,
 			> {
 				ElectionProperties::<T, I>::get(election_identifier)
@@ -652,7 +648,7 @@ pub mod pallet {
 			fn election_state(
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
 			) -> Result<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionState,
 				CorruptStorageError,
 			> {
 				ElectionState::<T, I>::get(unique_monotonic_identifier)
@@ -661,7 +657,7 @@ pub mod pallet {
 
 			fn set_election_state(
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
-				state: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionState,
+				state: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionState,
 			) -> Result<(), CorruptStorageError> {
 				if Self::election_state(unique_monotonic_identifier)? != state {
 					ElectionState::<T, I>::insert(unique_monotonic_identifier, state);
@@ -675,7 +671,7 @@ pub mod pallet {
 				for (_, (_, individual_component)) in
 					IndividualComponents::<T, I>::drain_prefix(unique_monotonic_identifier)
 				{
-					<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as
+					<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as
 				VoteStorage>::visit_shared_data_references_in_individual_component(&
 				individual_component, |shared_data_hash| { 		Pallet::<T,
 				I>::remove_shared_data_reference(shared_data_hash, unique_monotonic_identifier);
@@ -684,9 +680,7 @@ pub mod pallet {
 				ElectionConsensusHistoryUpToDate::<T, I>::remove(unique_monotonic_identifier);
 			}
 			fn delete_election(
-				composite_election_identifier: CompositeElectionIdentifierOf<
-					Self::ElectoralSystemRunner,
-				>,
+				composite_election_identifier: ElectionIdentifierOf<Self::ElectoralSystemRunner>,
 			) {
 				let unique_monotonic_identifier = composite_election_identifier.unique_monotonic();
 				Self::clear_election_votes(*unique_monotonic_identifier);
@@ -696,16 +690,16 @@ pub mod pallet {
 			}
 
 			fn refresh_election(
-				election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
-				new_extra: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionIdentifierExtra,
-				properties: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectionProperties,
+				election_identifier: ElectionIdentifierOf<Self::ElectoralSystemRunner>,
+				new_extra: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionIdentifierExtra,
+				properties: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties,
 			) -> Result<(), CorruptStorageError> {
 				if new_extra <= *election_identifier.extra() {
 					Err(CorruptStorageError::new())
 				} else {
 					ElectionProperties::<T, I>::remove(election_identifier);
 					let new_election_identifier =
-						CompositeElectionIdentifierOf::<Self::ElectoralSystemRunner>::new(
+						ElectionIdentifierOf::<Self::ElectoralSystemRunner>::new(
 							*election_identifier.unique_monotonic(),
 							new_extra,
 						);
@@ -715,9 +709,9 @@ pub mod pallet {
 			}
 
 			fn check_election_consensus(
-				election_identifier: CompositeElectionIdentifierOf<Self::ElectoralSystemRunner>,
+				election_identifier: ElectionIdentifierOf<Self::ElectoralSystemRunner>,
 			) -> Result<
-				ConsensusStatus<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Consensus>,
+				ConsensusStatus<<T::ElectoralSystemRunner as ElectoralSystemTypes>::Consensus>,
 				CorruptStorageError,
 			> {
 				let epoch_index = T::EpochInfo::epoch_index();
@@ -767,7 +761,7 @@ pub mod pallet {
 							})
 							.map(|(vote_components, validator_id)| {
 								if ContributingAuthorities::<T, I>::contains_key(&validator_id) {
-									match <<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as
+									match <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as
 								VoteStorage>::components_into_authority_vote(vote_components, |shared_data_hash|
 							{
 								 	// We don't bother to check if the reference has expired, as if we have the
@@ -784,7 +778,7 @@ pub mod pallet {
 								} else {
 									Ok(None)
 								}
-								.map(|props_and_vote| CompositeConsensusVote {
+								.map(|props_and_vote| ConsensusVote {
 									vote: props_and_vote,
 									validator_id,
 								})
@@ -795,7 +789,7 @@ pub mod pallet {
 
 						// Remove individual components from non-authorities
 						for (validator_id, (_, individual_component)) in individual_components {
-							<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as
+							<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as
 				VoteStorage>::visit_shared_data_references_in_individual_component(
 								&individual_component,
 								|shared_data_hash| {
@@ -818,7 +812,7 @@ pub mod pallet {
 										Some(&consensus_history.most_recent)
 									}
 								}),
-								CompositeConsensusVotes { votes },
+								ConsensusVotes { votes },
 							)?;
 
 						ElectionConsensusHistory::<T, I>::set(
@@ -871,40 +865,39 @@ pub mod pallet {
 				)
 			}
 
-			fn unsynchronised_settings(
-			) -> Result<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings,
+			fn unsynchronised_settings() -> Result<
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
 				CorruptStorageError,
-			>{
+			> {
 				ElectoralUnsynchronisedSettings::<T, I>::get().ok_or_else(CorruptStorageError::new)
 			}
 
 			fn unsynchronised_state() -> Result<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
 				CorruptStorageError,
 			> {
 				ElectoralUnsynchronisedState::<T, I>::get().ok_or_else(CorruptStorageError::new)
 			}
 
 			fn unsynchronised_state_map(
-				key: &<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
+				key: &<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
 			) ->
 				Option<
-					<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
+					<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue,
 			>{
 				ElectoralUnsynchronisedStateMap::<T, I>::get(key)
 			}
 
 			fn set_unsynchronised_state(
-				unsynchronised_state: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState,
+				unsynchronised_state: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
 			) {
 				ElectoralUnsynchronisedState::<T, I>::put(unsynchronised_state);
 			}
 
 			fn set_unsynchronised_state_map(
-				key: <T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapKey,
+				key: <T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
 				value: Option<
-					<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedStateMapValue,
+					<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue,
 				>,
 			) {
 				ElectoralUnsynchronisedStateMap::<T, I>::set(key, value);
@@ -919,7 +912,8 @@ pub mod pallet {
 			BitmapComponents, Config, CorruptStorageError, Pallet, UniqueMonotonicIdentifier,
 		};
 		use crate::{
-			electoral_system_runner::{BitmapComponentOf, ElectoralSystemRunner},
+			electoral_system::{BitmapComponentOf, ElectoralSystemTypes},
+			electoral_system_runner::ElectoralSystemRunner,
 			vote_storage::VoteStorage,
 		};
 		use bitvec::prelude::*;
@@ -1044,7 +1038,7 @@ pub mod pallet {
 					this.bitmaps.retain(|(bitmap_component, bitmap)| {
 						let retain = bitmap.any();
 						if !retain {
-							<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_references_in_bitmap_component(
+							<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_references_in_bitmap_component(
 								bitmap_component,
 								|shared_data_hash| {
 									Pallet::<T, I>::remove_shared_data_reference(
@@ -1114,7 +1108,7 @@ pub mod pallet {
 							true;
 						bitmap
 					}));
-					<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_references_in_bitmap_component(
+					<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_references_in_bitmap_component(
 						&bitmap_component,
 						|shared_data_hash| {
 							Pallet::<T, I>::add_shared_data_reference(
@@ -1187,7 +1181,7 @@ pub mod pallet {
 			pub(super) fn clear(unique_monotonic_identifier: UniqueMonotonicIdentifier) {
 				if let Some(this) = BitmapComponents::<T, I>::get(unique_monotonic_identifier) {
 					for (bitmap_component, _) in this.bitmaps {
-						<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_references_in_bitmap_component(
+						<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_references_in_bitmap_component(
 							&bitmap_component,
 							|shared_data_hash| {
 								Pallet::<T, I>::remove_shared_data_reference(
@@ -1220,8 +1214,8 @@ pub mod pallet {
 		pub fn vote(
 			origin: OriginFor<T>,
 			authority_votes: BoundedBTreeMap<
-				CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
-				CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
+				ElectionIdentifierOf<T::ElectoralSystemRunner>,
+				AuthorityVoteOf<T::ElectoralSystemRunner>,
 				ConstU32<MAXIMUM_VOTES_PER_EXTRINSIC>,
 			>,
 		) -> DispatchResult {
@@ -1238,18 +1232,14 @@ pub mod pallet {
 					Self::ensure_election_exists(election_identifier)?;
 
 				let (partial_vote, option_vote) = match authority_vote {
-					AuthorityVote::PartialVote(partial_vote) => {
-						(partial_vote, None)
-					},
-					AuthorityVote::Vote(vote) => {
-						(
-							<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::vote_into_partial_vote(
-								&vote,
-								|shared_data| SharedDataHash::of(&shared_data)
-							),
-							Some(vote)
-						)
-					},
+					AuthorityVote::PartialVote(partial_vote) => (partial_vote, None),
+					AuthorityVote::Vote(vote) => (
+						VoteStorageOf::<T::ElectoralSystemRunner>::vote_into_partial_vote(
+							&vote,
+							|shared_data| SharedDataHash::of(&shared_data),
+						),
+						Some(vote),
+					),
 				};
 
 				Self::handle_corrupt_storage(Self::take_vote_and_then(
@@ -1258,7 +1248,7 @@ pub mod pallet {
 					&authority,
 					authority_index,
 					|option_existing_vote, election_bitmap_components| {
-						let components = <<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::partial_vote_into_components(
+						let components = <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::partial_vote_into_components(
 							<T::ElectoralSystemRunner as ElectoralSystemRunner>::generate_vote_properties(
 								election_identifier,
 								option_existing_vote,
@@ -1281,7 +1271,7 @@ pub mod pallet {
 							components.individual_component
 						{
 							// Update shared data reference counts
-							<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_references_in_individual_component(
+							<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_references_in_individual_component(
 								&individual_component,
 								|shared_data_hash| Self::add_shared_data_reference(shared_data_hash, unique_monotonic_identifier, block_number),
 							);
@@ -1299,7 +1289,7 @@ pub mod pallet {
 
 				// Insert any `SharedData` provided as part of the `Vote`.
 				if let Some(vote) = option_vote {
-					<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_in_vote(
+					<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_in_vote(
 						vote,
 						|shared_data| Self::inner_provide_shared_data(shared_data),
 					)
@@ -1321,7 +1311,7 @@ pub mod pallet {
 		#[pallet::weight((T::WeightInfo::provide_shared_data(), DispatchClass::Operational))]
 		pub fn provide_shared_data(
 			origin: OriginFor<T>,
-			shared_data: <<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData,
+			shared_data: <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData,
 		) -> DispatchResult {
 			Self::ensure_can_vote(origin)?;
 			Self::inner_provide_shared_data(shared_data)?;
@@ -1357,7 +1347,7 @@ pub mod pallet {
 		#[pallet::weight((T::WeightInfo::delete_vote(), DispatchClass::Operational))]
 		pub fn delete_vote(
 			origin: OriginFor<T>,
-			election_identifier: CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
+			election_identifier: ElectionIdentifierOf<T::ElectoralSystemRunner>,
 		) -> DispatchResult {
 			let (epoch_index, authority, authority_index) = Self::ensure_can_vote(origin)?;
 			let unique_monotonic_identifier = Self::ensure_election_exists(election_identifier)?;
@@ -1390,11 +1380,9 @@ pub mod pallet {
 		pub fn update_settings(
 			origin: OriginFor<T>,
 			unsynchronised_settings: Option<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedSettings,
+				<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
 			>,
-			settings: Option<
-				<T::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings,
-			>,
+			settings: Option<<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings>,
 			ignore_corrupt_storage: CorruptStorageAdherance,
 		) -> DispatchResult {
 			Self::ensure_governance(origin, ignore_corrupt_storage)?;
@@ -1430,7 +1418,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::clear_election_votes())]
 		pub fn clear_election_votes(
 			origin: OriginFor<T>,
-			election_identifier: CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
+			election_identifier: ElectionIdentifierOf<T::ElectoralSystemRunner>,
 			ignore_corrupt_storage: CorruptStorageAdherance,
 			check_election_exists: bool,
 		) -> DispatchResult {
@@ -1450,7 +1438,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::invalidate_election_consensus_cache())]
 		pub fn invalidate_election_consensus_cache(
 			origin: OriginFor<T>,
-			election_identifier: CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
+			election_identifier: ElectionIdentifierOf<T::ElectoralSystemRunner>,
 			ignore_corrupt_storage: CorruptStorageAdherance,
 			check_election_exists: bool,
 		) -> DispatchResult {
@@ -1672,7 +1660,7 @@ pub mod pallet {
 		pub fn with_election_identifiers<
 			R,
 			F: FnOnce(
-				Vec<CompositeElectionIdentifierOf<T::ElectoralSystemRunner>>,
+				Vec<ElectionIdentifierOf<T::ElectoralSystemRunner>>,
 			) -> Result<R, CorruptStorageError>,
 		>(
 			f: F,
@@ -1797,10 +1785,10 @@ pub mod pallet {
 		pub fn filter_votes(
 			validator_id: &T::ValidatorId,
 			proposed_votes: BTreeMap<
-				CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
-				<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::Vote,
+				ElectionIdentifierOf<T::ElectoralSystemRunner>,
+				VoteOf<T::ElectoralSystemRunner>,
 			>,
-		) -> BTreeSet<CompositeElectionIdentifierOf<T::ElectoralSystemRunner>> {
+		) -> BTreeSet<ElectionIdentifierOf<T::ElectoralSystemRunner>> {
 			use frame_support::traits::OriginTrait;
 
 			if let Ok((epoch_index, authority, authority_index)) =
@@ -1808,54 +1796,51 @@ pub mod pallet {
 			{
 				let block_number = frame_system::Pallet::<T>::current_block_number();
 
-				Self::with_election_identifiers(
-					|election_identifiers| {
-						election_identifiers
-							.into_iter()
-							.map(|election_identifier| {
-								Ok((
-									election_identifier,
-									if let Some(proposed_vote) =
-										proposed_votes.get(&election_identifier)
+				Self::with_election_identifiers(|election_identifiers| {
+					election_identifiers
+						.into_iter()
+						.map(|election_identifier| {
+							Ok((
+								election_identifier,
+								if let Some(proposed_vote) =
+									proposed_votes.get(&election_identifier)
+								{
+									let unique_monotonic_identifier =
+										*election_identifier.unique_monotonic();
+
+									let mut contains_timed_out_shared_data_references = false;
+									let option_current_authority_vote = Pallet::<T, I>::get_vote(
+										epoch_index,
+										unique_monotonic_identifier,
+										&authority,
+										authority_index,
+										|unprovided_shared_data_hash| {
+											let option_reference_details =
+												SharedDataReferenceCount::<T, I>::get(
+													unprovided_shared_data_hash,
+													unique_monotonic_identifier,
+												);
+											if option_reference_details.is_none() ||
+												option_reference_details.unwrap().expires <
+													block_number
+											{
+												contains_timed_out_shared_data_references = true;
+											}
+										},
+									)?;
+
+									if let Some((
+										existing_vote_properties,
+										existing_authority_vote,
+									)) = option_current_authority_vote
+										.filter(|_| !contains_timed_out_shared_data_references)
 									{
-										let unique_monotonic_identifier =
-											*election_identifier.unique_monotonic();
-
-										let mut contains_timed_out_shared_data_references = false;
-										let option_current_authority_vote =
-											Pallet::<T, I>::get_vote(
-												epoch_index,
-												unique_monotonic_identifier,
-												&authority,
-												authority_index,
-												|unprovided_shared_data_hash| {
-													let option_reference_details =
-														SharedDataReferenceCount::<T, I>::get(
-															unprovided_shared_data_hash,
-															unique_monotonic_identifier,
-														);
-													if option_reference_details.is_none() ||
-														option_reference_details.unwrap().expires <
-															block_number
-													{
-														contains_timed_out_shared_data_references =
-															true;
-													}
-												},
-											)?;
-
-										if let Some((
-											existing_vote_properties,
-											existing_authority_vote,
-										)) = option_current_authority_vote
-											.filter(|_| !contains_timed_out_shared_data_references)
-										{
-											<T::ElectoralSystemRunner as ElectoralSystemRunner>::is_vote_needed(
+										<T::ElectoralSystemRunner as ElectoralSystemRunner>::is_vote_needed(
 												(
 													existing_vote_properties,
 													match &existing_authority_vote {
 														AuthorityVote::Vote(existing_vote) => {
-															<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::vote_into_partial_vote(
+															VoteStorageOf::<T::ElectoralSystemRunner>::vote_into_partial_vote(
 																existing_vote,
 																|shared_data| SharedDataHash::of(&shared_data)
 															)
@@ -1865,26 +1850,25 @@ pub mod pallet {
 													existing_authority_vote,
 												),
 												(
-													<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::vote_into_partial_vote(
+													VoteStorageOf::<T::ElectoralSystemRunner>::vote_into_partial_vote(
 														proposed_vote,
 														|shared_data| SharedDataHash::of(&shared_data)
 													),
 													proposed_vote.clone(),
 												),
 											)
-										} else {
-											true
-										}
 									} else {
-										false
-									},
-								))
-							})
-							.filter_ok(|(_election_identifier, needed)| *needed)
-							.map_ok(|(election_identifier, _needed)| (election_identifier))
-							.collect::<Result<BTreeSet<_>, _>>()
-					},
-				)
+										true
+									}
+								} else {
+									false
+								},
+							))
+						})
+						.filter_ok(|(_election_identifier, needed)| *needed)
+						.map_ok(|(election_identifier, _needed)| (election_identifier))
+						.collect::<Result<BTreeSet<_>, _>>()
+				})
 				.unwrap_or_default()
 			} else {
 				Default::default()
@@ -1918,8 +1902,8 @@ pub mod pallet {
 			R,
 			F: for<'a> FnOnce(
 				Option<(
-					CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
-					CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
+					VotePropertiesOf<T::ElectoralSystemRunner>,
+					AuthorityVoteOf<T::ElectoralSystemRunner>,
 				)>,
 				&'a mut ElectionBitmapComponents<T, I>,
 			) -> Result<R, CorruptStorageError>,
@@ -1938,7 +1922,7 @@ pub mod pallet {
 						IndividualComponents::<T, I>::take(unique_monotonic_identifier, authority);
 
 					let r = f(
-						<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::components_into_authority_vote(
+						<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::components_into_authority_vote(
 							VoteComponents {
 								bitmap_component: election_bitmap_components.take(authority_index)?,
 								individual_component: individual_component.clone(),
@@ -1951,7 +1935,7 @@ pub mod pallet {
 					// Remove references late to avoid deleting shared data that we will add
 					// references to inside `f`.
 					if let Some((_properties, individual_component)) = individual_component {
-						<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::visit_shared_data_references_in_individual_component(
+						<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::visit_shared_data_references_in_individual_component(
 							&individual_component,
 							|shared_data_hash| Self::remove_shared_data_reference(shared_data_hash, unique_monotonic_identifier),
 						);
@@ -1977,12 +1961,12 @@ pub mod pallet {
 			mut visit_unprovided_shared_data: VisitUnprovidedSharedData,
 		) -> Result<
 			Option<(
-				CompositeVotePropertiesOf<T::ElectoralSystemRunner>,
-				CompositeAuthorityVoteOf<T::ElectoralSystemRunner>,
+				VotePropertiesOf<T::ElectoralSystemRunner>,
+				AuthorityVoteOf<T::ElectoralSystemRunner>,
 			)>,
 			CorruptStorageError,
 		> {
-			<<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::components_into_authority_vote(
+			<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::components_into_authority_vote(
 				VoteComponents {
 					bitmap_component: ElectionBitmapComponents::<T, I>::with(
 						epoch_index,
@@ -2039,7 +2023,7 @@ pub mod pallet {
 			}
 		}
 		fn ensure_election_exists(
-			election_identifier: CompositeElectionIdentifierOf<T::ElectoralSystemRunner>,
+			election_identifier: ElectionIdentifierOf<T::ElectoralSystemRunner>,
 		) -> Result<UniqueMonotonicIdentifier, Error<T, I>> {
 			ensure!(
 				ElectionProperties::<T, I>::contains_key(election_identifier),
@@ -2112,7 +2096,7 @@ pub mod pallet {
 			}
 		}
 		fn inner_provide_shared_data(
-			shared_data: <<T::ElectoralSystemRunner as ElectoralSystemRunner>::Vote as VoteStorage>::SharedData,
+			shared_data: <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::SharedData,
 		) -> Result<(), Error<T, I>> {
 			let shared_data_hash = SharedDataHash::of(&shared_data);
 			let (unique_monotonic_identifiers, reference_details): (Vec<_>, Vec<_>) =

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -913,7 +913,6 @@ pub mod pallet {
 		};
 		use crate::{
 			electoral_system::{BitmapComponentOf, ElectoralSystemTypes},
-			electoral_system_runner::ElectoralSystemRunner,
 			vote_storage::VoteStorage,
 		};
 		use bitvec::prelude::*;

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -126,7 +126,7 @@ pub trait ElectoralSystemRunnerTestExt: Sized {
 	fn submit_votes<I: 'static>(
 		self,
 		validator_ids: &[u64],
-		vote: CompositeAuthorityVoteOf<MockElectoralSystemRunner>,
+		vote: AuthorityVoteOf<MockElectoralSystemRunner>,
 		expected_outcome: Result<(), Error<Test, I>>,
 	) -> Self
 	where
@@ -173,7 +173,7 @@ impl ElectoralSystemRunnerTestExt for TestRunner<TestContext> {
 	fn submit_votes<I: 'static>(
 		self,
 		validator_ids: &[u64],
-		vote: CompositeAuthorityVoteOf<MockElectoralSystemRunner>,
+		vote: AuthorityVoteOf<MockElectoralSystemRunner>,
 		expected_outcome: Result<(), Error<Test, I>>,
 	) -> Self
 	where
@@ -192,9 +192,10 @@ impl ElectoralSystemRunnerTestExt for TestRunner<TestContext> {
 								Call::<Test, I>::vote {
 									authority_votes: BoundedBTreeMap::try_from(
 										sp_std::iter::once((
-											CompositeElectionIdentifierOf::<
-												MockElectoralSystemRunner,
-											>::new(*umi, ()),
+											ElectionIdentifierOf::<MockElectoralSystemRunner>::new(
+												*umi,
+												(),
+											),
 											vote.clone(),
 										))
 										.collect::<BTreeMap<_, _>>(),
@@ -239,7 +240,7 @@ impl ElectoralSystemRunnerTestExt for TestRunner<TestContext> {
 
 #[test]
 fn consensus_state_transitions() {
-	const VOTE: CompositeAuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
+	const VOTE: AuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
 
 	election_test_ext(TestSetup { num_non_contributing_authorities: 2, ..Default::default() })
 		.new_election()
@@ -291,7 +292,7 @@ fn consensus_state_transitions() {
 
 #[test]
 fn authority_removes_and_re_adds_itself_from_contributing_set() {
-	const VOTE: CompositeAuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
+	const VOTE: AuthorityVoteOf<MockElectoralSystemRunner> = AuthorityVote::Vote(());
 
 	election_test_ext(Default::default())
 		.new_election()

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -26,7 +26,7 @@ use cf_traits::{
 use codec::{Decode, Encode};
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_cf_elections::{
-	electoral_system::{ElectoralReadAccess, ElectoralSystem},
+	electoral_system::{ElectoralReadAccess, ElectoralSystem, ElectoralSystemTypes},
 	electoral_systems::{
 		self,
 		composite::{tuple_7_impls::Hooks, CompositeRunner},
@@ -267,31 +267,37 @@ impl
 		): (
 			Vec<
 				ElectionIdentifier<
-					<SolanaBlockHeightTracking as ElectoralSystem>::ElectionIdentifierExtra,
-				>,
-			>,
-			Vec<
-				ElectionIdentifier<<SolanaFeeTracking as ElectoralSystem>::ElectionIdentifierExtra>,
-			>,
-			Vec<
-				ElectionIdentifier<
-					<SolanaIngressTracking as ElectoralSystem>::ElectionIdentifierExtra,
+					<SolanaBlockHeightTracking as ElectoralSystemTypes>::ElectionIdentifierExtra,
 				>,
 			>,
 			Vec<
 				ElectionIdentifier<
-					<SolanaNonceTracking as ElectoralSystem>::ElectionIdentifierExtra,
+					<SolanaFeeTracking as ElectoralSystemTypes>::ElectionIdentifierExtra,
 				>,
 			>,
 			Vec<
 				ElectionIdentifier<
-					<SolanaEgressWitnessing as ElectoralSystem>::ElectionIdentifierExtra,
+					<SolanaIngressTracking as ElectoralSystemTypes>::ElectionIdentifierExtra,
 				>,
 			>,
-			Vec<ElectionIdentifier<<SolanaLiveness as ElectoralSystem>::ElectionIdentifierExtra>>,
 			Vec<
 				ElectionIdentifier<
-					<SolanaVaultSwapTracking as ElectoralSystem>::ElectionIdentifierExtra,
+					<SolanaNonceTracking as ElectoralSystemTypes>::ElectionIdentifierExtra,
+				>,
+			>,
+			Vec<
+				ElectionIdentifier<
+					<SolanaEgressWitnessing as ElectoralSystemTypes>::ElectionIdentifierExtra,
+				>,
+			>,
+			Vec<
+				ElectionIdentifier<
+					<SolanaLiveness as ElectoralSystemTypes>::ElectionIdentifierExtra,
+				>,
+			>,
+			Vec<
+				ElectionIdentifier<
+					<SolanaVaultSwapTracking as ElectoralSystemTypes>::ElectionIdentifierExtra,
 				>,
 			>,
 		),

--- a/state-chain/runtime/src/migrations/solana_vault_swaps_migration.rs
+++ b/state-chain/runtime/src/migrations/solana_vault_swaps_migration.rs
@@ -3,8 +3,7 @@ use chainflip::solana_elections::SolanaVaultSwapsSettings;
 use frame_support::{pallet_prelude::Weight, storage::unhashed, traits::UncheckedOnRuntimeUpgrade};
 
 use pallet_cf_elections::{
-	electoral_system::ElectoralSystemTypes, electoral_system_runner::ElectoralSystemRunner, Config,
-	ElectoralSettings, ElectoralUnsynchronisedState,
+	electoral_system::ElectoralSystemTypes, Config, ElectoralSettings, ElectoralUnsynchronisedState,
 };
 #[cfg(feature = "try-runtime")]
 use sp_runtime::DispatchError;

--- a/state-chain/runtime/src/migrations/solana_vault_swaps_migration.rs
+++ b/state-chain/runtime/src/migrations/solana_vault_swaps_migration.rs
@@ -3,7 +3,8 @@ use chainflip::solana_elections::SolanaVaultSwapsSettings;
 use frame_support::{pallet_prelude::Weight, storage::unhashed, traits::UncheckedOnRuntimeUpgrade};
 
 use pallet_cf_elections::{
-	Config, ElectoralSettings, ElectoralSystemRunner, ElectoralUnsynchronisedState,
+	electoral_system::ElectoralSystemTypes, electoral_system_runner::ElectoralSystemRunner, Config,
+	ElectoralSettings, ElectoralUnsynchronisedState,
 };
 #[cfg(feature = "try-runtime")]
 use sp_runtime::DispatchError;
@@ -21,7 +22,7 @@ impl UncheckedOnRuntimeUpgrade for SolanaVaultSwapsMigration {
 		>::hashed_key())
 		.unwrap();
 		raw_unsynchronised_state.extend(0u32.encode());
-		ElectoralUnsynchronisedState::<Runtime, SolanaInstance>::put(<<Runtime as Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralUnsynchronisedState::decode(&mut &raw_unsynchronised_state[..]).unwrap());
+		ElectoralUnsynchronisedState::<Runtime, SolanaInstance>::put(<<Runtime as Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedState::decode(&mut &raw_unsynchronised_state[..]).unwrap());
 
 		let (usdc_token_mint_pubkey, swap_endpoint_data_account_address) =
 			match cf_runtime_utilities::genesis_hashes::genesis_hash::<Runtime>() {
@@ -56,7 +57,7 @@ impl UncheckedOnRuntimeUpgrade for SolanaVaultSwapsMigration {
 				}
 				.encode(),
 			);
-			ElectoralSettings::<Runtime, SolanaInstance>::insert(key, <<Runtime as Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemRunner>::ElectoralSettings::decode(&mut &raw_storage_at_key[..]).unwrap());
+			ElectoralSettings::<Runtime, SolanaInstance>::insert(key, <<Runtime as Config<SolanaInstance>>::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings::decode(&mut &raw_storage_at_key[..]).unwrap());
 		}
 
 		Weight::zero()


### PR DESCRIPTION
# Pull Request

Closes: PRO-1980

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR restructures a new trait, `ElectoralSystemTypes` which now contains all the associated types which were previously part of both `ElectoralSystem` and `ElectoralSystemRunner`. These now inherit from `ElectoralSystemTypes`.
