### PR TITLE
feat: trading strategy limits rpc

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -71,8 +71,8 @@ use state_chain_runtime::{
 		AuctionState, BoostPoolDepth, BoostPoolDetails, BrokerInfo, CcmData, ChainAccounts,
 		CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi, FailingWitnessValidators,
 		FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, RuntimeApiPenalty,
-		SimulatedSwapInformation, TradingStrategyInfo, TransactionScreeningEvents, ValidatorInfo,
-		VaultAddresses, VaultSwapDetails,
+		SimulatedSwapInformation, TradingStrategyInfo, TradingStrategyLimits,
+		TransactionScreeningEvents, ValidatorInfo, VaultAddresses, VaultSwapDetails,
 	},
 	safe_mode::RuntimeSafeMode,
 	Hash, NetworkFee, SolanaInstance,
@@ -984,6 +984,12 @@ pub trait CustomApi {
 		lp: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<TradingStrategyInfoHexAmounts>>;
+
+	#[method(name = "get_trading_strategy_limits")]
+	fn cf_trading_strategy_limits(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<TradingStrategyLimits>;
 }
 
 /// An RPC extension for the state chain node.
@@ -1234,6 +1240,7 @@ where
 		cf_get_open_deposit_channels(account_id: Option<state_chain_runtime::AccountId>) -> ChainAccounts,
 		cf_affiliate_details(broker: state_chain_runtime::AccountId, affiliate: Option<state_chain_runtime::AccountId>) -> Vec<(state_chain_runtime::AccountId, AffiliateDetails)>,
 		cf_vault_addresses() -> VaultAddresses,
+		cf_trading_strategy_limits() -> TradingStrategyLimits,
 	}
 
 	pass_through_and_flatten! {

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -164,7 +164,7 @@ pub mod pallet {
 	/// of asset A, as long as there is at least 70% of the required amount of asset B.
 	/// An asset that is not in this map is disabled from being deployed.
 	#[pallet::storage]
-	pub(super) type MinimumDeploymentAmountForStrategy<T: Config> = StorageValue<
+	pub type MinimumDeploymentAmountForStrategy<T: Config> = StorageValue<
 		_,
 		BTreeMap<Asset, AssetAmount>,
 		ValueQuery,
@@ -174,7 +174,7 @@ pub mod pallet {
 	/// Stores the minimum amount per asset that can be added to an existing strategy.
 	/// An asset that is not in this map is disabled from adding funds.
 	#[pallet::storage]
-	pub(super) type MinimumAddedFundsToStrategy<T: Config> = StorageValue<
+	pub type MinimumAddedFundsToStrategy<T: Config> = StorageValue<
 		_,
 		BTreeMap<Asset, AssetAmount>,
 		ValueQuery,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -47,7 +47,8 @@ use crate::{
 		BoostPoolDetails, BrokerInfo, CcmData, DispatchErrorWithMessage, FailingWitnessValidators,
 		FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, RuntimeApiPenalty,
 		SimulateSwapAdditionalOrder, SimulatedSwapInformation, TradingStrategyInfo,
-		TransactionScreeningEvents, ValidatorInfo, VaultAddresses, VaultSwapDetails,
+		TradingStrategyLimits, TransactionScreeningEvents, ValidatorInfo, VaultAddresses,
+		VaultSwapDetails,
 	},
 };
 use cf_amm::{
@@ -2399,6 +2400,15 @@ impl_runtime_apis! {
 				Strategies::iter().map(|(lp_id, strategy_id, strategy)| to_strategy_info(lp_id, strategy_id, strategy)).collect()
 			}
 
+		}
+
+		fn cf_trading_strategy_limits() -> TradingStrategyLimits{
+			TradingStrategyLimits{
+				minimum_deployment_amount: AssetMap::from_iter(pallet_cf_trading_strategy::MinimumDeploymentAmountForStrategy::<Runtime>::get().into_iter()
+					.map(|(asset, balance)| (asset, Some(balance)))),
+				minimum_added_funds_amount: AssetMap::from_iter(pallet_cf_trading_strategy::MinimumAddedFundsToStrategy::<Runtime>::get().into_iter()
+					.map(|(asset, balance)| (asset, Some(balance)))),
+			}
 		}
 	}
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -339,6 +339,12 @@ pub struct TradingStrategyInfo<Amount> {
 	pub balance: Vec<(Asset, Amount)>,
 }
 
+#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+pub struct TradingStrategyLimits {
+	pub minimum_deployment_amount: AssetMap<Option<AssetAmount>>,
+	pub minimum_added_funds_amount: AssetMap<Option<AssetAmount>>,
+}
+
 // READ THIS BEFORE UPDATING THIS TRAIT:
 //
 // ## When changing an existing method:
@@ -511,6 +517,7 @@ decl_runtime_apis!(
 		fn cf_get_trading_strategies(
 			lp_id: Option<AccountId32>,
 		) -> Vec<TradingStrategyInfo<AssetAmount>>;
+		fn cf_trading_strategy_limits() -> TradingStrategyLimits;
 	}
 );
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2155

## Checklist

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Simple RPC that gets an asset map of the trading strategy limits. 2 limits `minimum_deployment_amount` and `minimum_added_funds_amount`.
`None`/`null` means no limit is set, so the asset is disabled.

### Request
```bash
curl -H "Content-Type: application/json" \
-d '{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "cf_get_trading_strategy_limits",
  "params": []
}' http://localhost:9944
```

### Response
```json
{
  "jsonrpc": "2.0",
  "result": {
    "minimum_deployment_amount": {
      "Ethereum": {
        "ETH": null,
        "FLIP": null,
        "USDC": 20000000000,
        "USDT": 20000000000
      },
      "Polkadot": {
        "DOT": null
      },
      "Bitcoin": {
        "BTC": null
      },
      "Arbitrum": {
        "ETH": null,
        "USDC": 20000000000
      },
      "Solana": {
        "SOL": null,
        "USDC": 20000000000
      }
    },
    "minimum_added_funds_amount": {
      "Ethereum": {
        "ETH": null,
        "FLIP": null,
        "USDC": 10000000,
        "USDT": 10000000
      },
      "Polkadot": {
        "DOT": null
      },
      "Bitcoin": {
        "BTC": null
      },
      "Arbitrum": {
        "ETH": null,
        "USDC": 10000000
      },
      "Solana": {
        "SOL": null,
        "USDC": 10000000
      }
    }
  },
  "id": 1
}
```
