### PR TITLE
chore: add assert_matches! utility function for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8363,6 +8363,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-runtime 39.0.0",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+ "utilities",
 ]
 
 [[package]]
@@ -8409,6 +8410,7 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
  "strum 0.26.3",
  "strum_macros 0.26.4",
+ "utilities",
 ]
 
 [[package]]

--- a/engine/multisig/src/client/ceremony_manager/tests.rs
+++ b/engine/multisig/src/client/ceremony_manager/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use anyhow::Result;
 use cf_primitives::{AccountId, CeremonyId};
-use cf_utilities::{task_scope::task_scope, threshold_from_share_count};
+use cf_utilities::{assert_matches, task_scope::task_scope, threshold_from_share_count};
 use client::MultisigMessage;
 use futures::{Future, FutureExt};
 use rand::SeedableRng;
@@ -453,8 +453,8 @@ async fn should_route_p2p_message() {
 
 	// Check that a broadcast was sent out. Meaning that the ceremony received the message and moved
 	// to stage 2.
-	assert!(matches!(
+	assert_matches!(
 		outgoing_p2p_receiver.try_recv().unwrap(),
 		OutgoingMultisigStageMessages::Broadcast(..)
-	))
+	);
 }

--- a/engine/multisig/src/client/ceremony_runner/tests.rs
+++ b/engine/multisig/src/client/ceremony_runner/tests.rs
@@ -15,6 +15,7 @@ use crate::{
 	Rng,
 };
 
+use cf_utilities::assert_matches;
 use rand::SeedableRng;
 use sp_runtime::AccountId32;
 use tokio::sync::mpsc;
@@ -169,7 +170,7 @@ async fn should_process_delayed_messages_after_finishing_a_stage() {
 	// Process a stage 1 message. This will cause the ceremony to progress to stage 2 and process
 	// the delayed message. The processing of the delayed message will cause the completion of stage
 	// 2 and therefore fail with BroadcastFailure because the data we used was invalid.
-	assert!(matches!(
+	assert_matches!(
 		ceremony_runner
 			.process_or_delay_message(sender_account_id.clone(), gen_signing_data_stage1(1))
 			.await,
@@ -180,7 +181,7 @@ async fn should_process_delayed_messages_after_finishing_a_stage() {
 				SigningStageName::VerifyCommitmentsBroadcast2
 			)
 		)))
-	));
+	);
 }
 
 // Note: Clippy seems to throw a false positive without this.

--- a/engine/multisig/src/client/multisig_client_tests.rs
+++ b/engine/multisig/src/client/multisig_client_tests.rs
@@ -16,7 +16,7 @@ use mockall::predicate;
 
 use crate::client::key_store_api::MockKeyStoreAPI;
 use cf_primitives::GENESIS_EPOCH;
-use cf_utilities::{assert_err, assert_ok, testing::assert_future_can_complete};
+use cf_utilities::{assert_err, assert_matches, assert_ok, testing::assert_future_can_complete};
 use client::MultisigClient;
 
 #[tokio::test]
@@ -47,10 +47,10 @@ async fn should_ignore_rts_for_unknown_key() {
 	// Check that the signing request fails immediately with an "unknown key" error
 	let (_, failure_reason) = assert_err!(assert_future_can_complete(signing_request_fut));
 	assert_eq!(failure_reason, SigningFailureReason::UnknownKey);
-	assert!(matches!(
+	assert_matches!(
 		assert_ok!(assert_future_can_complete(ceremony_request_receiver.recv())),
 		CeremonyRequest { ceremony_id: DEFAULT_SIGNING_CEREMONY_ID, details: None }
-	));
+	);
 }
 
 #[tokio::test]

--- a/engine/src/common.rs
+++ b/engine/src/common.rs
@@ -1,3 +1,4 @@
+use cf_utilities::assert_matches;
 use std::ops::{Deref, DerefMut};
 
 struct MutexStateAndPoisonFlag<T> {
@@ -93,10 +94,10 @@ pub struct Signaller<T> {
 }
 impl<T: Clone + Send + 'static> Signaller<T> {
 	pub fn signal(self, t: T) {
-		assert!(matches!(
+		assert_matches!(
 			self.sender.try_broadcast(t),
 			Ok(None) | Err(async_broadcast::TrySendError::Closed(_))
-		));
+		);
 	}
 }
 

