### PR TITLE
fix: cancel_orders_batch benchmarking

### DIFF
--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -280,7 +280,7 @@ mod benchmarks {
 		T::LpBalance::credit_account(&caller, Asset::Eth, 1_000_000_000);
 		T::LpBalance::credit_account(&caller, Asset::Usdc, 1_000_000_000);
 
-		let orders_to_delete = (1i32..n as i32)
+		let orders_to_delete = (1i32..=n as i32)
 			.map(|i| {
 				assert_ok!(Pallet::<T>::set_range_order(
 					RawOrigin::Signed(caller.clone()).into(),


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Fixed an off by 1 error in cancel_orders_batch benchmarking
From review comments: https://github.com/chainflip-io/chainflip-backend/pull/5664#discussion_r1970717356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Extended the performance benchmark for order cancellation to include the maximum value, thereby broadening the tested range. This adjustment refines the simulation of higher order deletion scenarios, ensuring consistent reliability under varied conditions without affecting core functionality. These enhancements bolster the accuracy of performance assessments and support comprehensive evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->