### PR TITLE
test: add full witnessing pipeline proptests

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -20,7 +20,9 @@ pub mod vault_swaps;
 
 use crate::btc::rpc::{BtcRpcApi, VerboseTransaction};
 use bitcoin::{hashes::Hash, BlockHash};
-use cf_chains::btc::{self, deposit_address::DepositAddress, BlockNumber, CHANGE_ADDRESS_SALT};
+use cf_chains::btc::{
+	self, deposit_address::DepositAddress, BlockNumber, Hash as H256, CHANGE_ADDRESS_SALT,
+};
 use cf_primitives::EpochIndex;
 use futures_core::Future;
 
@@ -33,7 +35,7 @@ use pallet_cf_elections::{
 		block_height_tracking::{
 			primitives::Header, state_machine::InputHeaders, HWTypes, HeightWitnesserProperties,
 		},
-		block_witnesser::state_machine::BWElectionProperties,
+		block_witnesser::state_machine::{BWElectionProperties, BWElectionType},
 	},
 	VoteOf,
 };
@@ -60,7 +62,8 @@ use crate::{
 };
 use anyhow::Result;
 
-use sp_core::H256;
+use pallet_cf_elections::electoral_systems::block_witnesser::state_machine::BWTypes;
+
 use state_chain_runtime::chainflip::bitcoin_elections::{
 	BitcoinEgressWitnessingES, BitcoinFeeTracking, BitcoinVaultDepositWitnessingES,
 };
@@ -70,81 +73,6 @@ use crate::{
 	btc::cached_rpc::BtcCachingClient,
 	witness::btc::deposits::{egress_witnessing, vault_deposits},
 };
-
-#[derive(Clone)]
-pub struct BitcoinDepositChannelWitnessingVoter {
-	client: BtcCachingClient,
-}
-
-#[async_trait::async_trait]
-impl VoterApi<BitcoinDepositChannelWitnessingES> for BitcoinDepositChannelWitnessingVoter {
-	async fn vote(
-		&self,
-		_settings: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
-		properties: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<Option<VoteOf<BitcoinDepositChannelWitnessingES>>, anyhow::Error> {
-		let BWElectionProperties {
-			block_height: witness_range, properties: deposit_addresses, ..
-		} = properties;
-		let witness_range = BlockWitnessRange::try_new(witness_range)
-			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
-		tracing::info!("Deposit channel witnessing properties: {:?}", deposit_addresses);
-
-		let mut txs = vec![];
-		// we only ever expect this to be one for bitcoin, but for completeness, we loop.
-		tracing::info!("Witness range: {:?}", witness_range);
-		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
-			tracing::info!("Checking block {:?}", block);
-
-			let block_hash = self.client.block_hash(block).await?;
-
-			let block = self.client.block(block_hash).await?;
-
-			txs.extend(block.txdata);
-		}
-
-		let deposit_addresses = map_script_addresses(deposit_addresses);
-
-		let witnesses = deposit_witnesses(&txs, &deposit_addresses);
-
-		Ok(Some(witnesses))
-	}
-}
-
-#[derive(Clone)]
-pub struct BitcoinVaultDepositWitnessingVoter {
-	client: BtcCachingClient,
-}
-
-#[async_trait::async_trait]
-impl VoterApi<BitcoinVaultDepositWitnessingES> for BitcoinVaultDepositWitnessingVoter {
-	async fn vote(
-		&self,
-		_settings: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
-		properties: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectionProperties,
-	) -> Result<Option<VoteOf<BitcoinVaultDepositWitnessingES>>, anyhow::Error> {
-		let BWElectionProperties { block_height: witness_range, properties: vaults, .. } =
-			properties;
-		let witness_range = BlockWitnessRange::try_new(witness_range)
-			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
-
-		let mut txs = vec![];
-		// we only ever expect this to be one for bitcoin, but for completeness, we loop.
-		tracing::info!("Witness range: {:?}", witness_range);
-		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
-			tracing::info!("Checking block {:?}", block);
-
-			let block_hash = self.client.block_hash(block).await?;
-
-			let block = self.client.block(block_hash).await?;
-
-			txs.extend(block.txdata);
-		}
-
-		let witnesses = vault_deposits(&txs, &vaults);
-		Ok(Some(witnesses))
-	}
-}
 
 #[derive(Clone)]
 pub struct BitcoinBlockHeightTrackingVoter {
@@ -165,7 +93,7 @@ impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter 
 		let mut headers = VecDeque::new();
 
 		let header_from_btc_header =
-			|header: BlockHeader| -> anyhow::Result<Header<btc::Hash, btc::BlockNumber>> {
+			|header: BlockHeader| -> anyhow::Result<Header<TypesFor<BitcoinBlockHeightTracking>>> {
 				Ok(Header {
 					block_height: header.height,
 					hash: header.hash.to_byte_array().into(),
@@ -238,6 +166,114 @@ impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter 
 }
 
 #[derive(Clone)]
+pub struct BitcoinDepositChannelWitnessingVoter {
+	client: BtcCachingClient,
+}
+
+#[async_trait::async_trait]
+impl VoterApi<BitcoinDepositChannelWitnessingES> for BitcoinDepositChannelWitnessingVoter {
+	async fn vote(
+		&self,
+		_settings: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<Option<VoteOf<BitcoinDepositChannelWitnessingES>>, anyhow::Error> {
+		let BWElectionProperties {
+			block_height: witness_range,
+			properties: deposit_addresses,
+			election_type,
+			..
+		} = properties;
+		let witness_range = BlockWitnessRange::try_new(witness_range)
+			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
+		tracing::info!("Deposit channel witnessing properties: {:?}", deposit_addresses);
+
+		let mut txs = vec![];
+		let mut response_block_hash: Option<H256> = None;
+		tracing::info!("Witness range: {:?}", witness_range);
+		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
+			match election_type {
+				BWElectionType::Optimistic => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					response_block_hash = Some(block.header.hash.to_byte_array().into());
+					txs.extend(block.txdata);
+				},
+				BWElectionType::ByHash(hash) => {
+					let block = self
+						.client
+						.block(bitcoin::BlockHash::from_slice(hash.as_bytes()).unwrap())
+						.await?;
+					txs.extend(block.txdata);
+				},
+				BWElectionType::SafeBlockHeight => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					txs.extend(block.txdata);
+				},
+			}
+		}
+
+		let deposit_addresses = map_script_addresses(deposit_addresses);
+
+		let witnesses = deposit_witnesses(&txs, &deposit_addresses);
+
+		Ok(Some((witnesses, response_block_hash)))
+	}
+}
+
+#[derive(Clone)]
+pub struct BitcoinVaultDepositWitnessingVoter {
+	client: BtcCachingClient,
+}
+
+#[async_trait::async_trait]
+impl VoterApi<BitcoinVaultDepositWitnessingES> for BitcoinVaultDepositWitnessingVoter {
+	async fn vote(
+		&self,
+		_settings: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		properties: <BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectionProperties,
+	) -> Result<Option<VoteOf<BitcoinVaultDepositWitnessingES>>, anyhow::Error> {
+		let BWElectionProperties {
+			block_height: witness_range,
+			properties: vaults,
+			election_type,
+			..
+		} = properties;
+		let witness_range = BlockWitnessRange::try_new(witness_range)
+			.map_err(|_| anyhow::anyhow!("Failed to create witness range"))?;
+
+		let mut txs = vec![];
+		let mut response_block_hash: Option<H256> = None;
+		tracing::info!("Witness range: {:?}", witness_range);
+		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
+			match election_type {
+				BWElectionType::Optimistic => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					response_block_hash = Some(block.header.hash.to_byte_array().into());
+					txs.extend(block.txdata);
+				},
+				BWElectionType::ByHash(hash) => {
+					let block = self
+						.client
+						.block(bitcoin::BlockHash::from_slice(hash.as_bytes()).unwrap())
+						.await?;
+					txs.extend(block.txdata);
+				},
+				BWElectionType::SafeBlockHeight => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					txs.extend(block.txdata);
+				},
+			}
+		}
+
+		let witnesses = vault_deposits(&txs, &vaults);
+		Ok(Some((witnesses, response_block_hash)))
+	}
+}
+
+#[derive(Clone)]
 pub struct BitcoinEgressWitnessingVoter {
 	client: BtcCachingClient,
 }
@@ -249,23 +285,39 @@ impl VoterApi<BitcoinEgressWitnessingES> for BitcoinEgressWitnessingVoter {
 		_settings: <BitcoinEgressWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <BitcoinEgressWitnessingES as ElectoralSystemTypes>::ElectionProperties,
 	) -> Result<Option<VoteOf<BitcoinEgressWitnessingES>>, anyhow::Error> {
-		let BWElectionProperties { block_height: witness_range, properties: tx_hashes, .. } =
-			properties;
+		let BWElectionProperties {
+			block_height: witness_range,
+			properties: tx_hashes,
+			election_type,
+			..
+		} = properties;
 		let witness_range = BlockWitnessRange::try_new(witness_range).unwrap();
 
 		let mut txs = vec![];
-		// we only ever expect this to be one for bitcoin, but for completeness, we loop.
+		let mut response_block_hash: Option<H256> = None;
 		tracing::info!("Witness range: {:?}", witness_range);
 		for block in BlockWitnessRange::<cf_chains::Bitcoin>::into_range_inclusive(witness_range) {
-			tracing::info!("Checking block {:?}", block);
-
-			let block_hash = self.client.block_hash(block).await?;
-
-			let block = self.client.block(block_hash).await?;
-
-			txs.extend(block.txdata);
+			match election_type {
+				BWElectionType::Optimistic => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					response_block_hash = Some(block.header.hash.to_byte_array().into());
+					txs.extend(block.txdata);
+				},
+				BWElectionType::ByHash(hash) => {
+					let block = self
+						.client
+						.block(bitcoin::BlockHash::from_slice(hash.as_bytes()).unwrap())
+						.await?;
+					txs.extend(block.txdata);
+				},
+				BWElectionType::SafeBlockHeight => {
+					let block_hash = self.client.block_hash(block).await?;
+					let block = self.client.block(block_hash).await?;
+					txs.extend(block.txdata);
+				},
+			}
 		}
-
 		let witnesses = egress_witnessing(&txs, tx_hashes);
 
 		if witnesses.is_empty() {
@@ -274,7 +326,7 @@ impl VoterApi<BitcoinEgressWitnessingES> for BitcoinEgressWitnessingVoter {
 			tracing::info!("Witnesses from BTCE: {:?}", witnesses);
 		}
 
-		Ok(Some(witnesses))
+		Ok(Some((witnesses, response_block_hash)))
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -245,8 +245,6 @@ pub mod witness_period {
 	}
 
 	impl<C: ChainWitnessConfig> SaturatingStep for BlockWitnessRange<C> {
-		/// NOTE: This function is going to run for a very long time if count is very high
-		/// QUESTION: maybe don't loop `count` times?
 		fn saturating_forward(self, count: usize) -> Self {
 			let mut start = self;
 			start.root = start.root.saturating_add(C::WITNESS_PERIOD * (count as u32).into());

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -11,7 +11,7 @@ use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::vec_deque::VecDeque, vec::Vec};
+use sp_std::{collections::vec_deque::VecDeque, fmt::Debug, vec::Vec};
 
 //------------------------ inputs ---------------------------
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
@@ -144,6 +144,7 @@ impl<T: HWTypes> Statemachine for BlockHeightTrackingSM<T> {
 	fn step_specification(
 		before: &mut Self::State,
 		input: &Self::Input,
+		_output: &Self::Output,
 		_settings: &Self::Settings,
 		after: &Self::State,
 	) {
@@ -251,13 +252,13 @@ impl<T: HWTypes> Statemachine for BlockHeightTrackingSM<T> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
 
 	use crate::{
 		electoral_systems::{
 			block_height_tracking::BlockHeightChangeHook,
 			block_witnesser::state_machine::HookTypeFor,
-			state_machine::core::hook_test_utils::MockHook,
+			state_machine::core::{hook_test_utils::MockHook, Serde},
 		},
 		prop_do,
 	};
@@ -331,33 +332,36 @@ mod tests {
 		.prop_map(|state| BHWStateWrapper { state, block_height_update: Default::default() })
 	}
 
-	#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
-	struct TestTypes1 {}
-	impl HWTypes for TestTypes1 {
+	impl<
+			N: Serde
+				+ Copy
+				+ Ord
+				+ SaturatingStep
+				+ BlockZero
+				+ sp_std::fmt::Debug
+				+ Default
+				+ 'static,
+		> HWTypes for N
+	{
 		const BLOCK_BUFFER_SIZE: usize = 6;
-		type ChainBlockNumber = u32;
-		type ChainBlockHash = bool;
+		type ChainBlockNumber = N;
+		type ChainBlockHash = Vec<char>;
 		type BlockHeightChangeHook = MockHook<HookTypeFor<Self, BlockHeightChangeHook>>;
 	}
 
 	#[test]
 	pub fn test_dsm() {
-		BlockHeightTrackingSM::<TestTypes1>::test(
-			module_path!(),
-			generate_state(),
-			Just(()),
-			|indices| {
-				prop_oneof![
-					Just(SMInput::Context(())),
-					prop_do! {
-						let index in select(indices);
-						let input in generate_input(index);
-						return SMInput::Consensus((index, input))
-					}
-				]
-				.boxed()
-			},
-		);
+		BlockHeightTrackingSM::<u32>::test(module_path!(), generate_state(), Just(()), |indices| {
+			prop_oneof![
+				Just(SMInput::Context(())),
+				prop_do! {
+					let index in select(indices);
+					let input in generate_input(index);
+					return SMInput::Consensus((index, input))
+				}
+			]
+			.boxed()
+		});
 	}
 
 	struct TestChain {}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -2,13 +2,22 @@ use core::{iter::Step, ops::Range};
 
 use crate::electoral_systems::{
 	block_witnesser::{primitives::ChainProgressInner, state_machine::BWProcessorTypes},
-	state_machine::core::{Hook, Validate},
+	state_machine::core::{hook_test_utils::MockHook, Hook, Validate},
 };
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
 use derive_where::derive_where;
 use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
-use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, vec, vec::Vec};
+use sp_std::{
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	fmt::Debug,
+	marker::PhantomData,
+	vec,
+	vec::Vec,
+};
+
+#[cfg(test)]
+use proptest_derive::Arbitrary;
 
 ///
 /// BlockProcessor
@@ -44,6 +53,7 @@ use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, 
 	T::Event: Debug + Clone + Eq,
 	T::Rules: Debug + Clone + Eq,
 	T::Execute: Debug + Clone + Eq,
+	T::LogEventHook: Debug + Clone + Eq,
 )]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound(
@@ -52,6 +62,7 @@ use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, 
 	T::Event: Encode,
 	T::Rules: Encode,
 	T::Execute: Encode,
+	T::LogEventHook: Encode,
 ))]
 pub struct BlockProcessor<T: BWProcessorTypes> {
 	/// A mapping from block numbers to their corresponding BlockInfo (block data, the next age to
@@ -64,6 +75,7 @@ pub struct BlockProcessor<T: BWProcessorTypes> {
 	pub processed_events: BTreeMap<T::Event, T::ChainBlockNumber>,
 	pub rules: T::Rules,
 	pub execute: T::Execute,
+	pub delete_data: T::LogEventHook,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
 pub struct BlockProcessingInfo<BlockData> {
@@ -76,6 +88,17 @@ impl<BlockData> BlockProcessingInfo<BlockData> {
 		BlockProcessingInfo { block_data, next_age_to_process: Default::default(), safety_margin }
 	}
 }
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
+pub enum BlockProcessorEvent<T: BWProcessorTypes> {
+	DeleteBlock((T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>)),
+	DeleteEvents(Vec<T::Event>),
+	StoreReorgedEvents {
+		block: (T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>),
+		events: Vec<T::Event>,
+		new_block_number: T::ChainBlockNumber,
+	},
+}
+
 impl<BlockWitnessingProcessorDefinition: BWProcessorTypes> Default
 	for BlockProcessor<BlockWitnessingProcessorDefinition>
 {
@@ -85,6 +108,7 @@ impl<BlockWitnessingProcessorDefinition: BWProcessorTypes> Default
 			processed_events: Default::default(),
 			rules: Default::default(),
 			execute: Default::default(),
+			delete_data: Default::default(),
 		}
 	}
 }
