### PR TITLE
feat: upgrade subxt to 0.39.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,6 +37,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2020-0168: This advisory comes from `mach`, which is unmaintained but not a security issue. It's a dependency of `subxt`.
 # - RUSTSEC-2021-0139: This advisory comes from `ansi_term`, which is unmaintained but not a security issue. It's a dependency of `subxt`.
 # - RUSTSEC-2022-0061: This advisory is related to the deprecated `parity-wasm`, not a security issue. It's a dependency of `substrate`.
+# - RUSTSEC-2022-0080: This advisory comes from `parity-util-mem`, which is unmaintained but not a security issue. It's a dependency of `subxt`.
 # - RUSTSEC-2024-0336: This adivsory comes from rustls, which is a dependency of the `try-runtime-cli` crate.
 # - RUSTSEC-2024-0320: Unmaintained transitive `yaml-rust` dependency of `insta` crate. We only use insta for testing.
 # - RUSTSEC-2024-0370: Unmaintained transitive dependency. Only affects macro generation efficiency.
@@ -48,6 +49,7 @@ audit -D unmaintained -D unsound
     --ignore RUSTSEC-2021-0139
     --ignore RUSTSEC-2020-0168
     --ignore RUSTSEC-2022-0061
+    --ignore RUSTSEC-2022-0080
     --ignore RUSTSEC-2024-0320
     --ignore RUSTSEC-2024-0336
     --ignore RUSTSEC-2024-0344

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.96",
 ]
@@ -1384,8 +1384,8 @@ dependencies = [
  "rand",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-std",
  "utilities",
 ]
 
