### PR TITLE
feat: generate traces for solana elections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +626,55 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers 0.3.0",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -693,6 +757,53 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -1668,6 +1779,33 @@ dependencies = [
  "serde_json",
  "substrate-build-script-utils",
  "tokio",
+ "utilities",
+]
+
+[[package]]
+name = "chainflip-elections-tracker"
+version = "0.1.0"
+dependencies = [
+ "bitvec",
+ "chainflip-engine",
+ "custom-rpc",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "pallet-cf-elections",
+ "pallet-cf-validator",
+ "parity-scale-codec",
+ "serde",
+ "state-chain-runtime",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.19",
  "utilities",
 ]
 
@@ -4459,7 +4597,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "send_wrapper 0.4.0",
 ]
 
@@ -4651,6 +4789,18 @@ name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5147,6 +5297,19 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.5.2",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -5855,7 +6018,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -5880,7 +6043,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -5922,7 +6085,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -6019,6 +6182,15 @@ name = "keystream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "kvdb"
@@ -6777,6 +6949,9 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -6901,6 +7076,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -7820,10 +8001,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.2.0",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.4",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.4",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8a298402aa5c260be90d10dc54b5a7d4e1025c354848f8e2c976d761351049"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -9259,6 +9533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9322,6 +9606,19 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -9864,7 +10161,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
@@ -11048,7 +11345,7 @@ dependencies = [
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
 ]
 
@@ -13754,6 +14051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14213,6 +14516,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.4",
+ "socket2 0.5.8",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14220,11 +14553,30 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -14320,6 +14672,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.19",
+ "web-time",
 ]
 
 [[package]]
@@ -14821,6 +15191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15316,6 +15692,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "api/bin/chainflip-cli",
   "api/bin/chainflip-ingress-egress-tracker",
   "api/bin/chainflip-lp-api",
+  "api/bin/chainflip-elections-tracker",
   "api/lib",
   "engine",
   "engine-proc-macros",