@@ -135,13 +159,15 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 				last_block = last_height;
 			},
 			ChainProgressInner::Reorg(range) => {
-				last_block = *range.start();
-				let highest_safety_margin = self
-					.blocks_data
-					.extract_if(|block_number, _| range.contains(block_number))
-					.map(|(_, block_info)| block_info.safety_margin)
-					.max()
-					.unwrap_or(0);
+				last_block = (*range.start()).saturating_backward(1);
+				let mut highest_safety_margin = 0u32;
+				for n in range.clone() {
+					if let Some(block_info) = self.blocks_data.remove(&n) {
+						if block_info.safety_margin > highest_safety_margin {
+							highest_safety_margin = block_info.safety_margin;
+						}
+					}
+				}
 				for (_event, stored_expiry) in self.processed_events.iter_mut() {
 					let mut expiry = range.end().saturating_forward(highest_safety_margin as usize);
 					let new_expiry = stored_expiry.max(&mut expiry);
@@ -174,17 +200,21 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	) -> Vec<(T::ChainBlockNumber, T::Event)> {
 		let mut last_events: Vec<(T::ChainBlockNumber, T::Event)> = vec![];
 		for (block_height, mut block_info) in self.blocks_data.clone() {
-			let current_age = T::ChainBlockNumber::steps_between(&block_height, &last_height).0;
-			let age_range: Range<u32> =
-				block_info.next_age_to_process..current_age.saturating_add(1) as u32;
-			last_events.extend(self.process_rules_for_ages_and_block(
-				block_height,
-				age_range,
-				&block_info.block_data,
-				block_info.safety_margin,
-			));
-			block_info.next_age_to_process = (current_age as u32).saturating_add(1);
-			self.blocks_data.insert(block_height, block_info);
+			let new_age = T::ChainBlockNumber::steps_between(&block_height, &last_height).0;
+			// We ensure that we don't break anything in case the new age < next_age_to_process
+			if new_age as u32 >= block_info.next_age_to_process {
+				let age_range: Range<u32> =
+					(block_info.next_age_to_process)..new_age.saturating_add(1) as u32;
+				last_events.extend(self.process_rules_for_ages_and_block(
+					block_height,
+					block_height,
+					age_range,
+					&block_info.block_data,
+					block_info.safety_margin,
+				));
+				block_info.next_age_to_process = (new_age as u32).saturating_add(1);
+				self.blocks_data.insert(block_height, block_info);
+			}
 		}
 		last_events
 	}
@@ -214,6 +244,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	fn process_rules_for_ages_and_block(
 		&mut self,
 		block_number: T::ChainBlockNumber,
+		block_number_for_expiry: T::ChainBlockNumber,
 		age: Range<u32>,
 		data: &T::BlockData,
 		safety_margin: u32,
@@ -245,53 +276,52 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	}
 
 	fn clean_old(&mut self, last_height: T::ChainBlockNumber) {
-		self.blocks_data
-			.retain(|_key, block_info| block_info.next_age_to_process <= block_info.safety_margin);
-		self.processed_events.retain(|_, expiry_block| *expiry_block > last_height);
+		let removed_blocks = self.blocks_data.extract_if(|_key, block_info| {
+			block_info.next_age_to_process > block_info.safety_margin
+		});
+		let removed_events =
+			self.processed_events.extract_if(|_, expiry_block| *expiry_block <= last_height);
+
+		for (n, block) in removed_blocks {
+			self.delete_data.run(BlockProcessorEvent::DeleteBlock((n, block)));
+		}
+		self.delete_data
+			.run(BlockProcessorEvent::DeleteEvents(removed_events.map(|(a, _)| a).collect()));
 	}
 }
 
 #[cfg(test)]
-pub(crate) mod test {
+pub(crate) mod tests {
 
 	use crate::{
 		electoral_systems::{
 			block_witnesser::{
-				block_processor::BlockProcessor,
+				block_processor::{BlockProcessor, SMBlockProcessorInput},
 				primitives::ChainProgressInner,
-				state_machine::{BWProcessorTypes, ExecuteHook, HookTypeFor, RulesHook},
+				state_machine::{
+					BWProcessorTypes, ExecuteHook, HookTypeFor, LogEventHook, RulesHook,
+				},
 			},
-			state_machine::core::{Hook, TypesFor},
+			state_machine::core::{hook_test_utils::MockHook, Hook, Serde},
 		},
 		*,
 	};
-	use codec::{Decode, Encode};
-	use core::ops::{Range, RangeInclusive};
-	use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
+	use cf_chains::witness_period::{BlockZero, SaturatingStep};
+	use core::{
+		iter::Step,
+		ops::{Range, RangeInclusive},
+	};
+	use frame_support::{Deserialize, Serialize};
+	use proptest::prelude::Strategy;
+	use proptest_derive::Arbitrary;
 	use std::collections::BTreeMap;
 
 	const SAFETY_MARGIN: u32 = 3;
-	type BlockNumber = u64;
-
-	pub struct MockBlockProcessorDefinition;
-
-	type Types = TypesFor<MockBlockProcessorDefinition>;
-
+	type BlockNumber = u8;
+	type Types = u8;
 	type MockBlockData = Vec<u8>;
 
-	#[derive(
-		Debug,
-		Clone,
-		PartialEq,
-		Eq,
-		Encode,
-		Decode,
-		TypeInfo,
-		Deserialize,
-		Serialize,
-		Ord,
-		PartialOrd,
-	)]
+	#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 	pub enum MockBtcEvent {
 		PreWitness(u8),
 		Witness(u8),
@@ -304,22 +334,29 @@ pub(crate) mod test {
 		}
 	}
 
-	impl Hook<HookTypeFor<Types, RulesHook>> for Types {
+	impl<
+			BlockNumber: BlockZero
+				+ SaturatingStep
+				+ Clone
+				+ BWProcessorTypes<
+					ChainBlockNumber = BlockNumber,
+					BlockData = MockBlockData,
+					Event = MockBtcEvent,
+				>,
+		> Hook<HookTypeFor<BlockNumber, RulesHook>> for BlockNumber
+	{
 		fn run(
 			&mut self,
-			(block, age, block_data, safety_margin): (
-				cf_chains::btc::BlockNumber,
-				Range<u32>,
-				MockBlockData,
-				u32,
-			),
-		) -> Vec<(cf_chains::btc::BlockNumber, MockBtcEvent)> {
-			let mut results: Vec<(cf_chains::btc::BlockNumber, MockBtcEvent)> = vec![];
+			(block, age, block_data, safety_margin): (BlockNumber, Range<u32>, MockBlockData, u32),
+		) -> Vec<(BlockNumber, MockBtcEvent)> {
+			let mut results: Vec<(BlockNumber, MockBtcEvent)> = vec![];
 			if age.contains(&0u32) {
 				results.extend(
 					block_data
 						.iter()
-						.map(|deposit_witness| (block, MockBtcEvent::PreWitness(*deposit_witness)))
+						.map(|deposit_witness| {
+							(block.clone(), MockBtcEvent::PreWitness(*deposit_witness))
+						})
 						.collect::<Vec<_>>(),
 				)
 			}
@@ -327,7 +364,9 @@ pub(crate) mod test {
 				results.extend(
 					block_data
 						.iter()
-						.map(|deposit_witness| (block, MockBtcEvent::Witness(*deposit_witness)))
+						.map(|deposit_witness| {
+							(block.clone(), MockBtcEvent::Witness(*deposit_witness))
+						})
 						.collect::<Vec<_>>(),
 				)
 			}
@@ -365,12 +404,24 @@ pub(crate) mod test {
 		}
 	}
 
-	impl BWProcessorTypes for TypesFor<MockBlockProcessorDefinition> {
-		type ChainBlockNumber = BlockNumber;
+	impl<
+			N: Serde
+				+ Copy
+				+ Ord
+				+ SaturatingStep
+				+ Step
+				+ BlockZero
+				+ sp_std::fmt::Debug
+				+ Default
+				+ 'static,
+		> BWProcessorTypes for N
+	{
+		type ChainBlockNumber = N;
 		type BlockData = MockBlockData;
 		type Event = MockBtcEvent;
-		type Rules = Types;
-		type Execute = Types;
+		type Rules = Self;
+		type Execute = MockHook<HookTypeFor<Self, ExecuteHook>>;
+		type LogEventHook = MockHook<HookTypeFor<Self, LogEventHook>>;
 	}
 
 	/// tests that the processor correcly keep up to SAFETY MARGIN blocks (3), and remove them once
@@ -401,17 +452,6 @@ pub(crate) mod test {
 			processor.blocks_data.len(),
 			3,
 			"Max three (SAFETY MARGIN) blocks stored at any time"
-		);
-	}
-
-	///temp test, checking large progress delta
-	#[test]
-	fn temp_large_delta() {
-		let mut processor = BlockProcessor::<Types>::default();
-
-		processor.process_block_data(
-			ChainProgressInner::Progress(u32::MAX as u64),
-			Some((9, vec![1], SAFETY_MARGIN)),
 		);
 	}
 
@@ -457,10 +497,11 @@ pub(crate) mod test {
 			Some((11, vec![7, 8, 9], SAFETY_MARGIN)),
 		);
 
-		processor.process_block_data(ChainProgressInner::Reorg(RangeInclusive::new(9, 11)), None);
+		processor.process_block_data(ChainProgressInner::Reorg(9u8..=11), None);
 
 		// We reprocessed the reorged blocks, now all the deposit end up in block 11
 		let result = processor.process_rules_for_ages_and_block(
+			11,
 			11,
 			0..1,
 			&vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -481,7 +522,7 @@ pub(crate) mod test {
 		);
 		// we receive next block which contains a deposit already processed (reorg detected later)
 		let result =
-			processor.process_rules_for_ages_and_block(10, 0..1, &vec![3, 4, 5], SAFETY_MARGIN);
+			processor.process_rules_for_ages_and_block(10, 10, 0..1, &vec![3, 4, 5], SAFETY_MARGIN);
 		// The already processed events are saved, hence only the new one are present when
 		// processing the new block
 		assert_eq!(
@@ -505,7 +546,7 @@ pub(crate) mod test {
 
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(3)),
-			Some(10u64.saturating_add((SAFETY_MARGIN * 2).into()).saturating_add(1)).as_ref()
+			Some(10u8.saturating_add((SAFETY_MARGIN as u8 * 2).into()).saturating_add(1)).as_ref()
 		);
 	}
 
@@ -534,13 +575,13 @@ pub(crate) mod test {
 		);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(101u64.saturating_add((SAFETY_MARGIN).into()).saturating_add(1)).as_ref(),
+			Some(101u8.saturating_add((SAFETY_MARGIN as u8).into()).saturating_add(1)).as_ref(),
 		);
 		processor
 			.process_block_data(ChainProgressInner::Reorg(RangeInclusive::new(101, 105)), None);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(105u64.saturating_add((SAFETY_MARGIN).into())).as_ref(),
+			Some(105u8.saturating_add((SAFETY_MARGIN as u8).into())).as_ref(),
 		);
 	}
 
@@ -562,22 +603,22 @@ pub(crate) mod test {
 
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(101u64.saturating_add((SAFETY_MARGIN).into()).saturating_add(1)).as_ref(),
+			Some(101u8.saturating_add((SAFETY_MARGIN as u8).into()).saturating_add(1)).as_ref(),
 		);
 		processor
 			.process_block_data(ChainProgressInner::Reorg(RangeInclusive::new(101, 103)), None);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(103u64.saturating_add((SAFETY_MARGIN).into())).as_ref(),
+			Some(103u8.saturating_add((SAFETY_MARGIN as u8).into())).as_ref(),
 		);
 
 		processor.process_block_data(
 			ChainProgressInner::Progress(104),
-			Some((101, vec![1], SAFETY_MARGIN)),
+			Some((101u8, vec![1], SAFETY_MARGIN)),
 		);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(104u64.saturating_add((SAFETY_MARGIN).into()).saturating_add(1)).as_ref(),
+			Some(104u8.saturating_add((SAFETY_MARGIN as u8).into()).saturating_add(1)).as_ref(),
 		);
 		processor.process_block_data(
 			ChainProgressInner::Progress(104),
@@ -585,7 +626,7 @@ pub(crate) mod test {
 		);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(2)),
-			Some(104u64.saturating_add((SAFETY_MARGIN).into()).saturating_add(1)).as_ref(),
+			Some(104u8.saturating_add((SAFETY_MARGIN as u8).into()).saturating_add(1)).as_ref(),
 		);
 	}
 
@@ -606,46 +647,33 @@ pub(crate) mod test {
 		processor.process_block_data(ChainProgressInner::Progress(103), None);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(101u64.saturating_add((SAFETY_MARGIN * 2).into()).saturating_add(1)).as_ref(),
+			Some(101u8.saturating_add((SAFETY_MARGIN as u8 * 2).into()).saturating_add(1)).as_ref(),
 		);
 		processor
 			.process_block_data(ChainProgressInner::Reorg(RangeInclusive::new(101, 103)), None);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(103u64.saturating_add((SAFETY_MARGIN * 2).into())).as_ref(),
+			Some(103u8.saturating_add((SAFETY_MARGIN as u8 * 2).into())).as_ref(),
 		);
 		processor.process_block_data(ChainProgressInner::Progress(101), Some((101, vec![1, 2], 1)));
 		processor.process_block_data(ChainProgressInner::Progress(102), Some((102, vec![3], 1)));
 		processor.process_block_data(ChainProgressInner::Progress(103), None);
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
-			Some(103u64.saturating_add((SAFETY_MARGIN * 2).into())).as_ref(),
+			Some(103u8.saturating_add((SAFETY_MARGIN as u8 * 2).into())).as_ref(),
 		);
 		println!("{:?}", processor.processed_events);
 	}
 }
 
 // State-Machine Block Witness Processor
+#[cfg_attr(test, derive(Arbitrary))]
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum SMBlockProcessorInput<T: BWProcessorTypes> {
 	NewBlockData(T::ChainBlockNumber, T::ChainBlockNumber, T::BlockData),
 	ChainProgress(ChainProgressInner<T::ChainBlockNumber>),
 }
