### PR TITLE
feat: save all processed events

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -436,7 +436,7 @@ mod tests {
 				safemode_enabled: MockHook::new(safemode_enabled),
 				block_processor: BlockProcessor {
 					blocks_data: Default::default(),
-					reorg_events: Default::default(),
+					processed_events: Default::default(),
 					rules: Default::default(),
 					execute: Default::default(),
 				},


### PR DESCRIPTION
# Pull Request

Closes: PRO-2162

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Update block_processor logic to save all the processed events to cover few edge cases previously not covered, the events will be kept around for the `safety_margin` to avoid double processing them. 