### PR TITLE
specify rustup architecture as darwin

### DIFF
--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -45,7 +45,7 @@ jobs:
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install Rust Toolchain 💿
-        run: rustup toolchain install nightly
+        run: rustup toolchain install nightly-aarch64-apple-darwin
 
       - name: Build chainflip binaries 🏗️
         run: |


### PR DESCRIPTION
explicitly specify darwin arm as the rustup toolchain for m2 build actions