### PR TITLE
feat: add account id / withdrawal address to affiliate events

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -648,6 +648,7 @@ pub mod pallet {
 		},
 		/// A broker fee withdrawal has been requested.
 		WithdrawalRequested {
+			broker_id: T::AccountId,
 			egress_id: EgressId,
 			egress_asset: Asset,
 			egress_amount: AssetAmount,
@@ -1405,6 +1406,7 @@ pub mod pallet {
 				.map_err(Into::into)?;
 
 			Self::deposit_event(Event::<T>::WithdrawalRequested {
+				broker_id: account_id.clone(),
 				egress_amount,
 				egress_asset: asset,
 				egress_fee: fee_withheld,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -648,7 +648,7 @@ pub mod pallet {
 		},
 		/// A broker fee withdrawal has been requested.
 		WithdrawalRequested {
-			broker_id: T::AccountId,
+			account_id: T::AccountId,
 			egress_id: EgressId,
 			egress_asset: Asset,
 			egress_amount: AssetAmount,
@@ -1406,7 +1406,7 @@ pub mod pallet {
 				.map_err(Into::into)?;
 
 			Self::deposit_event(Event::<T>::WithdrawalRequested {
-				broker_id: account_id.clone(),
+				account_id: account_id.clone(),
 				egress_amount,
 				egress_asset: asset,
 				egress_fee: fee_withheld,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -712,6 +712,7 @@ pub mod pallet {
 		AffiliateRegistration {
 			broker_id: T::AccountId,
 			short_id: AffiliateShortId,
+			withdrawal_address: EthereumAddress,
 			affiliate_id: T::AccountId,
 		},
 		BrokerBondSet {
@@ -1273,6 +1274,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::AffiliateRegistration {
 				broker_id,
 				short_id,
+				withdrawal_address,
 				affiliate_id,
 			});
 

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1773,6 +1773,7 @@ mod affiliates {
 					Event::<Test>::AffiliateRegistration {
 						broker_id: BROKER,
 						short_id: SHORT_ID,
+						withdrawal_address,
 						affiliate_id: affiliate_account_id,
 					},
 				));

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -418,6 +418,7 @@ fn withdraw_broker_fees() {
 		assert!(egresses.len() == 1);
 		assert_eq!(egresses.pop().expect("must exist").amount(), 200);
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::WithdrawalRequested {
+			broker_id: BROKER,
 			egress_id: (ForeignChain::Ethereum, 1),
 			egress_asset: Asset::Eth,
 			egress_amount: 200,

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -418,7 +418,7 @@ fn withdraw_broker_fees() {
 		assert!(egresses.len() == 1);
 		assert_eq!(egresses.pop().expect("must exist").amount(), 200);
 		System::assert_last_event(RuntimeEvent::Swapping(Event::<Test>::WithdrawalRequested {
-			broker_id: BROKER,
+			account_id: BROKER,
 			egress_id: (ForeignChain::Ethereum, 1),
 			egress_asset: Asset::Eth,
 			egress_amount: 200,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2037

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Adds the broker_id to the WithdrawalRequest event.