--- a/engine/src/state_chain_observer/client/error_decoder.rs
+++ b/engine/src/state_chain_observer/client/error_decoder.rs
@@ -136,10 +136,10 @@ mod tests {
 		let dispatch_error = sp_runtime::DispatchError::decode(&mut &encoded_error[..]).unwrap();
 
 		// Message should be erased.
-		assert!(matches!(
+		cf_utilities::assert_matches!(
 			dispatch_error,
 			sp_runtime::DispatchError::Module(ModuleError { message: None, .. })
-		));
+		);
 
 		match ErrorDecoder::default().decode_dispatch_error(dispatch_error) {
 			super::DispatchError::KnownModuleError { pallet, name, error } => {

--- a/foreign-chains/solana/sol-prim/src/tests/pda.rs
+++ b/foreign-chains/solana/sol-prim/src/tests/pda.rs
@@ -7,12 +7,13 @@ mod failures {
 		pda::{Pda, PdaError},
 		Address, PdaAndBump,
 	};
+	use cf_utilities::assert_matches;
 
 	#[test]
 	fn seed_too_long() {
 		let public_key: Address =
 			"J4mK4RXAuizk5aMZw8Vz8W3y7mrCy6dcgniZ4qwZimZE".parse().expect("public key");
-		assert!(matches!(
+		assert_matches!(
 			Pda::from_address(public_key)
 				.expect("derive")
 				.chain_seed("01234567890123456789012345678912")
@@ -20,7 +21,7 @@ mod failures {
 				.chain_seed("012345678901234567890123456789123")
 				.expect_err("33 should be too much"),
 			PdaError::SeedTooLarge
-		));
+		);
 	}
 
 	#[test]
@@ -31,13 +32,13 @@ mod failures {
 			.map(|i| [i])
 			.try_fold(Pda::from_address(public_key).expect("derive"), Pda::chain_seed)
 			.expect("15 should be okay");
-		assert!(matches!(
+		assert_matches!(
 			(1..=consts::SOLANA_PDA_MAX_SEEDS)
 				.map(|i| [i])
 				.try_fold(Pda::from_address(public_key).expect("derive"), Pda::chain_seed)
 				.expect_err("16 should be too many"),
 			PdaError::TooManySeeds
-		));
+		);
 	}
 
 	#[test]
@@ -46,10 +47,10 @@ mod failures {
 			"J4mK4RXAuizk5aMZw8Vz8W3y7mrCy6dcgniZ4qwZimZE".parse().expect("public key");
 		let PdaAndBump { address, .. } =
 			Pda::from_address(public_key).expect("derive").finish().expect("finish");
-		assert!(matches!(
+		assert_matches!(
 			Pda::from_address(address).expect_err("PDA can't be a valid point on a curve"),
 			PdaError::NotAValidPoint,
-		))
+		);
 	}
 }
 

--- a/state-chain/amm/src/limit_orders/tests.rs
+++ b/state-chain/amm/src/limit_orders/tests.rs
@@ -6,7 +6,7 @@ use cf_amm_math::{
 
 use super::*;
 
-use cf_utilities::{assert_ok, assert_panics};
+use cf_utilities::{assert_matches, assert_ok, assert_panics};
 use rand::{Rng, SeedableRng};
 
 type LiquidityProvider = cf_primitives::AccountId;
@@ -276,7 +276,7 @@ fn test_float() {
 #[test]
 fn fee_hundredth_pips() {
 	for bad in [u32::MAX, ONE_IN_HUNDREDTH_PIPS, (ONE_IN_HUNDREDTH_PIPS / 2) + 1] {
-		assert!(matches!(PoolState::new(bad), Err(NewError::InvalidFeeAmount)));
+		assert_matches!(PoolState::new(bad), Err(NewError::InvalidFeeAmount));
 	}
 
 	for good in [0, 1, ONE_IN_HUNDREDTH_PIPS / 2] {
@@ -390,14 +390,14 @@ fn mint() {
 
 		for bad in [MIN_TICK - 1, MAX_TICK + 1] {
 			let mut pool_state = PoolState::new(0).unwrap();
-			assert!(matches!(
+			assert_matches!(
 				pool_state.collect_and_mint::<SD>(
 					&LiquidityProvider::from([0; 32]),
 					bad,
 					1000.into()
 				),
 				Err(PositionError::InvalidTick)
-			));
+			);
 		}
 
 		for good in [MAX_FIXED_POOL_LIQUIDITY, MAX_FIXED_POOL_LIQUIDITY - 1, 1.into()] {
@@ -414,10 +414,10 @@ fn mint() {
 
 		for bad in [MAX_FIXED_POOL_LIQUIDITY + 1, MAX_FIXED_POOL_LIQUIDITY + 2] {
 			let mut pool_state = PoolState::new(0).unwrap();
-			assert!(matches!(
+			assert_matches!(
 				pool_state.collect_and_mint::<SD>(&LiquidityProvider::from([0; 32]), 0, bad),
 				Err(PositionError::Other(MintError::MaximumLiquidity))
-			));
+			);
 		}
 	}
 
@@ -430,33 +430,33 @@ fn burn() {
 	fn inner<SD: SwapDirection + limit_orders::SwapDirection + range_orders::SwapDirection>() {
 		{
 			let mut pool_state = PoolState::new(0).unwrap();
-			assert!(matches!(
+			assert_matches!(
 				pool_state.collect_and_burn::<SD>(
 					&LiquidityProvider::from([0; 32]),
 					MIN_TICK - 1,
 					1000.into()
 				),
 				Err(PositionError::InvalidTick)
-			));
-			assert!(matches!(
+			);
+			assert_matches!(
 				pool_state.collect_and_burn::<SD>(
 					&LiquidityProvider::from([0; 32]),
 					MAX_TICK + 1,
 					1000.into()
 				),
 				Err(PositionError::InvalidTick)
-			));
+			);
 		}
 		{
 			let mut pool_state = PoolState::new(0).unwrap();
-			assert!(matches!(
+			assert_matches!(
 				pool_state.collect_and_burn::<SD>(
 					&LiquidityProvider::from([0; 32]),
 					120,
 					1000.into()
 				),
 				Err(PositionError::NonExistent)
-			));
+			);
 		}
 		{
 			let mut pool_state = PoolState::new(0).unwrap();

--- a/state-chain/cf-integration-tests/src/new_epoch.rs
+++ b/state-chain/cf-integration-tests/src/new_epoch.rs
@@ -8,6 +8,7 @@ use cf_chains::btc::{
 };
 use cf_primitives::{AccountRole, GENESIS_EPOCH};
 use cf_traits::{EpochInfo, KeyProvider};
+use cf_utilities::assert_matches;
 use frame_support::traits::UnfilteredDispatchable;
 use pallet_cf_environment::BitcoinAvailableUtxos;
 use pallet_cf_validator::RotationPhase;
@@ -165,14 +166,14 @@ fn epoch_rotates() {
 			testnet.move_to_the_end_of_epoch();
 			testnet.move_forward_blocks(1);
 
-			assert!(matches!(
+			assert_matches!(
 				Validator::current_rotation_phase(),
 				RotationPhase::KeygensInProgress(..)
-			));
+			);
 
 			testnet.move_forward_blocks(VAULT_ROTATION_BLOCKS);
 
-			assert!(matches!(Validator::current_rotation_phase(), RotationPhase::Idle));
+			assert_matches!(Validator::current_rotation_phase(), RotationPhase::Idle);
 
 			assert_eq!(
 				GENESIS_EPOCH + 1,

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -20,7 +20,7 @@ use cf_chains::{
 };
 use cf_primitives::{AccountRole, AuthorityCount, ForeignChain, SwapRequestId};
 use cf_test_utilities::{assert_events_match, assert_has_matching_event};
-use cf_utilities::bs58_array;
+use cf_utilities::{assert_matches, bs58_array};
 use codec::Encode;
 use frame_support::{
 	assert_err,
@@ -257,10 +257,10 @@ fn can_rotate_solana_vault() {
 			testnet.move_forward_blocks(10);
 
 			// Assert the RotateKey call is built, signed and broadcasted.
-			assert!(matches!(
+			assert_matches!(
 				Validator::current_rotation_phase(),
 				RotationPhase::ActivatingKeys(..)
-			));
+			);
 			System::assert_has_event(RuntimeEvent::SolanaThresholdSigner(
 				pallet_cf_threshold_signature::Event::<Runtime, SolanaInstance>::ThresholdSignatureSuccess {
 					request_id: 3,
@@ -763,14 +763,14 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 			// on_finalize: reach consensus on the egress vote and trigger the fallback mechanism.
 			SolanaElections::on_finalize(System::block_number() + 1);
 			assert_eq!(pallet_cf_ingress_egress::ScheduledEgressFetchOrTransfer::<Runtime, SolanaInstance>::decode_len(), Some(1));
-			assert!(matches!(pallet_cf_ingress_egress::ScheduledEgressFetchOrTransfer::<Runtime, SolanaInstance>::get()[0],
+			assert_matches!(pallet_cf_ingress_egress::ScheduledEgressFetchOrTransfer::<Runtime, SolanaInstance>::get()[0],
 				FetchOrTransfer::Transfer {
 					egress_id: (ForeignChain::Solana, 2),
 					asset: SolAsset::SolUsdc,
 					destination_address: FALLBACK_ADDRESS,
 					..
 				}
-			));
+			);
 
 			// Ensure the previous broadcast data has been cleaned up.
 			assert!(!pallet_cf_broadcast::PendingBroadcasts::<Runtime, SolanaInstance>::get().contains(&ccm_broadcast_id));

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -1298,10 +1298,10 @@ mod test {
 		];
 
 		for (invalid_address, intended_btc_net) in invalid_addresses {
-			assert!(matches!(
+			cf_utilities::assert_matches!(
 				ScriptPubkey::try_from_address(invalid_address, &intended_btc_net,),
 				Err(Error::InvalidAddress)
-			));
+			);
 		}
 
 		// Test cases from: https://rosettacode.org/wiki/Bitcoin/address_validation

--- a/state-chain/chains/src/eth.rs
+++ b/state-chain/chains/src/eth.rs
@@ -240,7 +240,7 @@ mod lifecycle_tests {
 
 	macro_rules! expect_deposit_state {
 		( $state:expr, $asset:expr, $pat:pat ) => {
-			assert!(matches!(
+			cf_utilities::assert_matches!(
 				DepositChannel::<Ethereum> {
 					channel_id: Default::default(),
 					address: Default::default(),
@@ -249,7 +249,7 @@ mod lifecycle_tests {
 				}
 				.fetch_id(),
 				$pat
-			));
+			);
 		};
 	}
 	#[test]

--- a/state-chain/chains/src/evm/api/all_batch.rs
+++ b/state-chain/chains/src/evm/api/all_batch.rs
@@ -61,6 +61,7 @@ mod test_all_batch {
 		AllBatch, FetchAssetParams,
 	};
 	use cf_primitives::chains::assets;
+	use cf_utilities::assert_matches;
 
 	use eth::api::EthereumApi;
 
@@ -225,7 +226,7 @@ mod test_all_batch {
 		.unwrap();
 
 		assert_eq!(all_batch.len(), 1usize);
-		assert!(matches!(all_batch[0].0, EthereumApi::AllBatch(..)));
+		assert_matches!(all_batch[0].0, EthereumApi::AllBatch(..));
 		let tx_builder = match &all_batch[0].0 {
 			EthereumApi::AllBatch(tx_builder) => tx_builder.clone(),
 			_ => unreachable!(),

--- a/state-chain/pallets/cf-funding/Cargo.toml
+++ b/state-chain/pallets/cf-funding/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 [dev-dependencies]
 pallet-cf-flip = { workspace = true, default-features = true }
 cf-test-utilities = { workspace = true, default-features = true }
+cf-utilities = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -1013,6 +1013,7 @@ fn redeem_funds_to_restricted_address_overrides_bound_and_executor_restrictions(
 
 #[cfg(test)]
 mod test_restricted_balances {
+	use cf_utilities::assert_matches;
 	use sp_core::H160;
 
 	use super::*;
@@ -1070,13 +1071,13 @@ mod test_restricted_balances {
 					));
 					let expected_redeemed_amount =
 						initial_balance - Flip::balance(&ALICE) - RedemptionTax::<Test>::get();
-					assert!(matches!(
+					assert_matches!(
 						cf_test_utilities::last_event::<Test>(),
 						RuntimeEvent::Funding(Event::RedemptionRequested {
 							account_id,
 							amount,
 							..
-						}) if account_id == ALICE && amount == expected_redeemed_amount));
+						}) if account_id == ALICE && amount == expected_redeemed_amount);
 				},
 				Some(e) => {
 					assert_noop!(

--- a/state-chain/pallets/cf-ingress-egress/Cargo.toml
+++ b/state-chain/pallets/cf-ingress-egress/Cargo.toml
@@ -41,6 +41,7 @@ sp-core = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
 pallet-cf-governance = { workspace = true, default-features = true }
 cf-test-utilities = { workspace = true, default-features = true }
+cf-utilities = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -43,6 +43,10 @@ use cf_traits::{
 	BalanceApi, DepositApi, EgressApi, EpochInfo, FetchesTransfersLimitProvider, FundingInfo,
 	GetBlockHeight, SafeMode, ScheduledEgressDetails, SwapOutputAction, SwapRequestType,
 };
+
+#[cfg(test)]
+use cf_utilities::assert_matches;
+
 use frame_support::{
 	assert_err, assert_noop, assert_ok,
 	traits::{Hooks, OriginTrait},
@@ -267,14 +271,14 @@ fn can_schedule_deposit_fetch() {
 		request_address_and_deposit(2u64, EthAsset::Eth);
 		request_address_and_deposit(3u64, EthAsset::Flip);
 
-		assert!(matches!(
+		assert_matches!(
 			&ScheduledEgressFetchOrTransfer::<Test, ()>::get()[..],
 			&[
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_FLIP, .. },
 			]
-		));
+		);
 
 		assert_has_event::<Test>(RuntimeEvent::IngressEgress(Event::DepositFetchesScheduled {
 			channel_id: 1,
@@ -283,7 +287,7 @@ fn can_schedule_deposit_fetch() {
 
 		request_address_and_deposit(4u64, EthAsset::Eth);
 
-		assert!(matches!(
+		assert_matches!(
 			&ScheduledEgressFetchOrTransfer::<Test, ()>::get()[..],
 			&[
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
@@ -291,7 +295,7 @@ fn can_schedule_deposit_fetch() {
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_FLIP, .. },
 				FetchOrTransfer::<Ethereum>::Fetch { asset: ETH_ETH, .. },
 			]
-		));
+		);
 	});
 }
 
@@ -771,10 +775,10 @@ fn multi_use_deposit_same_block() {
 				"Expected one AllBatch apicall to be scheduled for address deployment, got {:?}.",
 				pending_api_calls
 			);
-			assert!(matches!(
+			assert_matches!(
 				pending_callbacks.last().unwrap(),
 				RuntimeCall::IngressEgress(PalletCall::finalise_ingress { .. })
-			));
+			);
 		})
 		.then_execute_at_next_block(|ctx| {
 			MockEgressBroadcaster::dispatch_all_success_callbacks();

--- a/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/benchmarking.rs
@@ -8,6 +8,7 @@ use cf_runtime_utilities::StorageDecodeVariant;
 use cf_traits::{
 	AccountRoleRegistry, Chainflip, CurrentEpochIndex, KeyRotationStatusOuter, ThresholdSigner,
 };
+use cf_utilities::assert_matches;
 use frame_benchmarking::{account, v2::*, whitelist_account, whitelisted_caller};
 use frame_support::{
 	assert_ok,
@@ -163,10 +164,10 @@ mod benchmarks {
 			Pallet::<T, I>::on_initialize(5u32.into());
 		}
 
-		assert!(matches!(
+		assert_matches!(
 			<Pallet::<T, I> as KeyRotator>::status(),
 			AsyncResult::Ready(KeyRotationStatusOuter::Failed(..))
-		));
+		);
 	}
 
 	#[benchmark]
@@ -288,11 +289,11 @@ mod benchmarks {
 			KeygenOutcomeFor::<T, I>::Ok(AggKeyFor::<T, I>::benchmark_value()),
 		);
 
-		assert!(matches!(
+		assert_matches!(
 			PendingKeyRotation::<T, I>::get().unwrap(),
 			KeyRotationStatus::AwaitingKeygen { response_status, .. }
 				if response_status.remaining_candidate_count() == 149
-		))
+		);
 	}
 
 	#[benchmark]
@@ -322,11 +323,11 @@ mod benchmarks {
 			assert_ok!(call.dispatch_bypass_filter(origin.into()));
 		}
 
-		assert!(matches!(
+		assert_matches!(
 			PendingKeyRotation::<T, I>::get().unwrap(),
 			KeyRotationStatus::KeygenVerificationComplete { new_public_key }
 				if new_public_key == agg_key
-		))
+		);
 	}
 
 	// NOTE: Test suite not included because of dependency mismatch between benchmarks and mocks.

--- a/state-chain/pallets/cf-threshold-signature/src/mock.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/mock.rs
@@ -15,6 +15,7 @@ use cf_traits::{
 	AccountRoleRegistry, AsyncResult, KeyProvider, Slashing, StartKeyActivationResult,
 	ThresholdSigner, VaultActivator,
 };
+use cf_utilities::assert_matches;
 use codec::{Decode, Encode};
 use frame_support::dispatch::DispatchResultWithPostInfo;
 pub use frame_support::{
@@ -71,10 +72,10 @@ impl MockCallback<MockEthereumChainCrypto> {
 	pub fn call(self) {
 		match self {
 			Self::Regular(request_id, _) => {
-				assert!(matches!(
+				assert_matches!(
 					<EvmThresholdSigner as ThresholdSigner<_>>::signature_result(request_id).1,
 					AsyncResult::Ready(..)
-				));
+				);
 				CALL_DISPATCHED.with(|cell| *(cell.borrow_mut()) = Some(request_id));
 			},
 			Self::Keygen(call) => {
@@ -285,10 +286,10 @@ impl TestHelper for TestRunner<()> {
 				assert_eq!(current_ceremony_id(), initial_ceremony_id);
 			}
 
-			assert!(matches!(
+			assert_matches!(
 				EvmThresholdSigner::signer_and_signature(request_id).unwrap().signature_result,
 				AsyncResult::Pending
-			));
+			);
 		})
 	}
 
@@ -307,10 +308,10 @@ impl TestHelper for TestRunner<()> {
 				pending.remaining_respondents,
 				BTreeSet::from_iter(MockNominator::get_nominees().unwrap_or_default())
 			);
-			assert!(matches!(
+			assert_matches!(
 				EvmThresholdSigner::signer_and_signature(request_id).unwrap().signature_result,
 				AsyncResult::Pending
-			));
+			);
 			assert!(EvmThresholdSigner::request_callback(request_id).is_some());
 		})
 	}

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -8,6 +8,7 @@ use pallet_session::Config as SessionConfig;
 
 use cf_primitives::AccountRole;
 use cf_traits::{AccountRoleRegistry, KeyRotationStatusOuter, SafeMode, SetSafeMode};
+use cf_utilities::assert_matches;
 use frame_benchmarking::v2::*;
 use frame_support::{
 	assert_ok,
@@ -98,7 +99,7 @@ pub fn try_start_keygen<T: RuntimeConfig>(
 		bond: 100u32.into(),
 	}));
 
-	assert!(matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..)));
+	assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..));
 }
 
 #[allow(clippy::multiple_bound_locations)]
@@ -243,7 +244,7 @@ mod benchmarks {
 			Pallet::<T>::start_authority_rotation();
 		}
 
-		assert!(matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..)));
+		assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..));
 	}
 
 	#[benchmark]
@@ -255,8 +256,8 @@ mod benchmarks {
 			Pallet::<T>::start_authority_rotation();
 		}
 
-		assert!(matches!(<T as Config>::SafeMode::get(), SafeMode::CODE_RED));
-		assert!(matches!(CurrentRotationPhase::<T>::get(), RotationPhase::Idle));
+		assert_matches!(<T as Config>::SafeMode::get(), SafeMode::CODE_RED);
+		assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::Idle);
 	}
 
 	/**** 2. RotationPhase::KeygensInProgress *** */
@@ -288,10 +289,10 @@ mod benchmarks {
 			Pallet::<T>::on_initialize(1u32.into());
 		}
 
-		assert!(matches!(
+		assert_matches!(
 			CurrentRotationPhase::<T>::get(),
 			RotationPhase::KeyHandoversInProgress(..)
-		));
+		);
 	}
 
 	#[benchmark]
@@ -302,16 +303,16 @@ mod benchmarks {
 
 		let block = frame_system::Pallet::<T>::current_block_number();
 
-		assert!(matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..)));
+		assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..));
 
 		T::KeyRotator::set_status(AsyncResult::Ready(KeyRotationStatusOuter::KeygenComplete));
 
 		Pallet::<T>::on_initialize(block);
 
-		assert!(matches!(
+		assert_matches!(
 			CurrentRotationPhase::<T>::get(),
 			RotationPhase::KeyHandoversInProgress(..)
-		));
+		);
 
 		T::KeyRotator::set_status(AsyncResult::Ready(KeyRotationStatusOuter::KeyHandoverComplete));
 
@@ -324,7 +325,7 @@ mod benchmarks {
 			Pallet::<T>::on_initialize(1u32.into());
 		}
 
-		assert!(matches!(CurrentRotationPhase::<T>::get(), RotationPhase::NewKeysActivated(..)));
+		assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::NewKeysActivated(..));
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -13,7 +13,7 @@ use cf_traits::{
 	},
 	AccountRoleRegistry, SafeMode, SetSafeMode,
 };
-use cf_utilities::success_threshold_from_share_count;
+use cf_utilities::{assert_matches, success_threshold_from_share_count};
 use frame_support::{
 	assert_noop, assert_ok,
 	error::BadOrigin,
@@ -131,24 +131,24 @@ fn should_retry_rotation_until_success_with_failing_auctions() {
 		})
 		// Now that we have bidders, we should succeed the auction, and complete the rotation
 		.then_advance_n_blocks_and_execute_with_checks(1, || {
-			assert!(matches!(
+			assert_matches!(
 				CurrentRotationPhase::<Test>::get(),
 				RotationPhase::<Test>::KeygensInProgress(..)
-			));
+			);
 			MockKeyRotatorA::keygen_success();
 		})
 		.then_advance_n_blocks_and_execute_with_checks(2, || {
-			assert!(matches!(
+			assert_matches!(
 				CurrentRotationPhase::<Test>::get(),
 				RotationPhase::<Test>::KeyHandoversInProgress(..)
-			));
+			);
 			MockKeyRotatorA::key_handover_success();
 		})
 		.then_advance_n_blocks_and_execute_with_checks(2, || {
-			assert!(matches!(
+			assert_matches!(
 				CurrentRotationPhase::<Test>::get(),
 				RotationPhase::<Test>::ActivatingKeys(..)
-			));
+			);
 			MockKeyRotatorA::keys_activated();
 		})
 		.then_advance_n_blocks_and_execute_with_checks(2, || {
@@ -721,10 +721,10 @@ fn auction_params_must_be_valid_when_set() {
 			}
 		));
 		// Confirm we have an event
-		assert!(matches!(
+		assert_matches!(
 			last_event::<Test>(),
 			mock::RuntimeEvent::ValidatorPallet(Event::PalletConfigUpdated { .. }),
-		));
+		);
 	});
 }
 

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -9,6 +9,7 @@ use cf_traits::{
 	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo,
 	EpochTransitionHandler, VaultActivator,
 };
