### PR TITLE
fix: delete Solana channel state when closed

### DIFF
--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -470,7 +470,7 @@ impl DepositDetailsToTransactionInId<SolanaCrypto> for () {}
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::sol::compute_units_costs::*;
+	use crate::{sol::compute_units_costs::*, ChannelLifecycleHooks};
 
 	#[test]
 	fn can_calculate_gas_limit() {
@@ -506,5 +506,14 @@ mod test {
 			let tx_compute_limit = SolTrackedData::calculate_ccm_compute_limit(0, *asset);
 			assert_eq!(tx_compute_limit, default_compute_limit);
 		}
+	}
+
+	#[test]
+	fn solana_channel_recycling_is_assumed_to_be_deactivated() {
+		assert!(
+			<<Solana as Chain>::DepositChannelState as ChannelLifecycleHooks>::maybe_recycle(0).is_none(),
+			"It looks like Solana channel recycling is active. If this is intentional, ensure that the corresponding
+			unsynchronised state map in the delta_based_ingress election is not deleted when channels are closed."
+		);
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -352,6 +352,12 @@ where
 					// confirmed deposits have been ingressed.
 					if ready_total.block_number >= details.close_block {
 						Sink::on_channel_closed(account.clone());
+						// Removes the state.
+						// We need to remove this if we decide to recycle Solana channels.
+						ElectoralAccess::set_unsynchronised_state_map(
+							(account.clone(), details.asset),
+							None,
+						);
 						new_properties.remove(account);
 					}
 				}


### PR DESCRIPTION
This prevents Solana channels state from accumulating on-chain. We can revert this change if/when we activate Solana channel recycling. 