### PR TITLE
feat: BTC vault deposit electoral system

### DIFF
--- a/engine/src/elections/voter_api.rs
+++ b/engine/src/elections/voter_api.rs
@@ -81,6 +81,6 @@ macro_rules! generate_voter_api_tuple_impls {
 }
 
 generate_voter_api_tuple_impls!(tuple_1_impls: ((A, A0)));
-generate_voter_api_tuple_impls!(tuple_2_impls: ((A, A0), (B, B0)));
 generate_voter_api_tuple_impls!(tuple_3_impls: ((A, A0), (B, B0), (C, C0)));
+generate_voter_api_tuple_impls!(tuple_4_impls: ((A, A0), (B, B0), (C, C0), (D, D0)));
 generate_voter_api_tuple_impls!(tuple_7_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0), (FF, F0), (GG, G0)));

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -3,32 +3,13 @@ pub mod deposits;
 pub mod source;
 pub mod vault_swaps;
 
-use crate::{
-	btc::{
-		retry_rpc::{BtcRetryRpcApi, BtcRetryRpcClient},
-		rpc::VerboseTransaction,
-	},
-	db::PersistentKeyDB,
-	state_chain_observer::client::{
-		extrinsic_api::signed::SignedExtrinsicApi,
-		storage_api::StorageApi,
-		stream_api::{StreamApi, FINALIZED, UNFINALIZED},
-	},
-};
+use crate::btc::rpc::VerboseTransaction;
 use bitcoin::{hashes::Hash, BlockHash};
 use cf_chains::btc::{self, deposit_address::DepositAddress, BlockNumber, CHANGE_ADDRESS_SALT};
-use cf_primitives::{EpochIndex, NetworkEnvironment};
-use cf_utilities::task_scope::Scope;
+use cf_primitives::EpochIndex;
 use futures_core::Future;
-use source::BtcSource;
-use std::sync::Arc;
 
-use super::common::{
-	chain_source::{extension::ChainSourceExt, Header},
-	epoch_source::{EpochSourceBuilder, Vault},
-};
-
-use anyhow::Result;
+use super::common::{chain_source::Header, epoch_source::Vault};
 
 pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoricInfo>(
 	epoch: Vault<cf_chains::Bitcoin, ExtraInfo, ExtraHistoricInfo>,
@@ -62,128 +43,6 @@ pub async fn process_egress<ProcessCall, ProcessingFut, ExtraInfo, ExtraHistoric
 		)
 		.await;
 	}
