### PR TITLE
Feat: Core Functionality for Trading Strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8453,6 +8453,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-cf-trading-strategy"
+version = "0.1.0"
+dependencies = [
+ "cf-primitives",
+ "cf-runtime-utilities",
+ "cf-test-utilities",
+ "cf-traits",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
+]
+
+[[package]]
 name = "pallet-cf-validator"
 version = "0.1.0"
 dependencies = [
@@ -13632,6 +13649,7 @@ dependencies = [
  "pallet-cf-swapping",
  "pallet-cf-threshold-signature",
  "pallet-cf-tokenholder-governance",
+ "pallet-cf-trading-strategy",
  "pallet-cf-validator",
  "pallet-cf-vaults",
  "pallet-cf-witnesser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
   "state-chain/pallets/cf-validator",
   "state-chain/pallets/cf-vaults",
   "state-chain/pallets/cf-witnesser",
+  "state-chain/pallets/cf-trading-strategy",
   "state-chain/primitives",
   "state-chain/runtime",
   "state-chain/runtime-utilities",
@@ -261,6 +262,7 @@ pallet-cf-tokenholder-governance = { path = "state-chain/pallets/cf-tokenholder-
 pallet-cf-validator = { path = "state-chain/pallets/cf-validator", default-features = false }
 pallet-cf-vaults = { path = "state-chain/pallets/cf-vaults", default-features = false }
 pallet-cf-witnesser = { path = "state-chain/pallets/cf-witnesser", default-features = false }
+pallet-cf-trading-strategy = { path = "state-chain/pallets/cf-trading-strategy", default-features = false }
 
 cf-amm = { path = "state-chain/amm", default-features = false }
 cf-amm-math = { path = "state-chain/amm-math", default-features = false }

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/state_chain.rs
@@ -642,6 +642,7 @@ where
 		LiquidityProvider(_) |
 		LiquidityPools(_) |
 		SolanaElections(_) => {},
+		TradingStrategy(_) => {},
 	};
 
 	Ok(())

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -2,16 +2,12 @@
 
 pub mod test_utilities;
 
-pub use cf_primitives::Price;
+pub use cf_primitives::{Price, Tick};
 use sp_core::{U256, U512};
 
 /// Represents an amount of an asset, in its smallest unit i.e. Ethereum has 10^-18 precision, and
 /// therefore an `Amount` with the literal value of `1` would represent 10^-18 Ethereum.
 pub type Amount = U256;
-
-/// The `log1.0001(price)` rounded to the nearest integer. Note [Price] is always
-/// in units of asset One.
-pub type Tick = i32;
 
 /// The square root of the price.
 ///

--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -25,6 +25,8 @@ pub enum SetFeesError {
 	TypeInfo,
 	Deserialize,
 	Serialize,
+	PartialOrd,
+	Ord,
 	Hash,
 )]
 #[serde(rename_all = "snake_case")]

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_btc.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_btc.rs
@@ -21,6 +21,7 @@ use cf_traits::{
 		broadcaster::MockBroadcaster,
 		chain_tracking::ChainTracker,
 		fee_payment::MockFeePayment,
+		pool_api::MockPoolApi,
 		swap_limits_provider::MockSwapLimitsProvider,
 		swap_request_api::MockSwapRequestHandler,
 	},
@@ -92,7 +93,7 @@ impl pallet_cf_ingress_egress::Config for Test {
 	type AddressDerivation = MockAddressDerivation;
 	type AddressConverter = MockAddressConverter;
 	type Balance = MockBalance;
-	type PoolApi = Self;
+	type PoolApi = MockPoolApi;
 	type ChainApiCall = MockBitcoinApiCall<MockBtcEnvironment>;
 	type Broadcaster = MockEgressBroadcaster;
 	type DepositHandler = MockDepositHandler;

--- a/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks/mock_eth.rs
@@ -27,6 +27,7 @@ use cf_traits::{
 		chain_tracking::ChainTracker,
 		fee_payment::MockFeePayment,
 		fetches_transfers_limit_provider::MockFetchesTransfersLimitProvider,
+		pool_api::MockPoolApi,
 		swap_limits_provider::MockSwapLimitsProvider,
 		swap_request_api::MockSwapRequestHandler,
 	},
@@ -122,7 +123,7 @@ impl crate::Config for Test {
 	type AddressDerivation = MockAddressDerivation;
 	type AddressConverter = MockAddressConverter;
 	type Balance = MockBalance;
-	type PoolApi = Self;
+	type PoolApi = MockPoolApi;
 	type ChainApiCall = MockEthereumApiCall<MockEvmEnvironment>;
 	type Broadcaster = MockEgressBroadcaster;
 	type DepositHandler = MockDepositHandler;

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -12,7 +12,8 @@ use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
 		address_converter::MockAddressConverter, deposit_handler::MockDepositHandler,
-		egress_handler::MockEgressHandler, swap_request_api::MockSwapRequestHandler,
+		egress_handler::MockEgressHandler, pool_api::MockPoolApi,
+		swap_request_api::MockSwapRequestHandler,
 	},
 	AccountRoleRegistry, BalanceApi, BoostApi, HistoricalFeeMigration, MinimumDeposit,
 };
@@ -166,7 +167,7 @@ impl crate::Config for Test {
 	type AddressConverter = MockAddressConverter;
 	type SafeMode = MockRuntimeSafeMode;
 	type WeightInfo = ();
-	type PoolApi = Self;
+	type PoolApi = MockPoolApi;
 	type BalanceApi = MockBalanceApi;
 	#[cfg(feature = "runtime-benchmarks")]
 	type FeePayment = MockFeePayment<Self>;

--- a/state-chain/pallets/cf-pools/src/mock.rs
+++ b/state-chain/pallets/cf-pools/src/mock.rs
@@ -1,23 +1,20 @@
 use crate::{self as pallet_cf_pools, PalletSafeMode};
-use cf_chains::{assets::any::AssetMap, Ethereum};
-use cf_primitives::{Asset, AssetAmount};
+use cf_chains::Ethereum;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
 		balance_api::MockLpRegistration, egress_handler::MockEgressHandler,
 		swap_request_api::MockSwapRequestHandler,
+		trading_strategy_limits::MockTradingStrategyParameters,
 	},
-	AccountRoleRegistry, BalanceApi,
+	AccountRoleRegistry,
 };
-use frame_support::{derive_impl, parameter_types};
+use frame_support::derive_impl;
 use frame_system as system;
-use sp_runtime::DispatchResult;
-use sp_std::collections::btree_map::BTreeMap;
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;
 pub const BOB: <Test as frame_system::Config>::AccountId = 124u64;
 
