### PR TITLE
chore: cleanup state machine ES trait bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13364,6 +13364,7 @@ dependencies = [
  "cf-session-benchmarking",
  "cf-test-utilities",
  "cf-traits",
+ "derive-where",
  "ethabi",
  "frame-benchmarking",
  "frame-executive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ chrono = { version = "0.4.31" }
 config = { version = "0.13.1" }
 csv = { version = "1.1.6" }
 curve25519-dalek = { version = "4.1.3", default-features = false }
+derive-where = { version = "1.2.7" }
 digest = { version = "0.10.3", default-features = false }
 dyn-clone = { version = "1.0.16" }
 ed25519-dalek = { version = "2.1.1" }

--- a/engine/src/witness/btc_e.rs
+++ b/engine/src/witness/btc_e.rs
@@ -20,9 +20,12 @@ use pallet_cf_elections::{
 };
 use sp_core::bounded::alloc::collections::VecDeque;
 use state_chain_runtime::{
-	chainflip::bitcoin_elections::{
-		BitcoinBlockHeightTrackingES, BitcoinBlockHeightTrackingTypes,
-		BitcoinDepositChannelWitnessingES, BitcoinElectoralSystemRunner, BitcoinLiveness,
+	chainflip::{
+		bitcoin_elections::{
+			BitcoinBlockHeightTracking, BitcoinBlockHeightTrackingES,
+			BitcoinDepositChannelWitnessingES, BitcoinElectoralSystemRunner, BitcoinLiveness,
+		},
+		elections::TypesFor,
 	},
 	BitcoinInstance,
 };
@@ -138,9 +141,9 @@ impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter 
 					"bht: election_property=0, best_block_height={}, submitting last 6 blocks.",
 					best_block_header.block_height
 				);
-				best_block_header
-					.block_height
-					.saturating_sub(BitcoinBlockHeightTrackingTypes::BLOCK_BUFFER_SIZE as u64)
+				best_block_header.block_height.saturating_sub(
+					TypesFor::<BitcoinBlockHeightTracking>::BLOCK_BUFFER_SIZE as u64,
+				)
 			} else {
 				election_property
 			};