-}
-
-pub async fn start<
-	StateChainClient,
-	StateChainStream,
-	ProcessCall,
-	ProcessingFut,
-	PrewitnessCall,
-	PrewitnessFut,
->(
-	scope: &Scope<'_, anyhow::Error>,
-	btc_client: BtcRetryRpcClient,
-	process_call: ProcessCall,
-	prewitness_call: PrewitnessCall,
-	state_chain_client: Arc<StateChainClient>,
-	state_chain_stream: StateChainStream,
-	unfinalised_state_chain_stream: impl StreamApi<UNFINALIZED> + Clone,
-	epoch_source: EpochSourceBuilder<'_, '_, StateChainClient, (), ()>,
-	db: Arc<PersistentKeyDB>,
-) -> Result<()>
-where
-	StateChainClient: StorageApi + SignedExtrinsicApi + 'static + Send + Sync,
-	StateChainStream: StreamApi<FINALIZED> + Clone,
-	ProcessCall: Fn(state_chain_runtime::RuntimeCall, EpochIndex) -> ProcessingFut
-		+ Send
-		+ Sync
-		+ Clone
-		+ 'static,
-	ProcessingFut: Future<Output = ()> + Send + 'static,
-	PrewitnessCall: Fn(state_chain_runtime::RuntimeCall, EpochIndex) -> PrewitnessFut
-		+ Send
-		+ Sync
-		+ Clone
-		+ 'static,
-	PrewitnessFut: Future<Output = ()> + Send + 'static,
-{
-	let btc_source = BtcSource::new(btc_client.clone()).strictly_monotonic().shared(scope);
-
-	btc_source
-		.clone()
-		.chunk_by_time(epoch_source.clone(), scope)
-		.chain_tracking(state_chain_client.clone(), btc_client.clone())
-		.logging("chain tracking")
-		.spawn(scope);
-
-	let vaults = epoch_source.vaults::<cf_chains::Bitcoin>().await;
-
-	let block_source = btc_source
-		.then({
-			let btc_client = btc_client.clone();
-			move |header| {
-				let btc_client = btc_client.clone();
-				async move {
-					let block = btc_client.block(header.hash).await.expect("TODO: Delete this");
-					(header.data, block.txdata)
-				}
-			}
-		})
-		.shared(scope);
-
-	// Pre-witnessing stream.
-	block_source
-		.clone()
-		.chunk_by_vault(vaults.clone(), scope)
-		.deposit_addresses(
-			scope,
-			unfinalised_state_chain_stream.clone(),
-			state_chain_client.clone(),
-		)
-		.await
-		.private_deposit_channels(scope, unfinalised_state_chain_stream, state_chain_client.clone())
-		.await
-		.btc_deposits(prewitness_call)
-		.logging("pre-witnessing")
-		.spawn(scope);
-
-	let btc_safety_margin = match state_chain_client
-		.storage_value::<pallet_cf_ingress_egress::WitnessSafetyMargin<
-			state_chain_runtime::Runtime,
-			state_chain_runtime::BitcoinInstance,
-		>>(state_chain_stream.cache().hash)
-		.await?
-	{
-		Some(margin) => margin,
-		None => {
-			use chainflip_node::chain_spec::{berghain, devnet, perseverance};
-			match state_chain_client
-				.storage_value::<pallet_cf_environment::ChainflipNetworkEnvironment<state_chain_runtime::Runtime>>(
-					state_chain_stream.cache().hash,
-				)
-				.await?
-			{
-				NetworkEnvironment::Mainnet => berghain::BITCOIN_SAFETY_MARGIN,
-				NetworkEnvironment::Testnet => perseverance::BITCOIN_SAFETY_MARGIN,
-				NetworkEnvironment::Development => devnet::BITCOIN_SAFETY_MARGIN,
-			}
-		},
-	};
-
-	tracing::info!("Safety margin for Bitcoin is set to {btc_safety_margin} blocks.",);
-
-	// Full witnessing stream.
-	block_source
-		.lag_safety(btc_safety_margin)
-		.logging("safe block produced")
-		.chunk_by_vault(vaults, scope)
-		.deposit_addresses(scope, state_chain_stream.clone(), state_chain_client.clone())
-		.await
-		.private_deposit_channels(scope, state_chain_stream.clone(), state_chain_client.clone())
-		.await
-		.btc_deposits(process_call.clone())
-		.egress_items(scope, state_chain_stream, state_chain_client.clone())
-		.await
-		.then({
-			let process_call = process_call.clone();
-			move |epoch, header| process_egress(epoch, header, process_call.clone())
-		})
-		.continuous("Bitcoin".to_string(), db)
-		.logging("witnessing")
-		.spawn(scope);
-
-	Ok(())
 }
 
 fn success_witnesses<'a>(

