### PR TITLE
refactor: include expire block in liquidity deposit details

### DIFF
--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -30,6 +30,7 @@ use cf_chains::eth::Address as EthereumAddress;
 use cf_utilities::{clean_hex_address, round_f64, task_scope::task_scope};
 use chainflip_api::{
 	self as api,
+	lp::LiquidityDepositDetails,
 	primitives::{state_chain_runtime, FLIPPERINOS_PER_FLIP},
 	rpc_types::RedemptionAmount,
 	BrokerApi,
@@ -83,7 +84,7 @@ async fn run_cli() -> Result<()> {
 							.broker_api()
 							.withdraw_fees(params.asset, params.destination_address)
 							.await?;
-						println!("Withdrawal request successfull submitted: {}", withdraw_details);
+						println!("Withdrawal request successful submitted: {}", withdraw_details);
 					},
 					BrokerSubcommands::RegisterAccount => {
 						api.broker_api().register_account().await?;
@@ -97,7 +98,7 @@ async fn run_cli() -> Result<()> {
 						asset,
 						boost_fee,
 					} => {
-						let address = api
+						let LiquidityDepositDetails { deposit_address, deposit_chain_expiry_block } = api
 							.lp_api()
 							.request_liquidity_deposit_address(
 								asset,
@@ -106,7 +107,7 @@ async fn run_cli() -> Result<()> {
 							)
 							.await?
 							.unwrap_details();
-						println!("Deposit Address: {address}");
+						println!("Deposit Address: {deposit_address}\nDeposit chain expire block: {deposit_chain_expiry_block}");
 					},
 
 					LiquidityProviderSubcommands::RegisterLiquidityRefundAddress {

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -84,7 +84,7 @@ async fn run_cli() -> Result<()> {
 							.broker_api()
 							.withdraw_fees(params.asset, params.destination_address)
 							.await?;
-						println!("Withdrawal request successful submitted: {}", withdraw_details);
+						println!("Withdrawal request successfully submitted: {}", withdraw_details);
 					},
 					BrokerSubcommands::RegisterAccount => {
 						api.broker_api().register_account().await?;

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -30,7 +30,7 @@ use cf_chains::eth::Address as EthereumAddress;
 use cf_utilities::{clean_hex_address, round_f64, task_scope::task_scope};
 use chainflip_api::{
 	self as api,
-	lp::LiquidityDepositDetails,
+	lp::LiquidityDepositChannelDetails,
 	primitives::{state_chain_runtime, FLIPPERINOS_PER_FLIP},
 	rpc_types::RedemptionAmount,
 	BrokerApi,
@@ -98,7 +98,7 @@ async fn run_cli() -> Result<()> {
 						asset,
 						boost_fee,
 					} => {
-						let LiquidityDepositDetails { deposit_address, deposit_chain_expiry_block } = api
+						let LiquidityDepositChannelDetails { deposit_address, deposit_chain_expiry_block } = api
 							.lp_api()
 							.request_liquidity_deposit_address(
 								asset,
@@ -107,7 +107,7 @@ async fn run_cli() -> Result<()> {
 							)
 							.await?
 							.unwrap_details();
-						println!("Deposit Address: {deposit_address}\nDeposit chain expire block: {deposit_chain_expiry_block}");
+						println!("Deposit Address: {deposit_address}\nDeposit chain expiry block: {deposit_chain_expiry_block}");
 					},
 
 					LiquidityProviderSubcommands::RegisterLiquidityRefundAddress {

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -28,8 +28,8 @@ use cf_utilities::{
 use chainflip_api::{
 	self,
 	lp::{
-		CloseOrderJson, LimitOrRangeOrder, LimitOrder, LpApi, OpenSwapChannels, OrderIdJson,
-		RangeOrder, RangeOrderSizeJson, Side, Tick,
+		CloseOrderJson, LimitOrRangeOrder, LimitOrder, LiquidityDepositDetails, LpApi,
+		OpenSwapChannels, OrderIdJson, RangeOrder, RangeOrderSizeJson, Side, Tick,
 	},
 	primitives::{
 		chains::{assets::any::AssetMap, Bitcoin, Ethereum, Polkadot},
@@ -70,7 +70,7 @@ pub trait Rpc {
 		asset: Asset,
 		wait_for: Option<WaitFor>,
 		boost_fee: Option<BasisPoints>,
-	) -> RpcResult<ApiWaitForResult<String>>;
+	) -> RpcResult<ApiWaitForResult<LiquidityDepositDetails>>;
 
 	#[method(name = "register_liquidity_refund_address")]
 	async fn register_liquidity_refund_address(
@@ -250,13 +250,12 @@ impl RpcServer for RpcServerImpl {
 		asset: Asset,
 		wait_for: Option<WaitFor>,
 		boost_fee: Option<BasisPoints>,
-	) -> RpcResult<ApiWaitForResult<String>> {
+	) -> RpcResult<ApiWaitForResult<LiquidityDepositDetails>> {
 		Ok(self
 			.api
 			.lp_api()
 			.request_liquidity_deposit_address(asset, wait_for.unwrap_or_default(), boost_fee)
-			.await
-			.map(|result| result.map_details(|address| address.to_string()))?)
+			.await?)
 	}
 
 	async fn register_liquidity_refund_address(

--- a/api/cf-rpc-types/src/lp.rs
+++ b/api/cf-rpc-types/src/lp.rs
@@ -147,7 +147,7 @@ impl From<SwapRequestId> for SwapRequestResponse {
 	}
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct LiquidityDepositChannelDetails {
 	pub deposit_address: AddressString,
 	pub deposit_chain_expiry_block: <AnyChain as Chain>::ChainBlockNumber,

--- a/api/cf-rpc-types/src/lp.rs
+++ b/api/cf-rpc-types/src/lp.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_chains::{address::AddressString, Arbitrum, Solana};
+use cf_chains::{address::AddressString, AnyChain, Arbitrum, Chain, Solana};
 use cf_primitives::*;
 use sp_core::{
 	serde::{Deserialize, Serialize},
@@ -148,7 +148,7 @@ impl From<SwapRequestId> for SwapRequestResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct LiquidityDepositDetails {
+pub struct LiquidityDepositChannelDetails {
 	pub deposit_address: AddressString,
-	pub deposit_chain_expiry_block: u64,
+	pub deposit_chain_expiry_block: <AnyChain as Chain>::ChainBlockNumber,
 }

--- a/api/cf-rpc-types/src/lp.rs
+++ b/api/cf-rpc-types/src/lp.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_chains::{Arbitrum, Solana};
+use cf_chains::{address::AddressString, Arbitrum, Solana};
 use cf_primitives::*;
 use sp_core::{
 	serde::{Deserialize, Serialize},
@@ -145,4 +145,10 @@ impl From<SwapRequestId> for SwapRequestResponse {
 	fn from(swap_request_id: SwapRequestId) -> Self {
 		SwapRequestResponse { swap_request_id }
 	}
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LiquidityDepositDetails {
+	pub deposit_address: AddressString,
+	pub deposit_chain_expiry_block: u64,
 }

--- a/api/lib/src/lp.rs
+++ b/api/lib/src/lp.rs
@@ -39,8 +39,8 @@ use state_chain_runtime::RuntimeCall;
 use std::ops::Range;
 
 pub use cf_rpc_types::lp::{
-	CloseOrderJson, LimitOrRangeOrder, LimitOrder, LiquidityDepositDetails, OpenSwapChannels,
-	OrderIdJson, RangeOrder, RangeOrderChange, RangeOrderSizeJson,
+	CloseOrderJson, LimitOrRangeOrder, LimitOrder, LiquidityDepositChannelDetails,
+	OpenSwapChannels, OrderIdJson, RangeOrder, RangeOrderChange, RangeOrderSizeJson,
 };
 
 fn collect_range_order_returns(
@@ -170,7 +170,7 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 		asset: Asset,
 		wait_for: WaitFor,
 		boost_fee: Option<BasisPoints>,
-	) -> Result<ApiWaitForResult<LiquidityDepositDetails>> {
+	) -> Result<ApiWaitForResult<LiquidityDepositChannelDetails>> {
 		let wait_for_result = self
 			.submit_signed_extrinsic_wait_for(
 				pallet_cf_lp::Call::request_liquidity_deposit_address {
@@ -194,7 +194,7 @@ pub trait LpApi: SignedExtrinsicApi + Sized + Send + Sync + 'static {
 								deposit_chain_expiry_block,
 								..
 							},
-						) => Some(LiquidityDepositDetails {
+						) => Some(LiquidityDepositChannelDetails {
 							deposit_address: AddressString::from_encoded_address(deposit_address),
 							deposit_chain_expiry_block,
 						}),

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -98,7 +98,7 @@ async function testLiquidityDeposit(logger: Logger) {
   ).event;
 
   const liquidityDepositAddress = (
-    await lpApiRpc(logger, `lp_liquidity_deposit`, [testRpcAsset, 'InBlock'])
+    await lpApiRpc(logger, `lp_liquidity_deposit_v2`, [testRpcAsset, 'InBlock'])
   ).tx_details.response.deposit_address;
   const liquidityDepositEvent = await observeLiquidityDepositAddressReadyEvent;
 

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -99,7 +99,7 @@ async function testLiquidityDeposit(logger: Logger) {
 
   const liquidityDepositAddress = (
     await lpApiRpc(logger, `lp_liquidity_deposit`, [testRpcAsset, 'InBlock'])
-  ).tx_details.response;
+  ).tx_details.response.deposit_address;
   const liquidityDepositEvent = await observeLiquidityDepositAddressReadyEvent;
 
   assert.strictEqual(


### PR DESCRIPTION
# Pull Request

Closes: PRO-2039

## Checklist

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Added a new RPC `lp_request_liquidity_deposit_address`, It returns a struct with the address and expire block.
~~This is a breaking change for this RPC. @acdibble~~
