### PR TITLE
feat: instance specific voter logs

### DIFF
--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -244,6 +244,7 @@ where
 						SolanaLivenessVoter { client: client.clone() },
 						SolanaVaultSwapsVoter { client },
 					)),
+					"Solana",
 				)
 				.continuously_vote()
 				.await;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2067

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

As we introduce other chains to elections based witnessing, we need to be able to disambiguate between voter instances in the logs. 

Logs will appear like this:

```
{"timestamp":"2025-04-07T13:45:12.037022Z","level":"DEBUG","fields":{"message":"Voting task for election: 'ElectionIdentifier(UniqueMonotonicIdentifier(36), A(()))' initiated.","voter":"Solana"},"target":"chainflip_engine::elections","spans":[{"name":"voter-task"}]}
```