### PR TITLE
chore: remove prewitness swaps subscription

### DIFF
--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
 	},
 };
 use cf_amm::{
-	common::{PoolPairsMap, Side},
+	common::PoolPairsMap,
 	math::{Amount, Tick},
 	range_orders::Liquidity,
 };
@@ -72,11 +72,9 @@ use frame_support::{derive_impl, instances::*};
 pub use frame_system::Call as SystemCall;
 use monitoring_apis::MonitoringDataV2;
 use pallet_cf_governance::GovCallHash;
-use pallet_cf_ingress_egress::{
-	ChannelAction, DepositWitness, IngressOrEgress, OwedAmount, TargetChainAsset,
-};
+use pallet_cf_ingress_egress::{IngressOrEgress, OwedAmount, TargetChainAsset};
 use pallet_cf_pools::{
-	AskBidMap, AssetPair, HistoricalEarnedFees, OrderId, PoolLiquidity, PoolOrderbook, PoolPriceV1,
+	AskBidMap, HistoricalEarnedFees, OrderId, PoolLiquidity, PoolOrderbook, PoolPriceV1,
 	PoolPriceV2, UnidirectionalPoolDepth,
 };
 use pallet_cf_swapping::{

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -323,7 +323,7 @@ pub struct TransactionScreeningEvents {
 //  - Handle the dummy method gracefully in the custom rpc implementation using
 //    runtime_api().api_version().
 decl_runtime_apis!(
-	#[api_version(3)]
+	#[api_version(4)]
 	pub trait CustomRuntimeApi {
 		/// Returns true if the current phase is the auction phase.
 		fn cf_is_auction_phase() -> bool;

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -415,11 +415,6 @@ decl_runtime_apis!(
 		fn cf_max_swap_amount(asset: Asset) -> Option<AssetAmount>;
 		fn cf_min_deposit_amount(asset: Asset) -> AssetAmount;
 		fn cf_egress_dust_limit(asset: Asset) -> AssetAmount;
-		fn cf_prewitness_swaps(
-			base_asset: Asset,
-			quote_asset: Asset,
-			side: Side,
-		) -> Vec<AssetAmount>;
 		fn cf_scheduled_swaps(
 			base_asset: Asset,
 			quote_asset: Asset,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1639

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

It has been deprecated for a while, it's time to remove it in 1.9 to reduce the maintenance burden. 

Docs: https://github.com/chainflip-io/chainflip-docs/pull/516