### PR TITLE
feat: use environment variable to choose deposit-monitor image tag.

### DIFF
--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       start_period: 10s
 
   deposit-monitor:
-    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:dev-b7cc56fed1ed1fecd8460b59f43ed038edfe649e
+    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-dev-b7cc56fed1ed1fecd8460b59f43ed038edfe649e}
     platform: linux/amd64
     container_name: deposit-monitor
     restart: unless-stopped


### PR DESCRIPTION
if variable is not set, use given default value.

# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This is required for running the broker-level-screening test in the deposit-monitor repo's CI. Cherry pick of PR on main: https://github.com/chainflip-io/chainflip-backend/pull/5706.