+use cf_utilities::assert_matches;
 use frame_support::assert_noop;
 use std::collections::BTreeSet;
 
@@ -45,10 +46,10 @@ fn when_set_agg_key_with_agg_key_not_required_we_skip_to_completion() {
 
 		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, Some(Default::default()));
 
-		assert!(matches!(
+		assert_matches!(
 			PendingVaultActivation::<Test, _>::get().unwrap(),
 			VaultActivationStatus::Complete
-		))
+		);
 	});
 }
 
@@ -66,10 +67,10 @@ fn vault_start_block_number_is_set_correctly() {
 			.unwrap(),
 			1001
 		);
-		assert!(matches!(
+		assert_matches!(
 			PendingVaultActivation::<Test, _>::get().unwrap(),
 			VaultActivationStatus::Complete
-		));
+		);
 		assert_last_event!(Event::VaultActivationCompleted);
 	});
 }
@@ -83,10 +84,10 @@ fn vault_start_block_number_not_set_when_chain_not_initialized() {
 		VaultsPallet::start_key_activation(NEW_AGG_PUBKEY, Some(Default::default()));
 		VaultsPallet::activate_key();
 		assert!(VaultStartBlockNumbers::<Test, _>::iter_keys().next().is_none());
-		assert!(matches!(
+		assert_matches!(
 			PendingVaultActivation::<Test, _>::get().unwrap(),
 			VaultActivationStatus::Complete
-		));
+		);
 	});
 }
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -33,6 +33,13 @@ macro_rules! assert_err {
 	};
 }
 
