### PR TITLE
fix: m2-toolchain-nightly-2025-01-10-aarch64-apple-darwin

### DIFF
--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -45,7 +45,7 @@ jobs:
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Install Rust Toolchain 💿
-        run: rustup toolchain install nightly-aarch64-apple-darwin
+        run: rustup toolchain install nightly-2025-01-10-aarch64-apple-darwin
 
       - name: Build chainflip binaries 🏗️
         run: |


### PR DESCRIPTION
sets the m2 toolchain to nightly-2025-01-10-aarch64-apple-darwin