### PR TITLE
feat: bouncer run test command

### DIFF
--- a/bouncer/README.md
+++ b/bouncer/README.md
@@ -115,6 +115,12 @@ You can use `vitest`s `list` command to find the name of that test you what to r
 pnpm vitest list
 ```
 
+Or use the custom run test command with the file path of you test instead.
+
+```sh copy
+./commands/run_test.ts ./tests/myNewTest.ts
+```
+
 If your test uses the `SwapContext` within the `TestContext`, then the report will be automatically logged when the test finishes.
 If you would like to run your test with custom arguments, then you will have to create a test command file.
 See the `test_commands` folder for examples.

--- a/bouncer/commands/run_test.ts
+++ b/bouncer/commands/run_test.ts
@@ -9,9 +9,7 @@
 
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
-
-// Note: This must be the same path as the one in shared/utils/vitest.ts. Importing it here breaks vitest.
-export const testInfoFile = '/tmp/chainflip/test_info.csv';
+import { testInfoFile } from '../shared/utils';
 
 // Check that a test file was provided as an argument
 const testFile = process.argv[2];
@@ -40,19 +38,15 @@ try {
 }
 
 // Get the test info that was saved to the file
-const testNamesAndFunctions: { testName: string; functionName: string }[] = [];
+let testNamesAndFunctions;
 try {
-  const data = readFileSync(testInfoFile, 'utf8');
-  const rows = data.split('\n');
-  for (const row of rows) {
-    const columns = row.split(',');
-    if (columns.length >= 2) {
-      testNamesAndFunctions.push({
-        testName: columns[0].trim(),
-        functionName: columns[1].trim(),
-      });
-    }
-  }
+  testNamesAndFunctions = readFileSync(testInfoFile, 'utf8')
+    .split('\n')
+    .filter((row) => row.includes(','))
+    .map((row) => {
+      const [testName, functionName] = row.split(',').map((col) => col.trim());
+      return { testName, functionName };
+    });
 } catch (err) {
   console.error(`Error reading the ${testInfoFile} file:`, err);
   process.exit(1);

--- a/bouncer/commands/run_test.ts
+++ b/bouncer/commands/run_test.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env -S pnpm tsx
+// INSTRUCTIONS
+//
+// This command takes one argument.
+// It will find and run the test function (using vitest) in the test file provided as an argument.
+//
+// For example: ./commands/run_test.ts ./tests/boost.ts
+// This is the equivalent of running `pnpm vitest run -t "BoostingForAsset"`
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+
+// Note: This must be the same path as the one in shared/utils/vitest.ts. Importing it here breaks vitest.
+export const testInfoFile = '/tmp/chainflip/test_info.csv';
+
+// Check that a test file was provided as an argument
+const testFile = process.argv[2];
+if (!testFile) {
+  console.error('Usage: ./commands/run_test.ts ./tests/<test_file>');
+  process.exit(1);
+} else if (!existsSync(testFile)) {
+  console.error(`Test file ${testFile} not found`);
+  process.exit(1);
+}
+
+// Delete the old test info file
+try {
+  execSync(`rm -f ${testInfoFile}`);
+} catch (err) {
+  console.error(`Error deleting the ${testInfoFile} file:`, err);
+  process.exit(1);
+}
+
+// Run the vitest list command, this will cause the test info to be written to the file.
+try {
+  execSync('pnpm vitest list').toString();
+} catch (err) {
+  console.error('Error running the vitest list command:', err);
+  process.exit(1);
+}
+
+// Get the test info that was saved to the file
+const testNamesAndFunctions: { testName: string; functionName: string }[] = [];
+try {
+  const data = readFileSync(testInfoFile, 'utf8');
+  const rows = data.split('\n');
+  for (const row of rows) {
+    const columns = row.split(',');
+    if (columns.length >= 2) {
+      testNamesAndFunctions.push({
+        testName: columns[0].trim(),
+        functionName: columns[1].trim(),
+      });
+    }
+  }
+} catch (err) {
+  console.error(`Error reading the ${testInfoFile} file:`, err);
+  process.exit(1);
+}
+
+// Find a matching function in the given test file
+if (!testFile) {
+  console.error('Please provide a test file as an argument.');
+  process.exit(1);
+}
+let matchingTestName;
+try {
+  const data = readFileSync(testFile, 'utf8');
+  for (const { testName, functionName } of testNamesAndFunctions) {
+    if (data.includes(`function ${functionName}`)) {
+      // We found a match, this must be the test we want to run
+      matchingTestName = testName;
+      break;
+    }
+  }
+} catch (err) {
+  console.error(`Error reading the test file ${testFile}:`, err);
+  process.exit(1);
+}
+
+// Run the test using vitest
+if (!matchingTestName) {
+  console.error('No matching test function found');
+  process.exit(1);
+} else {
+  execSync(`pnpm vitest run -t "${matchingTestName}"`, { stdio: 'inherit' });
+}

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -50,6 +50,8 @@ export const ccmSupportedChains = ['Ethereum', 'Arbitrum', 'Solana'] as Chain[];
 export const vaultSwapSupportedChains = ['Ethereum', 'Arbitrum', 'Solana', 'Bitcoin'] as Chain[];
 export const evmChains = ['Ethereum', 'Arbitrum'] as Chain[];
 
+export const testInfoFile = '/tmp/chainflip/test_info.csv';
+
 export type Asset = SDKAsset;
 export type Chain = SDKChain;
 

--- a/bouncer/shared/utils/vitest.ts
+++ b/bouncer/shared/utils/vitest.ts
@@ -1,5 +1,25 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { afterEach, beforeEach, it } from 'vitest';
 import { TestContext } from './test_context';
+
+export const testInfoFile = '/tmp/chainflip/test_info.csv';
+
+// Write the test name and function name to a file to be used by the `run_test.ts` command
+function writeTestInfoFile(name: string, testFunction: (context: TestContext) => Promise<void>) {
+  try {
+    let existingContent = '';
+    if (existsSync(testInfoFile)) {
+      existingContent = readFileSync(testInfoFile, 'utf-8');
+    }
+    const newEntry = `${name},${testFunction.name}\n`;
+    if (!existingContent.includes(newEntry)) {
+      writeFileSync(testInfoFile, existingContent + newEntry);
+    }
+  } catch (e) {
+    // This file is not needed for tests to run, so we just log and continue
+    console.log('Unable to write test info', e);
+  }
+}
 
 // Create a new SwapContext for each test
 beforeEach<{ testContext: TestContext }>((context) => {
@@ -34,6 +54,8 @@ export function concurrentTest(
     createTestFunction(name, testFunction),
     timeoutSeconds * 1000,
   );
+
+  writeTestInfoFile(name, testFunction);
 }
 export function serialTest(
   name: string,
@@ -45,4 +67,6 @@ export function serialTest(
     createTestFunction(name, testFunction),
     timeoutSeconds * 1000,
   );
+
+  writeTestInfoFile(name, testFunction);
 }

--- a/bouncer/shared/utils/vitest.ts
+++ b/bouncer/shared/utils/vitest.ts
@@ -1,16 +1,12 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { afterEach, beforeEach, it } from 'vitest';
 import { TestContext } from './test_context';
-
-export const testInfoFile = '/tmp/chainflip/test_info.csv';
+import { testInfoFile } from '../utils';
 
 // Write the test name and function name to a file to be used by the `run_test.ts` command
 function writeTestInfoFile(name: string, testFunction: (context: TestContext) => Promise<void>) {
   try {
-    let existingContent = '';
-    if (existsSync(testInfoFile)) {
-      existingContent = readFileSync(testInfoFile, 'utf-8');
-    }
+    const existingContent = existsSync(testInfoFile) ? readFileSync(testInfoFile, 'utf-8') : '';
     const newEntry = `${name},${testFunction.name}\n`;
     if (!existingContent.includes(newEntry)) {
       writeFileSync(testInfoFile, existingContent + newEntry);


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] I am confident that the code works.
- [x] I have updated documentation where appropriate.

## Summary

Welcome back the `run_test.ts` command.
Solves the problem of having to know the name of the test to run it. Now you can just give the command a file path and it will run the test using `vitest`.
It works by exploiting the `vitest list` command to execute the `.test` files without running the tests. I use this to save the test names and function names to a file that I can then be cross referenced with the given test file to find the correct test name to run. A bit hacky, but it works great.

Usage: 
```sh copy
./commands/run_test.ts ./tests/boost.ts
```