-type AccountId = u64;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
@@ -35,77 +32,14 @@ impl system::Config for Test {
 
 impl_mock_chainflip!(Test);
 
-parameter_types! {
-	pub static AliceCollectedEth: AssetAmount = Default::default();
-	pub static AliceCollectedUsdc: AssetAmount = Default::default();
-	pub static BobCollectedEth: AssetAmount = Default::default();
-	pub static BobCollectedUsdc: AssetAmount = Default::default();
-	pub static AliceDebitedEth: AssetAmount = Default::default();
-	pub static AliceDebitedUsdc: AssetAmount = Default::default();
-	pub static BobDebitedEth: AssetAmount = Default::default();
-	pub static BobDebitedUsdc: AssetAmount = Default::default();
-	pub static RecordedFees: BTreeMap<AccountId, (Asset, AssetAmount)> = BTreeMap::new();
-}
-pub struct MockBalance;
-impl BalanceApi for MockBalance {
-	type AccountId = AccountId;
-
-	fn credit_account(who: &Self::AccountId, asset: Asset, amount: AssetAmount) {
-		match (*who, asset) {
-			(ALICE, Asset::Eth) => AliceCollectedEth::set(AliceCollectedEth::get() + amount),
-			(ALICE, Asset::Usdc) => AliceCollectedUsdc::set(AliceCollectedUsdc::get() + amount),
-			(BOB, Asset::Eth) => BobCollectedEth::set(BobCollectedEth::get() + amount),
-			(BOB, Asset::Usdc) => BobCollectedUsdc::set(BobCollectedUsdc::get() + amount),
-			_ => (),
-		}
-	}
-
-	fn try_credit_account(
-		who: &Self::AccountId,
-		asset: cf_primitives::Asset,
-		amount: cf_primitives::AssetAmount,
-	) -> DispatchResult {
-		Self::credit_account(who, asset, amount);
-		Ok(())
-	}
-
-	fn try_debit_account(
-		who: &Self::AccountId,
-		asset: cf_primitives::Asset,
-		amount: cf_primitives::AssetAmount,
-	) -> sp_runtime::DispatchResult {
-		match (*who, asset) {
-			(ALICE, Asset::Eth) => AliceDebitedEth::set(AliceDebitedEth::get() + amount),
-			(ALICE, Asset::Usdc) => AliceDebitedUsdc::set(AliceDebitedUsdc::get() + amount),
-			(BOB, Asset::Eth) => BobDebitedEth::set(BobDebitedEth::get() + amount),
-			(BOB, Asset::Usdc) => BobDebitedUsdc::set(BobDebitedUsdc::get() + amount),
-			_ => (),
-		}
-		Ok(())
-	}
-
-	fn free_balances(_who: &Self::AccountId) -> AssetMap<AssetAmount> {
-		unimplemented!()
-	}
-
-	fn get_balance(_who: &Self::AccountId, _asset: Asset) -> AssetAmount {
-		unimplemented!()
-	}
-}
-
-impl MockBalance {
-	pub fn assert_fees_recorded(who: &AccountId) {
-		assert!(RecordedFees::get().contains_key(who), "Fees not recorded for {:?}", who);
-	}
-}
-
 impl_mock_runtime_safe_mode!(pools: PalletSafeMode);
 impl pallet_cf_pools::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type LpBalance = MockBalance;
+	type LpBalance = cf_traits::mocks::balance_api::MockBalance;
 	type SwapRequestHandler = MockSwapRequestHandler<(Ethereum, MockEgressHandler<Ethereum>)>;
 	type LpRegistrationApi = MockLpRegistration;
 	type SafeMode = MockRuntimeSafeMode;
+	type TradingStrategyParameters = MockTradingStrategyParameters;
 	type WeightInfo = ();
 }
 

