### PR TITLE
feat: add RPC to return all current vault addresses (#5711)

### DIFF
--- a/api/bin/chainflip-broker-api/src/main.rs
+++ b/api/bin/chainflip-broker-api/src/main.rs
@@ -23,7 +23,7 @@ use chainflip_api::{
 	self,
 	primitives::{
 		state_chain_runtime::runtime_apis::{
-			ChainAccounts, TransactionScreeningEvents, VaultSwapDetails,
+			ChainAccounts, TransactionScreeningEvents, VaultAddresses, VaultSwapDetails,
 		},
 		AccountRole, AffiliateDetails, Affiliates, Asset, BasisPoints, CcmChannelMetadata,
 		DcaParameters,
@@ -167,6 +167,9 @@ pub trait Rpc {
 		&self,
 		affiliate_account_id: AccountId32,
 	) -> RpcResult<WithdrawFeesDetail>;
+
+	#[method(name = "get_vault_addresses", aliases = ["broker_getVaultAddresses"])]
+	async fn vault_addresses(&self) -> RpcResult<VaultAddresses>;
 }
 
 pub struct RpcServerImpl {
@@ -342,6 +345,10 @@ impl RpcServer for RpcServerImpl {
 		affiliate_account_id: AccountId32,
 	) -> RpcResult<WithdrawFeesDetail> {
 		Ok(self.api.broker_api().affiliate_withdrawal_request(affiliate_account_id).await?)
+	}
+
+	async fn vault_addresses(&self) -> RpcResult<VaultAddresses> {
+		Ok(self.api.raw_client().cf_vault_addresses(None).await?)
 	}
 }
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -79,7 +79,8 @@ use state_chain_runtime::{
 		AuctionState, BoostPoolDepth, BoostPoolDetails, BrokerInfo, CcmData, ChainAccounts,
 		CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi, FailingWitnessValidators,
 		FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, RuntimeApiPenalty,
-		SimulatedSwapInformation, TransactionScreeningEvents, ValidatorInfo, VaultSwapDetails,
+		SimulatedSwapInformation, TransactionScreeningEvents, ValidatorInfo, VaultAddresses,
+		VaultSwapDetails,
 	},
 	safe_mode::RuntimeSafeMode,
 	Hash, NetworkFee, SolanaInstance,
@@ -1048,6 +1049,12 @@ pub trait CustomApi {
 		affiliate: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<(state_chain_runtime::AccountId, AffiliateDetails)>>;
+
+	#[method(name = "get_vault_addresses")]
+	fn cf_vault_addresses(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<VaultAddresses>;
 }
 
 /// An RPC extension for the state chain node.
@@ -1313,6 +1320,7 @@ where
 		cf_pool_price(from_asset: Asset, to_asset: Asset) -> Option<PoolPriceV1>,
 		cf_get_open_deposit_channels(account_id: Option<state_chain_runtime::AccountId>) -> ChainAccounts,
 		cf_affiliate_details(broker: state_chain_runtime::AccountId, affiliate: Option<state_chain_runtime::AccountId>) -> Vec<(state_chain_runtime::AccountId, AffiliateDetails)>,
+		cf_vault_addresses() -> VaultAddresses,
 	}
 
 	pass_through_and_flatten! {
@@ -2115,6 +2123,8 @@ where
 mod test {
 	use std::collections::BTreeSet;
 
+	use cf_chains::address::EncodedAddress;
+
 	use super::*;
 	use cf_chains::{assets::sol, btc::ScriptPubkey};
 	use cf_primitives::{
@@ -2477,5 +2487,15 @@ mod test {
 			broker_commission: RpcFee { asset: Asset::Usdc, amount: 100u128.into() },
 		})
 		.unwrap());
+	}
+
+	#[test]
+	fn test_vault_addresses_custom_rpc() {
+		let val: VaultAddresses = VaultAddresses {
+			ethereum: EncodedAddress::Eth([0; 20]),
+			arbitrum: EncodedAddress::Arb([1; 20]),
+			bitcoin: vec![(ID_1.clone(), EncodedAddress::Btc(Vec::new()))],
+		};
+		insta::assert_json_snapshot!(val);
 	}
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__test__vault_addresses_custom_rpc.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__test__vault_addresses_custom_rpc.snap
@@ -1,0 +1,63 @@
+---
+source: state-chain/custom-rpc/src/lib.rs
+expression: val
+snapshot_kind: text
+---
+{
+  "ethereum": {
+    "Eth": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "arbitrum": {
+    "Arb": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1
+    ]
+  },
+  "bitcoin": [
+    [
+      "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",
+      {
+        "Btc": []
+      }
+    ]
+  ]
+}

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -83,6 +83,7 @@ use cf_primitives::{
 	chains::assets, AccountRole, Asset, AssetAmount, BasisPoints, Beneficiaries, ChannelId,
 	DcaParameters,
 };
+
 use cf_traits::{
 	AccountInfo, AccountRoleRegistry, BackupRewardsNotifier, BlockEmissions,
 	BroadcastAnyChainGovKey, Broadcaster, Chainflip, CommKeyBroadcaster, DepositApi, EgressApi,

--- a/state-chain/runtime/src/chainflip/address_derivation/btc.rs
+++ b/state-chain/runtime/src/chainflip/address_derivation/btc.rs
@@ -17,12 +17,44 @@
 use super::AddressDerivation;
 use crate::{BitcoinThresholdSigner, Environment, EpochKey, String};
 use cf_chains::{
-	address::{AddressDerivationApi, AddressDerivationError},
-	btc::deposit_address::DepositAddress,
+	address::{AddressDerivationApi, AddressDerivationError, EncodedAddress},
+	btc::{deposit_address::DepositAddress, AggKey, ScriptPubkey},
 	Bitcoin, Chain,
 };
 use cf_primitives::ChannelId;
 use cf_traits::KeyProvider;
+
+pub struct BitcoinPrivateBrokerDepositAddresses<Address> {
+	pub previous: Option<Address>,
+	pub current: Address,
+}
+
+impl<A> BitcoinPrivateBrokerDepositAddresses<A> {
+	pub fn map_address<B, F>(self, f: F) -> BitcoinPrivateBrokerDepositAddresses<B>
+	where
+		F: Fn(A) -> B,
+	{
+		BitcoinPrivateBrokerDepositAddresses {
+			previous: self.previous.map(&f),
+			current: f(self.current),
+		}
+	}
+}
+
+impl BitcoinPrivateBrokerDepositAddresses<ScriptPubkey> {
+	pub fn with_encoded_addresses(self) -> BitcoinPrivateBrokerDepositAddresses<EncodedAddress> {
+		self.map_address(|script_pubkey| {
+			EncodedAddress::from_chain_account::<Bitcoin>(
+				script_pubkey,
+				Environment::network_environment(),
+			)
+		})
+	}
+
+	pub fn current_address(&self) -> String {
+		self.current.to_address(&Environment::network_environment().into())
+	}
+}
 
 impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 	fn generate_address(
@@ -62,18 +94,23 @@ impl AddressDerivationApi<Bitcoin> for AddressDerivation {
 
 /// ONLY FOR USE IN RPC CALLS.
 ///
-/// Derives the BTC vault deposit address from the private channel id.
+/// Derives the current and previous BTC vault deposit addresses from the private channel id.
 /// Note: This function will **panic** if the private channel id is out of bounds or if there is
 /// no active epoch key for Bitcoin.
-pub(crate) fn derive_btc_vault_deposit_address(private_channel_id: u64) -> String {
-	let EpochKey { key, .. } = BitcoinThresholdSigner::active_epoch_key()
-		.expect("We should always have a key for the current epoch.");
-	DepositAddress::new(
-		key.current,
-		private_channel_id.try_into().expect("Private channel id out of bounds."),
-	)
-	.script_pubkey()
-	.to_address(&Environment::network_environment().into())
+///
+/// Note: If there is no previous key, we return `None` for the previous address.
+pub fn derive_btc_vault_deposit_addresses(
+	private_channel_id: u64,
+) -> BitcoinPrivateBrokerDepositAddresses<ScriptPubkey> {
+	let EpochKey { key: AggKey { previous, current }, .. } =
+		BitcoinThresholdSigner::active_epoch_key()
+			.expect("We should always have a key for the current epoch.");
+
+	let private_channel_id: u32 =
+		private_channel_id.try_into().expect("Private channel id out of bounds.");
+
+	BitcoinPrivateBrokerDepositAddresses { previous, current }
+		.map_address(|key| DepositAddress::new(key, private_channel_id).script_pubkey())
 }
 
 #[test]

--- a/state-chain/runtime/src/chainflip/vault_swaps.rs
+++ b/state-chain/runtime/src/chainflip/vault_swaps.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	chainflip::{
-		address_derivation::btc::derive_btc_vault_deposit_address, AddressConverter,
+		address_derivation::btc::derive_btc_vault_deposit_addresses, AddressConverter,
 		ChainAddressConverter, EvmEnvironment, SolEnvironment,
 	},
 	runtime_apis::{DispatchErrorWithMessage, EvmVaultSwapDetails, VaultSwapDetails},
@@ -111,7 +111,7 @@ pub fn bitcoin_vault_swap(
 
 	Ok(VaultSwapDetails::Bitcoin {
 		nulldata_payload: encode_swap_params_in_nulldata_payload(params),
-		deposit_address: derive_btc_vault_deposit_address(private_channel_id),
+		deposit_address: derive_btc_vault_deposit_addresses(private_channel_id).current_address(),
 	})
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -27,7 +27,9 @@ pub mod test_runner;
 mod weights;
 use crate::{
 	chainflip::{
-		address_derivation::btc::derive_btc_vault_deposit_address,
+		address_derivation::btc::{
+			derive_btc_vault_deposit_addresses, BitcoinPrivateBrokerDepositAddresses,
+		},
 		calculate_account_apy,
 		solana_elections::{
 			SolanaChainTrackingProvider, SolanaEgressWitnessingTrigger, SolanaIngress,
@@ -45,7 +47,7 @@ use crate::{
 		BoostPoolDetails, BrokerInfo, CcmData, DispatchErrorWithMessage, FailingWitnessValidators,
 		FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, RuntimeApiPenalty,
 		SimulateSwapAdditionalOrder, SimulatedSwapInformation, TransactionScreeningEvents,
-		ValidatorInfo, VaultSwapDetails,
+		ValidatorInfo, VaultAddresses, VaultSwapDetails,
 	},
 };
 use cf_amm::{
@@ -1943,7 +1945,7 @@ impl_runtime_apis! {
 					(asset, AssetBalances::get_balance(&account_id, asset))
 				).collect(),
 				btc_vault_deposit_address: BrokerPrivateBtcChannels::<Runtime>::get(&account_id)
-					.map(derive_btc_vault_deposit_address),
+					.map(|channel| derive_btc_vault_deposit_addresses(channel).current_address()),
 				affiliates: pallet_cf_swapping::AffiliateAccountDetails::<Runtime>::iter_prefix(&account_id).collect(),
 				bond: account_info.bond()
 			}
@@ -2327,6 +2329,21 @@ impl_runtime_apis! {
 					.collect()
 			} else {
 				pallet_cf_swapping::AffiliateAccountDetails::<Runtime>::iter_prefix(&broker).collect()
+			}
+		}
+
+		fn cf_vault_addresses() -> VaultAddresses {
+			VaultAddresses {
+				ethereum: EncodedAddress::Eth(Environment::eth_vault_address().into()),
+				arbitrum: EncodedAddress::Arb(Environment::arb_vault_address().into()),
+				bitcoin: BrokerPrivateBtcChannels::<Runtime>::iter()
+					.flat_map(|(account_id, channel_id)| {
+						let BitcoinPrivateBrokerDepositAddresses { previous, current } = derive_btc_vault_deposit_addresses(channel_id)
+							.with_encoded_addresses();
+						previous.into_iter().chain(core::iter::once(current))
+							.map(move |address| (account_id.clone(), address))
+					})
+					.collect(),
 			}
 		}
 	}

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -323,6 +323,13 @@ pub struct TransactionScreeningEvents {
 	pub btc_events: Vec<BrokerRejectionEventFor<cf_chains::Bitcoin>>,
 }
 
+#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+pub struct VaultAddresses {
+	pub ethereum: EncodedAddress,
+	pub arbitrum: EncodedAddress,
+	pub bitcoin: Vec<(AccountId32, EncodedAddress)>,
+}
+
 // READ THIS BEFORE UPDATING THIS TRAIT:
 //
 // ## When changing an existing method:
@@ -491,6 +498,7 @@ decl_runtime_apis!(
 			broker: AccountId32,
 			affiliate: Option<AccountId32>,
 		) -> Vec<(AccountId32, AffiliateDetails)>;
+		fn cf_vault_addresses() -> VaultAddresses;
 	}
 );
 


### PR DESCRIPTION
Cherry-picks #5711 to main. 



* feat: Added endpoint to return vault addresses

* refactor: added runtime call

* refactor: Extended the API to return also all deposit addresses

* tests: added snapshop tests for vault_address encoding

* refactor: applied requested changes

- Simplified return of vault addresses
- Handle None case in address derivation
- Removed BTC root vault

* chore: fixed clippy + tests

* chore: using struct instead of tuple

* chore: small refactors:

- rename struct
- encapsulate address conversions

---------