-
-// impl<T: BWProcessorTypes> Indexed for SMBlockProcessorInput<T> {
-// 	type Index = ();
-// 	fn has_index(&self, _idx: &Self::Index) -> bool {
-// 		true
-// 	}
-// }
-// impl<T: BWProcessorTypes> Validate for SMBlockProcessorInput<T> {
-// 	type Error = ();
-
-// 	fn is_valid(&self) -> Result<(), Self::Error> {
-// 		Ok(())
-// 	}
-// }
 
 impl<T: BWProcessorTypes> Validate for BlockProcessor<T> {
 	type Error = ();
@@ -655,7 +683,9 @@ impl<T: BWProcessorTypes> Validate for BlockProcessor<T> {
 }
 #[allow(dead_code)]
 pub struct SMBlockProcessorOutput<T: BWProcessorTypes> {
-	phantom_data: PhantomData<T>,
+	events: Vec<(T::ChainBlockNumber, T::Event)>,
+	deleted_data: BTreeMap<T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>>,
+	deleted_events: Vec<(T::ChainBlockNumber, (Vec<T::Event>, u32))>,
 }
 impl<T: BWProcessorTypes> Validate for SMBlockProcessorOutput<T> {
 	type Error = ();
@@ -667,57 +697,179 @@ pub struct SMBlockProcessor<T: BWProcessorTypes> {
 	_phantom: PhantomData<T>,
 }
 
-/*
-impl<T: BWProcessorTypes + 'static> Statemachine for SMBlockProcessor<T> {
-	type Input = SMBlockProcessorInput<T>;
-	type Settings = ();
-	type Output = SMBlockProcessorOutput<T>;
-	type State = BlockProcessor<T>;
-
-	fn input_index(_s: &mut Self::State) -> IndexOf<Self::Input> {}
-
-	fn step(s: &mut Self::State, i: Self::Input, _set: &Self::Settings) -> Self::Output {
-		match i {
-			SMBlockProcessorInput::NewBlockData(last_height, n, deposits) =>
-				s.process_block_data(ChainProgressInner::Progress(last_height), Some((n, deposits))),
-			SMBlockProcessorInput::ChainProgress(inner) => s.process_block_data(inner, None),
+use crate::electoral_systems::state_machine::core::IndexedValidate;
+impl<T: BWProcessorTypes + 'static + Debug>
+	IndexedValidate<BTreeSet<T::ChainBlockNumber>, SMBlockProcessorInput<T>> for SMBlockProcessor<T>
+{
+	type Error = ();
+	fn validate(
+		index: &BTreeSet<T::ChainBlockNumber>,
+		value: &SMBlockProcessorInput<T>,
+	) -> Result<(), Self::Error> {
+		match value {
+			SMBlockProcessorInput::NewBlockData(_, n, _) =>
+				if index.contains(n) {
+					Err(())
+				} else {
+					Ok(())
+				},
+			SMBlockProcessorInput::ChainProgress(_) => Ok(()),
 		}
-		SMBlockProcessorOutput { phantom_data: Default::default() }
 	}
 }
-	*/
 
-// #[cfg(test)]
-// fn step_specification(
-// 	before: &Self::State,
-// 	input: &Self::Input,
-// 	_settings: &Self::Settings,
-// 	after: &Self::State,
-// ) {
-// 	assert!(
-// 		after.blocks_data.len() <=
-// 			BitcoinIngressEgress::witness_safety_margin().unwrap() as usize,
-// 		"Too many blocks data, we should never have more than safety margin blocks"
-// 	);
-//
-// 	match input {
-// 		SMBlockProcessorInput::ChainProgress(chain_progress) => match chain_progress {
-// 			ChainProgressInner::Progress(_last_height) => {
-// 				assert!(after.processed_events.len() <= before.processed_events.len(), "If no reorg happened,
-// number of reorg events should stay the same or decrease"); 	// 			},
-// 	// 			ChainProgressInner::Reorg(range) =>
-// 	// 				for n in range.clone().into_iter() {
-// 	// 					assert!(after.processed_events.contains_key(&n), "Should always contains key for blocks
-// being reorged, even if no events were produced! (Empty vec)"); 	// 					assert!(
-// 	// 						!after.blocks_data.contains_key(&n),
-// 	// 						"Should never contain blocks data for blocks being reorged"
-// 	// 					);
-// 	// 				},
-// 	// 		},
-// 	// 		SMBlockProcessorInput::NewBlockData(last_height, n, _deposits) => {
-// 	// 			if last_height - BitcoinIngressEgress::witness_safety_margin().unwrap() > *n {
-// 	// 				assert!(!after.blocks_data.contains_key(n));
-// 	// 			}
-// 	// 		},
-// 	// 	}
-// 	// }
+use crate::electoral_systems::state_machine::state_machine::Statemachine;
+
+use super::state_machine::{ExecuteHook, HookTypeFor, LogEventHook};
+impl<
+		T: BWProcessorTypes<
+				LogEventHook = MockHook<HookTypeFor<T, LogEventHook>>,
+				Execute = MockHook<HookTypeFor<T, ExecuteHook>>,
+			>
+			+ 'static
+			+ Debug
+			+ Clone
+			+ Eq,
+	> Statemachine for SMBlockProcessor<T>
+{
+	type Input = SMBlockProcessorInput<T>;
+	type InputIndex = BTreeSet<T::ChainBlockNumber>;
+	type Settings = u32;
+	type Output = ();
+	type State = BlockProcessor<T>;
+
+	fn input_index(s: &mut Self::State) -> Self::InputIndex {
+		s.blocks_data.keys().cloned().collect()
+	}
+
+	fn step(s: &mut Self::State, i: Self::Input, set: &Self::Settings) -> Self::Output {
+		match i {
+			SMBlockProcessorInput::NewBlockData(last_height, n, deposits) => s.process_block_data(
+				ChainProgressInner::Progress(last_height),
+				Some((n, deposits, *set)),
+			),
+			SMBlockProcessorInput::ChainProgress(inner) => s.process_block_data(inner, None),
+		}
+	}
+
+	#[cfg(test)]
+	fn step_specification(
+		pre: &mut Self::State,
+		input: &Self::Input,
+		_output: &Self::Output,
+		settings: &Self::Settings,
+		post: &Self::State,
+	) {
+		use crate::{
+			asserts,
+			electoral_systems::{
+				block_witnesser::helpers::Merge,
+				state_machine::test_utils::{BTreeMultiSet, Container},
+			},
+		};
+		use std::collections::BTreeSet;
+
+		type BlocksData<T> = BTreeMap<
+			<T as BWProcessorTypes>::ChainBlockNumber,
+			BlockProcessingInfo<<T as BWProcessorTypes>::BlockData>,
+		>;
+
+		type Multiset<A> = Container<BTreeSet<A>>;
+
+		let active_events = |s: &BlocksData<T>| -> Multiset<T::Event> {
+			s.iter()
+				.flat_map(|(height, block_info)| {
+					let mut x: BlockProcessor<T> = Default::default();
+					x.rules.run((
+						*height,
+						(0..block_info.next_age_to_process),
+						block_info.block_data.clone(),
+						block_info.safety_margin,
+					))
+				})
+				.map(|(_number, event)| event)
+				.collect()
+		};
+
+		let history = &post.delete_data.call_history;
+		let deleted_blocks: BTreeMap<_, _> = history
+			.iter()
+			.filter_map(|event| match event {
+				BlockProcessorEvent::DeleteBlock(block) => Some(block),
+				_ => None,
+			})
+			.cloned()
+			.collect();
+
+		let deleted_events: Container<_> = history
+			.iter()
+			.filter_map(|event| match event {
+				BlockProcessorEvent::DeleteEvents(events) => Some(events),
+				_ => None,
+			})
+			.cloned()
+			.flatten()
+			.collect();
+
+		let stored_executed_events = &post.execute.call_history;
+
+		let events = |s: &Self::State| {
+			active_events(&s.blocks_data) + s.processed_events.keys().cloned().collect()
+		};
+		let deleted_events = active_events(&deleted_blocks) + deleted_events;
+
+		let executed_events = || -> Multiset<_> {
+			stored_executed_events.iter().flatten().map(|(_, v)| v).cloned().collect()
+		};
+		let executed_events_vector = || -> Container<BTreeMultiSet<_>> {
+			stored_executed_events.iter().flatten().map(|(_k, v)| v).cloned().collect()
+		};
+
+		let reorg =
+			matches!(input, SMBlockProcessorInput::ChainProgress(ChainProgressInner::Reorg(_)));
+		let blocks = |d: &BlocksData<T>| {
+			d.values()
+				.map(|block_info| block_info.block_data.clone())
+				.collect::<BTreeSet<_>>()
+		};
+
+		let deleted_new: BTreeSet<T::BlockData> = match input {
+			SMBlockProcessorInput::NewBlockData(n, i, x)
+				if i.saturating_forward(*settings as usize) <= *n =>
+				BTreeSet::from([x.clone()]),
+			_ => BTreeSet::new(),
+		};
+
+		let new_block: BTreeSet<T::BlockData> = match input {
+			SMBlockProcessorInput::NewBlockData(_n, _i, x) => BTreeSet::from([x.clone()]),
+			_ => BTreeSet::new(),
+		};
+
+		asserts! {
+
+			"the executed events are exactly those that are new (post events: {:?}, pre: {:?}, executed: {:?}, post-state: {:?})"
+			in events(post) + deleted_events == executed_events() + events(pre),
+			else
+				events(post),
+				events(pre),
+				executed_events(),
+				post
+			;
+
+			"stored events are never executed again"
+			in events(pre) & executed_events() == Container(BTreeSet::new());
+
+			"executed events are unique"
+			in executed_events_vector().0.0.iter().all(|(_x, n)| *n == 1);
+
+			// TODO: handle the reorg case
+			"blocks either stay in the blockstore or are included in the 'deleted output'"
+			in if !reorg {
+				blocks(&pre.blocks_data).is_subset(&blocks(&post.blocks_data).merge(blocks(&deleted_blocks)))
+			} else {true};
+
+			"new blocks are added to block data or are immediately deleted"
+			in new_block.is_subset(&blocks(&post.blocks_data).merge(deleted_new));
+		}
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/consensus.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/consensus.rs
@@ -11,7 +11,7 @@ use super::state_machine::{BWElectionProperties, BWTypes};
 
 pub struct BWConsensus<T: BWTypes> {
 	pub consensus: SupermajorityConsensus<SharedDataHash>,
-	pub data: BTreeMap<SharedDataHash, T::BlockData>,
+	pub data: BTreeMap<SharedDataHash, (T::BlockData, Option<T::ChainBlockHash>)>,
 	pub _phantom: sp_std::marker::PhantomData<T>,
 }
 
@@ -27,10 +27,10 @@ impl<T: BWTypes> Default for BWConsensus<T> {
 
 impl<T: BWTypes> ConsensusMechanism for BWConsensus<T>
 where
-	T::BlockData: Hashable,
+	(T::BlockData, Option<T::ChainBlockHash>): Hashable,
 {
-	type Vote = T::BlockData;
-	type Result = T::BlockData;
+	type Vote = (T::BlockData, Option<T::ChainBlockHash>);
+	type Result = (T::BlockData, Option<T::ChainBlockHash>);
 	type Settings = (Threshold, BWElectionProperties<T>);
 
 	fn insert_vote(&mut self, vote: Self::Vote) {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -5,6 +5,9 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 use crate::electoral_systems::state_machine::core::Validate;
 
 /// Keeps track of ongoing elections for the block witnesser.
@@ -138,8 +141,9 @@ fn generate_new_reorg_id<N: BlockZero + SaturatingStep + Ord + 'static>(indices:
 	index
 }
 
+#[cfg_attr(test, derive(Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub enum ChainProgressInner<ChainBlockNumber: SaturatingStep> {
+pub enum ChainProgressInner<ChainBlockNumber: SaturatingStep + PartialOrd> {
 	Progress(ChainBlockNumber),
 	Reorg(RangeInclusive<ChainBlockNumber>),
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -1,45 +1,444 @@
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
-use core::{iter::Step, ops::RangeInclusive};
+use core::{
+	iter::Step,
+	ops::{Range, RangeInclusive},
+};
+use derive_where::derive_where;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::{
+	cmp::max,
+	collections::{btree_map::BTreeMap, vec_deque::VecDeque},
+	iter,
+	vec::Vec,
+};
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 
-use crate::electoral_systems::state_machine::core::Validate;
+use crate::electoral_systems::state_machine::core::{fst, Hook, Validate};
 
-/// Keeps track of ongoing elections for the block witnesser.
+use super::state_machine::{BWElectionType, BWTypes};
+
+macro_rules! defx {
+	(
+		pub struct $Name:tt [$($ParamName:ident: $ParamType:tt),*] {
+			$($Definition:tt)*
+		} where $this:ident {
+			$($prop_name:ident : $prop:expr),*
+		} with {
+			$($Attributes:tt)*
+		}
+	) => {
+
+		$($Attributes)*
+		pub struct $Name<$($ParamName: $ParamType),*> {
+			$($Definition)*
+		}
+
+		impl<$($ParamName: $ParamType),*> Validate for $Name<$($ParamName),*> {
+
+			type Error = &'static str;
+
+			fn is_valid(&self) -> Result<(), Self::Error> {
+				let $this = self;
+
+				$(
+					ensure!($prop, stringify!($prop_name));
+				)*
+				Ok(())
+			}
+		}
+	};
+}
+
+defx! {
+
+	pub struct ElectionTracker2[T: BWTypes] {
+		/// The lowest block we haven't seen yet. I.e., we have seen blocks below.
+		pub seen_heights_below: T::ChainBlockNumber,
+
+		/// We always create elections until the next priority height, even if we
+		/// are in safe mode.
+		pub priority_elections_below: T::ChainBlockNumber,
+
+		/// Block hashes we got from the BHW.
+		pub queued_elections: BTreeMap<T::ChainBlockNumber, T::ChainBlockHash>,
+
+		/// Block heights which are queued but already past the safetymargin don't
+		/// have associated hashes. We just store a list of block height ranges.
+		pub queued_safe_elections: CompactHeightTracker<T::ChainBlockNumber>,
+
+		/// Hashes of elections currently ongoing
+		pub ongoing: BTreeMap<T::ChainBlockNumber, BWElectionType<T>>,
+
+		/// Optimistic blocks
+		pub optimistic_block_cache: BTreeMap<T::ChainBlockNumber, OptimisticBlock<T>>,
+
+		/// debug hook
+		pub events: T::ElectionTrackerEventHook,
+
+	} where this {
+
+		// queued_elections_are_consequtive:
+		// 	this.queued_elections.keys().zip(this.queued_elections.keys().skip(1))
+		// 	.all(|(left, right)| left.saturating_forward(1) == *right),
+
+		// queued_safe_height_is_not_queued:
+		// 	this.queued_safe_elections.clone().all(|height| !this.queued_elections.contains_key(&height))
+
+	} with {
+
+		#[derive_where(Debug, Clone, PartialEq, Eq;)]
+		#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+		#[codec(encode_bound(
+			T::ChainBlockNumber: Encode,
+			T::ChainBlockHash: Encode,
+			T::BlockData: Encode,
+			T::ElectionTrackerEventHook: Encode
+		))]
+
+	}
+
+}
+
+impl<T: BWTypes> ElectionTracker2<T> {
+	pub fn update_safe_elections(
+		&mut self,
+		reason: UpdateSafeElectionsReason,
+		f: impl Fn(&mut CompactHeightTracker<T::ChainBlockNumber>),
+	) {
+		let old = self.queued_safe_elections.clone();
+		f(&mut self.queued_safe_elections);
+		let new = self.queued_safe_elections.clone();
+		self.events.run(ElectionTrackerEvent::UpdateSafeElections { old, new, reason });
+	}
+
+	pub fn start_more_elections(&mut self, max_ongoing: usize, safemode: SafeModeStatus) {
+		// In case of a reorg we still want to recreate elections for blocks which we had
+		// elections for previously AND were touched by the reorg
+		let start_all_below = match safemode {
+			SafeModeStatus::Disabled => self.seen_heights_below.clone(),
+			SafeModeStatus::Enabled => self.priority_elections_below.clone(),
+		};
+
+		use BWElectionType::*;
+
+		// schedule at most `max_new_elections`
+		let max_new_elections = max_ongoing.saturating_sub(self.ongoing.len());
+
+		let safe_elections = self
+			.queued_safe_elections
+			.extract(max_new_elections)
+			.into_iter()
+			.map(|height| (height, SafeBlockHeight));
+
+		let hash_elections = self
+			.queued_elections
+			.extract_if(|n, _| *n < start_all_below)
+			.map(|(height, hash)| (height, ByHash(hash)));
+		let opti_elections = iter::once((self.seen_heights_below, Optimistic));
+
+		self.ongoing.extend(
+			safe_elections
+				.chain(hash_elections)
+				.chain(opti_elections)
+				.take(max_new_elections),
+		);
+	}
+
+	/// If an election is done we remove it from the ongoing list.
+	/// This function returns the current election type for the given block height.
+	/// Note that the election type might be different from the election type that was closed for
+	/// this height, due to:
+	///  - We had a reorg, and the hash we are querying for changed, and in the same statechain
+	///    block we receive a result for the old hash
+	///  - The election was `Optimistic`, we received a hash for it, and in the same statechain
+	///    block we got the result of the optimistic election, which might or might not be for the
+	///    hash we now got.
+	///  - The election was `ByHash`, but it got too old and its type changed to `SafeBlockHeight`
+	pub fn mark_election_done(
+		&mut self,
+		height: T::ChainBlockNumber,
+		received: &BWElectionType<T>,
+		received_hash: &Option<T::ChainBlockHash>,
+		received_data: T::BlockData,
+	) -> Option<T::BlockData> {
+		// update the lowest unseen block,
+		// currently this only has an effect if we get an Optimistic block
+		self.seen_heights_below = max(self.seen_heights_below, height.saturating_forward(1));
+
+		// Note: if we receive blockdata for a block number, and
+		// in the same statechain block there's a reorg which changes the hash of this block,
+		// then we shouldn't close the election.
+
+		use BWElectionType::*;
+		self.ongoing
+			.get(&height)
+			.cloned()
+			.and_then(|current| {
+				self.events.run(ElectionTrackerEvent::ComparingBlocks {
+					height,
+					hash: received_hash.clone(),
+					received: received.clone(),
+					current: current.clone(),
+				});
+
+				match (received, &current) {
+					// if we receive a result for the same election type as is currently open,
+					// we close it
+					(a, b) if a == b => Some(current),
+
+					// if we get consensus for a by-hash election whose hash doesn't match with
+					// the hash we have currently, we keep it open
+					(ByHash(a), ByHash(b)) if a != b => None,
+
+					// if we get an optimistic consensus for an election that is already by-hash,
+					// we check whether the `received_hash` is the same as the hash we're currently
+					// querying for. If it is, we accept the optimistic block as result for the
+					// by-hash election. otherwise we keep the by-hash election open.
+					(Optimistic, ByHash(current_hash)) =>
+						if received_hash.as_ref() == Some(current_hash) {
+							Some(current)
+						} else {
+							None
+						},
+
+					// If we get an optimistic consensus for an election that is already past
+					// safety-margin we ignore it, it's safer to re-query by block height. This
+					// should virtually never happen, only in case where the querying takes a *very*
+					// long time.
+					(Optimistic, SafeBlockHeight) => None,
+
+					// If we get a by-hash consensus for an election that is already past
+					// safety-margin, we ignore it. We've already deleted the hash for this
+					// election from storage, so we can't check whether we got the correct
+					// block. It's safer to re-query.
+					(ByHash(_), SafeBlockHeight) => None,
+
+					// All other cases should be impossible
+					(_, _) => None,
+				}
+			})
+			.inspect(|_| {
+				self.ongoing.remove(&height);
+			})
+			.and_then(|t| match t {
+				// we closed an optimistic election, this means we don't have the hash yet
+				// so we include the block in our optimistic cache
+				Optimistic => {
+					self.optimistic_block_cache.insert(
+						height,
+						OptimisticBlock {
+							hash: received_hash.clone().unwrap(),
+							data: received_data,
+						},
+					);
+					None
+				},
+				// Otherwise we know that this block is correct and can be forwarded to the
+				// block processor, thus we return it here.
+				ByHash(_) | SafeBlockHeight => Some(received_data),
+			})
+	}
+
+	/// This function schedules all elections up to `range.end()`
+	pub fn schedule_range(
+		&mut self,
+		range: RangeInclusive<T::ChainBlockNumber>,
+		mut hashes: BTreeMap<T::ChainBlockNumber, T::ChainBlockHash>,
+		safety_margin: usize,
+		is_reorg: bool,
+	) -> Vec<(T::ChainBlockNumber, OptimisticBlock<T>)> {
+		// Check whether there is a reorg concerning elections we have started previously.
+		// If there is, we ensure that all ongoing or previously finished elections inside the reorg
+		// range are going to be restarted once there is the capacity to do so.
+		if let Some(next_election) = self.next_election() {
+			if *range.start() < next_election {
+				// we set this value such that even in case of a reorg we create elections for up to
+				// this block
+				self.priority_elections_below =
+					max(next_election, self.priority_elections_below.clone());
+			}
+		}
+
+		// if there are safe elections scheduled for the reorg range, unschedule them,
+		// because it might be that we're gonna schedule them by-hash
+		self.queued_safe_elections.remove(range.clone());
+
+		// QUESTION: currently, the following check ensures that
+		// the highest scheduled election never decreases. Do we want this?
+		// It's difficult to imagine a situation where the highest block number
+		// after a reorg is lower than it was previously, and also, even if, in that
+		// case we simply keep the higher number that doesn't seem to be too much of a problem.
+		self.seen_heights_below =
+			max(self.seen_heights_below.clone(), range.end().clone().saturating_forward(1));
+
+		// if there are elections ongoing for the block heights we received, we stop them
+		self.ongoing.retain(|height, _| !hashes.contains_key(height));
+
+		// if we have optimistic blocks for the hashes we received, we will return them
+		let optimistic_blocks: BTreeMap<_, _> = if !is_reorg {
+			if self.queued_elections.is_empty() {
+				// we only want to use the single next block
+				let next_queued_height = hashes.first_key_value().unwrap().0.clone();
+
+				self.optimistic_block_cache
+					.extract_if(|height, block| {
+						hashes.get(height) == Some(&block.hash) && *height == next_queued_height
+					})
+					.collect()
+			} else {
+				Default::default()
+			}
+		} else {
+			Default::default()
+		};
+
+		// remove those hashes for which we had optimistic blocks
+		let _ = hashes
+			.extract_if(|height, hash| {
+				optimistic_blocks.get(&height).map(|block| block.hash == *hash).unwrap_or(false)
+			})
+			.collect::<Vec<_>>();
+
+		// adding all hashes to the queue
+		self.queued_elections.append(&mut hashes);
+
+		// clean up the queue by removing old hashes
+		let _ = self
+			.queued_elections
+			.extract_if(|height, _| height.saturating_forward(safety_margin) < *range.end())
+			.map(fst)
+			.for_each(|height| {
+				self.queued_safe_elections.insert(height);
+			});
+
+		// move ongoing elections from ByHash to SafeBlockHeight if they become old enough
+		self.ongoing.iter_mut().for_each(|(height, ty)| {
+			if height.saturating_forward(safety_margin) < *range.end() {
+				*ty = BWElectionType::SafeBlockHeight;
+			}
+		});
+
+		optimistic_blocks.into_iter().collect()
+	}
+
+	fn next_election(&self) -> Option<T::ChainBlockNumber> {
+		self.queued_elections.first_key_value().map(fst).cloned()
+	}
+}
+
+impl<T: BWTypes> Default for ElectionTracker2<T> {
+	fn default() -> Self {
+		Self {
+			seen_heights_below: T::ChainBlockNumber::zero(),
+			priority_elections_below: T::ChainBlockNumber::zero(),
+			queued_elections: Default::default(),
+			ongoing: Default::default(),
+			queued_safe_elections: Default::default(),
+			optimistic_block_cache: Default::default(),
+			events: Default::default(),
+		}
+	}
+}
+
+#[derive_where(Debug, Clone, PartialEq, Eq;)]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound(
+	T::ChainBlockNumber: Encode,
+	T::ChainBlockHash: Encode,
+	T::BlockData: Encode,
+))]
+pub struct OptimisticBlock<T: BWTypes> {
+	pub hash: T::ChainBlockHash,
+	pub data: T::BlockData,
+}
+
+#[derive_where(Debug, Clone, PartialEq, Eq;)]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+pub enum ElectionTrackerEvent<T: BWTypes> {
+	ComparingBlocks {
+		height: T::ChainBlockNumber,
+		hash: Option<T::ChainBlockHash>,
+		received: BWElectionType<T>,
+		current: BWElectionType<T>,
+	},
+	UpdateSafeElections {
+		old: CompactHeightTracker<T::ChainBlockNumber>,
+		new: CompactHeightTracker<T::ChainBlockNumber>,
+		reason: UpdateSafeElectionsReason,
+	},
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub struct ElectionTracker<N: Ord> {
-	/// The highest block height for which an election was started in the past.
-	/// New elections are going to be started if there is the capacity to do so
-	/// and that height has been witnessed (`highest_witnessed > highest_election`).
-	pub next_election: N,
+pub enum UpdateSafeElectionsReason {
+	OutOfSafetyMargin,
+	SafeElectionScheduled,
+	GotOptimisticBlock,
+	ReorgReceived,
+}
 
-	/// The highest block height that has been seen.
-	pub next_witnessed: N,
+#[derive_where(Default; )]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
+pub struct CompactHeightTracker<N> {
+	elections: VecDeque<Range<N>>,
+}
 
-	/// The highest block height that we had previously started elections for and
-	/// that was subsequently touched by a reorg.
-	pub next_priority_election: N,
+impl<N: Step + Ord> CompactHeightTracker<N> {
+	pub fn extract(&mut self, max_elements: usize) -> Vec<N> {
+		let mut result = Vec::new();
+		for r in self.elections.iter_mut() {
+			while result.len() < max_elements {
+				if let Some(x) = r.next() {
+					result.push(x);
+				} else {
+					// TODO: delete ranges when they are empty
+					break;
+				}
+			}
+		}
+		result
+	}
 
-	/// Map containing all currently active elections.
-	/// The associated u8 "reord_id" is somewhat an artifact of the fact that
-	/// this is intended to be used in an electoral system state machine. And the state machine
-	/// has to know when to re-open an election which is currently ongoing.
-	/// The state machine wouldn't close and reopen an election if the election properties
-	/// stay the same, so we have (N, u8) as election properties. And when we want to reopen
-	/// an ongoing election we change the u8 reorg_id.
-	pub ongoing: BTreeMap<N, u8>,
+	pub fn insert(&mut self, item: N) {
+		for r in self.elections.iter_mut().rev() {
+			let end_plus_one = N::forward(r.end.clone(), 1);
+			if item == end_plus_one {
+				r.end = end_plus_one;
+				return;
+			}
+			if r.contains(&item) {
+				return;
+			}
+		}
+		self.elections.push_back(item.clone()..N::forward(item, 1));
+	}
 
-	/// When an election for a given block height is requested by inserting it in `ongoing`, it is
-	/// always inserted with the current `reorg_id` as value.
-	/// When a reorg is detected, this id is mutated to a new unique value that is not in
-	/// `ongoing`. Elections in the range of a reorg are thus recreated with the new id, which
-	/// causes them to be restarted by the electoral system.
-	pub reorg_id: u8,
+	pub fn remove(&mut self, range: RangeInclusive<N>) {
+		for r in self.elections.iter_mut() {
+			range_difference(r, &(range.start().clone()..N::forward(range.end().clone(), 1)))
+		}
+	}
+}
+
+fn range_difference<N: Ord + Clone>(r: &mut Range<N>, s: &Range<N>) {
+	// ```
+	// [-- r --]
+	//     [-- s --]
+	// ```
+	if s.contains(&r.end) {
+		r.end = s.start.clone();
+	}
+
+	// ```
+	//     [-- r --]
+	// [-- s --]
+	// ```
+	if s.contains(&r.start) {
+		r.start = s.end.clone();
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
@@ -48,116 +447,9 @@ pub enum SafeModeStatus {
 	Disabled,
 }
 
-impl<N: Ord + SaturatingStep + Step + Copy> ElectionTracker<N> {
-	/// Given the current state, if there are less than `max_ongoing`
-	/// ongoing elections we push more elections into ongoing.
-	pub fn start_more_elections(&mut self, max_ongoing: usize, safemode: SafeModeStatus) {
-		// In case of a reorg we still want to recreate elections for blocks which we had
-		// elections for previously AND were touched by the reorg
-		let start_up_to = match safemode {
-			SafeModeStatus::Disabled => self.next_witnessed,
-			SafeModeStatus::Enabled => self.next_priority_election,
-		};
-
-		// filter out all elections which are ongoing, but shouldn't be, because
-		// they are in the scheduled range (for example because there was a reorg)
-		self.ongoing.retain(|height, _| *height < self.next_election);
-
-		// schedule
-		for height in self.next_election..start_up_to {
-			if self.ongoing.len() < max_ongoing {
-				self.ongoing.insert(height, self.reorg_id);
-				self.next_election = height.saturating_forward(1);
-			} else {
-				break;
-			}
-		}
-	}
-
-	/// If an election is done we remove it from the ongoing list
-	pub fn mark_election_done(&mut self, election: N) {
-		if self.ongoing.remove(&election).is_none() {
-			panic!("marking an election done which wasn't ongoing!")
-		}
-	}
-
-	/// This function schedules all elections up to `range.end()`
-	pub fn schedule_range(&mut self, range: RangeInclusive<N>) {
-		// Check whether there is a reorg concerning elections we have started previously.
-		// If there is, we ensure that all ongoing or previously finished elections inside the reorg
-		// range are going to be restarted once there is the capacity to do so.
-		if *range.start() < self.next_election {
-			// we set this value such that even in case of a reorg we create elections for up to
-			// this block
-			self.next_priority_election =
-				sp_std::cmp::max(self.next_election, self.next_priority_election);
-
-			// the next election we start is going to be the first block involved in the reorg
-			self.next_election = *range.start();
-
-			// and it's going to have a fresh `reorg_id` which forces the ES to recreate this
-			// election
-			self.reorg_id =
-				generate_new_reorg_id(&self.ongoing.values().cloned().collect::<Vec<_>>());
-		}
-
-		// QUESTION: currently, the following check ensures that
-		// the highest scheduled election never decreases. Do we want this?
-		// It's difficult to imagine a situation where the highest block number
-		// after a reorg is lower than it was previously, and also, even if, in that
-		// case we simply keep the higher number that doesn't seem to be too much of a problem.
-		if self.next_witnessed <= *range.end() {
-			self.next_witnessed = range.end().saturating_forward(1);
-		}
-	}
-}
-
-impl<N: Ord> Validate for ElectionTracker<N> {
-	type Error = &'static str;
-
-	fn is_valid(&self) -> Result<(), Self::Error> {
-		Ok(())
-	}
-}
-
-impl<N: BlockZero + Ord> Default for ElectionTracker<N> {
-	fn default() -> Self {
-		Self {
-			next_witnessed: BlockZero::zero(),
-			next_priority_election: BlockZero::zero(),
-			next_election: BlockZero::zero(),
-			ongoing: Default::default(),
-			reorg_id: 0,
-		}
-	}
-}
-
-/// Generates an element which is not in `indices`.
-fn generate_new_reorg_id<N: BlockZero + SaturatingStep + Ord + 'static>(indices: &[N]) -> N {
-	let mut index = N::zero();
-	while indices.iter().any(|ix| *ix == index) {
-		index = index.saturating_forward(1);
-	}
-	index
-}
-
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
 pub enum ChainProgressInner<ChainBlockNumber: SaturatingStep + PartialOrd> {
 	Progress(ChainBlockNumber),
 	Reorg(RangeInclusive<ChainBlockNumber>),
-}
-
-#[cfg(test)]
-mod tests {
-
-	use super::generate_new_reorg_id;
-	use proptest::prelude::*;
-
-	proptest! {
-		#[test]
-		fn indices_are_new(xs in prop::collection::vec(any::<u8>(), 0..3)) {
-			assert!(!xs.contains(&generate_new_reorg_id(&xs)));
-		}
-	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -1,16 +1,15 @@
 use super::{
 	super::state_machine::core::*,
 	block_processor::BlockProcessorEvent,
-	primitives::{ElectionTracker, SafeModeStatus},
+	primitives::{ElectionTracker2, ElectionTrackerEvent, SafeModeStatus},
 };
 use crate::electoral_systems::{
-	block_height_tracking::ChainProgress,
+	block_height_tracking::{ChainProgress, ChainProgressFor, ChainTypes},
 	block_witnesser::{block_processor::BlockProcessor, primitives::ChainProgressInner},
 	state_machine::{core::Validate, state_machine::Statemachine, state_machine_es::SMInput},
 };
-use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
-use core::{iter::Step, ops::Range};
+use core::ops::Range;
 use derive_where::derive_where;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
@@ -32,9 +31,22 @@ pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 	type ElectionProperties: PartialEq + Clone + Eq + Debug + 'static;
 	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>>;
 	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>>;
+
+	type ElectionTrackerEventHook: Hook<HookTypeFor<Self, ElectionTrackerEventHook>>
+		+ Default
+		+ Serde
+		+ Debug
+		+ Clone
+		+ Eq;
 }
 
 // hook types
+pub struct ElectionTrackerEventHook;
+impl<T: BWTypes> HookType for HookTypeFor<T, ElectionTrackerEventHook> {
+	type Input = ElectionTrackerEvent<T>;
+	type Output = ();
+}
+
 pub struct SafeModeEnabledHook;
 impl<T: BWTypes> HookType for HookTypeFor<T, SafeModeEnabledHook> {
 	type Input = ();
@@ -65,16 +77,7 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, LogEventHook> {
 	type Output = ();
 }
 
-pub trait BWProcessorTypes: Sized {
-	type ChainBlockNumber: Serde
-		+ Copy
-		+ Eq
-		+ Ord
-		+ SaturatingStep
-		+ Step
-		+ BlockZero
-		+ Debug
-		+ 'static;
+pub trait BWProcessorTypes: ChainTypes + Sized {
 	type BlockData: PartialEq + Clone + Debug + Eq + Ord + Serde + 'static;
 
 	type Event: Serde + Debug + Clone + Eq + Ord;
@@ -111,13 +114,16 @@ pub struct BlockWitnesserSettings {
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound(
 	T::ChainBlockNumber: Encode,
+	T::ChainBlockHash: Encode,
 	T::ElectionPropertiesHook: Encode,
 	T::SafeModeEnabledHook: Encode,
+	T::BlockData: Encode,
+	T::ElectionTrackerEventHook: Encode,
 
 	BlockProcessor<T>: Encode,
 ))]
 pub struct BlockWitnesserState<T: BWTypes> {
-	pub elections: ElectionTracker<T::ChainBlockNumber>,
+	pub elections: ElectionTracker2<T>,
 	pub generate_election_properties_hook: T::ElectionPropertiesHook,
 	pub safemode_enabled: T::SafeModeEnabledHook,
 	pub block_processor: BlockProcessor<T>,
@@ -128,7 +134,7 @@ impl<T: BWTypes> Validate for BlockWitnesserState<T> {
 	type Error = &'static str;
 
 	fn is_valid(&self) -> Result<(), Self::Error> {
-		self.elections.is_valid()
+		Ok(())
 	}
 }
 
@@ -148,33 +154,53 @@ where
 	}
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq;
-	T::ChainBlockNumber: Debug + Clone + Eq,
-	T::ElectionProperties: Debug + Clone + Eq,
-)]
-#[derive_where(Default;
-	T::ChainBlockNumber: Default,
-	T::ElectionProperties: Default,
-)]
+#[derive_where(Debug, Clone, PartialEq, Eq;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound(
+	T::ChainBlockHash: Encode,
 	T::ChainBlockNumber: Encode,
 	T::ElectionProperties: Encode,
 ))]
 pub struct BWElectionProperties<T: BWTypes> {
+	pub election_type: BWElectionType<T>,
 	pub block_height: T::ChainBlockNumber,
 	pub properties: T::ElectionProperties,
-	pub reorg_id: u8,
 }
 
