### PR TITLE
feat: `VoterApi::vote` now returns an Option.

### DIFF
--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -22,7 +22,7 @@ use std::{
 	collections::{BTreeMap, HashMap},
 	sync::Arc,
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use voter_api::CompositeVoterApi;
 
 const MAXIMUM_CONCURRENT_FILTER_REQUESTS: usize = 16;

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -177,7 +177,7 @@ where
 						pending_submissions.insert(election_identifier,	(partial_vote, vote));
 					},
 					Ok(None) => {
-						info!("Voting task for election '{:?}' returned 'None' (nothing to submit).", election_identifier);
+						debug!("Voting task for election '{:?}' returned 'None' (nothing to submit).", election_identifier);
 					},
 					Err(error) => {
 						warn!("Voting task for election '{:?}' failed with error: '{:?}'.", election_identifier, error);

--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -160,7 +160,7 @@ where
 			},
 			let (election_identifier, result_vote) = vote_tasks.next_or_pending() => {
 				match result_vote {
-					Ok(vote) => {
+					Ok(Some(vote)) => {
 						info!("Voting task for election: '{:?}' succeeded.", election_identifier);
 						// Create the partial_vote early so that SharedData can be provided as soon as the vote has been generated, rather than only after it is submitted.
 						let partial_vote = VoteStorageOf::<<state_chain_runtime::Runtime as pallet_cf_elections::Config<Instance>>::ElectoralSystemRunner>::vote_into_partial_vote(&vote, |shared_data| {
@@ -175,6 +175,9 @@ where
 						});
 
 						pending_submissions.insert(election_identifier,	(partial_vote, vote));
+					},
+					Ok(None) => {
+						info!("Voting task for election '{:?}' returned 'None' (nothing to submit).", election_identifier);
 					},
 					Err(error) => {
 						warn!("Voting task for election '{:?}' failed with error: '{:?}'.", election_identifier, error);

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -53,10 +53,10 @@ impl VoterApi<SolanaBlockHeightTracking> for SolanaBlockHeightTrackingVoter {
 		&self,
 		_settings: <SolanaBlockHeightTracking as ElectoralSystemTypes>::ElectoralSettings,
 		_properties: <SolanaBlockHeightTracking as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaBlockHeightTracking>, anyhow::Error> {
+	) -> Result<Option<VoteOf<SolanaBlockHeightTracking>>, anyhow::Error> {
 		let slot = self.client.get_slot(CommitmentConfig::finalized()).await;
 		CHAIN_TRACKING.set(&[cf_chains::Solana::NAME], Into::<u64>::into(slot));
-		Ok(slot)
+		Ok(Some(slot))
 	}
 }
 
@@ -71,7 +71,7 @@ impl VoterApi<SolanaIngressTracking> for SolanaIngressTrackingVoter {
 		&self,
 		settings: <SolanaIngressTracking as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <SolanaIngressTracking as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaIngressTracking>, anyhow::Error> {
+	) -> Result<Option<VoteOf<SolanaIngressTracking>>, anyhow::Error> {
 		sol_deposits::get_channel_ingress_amounts(
 			&self.client,
 			settings.vault_program,
@@ -82,6 +82,7 @@ impl VoterApi<SolanaIngressTracking> for SolanaIngressTrackingVoter {
 		.and_then(|vote| {
 			vote.try_into().map_err(|_| anyhow::anyhow!("Too many channels in election"))
 		})
+		.map(Option::Some)
 	}
 }
 
@@ -96,7 +97,7 @@ impl VoterApi<SolanaNonceTracking> for SolanaNonceTrackingVoter {
 		&self,
 		_settings: <SolanaNonceTracking as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <SolanaNonceTracking as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaNonceTracking>, anyhow::Error> {
+	) -> Result<Option<VoteOf<SolanaNonceTracking>>, anyhow::Error> {
 		let (nonce_account, previous_nonce, previous_slot) = properties;
 
 		let nonce_and_slot =
@@ -105,8 +106,10 @@ impl VoterApi<SolanaNonceTracking> for SolanaNonceTrackingVoter {
 				.map(|(nonce, slot)| MonotonicChangeVote { value: nonce, block: slot });
 		// If the nonce is not found, we default to the previous nonce and slot.
 		// The `MonotonicChange` electoral system ensure this vote is filtered.
-		Ok(nonce_and_slot
-			.unwrap_or(MonotonicChangeVote { value: previous_nonce, block: previous_slot }))
+		Ok(Some(
+			nonce_and_slot
+				.unwrap_or(MonotonicChangeVote { value: previous_nonce, block: previous_slot }),
+		))
 	}
 }
 
@@ -121,13 +124,14 @@ impl VoterApi<SolanaEgressWitnessing> for SolanaEgressWitnessingVoter {
 		&self,
 		_settings: <SolanaEgressWitnessing as ElectoralSystemTypes>::ElectoralSettings,
 		signature: <SolanaEgressWitnessing as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaEgressWitnessing>, anyhow::Error> {
+	) -> Result<Option<VoteOf<SolanaEgressWitnessing>>, anyhow::Error> {
 		egress_witnessing::get_finalized_fee_and_success_status(&self.client, signature)
 			.await
 			.map(|(tx_fee, transaction_successful)| TransactionSuccessDetails {
 				tx_fee,
 				transaction_successful,
 			})
+			.map(Option::Some)
 	}
 }
 
@@ -142,23 +146,25 @@ impl VoterApi<SolanaLiveness> for SolanaLivenessVoter {
 		&self,
 		_settings: <SolanaLiveness as ElectoralSystemTypes>::ElectoralSettings,
 		slot: <SolanaLiveness as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaLiveness>, anyhow::Error> {
-		Ok(SolHash::from_str(
-			&self
-				.client
-				.get_block(
-					slot,
-					RpcBlockConfig {
-						transaction_details: Some(TransactionDetails::None),
-						rewards: Some(false),
-						max_supported_transaction_version: Some(0),
-						..Default::default()
-					},
-				)
-				.await
-				.blockhash,
-		)
-		.map_err(|e| anyhow::anyhow!("Failed to convert blockhash String to SolHash: {e}"))?)
+	) -> Result<Option<VoteOf<SolanaLiveness>>, anyhow::Error> {
+		Ok(Some(
+			SolHash::from_str(
+				&self
+					.client
+					.get_block(
+						slot,
+						RpcBlockConfig {
+							transaction_details: Some(TransactionDetails::None),
+							rewards: Some(false),
+							max_supported_transaction_version: Some(0),
+							..Default::default()
+						},
+					)
+					.await
+					.blockhash,
+			)
+			.map_err(|e| anyhow::anyhow!("Failed to convert blockhash String to SolHash: {e}"))?,
+		))
 	}
 }
 
@@ -173,7 +179,7 @@ impl VoterApi<SolanaVaultSwapTracking> for SolanaVaultSwapsVoter {
 		&self,
 		settings: <SolanaVaultSwapTracking as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <SolanaVaultSwapTracking as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<VoteOf<SolanaVaultSwapTracking>, anyhow::Error> {
+	) -> Result<Option<VoteOf<SolanaVaultSwapTracking>>, anyhow::Error> {
 		program_swaps_witnessing::get_program_swaps(
 			&self.client,
 			settings.swap_endpoint_data_account_address,
@@ -190,6 +196,7 @@ impl VoterApi<SolanaVaultSwapTracking> for SolanaVaultSwapsVoter {
 			new_accounts: new_accounts.into_iter().collect::<BTreeSet<_>>(),
 			confirm_closed_accounts: confirm_closed_accounts.into_iter().collect::<BTreeSet<_>>(),
 		})
+		.map(Option::Some)
 	}
 }
 


### PR DESCRIPTION


# Pull Request

Closes: PRO-1979

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

The voter api can now signal that it doesn't have anything to vote for by returning `Ok(None)`. Previously, in such cases we had to return `Err(..)`, which lead to the RetrierClient scheduling an exponential backoff.
