### PR TITLE
feat: refresh solana ingress elections instead of recreate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3268,7 +3268,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -13269,7 +13269,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.8.0"
+version = "1.8.1"
 
 [lints]
 workspace = true

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 
 [package.metadata.deb]

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 
 [lints]

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,11 +3,11 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.8.0"
+version = "1.8.1"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_8_0"
+name = "chainflip_engine_v1_8_1"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.8.0"
+version = "1.8.1"
 
 [lib]
 proc-macro = true

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.8.0"
+version = "1.8.1"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
     # to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
     # manually.
     [
-        "target/release/libchainflip_engine_v1_8_0.so",
+        "target/release/libchainflip_engine_v1_8_1.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_8_0.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_8_1.so",
         "755",
     ],
     # The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -13,7 +13,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.8.0")]
+	#[engine_proc_macros::link_engine_library_version("1.8.1")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -11,7 +11,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.7.9";
-pub const NEW_VERSION: &str = "1.8.0";
+pub const NEW_VERSION: &str = "1.8.1";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.8.0"
+version = "1.8.1"
 
 [lib]
 crate-type = ["lib"]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "<TODO>"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.8.0"
+version = "1.8.1"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -413,6 +413,13 @@ register_checks! {
 			"Expected the election id to be incremented.",
 		);
 	},
+	election_id_updated_by(pre_finalize, post_finalize, update: impl Fn(ElectionIdentifierOf<ES>) -> ElectionIdentifierOf<ES> + Clone + 'static) {
+		assert_eq!(
+			update(pre_finalize.election_identifiers[0]),
+			post_finalize.election_identifiers[0],
+			"Expected the election id to be updated by given `update` function.",
+		);
+	},
 	all_elections_deleted(pre_finalize, post_finalize) {
 		assert!(
 			!pre_finalize.election_identifiers.is_empty(),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/delta_based_ingress.rs
@@ -546,7 +546,9 @@ mod channel_closure {
 				vec![
 					Check::channel_not_closed(DEFAULT_CHANNEL_ACCOUNT),
 					Check::ingressed(vec![(DEFAULT_CHANNEL_ACCOUNT, Asset::Sol, DEPOSIT_AMOUNT)]),
-					Check::election_id_incremented(),
+					Check::election_id_updated_by(|id| {
+						ElectionIdentifier::new(*id.unique_monotonic(), id.extra() + 1)
+					}),
 					// Channel state not cleaned up yet, since the channel is not yet closed.
 					Check::ended_at_state_map_state([DepositChannel {
 						total_ingressed: DEPOSIT_AMOUNT,
@@ -833,7 +835,9 @@ fn pending_ingresses_update_with_consensus() {
 					deposit_channel_pending.asset,
 					deposit_channel_pending.total_ingressed,
 				)]),
-				Check::election_id_incremented(),
+				Check::election_id_updated_by(|id| {
+					ElectionIdentifier::new(*id.unique_monotonic(), id.extra() + 1)
+				}),
 				Check::ended_at_state(to_state(vec![deposit_channel_with_next_deposit])),
 			],
 		)
@@ -910,7 +914,12 @@ mod multiple_deposits {
 			.test_on_finalize(
 				&{ TOTAL_1.block_number - 1 },
 				|_| {},
-				[Check::ingressed(vec![]), Check::election_id_incremented()],
+				[
+					Check::ingressed(vec![]),
+					Check::election_id_updated_by(|id| {
+						ElectionIdentifier::new(*id.unique_monotonic(), id.extra() + 1)
+					}),
+				],
 			)
 			// Simulate a second deposit at a later block.
 			.force_consensus_update(ConsensusStatus::Gained {
@@ -924,7 +933,9 @@ mod multiple_deposits {
 				|_| {},
 				[
 					Check::ingressed(vec![(DEPOSIT_ADDRESS, Asset::Sol, TOTAL_1.amount)]),
-					Check::election_id_incremented(),
+					Check::election_id_updated_by(|id| {
+						ElectionIdentifier::new(*id.unique_monotonic(), id.extra() + 1)
+					}),
 				],
 			)
 			// Finalize with chain tracking at the block of the second deposit. Both should be

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.8.0"
+version = "1.8.1"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -212,7 +212,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 180,
+	spec_version: 181,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2028

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Refreshes delta based ingress elections instead of recreating them.
