### PR TITLE
feat: update subxt to >0.41.0 with breaking changes fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,11 +4164,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7af3d1149d6063985bb62d97f3ea83060ce4d6f2d04c21f551d270e8d84a27c"
+checksum = "50c554ce2394e2c04426a070b4cb133c72f6f14c86b665f4e13094addd8e8958"
 dependencies = [
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-decode 0.16.0",
  "scale-info",
@@ -4211,6 +4211,18 @@ name = "frame-metadata"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -11676,9 +11688,9 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3173be608895eb117cf397ab4f31f00e2ed2c7af1c6e0b8f5d51d0a0967053"
+checksum = "6aebea322734465f39e4ad8100e1f9708c6c6c325d92b8780015d30c44fae791"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13888,13 +13900,13 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
  "jsonrpsee 0.24.8",
@@ -13924,8 +13936,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -13940,14 +13952,14 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
  "frame-decode",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde 0.5.0",
@@ -13969,8 +13981,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "futures",
  "futures-util",
@@ -13985,8 +13997,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "darling 0.20.10",
  "parity-scale-codec",
@@ -14005,11 +14017,11 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "frame-decode",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -14019,11 +14031,11 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "derive-where",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
  "impl-serde 0.5.0",
@@ -14042,8 +14054,8 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.39.0"
-source = "git+https://github.com/paritytech/subxt?rev=69ce6d7#69ce6d726ff6150c83fdfac52d867f2b3c69c6d3"
+version = "0.41.0"
+source = "git+https://github.com/paritytech/subxt?rev=da3ea0b#da3ea0b528c00d2ec6cbc618f46db382dc7bd117"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,9 +163,9 @@ x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
 
-# subxt dependency (at the moment points to the commit hash of the PR removing polkadot-sdk as dependency).
-# TODO: remove the commit hash when subxt is released > 0.39.0
-subxt = { git = "https://github.com/paritytech/subxt", rev = "69ce6d7" }
+# subxt dependency (at the moment points to the commit hash of the PR fixing subxt macro wasm loading).
+# TODO: remove the commit hash when subxt is released > 0.41.0
+subxt = { git = "https://github.com/paritytech/subxt", rev = "da3ea0b" }
 
 # PolkadotSdk Pallets
 pallet-aura = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-1.15.2+2", default-features = false }

--- a/api/cf-node-client/Cargo.toml
+++ b/api/cf-node-client/Cargo.toml
@@ -26,7 +26,7 @@ frame-metadata = { workspace = true, default-features = true, features = [
     "current",
 ] }
 frame-metadata-hash-extension = { workspace = true }
-subxt = { workspace = true, features = ["runtime-metadata-path"] }
+subxt = { workspace = true, features = ["runtime-wasm-path"] }
 
 cf-chains = { workspace = true, default-features = true }
 cf-primitives = { workspace = true }

--- a/api/cf-node-client/src/subxt_state_chain_config.rs
+++ b/api/cf-node-client/src/subxt_state_chain_config.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use subxt::{config::signed_extensions, Config};
+use subxt::{config::transaction_extensions, Config};
 
 pub enum StateChainConfig {}
 
@@ -27,17 +27,18 @@ impl Config for StateChainConfig {
 	type Hasher = subxt::config::substrate::BlakeTwo256;
 	type Header = subxt::config::substrate::SubstrateHeader<u32, Self::Hasher>;
 	type AssetId = u32; // Not used - we don't use pallet-assets
-	type ExtrinsicParams = signed_extensions::AnyOf<
+	type ExtrinsicParams = transaction_extensions::AnyOf<
 		Self,
 		(
-			signed_extensions::CheckSpecVersion,
-			signed_extensions::CheckTxVersion,
-			signed_extensions::CheckNonce,
-			signed_extensions::CheckGenesis<Self>,
-			signed_extensions::CheckMortality<Self>,
-			signed_extensions::ChargeAssetTxPayment<Self>,
-			signed_extensions::ChargeTransactionPayment,
-			signed_extensions::CheckMetadataHash,
+			transaction_extensions::VerifySignature<Self>,
+			transaction_extensions::CheckSpecVersion,
+			transaction_extensions::CheckTxVersion,
+			transaction_extensions::CheckNonce,
+			transaction_extensions::CheckGenesis<Self>,
+			transaction_extensions::CheckMortality<Self>,
+			transaction_extensions::ChargeAssetTxPayment<Self>,
+			transaction_extensions::ChargeTransactionPayment,
+			transaction_extensions::CheckMetadataHash,
 		),
 	>;
 }

--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -795,10 +795,6 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 						self.0.clone()
 					}
 
-					fn address(&self) -> <StateChainConfig as subxt::Config>::Address {
-						subxt::utils::MultiAddress::Id(self.0.clone())
-					}
-
 					fn sign(&self, bytes: &[u8]) -> <StateChainConfig as subxt::Config>::Signature {
 						use sp_core::Pair;
 						state_chain_runtime::Signature::Sr25519(self.1.sign(bytes))
@@ -826,11 +822,6 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 				const MAX_UPDATE_VERSION_RETRIES: usize = 10;
 				let mut update_successful = false;
 				for retry in 1..=MAX_UPDATE_VERSION_RETRIES {
-					let block_hash = subxt::utils::H256::from_slice(
-						finalized_block_stream.cache().hash.as_bytes(),
-					);
-					let block_number = finalized_block_stream.cache().number;
-
 					// Submitting transaction with subxt sometimes gets stuck without returning any
 					// error (see https://linear.app/chainflip/issue/PRO-1064/new-cfe-version-gets-stuck-on-startup),
 					// so we use a timeout to ensure we can recover:
@@ -859,11 +850,7 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 								),
 								&subxt_signer,
 								DefaultExtrinsicParamsBuilder::new()
-									.mortal_unchecked(
-										block_number.into(),
-										block_hash,
-										SIGNED_EXTRINSIC_LIFETIME.into(),
-									)
+									.mortal(SIGNED_EXTRINSIC_LIFETIME.into())
 									.nonce(current_nonce.into())
 									.build(),
 							)

--- a/engine/src/witness/dot.rs
+++ b/engine/src/witness/dot.rs
@@ -81,7 +81,7 @@ use polkadot::{
 };
 
 pub fn filter_map_events(
-	res_event_details: Result<EventDetails<PolkadotConfig>, subxt::ext::subxt_core::error::Error>,
+	res_event_details: Result<EventDetails<PolkadotConfig>, subxt::Error>,
 ) -> Option<(Phase, EventWrapper)> {
 	match res_event_details {
 		Ok(event_details) => match (event_details.pallet_name(), event_details.variant_name()) {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2123

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* This PR upgrades subxt to rev: [da3ea0b](https://github.com/paritytech/subxt/commit/da3ea0b528c00d2ec6cbc618f46db382dc7bd117) which includes our suggested fix to the wasm-loader in the subxt macro that was causing our CI to fail when the runtime is not built with std feature.
* Also had to make minor changes to fix breaking changes introduced by recent subxt commits such as: renaming signed_extentions to transaction_extensions 
