### PR TITLE
fix: more robust cancellation of strategy orders

### DIFF
--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1147,6 +1147,31 @@ impl<T: Config> PoolApi for Pallet<T> {
 		Pools::<T>::iter_keys().map(|asset_pair| asset_pair.assets()).collect()
 	}
 
+	fn cancel_all_limit_orders(account: &Self::AccountId) -> DispatchResult {
+		// Collect to avoid undefined behaviour (See StorageMap::iter_keys documentation)
+		for asset_pair in Pools::<T>::iter_keys().collect::<Vec<_>>() {
+			let pool = Pools::<T>::get(asset_pair).unwrap();
+
+			for (asset, orders) in
+				pool.limit_orders_cache.as_ref().into_iter().filter_map(|(asset, cache)| {
+					cache.get(account).cloned().map(|orders| (asset, orders))
+				}) {
+				for (id, tick) in orders {
+					Self::cancel_limit_order(
+						account,
+						asset_pair.assets().base,
+						asset_pair.assets().quote,
+						asset.sell_order(),
+						id,
+						tick,
+					)?;
+				}
+			}
+		}
+
+		Ok(())
+	}
+
 	fn update_limit_order(
 		account: &Self::AccountId,
 		base_asset: Asset,

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -1148,7 +1148,8 @@ impl<T: Config> PoolApi for Pallet<T> {
 	}
 
 	fn cancel_all_limit_orders(account: &Self::AccountId) -> DispatchResult {
-		// Collect to avoid undefined behaviour (See StorageMap::iter_keys documentation)
+		// Collect to avoid undefined behaviour (See StorageMap::iter_keys documentation).
+		// Note that we read one pool at a time to optimise memory usage.
 		for asset_pair in Pools::<T>::iter_keys().collect::<Vec<_>>() {
 			let pool = Pools::<T>::get(asset_pair).unwrap();
 
@@ -1338,7 +1339,8 @@ enum NoOpStatus {
 
 impl<T: Config> Pallet<T> {
 	fn inner_sweep(lp: &T::AccountId) -> DispatchResult {
-		// Collect to avoid undefined behaviour (See StorsgeMap::iter_keys documentation)
+		// Collect to avoid undefined behaviour (See StorageMap::iter_keys documentation).
+		// Note that we read one pool at a time to optimise memory usage.
 		for asset_pair in Pools::<T>::iter_keys().collect::<Vec<_>>() {
 			let mut pool = Pools::<T>::get(asset_pair).unwrap();
 

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -309,21 +309,7 @@ pub mod pallet {
 			let strategy =
 				Strategies::<T>::take(lp, &strategy_id).ok_or(Error::<T>::StrategyNotFound)?;
 
-			// TODO: instead of reading ticks from the strategy, we could extend PoolApi with
-			// a method to close all (limit) orders (which might be necessary for more complex
-			// strategies).
-			let TradingStrategy::SellAndBuyAtTicks { buy_tick, sell_tick, base_asset } = strategy;
-
-			for (side, tick) in [(Side::Buy, buy_tick), (Side::Sell, sell_tick)] {
-				T::PoolApi::cancel_limit_order(
-					&strategy_id,
-					base_asset,
-					STABLE_ASSET,
-					side,
-					STRATEGY_ORDER_ID,
-					tick,
-				)?;
-			}
+			T::PoolApi::cancel_all_limit_orders(&strategy_id)?;
 
 			for asset in strategy.supported_assets() {
 				let balance = T::BalanceApi::get_balance(&strategy_id, asset);

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -380,22 +380,22 @@ fn strategy_deployment_threshold() {
 	});
 }
 
-// #[test]
-// fn deregistration_check() {
-// 	new_test_ext()
-// 		.then_execute_with(|_| deploy_strategy())
-// 		.then_execute_with_keep_context(|_| {
-// 			assert!(matches!(
-// 				TradingStrategyDeregistrationCheck::<Test>::check(&LP),
-// 				Err(Error::<Test>::LpHasActiveStrategies)
-// 			));
-// 		})
-// 		.then_execute_with_keep_context(|strategy_id| {
-// 			assert_ok!(TradingStrategyPallet::close_strategy(
-// 				RuntimeOrigin::signed(LP),
-// 				*strategy_id
-// 			));
+#[test]
+fn deregistration_check() {
+	new_test_ext()
+		.then_execute_with(|_| deploy_strategy())
+		.then_execute_with_keep_context(|_| {
+			assert!(matches!(
+				TradingStrategyDeregistrationCheck::<Test>::check(&LP),
+				Err(Error::<Test>::LpHasActiveStrategies)
+			));
+		})
+		.then_execute_with_keep_context(|strategy_id| {
+			assert_ok!(TradingStrategyPallet::close_strategy(
+				RuntimeOrigin::signed(LP),
+				*strategy_id
+			));
 
-// 			assert_ok!(TradingStrategyDeregistrationCheck::<Test>::check(&LP));
-// 		});
-// }
+			assert_ok!(TradingStrategyDeregistrationCheck::<Test>::check(&LP));
+		});
+}

--- a/state-chain/traits/src/liquidity.rs
+++ b/state-chain/traits/src/liquidity.rs
@@ -138,6 +138,8 @@ pub trait PoolApi {
 		amount_change: IncreaseOrDecrease<AssetAmount>,
 	) -> DispatchResult;
 
+	fn cancel_all_limit_orders(account: &Self::AccountId) -> DispatchResult;
+
 	fn cancel_limit_order(
 		account: &Self::AccountId,
 		base_asset: Asset,

--- a/state-chain/traits/src/mocks/pool_api.rs
+++ b/state-chain/traits/src/mocks/pool_api.rs
@@ -76,6 +76,16 @@ impl PoolApi for MockPoolApi {
 		vec![]
 	}
 
+	fn cancel_all_limit_orders(who: &Self::AccountId) -> frame_support::dispatch::DispatchResult {
+		Self::mutate_value(LIMIT_ORDERS, |limit_orders: &mut Option<LimitOrderStorage>| {
+			if let Some(limit_orders) = limit_orders {
+				limit_orders.retain(|(_, account, _, _), _| account != who);
+			}
+
+			Ok(())
+		})
+	}
+
 	fn update_limit_order(
 		account: &Self::AccountId,
 		base_asset: Asset,


### PR DESCRIPTION
# Pull Request

## Summary

Now instead of having to remember which orders a strategy creates (which given the old code would result in an error if the strategy was closed in the same block as its creation), the strategy simply asks the pool api to cancel all of orders recorded to belong to that strategy. (I think this is a better solution since it will probably be more error prone keeping track of open orders in the strategy pallet especially once we add more complex strategies.) More context: https://github.com/chainflip-io/chainflip-backend/pull/5715#issuecomment-2724769776