--- a/engine/src/witness/btc_e.rs
+++ b/engine/src/witness/btc_e.rs
@@ -42,9 +42,10 @@ use crate::{
 use anyhow::Result;
 
 use sp_core::H256;
+use state_chain_runtime::chainflip::bitcoin_elections::BitcoinVaultDepositWitnessing;
 use std::sync::Arc;
 
-use crate::btc::retry_rpc::BtcRetryRpcClient;
+use crate::{btc::retry_rpc::BtcRetryRpcClient, witness::btc::deposits::vault_deposits};
 
 #[derive(Clone)]
 pub struct BitcoinDepositChannelWitnessingVoter {
@@ -59,7 +60,8 @@ impl VoterApi<BitcoinDepositChannelWitnessingES> for BitcoinDepositChannelWitnes
 		deposit_addresses: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectionProperties,
 	) -> Result<Option<VoteOf<BitcoinDepositChannelWitnessingES>>, anyhow::Error> {
 		let (witness_range, deposit_addresses, _extra) = deposit_addresses;
-		let witness_range = BlockWitnessRange::try_new(witness_range).unwrap();
+		let witness_range = BlockWitnessRange::try_new(witness_range)
+			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
 		tracing::info!("Deposit channel witnessing properties: {:?}", deposit_addresses);
 
 		let mut txs = vec![];
@@ -80,13 +82,43 @@ impl VoterApi<BitcoinDepositChannelWitnessingES> for BitcoinDepositChannelWitnes
 
 		let witnesses = deposit_witnesses(&txs, &deposit_addresses);
 
-		if witnesses.is_empty() {
-			tracing::info!("No witnesses found for BTCE");
-		} else {
-			tracing::info!("Witnesses from BTCE: {:?}", witnesses);
+		Ok(Some(ConstantIndex::new(witnesses)))
+	}
+}
+
+#[derive(Clone)]
+pub struct BitcoinVaultDepositWitnessingVoter {
+	client: BtcRetryRpcClient,
+}
+
+#[async_trait::async_trait]
+impl VoterApi<BitcoinVaultDepositWitnessing> for BitcoinVaultDepositWitnessingVoter {
+	async fn vote(
+		&self,
+		_settings: <BitcoinVaultDepositWitnessing as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <BitcoinVaultDepositWitnessing as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<Option<VoteOf<BitcoinVaultDepositWitnessing>>, anyhow::Error> {
+		let (witness_range, vaults, _extra) = properties;
+		let witness_range = BlockWitnessRange::try_new(witness_range)
+			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
+
+		let mut txs = vec![];
+		// we only ever expect this to be one for bitcoin, but for completeness, we loop.
+		tracing::info!("Witness range: {:?}", witness_range);
+		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
+			tracing::info!("Checking block {:?}", block);
+
+			// TODO: these queries should not be infinite
+			let block_hash = self.client.block_hash(block).await;
+
+			let block = self.client.block(block_hash).await?;
+
+			txs.extend(block.txdata);
 		}
 
-		Ok(Some(ConstantIndex { data: witnesses, _phantom: Default::default() }))
+		let witnesses = vault_deposits(&txs, &vaults);
+
+		Ok(Some(ConstantIndex::new(witnesses)))
 	}
 }
 
@@ -216,6 +248,7 @@ where
 					CompositeVoter::<BitcoinElectoralSystemRunner, _>::new((
 						BitcoinBlockHeightTrackingVoter { client: client.clone() },
 						BitcoinDepositChannelWitnessingVoter { client: client.clone() },
+						BitcoinVaultDepositWitnessingVoter { client: client.clone() },
 						BitcoinLivenessVoter { client },
 					)),
 				)

