### PR TITLE
refactor: store solana alt election results in unsynchronised state map

### DIFF
--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -228,15 +228,12 @@ impl VoterApi<SolanaAltWitnessing> for SolanaAltWitnessingVoter {
 		_settings: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectoralSettings,
 		alt_witnessing_identifier: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectionProperties,
 	) -> Result<Option<VoteOf<SolanaAltWitnessing>>, anyhow::Error> {
-		lookup_table_witnessing::get_lookup_table_state(
-			&self.client,
-			alt_witnessing_identifier.alt_addresses,
-		)
-		.await
-		// We wrap the vote in a Some here since the vote is always valid if there was no error in
-		// rpc while querying. This is so we come to consensus on "None" if the lookup table is not
-		// found.
-		.map(Some)
+		lookup_table_witnessing::get_lookup_table_state(&self.client, alt_witnessing_identifier.0)
+			.await
+			// We wrap the vote in a Some here since the vote is always valid if there was no error
+			// in rpc while querying. This is so we come to consensus on "None" if the lookup
+			// table is not found.
+			.map(Some)
 	}
 }
 

--- a/engine/src/witness/sol/lookup_table_witnessing.rs
+++ b/engine/src/witness/sol/lookup_table_witnessing.rs
@@ -1,4 +1,4 @@
-use cf_chains::sol::{api::AltConsensusResult, SolAddress};
+use cf_chains::sol::{api::AltWitnessingConsensusResult, SolAddress};
 
 use crate::sol::{
 	commitment_config::CommitmentConfig,
@@ -19,7 +19,7 @@ use std::str::FromStr;
 pub async fn get_lookup_table_state<SolRetryRpcClient>(
 	sol_rpc: &SolRetryRpcClient,
 	lookup_table_addresses: Vec<SolAddress>,
-) -> Result<AltConsensusResult<Vec<AddressLookupTableAccount>>, anyhow::Error>
+) -> Result<AltWitnessingConsensusResult<Vec<AddressLookupTableAccount>>, anyhow::Error>
 where
 	SolRetryRpcClient: SolRetryRpcApi + Send + Sync + Clone,
 {
@@ -42,8 +42,8 @@ where
 		})
 		.collect::<Result<Option<_>, _>>()
 		.map(|maybe_consensus_alts| match maybe_consensus_alts {
-			Some(alts) => AltConsensusResult::ValidConsensusAlts(alts),
-			None => AltConsensusResult::AltsInvalidNoConsensus,
+			Some(alts) => AltWitnessingConsensusResult::ValidConsensus(alts),
+			None => AltWitnessingConsensusResult::InvalidNoConsensus,
 		})
 }
 fn parse_alt_account_info(
@@ -296,7 +296,7 @@ mod tests {
 				let addresses =
 					get_lookup_table_state(&client, vec![mainnet_empty_address]).await.unwrap();
 
-				assert_eq!(addresses, AltConsensusResult::AltsInvalidNoConsensus);
+				assert_eq!(addresses, AltWitnessingConsensusResult::InvalidNoConsensus);
 
 				let mainnet_nonce_account: SolAddress =
 					SolAddress::from_str("3bVqyf58hQHsxbjnqnSkopnoyEHB9v9KQwhZj7h1DucW").unwrap();
@@ -304,7 +304,7 @@ mod tests {
 				let addresses =
 					get_lookup_table_state(&client, vec![mainnet_nonce_account]).await.unwrap();
 
-				assert_eq!(addresses, AltConsensusResult::AltsInvalidNoConsensus);
+				assert_eq!(addresses, AltWitnessingConsensusResult::InvalidNoConsensus);
 
 				Ok(())
 			}

--- a/foreign-chains/solana/sol-prim/src/consts.rs
+++ b/foreign-chains/solana/sol-prim/src/consts.rs
@@ -15,7 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Address, Digest};
-use cf_primitives::BlockNumber;
 use cf_utilities::bs58_array;
 
 pub const SOLANA_SIGNATURE_LEN: usize = 64;
@@ -77,4 +76,3 @@ pub const ACCOUNT_KEY_LENGTH_IN_TRANSACTION: usize = 32usize;
 pub const ACCOUNT_REFERENCE_LENGTH_IN_TRANSACTION: usize = 1usize;
 
 pub const MAX_CCM_USER_ALTS: u8 = 3u8;
-pub const EXPIRY_TIME_FOR_ALT_ELECTIONS: BlockNumber = 100u32;

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -778,6 +778,8 @@ impl<T, E> From<Result<T, E>> for AltConsensusResult<T> {
 }
 
 impl<T> AltConsensusResult<T> {
+	/// Group a vec of results into a single result.
+	/// Only return `ValidConsensusAlts` if all individual results are `ValidConsensusAlts`.
 	pub fn group(individuals: Vec<AltConsensusResult<T>>) -> AltConsensusResult<Vec<T>> {
 		individuals
 			.into_iter()

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -767,3 +767,28 @@ pub enum AltConsensusResult<T> {
 	ValidConsensusAlts(T),
 	AltsInvalidNoConsensus,
 }
+
+impl<T, E> From<Result<T, E>> for AltConsensusResult<T> {
+	fn from(value: Result<T, E>) -> Self {
+		match value {
+			Ok(r) => AltConsensusResult::ValidConsensusAlts(r),
+			Err(_) => AltConsensusResult::AltsInvalidNoConsensus,
+		}
+	}
+}
+
+impl<T> AltConsensusResult<T> {
+	pub fn group(individuals: Vec<AltConsensusResult<T>>) -> AltConsensusResult<Vec<T>> {
+		individuals
+			.into_iter()
+			.map(|individual| {
+				if let AltConsensusResult::ValidConsensusAlts(ind) = individual {
+					Ok(ind)
+				} else {
+					Err(())
+				}
+			})
+			.collect::<Result<Vec<T>, ()>>()
+			.into()
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -422,6 +422,22 @@ mod access {
 			Self::set_unsynchronised_state(unsynchronised_state)?;
 			Ok(t)
 		}
+
+		/// Allows you to mutate the value of the unsynchronised state map.
+		fn mutate_unsynchronised_state_map<
+			T,
+			F: for<'a> FnOnce(
+				&'a mut Option<<Self::ElectoralSystem as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue>,
+			) -> Result<T, CorruptStorageError>,
+		>(
+			key: <Self::ElectoralSystem as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
+			f: F,
+		) -> Result<T, CorruptStorageError>{
+			let mut unsynchronised_state_map = Self::unsynchronised_state_map(&key)?;
+			let t = f(&mut unsynchronised_state_map)?;
+			Self::set_unsynchronised_state_map(key, unsynchronised_state_map);
+			Ok(t)
+		}
 	}
 }
 pub use access::{

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -231,4 +231,22 @@ pub trait RunnerStorageAccessTrait {
 		Self::set_unsynchronised_state(unsynchronised_state);
 		Ok(t)
 	}
+
+	/// Allows you to mutate the value of a unsynchronised state map.
+	fn mutate_unsynchronised_state_map<
+		T,
+		F: for<'a> FnOnce(
+			&Self,
+			&'a mut Option<<Self::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue>,
+		) -> Result<T, CorruptStorageError>,
+	>(
+		&self,
+		key: <Self::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
+		f: F,
+	) -> Result<T, CorruptStorageError>{
+		let mut unsynchronised_state_map = Self::unsynchronised_state_map(&key);
+		let t = f(self, &mut unsynchronised_state_map)?;
+		Self::set_unsynchronised_state_map(key, unsynchronised_state_map);
+		Ok(t)
+	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system_runner.rs
@@ -231,22 +231,4 @@ pub trait RunnerStorageAccessTrait {
 		Self::set_unsynchronised_state(unsynchronised_state);
 		Ok(t)
 	}
-
-	/// Allows you to mutate the value of a unsynchronised state map.
-	fn mutate_unsynchronised_state_map<
-		T,
-		F: for<'a> FnOnce(
-			&Self,
-			&'a mut Option<<Self::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapValue>,
-		) -> Result<T, CorruptStorageError>,
-	>(
-		&self,
-		key: <Self::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralUnsynchronisedStateMapKey,
-		f: F,
-	) -> Result<T, CorruptStorageError>{
-		let mut unsynchronised_state_map = Self::unsynchronised_state_map(&key);
-		let t = f(self, &mut unsynchronised_state_map)?;
-		Self::set_unsynchronised_state_map(key, unsynchronised_state_map);
-		Ok(t)
-	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/exact_value.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/exact_value.rs
@@ -22,6 +22,7 @@ use crate::{
 	},
 	vote_storage, CorruptStorageError,
 };
+use cf_runtime_utilities::log_or_panic;
 use cf_utilities::success_threshold_from_share_count;
 use frame_support::{
 	pallet_prelude::{MaybeSerializeDeserialize, Member},
@@ -32,16 +33,7 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 /// This electoral system detects if something occurred or not. Voters simply vote if something
 /// happened, and if they haven't seen it happen, they don't vote.
 #[allow(clippy::type_complexity)]
-pub struct ExactValue<
-	Identifier,
-	Value,
-	Settings,
-	Hook,
-	ValidatorId,
-	StateChainBlockNumber,
-	UnsynchronisedStateMapKey,
-	UnsynchronisedStateMapValue,
-> {
+pub struct ExactValue<Identifier, Value, Settings, Hook, ValidatorId, StateChainBlockNumber> {
 	_phantom: core::marker::PhantomData<(
 		Identifier,
 		Value,
@@ -49,13 +41,17 @@ pub struct ExactValue<
 		Hook,
 		ValidatorId,
 		StateChainBlockNumber,
-		UnsynchronisedStateMapKey,
-		UnsynchronisedStateMapValue,
 	)>,
 }
 
 pub trait ExactValueHook<Identifier, Value> {
-	fn on_consensus(id: Identifier, value: Value);
+	type StorageKey: Parameter + Member;
+	type StorageValue: Parameter + Member;
+
+	/// Called when a consensus is reached. The hook can return a tuple of `(Self::StorageKey,
+	/// Self::StorageValue)` to be stored in the unsynchronised state map.
+	fn on_consensus(id: Identifier, value: Value)
+		-> Option<(Self::StorageKey, Self::StorageValue)>;
 }
 
 impl<
@@ -65,19 +61,7 @@ impl<
 		Hook: ExactValueHook<Identifier, Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		UnsynchronisedStateMapKey: Parameter + Member,
-		UnsynchronisedStateMapValue: Parameter + Member,
-	>
-	ExactValue<
-		Identifier,
-		Value,
-		Settings,
-		Hook,
-		ValidatorId,
-		StateChainBlockNumber,
-		UnsynchronisedStateMapKey,
-		UnsynchronisedStateMapValue,
-	>
+	> ExactValue<Identifier, Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	pub fn witness_exact_value<
 		ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static,
@@ -86,6 +70,27 @@ impl<
 	) -> Result<(), CorruptStorageError> {
 		ElectoralAccess::new_election((), identifier, ())?;
 		Ok(())
+	}
+
+	pub fn election_result<
+		ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static,
+	>(
+		id: Hook::StorageKey,
+	) -> Option<Hook::StorageValue> {
+		ElectoralAccess::mutate_unsynchronised_state_map(id.clone(), |storage| {
+			Ok(if let Some((counter, value)) = storage.take() {
+				if counter > 1 {
+					let _ = storage.insert((counter - 1, value.clone()));
+				}
+				Some(value)
+			} else {
+				None
+			})
+		})
+		.unwrap_or_else(|_| {
+			log_or_panic!("Failed to get election result for el {:?} due to corrupted storage", id);
+			None
+		})
 	}
 }
 
@@ -96,25 +101,14 @@ impl<
 		Hook: ExactValueHook<Identifier, Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		UnsynchronisedStateMapKey: Parameter + Member,
-		UnsynchronisedStateMapValue: Parameter + Member,
 	> ElectoralSystemTypes
-	for ExactValue<
-		Identifier,
-		Value,
-		Settings,
-		Hook,
-		ValidatorId,
-		StateChainBlockNumber,
-		UnsynchronisedStateMapKey,
-		UnsynchronisedStateMapValue,
-	>
+	for ExactValue<Identifier, Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	type ValidatorId = ValidatorId;
 	type StateChainBlockNumber = StateChainBlockNumber;
 	type ElectoralUnsynchronisedState = ();
-	type ElectoralUnsynchronisedStateMapKey = UnsynchronisedStateMapKey;
-	type ElectoralUnsynchronisedStateMapValue = UnsynchronisedStateMapValue;
+	type ElectoralUnsynchronisedStateMapKey = Hook::StorageKey;
+	type ElectoralUnsynchronisedStateMapValue = (u16, Hook::StorageValue);
 
 	type ElectoralUnsynchronisedSettings = ();
 	type ElectoralSettings = Settings;
@@ -134,19 +128,8 @@ impl<
 		Hook: ExactValueHook<Identifier, Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
 		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		UnsynchronisedStateMapKey: Parameter + Member,
-		UnsynchronisedStateMapValue: Parameter + Member,
 	> ElectoralSystem
-	for ExactValue<
-		Identifier,
-		Value,
-		Settings,
-		Hook,
-		ValidatorId,
-		StateChainBlockNumber,
-		UnsynchronisedStateMapKey,
-		UnsynchronisedStateMapValue,
-	>
+	for ExactValue<Identifier, Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifierOf<Self>,
@@ -183,7 +166,16 @@ impl<
 			let election_access = ElectoralAccess::election_mut(election_identifier);
 			let identifier = election_access.properties()?;
 			if let Some(witnessed_value) = election_access.check_consensus()?.has_consensus() {
-				Hook::on_consensus(identifier, witnessed_value);
+				if let Some((key, value)) = Hook::on_consensus(identifier, witnessed_value) {
+					ElectoralAccess::mutate_unsynchronised_state_map(key, |storage| {
+						if let Some((old_counter, _)) = storage.replace((1, value)) {
+							if let Some((counter, _)) = storage.as_mut() {
+								*counter = old_counter + 1;
+							};
+						}
+						Ok(())
+					})?;
+				}
 				election_access.delete();
 			}
 		}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks.rs
@@ -392,21 +392,21 @@ macro_rules! single_check_new {
 /// ```
 #[macro_export]
 macro_rules! register_checks {
-    (
-        $system:ident {
-            $(
-                $check_name:ident($arg_1:ident, $arg_2:ident $(, $param:ident : $param_type:ty)? ) $check_body:block
-            ),* $(,)?
-        }
-    ) => {
-        impl Check<$system> {
-            $(
-                pub fn $check_name($($param: $param_type)?) -> Box<dyn $crate::electoral_systems::mocks::Checkable<$system> + 'static> {
+	(
+		$system:ident {
+			$(
+				$check_name:ident($arg_1:ident, $arg_2:ident $(, $param:ident : $param_type:ty)? ) $check_body:block
+			),* $(,)?
+		}
+	) => {
+		impl Check<$system> {
+			$(
+				pub fn $check_name($($param: $param_type)?) -> Box<dyn $crate::electoral_systems::mocks::Checkable<$system> + 'static> {
 					Box::new($crate::single_check_new!(&$crate::electoral_systems::mocks::ElectoralSystemState<$system>, $arg_1, $arg_2, $check_body $(, $param)? ))
 				}
-            )*
-        }
-    };
+			)*
+		}
+	};
 	(
 		$(
 			#[extra_constraints: $( $t:ty : $tc:path ),+]#

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
@@ -20,6 +20,7 @@ pub(crate) use crate::register_checks;
 
 pub mod delta_based_ingress;
 pub mod egress_success;
+pub mod exact_value;
 pub mod liveness;
 pub mod monotonic_change;
 pub mod monotonic_median;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
@@ -28,8 +28,12 @@ thread_local! {
 
 pub struct MockHook;
 impl ExactValueHook<(), EgressData> for MockHook {
-	fn on_consensus(_id: (), _egress_data: EgressData) {
+	type StorageKey = ();
+	type StorageValue = EgressData;
+
+	fn on_consensus(id: (), egress_data: EgressData) -> Option<((), EgressData)> {
 		HOOK_CALLED.with(|hook_called| hook_called.set(true));
+		Some((id, egress_data))
 	}
 }
 
@@ -40,17 +44,27 @@ impl MockHook {
 }
 
 type EgressData = u64;
-type SimpleEgressSuccess = ExactValue<(), EgressData, (), MockHook, (), u32, (), ()>;
+type SimpleEgressSuccess = ExactValue<(), EgressData, (), MockHook, (), u32>;
 
 register_checks! {
 	SimpleEgressSuccess {
-		hook_called(_pre, _post) {
+		hook_called(_pre, post) {
 			assert!(MockHook::called(), "Hook should have been called!");
+			assert!(
+				post.unsynchronised_state_map
+					.contains_key(&()),
+				"State should have been set!"
+			)
 		},
-		hook_not_called(_pre, _post) {
+		hook_not_called(pre, post) {
 			assert!(
 				!MockHook::called(),
 				"Hook should not have been called!"
+			);
+			assert_eq!(
+				pre,
+				post,
+				"State should not have changed!"
 			);
 		},
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/egress_success.rs
@@ -24,16 +24,12 @@ use cf_primitives::AuthorityCount;
 
 thread_local! {
 	pub static HOOK_CALLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-	pub static SHOULD_EXPIRE_ELECTION: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 pub struct MockHook;
 impl ExactValueHook<(), EgressData> for MockHook {
 	fn on_consensus(_id: (), _egress_data: EgressData) {
 		HOOK_CALLED.with(|hook_called| hook_called.set(true));
-	}
-	fn should_expire_election(_id: ()) -> bool {
-		SHOULD_EXPIRE_ELECTION.with(|should_expire_election| should_expire_election.get())
 	}
 }
 
@@ -44,7 +40,7 @@ impl MockHook {
 }
 
 type EgressData = u64;
-type SimpleEgressSuccess = ExactValue<(), EgressData, (), MockHook, (), u32>;
+type SimpleEgressSuccess = ExactValue<(), EgressData, (), MockHook, (), u32, (), ()>;
 
 register_checks! {
 	SimpleEgressSuccess {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/exact_value.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/exact_value.rs
@@ -107,9 +107,10 @@ fn solana_election_result_reference_counting_works() {
 			id(2),
 			ConsensusStatus::Gained { most_recent: None, new: vec![22, 23] },
 		);
+		// Storage map should update with the new value
 		MockStorageAccess::set_consensus_status::<WitnessExactValueWithStorage>(
 			id(3),
-			ConsensusStatus::Gained { most_recent: None, new: vec![11, 12] },
+			ConsensusStatus::Gained { most_recent: None, new: vec![31, 32] },
 		);
 
 		assert_ok!(WitnessExactValueWithStorage::on_finalize::<
@@ -121,7 +122,7 @@ fn solana_election_result_reference_counting_works() {
 			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
 				first_id.clone()
 			),
-			Some(vec![11, 12])
+			Some(vec![31, 32])
 		);
 		assert_eq!(
 			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
@@ -133,7 +134,7 @@ fn solana_election_result_reference_counting_works() {
 			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
 				first_id.clone()
 			),
-			Some(vec![11, 12])
+			Some(vec![31, 32])
 		);
 
 		assert!(WitnessExactValueWithStorage::election_result::<

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/exact_value.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/exact_value.rs
@@ -1,0 +1,148 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::mocks::*;
+use crate::{
+	electoral_system::{ConsensusStatus, ElectoralSystem},
+	electoral_systems::exact_value::*,
+	ElectionIdentifier,
+};
+use codec::{Decode, Encode};
+use frame_support::assert_ok;
+use scale_info::TypeInfo;
+
+type WitnessExactValueWithStorage = ExactValue<MockIdentifier, Vec<u32>, (), MockHook, u32, u64>;
+
+#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, PartialOrd, Ord, Default)]
+pub struct MockIdentifier(Vec<u32>);
+
+impl From<Vec<u32>> for MockIdentifier {
+	fn from(value: Vec<u32>) -> Self {
+		Self(value)
+	}
+}
+
+pub struct MockHook;
+impl ExactValueHook<MockIdentifier, Vec<u32>> for MockHook {
+	type StorageKey = MockIdentifier;
+	type StorageValue = Vec<u32>;
+
+	fn on_consensus(id: MockIdentifier, value: Vec<u32>) -> Option<(MockIdentifier, Vec<u32>)> {
+		Some((id, value))
+	}
+}
+
+fn with_default_state() -> TestContext<WitnessExactValueWithStorage> {
+	TestSetup::<WitnessExactValueWithStorage>::default().build()
+}
+
+#[test]
+fn solana_election_result_reference_counting_works() {
+	with_default_state().then(|| {
+		let mock_id: MockIdentifier = vec![1u32, 2u32].into();
+		let id = |umi: u64| ElectionIdentifier::new(umi.into(), ());
+
+		// Start first election and come to consensus.
+		assert_ok!(WitnessExactValueWithStorage::witness_exact_value::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(mock_id.clone()));
+		assert!(WitnessExactValueWithStorage::election_result::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(mock_id.clone())
+		.is_none());
+
+		MockStorageAccess::set_consensus_status::<WitnessExactValueWithStorage>(
+			id(0),
+			ConsensusStatus::Gained { most_recent: None, new: vec![11, 12] },
+		);
+		assert_ok!(WitnessExactValueWithStorage::on_finalize::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(vec![id(0)], &()));
+
+		// First successful lookup `takes` the storage value.
+		assert_eq!(
+			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
+				mock_id.clone()
+			),
+			Some(vec![11, 12])
+		);
+		assert!(WitnessExactValueWithStorage::election_result::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(mock_id.clone())
+		.is_none());
+
+		// Start elections with overlapping and identical identifiers.
+		let first_id: MockIdentifier = vec![1u32, 2u32].into();
+		let overlap_id: MockIdentifier = vec![2u32, 3u32].into();
+
+		assert_ok!(WitnessExactValueWithStorage::witness_exact_value::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(first_id.clone()));
+		assert_ok!(WitnessExactValueWithStorage::witness_exact_value::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(overlap_id.clone()));
+		assert_ok!(WitnessExactValueWithStorage::witness_exact_value::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(first_id.clone()));
+
+		// Vote and come to consensus
+		MockStorageAccess::set_consensus_status::<WitnessExactValueWithStorage>(
+			id(1),
+			ConsensusStatus::Gained { most_recent: None, new: vec![11, 12] },
+		);
+		MockStorageAccess::set_consensus_status::<WitnessExactValueWithStorage>(
+			id(2),
+			ConsensusStatus::Gained { most_recent: None, new: vec![22, 23] },
+		);
+		MockStorageAccess::set_consensus_status::<WitnessExactValueWithStorage>(
+			id(3),
+			ConsensusStatus::Gained { most_recent: None, new: vec![11, 12] },
+		);
+
+		assert_ok!(WitnessExactValueWithStorage::on_finalize::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(vec![id(1), id(2), id(3)], &()));
+
+		// First lookup takes the value from the storage map
+		assert_eq!(
+			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
+				first_id.clone()
+			),
+			Some(vec![11, 12])
+		);
+		assert_eq!(
+			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
+				overlap_id.clone()
+			),
+			Some(vec![22, 23])
+		);
+		assert_eq!(
+			WitnessExactValueWithStorage::election_result::<MockAccess<WitnessExactValueWithStorage>>(
+				first_id.clone()
+			),
+			Some(vec![11, 12])
+		);
+
+		assert!(WitnessExactValueWithStorage::election_result::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(first_id.clone())
+		.is_none());
+		assert!(WitnessExactValueWithStorage::election_result::<
+			MockAccess<WitnessExactValueWithStorage>,
+		>(overlap_id.clone())
+		.is_none());
+	});
+}

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -29,17 +29,14 @@ use cf_chains::{
 	dot::{Polkadot, PolkadotAccountId, PolkadotHash, PolkadotIndex},
 	eth::Address as EvmAddress,
 	sol::{
-		api::{
-			AltConsensusResult, DurableNonceAndAccount, SolanaApi, SolanaEnvironment, SolanaGovCall,
-		},
-		SolAddress, SolAddressLookupTableAccount, SolApiEnvironment, SolHash, Solana,
-		NONCE_NUMBER_CRITICAL_NONCES,
+		api::{DurableNonceAndAccount, SolanaApi, SolanaEnvironment, SolanaGovCall},
+		SolAddress, SolApiEnvironment, SolHash, Solana, NONCE_NUMBER_CRITICAL_NONCES,
 	},
 	Chain,
 };
 use cf_primitives::{
 	chains::assets::{arb::Asset as ArbAsset, eth::Asset as EthAsset},
-	BroadcastId, NetworkEnvironment, SemVer, SwapRequestId,
+	BroadcastId, NetworkEnvironment, SemVer,
 };
 use cf_traits::{
 	Broadcaster, CompatibleCfeVersions, GetBitcoinFeeInfo, KeyProvider, NetworkEnvironmentProvider,
@@ -259,16 +256,6 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn solana_api_environment)]
 	pub type SolanaApiEnvironment<T> = StorageValue<_, SolApiEnvironment, ValueQuery>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn solana_ccm_swap_alts)]
-	pub type SolanaCcmSwapAlts<T> = StorageMap<
-		_,
-		Blake2_128Concat,
-		SwapRequestId,
-		AltConsensusResult<Vec<SolAddressLookupTableAccount>>,
-		OptionQuery,
-	>;
 
 	// OTHER ENVIRONMENT ITEMS
 	#[pallet::storage]
@@ -829,19 +816,6 @@ impl<T: Config> Pallet<T> {
 		} else {
 			log::error!("Nonce account {nonce_account} not found in unavailable nonce accounts");
 		}
-	}
-
-	pub fn add_sol_ccm_swap_alts(
-		swap_request_id: SwapRequestId,
-		alts: AltConsensusResult<Vec<SolAddressLookupTableAccount>>,
-	) {
-		SolanaCcmSwapAlts::<T>::insert(swap_request_id, alts);
-	}
-
-	pub fn take_sol_ccm_swap_alts(
-		swap_request_id: SwapRequestId,
-	) -> Option<AltConsensusResult<Vec<SolAddressLookupTableAccount>>> {
-		SolanaCcmSwapAlts::<T>::take(swap_request_id)
 	}
 }
 

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -23,9 +23,9 @@ use cf_chains::{
 	eth,
 	sol::{
 		api::{
-			AllNonceAccounts, AltConsensusResult, ApiEnvironment, ComputePrice, CurrentAggKey,
-			CurrentOnChainKey, DurableNonce, DurableNonceAndAccount, RecoverDurableNonce,
-			SolanaApi, SolanaEnvironment,
+			AllNonceAccounts, AltWitnessingConsensusResult, ApiEnvironment, ComputePrice,
+			CurrentAggKey, CurrentOnChainKey, DurableNonce, DurableNonceAndAccount,
+			RecoverDurableNonce, SolanaApi, SolanaEnvironment,
 		},
 		SolAddress, SolAddressLookupTableAccount, SolAmount, SolApiEnvironment, SolHash,
 	},
@@ -205,12 +205,15 @@ impl RecoverDurableNonce for MockSolEnvironment {
 	}
 }
 
-impl ChainEnvironment<Vec<SolAddress>, AltConsensusResult<Vec<SolAddressLookupTableAccount>>>
-	for MockSolEnvironment
+impl
+	ChainEnvironment<
+		Vec<SolAddress>,
+		AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>,
+	> for MockSolEnvironment
 {
 	fn lookup(
 		_alts: Vec<SolAddress>,
-	) -> Option<AltConsensusResult<Vec<SolAddressLookupTableAccount>>> {
+	) -> Option<AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>> {
 		None
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2167, PRO-2169

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary
ALT election results are now stored into the unsynchronised state map with Reference counting
ALT election results are now taken from the state map on ApiCall construction, managed with RC
Removed the expiry system from ALT witnessing elections
Added appropriate integration tests, and fixed a test with a TODO
