### PR TITLE
feat: refund fee

### DIFF
--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -201,7 +201,7 @@ pub trait Chain: Member + Parameter + ChainInstanceAlias {
 		+ Default
 		+ AtLeast32BitUnsigned
 		+ Into<AssetAmount>
-		+ TryFrom<AssetAmount>
+		+ TryFrom<AssetAmount, Error: Debug>
 		+ FullCodec
 		+ MaxEncodedLen
 		+ BenchmarkValue;

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2378,15 +2378,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				// NOTE: if asset is FLIP, we shouldn't need to swap, but it should still work, and
 				// it seems easiest to not write a special case (esp if we only support boost for
 				// BTC)
-				Some(T::SwapRequestHandler::init_swap_request(
+				Some(T::SwapRequestHandler::init_network_fee_swap_request(
 					asset.into(),
 					network_fee_from_boost.into(),
-					Asset::Flip,
-					SwapRequestType::NetworkFee,
-					Default::default(),
-					None,
-					None,
-					SwapOrigin::Internal,
 				))
 			} else {
 				None

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2757,15 +2757,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}), available_amount);
 
 			if !transaction_fee.is_zero() {
-				T::SwapRequestHandler::init_swap_request(
-					asset.into(),
-					transaction_fee.into(),
-					<T::TargetChain as Chain>::GAS_ASSET.into(),
-					SwapRequestType::IngressEgressFee,
-					Default::default(),
-					None, /* no refund params */
-					None, /* no DCA */
-					SwapOrigin::Internal,
+				T::SwapRequestHandler::init_ingress_egress_fee_swap_request::<T::TargetChain>(
+					asset,
+					transaction_fee,
 				);
 			}
 

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -1,15 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../../cf-doc-head.md")]
 
-use cf_chains::{
-	address::AddressConverter, AccountOrAddress, AnyChain, ForeignChainAddress,
-	RefundParametersExtended,
-};
+use cf_chains::{address::AddressConverter, AccountOrAddress, AnyChain, ForeignChainAddress};
 use cf_primitives::{AccountRole, Asset, AssetAmount, BasisPoints, DcaParameters, ForeignChain};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountRoleRegistry, BalanceApi, BoostApi, Chainflip, DepositApi,
-	EgressApi, LpRegistration, PoolApi, ScheduledEgressDetails, SwapOutputAction,
-	SwapRequestHandler, SwapRequestType,
+	EgressApi, LpRegistration, PoolApi, ScheduledEgressDetails, SwapRequestHandler,
 };
 
 use sp_std::vec;
