### PR TITLE
fix: Disable broker-level-screening tests for boosted deposits.

### DIFF
--- a/bouncer/test_commands/broker_level_screening.ts
+++ b/bouncer/test_commands/broker_level_screening.ts
@@ -1,4 +1,26 @@
 #!/usr/bin/env -S pnpm tsx
+// INSTRUCTIONS
+//
+// This command will run the broker-level-screening-test.
+// Note that the deposit monitor has to be running. Takes an
+// optional parameter, deciding whether it should test boosted
+// deposits or not.
+//
+// For example: ./test_commands/broker_level_screening.ts
+// will run a single test to reject a non-boosted deposit
+//
+// For example: ./test_commands/broker_level_screening.ts testBoostedDeposits
+// will run three tests:
+//  - reject a non-boosted deposit
+//  - reject a boosted deposit
+//  - don't reject a boosted deposit which was reported too late
+
+
 import { testBrokerLevelScreening } from '../tests/broker_level_screening';
 
-await testBrokerLevelScreening.run();
+let testBoostedDeposits = false;
+if (process.argv.length > 1) {
+    testBoostedDeposits = process.argv[2] == 'testBoostedDeposits';
+}
+
+await testBrokerLevelScreening.run(testBoostedDeposits);


### PR DESCRIPTION
# Pull Request

Closes: PRO-1971

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Disabling tests with boosted deposits, but they can still be run manually.

These cases are covered by a combination of the non-boosted test, and the unit tests in the ingress-egress pallet.

Disabling test due to flakiness.
