### PR TITLE
fix rustup install toolchain on m2 build

### DIFF
--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -45,7 +45,7 @@ jobs:
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install Rust Toolchain 💿
-        run: rustup toolchain install
+        run: rustup toolchain install nightly
 
       - name: Build chainflip binaries 🏗️
         run: |


### PR DESCRIPTION
explicitly names the toolchain to install via "rustup install toolchain" to be "nightly" in order to fix the m2 build CI job
