### PR TITLE
feat: safe mode for trading strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8470,6 +8470,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B2)",
 ]
 

--- a/state-chain/pallets/cf-trading-strategy/Cargo.toml
+++ b/state-chain/pallets/cf-trading-strategy/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 log = { workspace = true }
+serde = { workspace = true, features = ["derive", "alloc"] }
 
 # Local deps
 cf-primitives = { workspace = true }
@@ -45,6 +46,7 @@ std = [
     "frame-benchmarking?/std",
     "frame-support/std",
     "frame-system/std",
+    "serde/std",
 ]
 runtime-benchmarks = [
     "cf-traits/runtime-benchmarks",

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -157,8 +157,9 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_idle(_current_block: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
-			let mut weight_used: Weight = T::DbWeight::get().reads(1);
+			let mut weight_used: Weight = Weight::zero();
 
+			// We assume this consumes 0 weight since safe mode is likely in cache
 			if !T::SafeMode::get().strategy_execution_enabled {
 				return weight_used
 			}
@@ -167,7 +168,6 @@ pub mod pallet {
 			let order_update_thresholds = LimitOrderUpdateThresholds::<T>::get();
 
 			weight_used += T::DbWeight::get().reads(1);
-
 			let limit_order_update_weight = T::LpOrdersWeights::update_limit_order_weight();
 
 			for (_, strategy_id, strategy) in Strategies::<T>::iter() {

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -50,7 +50,7 @@ pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
 // have a fixed order id (at least until we develop more advanced strategies).
 const STRATEGY_ORDER_ID: OrderId = 0;
 
-impl_pallet_safe_mode!(PalletSafeMode; trading_strategies_enabled);
+impl_pallet_safe_mode!(PalletSafeMode; strategy_updates_enabled, strategy_closure_enabled, strategy_execution_enabled);
 
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
 pub enum TradingStrategy {
@@ -159,7 +159,7 @@ pub mod pallet {
 		fn on_idle(_current_block: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
 			let mut weight_used: Weight = T::DbWeight::get().reads(1);
 
-			if !T::SafeMode::get().trading_strategies_enabled {
+			if !T::SafeMode::get().strategy_execution_enabled {
 				return weight_used
 			}
 
@@ -259,7 +259,7 @@ pub mod pallet {
 			funding: BTreeMap<Asset, AssetAmount>,
 		) -> DispatchResult {
 			ensure!(
-				T::SafeMode::get().trading_strategies_enabled,
+				T::SafeMode::get().strategy_updates_enabled,
 				Error::<T>::TradingStrategiesDisabled
 			);
 
@@ -320,7 +320,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::close_strategy())]
 		pub fn close_strategy(origin: OriginFor<T>, strategy_id: T::AccountId) -> DispatchResult {
 			ensure!(
-				T::SafeMode::get().trading_strategies_enabled,
+				T::SafeMode::get().strategy_closure_enabled,
 				Error::<T>::TradingStrategiesDisabled
 			);
 
@@ -359,7 +359,7 @@ pub mod pallet {
 			funding: BTreeMap<Asset, AssetAmount>,
 		) -> DispatchResult {
 			ensure!(
-				T::SafeMode::get().trading_strategies_enabled,
+				T::SafeMode::get().strategy_updates_enabled,
 				Error::<T>::TradingStrategiesDisabled
 			);
 			let lp = &T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;

--- a/state-chain/pallets/cf-trading-strategy/src/mock.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/mock.rs
@@ -16,7 +16,7 @@
 
 use crate as pallet_cf_trading_strategy;
 use cf_traits::{
-	impl_mock_chainflip,
+	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{balance_api::MockLpRegistration, pool_api::MockPoolApi},
 	AccountRoleRegistry,
 };
@@ -37,6 +37,7 @@ impl frame_system::Config for Test {
 	type Block = frame_system::mocking::MockBlock<Test>;
 }
 
+impl_mock_runtime_safe_mode!(trading_strategies: crate::PalletSafeMode);
 impl pallet_cf_trading_strategy::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
@@ -44,6 +45,7 @@ impl pallet_cf_trading_strategy::Config for Test {
 	type PoolApi = MockPoolApi;
 	type LpOrdersWeights = MockPoolApi;
 	type LpRegistrationApi = MockLpRegistration;
+	type SafeMode = MockRuntimeSafeMode;
 }
 
 pub const LP: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -21,7 +21,7 @@ use cf_traits::{
 		balance_api::{MockBalance, MockLpRegistration},
 		pool_api::{MockLimitOrder, MockPoolApi},
 	},
-	BalanceApi, Side,
+	BalanceApi, SetSafeMode, Side,
 };
 use frame_support::{assert_err, assert_ok};
 
@@ -398,4 +398,111 @@ fn deregistration_check() {
 
 			assert_ok!(TradingStrategyDeregistrationCheck::<Test>::check(&LP));
 		});
+}
+
+mod safe_mode {
+
+	use super::*;
+
+	#[test]
+	fn deploy_strategy_safe_mode() {
+		new_test_ext().then_execute_with(|_| {
+			let initial_amounts: BTreeMap<_, _> =
+				[(BASE_ASSET, BASE_AMOUNT), (QUOTE_ASSET, QUOTE_AMOUNT)].into();
+
+			for (asset, amount) in initial_amounts.clone() {
+				MockLpRegistration::register_refund_address(LP, asset.into());
+				MockBalance::credit_account(&LP, asset, amount);
+			}
+
+			<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+
+			assert_err!(
+				TradingStrategyPallet::deploy_strategy(
+					RuntimeOrigin::signed(LP),
+					STRATEGY.clone(),
+					initial_amounts.clone(),
+				),
+				Error::<Test>::TradingStrategiesDisabled
+			);
+
+			<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_green();
+
+			assert_ok!(TradingStrategyPallet::deploy_strategy(
+				RuntimeOrigin::signed(LP),
+				STRATEGY.clone(),
+				initial_amounts.clone(),
+			));
+		});
+	}
+
+	#[test]
+	fn add_funds_to_strategy_safe_mode() {
+		new_test_ext()
+			.then_execute_with(|_| deploy_strategy())
+			.then_execute_with(|strategy_id| {
+				const AMOUNT: AssetAmount = 1000;
+				MockBalance::credit_account(&LP, BASE_ASSET, AMOUNT);
+
+				let amounts_to_add: BTreeMap<_, _> = [(BASE_ASSET, AMOUNT)].into();
+
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+
+				assert_err!(
+					TradingStrategyPallet::add_funds_to_strategy(
+						RuntimeOrigin::signed(LP),
+						strategy_id,
+						amounts_to_add.clone()
+					),
+					Error::<Test>::TradingStrategiesDisabled
+				);
+
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_green();
+
+				assert_ok!(TradingStrategyPallet::add_funds_to_strategy(
+					RuntimeOrigin::signed(LP),
+					strategy_id,
+					amounts_to_add.clone()
+				));
+			});
+	}
+
+	#[test]
+	fn close_strategy_safe_mode() {
+		new_test_ext()
+			.then_execute_with(|_| deploy_strategy())
+			.then_execute_with(|strategy_id| {
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+
+				assert_err!(
+					TradingStrategyPallet::close_strategy(RuntimeOrigin::signed(LP), strategy_id),
+					Error::<Test>::TradingStrategiesDisabled
+				);
+
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_green();
+
+				assert_ok!(TradingStrategyPallet::close_strategy(
+					RuntimeOrigin::signed(LP),
+					strategy_id
+				));
+			});
+	}
+
+	#[test]
+	fn strategy_order_updates_safe_mode() {
+		new_test_ext()
+			.then_execute_with(|_| deploy_strategy())
+			.then_execute_with(|_| {
+				// Code red should prevent limit orders from being created:
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+			})
+			.then_execute_at_next_block(|_| {
+				assert_eq!(MockPoolApi::get_limit_orders().len(), 0);
+				// Resetting to code green should allow limit order creation:
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_green();
+			})
+			.then_execute_at_next_block(|_| {
+				assert_eq!(MockPoolApi::get_limit_orders().len(), 2);
+			});
+	}
 }

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -402,6 +402,8 @@ fn deregistration_check() {
 
 mod safe_mode {
 
+	use cf_traits::SafeMode;
+
 	use super::*;
 
 	#[test]
@@ -415,7 +417,10 @@ mod safe_mode {
 				MockBalance::credit_account(&LP, asset, amount);
 			}
 
-			<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+			<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(PalletSafeMode {
+				strategy_updates_enabled: false,
+				..PalletSafeMode::CODE_GREEN
+			});
 
 			assert_err!(
 				TradingStrategyPallet::deploy_strategy(
@@ -446,7 +451,12 @@ mod safe_mode {
 
 				let amounts_to_add: BTreeMap<_, _> = [(BASE_ASSET, AMOUNT)].into();
 
-				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
+					PalletSafeMode {
+						strategy_updates_enabled: false,
+						..PalletSafeMode::CODE_GREEN
+					},
+				);
 
 				assert_err!(
 					TradingStrategyPallet::add_funds_to_strategy(
@@ -472,7 +482,12 @@ mod safe_mode {
 		new_test_ext()
 			.then_execute_with(|_| deploy_strategy())
 			.then_execute_with(|strategy_id| {
-				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
+					PalletSafeMode {
+						strategy_closure_enabled: false,
+						..PalletSafeMode::CODE_GREEN
+					},
+				);
 
 				assert_err!(
 					TradingStrategyPallet::close_strategy(RuntimeOrigin::signed(LP), strategy_id),
@@ -494,7 +509,12 @@ mod safe_mode {
 			.then_execute_with(|_| deploy_strategy())
 			.then_execute_with(|_| {
 				// Code red should prevent limit orders from being created:
-				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_code_red();
+				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
+					PalletSafeMode {
+						strategy_execution_enabled: false,
+						..PalletSafeMode::CODE_GREEN
+					},
+				);
 			})
 			.then_execute_at_next_block(|_| {
 				assert_eq!(MockPoolApi::get_limit_orders().len(), 0);

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1046,6 +1046,7 @@ impl pallet_cf_trading_strategy::Config for Runtime {
 	type WeightInfo = pallet_cf_trading_strategy::weights::PalletWeight<Runtime>;
 	type LpOrdersWeights = LiquidityPools;
 	type BalanceApi = AssetBalances;
+	type SafeMode = RuntimeSafeMode;
 	type PoolApi = LiquidityPools;
 	type LpRegistrationApi = LiquidityProvider;
 }

--- a/state-chain/runtime/src/safe_mode.rs
+++ b/state-chain/runtime/src/safe_mode.rs
@@ -31,6 +31,7 @@ impl_runtime_safe_mode! {
 	liquidity_provider: pallet_cf_lp::PalletSafeMode,
 	validator: pallet_cf_validator::PalletSafeMode,
 	pools: pallet_cf_pools::PalletSafeMode,
+	trading_strategies: pallet_cf_trading_strategy::PalletSafeMode,
 	reputation: pallet_cf_reputation::PalletSafeMode,
 	asset_balances: pallet_cf_asset_balances::PalletSafeMode,
 	threshold_signature_evm: pallet_cf_threshold_signature::PalletSafeMode<Instance16>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2116

## Summary

Added a single safe mode flag that disables:
- deployment of new strategies
- adding funds to strategies
- closing strategies
- automatic updates of limit orders (in `on_idle`)

Added unit tests to check all 4.
