### PR TITLE
fix: order_fills_for_block fix to show error only when result is none

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -2117,19 +2117,30 @@ where
 							previous_item = Some(new_item.clone());
 							previous_state = Some(new_state);
 
-							if let Ok(Some(header)) = client.header(hash) {
-								Some(Ok(BlockUpdate {
+							match client.header(hash) {
+								Ok(Some(header)) => Some(Ok(BlockUpdate {
 									block_hash: hash,
 									block_number: *header.number(),
 									data: new_item,
-								}))
-							} else if end_on_error {
-								Some(Err(internal_error(format!(
-									"Could not fetch block header for block {:?}",
-									hash
-								))))
-							} else {
-								None
+								})),
+								Ok(None) =>
+									if end_on_error {
+										Some(Err(internal_error(format!(
+											"Couldn't find block {:?}",
+											hash,
+										))))
+									} else {
+										None
+									},
+								Err(e) =>
+									if end_on_error {
+										Some(Err(internal_error(format!(
+											"Couldn't fetch block header for block {:?}: {}",
+											hash, e
+										))))
+									} else {
+										None
+									},
 							}
 						},
 						Err(error) => {

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -58,10 +58,9 @@ where
 		+ StorageProvider<B, BE>,
 	C::Api: CustomRuntimeApi<B>,
 {
-	let header = client
-		.header(hash)
-		.map_err(|e| call_error(e))?
-		.ok_or(internal_error(format!("Could not fetch block header for block {:?}", hash)))?;
+	let header = client.header(hash).map_err(|e| call_error(e))?.ok_or_else(|| {
+		internal_error(format!("Could not fetch block header for block {:?}", hash))
+	})?;
 
 	let pools = StorageQueryApi::new(client)
 		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(hash)?;


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* Fixes reported issues of seeing "Could not fetch block header"  internal error for lp_order_fills subscription