--- a/engine/src/witness/btc_e.rs
+++ b/engine/src/witness/btc_e.rs
@@ -21,8 +21,8 @@ use pallet_cf_elections::{
 use sp_core::bounded::alloc::collections::VecDeque;
 use state_chain_runtime::{
 	chainflip::bitcoin_elections::{
-		BitcoinBlockHeightTracking, BitcoinBlockHeightTrackingTypes,
-		BitcoinDepositChannelWitnessing, BitcoinElectoralSystemRunner, BitcoinLiveness,
+		BitcoinBlockHeightTrackingES, BitcoinBlockHeightTrackingTypes,
+		BitcoinDepositChannelWitnessingES, BitcoinElectoralSystemRunner, BitcoinLiveness,
 	},
 	BitcoinInstance,
 };
@@ -49,12 +49,12 @@ pub struct BitcoinDepositChannelWitnessingVoter {
 }
 
 #[async_trait::async_trait]
-impl VoterApi<BitcoinDepositChannelWitnessing> for BitcoinDepositChannelWitnessingVoter {
+impl VoterApi<BitcoinDepositChannelWitnessingES> for BitcoinDepositChannelWitnessingVoter {
 	async fn vote(
 		&self,
-		_settings: <BitcoinDepositChannelWitnessing as ElectoralSystemTypes>::ElectoralSettings,
-		deposit_addresses: <BitcoinDepositChannelWitnessing as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<Option<VoteOf<BitcoinDepositChannelWitnessing>>, anyhow::Error> {
+		_settings: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		deposit_addresses: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<Option<VoteOf<BitcoinDepositChannelWitnessingES>>, anyhow::Error> {
 		let (witness_range, deposit_addresses, _extra) = deposit_addresses;
 		let witness_range = BlockWitnessRange::try_new(witness_range).unwrap();
 		tracing::info!("Deposit channel witnessing properties: {:?}", deposit_addresses);
@@ -93,13 +93,13 @@ pub struct BitcoinBlockHeightTrackingVoter {
 }
 
 #[async_trait::async_trait]
-impl VoterApi<BitcoinBlockHeightTracking> for BitcoinBlockHeightTrackingVoter {
+impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter {
 	async fn vote(
 		&self,
-		_settings: <BitcoinBlockHeightTracking as ElectoralSystemTypes>::ElectoralSettings,
+		_settings: <BitcoinBlockHeightTrackingES as ElectoralSystemTypes>::ElectoralSettings,
 		// We could use 0 as a special case (to avoid requiring an Option)
-		properties: <BitcoinBlockHeightTracking as ElectoralSystemTypes>::ElectionProperties,
-	) -> std::result::Result<Option<VoteOf<BitcoinBlockHeightTracking>>, anyhow::Error> {
+		properties: <BitcoinBlockHeightTrackingES as ElectoralSystemTypes>::ElectionProperties,
+	) -> std::result::Result<Option<VoteOf<BitcoinBlockHeightTrackingES>>, anyhow::Error> {
 		tracing::info!("Block height tracking called properties: {:?}", properties);
 		let BlockHeightTrackingProperties { witness_from_index: election_property } = properties;
 

--- a/state-chain/pallets/cf-elections/Cargo.toml
+++ b/state-chain/pallets/cf-elections/Cargo.toml
@@ -32,8 +32,8 @@ itertools = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
 nanorand = { workspace = true, features = ["wyrand"] }
+derive-where = { workspace = true }
 duplicate = "2.0.0"
-derive-where = "1.2.7"
 
 # Parity deps
 codec = { workspace = true, features = ["derive", "bit-vec"] }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -1,6 +1,6 @@
 use core::{iter::Step, ops::RangeInclusive};
 
-use super::state_machine::core::{Hook, Validate};
+use super::{block_witnesser::state_machine::HookTypeFor, state_machine::core::{Hook, HookType, Validate}};
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
 use frame_support::ensure;
@@ -35,8 +35,15 @@ pub trait BlockHeightTrackingTypes: Ord + PartialEq + Clone + Debug + 'static {
 		+ Debug
 		+ 'static;
 
-	type BlockHeightChangeHook: Hook<Self::ChainBlockNumber, ()>;
+	type BlockHeightChangeHook: Hook<HookTypeFor<Self, BlockHeightChangeHook>>;
 }
+
+pub struct BlockHeightChangeHook;
+impl<T: BlockHeightTrackingTypes> HookType for HookTypeFor<T, BlockHeightChangeHook> {
+	type Input = T::ChainBlockNumber;
+	type Output = ();
+}
+
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -1,6 +1,9 @@
 use core::{iter::Step, ops::RangeInclusive};
 
-use super::{block_witnesser::state_machine::HookTypeFor, state_machine::core::{Hook, HookType, Validate}};
+use super::{
+	block_witnesser::state_machine::HookTypeFor,
+	state_machine::core::{Hook, HookType, Validate},
+};
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
 use frame_support::ensure;
@@ -43,7 +46,6 @@ impl<T: BlockHeightTrackingTypes> HookType for HookTypeFor<T, BlockHeightChangeH
 	type Input = T::ChainBlockNumber;
 	type Output = ();
 }
-
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -86,9 +86,20 @@ impl<T: BlockHeightTrackingTypes> Validate for BHWState<T> {
 	}
 }
 
-#[derive( Debug, Clone, PartialEq, Eq, Encode)]
-#[derive( Decode, TypeInfo, Deserialize, Serialize)]
-#[derive( Ord, PartialOrd, Default,)]
+#[derive(
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	TypeInfo,
+	Deserialize,
+	Serialize,
+	Ord,
+	PartialOrd,
+	Default,
+)]
 pub struct BHWStateWrapper<T: BlockHeightTrackingTypes> {
 	pub state: BHWState<T>,
 	pub block_height_update: T::BlockHeightChangeHook,
@@ -239,7 +250,13 @@ impl<T: BlockHeightTrackingTypes> StateMachine for BlockHeightTrackingSM<T> {
 #[cfg(test)]
 mod tests {
 
-	use crate::{electoral_systems::{block_height_tracking::BlockHeightChangeHook, block_witnesser::state_machine::HookTypeFor, state_machine::core::MultiIndexAndValue}, prop_do};
+	use crate::{
+		electoral_systems::{
+			block_height_tracking::BlockHeightChangeHook,
+			block_witnesser::state_machine::HookTypeFor, state_machine::core::MultiIndexAndValue,
+		},
+		prop_do,
+	};
 	use cf_chains::{
 		self,
 		witness_period::{BlockWitnessRange, BlockZero, SaturatingStep},

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -239,7 +239,7 @@ impl<T: BlockHeightTrackingTypes> StateMachine for BlockHeightTrackingSM<T> {
 #[cfg(test)]
 mod tests {
 
-	use crate::{electoral_systems::state_machine::core::MultiIndexAndValue, prop_do};
+	use crate::{electoral_systems::{block_height_tracking::BlockHeightChangeHook, block_witnesser::state_machine::HookTypeFor, state_machine::core::MultiIndexAndValue}, prop_do};
 	use cf_chains::{
 		self,
 		witness_period::{BlockWitnessRange, BlockZero, SaturatingStep},
@@ -319,7 +319,7 @@ mod tests {
 		const BLOCK_BUFFER_SIZE: usize = 6;
 		type ChainBlockNumber = u32;
 		type ChainBlockHash = bool;
-		type BlockHeightChangeHook = ConstantHook<u32, ()>;
+		type BlockHeightChangeHook = ConstantHook<HookTypeFor<Self, BlockHeightChangeHook>>;
 	}
 
 	#[test]
@@ -354,7 +354,7 @@ mod tests {
 		const BLOCK_BUFFER_SIZE: usize = 6;
 		type ChainBlockNumber = BlockWitnessRange<TestChain>;
 		type ChainBlockHash = bool;
-		type BlockHeightChangeHook = ConstantHook<Self::ChainBlockNumber, ()>;
+		type BlockHeightChangeHook = ConstantHook<HookTypeFor<Self, BlockHeightChangeHook>>;
 	}
 
 	#[test]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -86,20 +86,9 @@ impl<T: BlockHeightTrackingTypes> Validate for BHWState<T> {
 	}
 }
 
-#[derive(
-	Debug,
-	Clone,
-	PartialEq,
-	Eq,
-	Encode,
-	Decode,
-	TypeInfo,
-	Deserialize,
-	Serialize,
-	Ord,
-	PartialOrd,
-	Default,
-)]
+#[derive( Debug, Clone, PartialEq, Eq, Encode)]
+#[derive( Decode, TypeInfo, Deserialize, Serialize)]
+#[derive( Ord, PartialOrd, Default,)]
 pub struct BHWStateWrapper<T: BlockHeightTrackingTypes> {
 	pub state: BHWState<T>,
 	pub block_height_update: T::BlockHeightChangeHook,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -256,16 +256,18 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	}
 }
 
-
-
 #[cfg(test)]
 pub(crate) mod test {
 
 	use crate::{
 		electoral_systems::{
 			block_witnesser::{
-				block_processor::BlockProcessor, primitives::ChainProgressInner,
-				state_machine::{BWProcessorTypes, HookTypeFor, RulesHook, SafetyMarginHook, DedupEventsHook, ExecuteHook},
+				block_processor::BlockProcessor,
+				primitives::ChainProgressInner,
+				state_machine::{
+					BWProcessorTypes, DedupEventsHook, ExecuteHook, HookTypeFor, RulesHook,
+					SafetyMarginHook,
+				},
 			},
 			state_machine::core::{hook_test_utils::IncreasingHook, Hook, TypesFor},
 		},
@@ -298,8 +300,7 @@ pub(crate) mod test {
 		}
 	}
 
-	impl Hook<HookTypeFor<Types, RulesHook>> for Types
-	{
+	impl Hook<HookTypeFor<Types, RulesHook>> for Types {
 		fn run(
 			&mut self,
 			(block, age, block_data): (BlockNumber, u32, MockBlockData),
@@ -322,8 +323,7 @@ pub(crate) mod test {
 		}
 	}
 
-	impl Hook<HookTypeFor<Types, DedupEventsHook>> for Types
-	{
+	impl Hook<HookTypeFor<Types, DedupEventsHook>> for Types {
 		fn run(
 			&mut self,
 			events: Vec<(BlockNumber, MockBtcEvent)>,
@@ -561,7 +561,6 @@ impl<T: BWProcessorTypes + 'static> StateMachine for SMBlockProcessor<T> {
 		}
 	}
 }
-
 
 // #[cfg(test)]
 // fn step_specification(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -19,19 +19,17 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::{fmt::Debug, vec::Vec};
 
-
-/// Type which can be used for implementing traits that 
+/// Type which can be used for implementing traits that
 /// contain only type definitions, as used in many parts of
 /// the state machine based electoral systems.
 #[derive_where(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound())]
-#[serde(bound="")]
+#[serde(bound = "")]
 #[scale_info(skip_type_params(Tag1, Tag2))]
-pub struct HookTypeFor<Tag1,Tag2> {
-	_phantom: sp_std::marker::PhantomData<(Tag1, Tag2)>
+pub struct HookTypeFor<Tag1, Tag2> {
+	_phantom: sp_std::marker::PhantomData<(Tag1, Tag2)>,
 }
-
 
 pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 	// type ChainBlockNumber: Serde
@@ -47,7 +45,6 @@ pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 	type ElectionProperties: PartialEq + Clone + Eq + Debug + 'static;
 	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>>;
 	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>>;
-
 }
 
 // hook types
@@ -71,7 +68,7 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, RulesHook> {
 
 pub struct ExecuteHook;
 impl<T: BWProcessorTypes> HookType for HookTypeFor<T, ExecuteHook> {
-	type Input =(T::ChainBlockNumber, T::Event);
+	type Input = (T::ChainBlockNumber, T::Event);
 	type Output = ();
 }
 
@@ -87,11 +84,7 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, SafetyMarginHook> {
 	type Output = u32;
 }
 
-
-
-
-pub trait BWProcessorTypes : Sized {
-
+pub trait BWProcessorTypes: Sized {
 	type ChainBlockNumber: Serde
 		+ Copy
 		+ Eq
@@ -117,18 +110,8 @@ pub trait BWProcessorTypes : Sized {
 	// type BlockData: Serde + Clone;
 
 	type Event: Serde + Debug + Clone + Eq;
-	type Rules: Hook<HookTypeFor<Self, RulesHook>>
-			 + Default
-		+ Serde
-		+ Debug
-		+ Clone
-		+ Eq;
-	type Execute: Hook<HookTypeFor<Self, ExecuteHook>>
-		+ Default
-		+ Serde
-		+ Debug
-		+ Clone
-		+ Eq;
+	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + Serde + Debug + Clone + Eq;
+	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + Serde + Debug + Clone + Eq;
 	type DedupEvents: Hook<HookTypeFor<Self, DedupEventsHook>>
 		+ Default
 		+ Serde
@@ -136,7 +119,12 @@ pub trait BWProcessorTypes : Sized {
 		+ Clone
 		+ Eq;
 
-	type SafetyMargin: Hook<HookTypeFor<Self, SafetyMarginHook>> + Default + Serde + Debug + Clone + Eq;
+	type SafetyMargin: Hook<HookTypeFor<Self, SafetyMarginHook>>
+		+ Default
+		+ Serde
+		+ Debug
+		+ Clone
+		+ Eq;
 }
 
 #[derive(
@@ -434,11 +422,11 @@ mod tests {
 	use hook_test_utils::*;
 
 	fn generate_state<
-		T: BWTypes<SafeModeEnabledHook = ConstantHook<HookTypeFor<T, SafeModeEnabledHook>>,
-			SafetyMargin = ConstantHook<HookTypeFor<T, SafetyMarginHook>>
+		T: BWTypes<
+			SafeModeEnabledHook = ConstantHook<HookTypeFor<T, SafeModeEnabledHook>>,
+			SafetyMargin = ConstantHook<HookTypeFor<T, SafetyMarginHook>>,
 		>,
 	>() -> impl Strategy<Value = BWState<T>>
-
 	where
 		T::ChainBlockNumber: Arbitrary,
 		T::ElectionPropertiesHook: Default + Clone + Debug + Eq,
@@ -512,7 +500,7 @@ mod tests {
 	}
 
 	impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static>
-		BWProcessorTypes for N 
+		BWProcessorTypes for N
 	{
 		type ChainBlockNumber = N;
 		type BlockData = ();
@@ -521,9 +509,7 @@ mod tests {
 		type Execute = ConstantHook<HookTypeFor<Self, ExecuteHook>>;
 		type DedupEvents = ConstantHook<HookTypeFor<Self, DedupEventsHook>>;
 		type SafetyMargin = ConstantHook<HookTypeFor<Self, SafetyMarginHook>>;
-
 	}
-
 
 	impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static>
 		BWTypes for N

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -1,24 +1,21 @@
 use codec::{Decode, Encode};
+use derive_where::derive_where;
 use itertools::Either;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
-use derive_where::derive_where;
 
-
-/// Type which can be used for implementing traits that 
+/// Type which can be used for implementing traits that
 /// contain only type definitions, as used in many parts of
 /// the state machine based electoral systems.
 #[derive_where(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound())]
-#[serde(bound="")]
+#[serde(bound = "")]
 #[scale_info(skip_type_params(Tag))]
 pub(crate) struct TypesFor<Tag> {
-	_phantom: sp_std::marker::PhantomData<Tag>
+	_phantom: sp_std::marker::PhantomData<Tag>,
 }
-
-
 
 pub trait HookType {
 	type Input;
@@ -28,7 +25,6 @@ pub trait HookType {
 pub trait Hook<T: HookType> {
 	fn run(&mut self, input: T::Input) -> T::Output;
 }
-
 
 pub mod hook_test_utils {
 	use super::*;
@@ -59,16 +55,18 @@ pub mod hook_test_utils {
 		}
 	}
 
-	impl<T: HookType> Default for ConstantHook<T> 
-	where T::Output: Default
+	impl<T: HookType> Default for ConstantHook<T>
+	where
+		T::Output: Default,
 	{
 		fn default() -> Self {
 			Self::new(Default::default())
 		}
 	}
 
-	impl<T: HookType> Hook<T> for ConstantHook<T> 
-	where T::Output: Clone
+	impl<T: HookType> Hook<T> for ConstantHook<T>
+	where
+		T::Output: Clone,
 	{
 		fn run(&mut self, _input: T::Input) -> T::Output {
 			self.state.clone()
@@ -101,16 +99,18 @@ pub mod hook_test_utils {
 		}
 	}
 
-	impl<T: HookType> Default for IncreasingHook<T> 
-	where T::Output: Default
+	impl<T: HookType> Default for IncreasingHook<T>
+	where
+		T::Output: Default,
 	{
 		fn default() -> Self {
 			Self::new(Default::default(), Default::default())
 		}
 	}
 
-	impl<T: HookType> Hook<T> for IncreasingHook<T> 
-	where T::Output: Clone
+	impl<T: HookType> Hook<T> for IncreasingHook<T>
+	where
+		T::Output: Clone,
 	{
 		fn run(&mut self, _input: T::Input) -> T::Output {
 			self.counter += 1;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -8,6 +8,7 @@ pub trait Hook<A, B> {
 	fn run(&mut self, input: A) -> B;
 }
 
+
 pub mod hook_test_utils {
 	use super::*;
 	use codec::MaxEncodedLen;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser_new.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser_new.rs
@@ -14,7 +14,6 @@
 // State partially processed, how do we test that the state still gets processed until all the state
 // is processed.
 
-
 use core::ops::RangeInclusive;
 
 use super::{
@@ -25,7 +24,11 @@ use crate::{
 	electoral_system::{ConsensusVote, ConsensusVotes, ElectoralSystemTypes},
 	electoral_systems::{
 		block_height_tracking::ChainProgress,
-		block_witnesser::{block_processor::test::MockBlockProcessorDefinition, state_machine::{ElectionPropertiesHook, HookTypeFor, SafeModeEnabledHook}, *},
+		block_witnesser::{
+			block_processor::test::MockBlockProcessorDefinition,
+			state_machine::{ElectionPropertiesHook, HookTypeFor, SafeModeEnabledHook},
+			*,
+		},
 		state_machine::{
 			core::{ConstantIndex, Hook, TypesFor},
 			state_machine_es::{StateMachineES, StateMachineESInstance},
@@ -34,11 +37,8 @@ use crate::{
 	vote_storage,
 };
 use cf_chains::{mocks::MockEthereum, Chain};
-use codec::{Decode, Encode, MaxEncodedLen};
 use consensus::BWConsensus;
 use primitives::SafeModeStatus;
-use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
 use sp_std::collections::btree_set::BTreeSet;
 use state_machine::{BWSettings, BWState, BWStateMachine, BWTypes};
 
@@ -58,7 +58,6 @@ pub type ValidatorId = u16;
 
 pub type BlockData = Vec<u8>;
 
-
 fn range_n(start: u64, count: u64) -> RangeInclusive<u64> {
 	assert!(count > 0);
 	// TODO: Test with other witness ranges.
@@ -77,7 +76,6 @@ pub type Properties = BTreeSet<u16>;
 // 		BTreeSet::new()
 // 	}
 // }
-
 
 impl Hook<HookTypeFor<Types, ElectionPropertiesHook>> for Types {
 	fn run(&mut self, input: ChainBlockNumber) -> Properties {
@@ -145,18 +143,15 @@ impl ProcessBlockData<ChainBlockNumber, BlockData>
 }
  */
 
-
 type Types = TypesFor<MockBlockProcessorDefinition>;
 
 type ElectionProperties = Properties;
-
 
 impl Hook<HookTypeFor<Types, SafeModeEnabledHook>> for Types {
 	fn run(&mut self, _input: ()) -> SafeModeStatus {
 		SafeModeStatus::Disabled
 	}
 }
-
 
 /// Associating BW types to the struct
 impl BWTypes for Types {

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -17,6 +17,7 @@ substrate-wasm-builder = { workspace = true, optional = true }
 workspace = true
 
 [dependencies]
+derive-where = { workspace = true }
 hex-literal = { workspace = true }
 hex = { workspace = true }
 log = { workspace = true }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -13,6 +13,8 @@ mod signer_nomination;
 
 // Election pallet implementations
 mod bitcoin_block_processor;
+#[macro_use]
+pub mod elections;
 pub mod bitcoin_elections;
 pub mod solana_elections;
 pub mod vault_swaps;

--- a/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
@@ -8,7 +8,10 @@ use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
 
 use log::warn;
 use pallet_cf_elections::electoral_systems::{
-	block_witnesser::state_machine::{BWProcessorTypes, DedupEventsHook, ExecuteHook, HookTypeFor, RulesHook, SafetyMarginHook}, state_machine::core::Hook,
+	block_witnesser::state_machine::{
+		DedupEventsHook, ExecuteHook, HookTypeFor, RulesHook, SafetyMarginHook,
+	},
+	state_machine::core::Hook,
 };
 use pallet_cf_ingress_egress::{DepositWitness, ProcessedUpTo};
 
@@ -29,7 +32,6 @@ impl BtcEvent {
 }
 
 type Types = TypesFor<BitcoinDepositChannelWitnessing>;
-
 
 impl Hook<HookTypeFor<Types, ExecuteHook>> for Types {
 	fn run(&mut self, (block, input): (BlockNumber, BtcEvent)) {
@@ -107,7 +109,6 @@ impl Hook<HookTypeFor<Types, DedupEventsHook>> for Types {
 	}
 }
 
-
 impl Hook<HookTypeFor<Types, SafetyMarginHook>> for Types {
 	fn run(&mut self, _input: ()) -> u32 {
 		u64::steps_between(&0, &BitcoinIngressEgress::witness_safety_margin().unwrap_or(0)).0 as u32
@@ -116,204 +117,203 @@ impl Hook<HookTypeFor<Types, SafetyMarginHook>> for Types {
 #[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub struct BlockWitnessingProcessorDefinition {}
 
-
 #[cfg(test)]
 mod tests {
 	/*
-	use cf_chains::btc::BlockNumber;
-	use std::collections::BTreeMap;
+	   use cf_chains::btc::BlockNumber;
+	   use std::collections::BTreeMap;
 
-	// use crate::chainflip::bitcoin_block_processor::{ApplyRulesHook, SafetyMarginHook};
-	use codec::{Decode, Encode};
-	use core::ops::RangeInclusive;
-	use frame_support::pallet_prelude::TypeInfo;
-	use pallet_cf_elections::electoral_systems::block_witnesser::primitives::ChainProgressInner;
+	   // use crate::chainflip::bitcoin_block_processor::{ApplyRulesHook, SafetyMarginHook};
+	   use codec::{Decode, Encode};
+	   use core::ops::RangeInclusive;
+	   use frame_support::pallet_prelude::TypeInfo;
+	   use pallet_cf_elections::electoral_systems::block_witnesser::primitives::ChainProgressInner;
 
-	use crate::chainflip::bitcoin_block_processor::DedupEventsHook;
-	use cf_chains::btc::BtcAmount;
-	use pallet_cf_elections::electoral_systems::{
-		block_witnesser::{
-			block_processor::{BlockProcessor},
-			state_machine::BWProcessorTypes,
-		},
-		state_machine::core::{hook_test_utils::IncreasingHook, Hook},
-	};
-	use proptest::{
-		prelude::{any, prop, BoxedStrategy, Strategy},
-		prop_oneof,
-	};
-	use serde::{Deserialize, Serialize};
+	   use crate::chainflip::bitcoin_block_processor::DedupEventsHook;
+	   use cf_chains::btc::BtcAmount;
+	   use pallet_cf_elections::electoral_systems::{
+		   block_witnesser::{
+			   block_processor::{BlockProcessor},
+			   state_machine::BWProcessorTypes,
+		   },
+		   state_machine::core::{hook_test_utils::IncreasingHook, Hook},
+	   };
+	   use proptest::{
+		   prelude::{any, prop, BoxedStrategy, Strategy},
+		   prop_oneof,
+	   };
+	   use serde::{Deserialize, Serialize};
 
-	#[allow(dead_code)]
-	fn block_data() -> BoxedStrategy<MockDeposit> {
-		(any::<u64>(), any::<u32>())
-			.prop_map(|(amount, numb)| MockDeposit { amount, deposit_address: numb.to_string() })
-			.boxed()
-	}
-	#[allow(dead_code)]
-	fn blocks_data(
-		number_of_blocks: u64,
-	) -> BoxedStrategy<BTreeMap<BlockNumber, (MockBlockData, u32)>> {
-		prop::collection::btree_map(
-			0..number_of_blocks,
-			(vec![block_data()], (0..=0u32)),
-			RangeInclusive::new(0, number_of_blocks as usize),
-		)
-		.boxed()
-	}
-	#[allow(dead_code)]
-	fn generate_state() -> BoxedStrategy<BlockProcessor<MockBlockProcessorDefinition>> {
-		blocks_data(10)
-			.prop_map(|data| BlockProcessor {
-				blocks_data: data,
-				reorg_events: Default::default(),
-				rules: Default::default(),
-				execute: IncreasingHook::<(BlockNumber, MockBtcEvent), ()>::default(),
-				dedup_events: DedupEventsHook {},
-				safety_margin: Default::default(),
-			})
-			.boxed()
-	}
-	#[allow(dead_code)]
-	fn generate_input() -> BoxedStrategy<SMBlockProcessorInput<MockBlockProcessorDefinition>> {
-		prop_oneof![
-			(any::<u64>(), block_data()).prop_map(|(n, data)| SMBlockProcessorInput::NewBlockData(
-				n,
-				n,
-				vec![data]
-			)),
-			prop_oneof![
-				(0..=5u64).prop_map(ChainProgressInner::Progress),
-				(0..=5u64).prop_map(|n| ChainProgressInner::Reorg(
-					RangeInclusive::<BlockNumber>::new(n, n + 2)
-				)),
-			]
-			.prop_map(SMBlockProcessorInput::ChainProgress),
-		]
-		.boxed()
-	}
+	   #[allow(dead_code)]
+	   fn block_data() -> BoxedStrategy<MockDeposit> {
+		   (any::<u64>(), any::<u32>())
+			   .prop_map(|(amount, numb)| MockDeposit { amount, deposit_address: numb.to_string() })
+			   .boxed()
+	   }
+	   #[allow(dead_code)]
+	   fn blocks_data(
+		   number_of_blocks: u64,
+	   ) -> BoxedStrategy<BTreeMap<BlockNumber, (MockBlockData, u32)>> {
+		   prop::collection::btree_map(
+			   0..number_of_blocks,
+			   (vec![block_data()], (0..=0u32)),
+			   RangeInclusive::new(0, number_of_blocks as usize),
+		   )
+		   .boxed()
+	   }
+	   #[allow(dead_code)]
+	   fn generate_state() -> BoxedStrategy<BlockProcessor<MockBlockProcessorDefinition>> {
+		   blocks_data(10)
+			   .prop_map(|data| BlockProcessor {
+				   blocks_data: data,
+				   reorg_events: Default::default(),
+				   rules: Default::default(),
+				   execute: IncreasingHook::<(BlockNumber, MockBtcEvent), ()>::default(),
+				   dedup_events: DedupEventsHook {},
+				   safety_margin: Default::default(),
+			   })
+			   .boxed()
+	   }
+	   #[allow(dead_code)]
+	   fn generate_input() -> BoxedStrategy<SMBlockProcessorInput<MockBlockProcessorDefinition>> {
+		   prop_oneof![
+			   (any::<u64>(), block_data()).prop_map(|(n, data)| SMBlockProcessorInput::NewBlockData(
+				   n,
+				   n,
+				   vec![data]
+			   )),
+			   prop_oneof![
+				   (0..=5u64).prop_map(ChainProgressInner::Progress),
+				   (0..=5u64).prop_map(|n| ChainProgressInner::Reorg(
+					   RangeInclusive::<BlockNumber>::new(n, n + 2)
+				   )),
+			   ]
+			   .prop_map(SMBlockProcessorInput::ChainProgress),
+		   ]
+		   .boxed()
+	   }
 
-	#[derive(
-		Clone,
-		PartialEq,
-		Eq,
-		Serialize,
-		Deserialize,
-		Encode,
-		TypeInfo,
-		Decode,
-		Debug,
-		Ord,
-		PartialOrd,
-		Default,
-	)]
-	struct MockBlockProcessorDefinition {}
-	#[derive(
-		Clone,
-		PartialEq,
-		Eq,
-		Serialize,
-		Deserialize,
-		Encode,
-		TypeInfo,
-		Decode,
-		Debug,
-		Ord,
-		PartialOrd,
-		Default,
-	)]
-	struct MockDeposit {
-		pub amount: BtcAmount,
-		pub deposit_address: String,
-	}
-	type MockBlockData = Vec<MockDeposit>;
+	   #[derive(
+		   Clone,
+		   PartialEq,
+		   Eq,
+		   Serialize,
+		   Deserialize,
+		   Encode,
+		   TypeInfo,
+		   Decode,
+		   Debug,
+		   Ord,
+		   PartialOrd,
+		   Default,
+	   )]
+	   struct MockBlockProcessorDefinition {}
+	   #[derive(
+		   Clone,
+		   PartialEq,
+		   Eq,
+		   Serialize,
+		   Deserialize,
+		   Encode,
+		   TypeInfo,
+		   Decode,
+		   Debug,
+		   Ord,
+		   PartialOrd,
+		   Default,
+	   )]
+	   struct MockDeposit {
+		   pub amount: BtcAmount,
+		   pub deposit_address: String,
+	   }
+	   type MockBlockData = Vec<MockDeposit>;
 
-	#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
-	enum MockBtcEvent {
-		PreWitness(MockDeposit),
-		Witness(MockDeposit),
-	}
-	impl MockBtcEvent {
-		pub fn deposit_witness(&self) -> &MockDeposit {
-			match self {
-				MockBtcEvent::PreWitness(dw) | MockBtcEvent::Witness(dw) => dw,
-			}
-		}
-	}
+	   #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
+	   enum MockBtcEvent {
+		   PreWitness(MockDeposit),
+		   Witness(MockDeposit),
+	   }
+	   impl MockBtcEvent {
+		   pub fn deposit_witness(&self) -> &MockDeposit {
+			   match self {
+				   MockBtcEvent::PreWitness(dw) | MockBtcEvent::Witness(dw) => dw,
+			   }
+		   }
+	   }
 
-	impl Hook<(BlockNumber, u32, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>> for ApplyRulesHook {
-		fn run(
-			&mut self,
-			(block, age, block_data): (BlockNumber, u32, MockBlockData),
-		) -> Vec<(BlockNumber, MockBtcEvent)> {
-			// Prewitness rule
-			if age == 0 {
-				return block_data
-					.iter()
-					.map(|deposit_witness| {
-						(block, MockBtcEvent::PreWitness(deposit_witness.clone()))
-					})
-					.collect::<Vec<(BlockNumber, MockBtcEvent)>>();
-			}
-			//Full witness rule
-			if age == 3 {
-				return block_data
-					.iter()
-					.map(|deposit_witness| (block, MockBtcEvent::Witness(deposit_witness.clone())))
-					.collect::<Vec<(BlockNumber, MockBtcEvent)>>();
-			}
-			vec![]
-		}
-	}
+	   impl Hook<(BlockNumber, u32, MockBlockData), Vec<(BlockNumber, MockBtcEvent)>> for ApplyRulesHook {
+		   fn run(
+			   &mut self,
+			   (block, age, block_data): (BlockNumber, u32, MockBlockData),
+		   ) -> Vec<(BlockNumber, MockBtcEvent)> {
+			   // Prewitness rule
+			   if age == 0 {
+				   return block_data
+					   .iter()
+					   .map(|deposit_witness| {
+						   (block, MockBtcEvent::PreWitness(deposit_witness.clone()))
+					   })
+					   .collect::<Vec<(BlockNumber, MockBtcEvent)>>();
+			   }
+			   //Full witness rule
+			   if age == 3 {
+				   return block_data
+					   .iter()
+					   .map(|deposit_witness| (block, MockBtcEvent::Witness(deposit_witness.clone())))
+					   .collect::<Vec<(BlockNumber, MockBtcEvent)>>();
+			   }
+			   vec![]
+		   }
+	   }
 
-	impl Hook<Vec<(BlockNumber, MockBtcEvent)>, Vec<(BlockNumber, MockBtcEvent)>> for DedupEventsHook {
-		fn run(
-			&mut self,
-			events: Vec<(BlockNumber, MockBtcEvent)>,
-		) -> Vec<(BlockNumber, MockBtcEvent)> {
-			// Map: deposit_witness -> chosen BtcEvent
-			// todo! this is annoying, it require us to implement Ord down to the Chain type
-			let mut chosen: BTreeMap<MockDeposit, (BlockNumber, MockBtcEvent)> = BTreeMap::new();
+	   impl Hook<Vec<(BlockNumber, MockBtcEvent)>, Vec<(BlockNumber, MockBtcEvent)>> for DedupEventsHook {
+		   fn run(
+			   &mut self,
+			   events: Vec<(BlockNumber, MockBtcEvent)>,
+		   ) -> Vec<(BlockNumber, MockBtcEvent)> {
+			   // Map: deposit_witness -> chosen BtcEvent
+			   // todo! this is annoying, it require us to implement Ord down to the Chain type
+			   let mut chosen: BTreeMap<MockDeposit, (BlockNumber, MockBtcEvent)> = BTreeMap::new();
 
-			for (block, event) in events {
-				let deposit = event.deposit_witness();
+			   for (block, event) in events {
+				   let deposit = event.deposit_witness();
 
-				match chosen.get(deposit) {
-					None => {
-						// No event yet for this deposit, store it
-						chosen.insert(deposit.clone(), (block, event));
-					},
-					Some((_, existing_event)) => {
-						// There's already an event for this deposit
-						match (existing_event, &event) {
-							// If we already have a Witness, do nothing
-							(MockBtcEvent::Witness(_), MockBtcEvent::PreWitness(_)) => (),
-							// If we have a PreWitness and the new event is a Witness, override it
-							(MockBtcEvent::PreWitness(_), MockBtcEvent::Witness(_)) => {
-								chosen.insert(deposit.clone(), (block, event));
-							},
-							// This should be impossible to reach!
-							(_, _) => (),
-						}
-					},
-				}
-			}
-			chosen.into_values().collect()
-		}
-	}
-	impl BWProcessorTypes for MockBlockProcessorDefinition {
-		type ChainBlockNumber = BlockNumber;
-		type BlockData = MockBlockData;
-		type Event = MockBtcEvent;
-		type Rules = ApplyRulesHook;
-		type Execute = IncreasingHook<(Self::ChainBlockNumber, Self::Event), ()>;
-		type DedupEvents = DedupEventsHook;
-		type SafetyMargin = SafetyMarginHook;
-	}
+				   match chosen.get(deposit) {
+					   None => {
+						   // No event yet for this deposit, store it
+						   chosen.insert(deposit.clone(), (block, event));
+					   },
+					   Some((_, existing_event)) => {
+						   // There's already an event for this deposit
+						   match (existing_event, &event) {
+							   // If we already have a Witness, do nothing
+							   (MockBtcEvent::Witness(_), MockBtcEvent::PreWitness(_)) => (),
+							   // If we have a PreWitness and the new event is a Witness, override it
+							   (MockBtcEvent::PreWitness(_), MockBtcEvent::Witness(_)) => {
+								   chosen.insert(deposit.clone(), (block, event));
+							   },
+							   // This should be impossible to reach!
+							   (_, _) => (),
+						   }
+					   },
+				   }
+			   }
+			   chosen.into_values().collect()
+		   }
+	   }
+	   impl BWProcessorTypes for MockBlockProcessorDefinition {
+		   type ChainBlockNumber = BlockNumber;
+		   type BlockData = MockBlockData;
+		   type Event = MockBtcEvent;
+		   type Rules = ApplyRulesHook;
+		   type Execute = IncreasingHook<(Self::ChainBlockNumber, Self::Event), ()>;
+		   type DedupEvents = DedupEventsHook;
+		   type SafetyMargin = SafetyMarginHook;
+	   }
 
-	#[test]
-	fn test() {
-		let _processor = BlockProcessor::<MockBlockProcessorDefinition>::default();
-	}
- */
+	   #[test]
+	   fn test() {
+		   let _processor = BlockProcessor::<MockBlockProcessorDefinition>::default();
+	   }
+	*/
 }

--- a/state-chain/runtime/src/chainflip/elections.rs
+++ b/state-chain/runtime/src/chainflip/elections.rs
@@ -3,18 +3,6 @@ use derive_where::derive_where;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 
-/// Type which can be used to implement hooks. It implements
-/// all required bounds without requiring any bounds on the
-/// `Tag` type parameter.
-#[derive_where(Default, Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[codec(encode_bound())]
-#[serde(bound = "")]
-#[scale_info(skip_type_params(Tag))]
-pub struct StatelessHookFor<Tag> {
-	_phantom: sp_std::marker::PhantomData<Tag>,
-}
-
 /// Type which can be used for implementing traits that
 /// contain only type definitions, as used in many parts of
 /// the state machine based electoral systems.

--- a/state-chain/runtime/src/chainflip/elections.rs
+++ b/state-chain/runtime/src/chainflip/elections.rs
@@ -32,7 +32,7 @@ pub struct TypesFor<Tag> {
 
 
 macro_rules! impls {
-    (for $name:ty: $(#[doc = $doc_text:tt])? $trait:ident {$($trait_impl:tt)*} $($rest:tt)*) => {
+    (for $name:ty: $(#[doc = $doc_text:tt])? $trait:ty {$($trait_impl:tt)*} $($rest:tt)*) => {
         $(#[doc = $doc_text])?
         impl $trait for $name {
             $($trait_impl)*

--- a/state-chain/runtime/src/chainflip/elections.rs
+++ b/state-chain/runtime/src/chainflip/elections.rs
@@ -1,35 +1,31 @@
-
 use codec::{Decode, Encode};
+use derive_where::derive_where;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use derive_where::derive_where;
-
 
 /// Type which can be used to implement hooks. It implements
-/// all required bounds without requiring any bounds on the 
+/// all required bounds without requiring any bounds on the
 /// `Tag` type parameter.
 #[derive_where(Default, Debug, Clone, PartialEq, Eq;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound())]
-#[serde(bound="")]
+#[serde(bound = "")]
 #[scale_info(skip_type_params(Tag))]
 pub struct StatelessHookFor<Tag> {
-	_phantom: sp_std::marker::PhantomData<Tag>
+	_phantom: sp_std::marker::PhantomData<Tag>,
 }
 
-
-/// Type which can be used for implementing traits that 
+/// Type which can be used for implementing traits that
 /// contain only type definitions, as used in many parts of
 /// the state machine based electoral systems.
 #[derive_where(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound())]
-#[serde(bound="")]
+#[serde(bound = "")]
 #[scale_info(skip_type_params(Tag))]
 pub struct TypesFor<Tag> {
-	_phantom: sp_std::marker::PhantomData<Tag>
+	_phantom: sp_std::marker::PhantomData<Tag>,
 }
-
 
 macro_rules! impls {
     (for $name:ty: $(#[doc = $doc_text:tt])? $trait:ty {$($trait_impl:tt)*} $($rest:tt)*) => {

--- a/state-chain/runtime/src/chainflip/elections.rs
+++ b/state-chain/runtime/src/chainflip/elections.rs
@@ -15,6 +15,23 @@ pub struct TypesFor<Tag> {
 	_phantom: sp_std::marker::PhantomData<Tag>,
 }
 
+/// Syntax sugar for implementing multiple traits for a single type.
+///
+/// Example use:
+/// ```
+/// impls! {
+///     for u8:
+///     Clone {
+///         ...
+///     }
+///     Copy {
+///         ...
+///     }
+///     Default {
+///         ...
+///     }
+/// }
+/// ```
 macro_rules! impls {
     (for $name:ty: $(#[doc = $doc_text:tt])? $trait:ty {$($trait_impl:tt)*} $($rest:tt)*) => {
         $(#[doc = $doc_text])?

--- a/state-chain/runtime/src/chainflip/elections.rs
+++ b/state-chain/runtime/src/chainflip/elections.rs
@@ -1,0 +1,43 @@
+
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use derive_where::derive_where;
+
+
+/// Type which can be used to implement hooks. It implements
+/// all required bounds without requiring any bounds on the 
+/// `Tag` type parameter.
+#[derive_where(Default, Debug, Clone, PartialEq, Eq;)]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound())]
+#[serde(bound="")]
+#[scale_info(skip_type_params(Tag))]
+pub struct StatelessHookFor<Tag> {
+	_phantom: sp_std::marker::PhantomData<Tag>
+}
+
+
+/// Type which can be used for implementing traits that 
+/// contain only type definitions, as used in many parts of
+/// the state machine based electoral systems.
+#[derive_where(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord;)]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound())]
+#[serde(bound="")]
+#[scale_info(skip_type_params(Tag))]
+pub struct TypesFor<Tag> {
+	_phantom: sp_std::marker::PhantomData<Tag>
+}
+
+
+macro_rules! impls {
+    (for $name:ty: $(#[doc = $doc_text:tt])? $trait:ident {$($trait_impl:tt)*} $($rest:tt)*) => {
+        $(#[doc = $doc_text])?
+        impl $trait for $name {
+            $($trait_impl)*
+        }
+        impls!{for $name: $($rest)*}
+    };
+    (for $name:ty:) => {}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2053

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR cleans up how we use hooks, in particular:
 - there is a new trait `HookType` with two associated types `Input` and `Output`.
 - the `Hook` trait now takes `T: HookType` as generic type parameter instead of directly input and output. This allows us to omit specifying the concrete hook input and output types when we implement the hook.
 - There are new "tag types" for each hook, this is useful for the following:
 - When instantiating an electoral system, we now try to implement all traits for a single "associated types carrier type". That is, for example for the BW ES, we implement the traits `ElectoralSystemTypes`, `BlockHeightTrackingTypes`, `StateMachineEs` and a `Hook<...>` all for the same carrier type `TypesFor<BitcoinBlockheightTracking>`.
 - There is a new type wrapper `TypesFor<Tag>`, which is an empty struct for which all usual bounds (encode, serialize, typeinfo, ord, eq, default, etc.) are implemented *without* requiring any bounds on `Tag`. This means that it is easy to create new carrier types implementing all of these traits by simply wrapping your new empty struct type: `TypesFor<MyNewTag>`. 