### PR TITLE
fix: explicitly install rust toolchain on M2 Runners 🐛 (#5718)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -48,6 +48,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2025-0009: Transitive dependency use by rustls 0.20.9, as per the advisory, TLS is unaffected.
 # - RUSTSEC-2025-0010: Transitive dependency use by rustls 0.20.9, as per the advisory, TLS is unaffected.
 # - RUSTSEC-2024-0436: Paste is no longer maintained. This is a pre-processor macro, so not an immediate security concern.
+# - RUSTSEC-2025-0014: Humantime is no longer maintained. Transitive dependency of `env_logger`.
 cf-audit = '''
 audit -D unmaintained -D unsound
     --ignore RUSTSEC-2021-0139
@@ -64,4 +65,5 @@ audit -D unmaintained -D unsound
     --ignore RUSTSEC-2025-0009
     --ignore RUSTSEC-2025-0010
     --ignore RUSTSEC-2024-0436
+    --ignore RUSTSEC-2025-0014
 '''

--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Configure Git 🛠️
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Install Rust Toolchain 💿
+        run: rustup toolchain install
+
       - name: Build chainflip binaries 🏗️
         run: |
           cargo cf-build-${{ inputs.profile }} --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10095,7 +10095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13839,7 +13839,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix 0.38.43",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15442,7 +15442,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
* fix: explicitly install rust toolchain on M2 Runners 🐛

* chore: cargo audit

---------

Co-authored-by: Daniel <daniel@chainflip.io>