### PR TITLE
feat: add option hash to get open swap channels

### DIFF
--- a/api/cf-rpc-types/src/lp.rs
+++ b/api/cf-rpc-types/src/lp.rs
@@ -1,3 +1,4 @@
+use cf_chains::{Arbitrum, Solana};
 use cf_primitives::*;
 use sp_core::{
 	serde::{Deserialize, Serialize},
@@ -95,6 +96,8 @@ pub struct OpenSwapChannels {
 	pub ethereum: Vec<SwapChannelInfo<Ethereum>>,
 	pub bitcoin: Vec<SwapChannelInfo<Bitcoin>>,
 	pub polkadot: Vec<SwapChannelInfo<Polkadot>>,
+	pub arbitrum: Vec<SwapChannelInfo<Arbitrum>>,
+	pub solana: Vec<SwapChannelInfo<Solana>>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
# Pull Request

Closes: PRO-1167

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Adds hash to get_open_swap_channels, and adds fields for arbitrum and solana.

This should be backwards compatible because:
- Takes an optional new param. Defaults to None -> preserving current behaviour.
- We are only adding fields to the return type, so json parsing should still work