### PR TITLE
refactor: initialise when necessary

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2511,18 +2511,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 		}
 
+		let destination_address = match T::AddressConverter::decode_and_validate_address_for_asset(
+			destination_address,
+			destination_asset,
+		) {
+			Ok(address) => address,
+			Err(_) => {
+				emit_deposit_failed_event(DepositFailedReason::InvalidDestinationAddress);
+				return;
+			},
+		};
+
 		let action = ChannelAction::Swap {
 			destination_asset,
-			destination_address: match T::AddressConverter::decode_and_validate_address_for_asset(
-				destination_address,
-				destination_asset,
-			) {
-				Ok(address) => address,
-				Err(_) => {
-					emit_deposit_failed_event(DepositFailedReason::InvalidDestinationAddress);
-					return;
-				},
-			},
+			destination_address,
 			broker_fees,
 			channel_metadata: channel_metadata.clone(),
 			refund_params: refund_params


### PR DESCRIPTION
Minor refactor to initialise values only when necessary - some of these values are initialised very far away from where they're used, making it harder to read. 
Also, they're often never needed in the case of early returns.