--- a/engine/src/witness/btc_e.rs
+++ b/engine/src/witness/btc_e.rs
@@ -42,7 +42,7 @@ use crate::{
 use anyhow::Result;
 
 use sp_core::H256;
-use state_chain_runtime::chainflip::bitcoin_elections::BitcoinVaultDepositWitnessing;
+use state_chain_runtime::chainflip::bitcoin_elections::BitcoinVaultDepositWitnessingES;
 use std::sync::Arc;
 
 use crate::{btc::retry_rpc::BtcRetryRpcClient, witness::btc::deposits::vault_deposits};
@@ -92,12 +92,12 @@ pub struct BitcoinVaultDepositWitnessingVoter {
 }
 
 #[async_trait::async_trait]
-impl VoterApi<BitcoinVaultDepositWitnessing> for BitcoinVaultDepositWitnessingVoter {
+impl VoterApi<BitcoinVaultDepositWitnessingES> for BitcoinVaultDepositWitnessingVoter {
 	async fn vote(
 		&self,
-		_settings: <BitcoinVaultDepositWitnessing as ElectoralSystemTypes>::ElectoralSettings,
-		properties: <BitcoinVaultDepositWitnessing as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<Option<VoteOf<BitcoinVaultDepositWitnessing>>, anyhow::Error> {
+		_settings: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<Option<VoteOf<BitcoinVaultDepositWitnessingES>>, anyhow::Error> {
 		let (witness_range, vaults, _extra) = properties;
 		let witness_range = BlockWitnessRange::try_new(witness_range)
 			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;

--- a/state-chain/chains/src/evm.rs
+++ b/state-chain/chains/src/evm.rs
@@ -23,7 +23,20 @@ use sp_std::{convert::TryFrom, str, vec};
 
 use crate::DepositDetailsToTransactionInId;
 
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Default)]
+#[derive(
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	TypeInfo,
+	Default,
+	Serialize,
+	Deserialize,
+	Ord,
+	PartialOrd,
+)]
 pub struct DepositDetails {
 	// In the case of EVM Native Deposits (ETH or arbETH), because we need to detect ingresses by
 	// checking balances rather than using events, there can be more than one hash associated with

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -426,7 +426,9 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 		+ Into<cf_primitives::ForeignChain>
 		+ TryFrom<cf_primitives::Asset, Error: Debug>
 		+ IntoEnumIterator
-		+ Unpin;
+		+ Unpin
+		+ Ord
+		+ PartialOrd;
 
 	type ChainAssetMap<
 		T: Member
@@ -456,7 +458,9 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 		+ TryFrom<ForeignChainAddress>
 		+ IntoForeignChainAddress<Self>
 		+ Unpin
-		+ ToHumanreadableAddress;
+		+ ToHumanreadableAddress
+		+ Serialize
+		+ for<'a> Deserialize<'a>;
 
 	type DepositFetchId: Member
 		+ Parameter
@@ -471,7 +475,11 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 	type DepositDetails: Member
 		+ Parameter
 		+ BenchmarkValue
-		+ DepositDetailsToTransactionInId<Self::ChainCrypto>;
+		+ DepositDetailsToTransactionInId<Self::ChainCrypto>
+		+ Serialize
+		+ for<'a> Deserialize<'a>
+		+ Ord
+		+ PartialOrd;
 
 	type Transaction: Member + Parameter + BenchmarkValue + FeeRefundCalculator<Self>;
 
@@ -510,7 +518,11 @@ pub trait ChainCrypto: ChainCryptoInstanceAlias + Sized {
 		+ Parameter
 		+ Unpin
 		+ IntoTransactionInIdForAnyChain<Self>
-		+ BenchmarkValue;
+		+ BenchmarkValue
+		+ Serialize
+		+ for<'a> Deserialize<'a>
+		+ Ord
+		+ PartialOrd;
 
 	/// Uniquely identifies a transaction on the outgoing direction.
 	type TransactionOutId: Member + Parameter + Unpin + BenchmarkValue;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -96,19 +96,6 @@ pub trait BWProcessorTypes: Sized {
 		+ 'static;
 	type BlockData: PartialEq + Clone + Debug + Eq + Serde + 'static;
 
-	// type ChainBlockNumber: Serde
-	// 	+ Copy
-	// 	+ Eq
-	// 	+ Ord
-	// 	+ SaturatingStep
-	// 	+ Step
-	// 	+ BlockZero
-	// 	+ Debug
-	// 	+ Default
-	// 	+ 'static;
-
-	// type BlockData: Serde + Clone;
-
 	type Event: Serde + Debug + Clone + Eq;
 	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + Serde + Debug + Clone + Eq;
 	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + Serde + Debug + Clone + Eq;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/composite.rs
@@ -488,6 +488,6 @@ macro_rules! generate_electoral_system_tuple_impls {
 }
 
 generate_electoral_system_tuple_impls!(tuple_1_impls: ((A, A0)));
-generate_electoral_system_tuple_impls!(tuple_2_impls: ((A, A0), (B, B0)));
 generate_electoral_system_tuple_impls!(tuple_3_impls: ((A, A0), (B, B0), (C, C0)));
+generate_electoral_system_tuple_impls!(tuple_4_impls: ((A, A0), (B, B0), (C, C0), (D, D0)));
 generate_electoral_system_tuple_impls!(tuple_7_impls: ((A, A0), (B, B0), (C, C0), (D, D0), (EE, E0), (FF, F0), (GG, G0)));

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -153,7 +153,7 @@ impl<A: Indexed, B: Indexed<Index = A::Index>> Indexed for (A, B) {
 )]
 pub struct ConstantIndex<Idx, A> {
 	pub data: A,
-	pub _phantom: sp_std::marker::PhantomData<Idx>,
+	_phantom: sp_std::marker::PhantomData<Idx>,
 }
 impl<Idx, A> ConstantIndex<Idx, A> {
 	pub fn new(data: A) -> Self {

--- a/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
@@ -285,6 +285,6 @@ macro_rules! generate_vote_storage_tuple_impls {
 }
 
 generate_vote_storage_tuple_impls!(tuple_1_impls: (A));
-generate_vote_storage_tuple_impls!(tuple_2_impls: (A, B));
 generate_vote_storage_tuple_impls!(tuple_3_impls: (A, B, C));
+generate_vote_storage_tuple_impls!(tuple_4_impls: (A, B, C, D));
 generate_vote_storage_tuple_impls!(tuple_7_impls: (A, B, C, D, EE, FF, GG));

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -20,7 +20,6 @@ mod boost_pool;
 
 pub use boost_pool::OwedAmount;
 use boost_pool::{BoostPool, DepositFinalisationOutcomeForPool};
-
 use cf_chains::{
 	address::{
 		AddressConverter, AddressDerivationApi, AddressDerivationError, IntoForeignChainAddress,
@@ -49,6 +48,7 @@ use cf_traits::{
 	SwapRequestHandler, SwapRequestType,
 };
 use frame_support::{
+	OrdNoBound, PartialOrdNoBound,
 	__private::sp_tracing::warn,
 	pallet_prelude::{OptionQuery, *},
 	sp_runtime::{traits::Zero, DispatchError, Permill, Saturating},
@@ -411,9 +411,20 @@ pub mod pallet {
 	}
 
 	#[derive(
-		CloneNoBound, RuntimeDebugNoBound, PartialEqNoBound, EqNoBound, Encode, Decode, TypeInfo,
+		CloneNoBound,
+		RuntimeDebugNoBound,
+		PartialEqNoBound,
+		EqNoBound,
+		Encode,
+		Decode,
+		TypeInfo,
+		Serialize,
+		Deserialize,
+		OrdNoBound,
+		PartialOrdNoBound,
 	)]
 	#[scale_info(skip_type_params(T, I))]
+	#[serde(bound(serialize = "", deserialize = ""))]
 	pub struct VaultDepositWitness<T: Config<I>, I: 'static> {
 		pub input_asset: TargetChainAsset<T, I>,
 		pub deposit_address: Option<TargetChainAccount<T, I>>,
@@ -2199,7 +2210,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		None
 	}
 
-	fn process_vault_swap_request_prewitness(
+	pub fn process_vault_swap_request_prewitness(
 		block_height: TargetChainBlockNumber<T, I>,
 		VaultDepositWitness {
 			input_asset: asset,

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -190,7 +190,20 @@ pub const DEFAULT_MAX_AUTHORITY_SET_CONTRACTION: Percent = Percent::from_percent
 
 // Polkadot extrinsics are uniquely identified by <block number>-<extrinsic index>
 // https://wiki.polkadot.network/docs/build-protocol-info
-#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq, Eq)]
+#[derive(
+	Clone,
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	TypeInfo,
+	Debug,
+	PartialEq,
+	Eq,
+	Serialize,
+	Deserialize,
+	Ord,
+	PartialOrd,
+)]
 pub struct TxId {
 	pub block_number: PolkadotBlockNumber,
 	pub extrinsic_index: u32,

--- a/state-chain/runtime/src/chainflip/address_derivation/btc.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/btc.rs
@@ -7,6 +7,7 @@ use cf_chains::{
 };
 use cf_primitives::ChannelId;
 use cf_traits::KeyProvider;
+use sp_std::vec::Vec;
 
 impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 	fn generate_address(
@@ -42,6 +43,22 @@ impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 
 		Ok((channel_state.script_pubkey(), channel_state))
 	}
+}
+pub fn derive_current_and_previous_epoch_private_btc_vaults(
+	channel_id: ChannelId,
+) -> Result<Vec<<Bitcoin as Chain>::DepositChannelState>, AddressDerivationError> {
+	let channel_id: u32 = channel_id
+		.try_into()
+		.map_err(|_| AddressDerivationError::BitcoinChannelIdTooLarge)?;
+
+	let active_epoch_key = BitcoinThresholdSigner::active_epoch_key()
+		.ok_or(AddressDerivationError::MissingBitcoinVault)?
+		.key;
+
+	Ok([Some(active_epoch_key.current), active_epoch_key.previous]
+		.into_iter()
+		.filter_map(|key| key.map(|k| DepositAddress::new(k, channel_id)))
+		.collect())
 }
 
 /// ONLY FOR USE IN RPC CALLS.

--- a/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
@@ -6,25 +6,25 @@ use cf_primitives::chains::Bitcoin;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
 
-use log::warn;
+use crate::chainflip::bitcoin_elections::BlockDataVaultDeposit;
 use pallet_cf_elections::electoral_systems::{
 	block_witnesser::state_machine::{
 		DedupEventsHook, ExecuteHook, HookTypeFor, RulesHook, SafetyMarginHook,
 	},
 	state_machine::core::Hook,
 };
-use pallet_cf_ingress_egress::{DepositWitness, ProcessedUpTo};
+use pallet_cf_ingress_egress::{DepositWitness, VaultDepositWitness};
 
 use super::{bitcoin_elections::BitcoinDepositChannelWitnessing, elections::TypesFor};
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub enum BtcEvent {
-	PreWitness(DepositWitness<Bitcoin>),
-	Witness(DepositWitness<Bitcoin>),
+pub enum BtcEvent<T> {
+	PreWitness(T),
+	Witness(T),
 }
 
-impl BtcEvent {
-	fn deposit_witness(&self) -> &DepositWitness<Bitcoin> {
+impl<T> BtcEvent<T> {
+	fn deposit_witness(&self) -> &T {
 		match self {
 			BtcEvent::PreWitness(dw) | BtcEvent::Witness(dw) => dw,
 		}
@@ -41,8 +41,23 @@ impl Hook<HookTypeFor<Types, ExecuteHook>> for Types {
 			},
 			BtcEvent::Witness(deposit) => {
 				BitcoinIngressEgress::process_channel_deposit_full_witness(deposit, block);
-				warn!("Witness executed");
-				ProcessedUpTo::<Runtime, BitcoinInstance>::set(block);
+			},
+		}
+	}
+}
+impl Hook<(BlockNumber, BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>), ()>
+	for ExecuteEventHook
+{
+	fn run(
+		&mut self,
+		(block, input): (BlockNumber, BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>),
+	) {
+		match input {
+			BtcEvent::PreWitness(deposit) => {
+				let _ = BitcoinIngressEgress::process_vault_swap_request_prewitness(block, deposit);
+			},
+			BtcEvent::Witness(deposit) => {
+				BitcoinIngressEgress::process_vault_swap_request_full_witness(block, deposit);
 			},
 		}
 	}
@@ -51,13 +66,13 @@ impl Hook<HookTypeFor<Types, RulesHook>> for Types {
 	fn run(
 		&mut self,
 		(block, age, block_data): (BlockNumber, u32, BlockData),
-	) -> Vec<(BlockNumber, BtcEvent)> {
+	) -> Vec<(BlockNumber, BtcEvent<DepositWitness<Bitcoin>>)> {
 		// Prewitness rule
 		if age == 0 {
 			return block_data
 				.iter()
 				.map(|deposit_witness| (block, BtcEvent::PreWitness(deposit_witness.clone())))
-				.collect::<Vec<(BlockNumber, BtcEvent)>>();
+				.collect::<Vec<_>>();
 		}
 		//Full witness rule
 		if age ==
@@ -67,7 +82,38 @@ impl Hook<HookTypeFor<Types, RulesHook>> for Types {
 			return block_data
 				.iter()
 				.map(|deposit_witness| (block, BtcEvent::Witness(deposit_witness.clone())))
-				.collect::<Vec<(BlockNumber, BtcEvent)>>();
+				.collect::<Vec<_>>();
+		}
+		vec![]
+	}
+}
+
+impl
+	Hook<
+		(BlockNumber, u32, BlockDataVaultDeposit),
+		Vec<(BlockNumber, BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>)>,
+	> for ApplyRulesHook
+{
+	fn run(
+		&mut self,
+		(block, age, block_data): (BlockNumber, u32, BlockDataVaultDeposit),
+	) -> Vec<(BlockNumber, BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>)> {
+		// Prewitness rule
+		if age == 0 {
+			return block_data
+				.iter()
+				.map(|vault_deposit| (block, BtcEvent::PreWitness(vault_deposit.clone())))
+				.collect::<Vec<_>>();
+		}
+		//Full witness rule
+		if age ==
+			u64::steps_between(&0, &BitcoinIngressEgress::witness_safety_margin().unwrap_or(0)).0
+				as u32
+		{
+			return block_data
+				.iter()
+				.map(|vault_deposit| (block, BtcEvent::Witness(vault_deposit.clone())))
+				.collect::<Vec<_>>();
 		}
 		vec![]
 	}
@@ -76,14 +122,13 @@ impl Hook<HookTypeFor<Types, RulesHook>> for Types {
 /// Returns one event per deposit witness. If multiple events share the same deposit witness:
 /// - keep only the `Witness` variant,
 impl Hook<HookTypeFor<Types, DedupEventsHook>> for Types {
-	fn run(&mut self, events: Vec<(BlockNumber, BtcEvent)>) -> Vec<(BlockNumber, BtcEvent)> {
+	fn run(&mut self, events: Vec<(BlockNumber, BtcEvent<T>)>) -> Vec<(BlockNumber, BtcEvent)> {
 		// Map: deposit_witness -> chosen BtcEvent
 		// todo! this is annoying, it require us to implement Ord down to the Chain type
-		let mut chosen: BTreeMap<DepositWitness<Bitcoin>, (BlockNumber, BtcEvent)> =
-			BTreeMap::new();
+		let mut chosen: BTreeMap<T, (BlockNumber, BtcEvent<T>)> = BTreeMap::new();
 
 		for (block, event) in events {
-			let deposit: DepositWitness<Bitcoin> = event.deposit_witness().clone();
+			let deposit: T = event.deposit_witness().clone();
 
 			match chosen.get(&deposit) {
 				None => {
@@ -115,7 +160,30 @@ impl Hook<HookTypeFor<Types, SafetyMarginHook>> for Types {
 	}
 }
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
-pub struct BlockWitnessingProcessorDefinition {}
+pub struct BlockDepositWitnessingProcessorDefinition {}
+
+impl BWProcessorTypes for BlockDepositWitnessingProcessorDefinition {
+	type ChainBlockNumber = BlockNumber;
+	type BlockData = BlockData;
+	type Event = BtcEvent<DepositWitness<Bitcoin>>;
+	type Rules = ApplyRulesHook;
+	type Execute = ExecuteEventHook;
+	type DedupEvents = DedupEventsHook;
+	type SafetyMargin = SafetyMarginHook;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct BlockVaultWitnessingProcessorDefinition {}
+
+impl BWProcessorTypes for BlockVaultWitnessingProcessorDefinition {
+	type ChainBlockNumber = BlockNumber;
+	type BlockData = BlockDataVaultDeposit;
+	type Event = BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>;
+	type Rules = ApplyRulesHook;
+	type Execute = ExecuteEventHook;
+	type DedupEvents = DedupEventsHook;
+	type SafetyMargin = SafetyMarginHook;
+}
 
 #[cfg(test)]
 mod tests {
@@ -144,54 +212,54 @@ mod tests {
 	   };
 	   use serde::{Deserialize, Serialize};
 
-	   #[allow(dead_code)]
-	   fn block_data() -> BoxedStrategy<MockDeposit> {
-		   (any::<u64>(), any::<u32>())
-			   .prop_map(|(amount, numb)| MockDeposit { amount, deposit_address: numb.to_string() })
-			   .boxed()
-	   }
-	   #[allow(dead_code)]
-	   fn blocks_data(
-		   number_of_blocks: u64,
-	   ) -> BoxedStrategy<BTreeMap<BlockNumber, (MockBlockData, u32)>> {
-		   prop::collection::btree_map(
-			   0..number_of_blocks,
-			   (vec![block_data()], (0..=0u32)),
-			   RangeInclusive::new(0, number_of_blocks as usize),
-		   )
-		   .boxed()
-	   }
-	   #[allow(dead_code)]
-	   fn generate_state() -> BoxedStrategy<BlockProcessor<MockBlockProcessorDefinition>> {
-		   blocks_data(10)
-			   .prop_map(|data| BlockProcessor {
-				   blocks_data: data,
-				   reorg_events: Default::default(),
-				   rules: Default::default(),
-				   execute: IncreasingHook::<(BlockNumber, MockBtcEvent), ()>::default(),
-				   dedup_events: DedupEventsHook {},
-				   safety_margin: Default::default(),
-			   })
-			   .boxed()
-	   }
-	   #[allow(dead_code)]
-	   fn generate_input() -> BoxedStrategy<SMBlockProcessorInput<MockBlockProcessorDefinition>> {
-		   prop_oneof![
-			   (any::<u64>(), block_data()).prop_map(|(n, data)| SMBlockProcessorInput::NewBlockData(
-				   n,
-				   n,
-				   vec![data]
-			   )),
-			   prop_oneof![
-				   (0..=5u64).prop_map(ChainProgressInner::Progress),
-				   (0..=5u64).prop_map(|n| ChainProgressInner::Reorg(
-					   RangeInclusive::<BlockNumber>::new(n, n + 2)
-				   )),
-			   ]
-			   .prop_map(SMBlockProcessorInput::ChainProgress),
-		   ]
-		   .boxed()
-	   }
+	#[allow(dead_code)]
+	fn block_data() -> BoxedStrategy<MockDeposit> {
+		(any::<u64>(), any::<u32>())
+			.prop_map(|(amount, numb)| MockDeposit { amount, deposit_address: numb.to_string() })
+			.boxed()
+	}
+	#[allow(dead_code)]
+	fn blocks_data(
+		number_of_blocks: u64,
+	) -> BoxedStrategy<BTreeMap<BlockNumber, (MockBlockData, u32)>> {
+		prop::collection::btree_map(
+			0..number_of_blocks,
+			(vec![block_data()], (0..=0u32)),
+			RangeInclusive::new(0, number_of_blocks as usize),
+		)
+		.boxed()
+	}
+	#[allow(dead_code)]
+	fn generate_state() -> BoxedStrategy<BlockProcessor<MockBlockProcessorDefinition>> {
+		blocks_data(10)
+			.prop_map(|data| BlockProcessor {
+				blocks_data: data,
+				reorg_events: Default::default(),
+				rules: ApplyRulesHook {},
+				execute: IncreasingHook::<(BlockNumber, MockBtcEvent), ()>::default(),
+				dedup_events: DedupEventsHook {},
+				safety_margin: SafetyMarginHook {},
+			})
+			.boxed()
+	}
+	#[allow(dead_code)]
+	fn generate_input() -> BoxedStrategy<SMBlockProcessorInput<MockBlockProcessorDefinition>> {
+		prop_oneof![
+			(any::<u64>(), block_data()).prop_map(|(n, data)| SMBlockProcessorInput::NewBlockData(
+				n,
+				n,
+				vec![data]
+			)),
+			prop_oneof![
+				(0..=5u64).prop_map(ChainProgressInner::Progress),
+				(0..=5u64).prop_map(|n| ChainProgressInner::Reorg(
+					RangeInclusive::<BlockNumber>::new(n, n + 2)
+				)),
+			]
+			.prop_map(SMBlockProcessorInput::ChainProgress),
+		]
+		.boxed()
+	}
 
 	   #[derive(
 		   Clone,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2029

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Vault deposit witnessing ES for Bitcoin.
Use a different instance of the same electoral system to handle different witnesses:
- one for deposit channel
- one for vaults
- one for egress
- etc...

This allow us to keep the election votes small and possibly to only pause/unpause specific function of the witnessing.