-impl<T: BWTypes> IndexedValidate<BWElectionProperties<T>, T::BlockData> for BWStatemachine<T> {
+#[derive_where(Debug, Clone, PartialEq, Eq;)]
+#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[codec(encode_bound(
+	T::ChainBlockHash: Encode,
+	T::ChainBlockNumber: Encode,
+))]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub enum BWElectionType<T: ChainTypes> {
+	/// Querying blocks we haven't received a hash for yet
+	Optimistic,
+
+	/// Querying blocks by hash
+	ByHash(T::ChainBlockHash),
+
+	/// Querying "old" blocks that are below the safety margin,
+	/// and thus we don't care about the hash anymore
+	SafeBlockHeight,
+}
+
+impl<T: BWTypes> IndexedValidate<BWElectionProperties<T>, (T::BlockData, Option<T::ChainBlockHash>)>
+	for BWStatemachine<T>
+{
 	type Error = ();
 
 	fn validate(
-		_index: &BWElectionProperties<T>,
-		_value: &T::BlockData,
+		index: &BWElectionProperties<T>,
+		(_, hash): &(T::BlockData, Option<T::ChainBlockHash>),
 	) -> Result<(), Self::Error> {
-		Ok(())
+		use BWElectionType::*;
+		// ensure that a hash is only provided for `Optimistic` elections.
+		match (&index.election_type, hash) {
+			(ByHash(_), None) | (Optimistic, Some(_)) | (SafeBlockHeight, None) => Ok(()),
+			_ => Err(()),
+		}
 	}
 }
 