+#[macro_export]
+macro_rules! assert_matches {
+	($left:expr, $pattern:pat $(if $guard:expr)?$(,)?) => {
+		assert!(matches!($left, $pattern $(if $guard)?))
+	};
+}
+
 /// Note that the resulting `threshold` is the maximum number of parties *not* enough to generate a
 /// signature,
 ///
@@ -294,5 +301,25 @@ mod test_asserts {
 	#[test]
 	fn test_assert_ok_err() {
 		assert_panics!(assert_ok!(Err::<u32, u32>(1)));
+	}
+
+	#[test]
+	fn test_assert_matches() {
+		#[allow(dead_code)]
+		struct Foo {
+			pub a: u8,
+			pub b: u8,
+		}
+		#[allow(dead_code)]
+		enum Bar {
+			A(u8),
+			B(String),
+		}
+		assert_panics!(assert_matches!(Some(Bar::A(6u8)), Some(Bar::B(..))));
+		assert_panics!(assert_matches!(Some(Bar::A(6u8)), Some(Bar::A(value)) if value == 5u8));
+
+		assert_matches!(Some(vec![0x01]), Some(..));
+
+		assert_matches!(Some(Foo { a: 1u8, b: 2u8 }), Some(Foo { a: 1u8, .. }));
 	}
 }

--- a/utilities/src/with_std/dynamic_events.rs
+++ b/utilities/src/with_std/dynamic_events.rs
@@ -430,13 +430,13 @@ mod test {
 			raw_error,
 			outcome(failed_1),
 		);
-		assert!(matches!(
+		crate::assert_matches!(
 			outcome(failed_2).unwrap_err(),
 			DispatchError::KnownModuleError {
 				pallet,
 				name,
-				error
+				error,
 			} if pallet == ERROR_PALLET && name == ERROR_NAME && error == ERROR
-		));
+		);
 	}
 }


### PR DESCRIPTION
# Pull Request
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Added a new "assert_matches" utility macro that can be used to replace `assert!(matches!())`
Just adds a little syntactic sugar.
