### PR TITLE
feat: remove pool fee for limit orders

### DIFF
--- a/state-chain/amm/Cargo.toml
+++ b/state-chain/amm/Cargo.toml
@@ -25,7 +25,7 @@ sp-std = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true, features = ["std"] }
 cf-amm-math = { workspace = true, features = ["slow-tests"] }
-cf-utilities = { workspace = true }
+cf-utilities = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -195,6 +195,8 @@ pub(super) struct BaseToQuote {}
 pub(super) struct QuoteToBase {}
 
 pub(super) trait SwapDirection {
+	type Inverse: SwapDirection;
+
 	/// The asset this type of swap sells, i.e. the asset the swapper provides
 	const INPUT_SIDE: Pairs;
 
@@ -211,6 +213,8 @@ pub(super) trait SwapDirection {
 	fn increase_sqrt_price(sqrt_price: SqrtPriceQ64F96, delta: Tick) -> SqrtPriceQ64F96;
 }
 impl SwapDirection for BaseToQuote {
+	type Inverse = QuoteToBase;
+
 	const INPUT_SIDE: Pairs = Pairs::Base;
 
 	const WORST_SQRT_PRICE: SqrtPriceQ64F96 = MIN_SQRT_PRICE;
@@ -227,6 +231,8 @@ impl SwapDirection for BaseToQuote {
 	}
 }
 impl SwapDirection for QuoteToBase {
+	type Inverse = BaseToQuote;
+
 	const INPUT_SIDE: Pairs = Pairs::Quote;
 
 	const WORST_SQRT_PRICE: SqrtPriceQ64F96 = MAX_SQRT_PRICE;

--- a/state-chain/amm/src/range_orders.rs
+++ b/state-chain/amm/src/range_orders.rs
@@ -820,11 +820,7 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			let sqrt_price_next = if self.current_liquidity == 0 {
 				sqrt_price_target
 			} else {
-				let amount_minus_fees = mul_div_floor(
-					amount,
-					U256::from(ONE_IN_HUNDREDTH_PIPS - self.fee_hundredth_pips),
-					U256::from(ONE_IN_HUNDREDTH_PIPS),
-				); // This cannot overflow as we bound fee_hundredth_pips to <= ONE_IN_HUNDREDTH_PIPS/2
+				let amount_minus_fees = super::reduce_by_pool_fee(amount, self.fee_hundredth_pips);
 
 				let amount_required_to_reach_target = SD::input_amount_delta_ceil(
 					self.current_sqrt_price,

--- a/state-chain/pallets/cf-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-pools/src/benchmarking.rs
@@ -256,7 +256,6 @@ mod benchmarks {
 
 		match Pallet::<T>::pool_info(Asset::Eth, STABLE_ASSET) {
 			Ok(pool_info) => {
-				assert_eq!(pool_info.limit_order_fee_hundredth_pips, fee);
 				assert_eq!(pool_info.range_order_fee_hundredth_pips, fee);
 			},
 			Err(_) => panic!("Pool not found"),

--- a/state-chain/pallets/cf-pools/src/migrations.rs
+++ b/state-chain/pallets/cf-pools/src/migrations.rs
@@ -16,5 +16,17 @@
 
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
 
-pub type PalletMigration<T> = PlaceholderMigration<5, Pallet<T>>;
+mod remove_limit_order_pool_fee;
+
+pub type PalletMigration<T> = (
+	VersionedMigration<
+		5,
+		6,
+		remove_limit_order_pool_fee::Migration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<6, Pallet<T>>,
+);

--- a/state-chain/pallets/cf-pools/src/migrations/remove_limit_order_pool_fee.rs
+++ b/state-chain/pallets/cf-pools/src/migrations/remove_limit_order_pool_fee.rs
@@ -1,0 +1,94 @@
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+
+use crate::*;
+
+pub struct Migration<T: Config>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let range_order_fees: Vec<u32> = Pools::<T>::iter_values()
+			.map(|pool| pool.pool_state.range_order_fee())
+			.collect();
+
+		Ok(range_order_fees.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		// Setting pool fee for limit orders to 0 (to make sure all existing fees
+		// are collected correctly)
+
+		// Collect to avoid undefined behaviour (See StorageMap::iter_keys documentation).
+		for asset_pair in Pools::<T>::iter_keys().collect::<Vec<_>>() {
+			if let Err(err) =
+				Pallet::<T>::try_mutate_pool(asset_pair, |asset_pair: &AssetPair, pool| {
+					Pallet::<T>::set_pool_fee_for_limit_orders(pool, asset_pair, 0)
+				}) {
+				log_or_panic!("Failed to set pool fee for limit orders during migration: {err:?}");
+			}
+		}
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		// Range order fees should not have changed:
+		let old_range_order_fees: Vec<u32> = Decode::decode(&mut state.as_slice())
+			.map_err(|_| DispatchError::from("Failed to decode state"))?;
+
+		let new_range_order_fees: Vec<u32> = Pools::<T>::iter_values()
+			.map(|pool| pool.pool_state.range_order_fee())
+			.collect();
+
+		assert_eq!(old_range_order_fees, new_range_order_fees);
+
+		assert!(
+			Pools::<T>::iter_values().all(|pool| pool.pool_state.limit_order_fee() == 0),
+			"limit order pool fees should be set to 0"
+		);
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	const BASE_ASSET: Asset = Asset::Usdt;
+
+	#[track_caller]
+	fn assert_pool_fees(range_order_fee: u32, limit_order_fee: u32) {
+		let pool = Pools::<Test>::iter_values().next().unwrap();
+
+		assert_eq!(pool.pool_state.range_order_fee(), range_order_fee);
+		assert_eq!(pool.pool_state.limit_order_fee(), limit_order_fee);
+	}
+
+	use cf_amm::math::price_at_tick;
+	use cf_utilities::assert_ok;
+	use mock::{new_test_ext, RuntimeOrigin, Test};
+
+	use super::*;
+
+	#[test]
+	fn test_migration() {
+		const INIT_POOL_FEE: u32 = 500;
+
+		new_test_ext().execute_with(|| {
+			assert_ok!(Pallet::<Test>::new_pool(
+				RuntimeOrigin::root(),
+				BASE_ASSET,
+				STABLE_ASSET,
+				INIT_POOL_FEE,
+				price_at_tick(0).unwrap(),
+			));
+
+			assert_pool_fees(INIT_POOL_FEE, INIT_POOL_FEE);
+
+			Migration::<Test>::on_runtime_upgrade();
+
+			assert_pool_fees(INIT_POOL_FEE, 0);
+		});
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2034

## Summary

- As discussed, when comparing limit and range order prices I chose to "inverse adjust for fee" the limit order price since that led to much cleaner and less error prone code (even though this seems backwards).
- Added a test for fee adjustment math, and also a test to check that we can correctly transition between range and limit orders when executing a swap. Previously I don't think this was sufficiently tested: I almost missed an infinite loop because of this.
- Limit orders no longer charge pool fee; the pool fee field still exists in limit order's PoolState, but (as discussed) I think it would be easier to change the funcitonality first and then clean up later.
- Now setting pool fee only sets it for range orders.
- Added a migration to set limit order pool fee to 0 which is necessary to correctly "collect" fees from any existing limit orders.
- Updates to existing tests:
  - `limit_orders::historics` <- removed as it was focused on fee collection
  - `limit_orders::swap` <- removed a test case that checked fee collection
  - `cf_pools::can_update_pool_liquidity_fee_and_collect_for_limit_order` <- fee related, removed
  - `pallet_limit_order_is_in_sync_with_pool` and `test_cancel_orders_batch` <- minor updates related to fees
  - `cf_pools::fees_are_recorded` -> `range_order_fees_are_recorded`