--- a/state-chain/pallets/cf-trading-strategy/Cargo.toml
+++ b/state-chain/pallets/cf-trading-strategy/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "pallet-cf-trading-strategy"
+version = "0.1.0"
+authors = ["Chainflip Team <https://github.com/chainflip-io>"]
+description = "The trading strategy pallet."
+edition = "2021"
+homepage = "https://chainflip.io"
+license = "<TODO>"
+publish = false
+repository = "https://github.com/chainflip-io/chainflip-backend"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true
+
+[dependencies]
+log = { workspace = true }
+
+# Local deps
+cf-primitives = { workspace = true }
+cf-traits = { workspace = true }
+cf-runtime-utilities = { workspace = true }
+
+# Parity deps
+codec = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-std = { workspace = true }
+
+[dev-dependencies]
+cf-test-utilities = { workspace = true, default-features = true }
+
+[features]
+default = ["std"]
+std = [
+    "cf-primitives/std",
+    "cf-traits/std",
+    "codec/std",
+    "sp-std/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+]
+runtime-benchmarks = [
+    "cf-traits/runtime-benchmarks",
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+    "cf-runtime-utilities/runtime-benchmarks",
+]
+try-runtime = [
+    "cf-runtime-utilities/try-runtime",
+    "cf-traits/try-runtime",
+    "frame-support/try-runtime",
+    "frame-system/try-runtime",
+]

--- a/state-chain/pallets/cf-trading-strategy/README.md
+++ b/state-chain/pallets/cf-trading-strategy/README.md
@@ -1,0 +1,13 @@
+# Chainflip Trading Strategy Pallet
+
+## Overview
+
+This pallet can be used by LPs for creating and updating automated trading strategies.
+Each strategy is assigned a unique AccountId and has balance like a regular LP account.
+When LP creates a strategy, they transfer their funds to the strategy account.
+When strategy's balance reaches a certain threshold, a limit order is created/updated according
+to the strategy's parameters. When the order is filled, the funds are transferred back to the LP account
+(within the Pools pallet), which can trigger the creation of a new limit order.
+New funds can be added to the strategy an any time, however, the only way to withdraw funds from the strategy
+is to close it, which will trigger cancellation of any open orders and transfer of the remaining funds back
+to the LP account.

--- a/state-chain/pallets/cf-trading-strategy/src/benchmarking.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/benchmarking.rs
@@ -1,0 +1,16 @@
+use crate::{Config, Pallet};
+use frame_benchmarking::v2::*;
+
+// Keep this to avoid CI warnings about no benchmarks in the crate.
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn noop() {
+		#[block]
+		{
+			// Do nothing.
+		}
+	}
+}

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -1,0 +1,351 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod migrations;
+
+pub mod weights;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+use frame_support::sp_runtime::FixedU64;
+
+use cf_primitives::{Asset, AssetAmount, Tick, STABLE_ASSET};
+use cf_traits::{
+	AccountRoleRegistry, BalanceApi, Chainflip, IncreaseOrDecrease, NonceProvider, OrderId, Side,
+	TradingStrategyParameters, TradingStrategyParametersProvider,
+};
+
+pub use pallet::*;
+use weights::WeightInfo;
+
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
+
+// Note that strategies can only create one order per asset/side so we can just
+// have a fixed order id (at least until we develop more advanced strategies).
+const STRATEGY_ORDER_ID: OrderId = 0;
+
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
+struct TradingStrategyEntry<AccountId> {
+	base_asset: Asset,
+	owner: AccountId,
+	strategy: TradingStrategy,
+}
+
+#[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
+pub enum TradingStrategy {
+	SellAndBuyAtTicks { sell_tick: Tick, buy_tick: Tick },
+}
+
+fn derive_strategy_id<T: Config>(lp: &T::AccountId, nonce: T::Nonce) -> T::AccountId {
+	use frame_support::{sp_runtime::traits::TrailingZeroInput, Hashable};
+
+	// Combination of lp + nonce is unique for every successful call, so this should
+	// generate unique ids:
+	Decode::decode(&mut TrailingZeroInput::new(
+		(*b"chainflip/strategy_account", lp.clone(), nonce).blake2_256().as_ref(),
+	))
+	.unwrap()
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+
+	use cf_runtime_utilities::log_or_panic;
+	use cf_traits::PoolApi;
+
+	use super::*;
+
+	#[pallet::config]
+	#[pallet::disable_frame_system_supertrait_check]
+	pub trait Config: Chainflip {
+		/// The event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// Benchmark weights
+		type WeightInfo: WeightInfo;
+
+		type BalanceApi: BalanceApi<AccountId = Self::AccountId>;
+
+		type PoolApi: PoolApi<AccountId = Self::AccountId>;
+
+		type NonceProvider: NonceProvider<Self::AccountId, Self::Nonce>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::storage_version(PALLET_VERSION)]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	// Stores all deployed strategies by their id
+	#[pallet::storage]
+	pub(super) type Strategies<T: Config> =
+		StorageMap<_, Identity, T::AccountId, TradingStrategyEntry<T::AccountId>, OptionQuery>;
+
+	// Stores the minimum amount for each asset that triggers an update/creation of limit orders
+	#[pallet::storage]
+	pub type TradingStrategyParametersStorage<T: Config> =
+		StorageValue<_, TradingStrategyParameters, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_idle(_current_block: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
+			let mut weight_used: Weight = T::DbWeight::get().reads(1);
+
+			// TODO: use safe mode here checking if auto strategies are enabled
+
+			let parameters = Self::get_parameters();
+
+			weight_used += T::DbWeight::get().reads(1);
+
+			// TODO: use correct weight from pools pallet
+			let limit_order_update_weight = Weight::zero();
+
+			for (strategy_id, TradingStrategyEntry { base_asset, strategy, .. }) in
+				Strategies::<T>::iter()
+			{
+				match strategy {
+					TradingStrategy::SellAndBuyAtTicks { sell_tick, buy_tick } => {
+						let new_weight_estimate = weight_used
+							.saturating_add(limit_order_update_weight)
+							.saturating_add(limit_order_update_weight);
+
+						let mut update_limit_order_from_balance = |sell_asset, side, tick| {
+							weight_used += T::DbWeight::get().reads(1);
+							let balance = T::BalanceApi::get_balance(&strategy_id, sell_asset);
+
+							if balance >= parameters.get_order_update_threshold(&sell_asset) {
+								weight_used += limit_order_update_weight;
+
+								if T::PoolApi::update_limit_order(
+									&strategy_id,
+									base_asset,
+									STABLE_ASSET,
+									side,
+									STRATEGY_ORDER_ID,
+									Some(tick),
+									IncreaseOrDecrease::Increase(balance),
+								)
+								.is_err()
+								{
+									// Should be impossible to get an error since we just
+									// checked the balance above
+									log_or_panic!(
+										"Failed to update limit order for strategy {strategy_id:?}"
+									);
+								}
+							}
+						};
+
+						if remaining_weight.checked_sub(&new_weight_estimate).is_none() {
+							break;
+						}
+
+						update_limit_order_from_balance(base_asset, Side::Sell, sell_tick);
+						update_limit_order_from_balance(STABLE_ASSET, Side::Buy, buy_tick);
+					},
+				}
+			}
+
+			Weight::zero()
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		StrategyDeployed {
+			account_id: T::AccountId,
+			strategy_id: T::AccountId,
+			base_asset: Asset,
+			strategy: TradingStrategy,
+		},
+		FundsAddedToStrategy {
+			strategy_id: T::AccountId,
+			base_asset: Asset,
+			base_asset_amount: AssetAmount,
+			quote_asset_amount: AssetAmount,
+		},
+		StrategyClosed {
+			strategy_id: T::AccountId,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		StrategyNotFound,
+		AmountBelowDeploymentThreshold,
+		InvalidOwner,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::zero())] // TODO: benchmark
+		pub fn deploy_trading_strategy(
+			origin: OriginFor<T>,
+			base_asset_amount: AssetAmount,
+			quote_asset_amount: AssetAmount,
+			base_asset: Asset,
+			strategy: TradingStrategy,
+		) -> DispatchResult {
+			let lp = &T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+
+			let quote_asset = STABLE_ASSET;
+
+			let strategy_id = {
+				// Check that strategy is created with sufficient funds:
+				{
+					const ONE: FixedU64 = FixedU64::from_u32(1);
+					let parameters = TradingStrategyParametersStorage::<T>::get();
+					let fraction_of_required = |asset, provided| {
+						let required = parameters.get_strategy_deployment_threshold(&asset);
+
+						if required == 0 {
+							ONE
+						} else {
+							FixedU64::from_rational(provided, required)
+						}
+					};
+
+					ensure!(
+						fraction_of_required(base_asset, base_asset_amount) +
+							fraction_of_required(quote_asset, quote_asset_amount) >=
+							ONE,
+						Error::<T>::AmountBelowDeploymentThreshold
+					);
+				}
+
+				let nonce = T::NonceProvider::get_nonce(lp);
+
+				let strategy_id = derive_strategy_id::<T>(lp, nonce);
+
+				Self::deposit_event(Event::<T>::StrategyDeployed {
+					account_id: lp.clone(),
+					strategy_id: strategy_id.clone(),
+					base_asset,
+					strategy: strategy.clone(),
+				});
+
+				Strategies::<T>::insert(
+					strategy_id.clone(),
+					TradingStrategyEntry { base_asset, owner: lp.clone(), strategy },
+				);
+
+				strategy_id
+			};
+
+			Self::add_funds_to_existing_strategy(
+				lp,
+				&strategy_id,
+				base_asset,
+				base_asset_amount,
+				quote_asset_amount,
+			)
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(Weight::zero())] // TODO: benchmark
+		pub fn close_strategy(origin: OriginFor<T>, strategy_id: T::AccountId) -> DispatchResult {
+			let lp = &T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+
+			let TradingStrategyEntry { base_asset, owner, strategy } =
+				Strategies::<T>::take(&strategy_id).ok_or(Error::<T>::StrategyNotFound)?;
+
+			ensure!(lp == &owner, Error::<T>::InvalidOwner);
+
+			// TODO: instead of reading ticks from the strategy, we could extend PoolApi with
+			// a method to close all (limit) orders (which might be necessary for more complex
+			// strategies).
+			let TradingStrategy::SellAndBuyAtTicks { buy_tick, sell_tick } = strategy;
+
+			let cancel_limit_orders = |side, tick| {
+				T::PoolApi::update_limit_order(
+					&strategy_id,
+					base_asset,
+					STABLE_ASSET,
+					side,
+					STRATEGY_ORDER_ID,
+					Some(tick),
+					IncreaseOrDecrease::Decrease(AssetAmount::MAX),
+				)
+				.unwrap();
+			};
+
+			cancel_limit_orders(Side::Buy, buy_tick);
+			cancel_limit_orders(Side::Sell, sell_tick);
+
+			for asset in [base_asset, STABLE_ASSET] {
+				let balance = T::BalanceApi::get_balance(&strategy_id, asset);
+				T::BalanceApi::try_debit_account(&strategy_id, asset, balance)?;
+				T::BalanceApi::credit_account(lp, asset, balance);
+			}
+
+			Self::deposit_event(Event::<T>::StrategyClosed { strategy_id: strategy_id.clone() });
+
+			Ok(())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight(Weight::zero())] // TODO: benchmark
+		pub fn add_funds_to_strategy(
+			origin: OriginFor<T>,
+			base_asset_amount: AssetAmount,
+			quote_asset_amount: AssetAmount,
+			strategy_id: T::AccountId,
+		) -> DispatchResult {
+			let lp = &T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+
+			let strategy =
+				Strategies::<T>::get(&strategy_id).ok_or(Error::<T>::StrategyNotFound)?;
+
+			Self::add_funds_to_existing_strategy(
+				lp,
+				&strategy_id,
+				strategy.base_asset,
+				base_asset_amount,
+				quote_asset_amount,
+			)
+		}
+	}
+}
+
+impl<T: Config> TradingStrategyParametersProvider for Pallet<T> {
+	fn get_parameters() -> TradingStrategyParameters {
+		TradingStrategyParametersStorage::<T>::get()
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	fn add_funds_to_existing_strategy(
+		lp: &T::AccountId,
+		strategy_id: &T::AccountId,
+		base_asset: Asset,
+		base_asset_amount: AssetAmount,
+		quote_asset_amount: AssetAmount,
+	) -> DispatchResult {
+		if base_asset_amount > 0 {
+			T::BalanceApi::try_debit_account(lp, base_asset, base_asset_amount)?;
+			T::BalanceApi::credit_account(strategy_id, base_asset, base_asset_amount);
+		}
+
+		if quote_asset_amount > 0 {
+			T::BalanceApi::try_debit_account(lp, STABLE_ASSET, quote_asset_amount)?;
+			T::BalanceApi::credit_account(strategy_id, STABLE_ASSET, quote_asset_amount);
+		}
+
+		Self::deposit_event(Event::<T>::FundsAddedToStrategy {
+			strategy_id: strategy_id.clone(),
+			base_asset,
+			base_asset_amount,
+			quote_asset_amount,
+		});
+
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-trading-strategy/src/migrations.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/migrations.rs
@@ -1,0 +1,5 @@
+use cf_runtime_utilities::PlaceholderMigration;
+
+use crate::Pallet;
+
+pub type PalletMigration<T> = (PlaceholderMigration<1, Pallet<T>>,);

--- a/state-chain/pallets/cf-trading-strategy/src/mock.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/mock.rs
@@ -1,0 +1,46 @@
+use crate as pallet_cf_trading_strategy;
+use cf_traits::{
+	impl_mock_chainflip,
+	mocks::{nonce_provider::MockNonceProvider, pool_api::MockPoolApi},
+	AccountRoleRegistry,
+};
+use frame_support::derive_impl;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		TradingStrategyPallet: pallet_cf_trading_strategy
+	}
+);
+
+impl_mock_chainflip!(Test);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = frame_system::mocking::MockBlock<Test>;
+}
+
+impl pallet_cf_trading_strategy::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type BalanceApi = cf_traits::mocks::balance_api::MockBalance;
+	type PoolApi = MockPoolApi;
+	type NonceProvider = MockNonceProvider;
+}
+
+pub const LP: <Test as frame_system::Config>::AccountId = 123u64;
+pub const OTHER_LP: <Test as frame_system::Config>::AccountId = 234u64;
+
+cf_test_utilities::impl_test_helpers! {
+	Test,
+	RuntimeGenesisConfig::default(),
+	|| {
+		frame_support::assert_ok!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_liquidity_provider(
+			&LP,
+		));
+		frame_support::assert_ok!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_liquidity_provider(
+			&OTHER_LP,
+		));
+	}
+}

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -1,0 +1,259 @@
+use cf_primitives::{Asset, AssetAmount, Tick, STABLE_ASSET};
+use cf_test_utilities::assert_event_sequence;
+use cf_traits::{
+	mocks::{
+		balance_api::MockBalance,
+		pool_api::{MockLimitOrder, MockPoolApi},
+	},
+	BalanceApi, Side,
+};
+use frame_support::{assert_err, assert_ok};
+
+use crate::{mock::*, *};
+
+const BASE_ASSET: Asset = Asset::Usdt;
+const BASE_AMOUNT: AssetAmount = 100_000;
+const QUOTE_AMOUNT: AssetAmount = 50_000;
+
+const BUY_TICK: Tick = -1;
+const SELL_TICK: Tick = 1;
+
+type AccountId = u64;
+
+const STRATEGY: TradingStrategy =
+	TradingStrategy::SellAndBuyAtTicks { sell_tick: SELL_TICK, buy_tick: BUY_TICK };
+
+fn get_balance(account_id: AccountId) -> (AssetAmount, AssetAmount) {
+	(
+		MockBalance::get_balance(&account_id, BASE_ASSET),
+		MockBalance::get_balance(&account_id, STABLE_ASSET),
+	)
+}
+
+fn deploy_strategy() -> AccountId {
+	MockBalance::credit_account(&LP, BASE_ASSET, BASE_AMOUNT);
+	MockBalance::credit_account(&LP, STABLE_ASSET, QUOTE_AMOUNT);
+
+	assert_ok!(TradingStrategyPallet::deploy_trading_strategy(
+		RuntimeOrigin::signed(LP),
+		BASE_AMOUNT,
+		QUOTE_AMOUNT,
+		BASE_ASSET,
+		STRATEGY.clone(),
+	));
+
+	// An entry for the trading agent is created:
+	let (strategy_id, strategy_entry) = Strategies::<Test>::iter().next().unwrap();
+	assert_eq!(
+		strategy_entry,
+		TradingStrategyEntry { base_asset: BASE_ASSET, strategy: STRATEGY, owner: LP }
+	);
+
+	assert_event_sequence!(
+		Test,
+		RuntimeEvent::TradingStrategyPallet(Event::<Test>::StrategyDeployed {
+			account_id: LP,
+			strategy_id: id,
+			base_asset: BASE_ASSET,
+			strategy: STRATEGY,
+		}) if id == strategy_id,
+		RuntimeEvent::TradingStrategyPallet(Event::<Test>::FundsAddedToStrategy {
+			base_asset: BASE_ASSET,
+			strategy_id: id,
+			base_asset_amount: BASE_AMOUNT,
+			quote_asset_amount: QUOTE_AMOUNT,
+		}) if id == strategy_id,
+	);
+
+	// The funds are moved from the LP to the strategy:
+	assert_eq!(get_balance(strategy_id), (BASE_AMOUNT, QUOTE_AMOUNT));
+	assert_eq!(get_balance(LP), (0, 0));
+
+	strategy_id
+}
+
+#[test]
+fn automated_strategy_basic_usage() {
+	const ADDITIONAL_BASE_AMOUNT: AssetAmount = 5_000;
+
+	new_test_ext()
+		.then_execute_at_next_block(|_| deploy_strategy())
+		.then_execute_at_next_block(|strategy_id| {
+			// The strategy should have created two limit orders:
+			assert_eq!(
+				MockPoolApi::get_limit_orders(),
+				vec![
+					MockLimitOrder {
+						base_asset: BASE_ASSET,
+						account_id: strategy_id,
+						side: Side::Buy,
+						order_id: STRATEGY_ORDER_ID,
+						tick: BUY_TICK,
+						amount: QUOTE_AMOUNT
+					},
+					MockLimitOrder {
+						base_asset: BASE_ASSET,
+						account_id: strategy_id,
+						side: Side::Sell,
+						order_id: STRATEGY_ORDER_ID,
+						tick: SELL_TICK,
+						amount: BASE_AMOUNT
+					}
+				]
+			);
+
+			// Add additional funds by calling the add funds extrinsic.
+			MockBalance::credit_account(&LP, BASE_ASSET, ADDITIONAL_BASE_AMOUNT);
+			assert_ok!(TradingStrategyPallet::add_funds_to_strategy(
+				RuntimeOrigin::signed(LP),
+				ADDITIONAL_BASE_AMOUNT,
+				0,
+				strategy_id
+			));
+
+			// Update the threshold to check that limit orders won't be updated
+			// if the threshold is not reached:
+			TradingStrategyParametersStorage::<Test>::mutate(|params| {
+				params
+					.order_update_thresholds
+					.try_insert(BASE_ASSET, ADDITIONAL_BASE_AMOUNT * 2)
+					.unwrap();
+			});
+
+			assert_eq!(get_balance(LP), (0, 0));
+			assert_eq!(get_balance(strategy_id), (ADDITIONAL_BASE_AMOUNT, 0));
+
+			strategy_id
+		})
+		.then_execute_at_next_block(|strategy_id| {
+			// The funds have not been added to the limit order yet
+			assert_eq!(get_balance(strategy_id), (ADDITIONAL_BASE_AMOUNT, 0));
+
+			// This time we credit the strategy directly (which is what would happen
+			// if our limit order is executed in the pools pallet). Now the strategy
+			// should have enough free balance in BASE ASSET to update the limit order:
+			MockBalance::credit_account(&strategy_id, BASE_ASSET, ADDITIONAL_BASE_AMOUNT);
+
+			strategy_id
+		})
+		.then_execute_at_next_block(|strategy_id| {
+			// The should now have been used to update the limit order:
+			assert_eq!(get_balance(strategy_id), (0, 0));
+
+			assert_eq!(
+				MockPoolApi::get_limit_orders(),
+				vec![
+					MockLimitOrder {
+						base_asset: BASE_ASSET,
+						account_id: strategy_id,
+						side: Side::Buy,
+						order_id: STRATEGY_ORDER_ID,
+						tick: BUY_TICK,
+						amount: QUOTE_AMOUNT
+					},
+					MockLimitOrder {
+						base_asset: BASE_ASSET,
+						account_id: strategy_id,
+						side: Side::Sell,
+						order_id: STRATEGY_ORDER_ID,
+						tick: SELL_TICK,
+						amount: BASE_AMOUNT + ADDITIONAL_BASE_AMOUNT * 2
+					}
+				]
+			);
+		});
+}
+
+#[test]
+fn closing_strategy() {
+	const ADDITIONAL_BASE_AMOUNT: AssetAmount = 5_000;
+	new_test_ext()
+		.then_execute_at_next_block(|_| deploy_strategy())
+		.then_execute_at_next_block(|strategy_id| {
+			// Two orders must have been created:
+			assert_eq!(MockPoolApi::get_limit_orders().len(), 2);
+
+			// Credit the strategy account so has a non-zero free balance:
+			MockBalance::credit_account(&LP, BASE_ASSET, ADDITIONAL_BASE_AMOUNT);
+			assert_eq!(get_balance(LP), (ADDITIONAL_BASE_AMOUNT, 0));
+
+			// Other LPs can't close our strategy
+			assert_err!(
+				TradingStrategyPallet::close_strategy(RuntimeOrigin::signed(OTHER_LP), strategy_id),
+				Error::<Test>::InvalidOwner
+			);
+
+			// Closing the strategy
+			assert_ok!(TradingStrategyPallet::close_strategy(
+				RuntimeOrigin::signed(LP),
+				strategy_id
+			));
+
+			assert_event_sequence!(
+				Test,
+				RuntimeEvent::TradingStrategyPallet(Event::<Test>::StrategyClosed {
+					strategy_id: id,
+				}) if id == strategy_id,
+			);
+
+			// Limit orders should be closed:
+			assert!(MockPoolApi::get_limit_orders().is_empty());
+			assert_eq!(Strategies::<Test>::iter().count(), 0);
+			assert_eq!(get_balance(strategy_id), (0, 0));
+		});
+}
+
+#[test]
+fn strategy_deployment_threshold() {
+	const MIN_BASE_AMOUNT: AssetAmount = 10_000;
+	const MIN_QUOTE_AMOUNT: AssetAmount = 1_000;
+
+	new_test_ext().then_execute_at_next_block(|_| {
+		MockBalance::credit_account(&LP, BASE_ASSET, MIN_BASE_AMOUNT * 10);
+		MockBalance::credit_account(&LP, STABLE_ASSET, MIN_QUOTE_AMOUNT * 10);
+
+		TradingStrategyParametersStorage::<Test>::mutate(|params| {
+			params
+				.strategy_deployment_thresholds
+				.try_insert(BASE_ASSET, MIN_BASE_AMOUNT)
+				.unwrap();
+			params
+				.strategy_deployment_thresholds
+				.try_insert(STABLE_ASSET, MIN_QUOTE_AMOUNT)
+				.unwrap();
+		});
+
+		for (base_amount, quote_amount) in [
+			(MIN_BASE_AMOUNT - 1, 0),
+			(0, MIN_QUOTE_AMOUNT - 1),
+			(MIN_BASE_AMOUNT / 2 - 1, MIN_QUOTE_AMOUNT / 2),
+			(MIN_BASE_AMOUNT / 10 - 1, (MIN_QUOTE_AMOUNT * 9) / 10),
+		] {
+			assert_err!(
+				TradingStrategyPallet::deploy_trading_strategy(
+					RuntimeOrigin::signed(LP),
+					base_amount,
+					quote_amount,
+					BASE_ASSET,
+					STRATEGY.clone(),
+				),
+				Error::<Test>::AmountBelowDeploymentThreshold
+			);
+		}
+
+		for (base_amount, quote_amount) in [
+			(MIN_BASE_AMOUNT, 0),
+			(0, MIN_QUOTE_AMOUNT),
+			(MIN_BASE_AMOUNT / 2, MIN_QUOTE_AMOUNT / 2),
+			(MIN_BASE_AMOUNT / 10, (MIN_QUOTE_AMOUNT * 9) / 10),
+		] {
+			assert_ok!(TradingStrategyPallet::deploy_trading_strategy(
+				RuntimeOrigin::signed(LP),
+				base_amount,
+				quote_amount,
+				BASE_ASSET,
+				STRATEGY.clone(),
+			));
+		}
+	});
+}

