### PR TITLE
Fix: implement reject call for arbitrum

### DIFF
--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -19,6 +19,7 @@ pub enum ArbitrumApi<Environment: 'static> {
 	AllBatch(EvmTransactionBuilder<all_batch::AllBatch>),
 	ExecutexSwapAndCall(EvmTransactionBuilder<execute_x_swap_and_call::ExecutexSwapAndCall>),
 	TransferFallback(EvmTransactionBuilder<transfer_fallback::TransferFallback>),
+	RejectCall(EvmTransactionBuilder<all_batch::AllBatch>),
 	#[doc(hidden)]
 	#[codec(skip)]
 	_Phantom(PhantomData<Environment>, Never),
@@ -150,9 +151,24 @@ impl<E> From<EvmTransactionBuilder<transfer_fallback::TransferFallback>> for Arb
 	}
 }
 
-impl<E> RejectCall<Arbitrum> for ArbitrumApi<E> where
-	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>
+impl<E> RejectCall<Arbitrum> for ArbitrumApi<E>
+where
+	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
+	fn new_unsigned(
+		_deposit_details: <Arbitrum as Chain>::DepositDetails,
+		refund_address: <Arbitrum as Chain>::ChainAccount,
+		refund_amount: <Arbitrum as Chain>::ChainAmount,
+		asset: <Arbitrum as Chain>::ChainAsset,
+		deposit_fetch_id: <Arbitrum as Chain>::DepositFetchId,
+	) -> Result<Self, RejectError> {
+		Ok(Self::RejectCall(evm_all_batch_builder::<Arbitrum, _>(
+			vec![FetchAssetParams { deposit_fetch_id, asset }],
+			vec![TransferAssetParams { asset, amount: refund_amount, to: refund_address }],
+			E::token_address,
+			E::replay_protection(E::vault_address()),
+		)?))
+	}
 }
 
 macro_rules! map_over_api_variants {
@@ -162,6 +178,7 @@ macro_rules! map_over_api_variants {
 			ArbitrumApi::AllBatch($var) => $var_method,
 			ArbitrumApi::ExecutexSwapAndCall($var) => $var_method,
 			ArbitrumApi::TransferFallback($var) => $var_method,
+			ArbitrumApi::RejectCall($var) => $var_method,
 			ArbitrumApi::_Phantom(..) => unreachable!(),
 		}
 	};


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Currently the `RejectCall` implementation for Arbitrum is the default implementation and does nothing. This means that when an arbitrum tx is marked for rejection, the actual call to reject it cannot be executed. This means that funds are neither ingressed nor sent back.

The implementation itself is a copy of the code for Ethereum.