@@ -184,8 +210,10 @@ pub struct BWStatemachine<Types: BWTypes> {
 }
 
 impl<T: BWTypes> Statemachine for BWStatemachine<T> {
-	type Input =
-		SMInput<(BWElectionProperties<T>, T::BlockData), ChainProgress<T::ChainBlockNumber>>;
+	type Input = SMInput<
+		(BWElectionProperties<T>, (T::BlockData, Option<T::ChainBlockHash>)),
+		ChainProgressFor<T>,
+	>;
 	type InputIndex = Vec<BWElectionProperties<T>>;
 	type Settings = BlockWitnesserSettings;
 	type Output = Result<(), &'static str>;
@@ -196,48 +224,76 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			.ongoing
 			.clone()
 			.into_iter()
-			.map(|(block_height, reorg_id)| BWElectionProperties {
+			.map(|(block_height, election_type)| BWElectionProperties {
 				properties: s.generate_election_properties_hook.run(block_height),
+				election_type,
 				block_height,
-				reorg_id,
 			})
 			.collect()
 	}
 
 	fn step(s: &mut Self::State, i: Self::Input, settings: &Self::Settings) -> Self::Output {
-		let processor_input = match i {
-			SMInput::Context(ChainProgress::FirstConsensus(range)) => {
-				s.elections.next_election = *range.start();
-				s.elections.schedule_range(range.clone());
+		match i {
+			// TODO: unify these two cases
+			SMInput::Context(ChainProgress::Range(hashes, range)) => {
+				for (height, block) in s.elections.schedule_range(
+					range.clone(),
+					hashes.clone(),
+					settings.safety_margin as usize,
+					false,
+				) {
+					s.block_processor.process_block_data((
+						height,
+						block.data,
+						settings.safety_margin,
+					));
+				}
 
-				Some((ChainProgressInner::Progress(*range.start()), None))
+				s.block_processor.process_chain_progress(
+					ChainProgressInner::Progress(*range.end()),
+					T::SAFETY_MARGIN,
+				);
 			},
 
-			SMInput::Context(ChainProgress::Range(range)) => {
-				s.elections.schedule_range(range.clone());
-				if *range.start() < s.elections.next_witnessed {
-					//Reorg
-					Some((ChainProgressInner::Reorg(range.clone()), None))
-				} else {
-					Some((ChainProgressInner::Progress(*range.end()), None))
+			SMInput::Context(ChainProgress::Reorg(hashes, range)) => {
+				for (height, block) in s.elections.schedule_range(
+					range.clone(),
+					hashes.clone(),
+					settings.safety_margin as usize,
+					true,
+				) {
+					s.block_processor.process_block_data((
+						height,
+						block.data,
+						settings.safety_margin,
+					));
+				}
+
+				s.block_processor.process_chain_progress(
+					ChainProgressInner::Reorg(range.clone()),
+					T::SAFETY_MARGIN,
+				);
+			},
+
+			SMInput::Context(ChainProgress::None) => (),
+
+			SMInput::Consensus((properties, (blockdata, blockhash))) => {
+				log::info!("got {:?} block data: {:?}", properties.election_type, blockdata);
+
+				if let Some(blockdata) = s.elections.mark_election_done(
+					properties.block_height,
+					&properties.election_type,
+					&blockhash,
+					blockdata,
+				) {
+					s.block_processor.process_block_data((
+						properties.block_height,
+						blockdata,
+						settings.safety_margin,
+					));
 				}
 			},
-
-			SMInput::Context(ChainProgress::None) => None,
-
-			SMInput::Consensus((properties, blockdata)) => {
-				s.elections.mark_election_done(properties.block_height);
-				log::info!("got block data: {:?}", blockdata);
-				Some((
-					ChainProgressInner::Progress(s.elections.next_witnessed.saturating_backward(1)),
-					Some((properties.block_height, blockdata, settings.safety_margin)),
-				))
-			},
 		};
-
-		if let Some((progress, block)) = processor_input {
-			s.block_processor.process_block_data(progress, block);
-		}
 
 		s.elections.start_more_elections(
 			settings.max_concurrent_elections as usize,
@@ -247,6 +303,7 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 		Ok(())
 	}
 
+	/*
 	/// Specifiation for step function
 	#[cfg(test)]
 	fn step_specification(
@@ -393,13 +450,15 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			Context(None) => (),
 		}
 	}
+	*/
 }
 
 #[cfg(test)]
 pub mod tests {
+	use sp_std::iter::Step;
 	use std::collections::BTreeMap;
 
-	use cf_chains::{witness_period::BlockWitnessRange, ChainWitnessConfig};
+	use cf_chains::witness_period::{BlockZero, SaturatingStep};
 	use proptest::{
 		prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy},
 		prop_oneof,
@@ -410,6 +469,7 @@ pub mod tests {
 	use super::*;
 	use crate::prop_do;
 	use hook_test_utils::*;
+	use proptest::collection::*;
 
 	const SAFETY_MARGIN: u32 = 3;
 	fn generate_state<
@@ -417,28 +477,35 @@ pub mod tests {
 	>() -> impl Strategy<Value = BlockWitnesserState<T>>
 	where
 		T::ChainBlockNumber: Arbitrary,
+		T::ChainBlockHash: Arbitrary,
 		T::ElectionPropertiesHook: Default + Clone + Debug + Eq,
 		T::BlockData: Default + Clone + Debug + Eq,
 	{
 		prop_do! {
-			let (next_election, next_witnessed,
-				 next_priority_election, reorg_id,
+			let (next_election, seen_heights_below,
+				 priority_elections_below,
 				safemode_enabled) in (
 				any::<T::ChainBlockNumber>(),
 				any::<T::ChainBlockNumber>(),
 				any::<T::ChainBlockNumber>(),
-				any::<u8>(),
 				any::<bool>().prop_map(|b| if b {SafeModeStatus::Enabled} else {SafeModeStatus::Disabled})
 			);
 
-			let ongoing in proptest::collection::vec((any::<T::ChainBlockNumber>(), any::<u8>()), 0..10).prop_map(move |xs| xs.into_iter().filter(move |(height, _)| *height < next_election));
+			let (ongoing, queued_elections) in
+			(
+				proptest::collection::vec((any::<T::ChainBlockNumber>(), any::<BWElectionType<T>>()), 0..10).prop_map(move |xs| xs.into_iter().filter(move |(height, _)| *height < next_election)),
+				proptest::collection::vec((any::<T::ChainBlockNumber>(), any::<T::ChainBlockHash>()), 0..10).prop_map(move |xs| xs.into_iter().filter(move |(height, _)| *height < next_election))
+			);
 			LazyJust::new(move || BlockWitnesserState {
-				elections: ElectionTracker {
-					next_election,
-					next_witnessed,
-					next_priority_election,
+				elections: ElectionTracker2 {
+					// queued_next_safe_height: None,
+					queued_elections: BTreeMap::from_iter(queued_elections.clone()),
+					seen_heights_below,
+					priority_elections_below,
 					ongoing: BTreeMap::from_iter(ongoing.clone()),
-					reorg_id
+					queued_safe_elections: Default::default(),
+					optimistic_block_cache: Default::default(),
+					events: Default::default()
 				},
 				generate_election_properties_hook: Default::default(),
 				safemode_enabled: MockHook::new(safemode_enabled),
@@ -459,19 +526,23 @@ pub mod tests {
 	) -> BoxedStrategy<<BWStatemachine<T> as Statemachine>::Input>
 	where
 		T::ChainBlockNumber: Arbitrary,
+		T::ChainBlockHash: Arbitrary,
 		T::BlockData: Arbitrary,
 	{
 		let generate_input = |index: BWElectionProperties<T>| {
 			prop_oneof![
-				any::<T::BlockData>()
+				(any::<T::BlockData>(), any::<Option<T::ChainBlockHash>>())
 					.prop_map(move |data| (SMInput::Consensus((index.clone(), data)))),
 				prop_oneof![
 					Just(ChainProgress::None),
-					(any::<T::ChainBlockNumber>(), 0..20usize)
-						.prop_map(|(a, b)| ChainProgress::Range(a..=a.saturating_forward(b))),
-					(any::<T::ChainBlockNumber>(), 0..20usize).prop_map(|(a, b)| {
-						ChainProgress::FirstConsensus(a..=a.saturating_forward(b))
-					})
+					(
+						any::<T::ChainBlockNumber>(),
+						btree_map(any::<T::ChainBlockNumber>(), any::<T::ChainBlockHash>(), 0..20)
+					)
+						.prop_map(|(a, hashes)| ChainProgress::Range(
+							hashes.clone(),
+							a..=a.saturating_forward(hashes.len())
+						)),
 				]
 				.prop_map(SMInput::Context)
 			]
@@ -488,26 +559,34 @@ pub mod tests {
 		}
 	}
 
-	impl<N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static>
-		BWTypes for N
+	impl<
+			N: Serde + Copy + Ord + SaturatingStep + Step + BlockZero + Debug + Default + 'static,
+			H: Serde + Ord + Clone + Debug + Default + 'static,
+			D: Serde + Ord + Clone + Debug + Default + 'static,
+		> BWTypes for (N, H, Vec<D>)
 	{
 		type ElectionProperties = ();
 		type ElectionPropertiesHook = MockHook<HookTypeFor<Self, ElectionPropertiesHook>>;
 		type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>>;
+		type ElectionTrackerEventHook = MockHook<HookTypeFor<Self, ElectionTrackerEventHook>>;
 	}
+
+	type Types = (u32, Vec<u8>, Vec<u8>);
 
 	#[test]
 	pub fn test_bw_statemachine() {
-		BWStatemachine::<u32>::test(
+		BWStatemachine::<Types>::test(
 			file!(),
 			generate_state(),
 			prop_do! {
 				let max_concurrent_elections in 0..10u16;
 				return BlockWitnesserSettings { max_concurrent_elections, safety_margin: SAFETY_MARGIN}
 			},
-			generate_input::<u32>,
+			generate_input::<Types>,
 		);
 	}
+
+	/*
 
 	struct TestChain {}
 	impl ChainWitnessConfig for TestChain {
@@ -527,4 +606,5 @@ pub mod tests {
 			generate_input::<BlockWitnessRange<TestChain>>,
 		);
 	}
+	*/
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine.rs
@@ -1,5 +1,9 @@
+// #[cfg(test)]
+// pub mod chain;
 pub mod consensus;
 pub mod core;
 #[allow(clippy::module_inception)]
 pub mod state_machine;
 pub mod state_machine_es;
+#[cfg(test)]
+pub mod test_utils;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -93,6 +93,10 @@ pub mod hook_test_utils {
 			pub fn new(b: T::Output) -> Self {
 				Self { state: b, call_history: Vec::new(), _phantom: Default::default() }
 			}
+
+			pub fn take_history(&mut self) -> Vec<T::Input> {
+				sp_std::mem::take(&mut self.call_history)
+			}
 		}
 
 		impl Default where (T::Output: Default)
@@ -112,6 +116,33 @@ pub mod hook_test_utils {
 				self.call_history.push(input);
 				self.state.clone()
 			}
+		}
+	}
+
+	/// Hook to use for when we want to not do anything, for example
+	/// useful for "disabling" debug hooks in production.
+	/// It is marked as `inline` so shouldn't have any runtime cost.
+	#[derive(
+		Clone,
+		PartialEq,
+		Eq,
+		PartialOrd,
+		Ord,
+		Debug,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+		Serialize,
+		Deserialize,
+		Default,
+	)]
+	pub struct EmptyHook {}
+
+	impl<X: HookType<Output = ()>> Hook<X> for EmptyHook {
+		#[inline]
+		fn run(&mut self, _input: <X as HookType>::Input) -> <X as HookType>::Output {
+			()
 		}
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -182,3 +182,11 @@ impl<A, B: sp_std::fmt::Debug + Clone> Validate for Result<A, B> {
 
 /// Encapsulating usual constraints on types meant to be serialized
 pub trait Serde = Serialize + for<'a> Deserialize<'a>;
+
+// Nice functions to have
+pub fn fst<A, B>((a, _): (A, B)) -> A {
+	a
+}
+pub fn snd<A, B>((_, b): (A, B)) -> B {
+	b
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -97,6 +97,7 @@ pub trait Statemachine: 'static + IndexedValidate<Self::InputIndex, Self::Input>
 	fn step_specification(
 		_before: &mut Self::State,
 		_input: &Self::Input,
+		_output: &Self::Output,
 		_settings: &Self::Settings,
 		_after: &Self::State,
 	) {
@@ -153,10 +154,8 @@ pub trait Statemachine: 'static + IndexedValidate<Self::InputIndex, Self::Input>
 						let mut prev_state = state.clone();
 
 						// run step function and ensure that output is valid
-						assert!(
-							Self::step(&mut state, input.clone(), &settings).is_valid().is_ok(),
-							"step function failed"
-						);
+						let output = Self::step(&mut state, input.clone(), &settings);
+						assert!(output.is_valid().is_ok(), "step function failed");
 
 						// ensure that state is still well formed
 						assert!(
@@ -166,7 +165,13 @@ pub trait Statemachine: 'static + IndexedValidate<Self::InputIndex, Self::Input>
 						);
 
 						// ensure that step function computed valid state
-						Self::step_specification(&mut prev_state, &input, &settings, &state);
+						Self::step_specification(
+							&mut prev_state,
+							&input,
+							&output,
+							&settings,
+							&state,
+						);
 
 						println!("done test");
 						Ok(())

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/test_utils.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/test_utils.rs
@@ -1,0 +1,103 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+pub trait Logical {
+	fn and(self, other: Self) -> Self;
+	fn or(self, other: Self) -> Self;
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct Container<A: Logical>(pub A);
+
+impl<A: Logical> sp_std::ops::BitOr for Container<A> {
+	type Output = Self;
+
+	fn bitor(self, rhs: Self) -> Self::Output {
+		Container(self.0.or(rhs.0))
+	}
+}
+
+impl<A: Logical> sp_std::ops::BitAnd for Container<A> {
+	type Output = Self;
+
+	fn bitand(self, rhs: Self) -> Self::Output {
+		Container(self.0.and(rhs.0))
+	}
+}
+
+impl<A: Logical> sp_std::ops::Add for Container<A> {
+	type Output = Self;
+
+	fn add(self, rhs: Self) -> Self::Output {
+		Container(self.0.or(rhs.0))
+	}
+}
+
+impl<A, B> FromIterator<B> for Container<A>
+where
+	A: Logical + FromIterator<B>,
+{
+	fn from_iter<T: IntoIterator<Item = B>>(iter: T) -> Self {
+		Container(A::from_iter(iter))
+	}
+}
+
+// set
+
+impl<A: Clone + Ord> Logical for BTreeSet<A> {
+	fn and(self, other: Self) -> Self {
+		self.intersection(&other).cloned().collect()
+	}
+
+	fn or(self, other: Self) -> Self {
+		self.union(&other).cloned().collect()
+	}
+}
+
+// multi set
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct BTreeMultiSet<A>(pub BTreeMap<A, usize>);
+
+impl<A> Default for BTreeMultiSet<A> {
+	fn default() -> Self {
+		Self(Default::default())
+	}
+}
+
+impl<A: Ord> BTreeMultiSet<A> {
+	pub fn insert(&mut self, a: A) {
+		*self.0.entry(a).or_insert(0) += 1;
+	}
+}
+
+impl<A: Ord> FromIterator<A> for BTreeMultiSet<A> {
+	fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
+		let mut result = Self::default();
+		for x in iter {
+			result.insert(x);
+		}
+		result
+	}
+}
+
+impl<A: Ord + Clone> Logical for BTreeMultiSet<A> {
+	fn and(self, other: Self) -> Self {
+		let mut result = BTreeMap::new();
+		for (a, n) in &self.0 {
+			let m = other.0.get(a).unwrap_or(&0);
+			let min = sp_std::cmp::min(m, n);
+			if *min > 0 {
+				result.insert(a.clone(), *min);
+			}
+		}
+		BTreeMultiSet(result)
+	}
+
+	fn or(self, other: Self) -> Self {
+		let mut result = self.0.clone();
+		for (a, n) in &other.0 {
+			*result.entry(a.clone()).or_insert(0) += n;
+		}
+		BTreeMultiSet(result)
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests.rs
@@ -25,5 +25,6 @@ pub mod liveness;
 pub mod monotonic_change;
 pub mod monotonic_median;
 pub mod solana_vault_swap_accounts;
+pub mod statemachine_witnessing_pipeline;
 pub mod unsafe_median;
 pub mod utils;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -23,12 +23,12 @@ use super::{
 use crate::{
 	electoral_system::{ConsensusVote, ConsensusVotes, ElectoralSystemTypes},
 	electoral_systems::{
-		block_height_tracking::ChainProgress,
+		block_height_tracking::{ChainProgress, ChainProgressFor, ChainTypes},
 		block_witnesser::{
-			primitives::ElectionTracker,
 			state_machine::{
-				BWElectionProperties, BWProcessorTypes, ElectionPropertiesHook, ExecuteHook,
-				HookTypeFor, LogEventHook, RulesHook, SafeModeEnabledHook,
+				BWElectionProperties, BWProcessorTypes, ElectionPropertiesHook,
+				ElectionTrackerEventHook, ExecuteHook, HookTypeFor, LogEventHook, RulesHook,
+				SafeModeEnabledHook,
 			},
 			*,
 		},
@@ -67,8 +67,14 @@ impl Hook<HookTypeFor<Types, SafeModeEnabledHook>> for Types {
 	}
 }
 
-impl BWProcessorTypes for Types {
+impl ChainTypes for Types {
 	type ChainBlockNumber = u64;
+	type ChainBlockHash = u64;
+
+	const SAFETY_MARGIN: u32 = SAFETY_MARGIN;
+}
+
+impl BWProcessorTypes for Types {
 	type BlockData = Vec<u8>;
 	type Event = ();
 	type Rules = MockHook<HookTypeFor<Self, RulesHook>, "rules">;
@@ -82,6 +88,7 @@ impl BWTypes for Types {
 	type ElectionPropertiesHook =
 		MockHook<HookTypeFor<Self, ElectionPropertiesHook>, "generate_election_properties">;
 	type SafeModeEnabledHook = Self;
+	type ElectionTrackerEventHook = MockHook<HookTypeFor<Self, ElectionTrackerEventHook>>;
 }
 
 /// Associating the ES related types to the struct
@@ -96,16 +103,17 @@ impl ElectoralSystemTypes for Types {
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = BWElectionProperties<Self>;
 	type ElectionState = ();
-	type VoteStorage = vote_storage::bitmap::Bitmap<BlockData>;
-	type Consensus = BlockData;
-	type OnFinalizeContext = Vec<ChainProgress<u64>>;
+	type VoteStorage =
+		vote_storage::bitmap::Bitmap<(BlockData, Option<<Self as ChainTypes>::ChainBlockHash>)>;
+	type Consensus = (BlockData, Option<<Self as ChainTypes>::ChainBlockHash>);
+	type OnFinalizeContext = Vec<ChainProgressFor<Self>>;
 	type OnFinalizeReturn = Vec<()>;
 }
 
 /// Associating the state machine and consensus mechanism to the struct
 impl StatemachineElectoralSystemTypes for Types {
 	// both context and return have to be vectors, these are the item types
-	type OnFinalizeContextItem = ChainProgress<u64>;
+	type OnFinalizeContextItem = ChainProgressFor<Self>;
 	type OnFinalizeReturnItem = ();
 
 	// the actual state machine and consensus mechanisms of this ES
@@ -161,9 +169,12 @@ fn generate_votes(
 		votes: correct_voters
 			.clone()
 			.into_iter()
-			.map(|v| ConsensusVote { vote: Some(((), correct_data.clone())), validator_id: v })
+			.map(|v| ConsensusVote {
+				vote: Some(((), (correct_data.clone(), None))),
+				validator_id: v,
+			})
 			.chain(incorrect_voters.clone().into_iter().map(|v| ConsensusVote {
-				vote: Some(((), incorrect_data.clone())),
+				vote: Some(((), (incorrect_data.clone(), None))),
 				validator_id: v,
 			}))
 			.chain(
@@ -194,12 +205,14 @@ fn create_votes_expectation(
 			Default::default(),
 			consensus.clone(),
 		),
-		Some(consensus),
+		Some((consensus, None)),
 	)
 }
 
 const MAX_CONCURRENT_ELECTIONS: ElectionCount = 5;
 const SAFETY_MARGIN: u32 = 3;
+
+/*
 
 // We start an election for a block and there is nothing there. The base case.
 #[test]
@@ -709,3 +722,4 @@ fn elections_resolved_out_of_order_has_no_impact() {
 			],
 		);
 }
+ */

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -28,7 +28,7 @@ use crate::{
 			primitives::ElectionTracker,
 			state_machine::{
 				BWElectionProperties, BWProcessorTypes, ElectionPropertiesHook, ExecuteHook,
-				HookTypeFor, RulesHook, SafeModeEnabledHook,
+				HookTypeFor, LogEventHook, RulesHook, SafeModeEnabledHook,
 			},
 			*,
 		},
@@ -73,6 +73,7 @@ impl BWProcessorTypes for Types {
 	type Event = ();
 	type Rules = MockHook<HookTypeFor<Self, RulesHook>, "rules">;
 	type Execute = MockHook<HookTypeFor<Self, ExecuteHook>, "execute">;
+	type LogEventHook = MockHook<HookTypeFor<Self, LogEventHook>, "delete">;
 }
 
 /// Associating BW types to the struct

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -1,0 +1,285 @@
+//! This file tests the BlockWitnesser and the BlockHeightWitnesser state machines composed together
+//! on realistic inputs of a chain with many reorgs.
+
+pub mod chainstate_simulation;
+
+use core::marker::PhantomData;
+use std::{
+	collections::{BTreeMap, BTreeSet, VecDeque},
+	hash::DefaultHasher,
+};
+
+use proptest::test_runner::{Config, FileFailurePersistence, TestRunner};
+
+use crate::electoral_systems::{
+	block_height_tracking::{HWTypes, HeightWitnesserProperties},
+	block_witnesser::{
+		block_processor::{tests::MockBtcEvent, BlockProcessingInfo, BlockProcessorEvent},
+		state_machine::{BWProcessorTypes, BWTypes},
+	},
+};
+// use crate::electoral_systems::block_witnesser::block_processor::tests::MockBlockProcessorDefinition;
+use crate::electoral_systems::{
+	block_height_tracking::state_machine::{
+		tests::*, BHWState, BHWStateWrapper, BlockHeightTrackingSM, InputHeaders,
+	},
+	block_witnesser::{
+		block_processor::BlockProcessor,
+		primitives::SafeModeStatus,
+		state_machine::{
+			tests::*, BWElectionProperties, BWStatemachine, BlockWitnesserSettings,
+			BlockWitnesserState,
+		},
+	},
+	state_machine::{
+		core::{hook_test_utils::MockHook, IndexedValidate, TypesFor},
+		state_machine::Statemachine,
+		state_machine_es::SMInput,
+		test_utils::{BTreeMultiSet, Container},
+	},
+};
+use chainstate_simulation::*;
+
+macro_rules! if_matches {
+    ($($tt:tt)+) => {
+        |x| matches!(x, $($tt)+)
+    };
+}
+
+macro_rules! try_get {
+    ($($tt:tt)+) => {
+        |x| match x {$($tt)+(x) => Some(x), _ => None}
+    };
+}
+
+pub trait AbstractVoter<M: Statemachine> {
+	fn vote(&mut self, index: M::InputIndex) -> Option<Vec<M::Input>>;
+}
+
+#[test]
+pub fn test_all() {
+	type N = u8;
+	type BW = BWStatemachine<N>;
+	type BHW = BlockHeightTrackingSM<N>;
+
+	impl AbstractVoter<BHW> for FlatChainProgression<char> {
+		fn vote(
+			&mut self,
+			indices: <BHW as Statemachine>::InputIndex,
+		) -> Option<Vec<<BHW as Statemachine>::Input>> {
+			let chain = self.get_next_chain()?;
+
+			let mut result = Vec::new();
+
+			for index in indices {
+				let best_block = get_best_block(&chain);
+				if best_block.block_height < index.witness_from_index {
+					continue;
+				}
+
+				let bhw_input = match index {
+					HeightWitnesserProperties { witness_from_index } =>
+						if witness_from_index == 0 {
+							println!("########### first witnessing #################");
+							InputHeaders(VecDeque::from([best_block]))
+						} else {
+							let headers = (witness_from_index..=get_block_height(&chain))
+								.map(|height| get_block_header(&chain, height));
+							if headers.len() == 0 {
+								println!("no new blocks, continuing...");
+								continue;
+							}
+							if let Some(headers) = headers.into_iter().collect::<Option<Vec<_>>>() {
+								InputHeaders(VecDeque::from_iter(headers))
+							} else {
+								continue
+							}
+						},
+				};
+
+				result.push(SMInput::Consensus((index, bhw_input)));
+			}
+
+			Some(result)
+		}
+	}
+
+	impl AbstractVoter<BW> for FlatChainProgression<char> {
+		fn vote(
+			&mut self,
+			indices: <BW as Statemachine>::InputIndex,
+		) -> Option<Vec<<BW as Statemachine>::Input>> {
+			let mut inputs = Vec::new();
+			for index in indices {
+				let chain = self.get_next_chain()?;
+				if let Some(block_data) = get_block_header(&chain, index.block_height) {
+					inputs.push(SMInput::Consensus((
+						index,
+						block_data.hash.into_iter().map(|x| x as u8).collect(),
+					)));
+				}
+			}
+			Some(inputs)
+		}
+	}
+
+	let mut runner = TestRunner::new(Config {
+		cases: 256 * 16,
+		failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
+			"proptest-regressions-full-pipeline",
+		))),
+		..Default::default()
+	});
+	runner.run(&generate_blocks_with_tail(), |blocks| {
+
+        let mut chains = blocks_into_chain_progression(&blocks.blocks);
+
+        const SAFETY_MARGIN: u32 = 6;
+
+        // get final chain so we can check that we emitted the correct events:
+        let final_chain = chains.get_final_chain();
+        let finalized_blocks : Vec<_> = final_chain;
+        let finalized_events : BTreeSet<_> = finalized_blocks.iter().flat_map(|block| block.events.iter()).collect();
+
+        // prepare the state machines
+        let mut bhw_state: BHWStateWrapper<N> = BHWStateWrapper {
+            state: BHWState::Starting,
+            block_height_update: MockHook::new(())
+        };
+        let block_processor: BlockProcessor<N> = BlockProcessor {
+            blocks_data: Default::default(),
+            processed_events: Default::default(),
+            rules: Default::default(),
+            execute: MockHook::new(()),
+            delete_data: MockHook::new(()),
+        };
+        let mut bw_state: BlockWitnesserState<N> = BlockWitnesserState {
+            elections: Default::default(),
+            generate_election_properties_hook: Default::default(),
+            safemode_enabled: MockHook::new(SafeModeStatus::Disabled),
+            block_processor,
+            _phantom: core::marker::PhantomData,
+        };
+        let bw_settings = BlockWitnesserSettings {
+            max_concurrent_elections: 4,
+            safety_margin: SAFETY_MARGIN,
+        };
+
+        #[derive(Clone, Debug)]
+        enum BWTrace<T: BWTypes, T0: HWTypes> {
+            Input(<BWStatemachine<T> as Statemachine>::Input),
+            InputBHW(<BlockHeightTrackingSM<T0> as Statemachine>::Input),
+            Output(Vec<(T::ChainBlockNumber, T::Event)>),
+            Event(BlockProcessorEvent<T>)
+        }
+
+        let mut bw_history = Vec::new();
+        let mut total_outputs = Vec::new();
+
+        while chains.has_chains() {
+            // run BHW
+            let bhw_outputs = if let Some(inputs) = AbstractVoter::<BHW>::vote(&mut chains, BHW::input_index(&mut bhw_state)) {
+                let mut outputs = Vec::new();
+                for input in inputs {
+                    bw_history.push(BWTrace::InputBHW(input.clone()));
+
+                    let output = BHW::step(&mut bhw_state, input, &()).unwrap();
+                    outputs.push(output);
+                }
+                outputs
+            } else {
+                break
+            };
+
+            // ---- BW ----
+
+            let mut bw_outputs = if let Some(inputs) = AbstractVoter::<BW>::vote(&mut chains, BW::input_index(&mut bw_state)) {
+                let mut outputs = Vec::new();
+
+                // run BW on BHW outputs (context)
+                for bhw_output in bhw_outputs {
+                    bw_history.push(BWTrace::Input(SMInput::Context(bhw_output.clone())));
+
+                    BW::step(&mut bw_state, SMInput::Context(bhw_output), &bw_settings).unwrap();
+
+                    bw_history.extend(
+                        bw_state.block_processor.delete_data
+                        .take_history()
+                        .into_iter()
+                        .map(BWTrace::Event));
+
+                    let mut output = bw_state.block_processor.execute.take_history();
+                    bw_history.extend(
+                        output.iter().cloned().map(BWTrace::Output)
+                    );
+
+                    outputs.append(&mut output);
+                }
+
+                // run on BW inputs (consensus)
+                for input in inputs {
+                    bw_history.push(BWTrace::Input(input.clone()));
+
+                    BW::step(&mut bw_state, input, &bw_settings).unwrap();
+
+                    bw_history.extend(
+                        bw_state.block_processor.delete_data
+                        .take_history()
+                        .into_iter()
+                        .map(BWTrace::Event)
+                    );
+
+                    let mut output = bw_state.block_processor.execute.take_history();
+                    println!("got output: {output:?}");
+                    bw_history.extend(
+                        output.iter().cloned().map(BWTrace::Output)
+                    );
+
+                    outputs.append(&mut output);
+                }
+                outputs
+            } else {
+                break
+            };
+
+            total_outputs.append(&mut bw_outputs);
+        }
+
+        println!("----- outputs begin ------");
+        use std::fmt::Write;
+        let mut printed: String = Default::default();
+        for output in total_outputs.clone() {
+            if output.len() == 0 {
+                write!(printed, "No events").unwrap();
+            }
+            for (height, event) in output {
+                let event = match event {
+                    MockBtcEvent::PreWitness(data) => format!("Pre {}", data as char),
+                    MockBtcEvent::Witness(data) => format!("Wit {}", data as char),
+                };
+                write!(printed, "{height}: {}, ", event).unwrap();
+            }
+            writeln!(printed, "").unwrap();
+        }
+        println!("{printed}");
+        println!("----- outputs end ------");
+
+        let counted_events : Container<BTreeMultiSet<(u8, MockBtcEvent)>> = total_outputs.into_iter().flatten().collect();
+
+        // verify that each event was emitted only one time 
+        for (event, count) in counted_events.0.0.clone() {
+            if count > 1 {
+                panic!("Got event {event:?} in total {count} times           events: {printed}              bw_input_history: {bw_history:?}");
+            }
+        }
+
+        // ensure that we only emit witness events that are on the final chain
+        let emitted_witness_events : BTreeSet<_> = counted_events.0.0.keys().map(|(a,b)|b).filter_map(try_get!(MockBtcEvent::Witness)).map(|event| *event as char).collect();
+        let expected_witness_events : BTreeSet<_> = finalized_events.into_iter().cloned().collect();
+        assert!(emitted_witness_events.is_subset(&expected_witness_events),
+            "got witness events: {emitted_witness_events:?}, expected_witness_events: {expected_witness_events:?}, bw_input_history: {bw_history:?}"
+        );
+
+        Ok(())
+    }).unwrap();
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -9,30 +9,27 @@ use std::{
 	hash::DefaultHasher,
 };
 
+use frame_support::ensure;
+use itertools::Itertools;
 use proptest::test_runner::{Config, FileFailurePersistence, TestRunner};
 
 use crate::electoral_systems::{
-	block_height_tracking::{HWTypes, HeightWitnesserProperties},
-	block_witnesser::{
-		block_processor::{tests::MockBtcEvent, BlockProcessingInfo, BlockProcessorEvent},
-		state_machine::{BWProcessorTypes, BWTypes},
-	},
-};
-// use crate::electoral_systems::block_witnesser::block_processor::tests::MockBlockProcessorDefinition;
-use crate::electoral_systems::{
-	block_height_tracking::state_machine::{
-		tests::*, BHWState, BHWStateWrapper, BlockHeightTrackingSM, InputHeaders,
+	block_height_tracking::{
+		state_machine::{tests::*, BHWState, BHWStateWrapper, BlockHeightTrackingSM, InputHeaders},
+		HWTypes, HeightWitnesserProperties,
 	},
 	block_witnesser::{
-		block_processor::BlockProcessor,
-		primitives::SafeModeStatus,
+		block_processor::{
+			tests::MockBtcEvent, BlockProcessingInfo, BlockProcessor, BlockProcessorEvent,
+		},
+		primitives::{ElectionTrackerEvent, SafeModeStatus},
 		state_machine::{
-			tests::*, BWElectionProperties, BWStatemachine, BlockWitnesserSettings,
-			BlockWitnesserState,
+			tests::*, BWElectionProperties, BWElectionType, BWProcessorTypes, BWStatemachine,
+			BWTypes, BlockWitnesserSettings, BlockWitnesserState,
 		},
 	},
 	state_machine::{
-		core::{hook_test_utils::MockHook, IndexedValidate, TypesFor},
+		core::{hook_test_utils::MockHook, IndexedValidate, TypesFor, Validate},
 		state_machine::Statemachine,
 		state_machine_es::SMInput,
 		test_utils::{BTreeMultiSet, Container},
@@ -58,21 +55,23 @@ pub trait AbstractVoter<M: Statemachine> {
 
 #[test]
 pub fn test_all() {
-	type N = u8;
-	type BW = BWStatemachine<N>;
-	type BHW = BlockHeightTrackingSM<N>;
+	type Types = (u8, usize, Vec<char>);
+	type BW = BWStatemachine<Types>;
+	type BHW = BlockHeightTrackingSM<Types>;
+
+	const OFFSET: usize = 20;
 
 	impl AbstractVoter<BHW> for FlatChainProgression<char> {
 		fn vote(
 			&mut self,
 			indices: <BHW as Statemachine>::InputIndex,
 		) -> Option<Vec<<BHW as Statemachine>::Input>> {
-			let chain = self.get_next_chain()?;
+			let chain = MockChain::new_with_offset(OFFSET, self.get_next_chain()?);
 
 			let mut result = Vec::new();
 
 			for index in indices {
-				let best_block = get_best_block(&chain);
+				let best_block = chain.get_best_block_header();
 				if best_block.block_height < index.witness_from_index {
 					continue;
 				}
@@ -80,13 +79,11 @@ pub fn test_all() {
 				let bhw_input = match index {
 					HeightWitnesserProperties { witness_from_index } =>
 						if witness_from_index == 0 {
-							println!("########### first witnessing #################");
 							InputHeaders(VecDeque::from([best_block]))
 						} else {
-							let headers = (witness_from_index..=get_block_height(&chain))
-								.map(|height| get_block_header(&chain, height));
+							let headers = (witness_from_index..=chain.get_best_block_height())
+								.map(|height| chain.get_block_header(height));
 							if headers.len() == 0 {
-								println!("no new blocks, continuing...");
 								continue;
 							}
 							if let Some(headers) = headers.into_iter().collect::<Option<Vec<_>>>() {
@@ -111,12 +108,25 @@ pub fn test_all() {
 		) -> Option<Vec<<BW as Statemachine>::Input>> {
 			let mut inputs = Vec::new();
 			for index in indices {
-				let chain = self.get_next_chain()?;
-				if let Some(block_data) = get_block_header(&chain, index.block_height) {
-					inputs.push(SMInput::Consensus((
-						index,
-						block_data.hash.into_iter().map(|x| x as u8).collect(),
-					)));
+				let chain =
+					MockChain::<char, Types>::new_with_offset(OFFSET, self.get_next_chain()?);
+
+				use BWElectionType::*;
+				match index.election_type {
+					Optimistic =>
+						if let Some(block_data) = chain.get_block_by_height(index.block_height) {
+							let header = chain.get_block_header(index.block_height).unwrap();
+							inputs
+								.push(SMInput::Consensus((index, (block_data, Some(header.hash)))));
+						},
+					ByHash(hash) =>
+						if let Some(block_data) = chain.get_block_by_hash(hash) {
+							inputs.push(SMInput::Consensus((index, (block_data, None))));
+						},
+					SafeBlockHeight =>
+						if let Some(block_data) = chain.get_block_by_height(index.block_height) {
+							inputs.push(SMInput::Consensus((index, (block_data, None))));
+						},
 				}
 			}
 			Some(inputs)
@@ -124,7 +134,7 @@ pub fn test_all() {
 	}
 
 	let mut runner = TestRunner::new(Config {
-		cases: 256 * 16,
+		cases: 256 * 16 * 16 * 4,
 		failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
 			"proptest-regressions-full-pipeline",
 		))),
@@ -134,7 +144,7 @@ pub fn test_all() {
 
         let mut chains = blocks_into_chain_progression(&blocks.blocks);
 
-        const SAFETY_MARGIN: u32 = 6;
+        const SAFETY_MARGIN: u32 = 8;
 
         // get final chain so we can check that we emitted the correct events:
         let final_chain = chains.get_final_chain();
@@ -142,18 +152,18 @@ pub fn test_all() {
         let finalized_events : BTreeSet<_> = finalized_blocks.iter().flat_map(|block| block.events.iter()).collect();
 
         // prepare the state machines
-        let mut bhw_state: BHWStateWrapper<N> = BHWStateWrapper {
+        let mut bhw_state: BHWStateWrapper<Types> = BHWStateWrapper {
             state: BHWState::Starting,
             block_height_update: MockHook::new(())
         };
-        let block_processor: BlockProcessor<N> = BlockProcessor {
+        let block_processor: BlockProcessor<Types> = BlockProcessor {
             blocks_data: Default::default(),
             processed_events: Default::default(),
             rules: Default::default(),
             execute: MockHook::new(()),
             delete_data: MockHook::new(()),
         };
-        let mut bw_state: BlockWitnesserState<N> = BlockWitnesserState {
+        let mut bw_state: BlockWitnesserState<Types> = BlockWitnesserState {
             elections: Default::default(),
             generate_election_properties_hook: Default::default(),
             safemode_enabled: MockHook::new(SafeModeStatus::Disabled),
@@ -170,20 +180,31 @@ pub fn test_all() {
             Input(<BWStatemachine<T> as Statemachine>::Input),
             InputBHW(<BlockHeightTrackingSM<T0> as Statemachine>::Input),
             Output(Vec<(T::ChainBlockNumber, T::Event)>),
-            Event(BlockProcessorEvent<T>)
+            Event(BlockProcessorEvent<T>),
+            ET(ElectionTrackerEvent<T>)
         }
 
         let mut bw_history = Vec::new();
         let mut total_outputs = Vec::new();
+
+        let print_bw_history = |bw_history: &Vec<BWTrace<Types, Types>>|
+            bw_history.iter().map(|event| format!("{event:?}")).intersperse("\n".to_string()).collect::<String>();
 
         while chains.has_chains() {
             // run BHW
             let bhw_outputs = if let Some(inputs) = AbstractVoter::<BHW>::vote(&mut chains, BHW::input_index(&mut bhw_state)) {
                 let mut outputs = Vec::new();
                 for input in inputs {
+                    // ensure that input is correct
+                    BHW::validate(&BHW::input_index(&mut bhw_state), &input).unwrap();
+
                     bw_history.push(BWTrace::InputBHW(input.clone()));
 
-                    let output = BHW::step(&mut bhw_state, input, &()).unwrap();
+                    let output = BHW::step(&mut bhw_state, input, &())
+                    .map_err(|err| format!("err: {err} with history: {bw_history:?}"))
+                    .unwrap();
+                    // .expect(&format!("BHW failed with history: {bw_history:?}"));
+
                     outputs.push(output);
                 }
                 outputs
@@ -200,7 +221,17 @@ pub fn test_all() {
                 for bhw_output in bhw_outputs {
                     bw_history.push(BWTrace::Input(SMInput::Context(bhw_output.clone())));
 
+                    bw_state.elections.is_valid()
+                        .map_err(|err| format!("err: {err} with history: {}", print_bw_history(&bw_history)))
+                        .unwrap();
+
                     BW::step(&mut bw_state, SMInput::Context(bhw_output), &bw_settings).unwrap();
+
+                    bw_history.extend(
+                        bw_state.elections.events
+                        .take_history()
+                        .into_iter()
+                        .map(BWTrace::ET));
 
                     bw_history.extend(
                         bw_state.block_processor.delete_data
@@ -220,7 +251,17 @@ pub fn test_all() {
                 for input in inputs {
                     bw_history.push(BWTrace::Input(input.clone()));
 
+                    bw_state.elections.is_valid()
+                        .map_err(|err| format!("err: {err} with history: {}", print_bw_history(&bw_history)))
+                        .unwrap();
+
                     BW::step(&mut bw_state, input, &bw_settings).unwrap();
+
+                    bw_history.extend(
+                        bw_state.elections.events
+                        .take_history()
+                        .into_iter()
+                        .map(BWTrace::ET));
 
                     bw_history.extend(
                         bw_state.block_processor.delete_data
@@ -230,7 +271,6 @@ pub fn test_all() {
                     );
 
                     let mut output = bw_state.block_processor.execute.take_history();
-                    println!("got output: {output:?}");
                     bw_history.extend(
                         output.iter().cloned().map(BWTrace::Output)
                     );
@@ -245,7 +285,7 @@ pub fn test_all() {
             total_outputs.append(&mut bw_outputs);
         }
 
-        println!("----- outputs begin ------");
+        // println!("----- outputs begin ------");
         use std::fmt::Write;
         let mut printed: String = Default::default();
         for output in total_outputs.clone() {
@@ -261,23 +301,24 @@ pub fn test_all() {
             }
             writeln!(printed, "").unwrap();
         }
-        println!("{printed}");
-        println!("----- outputs end ------");
 
-        let counted_events : Container<BTreeMultiSet<(u8, MockBtcEvent)>> = total_outputs.into_iter().flatten().collect();
+        let counted_events : Container<BTreeMultiSet<(u8, MockBtcEvent<char>)>> = total_outputs.into_iter().flatten().collect();
 
         // verify that each event was emitted only one time 
         for (event, count) in counted_events.0.0.clone() {
             if count > 1 {
-                panic!("Got event {event:?} in total {count} times           events: {printed}              bw_input_history: {bw_history:?}");
+                panic!("Got event {event:?} in total {count} times           events: {printed}              bw_input_history: {}",
+                print_bw_history(&bw_history)
+            );
             }
         }
 
         // ensure that we only emit witness events that are on the final chain
         let emitted_witness_events : BTreeSet<_> = counted_events.0.0.keys().map(|(a,b)|b).filter_map(try_get!(MockBtcEvent::Witness)).map(|event| *event as char).collect();
         let expected_witness_events : BTreeSet<_> = finalized_events.into_iter().cloned().collect();
-        assert!(emitted_witness_events.is_subset(&expected_witness_events),
-            "got witness events: {emitted_witness_events:?}, expected_witness_events: {expected_witness_events:?}, bw_input_history: {bw_history:?}"
+        assert!(emitted_witness_events == expected_witness_events,
+            "got witness events: {emitted_witness_events:?}, expected_witness_events: {expected_witness_events:?}, bw_input_history: {}",
+            bw_history.iter().map(|event| format!("{event:?}")).intersperse("\n".to_string()).collect::<String>()
         );
 
         Ok(())

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline/chainstate_simulation.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline/chainstate_simulation.rs
@@ -1,0 +1,345 @@
+//! This file defines a proptest strategy for generating a sequence of states of a progressing
+//! blockchain. The blocks of the chain contain vectors of an arbitrary datatype. The generated
+//! sequence of states includes reorgs (block data may change within a given safety margin) and
+//! "stuttering" / where the chain state may remain unchanged or even revert to a previous state for
+//! a short time (modelling network delay and difference of the chainview when accessing from
+//! different rpc endpoints).
+
+use core::{
+	fmt::Debug,
+	ops::{Range, RangeInclusive},
+};
+
+use proptest::{collection::*, prelude::*};
+
+/// The basic data structure involved is an ordered tree which:
+///  - a leaf represents a single block
+///  - a branch represents a forked
+#[derive(Debug, Clone)]
+pub enum ForkedBlock<A> {
+	Block(A),
+	Fork(Vec<ForkedBlock<A>>),
+}
+
+impl<A> ForkedBlock<A> {
+	pub fn map<B>(self, f: &mut impl FnMut(A) -> B) -> ForkedBlock<B> {
+		use ForkedBlock::*;
+		match self {
+			Block(a) => Block(f(a)),
+			Fork(blocks) => Fork(blocks.into_iter().map(|block| block.map(f)).collect()),
+		}
+	}
+}
+
+/// Parameters describing what kind of forked blocks are generated.
+#[derive(Debug, Clone)]
+pub struct ConsumerParameters {
+	take: Range<usize>,
+	max_drop: usize,
+	max_ignore: usize,
+
+	// settings for `data delays`
+	time_steps_per_block: RangeInclusive<usize>,
+	max_data_delay: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConsumerChainParameters {
+	max_mainchain_length: usize,
+
+	max_fork_count: u32,
+	max_block_count: u32,
+	max_fork_length: usize,
+
+	item_parameters: ConsumerParameters,
+}
+
+pub fn generate_consumer(p: ConsumerParameters) -> impl Strategy<Value = Consumer> {
+	let p = p.clone();
+	(0..=p.max_drop, 0..=p.max_ignore, p.take, p.time_steps_per_block).prop_flat_map(
+		move |(drop, ignore, take, time_steps)| {
+			vec(0..p.max_data_delay, time_steps).prop_map(move |data_delays| Consumer {
+				drop,
+				ignore,
+				take,
+				data_delays,
+			})
+		},
+	)
+}
+
+pub fn generate_consumer_block(
+	p: ConsumerChainParameters,
+) -> impl Strategy<Value = ForkedBlock<Consumer>> {
+	let leaf = generate_consumer(p.item_parameters).prop_map(ForkedBlock::Block);
+	leaf.prop_recursive(
+		p.max_fork_count,
+		p.max_block_count,
+		p.max_fork_length as u32,
+		move |inner| vec(inner, 1..p.max_fork_length).prop_map(ForkedBlock::Fork),
+	)
+}
+
+pub fn generate_consumer_chain(
+	p: ConsumerChainParameters,
+) -> impl Strategy<Value = ForkedChain<Consumer>> {
+	let single = generate_consumer(p.item_parameters.clone()).prop_map(ForkedBlock::Block);
+	let forked = generate_consumer_block(p.clone());
+	vec(prop_oneof![single, forked], 0..=p.max_mainchain_length)
+}
+
+/// A (possibly forked) chain with content `A` is a vector of ordered trees.
+type ForkedChain<A> = Vec<ForkedBlock<A>>;
+
+/// A data structure which describes how to construct a
+/// block from a "stream" of items.
+#[derive(Clone, Debug)]
+pub struct Consumer {
+	/// How many items to ignore from the beginning of the stream.
+	/// These are not being consumed and not being removed.
+	ignore: usize,
+
+	/// How many items to drop from the stream (after ignoring `ignore`).
+	drop: usize,
+
+	/// How many items to take and include in this block (after dropping).
+	take: usize,
+
+	/// Unrelated to the (ignore/drop/take) consumer notion, but currently part
+	/// of this structure. This describes how views of the chainstate are generated
+	/// when this block is the "current" one.
+	data_delays: Vec<usize>,
+}
+
+pub struct FilledBlock<E> {
+	data: Vec<E>,
+	data_delays: Vec<usize>,
+}
+
+pub fn fill_block<E: Clone>(
+	input: ForkedBlock<Consumer>,
+	events: &mut Vec<E>,
+) -> ForkedBlock<FilledBlock<E>> {
+	use ForkedBlock::*;
+	match input {
+		Block(Consumer { ignore, drop, take, data_delays }) => {
+			{
+				let _dropped_events = events.drain(ignore..(ignore + drop));
+			}
+			let block_events = events.drain(ignore..(ignore + take));
+			Block(FilledBlock { data: block_events.collect(), data_delays: data_delays.clone() })
+		},
+		Fork(blocks) => Fork(fill_chain(blocks, &mut events.clone())),
+	}
+}
+
+pub fn fill_chain<E: Clone>(
+	chain: ForkedChain<Consumer>,
+	events: &mut Vec<E>,
+) -> ForkedChain<FilledBlock<E>> {
+	chain.into_iter().map(|block| fill_block(block, events)).collect()
+}
+
+pub fn create_time_steps<E: Clone>(chain: &ForkedChain<FilledBlock<E>>) -> Vec<FlatChain<E>> {
+	let mut chains = Vec::new();
+	let mut current_blocks = Vec::new();
+	use ForkedBlock::*;
+	for block in chain {
+		match block {
+			Block(FilledBlock { data, data_delays }) => {
+				current_blocks.push(FlatBlock { events: data.clone() });
+				chains.push(FlatChain {
+					blocks: current_blocks.clone(),
+					data_delays: data_delays.clone(),
+				});
+			},
+			Fork(forked_blocks) => {
+				let forked_chains = create_time_steps(forked_blocks);
+				chains.extend(forked_chains.into_iter().map(|mut forked_chain| {
+					let mut extended_current_chain = current_blocks.clone();
+					extended_current_chain.append(&mut forked_chain.blocks);
+					FlatChain {
+						blocks: extended_current_chain,
+						data_delays: forked_chain.data_delays,
+					}
+				}));
+			},
+		}
+	}
+	chains
+}
+
+// Temp
+#[derive(Debug, Clone)]
+pub struct FlatBlock<E> {
+	pub events: Vec<E>,
+}
+
+// Temp
+#[derive(Debug, Clone)]
+pub struct FlatChain<E> {
+	blocks: Vec<FlatBlock<E>>,
+	data_delays: Vec<usize>,
+}
+
+pub fn make_events() -> Vec<char> {
+	(0..26u8)
+		.into_iter()
+		.map(|x| (b'a' + x) as char)
+		.chain((0..26u8).into_iter().map(|x| (b'A' + x) as char))
+		.chain((0..10u8).into_iter().map(|x| (b'0' + x) as char))
+		.collect()
+}
+
+pub fn generate_blocks_with_tail() -> impl Strategy<Value = ForkedFilledChain> {
+	let p = ConsumerChainParameters {
+		max_mainchain_length: 10,
+		max_fork_count: 4,
+		max_block_count: 200,
+		max_fork_length: 4,
+		item_parameters: ConsumerParameters {
+			take: 3..5,
+			max_drop: 1,
+			max_ignore: 2,
+			time_steps_per_block: 1..=3,
+			max_data_delay: 2,
+		},
+	};
+	generate_consumer_chain(p)
+		// turn into chain progression
+		.prop_map(|mut blocks| {
+			// generate a large number of empty blocks, so all processors can run until completion
+			blocks.extend((0..5).map(|_| {
+				ForkedBlock::Block(Consumer {
+					ignore: 0,
+					drop: 0,
+					take: 0,
+					data_delays: vec![0, 0, 0, 0, 0],
+				})
+			}));
+
+			let filled_chain = fill_chain(blocks, &mut make_events());
+
+			ForkedFilledChain { blocks: filled_chain }
+		})
+}
+
+pub struct ForkedFilledChain {
+	pub blocks: ForkedChain<FilledBlock<char>>,
+}
+
+pub fn print_blocks(
+	blocks: &ForkedChain<FilledBlock<char>>,
+	height: usize,
+	f: &mut core::fmt::Formatter<'_>,
+) -> core::fmt::Result {
+	let mut forks = Vec::new();
+
+	let mut current_string = String::from_iter((0..height).map(|_| ' '));
+	current_string.push_str("|- ");
+
+	use ForkedBlock::*;
+	for block in blocks {
+		match block {
+			Fork(blocks) => forks.push((current_string.len(), blocks)),
+			Block(FilledBlock { data, data_delays }) =>
+				current_string.push_str(&format!("{data:?} [{data_delays:?}] -> ")),
+		}
+	}
+
+	writeln!(f, "{current_string}")?;
+
+	for (indent, fork) in forks {
+		print_blocks(fork, indent, f)?;
+	}
+
+	Ok(())
+}
+
+impl Debug for ForkedFilledChain {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		writeln!(f, "chains:")?;
+		print_blocks(&self.blocks, 0, f)
+	}
+}
+
+pub fn blocks_into_chain_progression(
+	filled_chain: &ForkedChain<FilledBlock<char>>,
+) -> FlatChainProgression<char> {
+	let time_steps = create_time_steps(&filled_chain);
+
+	for step in &time_steps {
+		println!("step: {step:?}");
+	}
+
+	let mut chain_progression = FlatChainProgression { chains: time_steps, age: 0 };
+
+	// attach dummy first block
+	for chain in &mut chain_progression.chains {
+		chain.blocks.insert(0, FlatBlock { events: vec![] });
+	}
+
+	chain_progression
+}
+
+use crate::electoral_systems::block_height_tracking::primitives::Header;
+type MockChain<E> = Vec<FlatBlock<E>>;
+type N = u8;
+pub fn get_block_height<E>(chain: &MockChain<E>) -> N {
+	chain.len() as u8 - 1
+}
+pub fn get_block_header<E: Clone>(chain: &MockChain<E>, height: N) -> Option<Header<Vec<E>, N>> {
+	let hash = chain.get(height as usize)?.events.clone();
+	let parent_hash = chain
+		.get(height.saturating_sub(1) as usize)
+		.map(|block| block.events.clone())
+		.unwrap_or(vec![]);
+	Some(Header { block_height: height, hash, parent_hash })
+}
+pub fn get_best_block<E: Clone>(chain: &MockChain<E>) -> Header<Vec<E>, N> {
+	let hash = chain.last().unwrap().events.clone();
+	let parent_hash = chain
+		.iter()
+		.rev()
+		.skip(1)
+		.next()
+		.map(|block| block.events.clone())
+		.unwrap_or(vec![]);
+	Header { block_height: chain.len() as u8 - 1, hash, parent_hash }
+}
+
+// Temp
+#[derive(Debug, Clone)]
+pub struct FlatChainProgression<E> {
+	chains: Vec<FlatChain<E>>,
+	age: usize,
+}
+
+impl<E: Clone> FlatChainProgression<E> {
+	pub fn get_next_chain(&mut self) -> Option<Vec<FlatBlock<E>>> {
+		let mut age_left = self.age;
+		for (chain_count, chain) in self.chains.iter().enumerate() {
+			if age_left < chain.data_delays.len() {
+				self.age += 1;
+				return Some(
+					self.chains
+						.get(chain_count.saturating_sub(*chain.data_delays.get(age_left).unwrap()))
+						.unwrap()
+						.blocks
+						.clone(),
+				);
+			} else {
+				age_left -= chain.data_delays.len();
+			}
+		}
+		None
+	}
+
+	pub fn has_chains(&self) -> bool {
+		self.chains.len() > 0
+	}
+
+	pub fn get_final_chain(&self) -> Vec<FlatBlock<E>> {
+		self.chains.last().unwrap().blocks.clone()
+	}
+}

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -125,6 +125,7 @@
 #![feature(adt_const_params)]
 #![feature(unsized_const_params)]
 #![feature(btree_extract_if)]
+#![feature(impl_trait_in_assoc_type)]
 #![cfg_attr(test, feature(closure_track_caller))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -41,7 +41,7 @@ use pallet_cf_elections::{
 		},
 		liveness::Liveness,
 		state_machine::{
-			core::Hook,
+			core::{hook_test_utils::EmptyHook, Hook},
 			state_machine_es::{StatemachineElectoralSystem, StatemachineElectoralSystemTypes},
 		},
 		unsafe_median::{UnsafeMedian, UpdateFeeHook},
@@ -158,6 +158,7 @@ impls! {
 		type Event = BtcEvent<DepositWitness<Bitcoin>>;
 		type Rules = Self;
 		type Execute = Self;
+		type LogEventHook = EmptyHook;
 	}
 
 	/// Associating BW types to the struct
@@ -245,6 +246,8 @@ impls! {
 		type Event = BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>;
 		type Rules = Self;
 		type Execute = Self;
+
+		type LogEventHook = EmptyHook;
 	}
 
 	/// Associating BW types to the struct
@@ -341,6 +344,8 @@ impls! {
 		type Event = BtcEvent<TransactionConfirmation<Runtime, BitcoinInstance>>;
 		type Rules = Self;
 		type Execute = Self;
+
+		type LogEventHook = EmptyHook;
 	}
 
 	/// Associating BW types to the struct

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -24,7 +24,8 @@ use pallet_cf_elections::{
 		block_height_tracking::{
 			consensus::BlockHeightTrackingConsensus,
 			state_machine::{BHWStateWrapper, BlockHeightTrackingSM, InputHeaders},
-			BlockHeightChangeHook, ChainProgress, HWTypes, HeightWitnesserProperties,
+			BlockHeightChangeHook, ChainProgressFor, ChainTypes, HWTypes,
+			HeightWitnesserProperties,
 		},
 		block_witnesser::{
 			consensus::BWConsensus,
@@ -79,6 +80,8 @@ pub struct OpenChannelDetails<ChainBlockNumber> {
 	pub close_block: ChainBlockNumber,
 }
 
+const SAFETY_MARGIN: u32 = 8;
+
 // ------------------------ block height tracking ---------------------------
 /// The electoral system for block height tracking
 pub struct BitcoinBlockHeightTracking;
@@ -86,11 +89,14 @@ pub struct BitcoinBlockHeightTracking;
 impls! {
 	for TypesFor<BitcoinBlockHeightTracking>:
 
-	/// Associating the SM related types to the struct
-	HWTypes {
-		const BLOCK_BUFFER_SIZE: usize = 6;
+	ChainTypes {
 		type ChainBlockNumber = btc::BlockNumber;
 		type ChainBlockHash = btc::Hash;
+		const SAFETY_MARGIN: u32 = SAFETY_MARGIN;
+	}
+	/// Associating the SM related types to the struct
+	HWTypes {
+		const BLOCK_BUFFER_SIZE: usize = SAFETY_MARGIN as usize;
 		type BlockHeightChangeHook = Self;
 	}
 
@@ -108,7 +114,7 @@ impls! {
 		type VoteStorage = vote_storage::bitmap::Bitmap<InputHeaders<Self>>;
 		type Consensus = InputHeaders<Self>;
 		type OnFinalizeContext = Vec<()>;
-		type OnFinalizeReturn = Vec<ChainProgress<btc::BlockNumber>>;
+		type OnFinalizeReturn = Vec<ChainProgressFor<Self>>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
 
@@ -116,7 +122,7 @@ impls! {
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
 		type OnFinalizeContextItem = ();
-		type OnFinalizeReturnItem = ChainProgress<btc::BlockNumber>;
+		type OnFinalizeReturnItem = ChainProgressFor<Self>;
 
 		// the actual state machine and consensus mechanisms of this ES
 		type ConsensusMechanism = BlockHeightTrackingConsensus<Self>;
@@ -150,9 +156,15 @@ pub(crate) type BlockDataDepositChannel = Vec<DepositWitness<Bitcoin>>;
 impls! {
 	for TypesFor<BitcoinDepositChannelWitnessing>:
 
+	ChainTypes {
+		type ChainBlockNumber = btc::BlockNumber;
+		type ChainBlockHash = btc::Hash;
+
+		const SAFETY_MARGIN: u32 = SAFETY_MARGIN;
+	}
+
 	/// Associating BW processor types
 	BWProcessorTypes {
-		type ChainBlockNumber = btc::BlockNumber;
 		type BlockData = BlockDataDepositChannel;
 
 		type Event = BtcEvent<DepositWitness<Bitcoin>>;
@@ -166,6 +178,7 @@ impls! {
 		type ElectionProperties = ElectionPropertiesDepositChannel;
 		type ElectionPropertiesHook = Self;
 		type SafeModeEnabledHook = Self;
+		type ElectionTrackerEventHook = EmptyHook;
 	}
 
 	/// Associating the ES related types to the struct
@@ -179,9 +192,9 @@ impls! {
 		type ElectionIdentifierExtra = ();
 		type ElectionProperties = BWElectionProperties<Self>;
 		type ElectionState = ();
-		type VoteStorage = vote_storage::bitmap::Bitmap<BlockDataDepositChannel>;
-		type Consensus = BlockDataDepositChannel;
-		type OnFinalizeContext = Vec<ChainProgress<btc::BlockNumber>>;
+		type VoteStorage = vote_storage::bitmap::Bitmap<(BlockDataDepositChannel, Option<btc::Hash>)>;
+		type Consensus = (BlockDataDepositChannel, Option<btc::Hash>);
+		type OnFinalizeContext = Vec<ChainProgressFor<Self>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -189,7 +202,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = ChainProgress<btc::BlockNumber>;
+		type OnFinalizeContextItem = ChainProgressFor<Self>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES
@@ -238,9 +251,15 @@ pub(crate) type BlockDataVaultDeposit = Vec<VaultDepositWitness<Runtime, Bitcoin
 impls! {
 	for TypesFor<BitcoinVaultDepositWitnessing>:
 
+	ChainTypes {
+		type ChainBlockNumber = btc::BlockNumber;
+		type ChainBlockHash = btc::Hash;
+
+		const SAFETY_MARGIN: u32 = SAFETY_MARGIN;
+	}
+
 	/// Associating BW processor types
 	BWProcessorTypes {
-		type ChainBlockNumber = BlockNumber;
 		type BlockData = BlockDataVaultDeposit;
 
 		type Event = BtcEvent<VaultDepositWitness<Runtime, BitcoinInstance>>;
@@ -255,6 +274,7 @@ impls! {
 		type ElectionProperties = ElectionPropertiesVaultDeposit;
 		type ElectionPropertiesHook = Self;
 		type SafeModeEnabledHook = Self;
+		type ElectionTrackerEventHook = EmptyHook;
 	}
 
 	/// Associating the ES related types to the struct
@@ -268,9 +288,9 @@ impls! {
 		type ElectionIdentifierExtra = ();
 		type ElectionProperties = BWElectionProperties<Self>;
 		type ElectionState = ();
-		type VoteStorage = vote_storage::bitmap::Bitmap<BlockDataVaultDeposit>;
-		type Consensus = BlockDataVaultDeposit;
-		type OnFinalizeContext = Vec<ChainProgress<btc::BlockNumber>>;
+		type VoteStorage = vote_storage::bitmap::Bitmap<(BlockDataVaultDeposit, Option<btc::Hash>)>;
+		type Consensus = (BlockDataVaultDeposit, Option<btc::Hash>);
+		type OnFinalizeContext = Vec<ChainProgressFor<Self>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -278,7 +298,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = ChainProgress<btc::BlockNumber>;
+		type OnFinalizeContextItem = ChainProgressFor<Self>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES
@@ -336,9 +356,15 @@ pub(crate) type EgressBlockData = Vec<TransactionConfirmation<Runtime, BitcoinIn
 impls! {
 	for TypesFor<BitcoinEgressWitnessing>:
 
+	ChainTypes {
+		type ChainBlockNumber = btc::BlockNumber;
+		type ChainBlockHash = btc::Hash;
+
+		const SAFETY_MARGIN: u32 = SAFETY_MARGIN;
+	}
+
 	/// Associating BW processor types
 	BWProcessorTypes {
-		type ChainBlockNumber = BlockNumber;
 		type BlockData = EgressBlockData;
 
 		type Event = BtcEvent<TransactionConfirmation<Runtime, BitcoinInstance>>;
@@ -353,6 +379,7 @@ impls! {
 		type ElectionProperties = ElectionPropertiesEgressWitnessing;
 		type ElectionPropertiesHook = Self;
 		type SafeModeEnabledHook = Self;
+		type ElectionTrackerEventHook = EmptyHook;
 	}
 
 	/// Associating the ES related types to the struct
@@ -366,9 +393,9 @@ impls! {
 		type ElectionIdentifierExtra = ();
 		type ElectionProperties = BWElectionProperties<Self>;
 		type ElectionState = ();
-		type VoteStorage = vote_storage::bitmap::Bitmap<EgressBlockData>;
-		type Consensus = EgressBlockData;
-		type OnFinalizeContext = Vec<ChainProgress<btc::BlockNumber>>;
+		type VoteStorage = vote_storage::bitmap::Bitmap<(EgressBlockData, Option<btc::Hash>)>;
+		type Consensus = (EgressBlockData, Option<btc::Hash>);
+		type OnFinalizeContext = Vec<ChainProgressFor<Self>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -376,7 +403,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = ChainProgress<btc::BlockNumber>;
+		type OnFinalizeContextItem = ChainProgressFor<Self>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES
@@ -505,7 +532,7 @@ impl
 				BitcoinDepositChannelWitnessingES,
 				RunnerStorageAccess<Runtime, BitcoinInstance>,
 			>,
-		>(deposit_channel_witnessing_identifiers.clone(), &chain_progress)?;
+		>(deposit_channel_witnessing_identifiers.clone(), &chain_progress.clone())?;
 
 		BitcoinVaultDepositWitnessingES::on_finalize::<
 			DerivedElectoralAccess<
@@ -513,7 +540,7 @@ impl
 				BitcoinVaultDepositWitnessingES,
 				RunnerStorageAccess<Runtime, BitcoinInstance>,
 			>,
-		>(vault_deposits_identifiers.clone(), &chain_progress)?;
+		>(vault_deposits_identifiers.clone(), &chain_progress.clone())?;
 
 		let last_btc_block =
 			pallet_cf_chain_tracking::CurrentChainState::<Runtime, BitcoinInstance>::get().unwrap();
@@ -524,7 +551,7 @@ impl
 				BitcoinEgressWitnessingES,
 				RunnerStorageAccess<Runtime, BitcoinInstance>,
 			>,
-		>(egress_identifiers, &chain_progress)?;
+		>(egress_identifiers, &chain_progress.clone())?;
 
 		BitcoinFeeTracking::on_finalize::<
 			DerivedElectoralAccess<


### PR DESCRIPTION
# Pull Request

Closes: PRO-2182

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR adds a proptest `Strategy` to generate a virtual chain progression with forks, reorgs and "fuzzy timing" which can be used to test the core statemachine logic for the witnessing. It's in `electoral_system/state_machine_chain.rs`. The goal was for the strategy to work nicely with the minimization feature of proptest which tries to find a minimal example when some input is found to break the given properties. It is not yet clear whether this goal succeeded 100%, but the generated inputs already have been highly helpful in finding edge-cases we haven't considered until now.

In `electoral_system/tests/statemachine_witnessing.rs` there's a proptest that uses the new `generate_chain_progression` strategy to generate progressing external chain states and runs them through both the BHW and BW in the same pattern as the state machines are fed with data in the `StatemachineElectoralSystem` instantiation in the `statemachine_es` file.

In order to be able to inspect what happens in the block processor, this PR also adds a new `LogEvent` hook, which is called in the block processor when block or event data is deleted.

This PR was build upon existing work for PRO-2064, but that part is not necessarily complete yet.

Existing properties that are successfully checked:
 - [x] No event is emitted twice
 - [x] All events on the "main" chain are emitted
 - [x] Only prewitness events are emitted for the forks (we statically know that fork size < safety margin)