### PR TITLE
feat: enforce minimum swap amount for on-chain swaps

### DIFF
--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -99,7 +99,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn internal_swap() {
+	fn on_chain_swap() {
 		let lp_id =
 			T::AccountRoleRegistry::whitelisted_caller_with_role(AccountRole::LiquidityProvider)
 				.unwrap();
@@ -114,7 +114,7 @@ mod benchmarks {
 		T::BalanceApi::credit_account(&lp_id, Asset::Eth, 1000);
 
 		#[extrinsic_call]
-		Pallet::<T>::internal_swap(
+		Pallet::<T>::on_chain_swap(
 			caller,
 			1000,
 			Asset::Eth,

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -14,7 +14,7 @@ use cf_traits::{
 		address_converter::MockAddressConverter, deposit_handler::MockDepositHandler,
 		egress_handler::MockEgressHandler, swap_request_api::MockSwapRequestHandler,
 	},
-	AccountRoleRegistry, BalanceApi, BoostApi, HistoricalFeeMigration,
+	AccountRoleRegistry, BalanceApi, BoostApi, HistoricalFeeMigration, MinimumDeposit,
 };
 use frame_support::{
 	assert_ok, derive_impl, parameter_types, sp_runtime::app_crypto::sp_core::H160,
@@ -72,6 +72,14 @@ impl HistoricalFeeMigration for MockMigrationHelper {
 
 	fn get_fee_amount(_account_id: Self::AccountId, _asset: Asset) -> AssetAmount {
 		todo!()
+	}
+}
+
+pub const MINIMUM_DEPOSIT: u128 = 100;
+pub struct MockMinimumDepositProvider;
+impl MinimumDeposit for MockMinimumDepositProvider {
+	fn get(_asset: Asset) -> AssetAmount {
+		MINIMUM_DEPOSIT
 	}
 }
 
@@ -165,6 +173,7 @@ impl crate::Config for Test {
 	type BoostApi = MockIngressEgressBoostApi;
 	type SwapRequestHandler = MockSwapRequestHandler<(Ethereum, MockEgressHandler<Ethereum>)>;
 	type MigrationHelper = MockMigrationHelper;
+	type MinimumDeposit = MockMinimumDepositProvider;
 }
 
 pub struct MockIngressEgressBoostApi;

--- a/state-chain/pallets/cf-lp/src/weights.rs
+++ b/state-chain/pallets/cf-lp/src/weights.rs
@@ -37,7 +37,7 @@ pub trait WeightInfo {
 	fn register_lp_account() -> Weight;
 	fn deregister_lp_account() -> Weight;
 	fn register_liquidity_refund_address() -> Weight;
-	fn internal_swap() -> Weight;
+	fn on_chain_swap() -> Weight;
 }
 
 /// Weights for pallet_cf_lp using the Substrate node and recommended hardware.
@@ -172,7 +172,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `Swapping::SwapQueue` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Swapping::SwapRequests` (r:0 w:1)
 	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn internal_swap() -> Weight {
+	fn on_chain_swap() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1051`
 		//  Estimated: `4516`
@@ -314,7 +314,7 @@ impl WeightInfo for () {
 	/// Proof: `Swapping::SwapQueue` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Swapping::SwapRequests` (r:0 w:1)
 	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn internal_swap() -> Weight {
+	fn on_chain_swap() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `1051`
 		//  Estimated: `4516`

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2111,7 +2111,7 @@ pub mod pallet {
 			input_asset: Asset,
 		) -> Result<AssetAmount, DispatchError> {
 			let refund_fee_usdc = MinimumNetworkFeePerChunk::<T>::get();
-			if (refund_fee_usdc == 0) || (total_input_amount == 0) {
+			if refund_fee_usdc.is_zero() || total_input_amount.is_zero() {
 				return Ok(total_input_amount)
 			}
 
@@ -2127,7 +2127,7 @@ pub mod pallet {
 				sp_std::cmp::min(required_refund_fee_as_input_asset, total_input_amount);
 			let remaining_amount_to_refund = total_input_amount.saturating_sub(refund_fee);
 
-			if refund_fee > 0 {
+			if !refund_fee.is_zero() {
 				Self::init_network_fee_swap_request(input_asset, refund_fee);
 			}
 

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1515,7 +1515,7 @@ mod on_chain_swapping {
 
 		new_test_ext()
 			.execute_with(|| {
-				Swapping::init_internal_swap_request(
+				Swapping::init_on_chain_swap_request(
 					INPUT_ASSET,
 					INPUT_AMOUNT,
 					OUTPUT_ASSET,
@@ -1592,7 +1592,7 @@ mod on_chain_swapping {
 		new_test_ext()
 			.execute_with(|| {
 				MinimumNetworkFeePerChunk::<Test>::set(MIN_NETWORK_FEE);
-				Swapping::init_internal_swap_request(
+				Swapping::init_on_chain_swap_request(
 					INPUT_ASSET,
 					INPUT_AMOUNT,
 					OUTPUT_ASSET,

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -48,6 +48,7 @@ use cf_chains::{
 		api::{EvmChainId, EvmEnvironmentProvider, EvmReplayProtection},
 		EvmCrypto, Transaction,
 	},
+	instances::{ArbitrumInstance, EthereumInstance, PolkadotInstance, SolanaInstance},
 	sol::{
 		api::{
 			AllNonceAccounts, ApiEnvironment, ComputePrice, CurrentAggKey, CurrentOnChainKey,
@@ -63,7 +64,8 @@ use cf_chains::{
 	Solana, TransactionBuilder,
 };
 use cf_primitives::{
-	chains::assets, AccountRole, Asset, BasisPoints, Beneficiaries, ChannelId, DcaParameters,
+	chains::assets, AccountRole, Asset, AssetAmount, BasisPoints, Beneficiaries, ChannelId,
+	DcaParameters,
 };
 use cf_traits::{
 	AccountInfo, AccountRoleRegistry, BackupRewardsNotifier, BlockEmissions,
@@ -981,5 +983,24 @@ impl FetchesTransfersLimitProvider for EvmLimit {
 
 	fn maybe_fetches_limit() -> Option<usize> {
 		Some(20)
+	}
+}
+
+pub struct MinimumDepositProvider;
+impl cf_traits::MinimumDeposit for MinimumDepositProvider {
+	fn get(asset: Asset) -> AssetAmount {
+		use pallet_cf_ingress_egress::MinimumDeposit;
+		match asset.into() {
+			ForeignChainAndAsset::Ethereum(asset) =>
+				MinimumDeposit::<Runtime, EthereumInstance>::get(asset),
+			ForeignChainAndAsset::Polkadot(asset) =>
+				MinimumDeposit::<Runtime, PolkadotInstance>::get(asset),
+			ForeignChainAndAsset::Bitcoin(asset) =>
+				MinimumDeposit::<Runtime, BitcoinInstance>::get(asset).into(),
+			ForeignChainAndAsset::Arbitrum(asset) =>
+				MinimumDeposit::<Runtime, ArbitrumInstance>::get(asset),
+			ForeignChainAndAsset::Solana(asset) =>
+				MinimumDeposit::<Runtime, SolanaInstance>::get(asset).into(),
+		}
 	}
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1185,3 +1185,7 @@ pub trait AffiliateRegistry {
 	/// Return the reverse mapping from account id to affiliate short id.
 	fn reverse_mapping(broker_id: &Self::AccountId) -> BTreeMap<Self::AccountId, AffiliateShortId>;
 }
+
+pub trait MinimumDeposit {
+	fn get(asset: Asset) -> AssetAmount;
+}

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -107,7 +107,7 @@ pub trait SwapRequestHandler {
 		)
 	}
 
-	fn init_internal_swap_request(
+	fn init_on_chain_swap_request(
 		input_asset: Asset,
 		input_amount: AssetAmount,
 		output_asset: Asset,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1999

## Checklist

- [x] I am confident that the code works.
- [x] I have written sufficient tests.

## Summary

- Renamed `internal swap` to `on-chain swap`
- Added a trait to get the minimum deposit from the ingress egress pallets.
- Added a check to the on-chain swap RPC, to make sure the amount is above the minimum.
- Added a check to cover this in the existing unit test.
- Manually confirmed that the minimum swap works via executing an on-chain swap in the bouncer.