### PR TITLE
feat: ignore redemption tax when redeem all

### DIFF
--- a/bouncer/tests/fund_redeem.ts
+++ b/bouncer/tests/fund_redeem.ts
@@ -83,7 +83,7 @@ async function main(logger: Logger, providedSeed?: string) {
   logger.debug(`Testing redeem all`);
   const redeemedAll = await redeemAndObserve(logger, seed, redeemEthAddress as HexString, 'Max');
   // We expect to redeem the entire amount minus the exact amount redeemed above + tax & gas for both redemptions
-  const expectedRedeemAllAmount = fundAmount - redeemedExact;
+  const expectedRedeemAllAmount = fundAmount - redeemedExact - redemptionTaxAmount;
   assert(
     redeemedAll >= expectedRedeemAllAmount - gasErrorMargin &&
       redeemedAll <= expectedRedeemAllAmount,

--- a/bouncer/tests/fund_redeem.ts
+++ b/bouncer/tests/fund_redeem.ts
@@ -83,7 +83,7 @@ async function main(logger: Logger, providedSeed?: string) {
   logger.debug(`Testing redeem all`);
   const redeemedAll = await redeemAndObserve(logger, seed, redeemEthAddress as HexString, 'Max');
   // We expect to redeem the entire amount minus the exact amount redeemed above + tax & gas for both redemptions
-  const expectedRedeemAllAmount = fundAmount - redeemedExact - redemptionTaxAmount * 2;
+  const expectedRedeemAllAmount = fundAmount - redeemedExact;
   assert(
     redeemedAll >= expectedRedeemAllAmount - gasErrorMargin &&
       redeemedAll <= expectedRedeemAllAmount,

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -380,7 +380,12 @@ pub mod pallet {
 				}
 			}
 
-			let redemption_fee = RedemptionTax::<T>::get();
+			// If we are redeeming the max amount, we don't charge a fee.
+			let redemption_fee = if amount == RedemptionAmount::Max {
+				T::Amount::zero()
+			} else {
+				RedemptionTax::<T>::get()
+			};
 
 			if let Some(bound_address) = BoundRedeemAddress::<T>::get(&account_id) {
 				ensure!(
@@ -409,8 +414,7 @@ pub mod pallet {
 			));
 
 			let (debit_amount, redeem_amount) = match amount {
-				RedemptionAmount::Max =>
-					(liquid_balance, liquid_balance.saturating_sub(redemption_fee)),
+				RedemptionAmount::Max => (liquid_balance, liquid_balance),
 				RedemptionAmount::Exact(amount) => (amount.saturating_add(redemption_fee), amount),
 			};
 

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -594,7 +594,6 @@ fn restore_restricted_balance_when_redemption_expires() {
 				Default::default()
 			));
 
-			// We ignore the redemption tax if we claim the max amount.
 			let (total_funds, restricted_amount) = if redeem_amount == RedemptionAmount::Max {
 				(TOTAL_FUNDS, RESTRICTED_AMOUNT - REDEMPTION_TAX)
 			} else {

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -1091,8 +1091,11 @@ mod test_restricted_balances {
 						bound_redeem_address,
 						Default::default()
 					));
-					let expected_redeemed_amount =
-						initial_balance - Flip::balance(&ALICE) - RedemptionTax::<Test>::get();
+					let expected_redeemed_amount = if redeem_amount == RedemptionAmount::Max {
+						initial_balance - Flip::balance(&ALICE)
+					} else {
+						initial_balance - Flip::balance(&ALICE) - RedemptionTax::<Test>::get()
+					};
 					assert_matches!(
 						cf_test_utilities::last_event::<Test>(),
 						RuntimeEvent::Funding(Event::RedemptionRequested {

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -595,7 +595,7 @@ fn restore_restricted_balance_when_redemption_expires() {
 			));
 
 			let (total_funds, restricted_amount) = if redeem_amount == RedemptionAmount::Max {
-				(TOTAL_FUNDS, RESTRICTED_AMOUNT - REDEMPTION_TAX)
+				(TOTAL_FUNDS, RESTRICTED_AMOUNT)
 			} else {
 				(TOTAL_FUNDS - REDEMPTION_TAX, RESTRICTED_AMOUNT - REDEMPTION_TAX)
 			};

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -596,7 +596,7 @@ fn restore_restricted_balance_when_redemption_expires() {
 
 			// We ignore the redemption tax if we claim the max amount.
 			let (total_funds, restricted_amount) = if redeem_amount == RedemptionAmount::Max {
-				(TOTAL_FUNDS, RESTRICTED_AMOUNT)
+				(TOTAL_FUNDS, RESTRICTED_AMOUNT - REDEMPTION_TAX)
 			} else {
 				(TOTAL_FUNDS - REDEMPTION_TAX, RESTRICTED_AMOUNT - REDEMPTION_TAX)
 			};
@@ -1081,7 +1081,6 @@ mod test_restricted_balances {
 			Bonder::<Test>::update_bond(&ALICE, bond);
 
 			let initial_balance = Flip::balance(&ALICE);
-			assert_eq!(initial_balance, TOTAL_BALANCE + REDEMPTION_TAX);
 
 			match maybe_error {
 				None => {
@@ -1091,11 +1090,10 @@ mod test_restricted_balances {
 						bound_redeem_address,
 						Default::default()
 					));
-					let expected_redeemed_amount = if redeem_amount == RedemptionAmount::Max {
-						initial_balance - Flip::balance(&ALICE)
-					} else {
-						initial_balance - Flip::balance(&ALICE) - RedemptionTax::<Test>::get()
-					};
+
+					let expected_redeemed_amount =
+						initial_balance - Flip::balance(&ALICE) - RedemptionTax::<Test>::get();
+
 					assert_matches!(
 						cf_test_utilities::last_event::<Test>(),
 						RuntimeEvent::Funding(Event::RedemptionRequested {
@@ -1487,7 +1485,7 @@ fn max_redemption_is_net_exact_is_gross() {
 	}
 
 	// Redeem as many unrestricted funds as possible.
-	do_test(UNRESTRICTED_ADDRESS, RedemptionAmount::Max, UNRESTRICTED_AMOUNT);
+	do_test(UNRESTRICTED_ADDRESS, RedemptionAmount::Max, UNRESTRICTED_AMOUNT - REDEMPTION_TAX);
 	// Redeem as many restricted funds as possible.
 	do_test(RESTRICTED_ADDRESS, RedemptionAmount::Max, TOTAL_BALANCE);
 	// Redeem exact amounts, should be reflected in the event.


### PR DESCRIPTION
# Pull Request

Closes: PRO-2035

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- We check if we try to redeem max and if we try to redeem the total balance of the account. If yes, we don't burn any tax and ignore the tax aside for the rest of the calculations
- Updated all tests where necessary and tried to understand if the change of the test makes sense