@@ -1398,8 +1398,8 @@ dependencies = [
  "rand",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
@@ -1438,10 +1438,10 @@ dependencies = [
  "sha2 0.10.8",
  "sha2-const",
  "sol-prim",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "ss58-registry",
  "strum 0.26.3",
  "thiserror 1.0.69",
@@ -1508,12 +1508,12 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-std",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
@@ -1531,10 +1531,10 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "utilities",
@@ -1558,10 +1558,10 @@ dependencies = [
  "hex-literal",
  "log",
  "parity-scale-codec",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -1574,8 +1574,8 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "rand",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -1586,9 +1586,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1606,9 +1606,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -1622,7 +1622,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "scale-info",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1724,7 +1724,7 @@ dependencies = [
  "serde",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
+ "sp-core",
  "state-chain-runtime",
  "tiny-bip39",
  "tokio",
@@ -1747,13 +1747,13 @@ dependencies = [
  "jsonrpsee 0.23.2",
  "sc-rpc",
  "serde",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
  "utilities",
 ]
 
@@ -1799,7 +1799,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
  "utilities",
 ]
 
@@ -1882,9 +1882,9 @@ dependencies = [
  "serde_path_to_error",
  "sha2 0.10.8",
  "sol-prim",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-version",
  "state-chain-runtime",
  "substrate-build-script-utils",
@@ -1931,13 +1931,13 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "state-chain-runtime",
  "substrate-build-script-utils",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
  "utilities",
 ]
 
@@ -1958,13 +1958,13 @@ dependencies = [
  "sc-rpc",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
  "substrate-build-script-utils",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
  "utilities",
 ]
 
@@ -2012,11 +2012,11 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-timestamp",
  "state-chain-runtime",
  "substrate-build-script-utils",
@@ -2641,19 +2641,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle 2.6.1",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
@@ -2708,10 +2695,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-api",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "state-chain-runtime",
  "thiserror 1.0.69",
  "utilities",
@@ -3238,20 +3225,6 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "hashbrown 0.12.3",
- "hex",
- "rand_core 0.6.4",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
@@ -3499,7 +3472,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror 1.0.69",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3510,9 +3483,9 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -3543,12 +3516,12 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
- "primitive-types",
+ "impl-serde 0.4.0",
+ "primitive-types 0.12.2",
  "scale-info",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3807,16 +3780,6 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -3963,16 +3926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "finito"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2384245d85162258a14b43567a9ee3598f5ae746a1581fb5d3d2cb780f0dbf95"
-dependencies = [
- "futures-timer",
- "pin-project",
-]
-
-[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4093,12 +4046,12 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-runtime-interface 28.0.0",
- "sp-storage 21.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-storage",
  "static_assertions",
 ]
 
@@ -4136,20 +4089,34 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.29.0",
+ "sp-externalities",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 38.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-storage 21.0.0",
- "sp-trie 37.0.0",
- "sp-wasm-interface 21.0.0",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-storage",
+ "sp-trie",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
  "thousands",
+]
+
+[[package]]
+name = "frame-decode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7af3d1149d6063985bb62d97f3ea83060ce4d6f2d04c21f551d270e8d84a27c"
+dependencies = [
+ "frame-metadata 18.0.0",
+ "parity-scale-codec",
+ "scale-decode 0.16.0",
+ "scale-info",
+ "scale-type-resolver",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4164,21 +4131,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-tracing 17.0.0",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878babb0b136e731cc77ec2fd883ff02745ff21e6fb662729953d44923df009c"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -4186,6 +4142,18 @@ name = "frame-metadata"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87cf1549fba25a6fcac22785b61698317d958e96cac72a59102ea45b9ae64692"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -4205,7 +4173,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4231,20 +4199,20 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
+ "sp-arithmetic",
+ "sp-core",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-debug-derive",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-staking",
- "sp-state-machine 0.43.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-tracing 17.0.0",
- "sp-weights 31.0.0",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
  "static_assertions",
  "tt-call",
 ]
@@ -4302,12 +4270,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "sp-version",
- "sp-weights 31.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -4320,8 +4288,8 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4342,7 +4310,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5481,6 +5449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-rlp"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5494,6 +5471,15 @@ name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -5762,53 +5748,32 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
-dependencies = [
- "jsonrpsee-client-transport 0.22.5",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-http-client 0.22.5",
- "jsonrpsee-types 0.22.5",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
 dependencies = [
  "jsonrpsee-client-transport 0.23.2",
  "jsonrpsee-core 0.23.2",
- "jsonrpsee-http-client 0.23.2",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types 0.23.2",
  "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
+ "jsonrpsee-ws-client 0.23.2",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "jsonrpsee-client-transport"
-version = "0.22.5"
+name = "jsonrpsee"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
 dependencies = [
- "futures-util",
- "http 0.2.12",
- "jsonrpsee-core 0.22.5",
- "pin-project",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "soketto 0.7.1",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls 0.25.0",
- "tokio-util",
- "tracing",
- "url",
+ "jsonrpsee-client-transport 0.24.8",
+ "jsonrpsee-core 0.24.8",
+ "jsonrpsee-types 0.24.8",
+ "jsonrpsee-ws-client 0.24.8",
 ]
 
 [[package]]
@@ -5837,26 +5802,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-core"
-version = "0.22.5"
+name = "jsonrpsee-client-transport"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
 dependencies = [
- "anyhow",
- "async-trait",
- "beef",
- "futures-timer",
+ "base64 0.22.1",
  "futures-util",
- "hyper 0.14.32",
- "jsonrpsee-types 0.22.5",
+ "http 1.2.0",
+ "jsonrpsee-core 0.24.8",
  "pin-project",
- "rustc-hash",
- "serde",
- "serde_json",
+ "rustls 0.23.21",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
+ "tokio-rustls 0.26.1",
+ "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5878,7 +5843,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5889,23 +5854,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-http-client"
-version = "0.22.5"
+name = "jsonrpsee-core"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
 dependencies = [
  "async-trait",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "jsonrpsee-core 0.22.5",
- "jsonrpsee-types 0.22.5",
+ "futures-timer",
+ "futures-util",
+ "jsonrpsee-types 0.24.8",
+ "pin-project",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower 0.4.13",
+ "tokio-stream",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -5976,12 +5941,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.22.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
 dependencies = [
- "anyhow",
  "beef",
+ "http 1.2.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5989,11 +5954,10 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.23.2"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
+checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
 dependencies = [
- "beef",
  "http 1.2.0",
  "serde",
  "serde_json",
@@ -6021,6 +5985,19 @@ dependencies = [
  "jsonrpsee-client-transport 0.23.2",
  "jsonrpsee-core 0.23.2",
  "jsonrpsee-types 0.23.2",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
+dependencies = [
+ "http 1.2.0",
+ "jsonrpsee-client-transport 0.24.8",
+ "jsonrpsee-core 0.24.8",
+ "jsonrpsee-types 0.24.8",
  "url",
 ]
 
@@ -6060,6 +6037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-hash"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
+dependencies = [
+ "primitive-types 0.13.1",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -6350,7 +6337,7 @@ dependencies = [
  "sha2 0.10.8",
  "smallvec",
  "thiserror 1.0.69",
- "uint",
+ "uint 0.9.5",
  "unsigned-varint 0.7.2",
  "void",
 ]
@@ -6809,7 +6796,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "trust-dns-resolver",
- "uint",
+ "uint 0.9.5",
  "unsigned-varint 0.8.0",
  "url",
  "webpki",
@@ -6940,15 +6927,6 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -7049,7 +7027,7 @@ dependencies = [
  "blake3",
  "frame-metadata 16.0.0",
  "parity-scale-codec",
- "scale-decode",
+ "scale-decode 0.13.1",
  "scale-info",
 ]
 
@@ -7242,6 +7220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multi-stash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
 name = "multiaddr"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7392,8 +7376,8 @@ dependencies = [
  "secp256k1 0.29.1",
  "serde",
  "sha2 0.10.8",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "state-chain-runtime",
  "strum 0.26.3",
  "strum_macros 0.26.4",
@@ -7565,12 +7549,6 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
-name = "no-std-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nodrop"
@@ -7974,9 +7952,9 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7989,7 +7967,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8006,10 +7984,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8028,10 +8006,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8052,10 +8030,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8072,7 +8050,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8090,10 +8068,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8116,8 +8094,8 @@ dependencies = [
  "rand",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-std",
  "utilities",
 ]
 
@@ -8138,11 +8116,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8162,10 +8140,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8184,10 +8162,10 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8207,10 +8185,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8227,10 +8205,10 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8252,10 +8230,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "utilities",
@@ -8277,10 +8255,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8301,11 +8279,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8325,11 +8303,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8351,11 +8329,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8378,10 +8356,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8400,10 +8378,10 @@ dependencies = [
  "pallet-cf-flip",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8426,11 +8404,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8451,10 +8429,10 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8473,10 +8451,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "utilities",
 ]
 
@@ -8493,11 +8471,11 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
 ]
@@ -8514,13 +8492,13 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -8536,9 +8514,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-storage 21.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-storage",
  "sp-timestamp",
 ]
 
@@ -8552,9 +8530,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8567,10 +8545,10 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
- "sp-weights 31.0.0",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8581,8 +8559,8 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.0",
- "sp-weights 31.0.0",
+ "sp-runtime",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8980,7 +8958,7 @@ dependencies = [
  "libc",
  "log",
  "polkavm-assembler",
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "polkavm-linux-raw",
 ]
 
@@ -8995,12 +8973,6 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
-
-[[package]]
-name = "polkavm-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
@@ -9010,32 +8982,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
-dependencies = [
- "polkavm-derive-impl-macro 0.8.0",
-]
-
-[[package]]
-name = "polkavm-derive"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
- "polkavm-derive-impl-macro 0.9.0",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
-dependencies = [
- "polkavm-common 0.8.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "polkavm-derive-impl-macro",
 ]
 
 [[package]]
@@ -9044,19 +8995,9 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "polkavm-derive-impl-macro"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
-dependencies = [
- "polkavm-derive-impl 0.8.0",
  "syn 2.0.96",
 ]
 
@@ -9066,7 +9007,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
- "polkavm-derive-impl 0.9.0",
+ "polkavm-derive-impl",
  "syn 2.0.96",
 ]
 
@@ -9080,7 +9021,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "object 0.32.2",
- "polkavm-common 0.9.0",
+ "polkavm-common",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -9227,11 +9168,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-serde 0.5.0",
+ "scale-info",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -9275,6 +9229,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9575,7 +9551,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto 0.9.6",
  "quinn-udp 0.3.2",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "thiserror 1.0.69",
  "tokio",
@@ -9594,7 +9570,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto 0.10.6",
  "quinn-udp 0.4.1",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.21.12",
  "thiserror 1.0.69",
  "tokio",
@@ -9610,7 +9586,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "slab",
  "thiserror 1.0.69",
@@ -9628,7 +9604,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.21.12",
  "slab",
  "thiserror 1.0.69",
@@ -9792,22 +9768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reconnecting-jsonrpsee-ws-client"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fa4f17e09edfc3131636082faaec633c7baa269396b4004040bc6c52f49f65"
-dependencies = [
- "cfg_aliases 0.2.1",
- "finito",
- "futures",
- "jsonrpsee 0.23.2",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9900,7 +9860,7 @@ checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "slice-group-by",
  "smallvec",
 ]
@@ -10163,6 +10123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10234,20 +10200,6 @@ dependencies = [
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring 0.17.8",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle 2.6.1",
- "zeroize",
 ]
 
 [[package]]
@@ -10370,13 +10322,12 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ruzstd"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
  "derive_more 0.99.18",
- "twox-hash",
 ]
 
 [[package]]
@@ -10429,8 +10380,8 @@ version = "29.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
  "log",
- "sp-core 34.0.0",
- "sp-wasm-interface 21.0.0",
+ "sp-core",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
 ]
 
@@ -10450,9 +10401,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10465,10 +10416,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 39.0.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10489,13 +10440,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
  "sp-genesis-builder",
- "sp-io 38.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-tracing 17.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -10540,11 +10491,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-keyring",
- "sp-keystore 0.40.0",
- "sp-panic-handler 13.0.0",
- "sp-runtime 39.0.0",
+ "sp-keystore",
+ "sp-panic-handler",
+ "sp-runtime",
  "sp-version",
  "thiserror 1.0.69",
  "tokio",
@@ -10566,14 +10517,14 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.29.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-statement-store",
- "sp-storage 21.0.0",
- "sp-trie 37.0.0",
+ "sp-storage",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
@@ -10594,13 +10545,13 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-database",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -10620,9 +10571,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -10642,16 +10593,16 @@ dependencies = [
  "sc-consensus-slots",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-consensus-slots",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -10687,15 +10638,15 @@ dependencies = [
  "sc-utils",
  "serde_json",
  "sp-api",
- "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-application-crypto",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
+ "sp-keystore",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -10715,8 +10666,8 @@ dependencies = [
  "sc-rpc",
  "serde",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -10733,14 +10684,14 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-telemetry",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -10755,14 +10706,14 @@ dependencies = [
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-io 38.0.0",
- "sp-panic-handler 13.0.0",
- "sp-runtime-interface 28.0.0",
- "sp-trie 37.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-panic-handler",
+ "sp-runtime-interface",
+ "sp-trie",
  "sp-version",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface",
  "tracing",
 ]
 
@@ -10774,7 +10725,7 @@ dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
@@ -10787,7 +10738,7 @@ dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface",
 ]
 
 [[package]]
@@ -10803,8 +10754,8 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 28.0.0",
- "sp-wasm-interface 21.0.0",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmtime",
 ]
 
@@ -10822,7 +10773,7 @@ dependencies = [
  "sc-network-common",
  "sc-network-sync",
  "sp-blockchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10833,9 +10784,9 @@ dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
  "serde_json",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror 1.0.69",
 ]
 
@@ -10861,10 +10812,10 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
+ "sp-core",
+ "sp-keystore",
  "sp-mixnet",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -10905,10 +10856,10 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -10934,7 +10885,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10951,7 +10902,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -10972,8 +10923,8 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -11002,12 +10953,12 @@ dependencies = [
  "sc-utils",
  "schnellru",
  "smallvec",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -11029,7 +10980,7 @@ dependencies = [
  "sc-network-types",
  "sc-utils",
  "sp-consensus",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
 ]
 
@@ -11075,11 +11026,11 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "sp-api",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-keystore 0.40.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "threadpool",
  "tracing",
 ]
@@ -11114,11 +11065,11 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
+ "sp-core",
+ "sp-keystore",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-statement-store",
  "sp-version",
@@ -11138,9 +11089,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-version",
  "thiserror 1.0.69",
 ]
@@ -11190,9 +11141,9 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-version",
  "thiserror 1.0.69",
  "tokio",
@@ -11243,16 +11194,16 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.43.0",
- "sp-storage 21.0.0",
+ "sp-state-machine",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
- "sp-trie 37.0.0",
+ "sp-trie",
  "sp-version",
  "static_init",
  "substrate-prometheus-endpoint",
@@ -11271,7 +11222,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 34.0.0",
+ "sp-core",
 ]
 
 [[package]]
@@ -11289,10 +11240,10 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-io 38.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
@@ -11329,20 +11280,20 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sc-client-api",
  "sc-tracing-proc-macro",
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 39.0.0",
- "sp-tracing 17.0.0",
+ "sp-runtime",
+ "sp-tracing",
  "thiserror 1.0.69",
  "tracing",
- "tracing-log 0.2.0",
- "tracing-subscriber 0.3.19",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -11374,10 +11325,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-runtime 39.0.0",
- "sp-tracing 17.0.0",
+ "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -11394,8 +11345,8 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -11411,7 +11362,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "prometheus",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -11419,6 +11370,16 @@ name = "scale-bits"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27243ab0d2d6235072b017839c5f0cd1a3b1ce45c0f7a715363b0c7d36c76c94"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11434,11 +11395,26 @@ checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
  "derive_more 0.99.18",
  "parity-scale-codec",
- "primitive-types",
- "scale-bits",
- "scale-decode-derive",
+ "primitive-types 0.12.2",
+ "scale-bits 0.6.0",
+ "scale-decode-derive 0.13.1",
  "scale-type-resolver",
  "smallvec",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d78196772d25b90a98046794ce0fe2588b39ebdfbdc1e45b4c6c85dd43bebad"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "scale-bits 0.7.0",
+ "scale-decode-derive 0.16.0",
+ "scale-type-resolver",
+ "smallvec",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -11454,25 +11430,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-encode"
-version = "0.7.2"
+name = "scale-decode-derive"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528464e6ae6c8f98e2b79633bf79ef939552e795e316579dab09c61670d56602"
+checksum = "2f4b54a1211260718b92832b661025d1f1a4b6930fbadd6908e00edd265fa5f7"
 dependencies = [
- "derive_more 0.99.18",
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64901733157f9d25ef86843bd783eda439fac7efb0ad5a615d12d2cf3a29464b"
+dependencies = [
  "parity-scale-codec",
- "primitive-types",
- "scale-bits",
+ "primitive-types 0.13.1",
+ "scale-bits 0.7.0",
  "scale-encode-derive",
  "scale-type-resolver",
  "smallvec",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.7.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef2618f123c88da9cd8853b69d766068f1eddc7692146d7dfe9b89e25ce2efd"
+checksum = "78a3993a13b4eafa89350604672c8757b7ea84c7c5947d4b3691e3169c96379b"
 dependencies = [
  "darling 0.20.10",
  "proc-macro-crate 3.2.0",
@@ -11514,7 +11502,7 @@ dependencies = [
  "hex",
  "insta",
  "parity-scale-codec",
- "scale-decode",
+ "scale-decode 0.13.1",
  "scale-info",
  "scale-type-resolver",
  "serde",
@@ -11548,35 +11536,33 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498d1aecf2ea61325d4511787c115791639c0fd21ef4f8e11e49dd09eff2bbac"
+checksum = "dc3173be608895eb117cf397ab4f31f00e2ed2c7af1c6e0b8f5d51d0a0967053"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
  "syn 2.0.96",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6ab090d823e75cfdb258aad5fe92e13f2af7d04b43a55d607d25fcc38c811"
+checksum = "8ca8b26b451ecb7fd7b62b259fa28add63d12ec49bbcac0e01fcb4b5ae0c09aa"
 dependencies = [
  "base58",
  "blake2 0.10.6",
- "derive_more 0.99.18",
  "either",
- "frame-metadata 15.1.0",
  "parity-scale-codec",
- "scale-bits",
- "scale-decode",
+ "scale-bits 0.7.0",
+ "scale-decode 0.16.0",
  "scale-encode",
- "scale-info",
  "scale-type-resolver",
  "serde",
+ "thiserror 2.0.11",
  "yap",
 ]
 
@@ -12120,34 +12106,33 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d1eaa97d77be4d026a1e7ffad1bb3b78448763b357ea6f8188d3e6f736a9b9"
+checksum = "966e72d77a3b2171bb7461d0cb91f43670c63558c62d7cf42809cae6c8b6b818"
 dependencies = [
  "arrayvec 0.7.6",
  "async-lock",
  "atomic-take",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bip39",
  "blake2-rfc",
  "bs58 0.5.1",
  "chacha20",
  "crossbeam-queue",
  "derive_more 0.99.18",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "either",
- "event-listener 4.0.3",
+ "event-listener 5.4.0",
  "fnv",
  "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
  "hmac 0.12.1",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libm",
  "libsecp256k1",
  "merlin",
- "no-std-net",
  "nom",
  "num-bigint",
  "num-rational",
@@ -12166,7 +12151,7 @@ dependencies = [
  "siphasher 1.0.1",
  "slab",
  "smallvec",
- "soketto 0.7.1",
+ "soketto 0.8.1",
  "twox-hash",
  "wasmi",
  "x25519-dalek",
@@ -12175,27 +12160,27 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.14.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5496f2d116b7019a526b1039ec2247dd172b8670633b1a64a614c9ea12c9d8c7"
+checksum = "2a33b06891f687909632ce6a4e3fd7677b24df930365af3d0bcb078310129f3f"
 dependencies = [
  "async-channel 2.3.1",
  "async-lock",
- "base64 0.21.7",
+ "base64 0.22.1",
  "blake2-rfc",
+ "bs58 0.5.1",
  "derive_more 0.99.18",
  "either",
- "event-listener 4.0.3",
+ "event-listener 5.4.0",
  "fnv",
  "futures-channel",
  "futures-lite",
  "futures-util",
  "hashbrown 0.14.5",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "lru",
- "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
  "rand",
@@ -12302,8 +12287,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sha2-const",
- "sp-core 34.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-core",
+ "sp-std",
  "thiserror 1.0.69",
  "utilities",
 ]
@@ -12333,13 +12318,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
+ "sp-core",
+ "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 39.0.0",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-trie",
  "sp-version",
  "thiserror 1.0.69",
 ]
@@ -12360,43 +12345,14 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ca6121c22c8bd3d1dce1f05c479101fd0d7b159bef2a3e8c834138d839c75c"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "38.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "25.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910c07fa263b20bf7271fdd4adcb5d3217dfdac14270592e0780223542e7e114"
-dependencies = [
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions",
+ "sp-core",
+ "sp-io",
 ]
 
 [[package]]
@@ -12420,7 +12376,7 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "sp-api",
  "sp-inherents",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12434,10 +12390,10 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-consensus",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-database",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -12450,10 +12406,10 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 39.0.0",
- "sp-state-machine 0.43.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
 ]
 
@@ -12466,10 +12422,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-inherents",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -12484,10 +12440,10 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-api",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12503,53 +12459,6 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d7a0fd8f16dcc3761198fc83be12872f823b37b749bc72a3a6a1f702509366"
-dependencies = [
- "array-bytes",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58 0.5.1",
- "dyn-clonable",
- "ed25519-zebra 3.1.0",
- "futures",
- "hash-db 0.16.0",
- "hash256-std-hasher",
- "impl-serde",
- "itertools 0.10.5",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types",
- "rand",
- "scale-info",
- "schnorrkel",
- "secp256k1 0.28.2",
- "secrecy",
- "serde",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.27.0",
- "sp-runtime-interface 26.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 20.0.0",
- "ss58-registry",
- "substrate-bip39 0.5.0",
- "thiserror 1.0.69",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
 version = "34.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
@@ -12559,11 +12468,11 @@ dependencies = [
  "bounded-collections",
  "bs58 0.5.1",
  "dyn-clonable",
- "ed25519-zebra 4.0.3",
+ "ed25519-zebra",
  "futures",
  "hash-db 0.16.0",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "itertools 0.11.0",
  "k256",
  "libsecp256k1",
@@ -12573,7 +12482,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
- "primitive-types",
+ "primitive-types 0.12.2",
  "rand",
  "scale-info",
  "schnorrkel",
@@ -12581,13 +12490,13 @@ dependencies = [
  "secrecy",
  "serde",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-debug-derive 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-externalities 0.29.0",
- "sp-runtime-interface 28.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-storage 21.0.0",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -12643,34 +12552,11 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d6a4572eadd4a63cff92509a210bf425501a0c5e76574b30a366ac77653787"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 20.0.0",
 ]
 
 [[package]]
@@ -12680,7 +12566,7 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 21.0.0",
+ "sp-storage",
 ]
 
 [[package]]
@@ -12692,7 +12578,7 @@ dependencies = [
  "scale-info",
  "serde_json",
  "sp-api",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12704,35 +12590,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-io"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e09bba780b55bd9e67979cd8f654a31e4a6cf45426ff371394a65953d2177f2"
-dependencies = [
- "bytes",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 31.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.27.0",
- "sp-keystore 0.37.0",
- "sp-runtime-interface 26.0.0",
- "sp-state-machine 0.38.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 16.0.0",
- "sp-trie 32.0.0",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -12746,17 +12605,17 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive 0.9.1",
+ "polkavm-derive",
  "rustversion",
  "secp256k1 0.28.2",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-externalities 0.29.0",
- "sp-keystore 0.40.0",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.43.0",
- "sp-tracing 17.0.0",
- "sp-trie 37.0.0",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-tracing",
+ "sp-trie",
  "tracing",
  "tracing-core",
 ]
@@ -12766,21 +12625,9 @@ name = "sp-keyring"
 version = "39.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
-dependencies = [
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
 ]
 
 [[package]]
@@ -12790,8 +12637,8 @@ source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-sub
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
+ "sp-core",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -12821,7 +12668,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 38.0.0",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -12830,8 +12677,8 @@ version = "34.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
  "sp-api",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -12845,48 +12692,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-panic-handler"
-version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81478b3740b357fa0ea10fcdc1ee02ebae7734e50f80342c4743476d9f78eeea"
-dependencies = [
- "backtrace",
- "regex",
-]
-
-[[package]]
 name = "sp-rpc"
 version = "32.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
- "sp-core 34.0.0",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3cb126971e7db2f0fcf8053dce740684c438c7180cfca1959598230f342c58"
-dependencies = [
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "paste",
- "rand",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 33.0.0",
- "sp-arithmetic 25.0.0",
- "sp-core 31.0.0",
- "sp-io 33.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 30.0.0",
+ "sp-core",
 ]
 
 [[package]]
@@ -12906,33 +12718,13 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-weights 31.0.0",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-std",
+ "sp-weights",
  "tracing",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "26.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a675ea4858333d4d755899ed5ed780174aa34fec15953428d516af5452295"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.8.0",
- "primitive-types",
- "sp-externalities 0.27.0",
- "sp-runtime-interface-proc-macro 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 20.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
- "static_assertions",
 ]
 
 [[package]]
@@ -12943,29 +12735,15 @@ dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.9.1",
- "primitive-types",
- "sp-externalities 0.29.0",
- "sp-runtime-interface-proc-macro 18.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-storage 21.0.0",
- "sp-tracing 17.0.0",
- "sp-wasm-interface 21.0.0",
+ "polkavm-derive",
+ "primitive-types 0.12.2",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195f32c628fee3ce1dfbbf2e7e52a30ea85f3589da9fe62a8b816d70fc06294"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.2.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -12989,9 +12767,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 34.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "sp-staking",
 ]
 
@@ -13004,30 +12782,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eae0eac8034ba14437e772366336f579398a46d101de13dbb781ab1e35e67c5"
-dependencies = [
- "hash-db 0.16.0",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "smallvec",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-panic-handler 13.0.1",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 32.0.0",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.28.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13041,13 +12797,13 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand",
  "smallvec",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-panic-handler 13.0.0",
- "sp-trie 37.0.0",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie",
  "thiserror 1.0.69",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
 ]
 
 [[package]]
@@ -13064,12 +12820,12 @@ dependencies = [
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
+ "sp-application-crypto",
+ "sp-core",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
- "sp-externalities 0.29.0",
- "sp-runtime 39.0.0",
- "sp-runtime-interface 28.0.0",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-runtime-interface",
  "thiserror 1.0.69",
  "x25519-dalek",
 ]
@@ -13077,38 +12833,18 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
-
-[[package]]
-name = "sp-storage"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dba5791cb3978e95daf99dad919ecb3ec35565604e88cd38d805d9d4981e8bd"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13119,21 +12855,8 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0351810b9d074df71c4514c5228ed05c250607cba131c1c9d1526760ab69c05c"
-dependencies = [
- "parity-scale-codec",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -13144,7 +12867,7 @@ dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -13153,7 +12876,7 @@ version = "34.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
  "sp-api",
- "sp-runtime 39.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13164,35 +12887,10 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-inherents",
- "sp-runtime 39.0.0",
- "sp-trie 37.0.0",
-]
-
-[[package]]
-name = "sp-trie"
-version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1aa91ad26c62b93d73e65f9ce7ebd04459c4bad086599348846a81988d6faa4"
-dependencies = [
- "ahash 0.8.11",
- "hash-db 0.16.0",
- "lazy_static",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand",
- "scale-info",
- "schnellru",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.28.0",
- "trie-root",
+ "sp-runtime",
+ "sp-trie",
 ]
 
 [[package]]
@@ -13210,11 +12908,11 @@ dependencies = [
  "rand",
  "scale-info",
  "schnellru",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
+ "sp-core",
+ "sp-externalities",
  "thiserror 1.0.69",
  "tracing",
- "trie-db 0.29.1",
+ "trie-db",
  "trie-root",
 ]
 
@@ -13223,14 +12921,14 @@ name = "sp-version"
 version = "37.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 39.0.0",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-runtime",
+ "sp-std",
  "sp-version-proc-macro",
  "thiserror 1.0.69",
 ]
@@ -13248,20 +12946,6 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef97172c42eb4c6c26506f325f48463e9bc29b2034a587f1b9e48c751229bee"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmtime",
-]
-
-[[package]]
-name = "sp-wasm-interface"
 version = "21.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
@@ -13274,22 +12958,6 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af6c661fe3066b29f9e1d258000f402ff5cc2529a9191972d214e5871d0ba87"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 25.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-weights"
 version = "31.0.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
@@ -13298,8 +12966,8 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 26.0.0",
- "sp-debug-derive 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-arithmetic",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13415,14 +13083,14 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
- "sp-core 34.0.0",
+ "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
- "sp-io 38.0.0",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 39.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -13481,6 +13149,16 @@ dependencies = [
  "sha-1 0.10.1",
  "thiserror 1.0.69",
  "tracing",
+]
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -13551,19 +13229,6 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b564c293e6194e8b222e52436bcb99f60de72043c7f845cf6c4406db4df121"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2 0.12.2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "substrate-bip39"
 version = "0.6.0"
 source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2#d4792faaa7ab3fbb9798dcc629564d182853690e"
 dependencies = [
@@ -13595,8 +13260,8 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 34.0.0",
- "sp-runtime 39.0.0",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13629,10 +13294,10 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker",
  "sc-executor",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
- "sp-tracing 17.0.0",
+ "sp-tracing",
  "sp-version",
  "strum 0.26.3",
  "tempfile",
@@ -13655,24 +13320,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a160cba1edbf3ec4fbbeaea3f1a185f70448116a6bccc8276bb39adb3b3053bd"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 16.0.0",
+ "frame-metadata 18.0.0",
  "futures",
  "hex",
- "impl-serde",
- "instant",
- "jsonrpsee 0.22.5",
+ "jsonrpsee 0.24.8",
  "parity-scale-codec",
- "primitive-types",
- "reconnecting-jsonrpsee-ws-client",
- "scale-bits",
- "scale-decode",
+ "primitive-types 0.13.1",
+ "scale-bits 0.7.0",
+ "scale-decode 0.16.0",
  "scale-encode",
  "scale-info",
  "scale-value",
@@ -13683,22 +13344,22 @@ dependencies = [
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
- "thiserror 1.0.69",
+ "subxt-rpcs",
+ "thiserror 2.0.11",
+ "tokio",
  "tokio-util",
  "tracing",
  "url",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
 name = "subxt-codegen"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d703dca0905cc5272d7cc27a4ac5f37dcaae7671acc7fef0200057cc8c317786"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
- "frame-metadata 16.0.0",
  "heck 0.5.0",
- "hex",
- "jsonrpsee 0.22.5",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
@@ -13706,51 +13367,49 @@ dependencies = [
  "scale-typegen",
  "subxt-metadata",
  "syn 2.0.96",
- "thiserror 1.0.69",
- "tokio",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "subxt-core"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af3b36405538a36b424d229dc908d1396ceb0994c90825ce928709eac1a159a"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
- "frame-metadata 16.0.0",
+ "frame-decode",
+ "frame-metadata 18.0.0",
  "hashbrown 0.14.5",
  "hex",
- "impl-serde",
+ "impl-serde 0.5.0",
+ "keccak-hash",
  "parity-scale-codec",
- "primitive-types",
- "scale-bits",
- "scale-decode",
+ "primitive-types 0.13.1",
+ "scale-bits 0.7.0",
+ "scale-decode 0.16.0",
  "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
- "sp-core 31.0.0",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 34.0.0",
  "subxt-metadata",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9406fbdb9548c110803cb8afa750f8b911d51eefdf95474b11319591d225d9"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
  "futures",
  "futures-util",
  "serde",
  "serde_json",
  "smoldot-light",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -13758,30 +13417,64 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c195f803d70687e409aba9be6c87115b5da8952cd83c4d13f2e043239818fcd"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
  "darling 0.20.10",
  "parity-scale-codec",
- "proc-macro-error",
+ "proc-macro-error2",
  "quote",
  "scale-typegen",
  "subxt-codegen",
+ "subxt-utils-fetchmetadata",
  "syn 2.0.96",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738be5890fdeff899bbffff4d9c0f244fe2a952fb861301b937e3aa40ebb55da"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
 dependencies = [
- "frame-metadata 16.0.0",
+ "frame-decode",
+ "frame-metadata 18.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+dependencies = [
+ "derive-where",
+ "frame-metadata 18.0.0",
+ "futures",
+ "hex",
+ "impl-serde 0.5.0",
+ "jsonrpsee 0.24.8",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-core",
+ "subxt-lightclient",
+ "thiserror 2.0.11",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.39.0"
+source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -14082,7 +13775,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.11.0",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "unicode-normalization",
@@ -14170,17 +13863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -14434,33 +14116,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
  "tracing-core",
 ]
 
@@ -14476,33 +14137,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-serde 0.1.3",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
- "matchers 0.1.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "parking_lot 0.12.3",
@@ -14514,21 +14153,8 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
- "tracing-serde 0.2.0",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
-dependencies = [
- "hash-db 0.16.0",
- "hashbrown 0.13.2",
- "log",
- "rustc-hex",
- "smallvec",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -14722,6 +14348,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14879,12 +14517,12 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "sp-core 34.0.0",
+ "sp-core",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber",
  "url",
  "warp",
 ]
@@ -15159,28 +14797,37 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.31.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+checksum = "50386c99b9c32bd2ed71a55b6dd4040af2580530fae8bdb9a6576571a80d0cca"
 dependencies = [
+ "arrayvec 0.7.6",
+ "multi-stash",
+ "num-derive",
+ "num-traits",
  "smallvec",
  "spin 0.9.8",
- "wasmi_arena",
+ "wasmi_collections",
  "wasmi_core",
  "wasmparser-nostd",
 ]
 
 [[package]]
-name = "wasmi_arena"
-version = "0.4.1"
+name = "wasmi_collections"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.14.5",
+ "string-interner",
+]
 
 [[package]]
 name = "wasmi_core"
-version = "0.13.0"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+checksum = "a23b3a7f6c8c3ceeec6b83531ee61f0013c56e51cbf2b14b0f213548b23a4b41"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -15407,6 +15054,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -15963,9 +15620,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yap"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4524214bc4629eba08d78ceb1d6507070cc0bcbbed23af74e19e6e924a24cf"
+checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
 
 # subxt dependency using the same Chainflip polkadot-sdk version
-subxt = { git = "https://github.com/chainflip-io/substrate-subxt.git", branch = "v039.0-chainflip-substrate-1.15.2+2" }
+subxt = { git = "https://github.com/chainflip-io/substrate-subxt.git", tag = "v039.0-chainflip-substrate-1.15.2+2" }
 
 # PolkadotSdk Pallets
 pallet-aura = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.15.2+2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ sha2-const = { version = "0.1.2", default-features = false }
 ss58-registry = { version = "1.41" }
 strum = { version = "0.26.3", default-features = false }
 strum_macros = { version = "0.26.4", default-features = false }
-subxt = { version = "0.37.0" }
+subxt = { version = "0.39.0" }
 syn = { version = "2.0.53" }
 tempfile = { version = "3.8.1" }
 thiserror = { version = "1.0.50", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,6 @@ sha2-const = { version = "0.1.2", default-features = false }
 ss58-registry = { version = "1.41" }
 strum = { version = "0.26.3", default-features = false }
 strum_macros = { version = "0.26.4", default-features = false }
-subxt = { version = "0.39.0" }
 syn = { version = "2.0.53" }
 tempfile = { version = "3.8.1" }
 thiserror = { version = "1.0.50", default-features = false }
@@ -161,6 +160,9 @@ web3 = { version = "0.19" }
 x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
+
+# subxt dependency using the same Chainflip polkadot-sdk version
+subxt = { git = "https://github.com/chainflip-io/substrate-subxt.git", branch = "v039.0-chainflip-substrate-1.15.2+2" }
 
 # PolkadotSdk Pallets
 pallet-aura = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.15.2+2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,8 +161,8 @@ x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
 
-# subxt dependency (at the moment points to the commit hash of the PR removing polkadot-sdk as dependency.
-# TODO: remove the commit hash when subxt is released > 0.39.0)
+# subxt dependency (at the moment points to the commit hash of the PR removing polkadot-sdk as dependency).
+# TODO: remove the commit hash when subxt is released > 0.39.0
 subxt = { git = "https://github.com/paritytech/subxt", rev = "69ce6d7" }
 
 # PolkadotSdk Pallets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,8 +161,9 @@ x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
 
-# subxt dependency using the same Chainflip polkadot-sdk version
-subxt = { git = "https://github.com/chainflip-io/substrate-subxt.git", tag = "v039.0-chainflip-substrate-1.15.2+2" }
+# subxt dependency (at the moment points to the commit hash of the PR removing polkadot-sdk as dependency.
+# TODO: remove the commit hash when subxt is released > 0.39.0)
+subxt = { git = "https://github.com/paritytech/subxt", rev = "69ce6d7" }
 
 # PolkadotSdk Pallets
 pallet-aura = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.15.2+2", default-features = false }

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing.rs
@@ -5,7 +5,6 @@ pub mod state_chain;
 
 use self::state_chain::handle_call;
 use crate::{settings::DepositTrackerSettings, store::RedisStore};
-use cf_chains::dot::PolkadotHash;
 use cf_utilities::task_scope;
 use chainflip_api::primitives::{
 	chains::assets::eth::Asset as EthAsset, Asset, NetworkEnvironment,
@@ -21,7 +20,7 @@ use chainflip_engine::{
 };
 
 use anyhow::anyhow;
-use sp_core::H160;
+use sp_core::{H160, H256};
 use std::collections::HashMap;
 
 #[derive(Clone)]
@@ -33,7 +32,7 @@ pub(super) struct EnvironmentParameters {
 	usdc_contract_address: H160,
 	usdt_contract_address: H160,
 	supported_erc20_tokens: HashMap<H160, Asset>,
-	dot_genesis_hash: PolkadotHash,
+	dot_genesis_hash: H256,
 	pub chainflip_network: NetworkEnvironment,
 }
 

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing.rs
@@ -20,7 +20,8 @@ use chainflip_engine::{
 };
 
 use anyhow::anyhow;
-use sp_core::{H160, H256};
+use chainflip_engine::dot::PolkadotHash;
+use sp_core::H160;
 use std::collections::HashMap;
 
 #[derive(Clone)]
@@ -32,7 +33,7 @@ pub(super) struct EnvironmentParameters {
 	usdc_contract_address: H160,
 	usdt_contract_address: H160,
 	supported_erc20_tokens: HashMap<H160, Asset>,
-	dot_genesis_hash: H256,
+	dot_genesis_hash: PolkadotHash,
 	pub chainflip_network: NetworkEnvironment,
 }
 
@@ -81,12 +82,15 @@ async fn get_env_parameters(state_chain_client: &StateChainClient<()>) -> Enviro
 		.map(|(asset, address)| (address, asset.into()))
 		.collect();
 
-	let dot_genesis_hash = state_chain_client
-		.storage_value::<pallet_cf_environment::PolkadotGenesisHash<state_chain_runtime::Runtime>>(
-			state_chain_client.latest_finalized_block().hash,
-		)
-		.await
-		.expect(STATE_CHAIN_CONNECTION);
+	let dot_genesis_hash = PolkadotHash::from_slice(
+		state_chain_client
+			.storage_value::<pallet_cf_environment::PolkadotGenesisHash<state_chain_runtime::Runtime>>(
+				state_chain_client.latest_finalized_block().hash,
+			)
+			.await
+			.expect(STATE_CHAIN_CONNECTION)
+			.as_bytes(),
+	);
 
 	let chainflip_network = state_chain_client
 		.storage_value::<pallet_cf_environment::ChainflipNetworkEnvironment<state_chain_runtime::Runtime>>(

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/dot.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/dot.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
+use super::EnvironmentParameters;
+use crate::DepositTrackerSettings;
 use cf_utilities::task_scope::Scope;
 use chainflip_api::primitives::EpochIndex;
 use chainflip_engine::{
-	dot::retry_rpc::DotRetryRpcClient,
+	dot::{retry_rpc::DotRetryRpcClient, PolkadotHash},
 	settings::NodeContainer,
 	state_chain_observer::client::{
 		storage_api::StorageApi,
@@ -16,10 +18,6 @@ use chainflip_engine::{
 	},
 };
 use futures::Future;
-
-use crate::DepositTrackerSettings;
-
-use super::EnvironmentParameters;
 
 pub(super) async fn start<ProcessCall, ProcessingFut>(
 	scope: &Scope<'_, anyhow::Error>,
@@ -41,7 +39,7 @@ where
 	let dot_client = DotRetryRpcClient::new(
 		scope,
 		NodeContainer { primary: settings.dot, backup: None },
-		env_params.dot_genesis_hash,
+		PolkadotHash::from_slice(env_params.dot_genesis_hash.as_bytes()),
 	)?;
 
 	let epoch_source = epoch_source

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/dot.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/dot.rs
@@ -5,7 +5,7 @@ use crate::DepositTrackerSettings;
 use cf_utilities::task_scope::Scope;
 use chainflip_api::primitives::EpochIndex;
 use chainflip_engine::{
-	dot::{retry_rpc::DotRetryRpcClient, PolkadotHash},
+	dot::retry_rpc::DotRetryRpcClient,
 	settings::NodeContainer,
 	state_chain_observer::client::{
 		storage_api::StorageApi,
@@ -39,7 +39,7 @@ where
 	let dot_client = DotRetryRpcClient::new(
 		scope,
 		NodeContainer { primary: settings.dot, backup: None },
-		PolkadotHash::from_slice(env_params.dot_genesis_hash.as_bytes()),
+		env_params.dot_genesis_hash,
 	)?;
 
 	let epoch_source = epoch_source

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -46,7 +46,7 @@ serde = { workspace = true, default-features = true, features = [
 ] }
 serde_json = { workspace = true }
 sha2 = { workspace = true, default-features = true }
-subxt = { workspace = true, features = ["substrate-compat"] }
+subxt = { workspace = true }
 thiserror = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-stream = { workspace = true, features = ["sync"] }

--- a/engine/src/dot.rs
+++ b/engine/src/dot.rs
@@ -1,3 +1,6 @@
 pub mod http_rpc;
 pub mod retry_rpc;
 pub mod rpc;
+
+pub type PolkadotHash = <subxt::PolkadotConfig as subxt::Config>::Hash;
+pub type PolkadotHeader = <subxt::PolkadotConfig as subxt::Config>::Header;

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -1,4 +1,4 @@
-use cf_chains::dot::{PolkadotHash, RuntimeVersion};
+use cf_chains::dot::RuntimeVersion;
 use cf_primitives::PolkadotBlockNumber;
 use futures_core::Future;
 use http::uri::Uri;
@@ -7,7 +7,6 @@ use jsonrpsee::{
 	http_client::{HttpClient, HttpClientBuilder},
 };
 use serde_json::value::RawValue;
-use sp_core::H256;
 use subxt::{
 	backend::{
 		legacy::{
@@ -29,6 +28,8 @@ use tracing::{error, warn};
 use crate::constants::RPC_RETRY_CONNECTION_INTERVAL;
 
 use super::rpc::DotRpcApi;
+
+use crate::dot::PolkadotHash;
 
 pub struct PolkadotHttpClient(HttpClient);
 
@@ -164,7 +165,7 @@ impl DotHttpRpcClient {
 		})
 	}
 
-	pub async fn metadata(&self, block_hash: H256) -> Result<subxt::Metadata> {
+	pub async fn metadata(&self, block_hash: PolkadotHash) -> Result<subxt::Metadata> {
 		Ok(self.rpc_methods.state_get_metadata(Some(block_hash)).await?)
 	}
 }
@@ -235,7 +236,7 @@ impl DotRpcApi for DotHttpRpcClient {
 		}
 	}
 
-	async fn runtime_version(&self, block_hash: Option<H256>) -> Result<RuntimeVersion> {
+	async fn runtime_version(&self, block_hash: Option<PolkadotHash>) -> Result<RuntimeVersion> {
 		Ok(self.rpc_methods.state_get_runtime_version(block_hash).await.map(|v| {
 			RuntimeVersion {
 				spec_version: v.spec_version,
@@ -271,19 +272,29 @@ mod tests {
 		// Block hash of the block that a runtime update occurred in. Using 2 different blocks with
 		// runtime updates to test.
 		let block_hash_of_runtime_updates = vec![
-			H256::from_str("0xa0b52be60216f8e0f2eb5bd17fa3c66908cc1652f3080a90d3ab20b2d352b610")
-				.unwrap(),
-			H256::from_str("0xa0138c9d6686f9d80c3fa8a7e175951842ca400f43e479ba694d6d4da69969ea")
-				.unwrap(),
+			PolkadotHash::from_str(
+				"0xa0b52be60216f8e0f2eb5bd17fa3c66908cc1652f3080a90d3ab20b2d352b610",
+			)
+			.unwrap(),
+			PolkadotHash::from_str(
+				"0xa0138c9d6686f9d80c3fa8a7e175951842ca400f43e479ba694d6d4da69969ea",
+			)
+			.unwrap(),
 			// runtime upgrade block
-			H256::from_str("0xb2c53eb7137113a73bdc02c7bd90a55a70b7b257d451453024d8b04122c30924")
-				.unwrap(),
+			PolkadotHash::from_str(
+				"0xb2c53eb7137113a73bdc02c7bd90a55a70b7b257d451453024d8b04122c30924",
+			)
+			.unwrap(),
 			// next block was failing here
-			H256::from_str("0x2c10ed1032a734cbcc93d7ba033a8ec9fa1b54e8ef1f121fe63a77bc1288e00b")
-				.unwrap(),
+			PolkadotHash::from_str(
+				"0x2c10ed1032a734cbcc93d7ba033a8ec9fa1b54e8ef1f121fe63a77bc1288e00b",
+			)
+			.unwrap(),
 			// block with 4 dot transfer :( that was missed
-			H256::from_str("0x0901b861c6db91f7f417a2fa20f3c82f005631f7d441a2a9e8fa5e2e55c6624c")
-				.unwrap(),
+			PolkadotHash::from_str(
+				"0x0901b861c6db91f7f417a2fa20f3c82f005631f7d441a2a9e8fa5e2e55c6624c",
+			)
+			.unwrap(),
 		];
 
 		let dot_http_rpc =

--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -11,7 +11,7 @@ use core::time::Duration;
 use futures_core::Stream;
 use std::pin::Pin;
 use subxt::{
-	backend::legacy::rpc_methods::Bytes, config::Header as SubxtHeader, events::Events, Config,
+	backend::legacy::rpc_methods::Bytes, config::Header as SubxtHeader, events::Events,
 	PolkadotConfig,
 };
 
@@ -232,7 +232,7 @@ impl DotRetrySubscribeApi for DotRetryRpcClient {
 #[async_trait::async_trait]
 impl ChainClient for DotRetryRpcClient {
 	type Index = <Polkadot as cf_chains::Chain>::ChainBlockNumber;
-	type Hash = <PolkadotConfig as Config>::Hash;
+	type Hash = PolkadotHash;
 	type Data = Events<PolkadotConfig>;
 
 	async fn header_at_index(

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use subxt::{
 	backend::legacy::rpc_methods::{BlockDetails, Bytes},
 	events::Events,
+	ext::subxt_rpcs,
 	OnlineClient, PolkadotConfig,
 };
 use tokio::sync::RwLock;
@@ -50,7 +51,7 @@ macro_rules! refresh_connection_on_error {
 
 impl DotRpcClient {
 	pub async fn new(polkadot_network_ws_url: &str, http_client: DotHttpRpcClient) -> Result<Self> {
-		if subxt::utils::validate_url_is_secure(polkadot_network_ws_url).is_err() {
+		if subxt_rpcs::utils::validate_url_is_secure(polkadot_network_ws_url).is_err() {
 			warn!("Using insecure Polkadot websocket endpoint: {polkadot_network_ws_url}");
 		}
 
@@ -187,7 +188,7 @@ async fn create_online_client(
 	ws_endpoint: &SecretUrl,
 	expected_genesis_hash: Option<PolkadotHash>,
 ) -> Result<OnlineClient<PolkadotConfig>> {
-	if subxt::utils::validate_url_is_secure(ws_endpoint.as_ref()).is_err() {
+	if subxt_rpcs::utils::validate_url_is_secure(ws_endpoint.as_ref()).is_err() {
 		warn!("Using insecure Polkadot websocket endpoint: {ws_endpoint}");
 	}
 

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -1,25 +1,22 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use cf_chains::dot::{PolkadotHash, RuntimeVersion};
+use cf_chains::dot::RuntimeVersion;
 use cf_primitives::PolkadotBlockNumber;
 use cf_utilities::redact_endpoint_secret::SecretUrl;
 use futures::{Stream, StreamExt, TryStreamExt};
-use sp_core::H256;
 use std::sync::Arc;
 use subxt::{
 	backend::legacy::rpc_methods::{BlockDetails, Bytes},
 	events::Events,
-	Config, OnlineClient, PolkadotConfig,
+	OnlineClient, PolkadotConfig,
 };
 use tokio::sync::RwLock;
 use tracing::warn;
 
-use anyhow::{anyhow, bail, Result};
-
 use super::http_rpc::DotHttpRpcClient;
-
-pub type PolkadotHeader = <PolkadotConfig as Config>::Header;
+use crate::dot::{PolkadotHash, PolkadotHeader};
+use anyhow::{anyhow, bail, Result};
 
 #[derive(Clone)]
 pub struct DotRpcClient {
@@ -96,7 +93,7 @@ pub trait DotRpcApi: Send + Sync {
 		parent_hash: PolkadotHash,
 	) -> Result<Option<Events<PolkadotConfig>>>;
 
-	async fn runtime_version(&self, at: Option<H256>) -> Result<RuntimeVersion>;
+	async fn runtime_version(&self, at: Option<PolkadotHash>) -> Result<RuntimeVersion>;
 
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash>;
 }
@@ -115,7 +112,7 @@ impl DotRpcApi for DotRpcClient {
 		self.http_client.block(block_hash).await
 	}
 
-	async fn runtime_version(&self, at: Option<H256>) -> Result<RuntimeVersion> {
+	async fn runtime_version(&self, at: Option<PolkadotHash>) -> Result<RuntimeVersion> {
 		self.http_client.runtime_version(at).await
 	}
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -35,13 +35,13 @@ use state_chain_observer::client::{
 use self::{
 	btc::retry_rpc::BtcRetryRpcClient,
 	db::{KeyStore, PersistentKeyDB},
-	dot::retry_rpc::DotRetryRpcClient,
+	dot::{retry_rpc::DotRetryRpcClient, PolkadotHash},
 	evm::{retry_rpc::EvmRetryRpcClient, rpc::EvmRpcSigningClient},
 	settings::{CommandLineOptions, Settings, DEFAULT_SETTINGS_DIR},
 	sol::retry_rpc::SolRetryRpcClient,
 };
 use anyhow::Context;
-use cf_chains::{dot::PolkadotHash, Chain};
+use cf_chains::Chain;
 use cf_primitives::AccountRole;
 use chainflip_node::chain_spec::use_chainflip_account_id_encoding;
 use clap::Parser;
@@ -74,42 +74,42 @@ pub fn settings_and_run_main(
 	};
 
 	match tokio::runtime::Builder::new_multi_thread()
-		.enable_all()
-		.build()
-		.unwrap()
-		.block_on(async {
-			// Note: the greeting should only be printed in normal mode (i.e. not for short-lived
-			// commands like `--version`), so we execute it only after the settings have been parsed.
-			cf_utilities::print_start_and_end!(async run_main(settings, if start_from == NO_START_FROM { None } else { Some(start_from) }))
-		}) {
-		Ok(()) => ExitStatus { status_code: SUCCESS, at_block: NO_START_FROM },
-		Err(ErrorType::Error(e)) => {
-			if let Some(CreateStateChainClientError::CompatibilityError(block_compatibility)) =
-				e.downcast_ref::<CreateStateChainClientError>()
-			{
-				match block_compatibility.compatibility {
-					// we're no longer compatible, so we want to pass on the start to the one that is
-					// now compatible so that it can start from that number, ensuring we don't miss any blocks.
-					CfeCompatibility::NoLongerCompatible => ExitStatus {
-						status_code: engine_upgrade_utils::NO_LONGER_COMPATIBLE,
-						at_block: block_compatibility.at_block.number,
-					},
-					CfeCompatibility::NotYetCompatible => ExitStatus {
-						status_code: engine_upgrade_utils::NOT_YET_COMPATIBLE,
-						at_block: NO_START_FROM,
-					},
-					_ => {
-						unreachable!("We should never get here");
-					},
-				}
-			} else {
-				tracing::error!("Unknown error: {:?}", e);
-				ExitStatus { status_code: engine_upgrade_utils::UNKNOWN_ERROR, at_block: NO_START_FROM }
-			}
-		},
-		Err(ErrorType::Panic) =>
-			ExitStatus { status_code: engine_upgrade_utils::PANIC, at_block: NO_START_FROM },
-	}
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            // Note: the greeting should only be printed in normal mode (i.e. not for short-lived
+            // commands like `--version`), so we execute it only after the settings have been parsed.
+            cf_utilities::print_start_and_end!(async run_main(settings, if start_from == NO_START_FROM { None } else { Some(start_from) }))
+        }) {
+        Ok(()) => ExitStatus { status_code: SUCCESS, at_block: NO_START_FROM },
+        Err(ErrorType::Error(e)) => {
+            if let Some(CreateStateChainClientError::CompatibilityError(block_compatibility)) =
+                e.downcast_ref::<CreateStateChainClientError>()
+            {
+                match block_compatibility.compatibility {
+                    // we're no longer compatible, so we want to pass on the start to the one that is
+                    // now compatible so that it can start from that number, ensuring we don't miss any blocks.
+                    CfeCompatibility::NoLongerCompatible => ExitStatus {
+                        status_code: engine_upgrade_utils::NO_LONGER_COMPATIBLE,
+                        at_block: block_compatibility.at_block.number,
+                    },
+                    CfeCompatibility::NotYetCompatible => ExitStatus {
+                        status_code: engine_upgrade_utils::NOT_YET_COMPATIBLE,
+                        at_block: NO_START_FROM,
+                    },
+                    _ => {
+                        unreachable!("We should never get here");
+                    },
+                }
+            } else {
+                tracing::error!("Unknown error: {:?}", e);
+                ExitStatus { status_code: engine_upgrade_utils::UNKNOWN_ERROR, at_block: NO_START_FROM }
+            }
+        },
+        Err(ErrorType::Panic) =>
+            ExitStatus { status_code: engine_upgrade_utils::PANIC, at_block: NO_START_FROM },
+    }
 }
 
 async fn run_main(
@@ -287,13 +287,14 @@ async fn run_main(
 				BtcRetryRpcClient::new(scope, settings.btc.nodes, expected_btc_network).await?
 			};
 			let dot_client = {
-				let expected_dot_genesis_hash = PolkadotHash::from(
+				let expected_dot_genesis_hash = PolkadotHash::from_slice(
 					state_chain_client
 						.storage_value::<pallet_cf_environment::PolkadotGenesisHash<state_chain_runtime::Runtime>>(
 							state_chain_client.latest_finalized_block().hash,
 						)
 						.await
-						.expect(STATE_CHAIN_CONNECTION),
+						.expect(STATE_CHAIN_CONNECTION)
+						.as_bytes(),
 				);
 				DotRetryRpcClient::new(scope, settings.dot.nodes, expected_dot_genesis_hash)?
 			};

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -814,7 +814,9 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 				const MAX_UPDATE_VERSION_RETRIES: usize = 10;
 				let mut update_successful = false;
 				for retry in 1..=MAX_UPDATE_VERSION_RETRIES {
-					let block_hash = finalized_block_stream.cache().hash;
+					let block_hash = subxt::utils::H256::from_slice(
+						finalized_block_stream.cache().hash.as_bytes(),
+					);
 					let block_number = finalized_block_stream.cache().number;
 
 					// Submitting transaction with subxt sometimes gets stuck without returning any

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -20,7 +20,9 @@ use jsonrpsee::core::ClientError;
 use sp_core::{Pair, H256};
 use state_chain_runtime::AccountId;
 use std::{pin::Pin, sync::Arc, time::Duration};
-use subxt::{backend::rpc::RpcClient, config::DefaultExtrinsicParamsBuilder, OnlineClient};
+use subxt::{
+	backend::rpc::RpcClient, config::DefaultExtrinsicParamsBuilder, ext::subxt_rpcs, OnlineClient,
+};
 use subxt_state_chain_config::StateChainConfig;
 use thiserror::Error;
 use tokio::sync::watch;
@@ -826,7 +828,7 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 						let current_nonce = rpc_client
 							.request::<u32>(
 								"system_accountNextIndex",
-								subxt::rpc_params![&subxt_signer.account_id()],
+								subxt_rpcs::rpc_params![&subxt_signer.account_id()],
 							)
 							.await?;
 

--- a/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
+++ b/engine/src/state_chain_observer/client/subxt_state_chain_config.rs
@@ -4,12 +4,12 @@ pub enum StateChainConfig {}
 
 impl Config for StateChainConfig {
 	// We cannot use our own Runtime's types for every associated type here, see comments below.
-	type Hash = <state_chain_runtime::Runtime as frame_system::Config>::Hash;
+	type Hash = subxt::utils::H256;
 	type AccountId = subxt::utils::AccountId32; // Requires EncodeAsType trait (which our AccountId doesn't)
 	type Address = subxt::utils::MultiAddress<Self::AccountId, ()>; // Must be convertible from Self::AccountId
 	type Signature = state_chain_runtime::Signature;
-	type Hasher = subxt::ext::sp_runtime::traits::BlakeTwo256; // Requires subxt's custom Hash trait
-	type Header = subxt::ext::sp_runtime::generic::Header<u32, Self::Hasher>; // Requires subxt's custom Header trait
+	type Hasher = subxt::config::substrate::BlakeTwo256;
+	type Header = subxt::config::substrate::SubstrateHeader<u32, Self::Hasher>;
 	type AssetId = u32; // Not used - we don't use pallet-assets
 	type ExtrinsicParams = signed_extensions::AnyOf<
 		Self,

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -3,7 +3,7 @@ mod dot_deposits;
 mod dot_source;
 
 use cf_chains::dot::{
-	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotHash, PolkadotSignature,
+	PolkadotAccountId, PolkadotBalance, PolkadotExtrinsicIndex, PolkadotSignature,
 	PolkadotTransactionId, PolkadotUncheckedExtrinsic,
 };
 use cf_primitives::{EpochIndex, PolkadotBlockNumber};
@@ -24,7 +24,10 @@ use cf_utilities::task_scope::Scope;
 
 use crate::{
 	db::PersistentKeyDB,
-	dot::retry_rpc::{DotRetryRpcApi, DotRetryRpcClient},
+	dot::{
+		retry_rpc::{DotRetryRpcApi, DotRetryRpcClient},
+		PolkadotHash,
+	},
 	state_chain_observer::client::{
 		extrinsic_api::signed::SignedExtrinsicApi,
 		storage_api::StorageApi,
@@ -33,6 +36,7 @@ use crate::{
 	},
 	witness::common::chain_source::extension::ChainSourceExt,
 };
+
 use anyhow::Result;
 pub use dot_source::{DotFinalisedSource, DotUnfinalisedSource};
 
@@ -153,20 +157,20 @@ pub async fn process_egress<ProcessCall, ProcessingFut>(
 							"Witnessing transaction_succeeded. signature: {signature:?}"
 						);
 						process_call(
-							pallet_cf_broadcast::Call::<_, PolkadotInstance>::transaction_succeeded {
-								tx_out_id: signature,
-								signer_id: epoch.info.0,
-								tx_fee,
-								tx_metadata: (),
-								transaction_ref: PolkadotTransactionId {
-									block_number: header.index,
-									extrinsic_index
-								}
-							}
-							.into(),
-							epoch.index,
-						)
-						.await;
+                            pallet_cf_broadcast::Call::<_, PolkadotInstance>::transaction_succeeded {
+                                tx_out_id: signature,
+                                signer_id: epoch.info.0,
+                                tx_fee,
+                                tx_metadata: (),
+                                transaction_ref: PolkadotTransactionId {
+                                    block_number: header.index,
+                                    extrinsic_index
+                                }
+                            }
+                                .into(),
+                            epoch.index,
+                        )
+                            .await;
 					}
 				},
 			Err(error) => {

--- a/engine/src/witness/dot/dot_chain_tracking.rs
+++ b/engine/src/witness/dot/dot_chain_tracking.rs
@@ -1,10 +1,12 @@
-use cf_chains::dot::{PolkadotHash, PolkadotTrackedData};
+use cf_chains::dot::PolkadotTrackedData;
 use subxt::events::Phase;
-
-use crate::{dot::retry_rpc::DotRetryRpcApi, witness::dot::EventWrapper};
 
 use super::super::common::{
 	chain_source::Header, chunked_chain_source::chunked_by_time::chain_tracking::GetTrackedData,
+};
+use crate::{
+	dot::{retry_rpc::DotRetryRpcApi, PolkadotHash},
+	witness::dot::EventWrapper,
 };
 
 #[async_trait::async_trait]

--- a/engine/src/witness/dot/dot_deposits.rs
+++ b/engine/src/witness/dot/dot_deposits.rs
@@ -6,18 +6,17 @@ use state_chain_runtime::PolkadotInstance;
 use super::super::common::chunked_chain_source::chunked_by_vault::{
 	builder::ChunkedByVaultBuilder, ChunkedByVault,
 };
-use crate::witness::{
-	common::{
-		chunked_chain_source::chunked_by_vault::deposit_addresses::Addresses, RuntimeCallHasChain,
-		RuntimeHasChain,
+use crate::{
+	dot::PolkadotHash,
+	witness::{
+		common::{
+			chunked_chain_source::chunked_by_vault::deposit_addresses::Addresses,
+			RuntimeCallHasChain, RuntimeHasChain,
+		},
+		dot::EventWrapper,
 	},
-	dot::EventWrapper,
 };
-use cf_chains::{
-	assets::dot::Asset,
-	dot::{PolkadotAccountId, PolkadotHash},
-	Polkadot,
-};
+use cf_chains::{assets::dot::Asset, dot::PolkadotAccountId, Polkadot};
 use subxt::events::Phase;
 
 impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {

--- a/engine/src/witness/dot/dot_source.rs
+++ b/engine/src/witness/dot/dot_source.rs
@@ -1,7 +1,6 @@
 use std::{pin::Pin, time::Duration};
 
 use crate::retrier::NoRetryLimit;
-use cf_chains::dot::PolkadotHash;
 use cf_primitives::PolkadotBlockNumber;
 use futures_util::stream;
 use subxt::{events::Events, PolkadotConfig};
@@ -9,7 +8,7 @@ use subxt::{events::Events, PolkadotConfig};
 use crate::{
 	dot::{
 		retry_rpc::{DotRetryRpcApi, DotRetrySubscribeApi},
-		rpc::PolkadotHeader,
+		PolkadotHash, PolkadotHeader,
 	},
 	witness::common::{
 		chain_source::{BoxChainStream, ChainClient, ChainSource, Header},

--- a/utilities/scale-json-event-logger/Cargo.toml
+++ b/utilities/scale-json-event-logger/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 env_logger = { workspace = true }
 scale-info = { workspace = true }
 log = { workspace = true }
-subxt = { workspace = true, features = ["substrate-compat"] }
+subxt = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 cf-utilities = { package = "utilities", path = ".." }
 hex = { workspace = true }

--- a/utilities/scale-json-event-logger/src/main.rs
+++ b/utilities/scale-json-event-logger/src/main.rs
@@ -4,11 +4,7 @@ use anyhow::Context;
 use cf_utilities::{dynamic_events::EventDecoder, scale_json::ext::JsonValue};
 use env_logger::Env;
 use std::str::FromStr;
-use subxt::{
-	backend::BackendExt,
-	ext::{futures::TryStreamExt, sp_core::H256},
-	SubstrateConfig,
-};
+use subxt::{backend::BackendExt, ext::futures::TryStreamExt, utils::H256, SubstrateConfig};
 
 const HELP: &str = r#"
 Usage: scale-json-event-logger <network> <latest|follow|0xhash> [path...]


### PR DESCRIPTION
# Pull Request

Closes: PRO-2026

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* Subxt 0.39.0 introduces breaking changes. subxt is now completely decoupled from subtrate and doesn't require it as dependency (`substrate-compat` feature is removed)
* They have introduced basic types instead of substrate types such as: `subxt::utils::H256` instead of `sp_core::H256`. 
* The changes made in this PR mainly address this type conversion issues especially for the `dot` chain. 
* There were a lot of assumptions that the dot chain hash type is `sp_core::H256`, this PR changes the dot hash type to be `pub type PolkadotHash = <subxt::PolkadotConfig as subxt::Config>::Hash;` 
* PR passes full bouncer tests
* ~~To not have polkadot version mismatch issues, this PR uses our fork [substrate-subxt](https://github.com/chainflip-io/substrate-subxt) that depends on the same version as `chainflip-backend`~~
* Uses [non-released yet subxt](https://github.com/paritytech/subxt/pull/1926) that does not depend on polkadot-sdk
