### PR TITLE
fix: eth broker level screening, push empty events in broker api

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -240,13 +240,6 @@ impl RpcServer for RpcServerImpl {
 					.await
 				{
 					Ok(events) => {
-						// We only want to send a notification if there have been events.
-						// If other chains are added, they have to be considered here as
-						// well.
-						if events.btc_events.is_empty() {
-							continue;
-						}
-
 						let block_update = BlockUpdate {
 							block_hash: block.hash,
 							block_number: block.number,


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

We had an "optimization" in place in 1.7 where we wouldn't push events if they vec was empty, on main we already removed it. This PR also removes it here.

In particular, since we now also have eth events this would have meant that we won't push any events if there aren't any btc events.