--- a/state-chain/pallets/cf-trading-strategy/src/weights.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/weights.rs
@@ -1,0 +1,10 @@
+use core::marker::PhantomData;
+
+pub trait WeightInfo {}
+
+pub struct PalletWeight<T>(PhantomData<T>);
+
+impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {}
+
+// For backwards compatibility and tests
+impl WeightInfo for () {}

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -109,6 +109,10 @@ pub type BroadcastId = u32;
 /// bits.
 pub type Price = U256;
 
+/// The `log1.0001(price)` rounded to the nearest integer. Note [Price] is always
+/// in units of asset One.
+pub type Tick = i32;
+
 define_wrapper_type!(SwapId, u64, extra_derives: Serialize, Deserialize);
 
 define_wrapper_type!(SwapRequestId, u64, extra_derives: Serialize, Deserialize);

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -56,6 +56,7 @@ pallet-cf-validator = { workspace = true }
 pallet-cf-vaults = { workspace = true }
 pallet-cf-witnesser = { workspace = true }
 pallet-cf-cfe-interface = { workspace = true }
+pallet-cf-trading-strategy = { workspace = true }
 
 # SCALE
 codec = { workspace = true, features = ["derive"] }
@@ -130,6 +131,7 @@ runtime-benchmarks = [
   "pallet-cf-swapping/runtime-benchmarks",
   "pallet-cf-threshold-signature/runtime-benchmarks",
   "pallet-cf-tokenholder-governance/runtime-benchmarks",
+  "pallet-cf-trading-strategy/runtime-benchmarks",
   "pallet-cf-validator/runtime-benchmarks",
   "pallet-cf-vaults/runtime-benchmarks",
   "pallet-cf-witnesser/runtime-benchmarks",
@@ -180,6 +182,7 @@ std = [
   "pallet-cf-validator/std",
   "pallet-cf-vaults/std",
   "pallet-cf-witnesser/std",
+  "pallet-cf-trading-strategy/std",
   "pallet-grandpa/std",
   "pallet-session/std",
   "pallet-timestamp/std",
@@ -231,6 +234,7 @@ try-runtime = [
   "pallet-cf-validator/try-runtime",
   "pallet-cf-vaults/try-runtime",
   "pallet-cf-witnesser/try-runtime",
+  "pallet-cf-trading-strategy/try-runtime",
   "pallet-cf-cfe-interface/try-runtime",
   "pallet-timestamp/try-runtime",
   "pallet-transaction-payment/try-runtime",

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -1004,3 +1004,11 @@ impl cf_traits::MinimumDeposit for MinimumDepositProvider {
 		}
 	}
 }
+
+pub struct NonceProvider;
+
+impl cf_traits::NonceProvider<AccountId, super::Nonce> for NonceProvider {
+	fn get_nonce(account: &AccountId) -> super::Nonce {
+		System::account_nonce(account)
+	}
+}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -517,6 +517,7 @@ impl pallet_cf_pools::Config for Runtime {
 	type LpRegistrationApi = LiquidityProvider;
 	type SwapRequestHandler = Swapping;
 	type SafeMode = RuntimeSafeMode;
+	type TradingStrategyParameters = TradingStrategy;
 	type WeightInfo = ();
 }
 
@@ -1022,6 +1023,14 @@ impl pallet_cf_elections::Config<Instance5> for Runtime {
 	type WeightInfo = pallet_cf_elections::weights::PalletWeight<Runtime>;
 }
 
+impl pallet_cf_trading_strategy::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_cf_trading_strategy::weights::PalletWeight<Runtime>;
+	type BalanceApi = AssetBalances;
+	type PoolApi = LiquidityPools;
+	type NonceProvider = chainflip::NonceProvider;
+}
+
 #[frame_support::runtime]
 mod runtime {
 	#[runtime::runtime]
@@ -1137,6 +1146,9 @@ mod runtime {
 
 	#[runtime::pallet_index(47)]
 	pub type AssetBalances = pallet_cf_asset_balances;
+
+	#[runtime::pallet_index(48)]
+	pub type TradingStrategy = pallet_cf_trading_strategy;
 }
 
 /// The address format for describing accounts.
@@ -1233,6 +1245,8 @@ pub type PalletExecutionOrder = (
 	SolanaIngressEgress,
 	// Liquidity Pools
 	LiquidityPools,
+	// Miscellaneous
+	TradingStrategy,
 );
 
 /// Contains:
@@ -1293,6 +1307,7 @@ type PalletMigrations = (
 	pallet_cf_ingress_egress::migrations::PalletMigration<Runtime, SolanaInstance>,
 	pallet_cf_pools::migrations::PalletMigration<Runtime>,
 	pallet_cf_cfe_interface::migrations::PalletMigration<Runtime>,
+	pallet_cf_trading_strategy::migrations::PalletMigration<Runtime>,
 );
 
 macro_rules! instanced_migrations {
@@ -1371,6 +1386,7 @@ mod benches {
 		[pallet_cf_cfe_interface, CfeInterface]
 		[pallet_cf_asset_balances, AssetBalances]
 		[pallet_cf_elections, SolanaElections]
+		[pallet_cf_trading_strategy, TradingStrategy]
 	);
 }
 

--- a/state-chain/traits/Cargo.toml
+++ b/state-chain/traits/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 log = { workspace = true }
+serde = { workspace = true, features = ["derive", "alloc"] }
 
 # Internal
 cf-chains = { workspace = true }
@@ -29,7 +30,6 @@ sp-std = { workspace = true }
 [dev-dependencies]
 sp-io = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
-serde = { workspace = true, features = ["derive", "alloc"] }
 
 [features]
 default = ["std"]

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -41,8 +41,8 @@ use frame_support::{
 		traits::{AtLeast32BitUnsigned, Bounded, MaybeSerializeDeserialize},
 		DispatchError, DispatchResult, FixedPointOperand, Percent, RuntimeDebug,
 	},
-	traits::{EnsureOrigin, Get, Imbalance, IsType, UnfilteredDispatchable},
-	CloneNoBound, EqNoBound, Hashable, Parameter, PartialEqNoBound,
+	traits::{ConstU32, EnsureOrigin, Get, Imbalance, IsType, UnfilteredDispatchable},
+	BoundedBTreeMap, CloneNoBound, EqNoBound, Hashable, Parameter, PartialEqNoBound,
 };
 use scale_info::TypeInfo;
 use sp_std::{
@@ -1188,4 +1188,27 @@ pub trait AffiliateRegistry {
 
 pub trait MinimumDeposit {
 	fn get(asset: Asset) -> AssetAmount;
+}
+
+#[derive(Decode, Encode, Default, Debug, TypeInfo)]
+pub struct TradingStrategyParameters {
+	pub order_update_thresholds: BoundedBTreeMap<Asset, AssetAmount, ConstU32<1000>>,
+	pub strategy_deployment_thresholds: BoundedBTreeMap<Asset, AssetAmount, ConstU32<1000>>,
+}
+
+impl TradingStrategyParameters {
+	pub fn get_order_update_threshold(&self, asset: &Asset) -> AssetAmount {
+		self.order_update_thresholds.get(asset).copied().unwrap_or_default()
+	}
+	pub fn get_strategy_deployment_threshold(&self, asset: &Asset) -> AssetAmount {
+		self.strategy_deployment_thresholds.get(asset).copied().unwrap_or_default()
+	}
+}
+
+pub trait TradingStrategyParametersProvider {
+	fn get_parameters() -> TradingStrategyParameters;
+}
+
+pub trait NonceProvider<AccountId, Nonce> {
+	fn get_nonce(account: &AccountId) -> Nonce;
 }

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -1,8 +1,59 @@
-use cf_amm::common::PoolPairsMap;
+pub use cf_amm::common::{PoolPairsMap, Side};
 use cf_chains::assets::any::AssetMap;
-use cf_primitives::{Asset, AssetAmount};
+use cf_primitives::{Asset, AssetAmount, Tick};
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::{DispatchError, DispatchResult};
-use sp_std::{vec, vec::Vec};
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sp_std::vec::Vec;
+
+pub type OrderId = u64;
+
+/// Indicates if an LP wishes to increase or decrease the size of an order.
+#[derive(
+	Copy,
+	Clone,
+	Debug,
+	Encode,
+	Decode,
+	TypeInfo,
+	MaxEncodedLen,
+	PartialEq,
+	Eq,
+	Deserialize,
+	Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum IncreaseOrDecrease<T> {
+	Increase(T),
+	Decrease(T),
+}
+
+impl<T> IncreaseOrDecrease<T> {
+	pub fn abs(&self) -> &T {
+		match self {
+			IncreaseOrDecrease::Increase(t) => t,
+			IncreaseOrDecrease::Decrease(t) => t,
+		}
+	}
+
+	pub fn map<R, F: FnOnce(T) -> R>(self, f: F) -> IncreaseOrDecrease<R> {
+		match self {
+			IncreaseOrDecrease::Increase(t) => IncreaseOrDecrease::Increase(f(t)),
+			IncreaseOrDecrease::Decrease(t) => IncreaseOrDecrease::Decrease(f(t)),
+		}
+	}
+
+	pub fn try_map<R, E, F: FnOnce(T) -> Result<R, E>>(
+		self,
+		f: F,
+	) -> Result<IncreaseOrDecrease<R>, E> {
+		Ok(match self {
+			IncreaseOrDecrease::Increase(t) => IncreaseOrDecrease::Increase(f(t)?),
+			IncreaseOrDecrease::Decrease(t) => IncreaseOrDecrease::Decrease(f(t)?),
+		})
+	}
+}
 
 pub trait LpDepositHandler {
 	type AccountId;
@@ -49,27 +100,16 @@ pub trait PoolApi {
 	fn open_order_balances(who: &Self::AccountId) -> AssetMap<AssetAmount>;
 
 	fn pools() -> Vec<PoolPairsMap<Asset>>;
-}
 
-impl<T: frame_system::Config> PoolApi for T {
-	type AccountId = T::AccountId;
-
-	fn sweep(_who: &Self::AccountId) -> Result<(), DispatchError> {
-		Ok(())
-	}
-
-	fn open_order_count(
-		_who: &Self::AccountId,
-		_asset_pair: &PoolPairsMap<Asset>,
-	) -> Result<u32, DispatchError> {
-		Ok(0)
-	}
-	fn open_order_balances(_who: &Self::AccountId) -> AssetMap<AssetAmount> {
-		AssetMap::from_fn(|_| 0)
-	}
-	fn pools() -> Vec<PoolPairsMap<Asset>> {
-		vec![]
-	}
+	fn update_limit_order(
+		account: &Self::AccountId,
+		base_asset: Asset,
+		quote_asset: Asset,
+		side: Side,
+		id: OrderId,
+		option_tick: Option<Tick>,
+		amount_change: IncreaseOrDecrease<AssetAmount>,
+	) -> DispatchResult;
 }
 
 pub trait SwappingApi {

--- a/state-chain/traits/src/mocks.rs
+++ b/state-chain/traits/src/mocks.rs
@@ -30,8 +30,10 @@ pub mod ingress_egress_fee_handler;
 pub mod key_provider;
 pub mod key_rotator;
 pub mod liability_tracker;
+pub mod nonce_provider;
 pub mod offence_reporting;
 pub mod on_account_funded;
+pub mod pool_api;
 pub mod qualify_node;
 pub mod reputation_resetter;
 pub mod safe_mode;
@@ -41,6 +43,7 @@ pub mod swap_request_api;
 pub mod threshold_signer;
 pub mod time_source;
 pub mod tracked_data_provider;
+pub mod trading_strategy_limits;
 pub mod waived_fees_mock;
 
 #[macro_export]

--- a/state-chain/traits/src/mocks/nonce_provider.rs
+++ b/state-chain/traits/src/mocks/nonce_provider.rs
@@ -1,0 +1,27 @@
+use crate::NonceProvider;
+
+use super::{MockPallet, MockPalletStorage};
+
+pub struct MockNonceProvider {}
+
+const NONCE: &[u8] = b"NONCE";
+
+type AccountId = u64;
+type Nonce = u32;
+
+impl NonceProvider<AccountId, Nonce> for MockNonceProvider {
+	fn get_nonce(_account: &AccountId) -> u32 {
+		// Here we just make sure we provide a new value each time this funciton is called which
+		// is good enough for current tests
+		Self::mutate_value(NONCE, |value: &mut Option<u32>| {
+			let nonce = value.get_or_insert_default();
+			let current = *nonce;
+			*nonce += 1;
+			current
+		})
+	}
+}
+
+impl MockPallet for MockNonceProvider {
+	const PREFIX: &'static [u8] = b"MockNonceProvider";
+}

--- a/state-chain/traits/src/mocks/pool_api.rs
+++ b/state-chain/traits/src/mocks/pool_api.rs
@@ -1,0 +1,154 @@
+use std::collections::BTreeMap;
+
+use cf_amm::{
+	common::{PoolPairsMap, Side},
+	math::Tick,
+};
+use cf_chains::assets::any::AssetMap;
+use cf_primitives::{Asset, AssetAmount, STABLE_ASSET};
+use codec::{Decode, Encode};
+use frame_support::sp_runtime::{DispatchError, DispatchResult};
+use scale_info::TypeInfo;
+
+use crate::{mocks::balance_api::MockBalance, BalanceApi, IncreaseOrDecrease, OrderId, PoolApi};
+
+use super::{MockPallet, MockPalletStorage};
+
+pub struct MockPoolApi {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
+struct TickAndAmount {
+	tick: Tick,
+	amount: AssetAmount,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct MockLimitOrder {
+	pub base_asset: Asset,
+	pub account_id: AccountId,
+	pub side: Side,
+	pub order_id: OrderId,
+	pub tick: Tick,
+	pub amount: AssetAmount,
+}
+
+impl MockPallet for MockPoolApi {
+	const PREFIX: &'static [u8] = b"MockPoolApi";
+}
+
+const LIMIT_ORDERS: &[u8] = b"LIMIT_ORDERS";
+
+impl MockPoolApi {
+	pub fn get_limit_orders() -> Vec<MockLimitOrder> {
+		Self::get_value::<LimitOrderStorage>(LIMIT_ORDERS)
+			.unwrap_or_default()
+			.into_iter()
+			.map(|((base_asset, account_id, side, order_id), TickAndAmount { tick, amount })| {
+				MockLimitOrder { base_asset, account_id, side, order_id, tick, amount }
+			})
+			.collect()
+	}
+}
+
+type AccountId = u64;
+
+type LimitOrderStorage = BTreeMap<(Asset, AccountId, Side, OrderId), TickAndAmount>;
+
+impl PoolApi for MockPoolApi {
+	type AccountId = AccountId;
+
+	fn sweep(_who: &Self::AccountId) -> Result<(), DispatchError> {
+		Ok(())
+	}
+
+	fn open_order_count(
+		_who: &Self::AccountId,
+		_asset_pair: &PoolPairsMap<Asset>,
+	) -> Result<u32, DispatchError> {
+		Ok(0)
+	}
+
+	fn open_order_balances(_who: &Self::AccountId) -> AssetMap<AssetAmount> {
+		AssetMap::from_fn(|_| 0)
+	}
+
+	fn pools() -> Vec<PoolPairsMap<Asset>> {
+		vec![]
+	}
+
+	fn update_limit_order(
+		account: &Self::AccountId,
+		base_asset: Asset,
+		quote_asset: Asset,
+		side: Side,
+		id: OrderId,
+		option_tick: Option<cf_primitives::Tick>,
+		amount_change: IncreaseOrDecrease<AssetAmount>,
+	) -> DispatchResult {
+		assert_eq!(quote_asset, STABLE_ASSET);
+		println!("[MockPoolApi]: update_limit_order");
+
+		Self::mutate_value(LIMIT_ORDERS, |limit_orders: &mut Option<LimitOrderStorage>| {
+			let limit_orders = limit_orders.get_or_insert_default();
+
+			let key = (base_asset, *account, side, id);
+
+			let order = limit_orders.remove(&key);
+
+			// Handle balance changes
+			let sold_asset = if side == Side::Buy { quote_asset } else { base_asset };
+			match amount_change {
+				IncreaseOrDecrease::Increase(amount) =>
+					MockBalance::try_debit_account(account, sold_asset, amount).unwrap(),
+				IncreaseOrDecrease::Decrease(amount) =>
+					MockBalance::credit_account(account, sold_asset, amount),
+			};
+
+			let maybe_order = match order {
+				None => {
+					// Creating new order if none exists
+					let tick = option_tick
+						.expect("Tick must be provided for an order that does not exist");
+					let amount = match amount_change {
+						IncreaseOrDecrease::Increase(amount) => amount,
+						IncreaseOrDecrease::Decrease(_) =>
+							panic!("cannot decrease amount if order does not exist"),
+					};
+
+					println!("[MockPoolApi]: order did not exist");
+
+					Some(TickAndAmount { tick, amount })
+				},
+				Some(mut order) => {
+					if let Some(tick) = option_tick {
+						order.tick = tick;
+					}
+
+					println!("[MockPoolApi]: order exists");
+
+					match amount_change {
+						IncreaseOrDecrease::Increase(amount) => {
+							order.amount += amount;
+							Some(order)
+						},
+						IncreaseOrDecrease::Decrease(amount) =>
+							if order.amount < amount {
+								// Negative amount means we are removing the order
+								None
+							} else {
+								order.amount -= amount;
+								Some(order)
+							},
+					}
+				},
+			};
+
+			if let Some(order) = maybe_order {
+				println!("[MockPoolApi]: Order is added");
+				limit_orders.insert(key, order);
+			}
+		});
+
+		Ok(())
+	}
+}

--- a/state-chain/traits/src/mocks/trading_strategy_limits.rs
+++ b/state-chain/traits/src/mocks/trading_strategy_limits.rs
@@ -1,0 +1,28 @@
+use cf_primitives::{Asset, AssetAmount};
+
+use crate::{TradingStrategyParameters, TradingStrategyParametersProvider};
+
+use super::{MockPallet, MockPalletStorage};
+
+pub struct MockTradingStrategyParameters {}
+
+impl MockPallet for MockTradingStrategyParameters {
+	const PREFIX: &'static [u8] = b"TradingStrategyParametersProvider";
+}
+
+const ORDER_UPDATE_THRESHOLDS: &[u8] = b"ORDER_UPDATE_THRESHOLDS";
+
+impl MockTradingStrategyParameters {
+	pub fn set_order_update_threshold(asset: &Asset, new_threshold: AssetAmount) {
+		Self::mutate_value(ORDER_UPDATE_THRESHOLDS, |thresholds| {
+			let thresholds: &mut TradingStrategyParameters = thresholds.get_or_insert_default();
+			thresholds.order_update_thresholds.try_insert(*asset, new_threshold).unwrap();
+		})
+	}
+}
+
+impl TradingStrategyParametersProvider for MockTradingStrategyParameters {
+	fn get_parameters() -> TradingStrategyParameters {
+		Self::get_value::<TradingStrategyParameters>(ORDER_UPDATE_THRESHOLDS).unwrap_or_default()
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2108

## Summary

- Added a new pallet, Trading Strategy, with extrinsics to create a strategy, add new funds to an existing strategy and to close a strategy.
  - strategy id is derived from LP's account and their nonce (this ensures uniqueness of strategy id)
  - adding funds to the strategy moves funds from their account to the strategy's acount;
  - on_idle checks balances of all strategies to see if they are above the threshold for updating limit orders (and updates limit orders if so); limit orders aren't updated if we run out of remaining_weight.
- Moved some "primitive" types out of the pools pallet to where they can be accessed by other pallets: cf-primitives and cf-traits. I preferred cf-traits when the type in question was already part of the signature explosed by one of the traits.
- Conditional autosweeping: when a swap is executed against a pool, we check all pool's limit orders to see if the amount "collectable" is above the threshold (provided by the new pallet via `TradingStrategyParameters` trait) and sweeps the order if so.
- Renamed `inner_update_limit_order` (from cf-pools) to `inner_update_limit_order_at_tick` to make it more clear that it doesn't change the tick, but rather uses it to identify orders. The code from `update_limit_order` and `set_limit_order` (which *does* support changing the tick) was moved to separate functions (inner_update_limit_order and inner_set_limit_order. 
- Updated cf-pools tests to use MockBalance from cf-traits instead of a bespoke mock defined in the pallet (which only supported hardcoded accounts.)
- Unit tests for auto-sweeping and all new extrinsics.

As discussed, I omitted a few things so that we can have core functionality merged first (and early):

- use correct weight for update_limit_order in cf-trading-strategy's on_idle
- benchmarks for new extrinsics
- integration (and bouncer?) tests
- extend `LimitOrderUpdated` event to include the type of order (whether if was updated by LP or through a strategy)
- ensuring that all strategies are closed for LP when their account is deleted
- explicitly limiting assets for which strategies can't be created?
- updating thresholds (for creating a strategy and updating limit orders) via governance + setting default values (?)

I will update linear to add these as sub-issues.