### PR TITLE
feat: add channel action type to result of `cf_all_open_deposit_channels` rpc.

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -5,7 +5,9 @@ use cf_utilities::{
 use chainflip_api::{
 	self,
 	primitives::{
-		state_chain_runtime::runtime_apis::{ChainAccounts, TransactionScreeningEvents},
+		state_chain_runtime::runtime_apis::{
+			ChainAccounts, ChannelActionType, TransactionScreeningEvents,
+		},
 		AccountRole, Affiliates, Asset, BasisPoints, CcmChannelMetadata, DcaParameters,
 	},
 	settings::StateChain,
@@ -108,7 +110,9 @@ pub trait Rpc {
 	) -> RpcResult<ChainAccounts>;
 
 	#[method(name = "all_open_deposit_channels", aliases = ["broker_allOpenDepositChannels"])]
-	async fn all_open_deposit_channels(&self) -> RpcResult<Vec<(AccountId32, ChainAccounts)>>;
+	async fn all_open_deposit_channels(
+		&self,
+	) -> RpcResult<Vec<(AccountId32, ChannelActionType, ChainAccounts)>>;
 
 	#[subscription(name = "subscribe_transaction_screening_events", item = BlockUpdate<TransactionScreeningEvents>)]
 	async fn subscribe_transaction_screening_events(&self) -> SubscriptionResult;
@@ -205,7 +209,9 @@ impl RpcServer for RpcServerImpl {
 			.map_err(BrokerApiError::ClientError)
 	}
 
-	async fn all_open_deposit_channels(&self) -> RpcResult<Vec<(AccountId32, ChainAccounts)>> {
+	async fn all_open_deposit_channels(
+		&self,
+	) -> RpcResult<Vec<(AccountId32, ChannelActionType, ChainAccounts)>> {
 		self.api
 			.state_chain_client
 			.base_rpc_client

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -53,9 +53,9 @@ use state_chain_runtime::{
 	},
 	runtime_apis::{
 		AuctionState, BoostPoolDepth, BoostPoolDetails, BrokerInfo, ChainAccounts,
-		CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi, FailingWitnessValidators,
-		LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, RuntimeApiPenalty,
-		SimulatedSwapInformationV2, TransactionScreeningEvents, ValidatorInfo,
+		ChannelActionType, CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi,
+		FailingWitnessValidators, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo,
+		RuntimeApiPenalty, SimulatedSwapInformationV2, TransactionScreeningEvents, ValidatorInfo,
 	},
 	safe_mode::RuntimeSafeMode,
 	Block, Hash, NetworkFee, SolanaInstance,
@@ -992,7 +992,7 @@ pub trait CustomApi {
 	fn cf_all_open_deposit_channels(
 		&self,
 		at: Option<state_chain_runtime::Hash>,
-	) -> RpcResult<Vec<(state_chain_runtime::AccountId, ChainAccounts)>>;
+	) -> RpcResult<Vec<(state_chain_runtime::AccountId, ChannelActionType, ChainAccounts)>>;
 }
 
 /// An RPC extension for the state chain node.
@@ -1247,7 +1247,7 @@ where
 		cf_boost_pools_depth() -> Vec<BoostPoolDepth>,
 		cf_pool_price(from_asset: Asset, to_asset: Asset) -> Option<PoolPriceV1>,
 		cf_get_open_deposit_channels(account_id: Option<state_chain_runtime::AccountId>) -> ChainAccounts,
-		cf_all_open_deposit_channels() -> Vec<(state_chain_runtime::AccountId, ChainAccounts)>,
+		cf_all_open_deposit_channels() -> Vec<(state_chain_runtime::AccountId, ChannelActionType, ChainAccounts)>,
 	}
 
 	pass_through_and_flatten! {

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -16,7 +16,7 @@ use codec::{Decode, Encode};
 use core::{ops::Range, str};
 use frame_support::sp_runtime::AccountId32;
 use pallet_cf_governance::GovCallHash;
-pub use pallet_cf_ingress_egress::OwedAmount;
+pub use pallet_cf_ingress_egress::{ChannelAction, OwedAmount};
 use pallet_cf_pools::{
 	AskBidMap, PoolInfo, PoolLiquidity, PoolOrderbook, PoolOrders, PoolPriceV1, PoolPriceV2,
 	UnidirectionalPoolDepth,
@@ -219,6 +219,36 @@ pub struct ChainAccounts {
 	pub eth_chain_accounts: Vec<ChainAccountFor<cf_chains::Ethereum>>,
 }
 
+#[derive(
+	Serialize,
+	Deserialize,
+	Encode,
+	Decode,
+	Eq,
+	PartialEq,
+	TypeInfo,
+	Debug,
+	Clone,
+	Copy,
+	PartialOrd,
+	Ord,
+)]
+pub enum ChannelActionType {
+	Swap,
+	LiquidityProvision,
+	CcmTransfer,
+}
+
+impl<AccountId> From<ChannelAction<AccountId>> for ChannelActionType {
+	fn from(action: ChannelAction<AccountId>) -> Self {
+		match action {
+			ChannelAction::Swap { .. } => ChannelActionType::Swap,
+			ChannelAction::LiquidityProvision { .. } => ChannelActionType::LiquidityProvision,
+			ChannelAction::CcmTransfer { .. } => ChannelActionType::CcmTransfer,
+		}
+	}
+}
+
 #[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
 pub enum TransactionScreeningEvent<TxId> {
 	TransactionRejectionRequestReceived {
@@ -390,7 +420,7 @@ decl_runtime_apis!(
 		fn cf_minimum_chunk_size(asset: Asset) -> AssetAmount;
 		fn cf_get_open_deposit_channels(account_id: Option<AccountId32>) -> ChainAccounts;
 		fn cf_transaction_screening_events() -> TransactionScreeningEvents;
-		fn cf_all_open_deposit_channels() -> Vec<(AccountId32, ChainAccounts)>;
+		fn cf_all_open_deposit_channels() -> Vec<(AccountId32, ChannelActionType, ChainAccounts)>;
 	}
 );
 


### PR DESCRIPTION


# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Adds the channel action type to the rpc call, such that the deposit monitor can apply custom logic for deposit channel vs swap screening.
