### PR TITLE
chore: bump elections version

### DIFF
--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -124,7 +124,7 @@ use frame_system::pallet_prelude::*;
 
 pub use pallet::*;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(4);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(5);
 
 pub use pallet::UniqueMonotonicIdentifier;
 


### PR DESCRIPTION
We bumped it on release/1.8 - so need to do so here too.