@@ -37,7 +33,7 @@ impl_pallet_safe_mode!(PalletSafeMode; deposit_enabled, withdrawal_enabled);
 
 #[frame_support::pallet]
 pub mod pallet {
-	use cf_chains::{AccountOrAddress, Chain, SwapOrigin};
+	use cf_chains::{AccountOrAddress, Chain};
 	use cf_primitives::{BlockNumber, ChannelId, EgressId, Price};
 	use cf_traits::HistoricalFeeMigration;
 
@@ -347,23 +343,14 @@ pub mod pallet {
 			T::BalanceApi::try_debit_account(&account_id, input_asset, amount)
 				.map_err(|_| Error::<T>::InsufficientBalance)?;
 
-			T::SwapRequestHandler::init_swap_request(
+			T::SwapRequestHandler::init_internal_swap_request(
 				input_asset,
 				amount,
 				output_asset,
-				SwapRequestType::Regular {
-					output_action: SwapOutputAction::CreditOnChain {
-						account_id: account_id.clone(),
-					},
-				},
-				Default::default(), /* no broker fees */
-				Some(RefundParametersExtended {
-					retry_duration,
-					refund_destination: AccountOrAddress::InternalAccount(account_id.clone()),
-					min_price,
-				}),
+				retry_duration,
+				min_price,
 				dca_params,
-				SwapOrigin::OnChainAccount(account_id),
+				account_id,
 			);
 
 			Ok(())

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -841,16 +841,7 @@ pub mod pallet {
 				{
 					weight_used.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
 					CollectedNetworkFee::<T>::mutate(|collected_fee| {
-						Self::init_swap_request(
-							Asset::Usdc,
-							*collected_fee,
-							Asset::Flip,
-							SwapRequestType::NetworkFee,
-							Default::default(),
-							None, /* no refund */
-							None, /* no DCA */
-							SwapOrigin::Internal,
-						);
+						Self::init_network_fee_swap_request(Asset::Usdc, *collected_fee);
 
 						collected_fee.set_zero();
 					});
@@ -2129,16 +2120,7 @@ pub mod pallet {
 			let remaining_amount_to_refund = total_input_amount.saturating_sub(refund_fee);
 
 			if refund_fee > 0 {
-				Self::init_swap_request(
-					input_asset,
-					refund_fee,
-					Asset::Flip,
-					SwapRequestType::NetworkFee,
-					Default::default(), /* broker fees */
-					None,
-					None,
-					SwapOrigin::Internal,
-				);
+				Self::init_network_fee_swap_request(input_asset, refund_fee);
 			}
 
 			Ok(remaining_amount_to_refund)

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2293,7 +2293,7 @@ pub mod pallet {
 				required_gas.into(),
 				true,
 			)
-			.map(|amount| C::ChainAmount::try_from(amount).expect("Asset amount is for this chain"))
+			.and_then(|amount| C::ChainAmount::try_from(amount).ok())
 		}
 
 		fn calculate_input_for_desired_output(
@@ -2336,8 +2336,11 @@ pub mod pallet {
 				.defensive_proof(
 					"Unexpected overflow occurred during asset conversion. Please report this to Chainflip Labs."
 				)?;
-
-				Some(input_amount_to_convert.unique_saturated_into())
+				if input_amount_to_convert.is_zero() {
+					None
+				} else {
+					Some(input_amount_to_convert.unique_saturated_into())
+				}
 			}
 		}
 	}

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1513,21 +1513,14 @@ mod on_chain_swapping {
 
 		new_test_ext()
 			.execute_with(|| {
-				Swapping::init_swap_request(
+				Swapping::init_internal_swap_request(
 					INPUT_ASSET,
 					INPUT_AMOUNT,
 					OUTPUT_ASSET,
-					SwapRequestType::Regular {
-						output_action: SwapOutputAction::CreditOnChain { account_id: LP_ACCOUNT },
-					},
-					Default::default(),
-					Some(RefundParametersExtended {
-						retry_duration: 0,
-						refund_destination: AccountOrAddress::InternalAccount(LP_ACCOUNT),
-						min_price,
-					}),
+					0,
+					min_price,
 					None,
-					SwapOrigin::OnChainAccount(LP_ACCOUNT),
+					LP_ACCOUNT,
 				);
 
 				assert_has_matching_event!(
@@ -1597,21 +1590,14 @@ mod on_chain_swapping {
 		new_test_ext()
 			.execute_with(|| {
 				MinimumNetworkFeePerChunk::<Test>::set(MIN_NETWORK_FEE);
-				Swapping::init_swap_request(
+				Swapping::init_internal_swap_request(
 					INPUT_ASSET,
 					INPUT_AMOUNT,
 					OUTPUT_ASSET,
-					SwapRequestType::Regular {
-						output_action: SwapOutputAction::CreditOnChain { account_id: LP_ACCOUNT },
-					},
-					Default::default(),
-					Some(RefundParametersExtended {
-						retry_duration: 0,
-						refund_destination: AccountOrAddress::InternalAccount(LP_ACCOUNT),
-						min_price,
-					}),
+					0,
+					min_price,
 					Some(DcaParameters { number_of_chunks: 2, chunk_interval: 2 }),
-					SwapOrigin::OnChainAccount(LP_ACCOUNT),
+					LP_ACCOUNT,
 				);
 
 				assert_has_matching_event!(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1296,166 +1296,6 @@ fn broker_deregistration_checks_private_channels() {
 	});
 }
 
-#[test]
-fn swap_output_amounts_correctly_account_for_fees() {
-	for (from, to) in
-		// non-stable to non-stable, non-stable to stable, stable to non-stable
-		[(Asset::Btc, Asset::Eth), (Asset::Btc, Asset::Usdc), (Asset::Usdc, Asset::Eth)]
-	{
-		new_test_ext().execute_with(|| {
-			const INPUT_AMOUNT: AssetAmount = 1000;
-
-			let network_fee = Permill::from_percent(1);
-			NetworkFee::set(network_fee);
-
-			let expected_output: AssetAmount = {
-				let usdc_amount = if from == Asset::Usdc {
-					INPUT_AMOUNT
-				} else {
-					INPUT_AMOUNT * DEFAULT_SWAP_RATE
-				};
-
-				let usdc_after_network_fees = usdc_amount - network_fee * usdc_amount;
-
-				if to == Asset::Usdc {
-					usdc_after_network_fees
-				} else {
-					usdc_after_network_fees * DEFAULT_SWAP_RATE
-				}
-			};
-
-			{
-				Swapping::init_swap_request(
-					from,
-					INPUT_AMOUNT,
-					to,
-					SwapRequestType::Regular {
-						output_action: SwapOutputAction::Egress {
-							output_address: ForeignChainAddress::Eth(H160::zero()),
-							ccm_deposit_metadata: None,
-						},
-					},
-					Default::default(),
-					None,
-					None,
-					SwapOrigin::Vault {
-						tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
-						broker_id: Some(BROKER),
-					},
-				);
-
-				Swapping::on_finalize(System::block_number() + SWAP_DELAY_BLOCKS as u64);
-
-				assert_eq!(
-					MockEgressHandler::<AnyChain>::get_scheduled_egresses(),
-					vec![MockEgressParameter::Swap {
-						asset: to,
-						amount: expected_output,
-						fee: 0,
-						destination_address: ForeignChainAddress::Eth(H160::zero()),
-					},]
-				);
-			}
-		});
-	}
-}
-
-#[test]
-fn test_buy_back_flip() {
-	new_test_ext().execute_with(|| {
-		const INTERVAL: BlockNumberFor<Test> = 5;
-		const SWAP_AMOUNT: AssetAmount = 1000;
-		const NETWORK_FEE: Permill = Permill::from_percent(2);
-
-		NetworkFee::set(NETWORK_FEE);
-
-		// Get some network fees, just like we did a swap.
-		let FeeTaken { remaining_amount, fee: network_fee } =
-			Swapping::take_network_fee(SWAP_AMOUNT, false);
-
-		// Sanity check the network fee.
-		assert_eq!(network_fee, CollectedNetworkFee::<Test>::get());
-		assert_eq!(network_fee, 20);
-		assert_eq!(remaining_amount + network_fee, SWAP_AMOUNT);
-
-		// The default buy interval is zero. Check that buy back is disabled & on_initialize does
-		// not panic.
-		assert_eq!(FlipBuyInterval::<Test>::get(), 0);
-		Swapping::on_initialize(1);
-		assert_eq!(network_fee, CollectedNetworkFee::<Test>::get());
-
-		// Set a non-zero buy interval
-		FlipBuyInterval::<Test>::set(INTERVAL);
-
-		// Nothing is bought if we're not at the interval.
-		Swapping::on_initialize(INTERVAL * 3 - 1);
-		assert_eq!(network_fee, CollectedNetworkFee::<Test>::get());
-
-		// If we're at an interval, we should buy flip.
-		Swapping::on_initialize(INTERVAL * 3);
-		assert_eq!(0, CollectedNetworkFee::<Test>::get());
-
-		// Note that the network fee will not be charged in this case:
-		assert_eq!(
-			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS))
-				.first()
-				.expect("Should have scheduled a swap usdc -> flip"),
-			&Swap::new(1.into(), 1.into(), STABLE_ASSET, Asset::Flip, network_fee, None, [],)
-		);
-	});
-}
-
-#[test]
-fn test_calculate_input_for_gas_output() {
-	use cf_chains::assets::eth::Asset as EthereumAsset;
-	const FLIP: EthereumAsset = EthereumAsset::Flip;
-
-	new_test_ext().execute_with(|| {
-		// If swap simulation fails -> no conversion.
-		MockSwappingApi::set_swaps_should_fail(true);
-		assert!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 1000).is_none());
-
-		// Set swap rate to 2 and turn swaps back on.
-		SwapRate::set(2_f64);
-		MockSwappingApi::set_swaps_should_fail(false);
-
-		// Desired output is zero -> trivially ok.
-		assert_eq!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 0), Some(0));
-
-		// Desired output requires 2 swap legs, each with a swap rate of 2. So output should be
-		// 1/4th of input.
-		assert_eq!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 1000), Some(250));
-
-		// Desired output is gas asset, requires 1 swap leg. So output should be 1/2 of input.
-		assert_eq!(
-			Swapping::calculate_input_for_gas_output::<Ethereum>(EthereumAsset::Usdc, 1000),
-			Some(500)
-		);
-
-		// Input is gas asset -> trivially ok.
-		assert_eq!(
-			Swapping::calculate_input_for_gas_output::<Ethereum>(
-				cf_chains::assets::eth::GAS_ASSET,
-				1000
-			),
-			Some(1000)
-		);
-	});
-}
-
-#[test]
-fn test_fee_estimation_basis() {
-	for asset in Asset::all() {
-		if !asset.is_gas_asset() {
-			assert!(
-				utilities::fee_estimation_basis(asset).is_some(),
-	             "No fee estimation cap defined for {:?}. Add one to the fee_estimation_basis function definition.",
-	             asset,
-	         );
-		}
-	}
-}
-
 #[cfg(test)]
 mod swap_batching {
 
@@ -1746,6 +1586,8 @@ mod on_chain_swapping {
 
 		// We require the minimum network fee to be non-zero for the refund fee to work, so this
 		// must be taken into account in the min_price calculation.
+		// Note that the `NetworkFee` is set to 0 by default, so the minimum network fee will be
+		// charged instead.
 		let min_price = U256::from(
 			(DEFAULT_SWAP_RATE as f64 *
 				DEFAULT_SWAP_RATE as f64 *
@@ -1803,11 +1645,10 @@ mod on_chain_swapping {
 			})
 			.then_process_blocks_until_block(CHUNK_2_BLOCK)
 			.then_execute_with(|_| {
-				const REFUND_FEE: AssetAmount = MIN_NETWORK_FEE * NEW_SWAP_RATE as u128;
+				const REFUND_FEE: AssetAmount = MIN_NETWORK_FEE / NEW_SWAP_RATE as u128;
 				// Only one chunk is expected to be swapped:
 				const EXPECTED_OUTPUT_AMOUNT: AssetAmount =
-					CHUNK_AMOUNT * DEFAULT_SWAP_RATE * DEFAULT_SWAP_RATE -
-						MIN_NETWORK_FEE * DEFAULT_SWAP_RATE;
+					(CHUNK_AMOUNT * DEFAULT_SWAP_RATE - MIN_NETWORK_FEE) * DEFAULT_SWAP_RATE;
 				const EXPECTED_REFUND_AMOUNT: AssetAmount = CHUNK_AMOUNT - REFUND_FEE;
 
 				assert_event_sequence!(

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -636,3 +636,23 @@ fn test_refund_fee_calculation() {
 		assert_eq!(Swapping::take_refund_fee(3, Asset::Eth), Ok(0));
 	});
 }
+
+#[test]
+fn gas_calculation_can_handle_invalid_swap_rate() {
+	new_test_ext().execute_with(|| {
+		fn test_invalid_swap_rate(swap_rate: f64) {
+			SwapRate::set(swap_rate);
+			assert_eq!(
+				Swapping::calculate_input_for_gas_output::<Ethereum>(
+					cf_chains::assets::eth::Asset::Flip,
+					1000
+				),
+				None
+			);
+		}
+
+		test_invalid_swap_rate(1_f64 / (u128::MAX as f64));
+		test_invalid_swap_rate(0_f64);
+		test_invalid_swap_rate(u128::MAX as f64);
+	});
+}

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -222,16 +222,7 @@ fn network_fee_swap_gets_burnt() {
 
 	new_test_ext()
 		.execute_with(|| {
-			Swapping::init_swap_request(
-				INPUT_ASSET,
-				AMOUNT,
-				OUTPUT_ASSET,
-				SwapRequestType::NetworkFee,
-				Default::default(),
-				None,
-				None,
-				SwapOrigin::Internal,
-			);
+			Swapping::init_network_fee_swap_request(INPUT_ASSET, AMOUNT);
 
 			assert_eq!(FlipToBurn::<Test>::get(), 0);
 

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -153,54 +153,63 @@ fn test_network_fee_calculation() {
 }
 
 #[test]
-fn test_calculate_input_for_gas_output() {
-	use cf_chains::assets::eth::Asset as EthereumAsset;
-	const FLIP: EthereumAsset = EthereumAsset::Flip;
-
+fn test_calculate_input_for_desired_output() {
 	new_test_ext().execute_with(|| {
 		// If swap simulation fails -> no conversion.
 		MockSwappingApi::set_swaps_should_fail(true);
-		assert!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 1000).is_none());
+		assert!(Swapping::calculate_input_for_desired_output(Asset::Flip, Asset::Eth, 1000, true)
+			.is_none());
 
 		// Set swap rate to 2 and turn swaps back on.
 		SwapRate::set(2_f64);
 		MockSwappingApi::set_swaps_should_fail(false);
 
 		// Desired output is zero -> trivially ok.
-		assert_eq!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 0), Some(0));
+		assert_eq!(
+			Swapping::calculate_input_for_desired_output(Asset::Flip, Asset::Eth, 0, true),
+			Some(0)
+		);
 
 		// Desired output requires 2 swap legs, each with a swap rate of 2. So output should be
 		// 1/4th of input.
-		assert_eq!(Swapping::calculate_input_for_gas_output::<Ethereum>(FLIP, 1000), Some(250));
+		assert_eq!(
+			Swapping::calculate_input_for_desired_output(Asset::Flip, Asset::Eth, 1000, true),
+			Some(250)
+		);
+		// Answer should be the same for gas calculation function
+		assert_eq!(
+			Swapping::calculate_input_for_gas_output::<Ethereum>(
+				cf_chains::assets::eth::Asset::Flip,
+				1000
+			),
+			Some(250)
+		);
 
 		// Desired output is gas asset, requires 1 swap leg. So output should be 1/2 of input.
 		assert_eq!(
-			Swapping::calculate_input_for_gas_output::<Ethereum>(EthereumAsset::Usdc, 1000),
+			Swapping::calculate_input_for_desired_output(Asset::Usdc, Asset::Eth, 1000, true),
 			Some(500)
 		);
 
-		// Input is gas asset -> trivially ok.
+		// Input is same asset -> trivially ok.
 		assert_eq!(
-			Swapping::calculate_input_for_gas_output::<Ethereum>(
-				cf_chains::assets::eth::GAS_ASSET,
-				1000
-			),
+			Swapping::calculate_input_for_desired_output(Asset::Eth, Asset::Eth, 1000, true),
 			Some(1000)
 		);
-	});
-}
 
-#[test]
-fn test_fee_estimation_basis() {
-	for asset in Asset::all() {
-		if !asset.is_gas_asset() {
-			assert!(
-				utilities::fee_estimation_basis(asset).is_some(),
-	             "No fee estimation cap defined for {:?}. Add one to the fee_estimation_basis function definition.",
-	             asset,
-	         );
-		}
-	}
+		// Make sure the network fee is taken.
+		NetworkFee::set(Permill::from_percent(1));
+		assert_eq!(
+			Swapping::calculate_input_for_desired_output(Asset::Eth, Asset::Usdc, 1000, true),
+			Some(505)
+		);
+
+		// Now that the network fee is not 0, make sure it can be ignored if desired.
+		assert_eq!(
+			Swapping::calculate_input_for_desired_output(Asset::Eth, Asset::Usdc, 1000, false),
+			Some(500)
+		);
+	});
 }
 
 #[test]
@@ -630,9 +639,9 @@ fn test_refund_fee_calculation() {
 		assert_eq!(Swapping::take_refund_fee(5, Asset::Usdc), Ok(0));
 		assert_eq!(Swapping::take_refund_fee(u128::MAX, Asset::Usdc), Ok(u128::MAX - 10));
 
-		// Conversion needed, so the refund fee is 10 * DEFAULT_SWAP_RATE = 20
-		assert_eq!(Swapping::take_refund_fee(1000, Asset::Eth), Ok(980));
+		// Conversion needed, so the refund fee is 10 / DEFAULT_SWAP_RATE = 5
+		assert_eq!(Swapping::take_refund_fee(1000, Asset::Eth), Ok(995));
 		assert_eq!(Swapping::take_refund_fee(0, Asset::Eth), Ok(0));
-		assert_eq!(Swapping::take_refund_fee(15, Asset::Eth), Ok(0));
+		assert_eq!(Swapping::take_refund_fee(3, Asset::Eth), Ok(0));
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -638,9 +638,9 @@ fn test_refund_fee_calculation() {
 }
 
 #[test]
-fn gas_calculation_can_handle_invalid_swap_rate() {
+fn gas_calculation_can_handle_extreme_swap_rate() {
 	new_test_ext().execute_with(|| {
-		fn test_invalid_swap_rate(swap_rate: f64) {
+		fn test_extreme_swap_rate(swap_rate: f64) {
 			SwapRate::set(swap_rate);
 			assert_eq!(
 				Swapping::calculate_input_for_gas_output::<Ethereum>(
@@ -651,8 +651,19 @@ fn gas_calculation_can_handle_invalid_swap_rate() {
 			);
 		}
 
-		test_invalid_swap_rate(1_f64 / (u128::MAX as f64));
-		test_invalid_swap_rate(0_f64);
-		test_invalid_swap_rate(u128::MAX as f64);
+		test_extreme_swap_rate(1_f64 / (u128::MAX as f64));
+		test_extreme_swap_rate(0_f64);
+		test_extreme_swap_rate(u128::MAX as f64);
+
+		// Using Solana here because it has a ChainAmount of u64, so the conversion to AssetAmount
+		// will fail when gas needed is larger than u64::MAX.
+		SwapRate::set(0.5);
+		assert_eq!(
+			Swapping::calculate_input_for_gas_output::<cf_chains::Solana>(
+				cf_chains::assets::sol::Asset::SolUsdc,
+				u64::MAX
+			),
+			None
+		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -618,3 +618,21 @@ fn min_network_fee_is_enforced_in_regular_swaps() {
 			);
 		});
 }
+
+#[test]
+fn test_refund_fee_calculation() {
+	new_test_ext().execute_with(|| {
+		MinimumNetworkFeePerChunk::<Test>::set(10);
+
+		// Usdc, no conversion needed, so the refund fee is just 10
+		assert_eq!(Swapping::take_refund_fee(1000, Asset::Usdc), Ok(990));
+		assert_eq!(Swapping::take_refund_fee(0, Asset::Usdc), Ok(0));
+		assert_eq!(Swapping::take_refund_fee(5, Asset::Usdc), Ok(0));
+		assert_eq!(Swapping::take_refund_fee(u128::MAX, Asset::Usdc), Ok(u128::MAX - 10));
+
+		// Conversion needed, so the refund fee is 10 * DEFAULT_SWAP_RATE = 20
+		assert_eq!(Swapping::take_refund_fee(1000, Asset::Eth), Ok(980));
+		assert_eq!(Swapping::take_refund_fee(0, Asset::Eth), Ok(0));
+		assert_eq!(Swapping::take_refund_fee(15, Asset::Eth), Ok(0));
+	});
+}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -988,6 +988,17 @@ pub trait AssetConverter {
 		input_asset: C::ChainAsset,
 		required_gas: C::ChainAmount,
 	) -> Option<C::ChainAmount>;
+
+	/// Calculate the amount that is required to receive the given amount of a different asset after
+	/// a swap.
+	///
+	/// Use this for transaction fees only.
+	fn calculate_input_for_desired_output(
+		input_asset: Asset,
+		output_asset: Asset,
+		desired_output_amount: AssetAmount,
+		with_network_fee: bool,
+	) -> Option<AssetAmount>;
 }
 
 pub trait IngressEgressFeeApi<C: Chain> {

--- a/state-chain/traits/src/mocks/asset_converter.rs
+++ b/state-chain/traits/src/mocks/asset_converter.rs
@@ -33,7 +33,7 @@ impl AssetConverter for MockAssetConverter {
 			required_gas.into(),
 			true,
 		)
-		.map(|amount| C::ChainAmount::try_from(amount).expect("Asset amount is for this chain"))
+		.and_then(|amount| C::ChainAmount::try_from(amount).ok())
 	}
 
 	fn calculate_input_for_desired_output(

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -71,4 +71,20 @@ pub trait SwapRequestHandler {
 		dca_params: Option<DcaParameters>,
 		origin: SwapOrigin<Self::AccountId>,
 	) -> SwapRequestId;
+
+	fn init_network_fee_swap_request(
+		input_asset: Asset,
+		input_amount: AssetAmount,
+	) -> SwapRequestId {
+		Self::init_swap_request(
+			input_asset,
+			input_amount,
+			Asset::Flip,
+			SwapRequestType::NetworkFee,
+			Default::default(), /* broker fees */
+			None,               /* refund params */
+			None,               /* dca params */
+			SwapOrigin::Internal,
+		)
+	}
 }

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -1,8 +1,11 @@
 use cf_chains::{
 	address::{AddressConverter, EncodedAddress},
-	CcmDepositMetadataGeneric, ForeignChainAddress, RefundParametersExtended, SwapOrigin,
+	AccountOrAddress, CcmDepositMetadataGeneric, Chain, ForeignChainAddress,
+	RefundParametersExtended, SwapOrigin,
 };
-use cf_primitives::{Asset, AssetAmount, Beneficiaries, DcaParameters, SwapRequestId};
+use cf_primitives::{
+	Asset, AssetAmount, Beneficiaries, BlockNumber, DcaParameters, Price, SwapRequestId,
+};
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
@@ -59,7 +62,7 @@ pub type SwapRequestType<AccountId> = SwapRequestTypeGeneric<ForeignChainAddress
 pub type SwapRequestTypeEncoded<AccountId> = SwapRequestTypeGeneric<EncodedAddress, AccountId>;
 
 pub trait SwapRequestHandler {
-	type AccountId;
+	type AccountId: Clone;
 
 	fn init_swap_request(
 		input_asset: Asset,
@@ -85,6 +88,49 @@ pub trait SwapRequestHandler {
 			None,               /* refund params */
 			None,               /* dca params */
 			SwapOrigin::Internal,
+		)
+	}
+
+	fn init_ingress_egress_fee_swap_request<C: Chain>(
+		input_asset: C::ChainAsset,
+		input_amount: C::ChainAmount,
+	) -> SwapRequestId {
+		Self::init_swap_request(
+			input_asset.into(),
+			input_amount.into(),
+			C::GAS_ASSET.into(),
+			SwapRequestType::IngressEgressFee,
+			Default::default(), /* broker fees */
+			None,               /* refund params */
+			None,               /* dca params */
+			SwapOrigin::Internal,
+		)
+	}
+
+	fn init_internal_swap_request(
+		input_asset: Asset,
+		input_amount: AssetAmount,
+		output_asset: Asset,
+		retry_duration: BlockNumber,
+		min_price: Price,
+		dca_params: Option<DcaParameters>,
+		account_id: Self::AccountId,
+	) -> SwapRequestId {
+		Self::init_swap_request(
+			input_asset,
+			input_amount,
+			output_asset,
+			SwapRequestType::Regular {
+				output_action: SwapOutputAction::CreditOnChain { account_id: account_id.clone() },
+			},
+			Default::default(), /* no broker fees */
+			Some(RefundParametersExtended {
+				retry_duration,
+				refund_destination: AccountOrAddress::InternalAccount(account_id.clone()),
+				min_price,
+			}),
+			dca_params,
+			SwapOrigin::OnChainAccount(account_id),
 		)
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2000

## Checklist

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have updated documentation where appropriate.

## Summary

- Reusing the minimum network fee as a refund fee.
- Made the gas fee calculation more general so I could reuse the code for the refund fee.
	- Add fee estimation basis for the rest of the assets, not just gas ones anymore.
- Updated an existing refund test to take the refund fee into account and check that it operates correctly.
- Added some more init swap request functions for the different types.
- Removed a few duplicate swapping unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced swap functionality with dedicated fee management options, allowing for network, ingress/egress, and internal fee processing.
	- Added improved asset estimation for determining the necessary input to achieve a desired output, including clearer refund fee calculations.

- **Refactor**
	- Streamlined swap request processing by reducing complexity in request parameters.
	- Improved error reporting during conversions, leading to more precise handling of fee-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->