### PR TITLE
fix: correctly estimate input amount in scheduled swaps

### DIFF
--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -18,7 +18,7 @@
 use cf_amm::{
 	common::{PoolPairsMap, Side},
 	limit_orders::{self, Collected, PositionInfo},
-	math::{bounded_sqrt_price, Amount, Price, SqrtPriceQ64F96, Tick},
+	math::{bounded_sqrt_price, Amount, Price, SqrtPriceQ64F96, Tick, MAX_SQRT_PRICE},
 	range_orders::{self, Liquidity},
 	PoolState,
 };
@@ -2302,5 +2302,28 @@ impl<T: Config> OnKilledAccount<T::AccountId> for DeleteHistoricalEarnedFees<T> 
 impl<T: Config> LpOrdersWeightsProvider for Pallet<T> {
 	fn update_limit_order_weight() -> Weight {
 		T::WeightInfo::update_limit_order()
+	}
+}
+
+impl<T: Config> cf_traits::PoolPriceProvider for Pallet<T> {
+	fn pool_price(
+		base_asset: Asset,
+		quote_asset: Asset,
+	) -> Result<cf_traits::PoolPrice, DispatchError> {
+		use cf_amm::math::sqrt_price_to_price;
+
+		// NOTE: we can default to max price because None is only ever returned by
+		// Self::pool_price when the range order is at its maximum tick (irrespective
+		// of whether the pool has liquidity)
+		Self::pool_price(base_asset, quote_asset).map(|price| cf_traits::PoolPrice {
+			sell: price
+				.sell
+				.map(|p| p.price)
+				.unwrap_or_else(|| sqrt_price_to_price(MAX_SQRT_PRICE)),
+			buy: price
+				.buy
+				.map(|p| p.price)
+				.unwrap_or_else(|| sqrt_price_to_price(MAX_SQRT_PRICE)),
+		})
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -409,7 +409,7 @@ where
 pub mod pallet {
 	use core::cmp::max;
 
-	use cf_amm::math::{output_amount_ceil, sqrt_price_to_price, SqrtPriceQ64F96};
+	use cf_amm::math::output_amount_ceil;
 	use cf_chains::{
 		address::EncodedAddress, AnyChain, Chain, RefundParametersExtended,
 		RefundParametersExtendedEncoded,
@@ -418,7 +418,9 @@ pub mod pallet {
 		AffiliateShortId, Asset, AssetAmount, BasisPoints, BlockNumber, DcaParameters, EgressId,
 		SwapId, SwapOutput, SwapRequestId,
 	};
-	use cf_traits::{AccountRoleRegistry, Chainflip, EgressApi, ScheduledEgressDetails};
+	use cf_traits::{
+		AccountRoleRegistry, Chainflip, EgressApi, PoolPriceProvider, ScheduledEgressDetails,
+	};
 	use frame_system::WeightInfo as SystemWeightInfo;
 	use sp_runtime::SaturatedConversion;
 
@@ -468,6 +470,8 @@ pub mod pallet {
 
 		/// The balance API for interacting with the asset-balance pallet.
 		type BalanceApi: BalanceApi<AccountId = <Self as frame_system::Config>::AccountId>;
+
+		type PoolPriceApi: PoolPriceProvider;
 
 		type ChannelIdAllocator: ChannelIdAllocator;
 
@@ -1337,11 +1341,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		#[allow(clippy::result_unit_err)]
-		pub fn get_scheduled_swap_legs(
-			swaps: Vec<Swap<T>>,
-			base_asset: Asset,
-			pool_sell_price: Option<SqrtPriceQ64F96>,
-		) -> Vec<SwapLegInfo> {
+		pub fn get_scheduled_swap_legs(swaps: Vec<Swap<T>>, base_asset: Asset) -> Vec<SwapLegInfo> {
 			let mut swaps: Vec<_> = swaps.into_iter().map(SwapState::new).collect();
 
 			// Can ignore the result here because we use pool price fallback below
@@ -1387,10 +1387,19 @@ pub mod pallet {
 						let amount = swap.stable_amount.or_else(|| {
 							// If the swap into stable asset failed, fallback to estimating the
 							// amount via pool price.
+
+							// Should be able to successfully retrieve the price since the pool
+							// should exist as we wouldn't need to estimate if input asset
+							// was already STABLE_ASSET):
+							let sell_price =
+								T::PoolPriceApi::pool_price(swap.input_asset(), STABLE_ASSET)
+									.ok()
+									.map(|price| price.sell)?;
+
 							Some(
 								output_amount_ceil(
 									cf_amm::math::Amount::from(swap.input_amount()),
-									sqrt_price_to_price(pool_sell_price?),
+									sell_price,
 								)
 								.saturated_into(),
 							)

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -26,7 +26,7 @@ use cf_traits::{
 	mocks::{
 		address_converter::MockAddressConverter, balance_api::MockBalance, bonding::MockBonderFor,
 		deposit_handler::MockDepositHandler, egress_handler::MockEgressHandler,
-		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
+		ingress_egress_fee_handler::MockIngressEgressFeeHandler, pool_price_api::MockPoolPriceApi,
 	},
 	AccountRoleRegistry, ChannelIdAllocator, SwappingApi,
 };
@@ -200,6 +200,7 @@ impl pallet_cf_swapping::Config for Test {
 	type NetworkFee = NetworkFee;
 	type ChannelIdAllocator = MockChannelIdAllocator;
 	type Bonder = MockBonderFor<Self>;
+	type PoolPriceApi = MockPoolPriceApi;
 }
 
 pub const ALICE: <Test as frame_system::Config>::AccountId = 123u64;

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -28,7 +28,7 @@ use crate::{
 	CollectedRejectedFunds, Error, Event, MaximumSwapAmount, Pallet, Swap, SwapOrigin, SwapQueue,
 	SwapType,
 };
-use cf_amm::math::{price_to_sqrt_price, PRICE_FRACTIONAL_BITS};
+use cf_amm::math::PRICE_FRACTIONAL_BITS;
 use cf_chains::{
 	self,
 	address::{AddressConverter, EncodedAddress, ForeignChainAddress},
@@ -47,6 +47,7 @@ use cf_traits::{
 		egress_handler::{MockEgressHandler, MockEgressParameter},
 		funding_info::MockFundingInfo,
 		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
+		pool_price_api::MockPoolPriceApi,
 	},
 	AccountRoleRegistry, AssetConverter, Chainflip, SetSafeMode,
 };
@@ -1114,7 +1115,7 @@ fn test_get_scheduled_swap_legs() {
 		assert_ne!(INIT_AMOUNT, INTERMEDIATE_AMOUNT);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip, None),
+			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip),
 			vec![
 				SwapLegInfo {
 					swap_id: SwapId(1),
@@ -1187,10 +1188,16 @@ fn test_get_scheduled_swap_legs_fallback() {
 		// The swap simulation must fail for it to use the fallback price estimation
 		MockSwappingApi::set_swaps_should_fail(true);
 
-		let sqrt_price = price_to_sqrt_price((U256::from(PRICE)) << PRICE_FRACTIONAL_BITS);
+		// Only setting pool price for FLIP to make sure that the test would fail
+		// if the code tried to use the price of some other asset
+		MockPoolPriceApi::set_pool_price(
+			Asset::Flip,
+			STABLE_ASSET,
+			U256::from(PRICE) << PRICE_FRACTIONAL_BITS,
+		);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth, Some(sqrt_price)),
+			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth),
 			vec![
 				SwapLegInfo {
 					swap_id: SwapId(1),
@@ -1236,7 +1243,7 @@ fn test_get_scheduled_swap_legs_for_dca() {
 			vec![create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, Some(dca_params))];
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth, None),
+			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth),
 			vec![SwapLegInfo {
 				swap_id: SwapId(1),
 				swap_request_id: SwapRequestId(1),

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -330,6 +330,7 @@ impl pallet_cf_swapping::Config for Runtime {
 	type CcmValidityChecker = CcmValidityChecker;
 	type NetworkFee = NetworkFee;
 	type BalanceApi = AssetBalances;
+	type PoolPriceApi = LiquidityPools;
 	type ChannelIdAllocator = BitcoinIngressEgress;
 	type Bonder = Bonder<Runtime>;
 }
@@ -2037,12 +2038,7 @@ impl_runtime_apis! {
 					.cloned()
 					.collect();
 
-				let pool_sell_price = LiquidityPools::pool_price(base_asset, quote_asset).
-					expect("Pool should exist")
-					.sell
-					.map(|price| price.sqrt_price);
-
-				Swapping::get_scheduled_swap_legs(swaps, base_asset, pool_sell_price)
+				Swapping::get_scheduled_swap_legs(swaps, base_asset)
 					.into_iter()
 					.map(move |swap| (swap, execute_at))
 			}).collect()

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -46,7 +46,7 @@ use cf_chains::{
 use cf_primitives::{
 	AccountRole, AffiliateShortId, Asset, AssetAmount, AuthorityCount, BasisPoints, Beneficiaries,
 	BlockNumber, BroadcastId, ChannelId, DcaParameters, Ed25519PublicKey, EgressCounter, EgressId,
-	EpochIndex, FlipBalance, ForeignChain, GasAmount, Ipv6Addr, NetworkEnvironment, SemVer,
+	EpochIndex, FlipBalance, ForeignChain, GasAmount, Ipv6Addr, NetworkEnvironment, Price, SemVer,
 	ThresholdSignatureRequestId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
@@ -1226,4 +1226,17 @@ pub trait MinimumDeposit {
 // Used for exposing weights from the Pools pallet
 pub trait LpOrdersWeightsProvider {
 	fn update_limit_order_weight() -> Weight;
+}
+
+#[derive(
+	Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+)]
+pub struct PoolPrice {
+	pub sell: Price,
+	pub buy: Price,
+}
+
+// Used to get price of a given pool
+pub trait PoolPriceProvider {
+	fn pool_price(base_asset: Asset, quote_asset: Asset) -> Result<PoolPrice, DispatchError>;
 }

--- a/state-chain/traits/src/mocks.rs
+++ b/state-chain/traits/src/mocks.rs
@@ -49,6 +49,7 @@ pub mod liability_tracker;
 pub mod offence_reporting;
 pub mod on_account_funded;
 pub mod pool_api;
+pub mod pool_price_api;
 pub mod qualify_node;
 pub mod reputation_resetter;
 pub mod safe_mode;

--- a/state-chain/traits/src/mocks/pool_price_api.rs
+++ b/state-chain/traits/src/mocks/pool_price_api.rs
@@ -1,0 +1,29 @@
+use cf_primitives::{Asset, Price};
+
+use crate::{PoolPrice, PoolPriceProvider};
+
+use frame_support::sp_runtime::DispatchError;
+
+use super::{MockPallet, MockPalletStorage};
+
+pub struct MockPoolPriceApi {}
+
+impl MockPallet for MockPoolPriceApi {
+	const PREFIX: &'static [u8] = b"MockPoolPriceApi";
+}
+
+const POOL_PRICES: &[u8] = b"POOL_PRICES";
+
+impl MockPoolPriceApi {
+	pub fn set_pool_price(base_asset: Asset, quote_asset: Asset, price: Price) {
+		Self::put_storage::<_, Price>(POOL_PRICES, (base_asset, quote_asset), price)
+	}
+}
+
+impl PoolPriceProvider for MockPoolPriceApi {
+	fn pool_price(base_asset: Asset, quote_asset: Asset) -> Result<PoolPrice, DispatchError> {
+		let price = Self::get_storage::<_, Price>(POOL_PRICES, (base_asset, quote_asset))
+			.expect("price should have been set");
+		Ok(PoolPrice { sell: price, buy: price })
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-1929

## Summary

- In the fallback case (no liquidity) we now use the price of the correct asset when estimating input
- For this I added a `PoolPriceApi` trait so that the prices are available from the swapping pallet (previously we were passing the price as a parameter, but now we would need prices for multiple/all assets)
- The use of `PoolPriceApi` means we can write a better test that would catch this bug
