### PR TITLE
feat: returning detailed account information for affiliate in the cf_account_info rpc for brokers

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -241,6 +241,7 @@ pub enum RpcAccountInfo {
 	Broker {
 		flip_balance: NumberOrHex,
 		bond: NumberOrHex,
+		#[deprecated(note = "This field is deprecated and will be replaced in a future release")]
 		earned_fees: any::AssetMap<NumberOrHex>,
 		affiliates: Vec<(AffiliateShortId, AccountId)>,
 		btc_vault_deposit_address: Option<String>,

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -274,9 +274,7 @@ impl RpcAccountInfo {
 	fn unregistered(balance: u128, asset_balances: any::AssetMap<u128>) -> Self {
 		Self::Unregistered {
 			flip_balance: balance.into(),
-			asset_balances: cf_chains::assets::any::AssetMap::from_iter_or_default(
-				asset_balances.iter().map(|(asset, balance)| (asset, (*balance).into())),
-			),
+			asset_balances: asset_balances.map(Into::into),
 		}
 	}
 

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -1,6 +1,5 @@
 ---
 source: state-chain/custom-rpc/src/lib.rs
 expression: "serde_json::to_value(broker).unwrap()"
-snapshot_kind: text
 ---
-{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT"]],"bond":"0x0","btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",null],[2,"5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt","0x0202020202020202020202020202020202020202"]],"bond":"0x0","btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__broker_serialization.snap
@@ -1,5 +1,39 @@
 ---
 source: state-chain/custom-rpc/src/lib.rs
-expression: "serde_json::to_value(broker).unwrap()"
+expression: broker
 ---
-{"affiliates":[[1,"5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",null],[2,"5C7LYpP2ZH3tpKbvVvwiVe54AapxErdPBbvkYhe6y9ZBkqWt","0x0202020202020202020202020202020202020202"]],"bond":"0x0","btc_vault_deposit_address":"tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk","earned_fees":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0xde0b6b3a7640000","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"broker"}
+{
+  "role": "broker",
+  "flip_balance": "0x0",
+  "bond": "0x0",
+  "earned_fees": {
+    "Ethereum": {
+      "ETH": "0x0",
+      "FLIP": "0xde0b6b3a7640000",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Polkadot": {
+      "DOT": "0x0"
+    },
+    "Bitcoin": {
+      "BTC": "0x0"
+    },
+    "Arbitrum": {
+      "ETH": "0x0",
+      "USDC": "0x0"
+    },
+    "Solana": {
+      "SOL": "0x0",
+      "USDC": "0x0"
+    }
+  },
+  "affiliates": [
+    {
+      "account_id": "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",
+      "short_id": 1,
+      "withdrawal_address": "0xcfcfcfcfcfcfcfcfcfcfcfcfcfcfcfcfcfcfcfcf"
+    }
+  ],
+  "btc_vault_deposit_address": "tb1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsn60vlk"
+}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__no_account_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__no_account_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: state-chain/custom-rpc/src/lib.rs
-expression: "serde_json::to_value(RpcAccountInfo::unregistered(0)).unwrap()"
+expression: "serde_json::to_value(RpcAccountInfo::unregistered(0,\nany::AssetMap::default())).unwrap()"
+snapshot_kind: text
 ---
-{"flip_balance":"0x0","role":"unregistered"}
+{"asset_balances":{"Arbitrum":{"ETH":"0x0","USDC":"0x0"},"Bitcoin":{"BTC":"0x0"},"Ethereum":{"ETH":"0x0","FLIP":"0x0","USDC":"0x0","USDT":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0"}},"flip_balance":"0x0","role":"unregistered"}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -2000,7 +2000,7 @@ impl_runtime_apis! {
 				).collect(),
 				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
 					.map(derive_btc_vault_deposit_address),
-				affiliates: pallet_cf_swapping::AffiliateIdMapping::<Runtime>::iter_prefix(&account_id).collect(),
+				affiliates: pallet_cf_swapping::AffiliateAccountDetails::<Runtime>::iter_prefix(&account_id).collect(),
 				bond: account_info.bond()
 			}
 		}

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -10,9 +10,9 @@ use cf_chains::{
 	VaultSwapExtraParametersEncoded,
 };
 use cf_primitives::{
-	AccountRole, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints, BlockNumber,
-	BroadcastId, DcaParameters, EpochIndex, FlipBalance, ForeignChain, GasAmount,
-	NetworkEnvironment, PrewitnessedDepositId, SemVer,
+	AccountRole, Affiliates, Asset, AssetAmount, BasisPoints, BlockNumber, BroadcastId,
+	DcaParameters, EpochIndex, FlipBalance, ForeignChain, GasAmount, NetworkEnvironment,
+	PrewitnessedDepositId, SemVer,
 };
 use cf_traits::SwapLimits;
 use codec::{Decode, Encode};

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -191,12 +191,23 @@ pub struct LiquidityProviderInfo {
 	pub boost_balances: AssetMap<Vec<LiquidityProviderBoostPoolInfo>>,
 }
 
-#[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, TypeInfo, Default)]
 pub struct BrokerInfo {
 	pub earned_fees: Vec<(Asset, AssetAmount)>,
 	pub btc_vault_deposit_address: Option<String>,
-	pub affiliates: Vec<(AffiliateShortId, AccountId32)>,
+	pub affiliates: Vec<(AccountId32, AffiliateDetails)>,
 	pub bond: AssetAmount,
+}
+
+#[derive(Encode, Decode, Eq, PartialEq, TypeInfo)]
+pub struct BrokerInfoLegacy {
+	pub earned_fees: Vec<(Asset, AssetAmount)>,
+}
+
+impl From<BrokerInfoLegacy> for BrokerInfo {
+	fn from(legacy: BrokerInfoLegacy) -> Self {
+		BrokerInfo { earned_fees: legacy.earned_fees, ..Default::default() }
+	}
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]
@@ -414,6 +425,8 @@ decl_runtime_apis!(
 			quote_asset: Asset,
 		) -> Vec<(SwapLegInfo, BlockNumber)>;
 		fn cf_liquidity_provider_info(account_id: AccountId32) -> LiquidityProviderInfo;
+		#[changed_in(3)]
+		fn cf_broker_info(account_id: AccountId32) -> BrokerInfoLegacy;
 		fn cf_broker_info(account_id: AccountId32) -> BrokerInfo;
 		fn cf_account_role(account_id: AccountId32) -> Option<AccountRole>;
 		fn cf_free_balances(account_id: AccountId32) -> AssetMap<AssetAmount>;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2038

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

- Return affiliate details + usdc balance of affiliates for a broker account
- Deprecated earned_fees field
