### PR TITLE
fix: no gaps in root btc source

### DIFF
--- a/engine/src/witness/btc/source.rs
+++ b/engine/src/witness/btc/source.rs
@@ -89,9 +89,11 @@ where
 
 						let yield_new_best_header: bool = match &mut stream_state {
 							Some(state)
-								if state.last_block_yielded_index.saturating_add(1) ==
-									best_block_header.height || state.last_block_yielded_hash !=
-									best_block_header.hash =>
+								// We want to immediately yield the new best header if we've reorged on the same block
+								// or it's the next block we expect
+								if (state.last_block_yielded_index == best_block_header.height &&
+									state.last_block_yielded_hash != best_block_header.hash) ||
+									state.last_block_yielded_index.saturating_add(1) == best_block_header.height =>
 								true,
 							// If we don't yet have state (we're initialising), then we want to
 							// yield the new best header immediately

--- a/engine/src/witness/btc/source.rs
+++ b/engine/src/witness/btc/source.rs
@@ -101,9 +101,9 @@ where
 								if state.last_block_yielded_index < best_block_header.height =>
 							{
 								// Update the state for the next iteration to backfill
-								stream_state.as_mut().map(|state| {
+								if let Some(state) = stream_state.as_mut() {
 									state.best_known_block_height = best_block_header.height;
-								});
+								}
 								false
 							},
 							// do nothing, just loop again.

--- a/engine/src/witness/btc/source.rs
+++ b/engine/src/witness/btc/source.rs
@@ -103,9 +103,7 @@ where
 								if state.last_block_yielded_index < best_block_header.height =>
 							{
 								// Update the state for the next iteration to backfill
-								if let Some(state) = stream_state.as_mut() {
-									state.best_known_block_index = best_block_header.height;
-								}
+								state.best_known_block_index = best_block_header.height;
 								false
 							},
 							// do nothing, just loop again.

--- a/engine/src/witness/btc/source.rs
+++ b/engine/src/witness/btc/source.rs
@@ -29,7 +29,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(5);
 pub struct BtcSourceState {
 	last_block_yielded_hash: BlockHash,
 	last_block_yielded_index: btc::BlockNumber,
-	best_known_block_height: btc::BlockNumber,
+	best_known_block_index: btc::BlockNumber,
 }
 
 #[async_trait::async_trait]
@@ -57,11 +57,11 @@ where
 						// We don't want to wait for the tick if we have backfilling to do, so we do
 						// it here before awaiting the tick.
 						if let Some(state) = &stream_state {
-							if state.best_known_block_height > state.last_block_yielded_index {
+							if state.best_known_block_index > state.last_block_yielded_index {
 								tracing::debug!(
 									"Backfilling BTC source from index {} to {}",
 									state.last_block_yielded_index,
-									state.best_known_block_height,
+									state.best_known_block_index,
 								);
 								let header = client
 									.header_at_index(
@@ -75,7 +75,7 @@ where
 										Some(BtcSourceState {
 											last_block_yielded_hash: header.hash,
 											last_block_yielded_index: header.index,
-											best_known_block_height: state.best_known_block_height,
+											best_known_block_index: state.best_known_block_index,
 										}),
 										tick,
 									),
@@ -102,7 +102,7 @@ where
 							{
 								// Update the state for the next iteration to backfill
 								if let Some(state) = stream_state.as_mut() {
-									state.best_known_block_height = best_block_header.height;
+									state.best_known_block_index = best_block_header.height;
 								}
 								false
 							},
@@ -124,7 +124,7 @@ where
 									Some(BtcSourceState {
 										last_block_yielded_hash: best_block_header.hash,
 										last_block_yielded_index: best_block_header.height,
-										best_known_block_height: best_block_header.height,
+										best_known_block_index: best_block_header.height,
 									}),
 									tick,
 								),

--- a/engine/src/witness/common/chain_source/strictly_monotonic.rs
+++ b/engine/src/witness/common/chain_source/strictly_monotonic.rs
@@ -83,6 +83,7 @@ mod test {
 					Header { index: 4u32, hash: (), parent_hash: Some(()), data: () },
 					Header { index: 3u32, hash: (), parent_hash: Some(()), data: () },
 					Header { index: 2u32, hash: (), parent_hash: Some(()), data: () },
+					Header { index: 10u32, hash: (), parent_hash: Some(()), data: () },
 				]),
 				last_output: None
 			}
@@ -90,7 +91,7 @@ mod test {
 			.await
 			.into_iter()
 			.map(|header| header.index),
-			[4, 5, 6]
+			[4, 5, 6, 10]
 		));
 	}
 }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Fixes an extreme BTC witnessing edge case that's only currently possible when a sub 5 second bitcoin block occurs. In most cases this is handled. But can occur under very specific rotation conditions. This will be more simply resolved with the upcoming larger witnessing refactor. 