### PR TITLE
feat: reuse decode_cf_parameters

### DIFF
--- a/engine/src/witness/evm/vault.rs
+++ b/engine/src/witness/evm/vault.rs
@@ -43,7 +43,7 @@ use state_chain_runtime::{EthereumInstance, Runtime, RuntimeCall};
 
 abigen!(Vault, "$CF_ETH_CONTRACT_ABI_ROOT/$CF_ETH_CONTRACT_ABI_TAG/IVault.json");
 
-fn decode_cf_parameters<RefundAddress, CcmData>(
+pub fn decode_cf_parameters<RefundAddress, CcmData>(
 	cf_parameters: &[u8],
 	block_height: u64,
 ) -> Result<(VaultSwapParameters<RefundAddress>, CcmData)>

--- a/engine/src/witness/sol/vault_swaps_witnessing.rs
+++ b/engine/src/witness/sol/vault_swaps_witnessing.rs
@@ -14,23 +14,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sol::{
-	commitment_config::CommitmentConfig,
-	retry_rpc::{SolRetryRpcApi, SolRetryRpcClient},
-	rpc_client_api::{RpcAccountInfoConfig, UiAccount, UiAccountData, UiAccountEncoding},
+use crate::{
+	sol::{
+		commitment_config::CommitmentConfig,
+		retry_rpc::{SolRetryRpcApi, SolRetryRpcClient},
+		rpc_client_api::{RpcAccountInfoConfig, UiAccount, UiAccountData, UiAccountEncoding},
+	},
+	witness::evm::vault::decode_cf_parameters,
 };
 use anyhow::{anyhow, bail, ensure, Context};
 use base64::Engine;
 use cf_chains::{
 	address::EncodedAddress,
 	assets::sol::Asset as SolAsset,
-	cf_parameters::{
-		CfParameters, VaultSwapParameters, VersionedCcmCfParameters, VersionedCfParameters,
-	},
+	cf_parameters::VaultSwapParameters,
 	sol::{api::VaultSwapAccountAndSender, SolAddress},
 	CcmChannelMetadata, CcmDepositMetadata, ForeignChainAddress,
 };
-use codec::Decode;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use sol_prim::program_instructions::{
@@ -136,23 +136,13 @@ pub async fn get_vault_swaps(
 							},
 						) = match ccm_parameters {
 							None => {
-								let VersionedCfParameters::V0(CfParameters {
-									ccm_additional_data: (),
-									vault_swap_parameters,
-								}) = VersionedCfParameters::decode(&mut &cf_parameters[..])
-									.map_err(|e| {
-										anyhow!("Error while decoding VersionedCfParameters for solana vault swap: {}.", e)
-									})?;
+								let (vault_swap_parameters, ()) =
+									decode_cf_parameters(&cf_parameters[..], creation_slot)?;
 								(None, vault_swap_parameters)
 							},
 							Some(ccm_parameters) => {
-								let VersionedCcmCfParameters::V0(CfParameters {
-									ccm_additional_data,
-									vault_swap_parameters
-									}) = VersionedCcmCfParameters::decode(&mut &cf_parameters[..]).map_err(|e| {
-											anyhow!("Error while decoding VersionedCcmCfParameters for solana vault swap: {}.", e)
-										},
-									)?;
+								let (vault_swap_parameters, ccm_additional_data) =
+									decode_cf_parameters(&cf_parameters[..], creation_slot)?;
 
 								(
 									Some(CcmDepositMetadata {


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

When looking into other stuff I realized we manually decode the `cf_parameters` in two different places which is prone to error in the future.
