### PR TITLE
fix: prevent subscriptions dropping by properly unpinning blocks

### DIFF
--- a/state-chain/custom-rpc/Cargo.toml
+++ b/state-chain/custom-rpc/Cargo.toml
@@ -18,6 +18,7 @@ futures = { workspace = true }
 jsonrpsee = { workspace = true, features = ["full"] }
 hex = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -2166,6 +2166,10 @@ where
 				FollowEvent::NewBlock(sc_rpc_spec_v2::chain_head::NewBlock {
 					block_hash, ..
 				}) => sub_gc.add(&[block_hash]).await,
+				FollowEvent::Finalized(sc_rpc_spec_v2::chain_head::Finalized {
+					finalized_block_hashes,
+					..
+				}) => sub_gc.add(&finalized_block_hashes).await,
 				_ => {},
 			}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2152

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* This PR adds a subscription garbage collector where it tracks the all pinned blocks reported by `chainhead_v1_follow` and starts unpinning old blocks once the its queue reaches a certain capacity (default 64)
* Manual tests were carried out on a local node with MAX_PINNED_BLOCKS set to 32 to speed up seeing subscriptions dropping effect.
* A full test with 100 subscriptions was run on a local node with MAX_PINNED_BLOCKS set to the default 512.
