### PR TITLE
chore: re-enable block witnesser tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
 [workspace.lints.clippy]
 blocks_in_conditions = "allow"
 missing_const_for_thread_local = "allow"
+len_zero = "allow"
 
 [workspace.dependencies]
 # Third party crates

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -72,6 +72,19 @@ pub mod instances;
 
 pub mod mocks;
 
+
+
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[derive( Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+pub struct Steps(u32);
+
+impl Steps {
+	pub fn one() -> Self {
+		Steps(1)
+	}
+}
+
+
 pub mod witness_period {
 	use crate::ChainWitnessConfig;
 	use codec::{Decode, Encode};

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -72,10 +72,21 @@ pub mod instances;
 
 pub mod mocks;
 
-
-
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[derive( Debug, Clone, Copy, PartialEq, Eq, Default, PartialOrd, Ord)]
+#[derive(
+	Encode,
+	Decode,
+	TypeInfo,
+	Deserialize,
+	Serialize,
+	Debug,
+	Clone,
+	Copy,
+	PartialEq,
+	Eq,
+	Default,
+	PartialOrd,
+	Ord,
+)]
 pub struct Steps(u32);
 
 impl Steps {
@@ -83,7 +94,6 @@ impl Steps {
 		Steps(1)
 	}
 }
-
 
 pub mod witness_period {
 	use crate::ChainWitnessConfig;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -1,3 +1,5 @@
+use core::iter::Step;
+
 use crate::electoral_systems::{
 	block_witnesser::{primitives::ChainProgressInner, state_machine::BWProcessorTypes},
 	state_machine::{
@@ -5,8 +7,10 @@ use crate::electoral_systems::{
 		state_machine::StateMachine,
 	},
 };
+use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
+use derive_where::derive_where;
+use frame_support::{pallet_prelude::TypeInfo, CloneNoBound, Deserialize, Serialize};
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, vec, vec::Vec};
 
 ///
@@ -40,15 +44,35 @@ use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, 
 ///     - `Execute`: A hook to execute generated events.
 ///     - `DedupEvents`: A hook to deduplicate events.
 ///     - `SafetyMargin`: A hook to retrieve the chain specific safety-margin
-#[derive(
-	Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize, Deserialize,
+// #[derive(
+// 	Debug, CloneNoBound, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize, Deserialize,
+// )]
+
+#[derive_where(Debug, Clone, PartialEq, Eq;
+	T::ChainBlockNumber: Debug + Clone + Eq, 
+	T::BlockData: Debug + Clone + Eq, 
+	T::Event: Debug + Clone + Eq,
+	T::Rules: Debug + Clone + Eq, 
+	T::Execute: Debug + Clone + Eq, 
+	T::DedupEvents: Debug + Clone + Eq,
+	T::SafetyMargin: Debug + Clone + Eq,
 )]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound(
+	T::ChainBlockNumber: Encode, 
+	T::BlockData: Encode, 
+	T::Event: Encode,
+	T::Rules: Encode, 
+	T::Execute: Encode, 
+	T::DedupEvents: Encode,
+	T::SafetyMargin: Encode,
+))]
 pub struct BlockProcessor<T: BWProcessorTypes> {
 	/// A mapping from block numbers to their corresponding block data and the next age to be
 	/// processed. The "age" represents the block height difference between head of the chain and
 	/// block that we are processing, and it's used to know what rules have already been processed
 	/// for such block
-	pub blocks_data: BTreeMap<T::ChainBlockNumber, (T::BlockData, T::ChainBlockNumber)>,
+	pub blocks_data: BTreeMap<T::ChainBlockNumber, (T::BlockData, u32)>,
 	pub reorg_events: BTreeMap<T::ChainBlockNumber, Vec<T::Event>>,
 	pub rules: T::Rules,
 	pub execute: T::Execute,
@@ -123,9 +147,9 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 					let block_data = self.blocks_data.remove(&n);
 					if let Some((data, next_age)) = block_data {
 						// We need to get only events already processed (next_age not included)
-						for age in 0..next_age.into() {
+						for age in 0..next_age as u32 {
 							let events = self
-								.process_rules_for_age_and_block(n, age.into(), &data)
+								.process_rules_for_age_and_block(n, age, &data)
 								.into_iter()
 								.map(|(_, event)| event)
 								.collect::<Vec<_>>();
@@ -170,16 +194,18 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 		last_height: T::ChainBlockNumber,
 	) -> Vec<(T::ChainBlockNumber, T::Event)> {
 		let mut last_events: Vec<(T::ChainBlockNumber, T::Event)> = vec![];
-		for (block, (data, next_age)) in self.blocks_data.clone() {
-			for age in next_age.into()..=last_height.into().saturating_sub(block.into()) {
+		for (block_height, (data, next_age)) in self.blocks_data.clone() {
+			let current_age = T::ChainBlockNumber::steps_between(&block_height, &last_height).0;
+			for age in next_age..=current_age as u32
+			{
 				last_events = last_events
 					.into_iter()
-					.chain(self.process_rules_for_age_and_block(block, age.into(), &data))
+					.chain(self.process_rules_for_age_and_block(block_height, age, &data))
 					.collect();
 			}
 			self.blocks_data.insert(
-				block,
-				(data.clone(), (last_height.into().saturating_sub(block.into()) + 1).into()),
+				block_height,
+				(data.clone(), current_age as u32 + 1),
 			);
 		}
 		last_events
@@ -207,7 +233,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	fn process_rules_for_age_and_block(
 		&mut self,
 		block: T::ChainBlockNumber,
-		age: T::ChainBlockNumber,
+		age: u32,
 		data: &T::BlockData,
 	) -> Vec<(T::ChainBlockNumber, T::Event)> {
 		let events: Vec<(T::ChainBlockNumber, T::Event)> =
@@ -225,7 +251,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	}
 	fn clean_old(&mut self, last_height: T::ChainBlockNumber) {
 		self.blocks_data
-			.retain(|_key, (_, next_age)| *next_age <= self.safety_margin.run(()));
+			.retain(|_key, (_, next_age)| *next_age as u32 <= self.safety_margin.run(()));
 		// Todo! Do we want to keep these events around for longer? is there any benefit?
 		// If we keep these for let's say 100 blocks we can then prevent double processing things
 		// that are reorged up to 100 blocks later, what are the chanches of smth like this
@@ -233,7 +259,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 		// remove the blocks from block_data as soon as safety margin is reached (we would have to
 		// increase the size of blocks_data as well)
 		self.reorg_events
-			.retain(|key, _| *key > last_height - self.safety_margin.run(()));
+			.retain(|key, _| key.saturating_forward(self.safety_margin.run(()) as usize) > last_height);
 	}
 }
 
@@ -254,7 +280,7 @@ pub(crate) mod test {
 	use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
 	use std::collections::BTreeMap;
 
-	const SAFETY_MARGIN: u64 = 3;
+	const SAFETY_MARGIN: usize = 3;
 	type BlockNumber = u64;
 	#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 	pub struct MockBlockProcessorDefinition {}
@@ -290,12 +316,12 @@ pub(crate) mod test {
 		Default,
 	)]
 	pub struct MockApplyRulesHook {}
-	impl Hook<(BlockNumber, BlockNumber, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>>
+	impl Hook<(BlockNumber, u32, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>>
 		for MockApplyRulesHook
 	{
 		fn run(
 			&mut self,
-			(block, age, block_data): (BlockNumber, BlockNumber, MockBlockData),
+			(block, age, block_data): (BlockNumber, u32, MockBlockData),
 		) -> Vec<(BlockNumber, MockBtcEvent)> {
 			// Prewitness rule
 			if age == 0 {
@@ -305,7 +331,7 @@ pub(crate) mod test {
 					.collect::<Vec<(BlockNumber, MockBtcEvent)>>();
 			}
 			//Full witness rule
-			if age == SAFETY_MARGIN {
+			if age == SAFETY_MARGIN as u32 {
 				return block_data
 					.iter()
 					.map(|deposit_witness| (block, MockBtcEvent::Witness(*deposit_witness)))
@@ -385,8 +411,8 @@ pub(crate) mod test {
 		Default,
 	)]
 	pub struct MockSafetyMargin {}
-	impl Hook<(), BlockNumber> for MockSafetyMargin {
-		fn run(&mut self, _input: ()) -> BlockNumber {
+	impl Hook<(), u32> for MockSafetyMargin {
+		fn run(&mut self, _input: ()) -> u32 {
 			3
 		}
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -44,10 +44,6 @@ use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, 
 ///     - `Execute`: A hook to execute generated events.
 ///     - `DedupEvents`: A hook to deduplicate events.
 ///     - `SafetyMargin`: A hook to retrieve the chain specific safety-margin
-// #[derive(
-// 	Debug, CloneNoBound, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize,
-// Deserialize, )]
-
 #[derive_where(Debug, Clone, PartialEq, Eq;
 	T::ChainBlockNumber: Debug + Clone + Eq,
 	T::BlockData: Debug + Clone + Eq,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
@@ -89,6 +89,10 @@ macro_rules! asserts {
 		assert!($expr, $description);
 		asserts!{$($tail)*}
 	};
+	($description:tt in $expr:expr, else $($vars:expr), +; $($tail:tt)*) => {
+		assert!($expr, $description, $($vars), +);
+		asserts!{$($tail)*}
+	};
 	($description:tt in $expr:expr, where {$($tt:tt)*} $($tail:tt)*) => {
 		{
 			$($tt)*

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -94,7 +94,7 @@ impl<N: Ord + SaturatingStep + Step + Copy> ElectionTracker<N> {
 
 			// and it's going to have a fresh `reorg_id` which forces the ES to recreate this
 			// election
-			self.reorg_id = generate_new_reorg_id(self.ongoing.values());
+			self.reorg_id = generate_new_reorg_id(&self.ongoing.values().cloned().collect());
 		}
 
 		// QUESTION: currently, the following check ensures that
@@ -130,10 +130,10 @@ impl<N: BlockZero + Ord> Default for ElectionTracker<N> {
 
 /// Generates an element which is not in `indices`.
 fn generate_new_reorg_id<'a, N: BlockZero + SaturatingStep + Ord + 'static>(
-	mut indices: impl Iterator<Item = &'a N> + Clone,
+	indices: &Vec<N>,
 ) -> N {
 	let mut index = N::zero();
-	while indices.any(|ix| *ix == index) {
+	while indices.iter().any(|ix| *ix == index) {
 		index = index.saturating_forward(1);
 	}
 	index
@@ -154,7 +154,7 @@ mod tests {
 	proptest! {
 		#[test]
 		fn indices_are_new(xs in prop::collection::vec(any::<u8>(), 0..3)) {
-			assert!(!xs.contains(&generate_new_reorg_id(xs.iter())));
+			assert!(!xs.contains(&generate_new_reorg_id(&xs)));
 		}
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -3,7 +3,7 @@ use codec::{Decode, Encode};
 use core::{iter::Step, ops::RangeInclusive};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 use crate::electoral_systems::state_machine::core::Validate;
 
@@ -94,7 +94,8 @@ impl<N: Ord + SaturatingStep + Step + Copy> ElectionTracker<N> {
 
 			// and it's going to have a fresh `reorg_id` which forces the ES to recreate this
 			// election
-			self.reorg_id = generate_new_reorg_id(&self.ongoing.values().cloned().collect());
+			self.reorg_id =
+				generate_new_reorg_id(&self.ongoing.values().cloned().collect::<Vec<_>>());
 		}
 
 		// QUESTION: currently, the following check ensures that
@@ -129,9 +130,7 @@ impl<N: BlockZero + Ord> Default for ElectionTracker<N> {
 }
 
 /// Generates an element which is not in `indices`.
-fn generate_new_reorg_id<'a, N: BlockZero + SaturatingStep + Ord + 'static>(
-	indices: &Vec<N>,
-) -> N {
+fn generate_new_reorg_id<N: BlockZero + SaturatingStep + Ord + 'static>(indices: &[N]) -> N {
 	let mut index = N::zero();
 	while indices.iter().any(|ix| *ix == index) {
 		index = index.saturating_forward(1);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -48,16 +48,13 @@ pub trait BWProcessorTypes {
 		+ Step
 		+ BlockZero
 		+ Debug
-		+ Into<u64>
 		+ Default
-		+ From<u64>
-		+ Sub<Output = Self::ChainBlockNumber>
 		+ 'static;
 
 	type BlockData: Serde + Clone;
 	type Event: Serde + Debug + Clone + Eq;
 	type Rules: Hook<
-			(Self::ChainBlockNumber, Self::ChainBlockNumber, Self::BlockData),
+			(Self::ChainBlockNumber, u32, Self::BlockData),
 			Vec<(Self::ChainBlockNumber, Self::Event)>,
 		> + Default
 		+ Serde
@@ -77,7 +74,7 @@ pub trait BWProcessorTypes {
 		+ Clone
 		+ Eq;
 
-	type SafetyMargin: Hook<(), Self::ChainBlockNumber> + Default + Serde + Debug + Clone + Eq;
+	type SafetyMargin: Hook<(), u32> + Default + Serde + Debug + Clone + Eq;
 }
 
 #[derive(
@@ -98,8 +95,19 @@ pub struct BWSettings {
 	pub max_concurrent_elections: u16,
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq; T::SafeModeEnabledHook: Debug + Clone + Eq, T::ElectionPropertiesHook: Debug + Clone + Eq, T::BWProcessorTypes: Debug + Clone + Eq)]
+#[derive_where(Debug, Clone, PartialEq, Eq;
+	T::SafeModeEnabledHook: Debug + Clone + Eq,
+	T::ElectionPropertiesHook: Debug + Clone + Eq,
+	BlockProcessor<T::BWProcessorTypes>: Debug + Clone + Eq, 
+)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound(
+	T::ChainBlockNumber: Encode, 
+	T::ElectionPropertiesHook: Encode, 
+	T::SafeModeEnabledHook: Encode,
+
+	BlockProcessor<T::BWProcessorTypes>: Encode, 
+))]
 pub struct BWState<T: BWTypes> {
 	pub elections: ElectionTracker<T::ChainBlockNumber>,
 	pub generate_election_properties_hook: T::ElectionPropertiesHook,
@@ -254,8 +262,8 @@ impl<T: BWTypes> StateMachine for BWStateMachine<T> {
 			"an increase of `highest_priority` can only happen if `could_increase` holds before"
 			in (before.elections.highest_priority < after.elections.highest_priority).implies(could_increase(before));
 
-			"if an increase happens, afterwards no increase can happen"
-			in (before.elections.highest_priority < after.elections.highest_priority).implies(!could_increase(after));
+			"if safemode is enabled, if an increase happens, afterwards no increase can happen"
+			in (before.elections.highest_priority < after.elections.highest_priority && safemode_enabled).implies(!could_increase(after));
 
 			"if no increase can happen, then as long as we have safemode, it can't happen in the future as well"
 			in (!could_increase(before) && safemode_enabled && !is_first_consensus).implies(!could_increase(after));
@@ -340,27 +348,6 @@ impl<T: BWTypes> StateMachine for BWStateMachine<T> {
 							)
 					}
 				}
-				// } else {
-				// if safe mode is enabled, ongoing elections shouldn't change
-				// assert!(
-				// 	before.elections.ongoing == after.elections.ongoing,
-				// 	"if safemode is enabled, ongoing elections shouldn't change (except being closed
-				// when they come to consensus)" );
-
-				// but the next_election should still be updated in order to restart the
-				// reorg'ed elections after safemode is disabled
-				// if *range.start() < before_next_election {
-				// 	// assert!(
-				// 	// 	after.elections.next_election == *range.start(),
-				// 	// 	"if safemode is enabled, and a reorg happens, next_election should be the
-				// start of the reorg range" 	// );
-				// } else {
-				// 	assert!(
-				// 		after.elections.next_election == before_next_election,
-				// 		"if safemode is enabled, and no (relevant) reorg happens, next_election should
-				// not be udpated" 	);
-				// }
-				// }
 			},
 
 			Context(None) => (),
@@ -370,150 +357,134 @@ impl<T: BWTypes> StateMachine for BWStateMachine<T> {
 
 #[cfg(test)]
 mod tests {
-	// use std::collections::BTreeMap;
-	//
-	// use cf_chains::{witness_period::BlockWitnessRange, ChainWitnessConfig};
-	// use proptest::{
-	// 	prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy},
-	// 	strategy::LazyJust,
-	// };
-	//
-	// use super::*;
-	// use crate::prop_do;
-	// use hook_test_utils::*;
-	//
-	// fn generate_state<T: BWTypes<SafeModeEnabledHook = ConstantHook<(), SafeModeStatus>>>(
-	// ) -> impl Strategy<Value = BWState<T>>
-	// where
-	// 	T::ChainBlockNumber: Arbitrary,
-	// 	T::ElectionPropertiesHook: Default + Clone + Debug + Eq , <T as BWTypes>::BlockProcessor:
-	// Default, {
-	// 	prop_do! {
-	// 		// let next_election in any::<T::ChainBlockNumber>();
-	// 		// let highest_scheduled in any::<T::ChainBlockNumber>();
-	// 		// let highest_started_and_touched_by_reorg in any::<T::ChainBlockNumber>();
-	// 		// let reorg_id in any::<u8>();
-	// 		// let safemode_enabled in any::<bool>().prop_map(|b| if b {SafeModeStatus::Enabled} else
-	// {SafeModeStatus::Disabled});
-	//
-	// 		let (highest_election, highest_scheduled, highest_started_and_touched_by_reorg, reorg_id,
-	// safemode_enabled) in ( 			// Just(T::ChainBlockNumber::zero()),
-	// 			any::<T::ChainBlockNumber>(),
-	// 			any::<T::ChainBlockNumber>(),
-	// 			any::<T::ChainBlockNumber>(),
-	// 			any::<u8>(),
-	// 			any::<bool>().prop_map(|b| if b {SafeModeStatus::Enabled} else {SafeModeStatus::Disabled})
-	// 		);
-	//
-	// 		// let ongoing in prop::collection::vec((any::<T::ChainBlockNumber>(), any::<u8>()),
-	// 0..10).prop_map(move |xs| xs.into_iter().filter(move |(height, _)| *height < next_election));
-	// 		LazyJust::new(move || BWState {
-	// 			elections: ElectionTracker {
-	// 				highest_election: highest_election.clone(),
-	// 				highest_witnessed: highest_scheduled.clone(),
-	// 				highest_priority: highest_started_and_touched_by_reorg.clone(),
-	// 				ongoing: BTreeMap::new(), // BTreeMap::from_iter(ongoing.clone()),
-	// 				reorg_id
-	// 			},
-	// 			generate_election_properties_hook: Default::default(),
-	// 			safemode_enabled: ConstantHook::new(safemode_enabled),
-	// 			block_processor: Default::default(),
-	// 			_phantom: core::marker::PhantomData,
-	// 		})
-	// 	}
-	//
-	// 	// Just(
-	// 	// 	BWState {
-	// 	// 	elections: ElectionTracker {
-	// 	// 		next_election: BlockZero::zero(),
-	// 	// 		highest_seen: BlockZero::zero(),
-	// 	// 		highest_priority: BlockZero::zero(),
-	// 	// 		ongoing: BTreeMap::new(),
-	// 	// 		reorg_id: 0,
-	// 	// 	},
-	// 	// 	generate_election_properties_hook: Default::default(),
-	// 	// 	safemode_enabled: ConstantHook::new(SafeModeStatus::Disabled),
-	// 	// 	_phantom: core::marker::PhantomData,
-	// 	// }
-	// 	// )
-	// }
-	//
-	// fn generate_input<T: BWTypes<BlockData = ()>>(
-	// 	indices: IndexOf<<BWStateMachine<T> as StateMachine>::Input>,
-	// ) -> BoxedStrategy<<BWStateMachine<T> as StateMachine>::Input>
-	// where
-	// 	T::ChainBlockNumber: Arbitrary,
-	// {
-	// 	/*
-	// 	let generate_input = |index| {
-	// 		prop_oneof![
-	// 			Just(SMInput::Vote(MultiIndexAndValue(index, ConstantIndex::new(())))),
-	// 			prop_oneof![
-	// 				Just(ChainProgress::None),
-	// 				(any::<T::ChainBlockNumber>(), 0..20usize)
-	// 					.prop_map(|(a, b)| ChainProgress::Range(a..=a.saturating_forward(b))),
-	// 				(any::<T::ChainBlockNumber>(), 0..20usize).prop_map(|(a, b)| {
-	// 					ChainProgress::FirstConsensus(a..=a.saturating_forward(b))
-	// 				})
-	// 			]
-	// 			.prop_map(SMInput::Context)
-	// 		]
-	// 	};
-	//
-	// 	if indices.len() > 0 {
-	// 		prop_do! {
-	// 			let index in select(indices);
-	// 			generate_input(index.clone())
-	// 			// return SMInput::Vote(MultiIndexAndValue(index, ConstantIndex::new(input)))
-	// 		}
-	// 		.boxed()
-	// 	} else {
-	// 		Just(SMInput::Context(ChainProgress::None)).boxed()
-	// 	}
-	// 	*/
-	//
-	// 	Just(SMInput::Context(ChainProgress::None)).boxed()
-	// }
-	//
-	// // impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + 'static> BWTypes
-	// for N { // 	type ChainBlockNumber = N;
-	// // 	type BlockData = ();
-	// // 	type ElectionProperties = ();
-	// // 	type ElectionPropertiesHook = ConstantHook<N, ()>;
-	// // 	type SafeModeEnabledHook = ConstantHook<(), SafeModeStatus>;
-	// // 	type BWProcessorTypes = ();
-	// // 	type BlockProcessor = ();
-	// // }
-	//
-	// // #[test]
-	// // pub fn test_bw_statemachine() {
-	// // 	BWStateMachine::<u8>::test(
-	// // 		file!(),
-	// // 		generate_state(),
-	// // 		prop_do! {
-	// // 			let max_concurrent_elections in 0..10u16;
-	// // 			return BWSettings { max_concurrent_elections }
-	// // 		},
-	// // 		generate_input::<u8>,
-	// // 	);
-	// // }
-	//
-	// struct TestChain {}
-	// impl ChainWitnessConfig for TestChain {
-	// 	const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
-	// 	type ChainBlockNumber = u32;
-	// }
-	//
-	// // #[test]
-	// // pub fn test_bw_statemachine2() {
-	// // 	BWStateMachine::<BlockWitnessRange<TestChain>>::test(
-	// // 		file!(),
-	// // 		generate_state(),
-	// // 		prop_do! {
-	// // 			let max_concurrent_elections in 0..10u16;
-	// // 			return BWSettings { max_concurrent_elections }
-	// // 		},
-	// // 		generate_input::<BlockWitnessRange<TestChain>>,
-	// // 	);
-	// // }
+	use std::collections::BTreeMap;
+	
+	use cf_chains::{witness_period::BlockWitnessRange, ChainWitnessConfig};
+	use proptest::{
+		prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy}, prop_oneof, sample::select, strategy::LazyJust
+	};
+	
+	use super::*;
+	use crate::prop_do;
+	use hook_test_utils::*;
+	
+	fn generate_state<T: BWTypes<SafeModeEnabledHook = ConstantHook<(), SafeModeStatus>>>(
+	) -> impl Strategy<Value = BWState<T>>
+	where
+		T::ChainBlockNumber: Arbitrary,
+		T::ElectionPropertiesHook: Default + Clone + Debug + Eq ,
+	{
+		prop_do! {
+			let (highest_election, highest_scheduled,
+				 highest_started_and_touched_by_reorg, reorg_id,
+				safemode_enabled) in (
+		 		any::<T::ChainBlockNumber>(),
+				any::<T::ChainBlockNumber>(),
+				any::<T::ChainBlockNumber>(),
+				any::<u8>(),
+				any::<bool>().prop_map(|b| if b {SafeModeStatus::Enabled} else {SafeModeStatus::Disabled})
+			);
+	
+			let ongoing in proptest::collection::vec((any::<T::ChainBlockNumber>(), any::<u8>()), 0..10).prop_map(move |xs| xs.into_iter().filter(move |(height, _)| *height <= highest_election));
+			LazyJust::new(move || BWState {
+				elections: ElectionTracker {
+					highest_election: highest_election.clone(),
+					highest_witnessed: highest_scheduled.clone(),
+					highest_priority: highest_started_and_touched_by_reorg.clone(),
+					ongoing: BTreeMap::from_iter(ongoing.clone()),
+					reorg_id
+				},
+				generate_election_properties_hook: Default::default(),
+				safemode_enabled: ConstantHook::new(safemode_enabled),
+				block_processor: Default::default(),
+				_phantom: core::marker::PhantomData,
+			})
+		}
+	}
+	
+	fn generate_input<T: BWTypes<BlockData = ()>>(
+		indices: IndexOf<<BWStateMachine<T> as StateMachine>::Input>,
+	) -> BoxedStrategy<<BWStateMachine<T> as StateMachine>::Input>
+	where
+		T::ChainBlockNumber: Arbitrary,
+	{
+		let generate_input = |index| {
+			prop_oneof![
+				Just(SMInput::Vote(MultiIndexAndValue(index, ConstantIndex::new(())))),
+				prop_oneof![
+					Just(ChainProgress::None),
+					(any::<T::ChainBlockNumber>(), 0..20usize)
+						.prop_map(|(a, b)| ChainProgress::Range(a..=a.saturating_forward(b))),
+					(any::<T::ChainBlockNumber>(), 0..20usize).prop_map(|(a, b)| {
+						ChainProgress::FirstConsensus(a..=a.saturating_forward(b))
+					})
+				]
+				.prop_map(SMInput::Context)
+			]
+		};
+	
+		if indices.len() > 0 {
+			prop_do! {
+				let index in select(indices);
+				generate_input(index.clone())
+			}
+			.boxed()
+		} else {
+			Just(SMInput::Context(ChainProgress::None)).boxed()
+		}
+	}
+
+	impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static> BWProcessorTypes for N {
+		type ChainBlockNumber = N;
+		type BlockData = ();
+		type Event = ();
+		type Rules = ConstantHook<
+			(Self::ChainBlockNumber, u32, Self::BlockData),
+			Vec<(Self::ChainBlockNumber, Self::Event)>,
+		> ;
+		type Execute = ConstantHook<(Self::ChainBlockNumber, Self::Event), ()>;
+		type DedupEvents = ConstantHook<Vec<(Self::ChainBlockNumber, Self::Event)>, Vec<(Self::ChainBlockNumber, Self::Event)>>;
+		type SafetyMargin = ConstantHook<(), u32>;
+	}
+	
+	impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static> BWTypes for N {
+		type BlockData = ();
+		type ElectionProperties = ();
+		type ElectionPropertiesHook = ConstantHook<N, ()>;
+		type SafeModeEnabledHook = ConstantHook<(), SafeModeStatus>;
+		type BWProcessorTypes = N;
+		type ChainBlockNumber = N;
+	}
+	
+	#[test]
+	pub fn test_bw_statemachine() {
+		BWStateMachine::<u32>::test(
+			file!(),
+			generate_state(),
+			prop_do! {
+				let max_concurrent_elections in 0..10u16;
+				return BWSettings { max_concurrent_elections }
+			},
+			generate_input::<u32>,
+		);
+	}
+	
+	struct TestChain {}
+	impl ChainWitnessConfig for TestChain {
+		const WITNESS_PERIOD: Self::ChainBlockNumber = 1;
+		type ChainBlockNumber = u32;
+	}
+	
+	#[test]
+	pub fn test_bw_statemachine2() {
+		BWStateMachine::<BlockWitnessRange<TestChain>>::test(
+			file!(),
+			generate_state(),
+			prop_do! {
+				let max_concurrent_elections in 0..10u16;
+				return BWSettings { max_concurrent_elections }
+			},
+			generate_input::<BlockWitnessRange<TestChain>>,
+		);
+	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine.rs
@@ -1,4 +1,5 @@
 pub mod consensus;
 pub mod core;
+#[allow(clippy::module_inception)]
 pub mod state_machine;
 pub mod state_machine_es;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -13,7 +13,7 @@ pub mod hook_test_utils {
 	use codec::MaxEncodedLen;
 
 	#[derive(
-		Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
+		Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize, Deserialize
 	)]
 	pub struct ConstantHook<A, B> {
 		pub state: B,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -13,7 +13,18 @@ pub mod hook_test_utils {
 	use codec::MaxEncodedLen;
 
 	#[derive(
-		Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, MaxEncodedLen, Serialize, Deserialize
+		Clone,
+		PartialEq,
+		Eq,
+		PartialOrd,
+		Ord,
+		Debug,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+		Serialize,
+		Deserialize,
 	)]
 	pub struct ConstantHook<A, B> {
 		pub state: B,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -179,7 +179,10 @@ pub fn run_with_timeout<
 				)
 				.await
 				.map_err(move |_| format!("task failed with input {:#?}", a3))
-				.map_err(|err| {println!("{err}"); err})
+				.map_err(|err| {
+					println!("{err}");
+					err
+				})
 				.unwrap()
 			})
 			.unwrap()

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -178,7 +178,8 @@ pub fn run_with_timeout<
 					tokio::task::spawn_blocking(move || f2(a2)),
 				)
 				.await
-				.map_err(move |_| format!("task failed with input {:?}", a3))
+				.map_err(move |_| format!("task failed with input {:#?}", a3))
+				.map_err(|err| {println!("{err}"); err})
 				.unwrap()
 			})
 			.unwrap()

--- a/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
@@ -1,4 +1,4 @@
-use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec, iter::Step};
+use sp_std::{collections::btree_map::BTreeMap, iter::Step, vec, vec::Vec};
 
 use crate::{chainflip::bitcoin_elections::BlockData, BitcoinIngressEgress, Runtime};
 use cf_chains::{btc::BlockNumber, instances::BitcoinInstance};
@@ -85,7 +85,10 @@ impl Hook<(BlockNumber, u32, BlockData), Vec<(BlockNumber, BtcEvent)>> for Apply
 				.collect::<Vec<(BlockNumber, BtcEvent)>>();
 		}
 		//Full witness rule
-		if age == u64::steps_between(&0, &BitcoinIngressEgress::witness_safety_margin().unwrap_or(0)).0 as u32 {
+		if age ==
+			u64::steps_between(&0, &BitcoinIngressEgress::witness_safety_margin().unwrap_or(0)).0
+				as u32
+		{
 			return block_data
 				.iter()
 				.map(|deposit_witness| (block, BtcEvent::Witness(deposit_witness.clone())))
@@ -305,9 +308,7 @@ mod tests {
 		}
 	}
 
-	impl Hook<(BlockNumber, u32, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>>
-		for ApplyRulesHook
-	{
+	impl Hook<(BlockNumber, u32, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>> for ApplyRulesHook {
 		fn run(
 			&mut self,
 			(block, age, block_data): (BlockNumber, u32, MockBlockData),

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(btree_extract_if)]
+#![feature(step_trait)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
 pub mod chainflip;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2043

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Re-enables the blockwitnesser ES fuzzy tests. Also uses `u32` for block ages in the block processor.

**NOTE**: Currently, due to some inefficiencies in the way we process rules in the block processor, the prop tests take an "infinitely" long time to run.