--- a/api/bin/chainflip-elections-tracker/Cargo.toml
+++ b/api/bin/chainflip-elections-tracker/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "chainflip-elections-tracker"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tracing = "0.1.41"
+tracing-core = "0.1.33"
+tracing-opentelemetry = "0.28.0"
+tracing-subscriber = "0.3.19"
+opentelemetry = "0.27.1"
+opentelemetry_sdk = { version =  "0.27.1", features = ["async-std", "rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.27.0", features = ["grpc-tonic"] }
+opentelemetry-stdout = "0.27.0"
+
+# workspaced deps
+tokio = { workspace = true, features = ["rt-multi-thread"]}
+bitvec = { workspace = true, default-features = false }
+codec = { workspace = true, default-features = false }
+futures-util = { workspace = true }
+futures = { workspace = true }
+futures-core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+# local dependencies
+pallet-cf-elections = { workspace = true, default-features = true }
+pallet-cf-validator = { workspace = true, default-features = true }
+chainflip-engine = { workspace = true }
+custom-rpc = { workspace = true }
+state-chain-runtime = { workspace = true, default-features = true }
+cf-utilities = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/api/bin/chainflip-elections-tracker/src/README.md
+++ b/api/bin/chainflip-elections-tracker/src/README.md
@@ -2,7 +2,7 @@
 # Chainflip Elections Tracker
 
 This binary runs alongside a chainflip node, and tracks the state of elections.
-It computes which parts of the state changed and pushes this information in form
+It computes which parts of the state changed and pushes this information in the form
 of OTLP traces to a given OTLP endpoint. 
 
 ## Configuration

--- a/api/bin/chainflip-elections-tracker/src/README.md
+++ b/api/bin/chainflip-elections-tracker/src/README.md
@@ -1,0 +1,12 @@
+
+# Chainflip Elections Tracker
+
+This binary runs alongside a chainflip node, and tracks the state of elections.
+It computes which parts of the state changed and pushes this information in form
+of OTLP traces to a given OTLP endpoint. 
+
+## Configuration
+There are two configurable environment variables:
+ - `CF_RPC_NODE`: Url of the chainflip node to connect to for the block stream. Default: `http://localhost:9944`.
+ - `OTLP_BACKEND`: Url of the OTLP backend for pushing traces to. Default: `http://localhost:4317`.
+ 

--- a/api/bin/chainflip-elections-tracker/src/elections.rs
+++ b/api/bin/chainflip-elections-tracker/src/elections.rs
@@ -158,9 +158,11 @@ where
 	let key0 = RootBlockHeight(root_height);
 	trace.insert(vec![key0.clone()], end.with_attribute("height".into(), format!("{root_height}")));
 
-
 	for name in data.electoral_system_names {
-		trace.insert(vec![key0.clone(), ElectoralSystem(name.clone())], end.with_attribute("height".into(), format!("{root_height}")));
+		trace.insert(
+			vec![key0.clone(), ElectoralSystem(name.clone())],
+			end.with_attribute("height".into(), format!("{root_height}")),
+		);
 	}
 
 	for (identifier, (name, properties)) in &data.elections {

--- a/api/bin/chainflip-elections-tracker/src/elections.rs
+++ b/api/bin/chainflip-elections-tracker/src/elections.rs
@@ -158,6 +158,11 @@ where
 	let key0 = RootBlockHeight(root_height);
 	trace.insert(vec![key0.clone()], end.with_attribute("height".into(), format!("{root_height}")));
 
+
+	for name in data.electoral_system_names {
+		trace.insert(vec![key0.clone(), ElectoralSystem(name.clone())], end.with_attribute("height".into(), format!("{root_height}")));
+	}
+
 	for (identifier, (name, properties)) in &data.elections {
 		let input = identifier.encode();
 		let mut other: &[u8] = &input;

--- a/api/bin/chainflip-elections-tracker/src/elections.rs
+++ b/api/bin/chainflip-elections-tracker/src/elections.rs
@@ -11,6 +11,7 @@ use pallet_cf_elections::{
 pub struct ElectionData<ES: ElectoralSystemTypes> {
 	pub height: u32,
 
+	#[allow(clippy::type_complexity)]
 	pub bitmaps: BTreeMap<
 		UniqueMonotonicIdentifier,
 		Vec<(BitmapComponentOf<ES>, BitVec<u8, bitvec::order::Lsb0>)>,
@@ -169,7 +170,7 @@ where
 
 		// no votes
 		for authority_id in 0..data.validators {
-			if votes.get(&(*identifier, authority_id)).is_none() {
+			if !votes.contains_key(&(*identifier, authority_id)) {
 				trace.insert(
 					cloned_vec([&key0, &key1, &key2, &Category(extra.clone(), NoVote)]),
 					start.clone(),

--- a/api/bin/chainflip-elections-tracker/src/elections.rs
+++ b/api/bin/chainflip-elections-tracker/src/elections.rs
@@ -1,0 +1,217 @@
+use std::{
+	collections::BTreeMap,
+	fmt::Display,
+};
+
+use bitvec::prelude::*;
+use codec::{Decode, Encode};
+use pallet_cf_elections::{
+	ElectionIdentifierOf, ElectoralSystemTypes, IndividualComponentOf,
+	UniqueMonotonicIdentifier,
+	electoral_system::BitmapComponentOf,
+};
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Encode, Decode)]
+pub struct ElectionData<ES: ElectoralSystemTypes> {
+	pub height: u32,
+
+	pub bitmaps: BTreeMap<
+		UniqueMonotonicIdentifier,
+		Vec<(BitmapComponentOf<ES>, BitVec<u8, bitvec::order::Lsb0>)>,
+	>,
+
+	pub individual_components:
+		BTreeMap<UniqueMonotonicIdentifier, BTreeMap<usize, IndividualComponentOf<ES>>>,
+
+	pub elections: BTreeMap<ElectionIdentifierOf<ES>, (String, ES::ElectionProperties)>,
+
+	pub electoral_system_names: Vec<String>,
+
+	pub validators: u32,
+
+	pub _phantom: std::marker::PhantomData<ES>,
+}
+
+// NOTE! the order is important for ordering the traces!
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum Category {
+	Properties,
+	NoVote,
+	Vote(String),
+}
+use crate::trace::StateTree;
+
+use self::Category::*;
+
+impl Display for Category {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			NoVote => write!(f, "Computing vote"),
+			Vote(s) => write!(f, "Election unchanged: {s}"),
+			Properties => write!(f, "New properties"),
+		}
+	}
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub enum Key {
+	RootBlockHeight(u32),
+	ElectoralSystem(String),
+	Election(String),
+	Category(String, Category),
+	Validator(u32),
+	State { summary: String },
+}
+
+use Key::*;
+
+impl Display for Key {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			RootBlockHeight(h) => write!(f, "blocks {h}-..."),
+			Election(e) => write!(f, "{e}"),
+			Key::Category(extra, category) => write!(f, "[{extra}] {category}"),
+			Validator(x) => write!(f, "Validator {x}"),
+			ElectoralSystem(name) => write!(f, "ES {name}"),
+			State { summary } => write!(f, "{summary}"),
+		}
+	}
+}
+
+
+pub fn cloned_vec<'a, XS: IntoIterator<Item = &'a X>, X>(xs: XS) -> Vec<X>
+where
+	X: Clone + 'a,
+{
+	xs.into_iter().cloned().collect()
+}
+
+/// Initial value from which the trace state will be created
+#[derive(Clone)]
+pub struct TraceInit {
+	pub end_immediately: bool,
+	pub attributes: Vec<(String, String)>,
+}
+
+impl TraceInit {
+	pub fn with_attribute(&self, key: String, value: String) -> Self {
+		let mut result = self.clone();
+		result.attributes.push((key, value));
+		result
+	}
+}
+
+struct AsHex(Vec<u8>);
+
+impl Display for AsHex {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		for b in &self.0 {
+			write!(f, "{b:x}")?;
+		}
+		Ok(())
+	}
+}
+
+pub fn make_traces<ES: ElectoralSystemTypes>(data: ElectionData<ES>) -> StateTree<Key, TraceInit>
+where
+	IndividualComponentOf<ES>: Encode,
+{
+	let mut votes: BTreeMap<(ElectionIdentifierOf<ES>, u32), (String, String)> = BTreeMap::new();
+
+	for (identifier, (_name, _properties)) in &data.elections {
+		if let Some(bitmaps) = data.bitmaps.get(identifier.unique_monotonic()) {
+			for (component, bitmap) in bitmaps {
+				for (id, bit) in bitmap.iter().enumerate() {
+					if *bit {
+						votes.insert(
+							(*identifier, id as u32),
+							(AsHex(component.encode()).to_string(), format!("{component:?}")),
+						);
+					}
+				}
+			}
+		}
+
+		if let Some(individual_components) =
+			data.individual_components.get(identifier.unique_monotonic())
+		{
+			for (authority_index, component) in individual_components {
+				votes.insert(
+					(*identifier, *authority_index as u32),
+					(AsHex(component.encode()).to_string(), format!("{component:?}")),
+				);
+			}
+		}
+	}
+
+	let end = TraceInit { end_immediately: true, attributes: Vec::new() };
+	let start = TraceInit { end_immediately: false, attributes: Vec::new() };
+
+	let mut trace = StateTree::new();
+
+	let root_height = data.height - (data.height % 50);
+	let key0 = RootBlockHeight(root_height);
+	trace.insert(vec![key0.clone()], end.with_attribute("height".into(), format!("{root_height}")));
+
+	for (identifier, (name, properties)) in &data.elections {
+		let input = identifier.encode();
+		let mut other: &[u8] = &input;
+		let id: u64 = Decode::decode(&mut other).unwrap();
+		let extra = format!("{:?}", identifier.extra());
+
+		let key1 = ElectoralSystem(name.clone());
+		let key2 = Election(format!("{name} ({id})"));
+
+		// election id
+		trace.insert(cloned_vec([&key0, &key1, &key2]), end.clone());
+
+		// properties
+		let key3 = Category(extra.clone(), Properties);
+		trace.insert(cloned_vec([&key0, &key1, &key2, &key3]), 
+			end.with_attribute("Properties".into(), format!("{properties:#?}"))
+		);
+
+		// no votes
+		for authority_id in 0..data.validators {
+			if votes.get(&(*identifier, authority_id)).is_none() {
+				trace.insert(
+					cloned_vec([&key0, &key1, &key2, &Category(extra.clone(), NoVote)]),
+					start.clone(),
+				);
+				trace.insert(
+					cloned_vec([
+						&key0,
+						&key1,
+						&key2,
+						&Category(extra.clone(), NoVote),
+						&Validator(authority_id),
+					]),
+					start.clone(),
+				);
+			}
+		}
+
+		// votes
+		for authority_id in 0..data.validators {
+			if let Some(s) = votes.get(&(*identifier, authority_id)) {
+				trace.insert(
+					cloned_vec([&key0, &key1, &key2, &Category(extra.clone(), Vote(s.0.clone()))]),
+					start.with_attribute("vote".into(), s.1.clone()),
+				);
+				trace.insert(
+					cloned_vec([
+						&key0,
+						&key1,
+						&key2,
+						&Category(extra.clone(), Vote(s.0.clone())),
+						&Validator(authority_id),
+					]),
+					start.with_attribute("vote".into(), s.1.clone()),
+				);
+			}
+		}
+	}
+
+	trace
+}

--- a/api/bin/chainflip-elections-tracker/src/elections.rs
+++ b/api/bin/chainflip-elections-tracker/src/elections.rs
@@ -1,16 +1,11 @@
-use std::{
-	collections::BTreeMap,
-	fmt::Display,
-};
+use std::{collections::BTreeMap, fmt::Display};
 
 use bitvec::prelude::*;
 use codec::{Decode, Encode};
 use pallet_cf_elections::{
-	ElectionIdentifierOf, ElectoralSystemTypes, IndividualComponentOf,
-	UniqueMonotonicIdentifier,
+	ElectionIdentifierOf, ElectoralSystemTypes, IndividualComponentOf, UniqueMonotonicIdentifier,
 	electoral_system::BitmapComponentOf,
 };
-
 
 #[derive(Debug, Eq, PartialEq, Clone, Encode, Decode)]
 pub struct ElectionData<ES: ElectoralSystemTypes> {
@@ -78,7 +73,6 @@ impl Display for Key {
 		}
 	}
 }
-
 
 pub fn cloned_vec<'a, XS: IntoIterator<Item = &'a X>, X>(xs: XS) -> Vec<X>
 where
@@ -168,8 +162,9 @@ where
 
 		// properties
 		let key3 = Category(extra.clone(), Properties);
-		trace.insert(cloned_vec([&key0, &key1, &key2, &key3]), 
-			end.with_attribute("Properties".into(), format!("{properties:#?}"))
+		trace.insert(
+			cloned_vec([&key0, &key1, &key2, &key3]),
+			end.with_attribute("Properties".into(), format!("{properties:#?}")),
 		);
 
 		// no votes

--- a/api/bin/chainflip-elections-tracker/src/main.rs
+++ b/api/bin/chainflip-elections-tracker/src/main.rs
@@ -107,7 +107,7 @@ async fn observe_elections<T: Tracer + Send>(
 				.map(|(k,v)| (k, v.bitmaps))
 				.collect();
 
-			const ELECTORAL_SYSTEM_NAMES : [&'static str; 6] = ["Blockheight", "Ingress", "Nonce", "Egress", "Liveness", "Vaultswap"];
+			const ELECTORAL_SYSTEM_NAMES : [&str; 6] = ["Blockheight", "Ingress", "Nonce", "Egress", "Liveness", "Vaultswap"];
 
 			let elections = all_properties.iter()
 				.map(|(key, val)| {

--- a/api/bin/chainflip-elections-tracker/src/main.rs
+++ b/api/bin/chainflip-elections-tracker/src/main.rs
@@ -126,7 +126,7 @@ async fn observe_elections<T: Tracer + Send>(
 				bitmaps,
 				elections,
 				individual_components,
-				validators: validators.len() as u32,
+				validators_count: validators.len() as u32,
 				_phantom: Default::default(),
 				electoral_system_names: vec![
 							"Blockheight".into(),

--- a/api/bin/chainflip-elections-tracker/src/main.rs
+++ b/api/bin/chainflip-elections-tracker/src/main.rs
@@ -107,17 +107,19 @@ async fn observe_elections<T: Tracer + Send>(
 				.map(|(k,v)| (k, v.bitmaps))
 				.collect();
 
+			const ELECTORAL_SYSTEM_NAMES : [&'static str; 6] = ["Blockheight", "Ingress", "Nonce", "Egress", "Liveness", "Vaultswap"];
+
 			let elections = all_properties.iter()
 				.map(|(key, val)| {
-					let name = match val {
-							CompositeElectionProperties::A(_)  => "Blockheight",
-							CompositeElectionProperties::B(_)  => "Ingress",
-							CompositeElectionProperties::C(_)  => "Nonce",
-							CompositeElectionProperties::D(_)  => "Egress",
-							CompositeElectionProperties::EE(_) => "Liveness",
-							CompositeElectionProperties::FF(_) => "Vaultswap",
+					let index = match val {
+							CompositeElectionProperties::A(_)  => 0,
+							CompositeElectionProperties::B(_)  => 1,
+							CompositeElectionProperties::C(_)  => 2,
+							CompositeElectionProperties::D(_)  => 3,
+							CompositeElectionProperties::EE(_) => 4,
+							CompositeElectionProperties::FF(_) => 5,
 						};
-					(*key, (name.into(), val.clone()))
+					(*key, (ELECTORAL_SYSTEM_NAMES[index].into(), val.clone()))
 				})
 				.collect();
 
@@ -128,14 +130,7 @@ async fn observe_elections<T: Tracer + Send>(
 				individual_components,
 				validators_count: validators.len() as u32,
 				_phantom: Default::default(),
-				electoral_system_names: vec![
-							"Blockheight".into(),
-							"Ingress".into(),
-							"Nonce".into(),
-							"Egress".into(),
-							"Liveness".into(),
-							"Vaultswap".into(),
-				],
+				electoral_system_names: ELECTORAL_SYSTEM_NAMES.iter().map(|name| (*name).into()).collect(),
 			};
 
 			let new_full_trace = make_traces(result);

--- a/api/bin/chainflip-elections-tracker/src/main.rs
+++ b/api/bin/chainflip-elections-tracker/src/main.rs
@@ -1,0 +1,213 @@
+#![feature(btree_extract_if)]
+
+pub mod elections;
+pub mod trace;
+
+use std::collections::BTreeMap;
+
+use chainflip_engine::state_chain_observer::client::StateChainClient;
+use elections::{Key, TraceInit, make_traces, ElectionData};
+use opentelemetry::trace::{
+	Span, TraceContextExt as _, Tracer, TracerProvider as _,
+};
+use state_chain_runtime::chainflip::solana_elections::SolanaElectoralSystemRunner;
+use cf_utilities::task_scope::{self};
+use chainflip_engine::state_chain_observer::client::storage_api::StorageApi;
+use futures::StreamExt;
+use futures_util::FutureExt;
+use opentelemetry::{Context, KeyValue, global};
+use opentelemetry_sdk::{
+	Resource,
+	trace::{RandomIdGenerator, TracerProvider},
+};
+use opentelemetry_otlp::WithExportConfig;
+use pallet_cf_elections::{
+	UniqueMonotonicIdentifier,
+	electoral_systems::composite::tuple_6_impls::*,
+};
+use state_chain_runtime::{Runtime, SolanaInstance};
+use std::env;
+use trace::{NodeDiff, StateTree, diff, get_key_name, map_with_parent};
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 3)]
+async fn main() {
+
+
+	// get env vars
+	let rpc_url = env::var("CF_RPC_NODE").expect("CF_RPC_NODE required");
+	let opentelemetry_backend_url = env::var("OPTL_BACKEND_URL")
+		.unwrap_or("http://localhost:4317".into());
+
+	// setup opentelemetry tracer
+	let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+		.with_batch_exporter(
+			opentelemetry_otlp::SpanExporter::builder()
+				.with_tonic()
+        		.with_endpoint(&opentelemetry_backend_url)
+				.build()
+				.unwrap(),
+			opentelemetry_sdk::runtime::Tokio,
+		)
+		.with_id_generator(RandomIdGenerator::default())
+		.with_resource(Resource::new(vec![KeyValue::new("service.name", "es-overview")]))
+		.build();
+
+	global::set_tracer_provider(tracer_provider.clone());
+	let tracer = tracer_provider.tracer("tracer-name-new");
+	observe_elections(tracer, tracer_provider, rpc_url).await;
+}
+
+
+async fn observe_elections<T: Tracer + Send>(tracer: T, tracer_provider: TracerProvider, rpc_url: String)
+where
+	T::Span: Span + Send + Sync + 'static,
+{
+	task_scope::task_scope(|scope| async move {
+
+		let (_finalized_stream, unfinalized_stream, client) = StateChainClient::connect_without_account(&scope, &rpc_url).await.unwrap();
+
+		unfinalized_stream.fold((client, (BTreeMap::new(), BTreeMap::new()), tracer), async |(client, (overview_trace, detailed_traces), tracer), block| {
+
+			let _results = tracer_provider.force_flush();
+
+			let block_hash = block.hash;
+
+			let bitmaps : BTreeMap<UniqueMonotonicIdentifier,
+				_
+				> = client
+				.storage_map::<pallet_cf_elections::BitmapComponents::<Runtime, SolanaInstance>, BTreeMap<_,_>>(block_hash)
+				.await
+				.expect("could not get storage")
+			;
+
+			let all_properties : BTreeMap<_,_> = client
+				.storage_map::<pallet_cf_elections::ElectionProperties::<Runtime, SolanaInstance>, BTreeMap<_,_>>(block_hash)
+				.await
+				.expect("could not get storage");
+
+			let validators : Vec<_> = client
+				.storage_value::<pallet_cf_validator::CurrentAuthorities::<Runtime>>(block_hash)
+				.await
+				.expect("could not get storage");
+
+			let mut individual_components = BTreeMap::new();
+			for (key, _prop) in &all_properties {
+				for (validator_index, validator) in validators.iter().enumerate() {
+
+					if let Some((_, comp)) = client.storage_double_map_entry::<pallet_cf_elections::IndividualComponents::<Runtime, SolanaInstance>>(block_hash, key.unique_monotonic(), validator)
+					.await.expect("could not get storage") {
+						println!("got individual component for election {key:?} for vld {validator_index}: {comp:?}");
+						individual_components.entry(*key.unique_monotonic()).or_insert(BTreeMap::new()).insert(validator_index, comp);
+					}
+				}
+			}
+
+			let bitmaps = bitmaps.into_iter()
+				.map(|(k,v)| (k, v.bitmaps))
+				.collect();
+
+			let elections = all_properties.iter()
+				.map(|(key, val)| {
+					let name = match val {
+							CompositeElectionProperties::A(_)  => "Blockheight",
+							CompositeElectionProperties::B(_)  => "Ingress",
+							CompositeElectionProperties::C(_)  => "Nonce",
+							CompositeElectionProperties::D(_)  => "Egress",
+							CompositeElectionProperties::EE(_) => "Liveness",
+							CompositeElectionProperties::FF(_) => "Vaultswap",
+						};
+					(key.clone(), (name.into(), val.clone()))
+				})
+				.collect();
+
+			let result : ElectionData<SolanaElectoralSystemRunner> = ElectionData {
+				height: block.number,
+				bitmaps,
+				elections,
+				individual_components,
+				validators: validators.len() as u32,
+				_phantom: Default::default(),
+				electoral_system_names: vec![
+							"Blockheight".into(),
+							"Ingress".into(),
+							"Nonce".into(),
+							"Egress".into(),
+							"Liveness".into(),
+							"Vaultswap".into(),
+				],
+			};
+
+			let new_full_trace = make_traces(result);
+			let new_overview_trace = new_full_trace.iter().map(|(k,v)| (k.clone(), v.clone())).filter(|(key, _)| key.len() <= 4).collect::<BTreeMap<_,_>>();
+			let new_detailed_traces = new_full_trace.iter().map(|(k,v)| (k.clone(), v.clone())).filter(|(key, _)| key.len() >= 2).collect::<BTreeMap<_,_>>();
+
+			let overview_trace = push_traces(&tracer, overview_trace, new_overview_trace);
+			let detailed_traces = push_traces(&tracer, detailed_traces, new_detailed_traces);
+
+			(client, (overview_trace, detailed_traces), tracer)
+
+		}).await;
+
+		Ok(())
+
+	 }.boxed()).await.unwrap()
+}
+
+fn push_traces<T: Tracer + Send>(
+	tracer: &T,
+	current: StateTree<Key, Context>,
+	new: StateTree<Key, TraceInit>,
+) -> StateTree<Key, Context>
+where
+	T::Span: Span + Send + Sync + 'static,
+{
+	let traces =
+		map_with_parent(diff(current, new), |k, p: Option<&Option<Context>>, d: NodeDiff<Context, TraceInit>| {
+			match d {
+				trace::NodeDiff::Left(context) => {
+					println!("closing trace {k:?}");
+					context.span().end();
+					None
+				},
+				trace::NodeDiff::Right(TraceInit { end_immediately, attributes: values }) => {
+					let context = if let Some(Some(context)) = p {
+						let key = get_key_name(k);
+
+						let mut span = tracer.start_with_context(key, &context);
+						for (key, value) in values {
+							span.set_attribute(KeyValue::new(key, value));
+						}
+						let context = context.with_span(span);
+
+						println!("open trace {k:?}");
+
+						context
+					} else {
+						let key = get_key_name(k);
+
+						let context =
+							Context::new().with_value(KeyValue::new("key", format!("{key:?}")));
+						let mut span = tracer.start_with_context(key, &context);
+						for (key, value) in values {
+							span.set_attribute(KeyValue::new(key, value));
+						}
+						let context = context.with_span(span);
+						println!("open trace {k:?} [NO PARENT]");
+						context
+					};
+					if end_immediately {
+						context.span().end();
+					}
+					Some(context)
+				},
+				trace::NodeDiff::Both(x, _) => Some(x),
+			}
+		})
+		.into_iter()
+		.filter_map(|(k, v)| match v {
+			Some(v) => Some((k, v)),
+			None => None,
+		})
+		.collect();
+	traces
+}

--- a/api/bin/chainflip-elections-tracker/src/trace.rs
+++ b/api/bin/chainflip-elections-tracker/src/trace.rs
@@ -66,7 +66,6 @@ pub fn get_key_name<'a, K: std::fmt::Display>(key: &'a Vec<K>) -> String {
 	key.last().map(|x| format!("{x}")).unwrap_or("root".into())
 }
 
-
 fn zip_with<K: Ord, V, W, X>(
 	x: BTreeMap<K, V>,
 	mut y: BTreeMap<K, W>,

--- a/api/bin/chainflip-elections-tracker/src/trace.rs
+++ b/api/bin/chainflip-elections-tracker/src/trace.rs
@@ -48,13 +48,12 @@ pub fn map_with_parent<K: Ord, V, W>(
 	let mut processed = BTreeMap::new();
 	for length in 0..10 {
 		for (key, value) in this.extract_if(|k, _| k.len() == length) {
-			let p;
-			if key.len() > 0 {
+			let p = if !key.is_empty() {
 				let parent_key = &key[0..key.len() - 1];
-				p = processed.get(parent_key);
+				processed.get(parent_key)
 			} else {
-				p = None;
-			}
+				None
+			};
 			let v = f(&key, p, value);
 			processed.insert(key, v);
 		}
@@ -62,7 +61,7 @@ pub fn map_with_parent<K: Ord, V, W>(
 	processed
 }
 
-pub fn get_key_name<'a, K: std::fmt::Display>(key: &'a Vec<K>) -> String {
+pub fn get_key_name<K: std::fmt::Display>(key: &[K]) -> String {
 	key.last().map(|x| format!("{x}")).unwrap_or("root".into())
 }
 

--- a/api/bin/chainflip-elections-tracker/src/trace.rs
+++ b/api/bin/chainflip-elections-tracker/src/trace.rs
@@ -1,0 +1,87 @@
+use std::collections::BTreeMap;
+
+pub type StateTree<K, V> = BTreeMap<Vec<K>, V>;
+
+pub enum NodeDiff<V, W> {
+	Left(V),
+	Right(W),
+	Both(V, W),
+}
+
+impl<V, W> NodeDiff<V, W> {
+	pub fn get_left(&self) -> Option<&W> {
+		match self {
+			Left(_) => None,
+			Right(a) => Some(a),
+			Both(_, a) => Some(a),
+		}
+	}
+
+	pub fn get_right(&self) -> Option<&W> {
+		match self {
+			Left(_) => None,
+			Right(a) => Some(a),
+			Both(_, a) => Some(a),
+		}
+	}
+}
+
+use NodeDiff::*;
+
+pub fn diff<K: Ord, V, W>(a: StateTree<K, V>, b: StateTree<K, W>) -> StateTree<K, NodeDiff<V, W>> {
+	zip_with(a, b, |v, w| match (v, w) {
+		(None, None) => None,
+		(None, Some(w)) => Some(Right(w)),
+		(Some(v), None) => Some(Left(v)),
+		(Some(v), Some(w)) => Some(Both(v, w)),
+	})
+}
+pub fn fmap<K: Ord, V, W>(this: BTreeMap<K, V>, f: &impl Fn(V) -> W) -> BTreeMap<K, W> {
+	this.into_iter().map(|(k, v)| (k, f(v))).collect()
+}
+
+// TODO! This has currently a hardcoded 10!
+pub fn map_with_parent<K: Ord, V, W>(
+	mut this: StateTree<K, V>,
+	f: impl Fn(&Vec<K>, Option<&W>, V) -> W,
+) -> StateTree<K, W> {
+	let mut processed = BTreeMap::new();
+	for length in 0..10 {
+		for (key, value) in this.extract_if(|k, _| k.len() == length) {
+			let p;
+			if key.len() > 0 {
+				let parent_key = &key[0..key.len() - 1];
+				p = processed.get(parent_key);
+			} else {
+				p = None;
+			}
+			let v = f(&key, p, value);
+			processed.insert(key, v);
+		}
+	}
+	processed
+}
+
+pub fn get_key_name<'a, K: std::fmt::Display>(key: &'a Vec<K>) -> String {
+	key.last().map(|x| format!("{x}")).unwrap_or("root".into())
+}
+
+
+fn zip_with<K: Ord, V, W, X>(
+	x: BTreeMap<K, V>,
+	mut y: BTreeMap<K, W>,
+	f: impl Fn(Option<V>, Option<W>) -> Option<X>,
+) -> BTreeMap<K, X> {
+	let mut result = BTreeMap::new();
+	for (k, v) in x.into_iter() {
+		if let Some(x) = f(Some(v), y.remove(&k)) {
+			result.insert(k, x);
+		}
+	}
+	for (k, w) in y.into_iter() {
+		if let Some(x) = f(None, Some(w)) {
+			result.insert(k, x);
+		}
+	}
+	result
+}

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -930,7 +930,7 @@ pub mod pallet {
 		pub struct ElectionBitmapComponents<T: Config<I>, I: 'static> {
 			epoch: EpochIndex,
 			#[allow(clippy::type_complexity)]
-			bitmaps:
+			pub bitmaps:
 				Vec<(BitmapComponentOf<T::ElectoralSystemRunner>, BitVec<u8, bitvec::order::Lsb0>)>,
 			#[codec(skip)]
 			_phantom: core::marker::PhantomData<(T, I)>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2015

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR introduces a new binary `chainflip-elections-tracker` which runs alongside a chainflip node and watches the state of elections in each block. It computes which part of the state have changed and pushes this information in form of OTLP traces to a compatible backend, for example to be ingested by Grafana Tempo.

This is a first version with basic tracking of elections. For example, it does not "backfill" blocks if it was shut down for a while. Further functionality is going to be added on a by-need basis.
