### PR TITLE
feat: remove dedup hook

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -68,12 +68,6 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, RulesHook> {
 
 pub struct ExecuteHook;
 impl<T: BWProcessorTypes> HookType for HookTypeFor<T, ExecuteHook> {
-	type Input = (T::ChainBlockNumber, T::Event);
-	type Output = ();
-}
-
-pub struct DedupEventsHook;
-impl<T: BWProcessorTypes> HookType for HookTypeFor<T, DedupEventsHook> {
 	type Input = Vec<(T::ChainBlockNumber, T::Event)>;
 	type Output = Vec<(T::ChainBlockNumber, T::Event)>;
 }
@@ -99,12 +93,6 @@ pub trait BWProcessorTypes: Sized {
 	type Event: Serde + Debug + Clone + Eq;
 	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + Serde + Debug + Clone + Eq;
 	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + Serde + Debug + Clone + Eq;
-	type DedupEvents: Hook<HookTypeFor<Self, DedupEventsHook>>
-		+ Default
-		+ Serde
-		+ Debug
-		+ Clone
-		+ Eq;
 
 	type SafetyMargin: Hook<HookTypeFor<Self, SafetyMarginHook>>
 		+ Default
@@ -446,7 +434,6 @@ mod tests {
 					reorg_events: Default::default(),
 					rules: Default::default(),
 					execute: Default::default(),
-					dedup_events: Default::default(),
 					safety_margin: ConstantHook::new(1),
 				},
 				_phantom: core::marker::PhantomData,
@@ -494,7 +481,6 @@ mod tests {
 		type Event = ();
 		type Rules = ConstantHook<HookTypeFor<Self, RulesHook>>;
 		type Execute = ConstantHook<HookTypeFor<Self, ExecuteHook>>;
-		type DedupEvents = ConstantHook<HookTypeFor<Self, DedupEventsHook>>;
 		type SafetyMargin = ConstantHook<HookTypeFor<Self, SafetyMarginHook>>;
 	}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser_new.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser_new.rs
@@ -239,7 +239,7 @@ fn generate_votes(
 ) -> ConsensusVotes<SimpleBlockWitnesser> {
 	println!("Generate votes called");
 
-	let to_vote = |data| ConstantIndex { data, _phantom: Default::default() };
+	let to_vote = |data| ConstantIndex::new(data);
 
 	let incorrect_data = vec![1u8, 2, 3];
 	assert_ne!(incorrect_data, correct_data);

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -159,7 +159,6 @@ impls! {
 		type Event = BtcEvent<DepositWitness<Bitcoin>>;
 		type Rules = Self;
 		type Execute = Self;
-		type DedupEvents = Self;
 		type SafetyMargin = Self;
 	}
 
@@ -240,7 +239,6 @@ pub type BitcoinDepositChannelWitnessingES =
 
 // ------------------------ vault deposit witnessing ---------------------------
 /// The electoral system for vault deposit witnessing
-
 pub struct BitcoinVaultDepositWitnessing;
 
 type ElectionPropertiesVaultDeposit = Vec<(DepositAddress, AccountId, ChannelId)>;
@@ -257,7 +255,6 @@ impls! {
 		type Event = BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>;
 		type Rules = Self;
 		type Execute = Self;
-		type DedupEvents = Self;
 		type SafetyMargin = Self;
 	}
 
@@ -364,7 +361,6 @@ impls! {
 		type Event = BtcEvent<TransactionConfirmation<Runtime, BitcoinInstance>>;
 		type Rules = Self;
 		type Execute = Self;
-		type DedupEvents = Self;
 		type SafetyMargin = Self;
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2054

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Remove dedup hook and perform the deduplication (which is common to all the ES) inside the execute hook -> this can now easily be generalized into a function.
