### PR TITLE
fix: throw error if runtime upgrade test fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13670,6 +13670,7 @@ dependencies = [
  "paste",
  "scale-info",
  "serde",
+ "sol-prim",
  "sp-api 34.0.0",
  "sp-block-builder",
  "sp-consensus-aura",

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -31,10 +31,10 @@ assets = [
     # The old version gets put into target/release/deps by the package github actions workflow.
     # It downloads the correct version from the releases page.
     [
-        "target/release/libchainflip_engine_v1_8_2.so",
+        "target/release/libchainflip_engine_v1_8_4.so",
         # This is the path where the engine dylib is searched for on linux.
         # As set in the build.rs file.
-        "usr/lib/chainflip-engine/libchainflip_engine_v1_8_2.so",
+        "usr/lib/chainflip-engine/libchainflip_engine_v1_8_4.so",
         "755",
     ],
 ]

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -19,7 +19,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.8.2")]
+	#[engine_proc_macros::link_engine_library_version("1.8.4")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -26,7 +26,7 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.8.2";
+pub const OLD_VERSION: &str = "1.8.4";
 pub const NEW_VERSION: &str = "1.9.0";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -75,7 +75,7 @@ pub enum PalletConfigUpdate {
 	BroadcastTimeout { blocks: u32 },
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(12);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(13);
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/state-chain/pallets/cf-broadcast/src/migrations.rs
+++ b/state-chain/pallets/cf-broadcast/src/migrations.rs
@@ -17,4 +17,4 @@
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
 
-pub type PalletMigration<T, I> = (PlaceholderMigration<12, Pallet<T, I>>,);
+pub type PalletMigration<T, I> = (PlaceholderMigration<13, Pallet<T, I>>,);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/blockchain/delta_based_ingress.rs
@@ -21,6 +21,7 @@ use crate::{
 	},
 	vote_storage, CorruptStorageError, ElectionIdentifier,
 };
+#[cfg(feature = "runtime-benchmarks")]
 use cf_chains::benchmarking_value::BenchmarkValue;
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::IngressSink;

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -55,7 +55,7 @@ pub mod weights;
 pub use weights::WeightInfo;
 pub mod migrations;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(13);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(14);
 
 const INITIAL_CONSOLIDATION_PARAMETERS: utxo_selection::ConsolidationParameters =
 	utxo_selection::ConsolidationParameters {

--- a/state-chain/pallets/cf-threshold-signature/src/lib.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/lib.rs
@@ -184,7 +184,7 @@ pub enum KeyRotationStatus<T: Config<I>, I: 'static = ()> {
 	},
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(6);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
 
 const THRESHOLD_SIGNATURE_RESPONSE_TIMEOUT_DEFAULT: u32 = 10;
 const KEYGEN_CEREMONY_RESPONSE_TIMEOUT_BLOCKS_DEFAULT: u32 = 90;

--- a/state-chain/pallets/cf-threshold-signature/src/migrations.rs
+++ b/state-chain/pallets/cf-threshold-signature/src/migrations.rs
@@ -17,4 +17,4 @@
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
 
-pub type PalletMigration<T, I> = PlaceholderMigration<6, Pallet<T, I>>;
+pub type PalletMigration<T, I> = PlaceholderMigration<7, Pallet<T, I>>;

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -26,6 +26,9 @@ ethabi = { workspace = true }
 bitvec = { workspace = true }
 paste = { workspace = true }
 
+# Remove this after 1.9 migration
+sol-prim = { workspace = true }
+
 # Chainflip local dependencies
 cf-amm = { workspace = true }
 cf-chains = { workspace = true }

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1331,6 +1331,13 @@ type PalletMigrations = (
 	pallet_cf_trading_strategy::migrations::PalletMigration<Runtime>,
 );
 
+pub struct NoopMigration;
+impl frame_support::traits::UncheckedOnRuntimeUpgrade for NoopMigration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		log::info!("🤷 Noop migration");
+		Default::default()
+	}
+}
 macro_rules! instanced_migrations {
 	(
 		module: $module:ident,
@@ -1354,7 +1361,7 @@ macro_rules! instanced_migrations {
 				VersionedMigration<
 					$from,
 					$to,
-					(),
+					NoopMigration,
 					$module::Pallet<Runtime, $exclude>,
 					DbWeight,
 				>,
@@ -1372,6 +1379,31 @@ type MigrationsForV1_9 = (
 		to: 6,
 		include_instances: [SolanaInstance],
 		exclude_instances: [],
+	),
+	instanced_migrations!(
+		module: pallet_cf_broadcast,
+		migration: migrations::sol_versioned_transactions::SolVersionedTransactionBroadcastPallet,
+		from: 12,
+		to: 13,
+		include_instances: [SolanaInstance],
+		exclude_instances: [
+			EthereumInstance,
+			PolkadotInstance,
+			BitcoinInstance,
+			ArbitrumInstance,
+		],
+	),
+	instanced_migrations!(
+		module: pallet_cf_threshold_signature,
+		migration: migrations::sol_versioned_transactions::SolVersionedTransactionThresholdSignerPallet,
+		from: 6,
+		to: 7,
+		include_instances: [SolanaInstance],
+		exclude_instances: [
+			EvmInstance,
+			PolkadotInstance,
+			BitcoinInstance,
+		],
 	),
 );
 

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -18,3 +18,4 @@
 
 pub mod backoff_settings_migration;
 pub mod housekeeping;
+pub mod sol_versioned_transactions;

--- a/state-chain/runtime/src/migrations/sol_versioned_transactions.rs
+++ b/state-chain/runtime/src/migrations/sol_versioned_transactions.rs
@@ -1,0 +1,205 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::*;
+
+use cf_chains::sol::{api::SolanaApi, SolAddress};
+use codec::{Decode, Encode};
+use frame_support::{pallet_prelude::Weight, traits::UncheckedOnRuntimeUpgrade};
+use pallet_cf_broadcast::{TransactionFor, TransactionOutIdFor};
+use scale_info::TypeInfo;
+
+pub mod old {
+	use super::*;
+	use cf_chains::sol::api::SolanaTransactionType;
+	use cf_primitives::{AuthorityCount, ThresholdSignatureRequestId};
+	use pallet_cf_threshold_signature::ThresholdCeremonyType;
+	use sol_prim::transaction::legacy::DeprecatedLegacyMessage;
+	use sp_runtime::AccountId32;
+
+	#[derive(Encode, Decode)]
+	pub struct RequestContext {
+		pub request_id: u32,
+		/// The number of ceremonies attempted so far, excluding the current one.
+		/// Currently we do not limit the number of retry attempts for ceremony type Standard.
+		/// Most transactions are critical, so we should retry until success.
+		pub attempt_count: AuthorityCount,
+		/// The payload to be signed over.
+		pub payload: DeprecatedLegacyMessage,
+	}
+
+	#[derive(Encode, Decode)]
+	pub struct CeremonyContext {
+		pub request_context: RequestContext,
+		/// The respondents that have yet to reply.
+		pub remaining_respondents: BTreeSet<AccountId32>,
+		/// The number of blame votes (accusations) each authority has received.
+		pub blame_counts: BTreeMap<AccountId32, AuthorityCount>,
+		/// The candidates participating in the signing ceremony (ie. the threshold set).
+		pub candidates: BTreeSet<AccountId32>,
+		/// The epoch in which the ceremony was started.
+		pub epoch: EpochIndex,
+		/// The key we want to sign with.
+		pub key: SolAddress,
+		/// Determines how/if we deal with ceremony failure.
+		pub threshold_ceremony_type: ThresholdCeremonyType,
+	}
+
+	#[derive(Encode, Decode, TypeInfo)]
+	pub enum BroadcastCall {
+		#[codec(index = 1)]
+		OnSignatureReady {
+			threshold_request_id: ThresholdSignatureRequestId,
+			threshold_signature_payload: DeprecatedLegacyMessage,
+			api_call: SolanaApi,
+			broadcast_id: BroadcastId,
+			initiated_at: u64,
+			should_broadcast: bool,
+		},
+	}
+
+	#[derive(Encode, Decode, TypeInfo)]
+	pub enum RuntimeCall {
+		#[codec(index = 43)]
+		Broadcast(BroadcastCall),
+	}
+
+	#[derive(Encode, Decode, TypeInfo)]
+	pub struct BroadcastData<T: pallet_cf_broadcast::Config<I>, I: 'static> {
+		pub broadcast_id: BroadcastId,
+		pub transaction_payload: TransactionFor<T, I>,
+		pub threshold_signature_payload: DeprecatedLegacyMessage,
+		pub transaction_out_id: TransactionOutIdFor<T, I>,
+		pub nominee: Option<T::ValidatorId>,
+	}
+
+	#[derive(Encode, Decode, TypeInfo)]
+	pub struct LegacyTransaction {
+		pub signatures: Vec<sol_prim::Signature>,
+		pub message: DeprecatedLegacyMessage,
+	}
+
+	#[derive(Encode, Decode, TypeInfo)]
+	pub struct SolanaApi {
+		pub call_type: SolanaTransactionType,
+		pub transaction: LegacyTransaction,
+		pub signer: Option<SolAddress>,
+	}
+}
+
+pub struct SolVersionedTransactionBroadcastPallet;
+
+impl UncheckedOnRuntimeUpgrade for SolVersionedTransactionBroadcastPallet {
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("🌞 Running Broadcast Pallet migrations for Solana versioned transactions.");
+
+		pallet_cf_broadcast::AwaitingBroadcast::<Runtime, SolanaInstance>::translate_values::<
+			old::BroadcastData<Runtime, SolanaInstance>,
+			_,
+		>(|old_value| {
+			Some(pallet_cf_broadcast::BroadcastData {
+				broadcast_id: old_value.broadcast_id,
+				transaction_payload: old_value.transaction_payload,
+				threshold_signature_payload: sol_prim::transaction::VersionedMessage::Legacy(
+					old_value.threshold_signature_payload,
+				),
+				transaction_out_id: old_value.transaction_out_id,
+				nominee: old_value.nominee,
+			})
+		});
+		pallet_cf_broadcast::PendingApiCalls::<Runtime, SolanaInstance>::translate_values::<
+			old::SolanaApi,
+			_,
+		>(|old_value| {
+			Some(SolanaApi {
+				call_type: old_value.call_type,
+				transaction: sol_prim::transaction::VersionedTransaction {
+					signatures: old_value.transaction.signatures,
+					message: sol_prim::transaction::VersionedMessage::Legacy(
+						old_value.transaction.message,
+					),
+				},
+				signer: old_value.signer,
+				_phantom: Default::default(),
+			})
+		});
+
+		Weight::zero()
+	}
+}
+
+pub struct SolVersionedTransactionThresholdSignerPallet;
+
+impl UncheckedOnRuntimeUpgrade for SolVersionedTransactionThresholdSignerPallet {
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("🌞 Running Threshold Pallet migrations for Solana versioned transactions.");
+
+		pallet_cf_threshold_signature::RequestCallback::<Runtime, SolanaInstance>::translate_values::<
+			old::RuntimeCall,
+			_,
+		>(|old_value| match old_value {
+			old::RuntimeCall::Broadcast(old::BroadcastCall::OnSignatureReady {
+				threshold_request_id,
+				threshold_signature_payload,
+				api_call,
+				broadcast_id,
+				initiated_at,
+				should_broadcast,
+			}) => Some(crate::RuntimeCall::SolanaBroadcaster(
+				pallet_cf_broadcast::Call::on_signature_ready {
+					threshold_request_id,
+					threshold_signature_payload: sol_prim::transaction::VersionedMessage::Legacy(
+						threshold_signature_payload,
+					),
+					api_call: Box::new(SolanaApi {
+						call_type: api_call.call_type,
+						transaction: sol_prim::transaction::VersionedTransaction {
+							signatures: api_call.transaction.signatures,
+							message: sol_prim::transaction::VersionedMessage::Legacy(
+								api_call.transaction.message,
+							),
+						},
+						signer: api_call.signer,
+						_phantom: Default::default(),
+					}),
+					broadcast_id,
+					initiated_at,
+					should_broadcast,
+				},
+			)),
+		});
+		pallet_cf_threshold_signature::PendingCeremonies::<Runtime, SolanaInstance>::translate_values::<
+			old::CeremonyContext,
+			_,
+		>(|old_value| {
+			Some(pallet_cf_threshold_signature::CeremonyContext {
+				request_context: pallet_cf_threshold_signature::RequestContext {
+					request_id: old_value.request_context.request_id,
+					attempt_count: old_value.request_context.attempt_count,
+					payload: sol_prim::transaction::VersionedMessage::Legacy(old_value.request_context.payload),
+				},
+				remaining_respondents: old_value.remaining_respondents,
+				blame_counts: old_value.blame_counts,
+				candidates: old_value.candidates,
+				epoch: old_value.epoch,
+				key: old_value.key,
+				threshold_ceremony_type: old_value.threshold_ceremony_type,
+			})
+		});
+
+		Weight::zero()
+	}
+}


### PR DESCRIPTION
This ensures we exit (early) with an error if the runtime upgrade test fails. 

Since we were ignoring this previously, some errors had slipped into main, so this PR fixes those too:
- bumps the upgrade_from version to 1.8.4
- migrate solana txs to VersionedTransaction format. 
- enviroment pallet storage version bumped