### PR TITLE
fix: refresh evm replay protection with correct contract address

### DIFF
--- a/state-chain/cf-integration-tests/src/broadcasting.rs
+++ b/state-chain/cf-integration-tests/src/broadcasting.rs
@@ -17,7 +17,8 @@
 use super::*;
 use cf_chains::{
 	btc::{deposit_address::DepositAddress, ScriptPubkey, Utxo},
-	AllBatch, Bitcoin, ForeignChain, TransferAssetParams,
+	eth::api::EthereumApi,
+	AllBatch, ApiCall, Bitcoin, ForeignChain, TransferAssetParams, UpdateFlipSupply,
 };
 use cf_primitives::{chains::assets::btc, AuthorityCount, BroadcastId};
 use cf_traits::{Broadcaster, EpochInfo};
@@ -129,4 +130,28 @@ fn bitcoin_broadcast_delay_works() {
 				);
 			}
 		});
+}
+
+#[test]
+fn refresh_replay_protection() {
+	super::genesis::with_test_defaults().build().execute_with(|| {
+		let mut api_call = <<Runtime as pallet_cf_emissions::Config>::ApiCall as UpdateFlipSupply<_>>::new_unsigned(1_000_000, 1);
+
+		let old_replay_protection = match &api_call {
+			EthereumApi::UpdateFlipSupply(call) => call.replay_protection(),
+			_ => unreachable!("Expected EthereumApi::UpdateFlipSupply"),
+		};
+
+		api_call.refresh_replay_protection();
+		let new_replay_protection = match &api_call {
+			EthereumApi::UpdateFlipSupply(call) => call.replay_protection(),
+			_ => unreachable!("Expected EthereumApi::UpdateFlipSupply"),
+		};
+
+		assert_ne!(old_replay_protection, new_replay_protection);
+		// Only the nonce should change
+		assert_ne!(old_replay_protection.nonce, new_replay_protection.nonce);
+		assert_eq!(old_replay_protection.chain_id, new_replay_protection.chain_id);
+		assert_eq!(old_replay_protection.contract_address, new_replay_protection.contract_address);
+	});
 }

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -32,6 +32,7 @@ use pallet_cf_elections::{
 use pallet_cf_validator::SetSizeParameters;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
+use sp_core::H160;
 use sp_runtime::{Percent, Permill};
 use state_chain_runtime::{
 	chainflip::{
@@ -300,6 +301,11 @@ impl ExtBuilder {
 					(Default::default(), Default::default()),
 					(Default::default(), Default::default()),
 				],
+				// Exact values not important, but should be different from each other.
+				eth_key_manager_address: H160::repeat_byte(0x01),
+				eth_vault_address: H160::repeat_byte(0x02),
+				state_chain_gateway_address: H160::repeat_byte(0x03),
+				flip_token_address: H160::repeat_byte(0x04),
 				..Default::default()
 			},
 			polkadot_threshold_signer: Default::default(),

--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -217,11 +217,10 @@ impl<E: ReplayProtectionProvider<Arbitrum> + EvmEnvironmentProvider<Arbitrum>> A
 	}
 
 	fn refresh_replay_protection(&mut self) {
-		map_over_api_variants!(
-			self,
-			call,
-			call.refresh_replay_protection(E::replay_protection(E::key_manager_address()))
-		)
+		let EvmReplayProtection { contract_address, .. } =
+			map_over_api_variants!(self, call, call.replay_protection());
+		let new_replay_protection = E::replay_protection(contract_address);
+		map_over_api_variants!(self, call, call.refresh_replay_protection(new_replay_protection))
 	}
 
 	fn signer(&self) -> Option<<EvmCrypto as ChainCrypto>::AggKey> {

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -364,7 +364,9 @@ impl<E: ReplayProtectionProvider<Ethereum> + EvmEnvironmentProvider<Ethereum>> A
 	}
 
 	fn refresh_replay_protection(&mut self) {
-		let new_replay_protection = E::replay_protection(E::key_manager_address());
+		let EvmReplayProtection { contract_address, .. } =
+			map_over_api_variants!(self, call, call.replay_protection());
+		let new_replay_protection = E::replay_protection(contract_address);
 		map_over_api_variants!(self, call, call.refresh_replay_protection(new_replay_protection))
 	}
 


### PR DESCRIPTION
Fixes an issue with `refresh_replay_protection` on Eth/Arb whereby we would always override the contract address with the key manager address. 