### PR TITLE
feat: ability to delay boost

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -413,6 +413,9 @@ pub enum PalletConfigUpdate<T: Config<I>, I: 'static> {
 	SetWitnessSafetyMargin {
 		margin: TargetChainBlockNumber<T, I>,
 	},
+	SetBoostDelay {
+		delay_blocks: BlockNumberFor<T>,
+	},
 }
 
 #[frame_support::pallet]
@@ -1033,6 +1036,9 @@ pub mod pallet {
 		WitnessSafetyMarginSet {
 			margin: TargetChainBlockNumber<T, I>,
 		},
+		BoostDelaySet {
+			delay_blocks: BlockNumberFor<T>,
+		},
 	}
 
 	#[derive(CloneNoBound, PartialEqNoBound, EqNoBound)]
@@ -1510,6 +1516,10 @@ pub mod pallet {
 					PalletConfigUpdate::SetWitnessSafetyMargin { margin } => {
 						WitnessSafetyMargin::<T, I>::set(Some(margin));
 						Self::deposit_event(Event::<T, I>::WitnessSafetyMarginSet { margin });
+					},
+					PalletConfigUpdate::SetBoostDelay { delay_blocks } => {
+						BoostDelayBlocks::<T, I>::set(delay_blocks);
+						Self::deposit_event(Event::<T, I>::BoostDelaySet { delay_blocks });
 					},
 				}
 			}

--- a/state-chain/pallets/cf-ingress-egress/src/mocks.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks.rs
@@ -341,7 +341,7 @@ impl<Ctx: Clone> RequestAddress for TestExternalities<Test, Ctx> {
 	where
 		Test: Config<I>,
 	{
-		self.then_execute_at_next_block(|_| {
+		self.then_execute_with(|_| {
 			requests
 				.iter()
 				.cloned()

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1553,7 +1553,7 @@ mod delayed_boosting {
 
 			assert_eq!(
 				BoostedVaultTransactions::<Test, ()>::get(&TX_ID),
-				Some(BoostStatus::BoostPending)
+				BoostStatus::BoostPending
 			);
 
 			// EDGE CASE: full witness arrives before the delayed prewitness is processed,
@@ -1613,7 +1613,7 @@ mod delayed_boosting {
 
 				assert_eq!(
 					BoostedVaultTransactions::<Test, ()>::get(&tx_id),
-					Some(BoostStatus::BoostPending)
+					BoostStatus::BoostPending
 				);
 
 				(deposit, tx_id)
@@ -1630,7 +1630,7 @@ mod delayed_boosting {
 
 				assert_matches!(
 					BoostedVaultTransactions::<Test, ()>::get(&tx_id),
-					Some(BoostStatus::Boosted { .. })
+					BoostStatus::Boosted { .. }
 				);
 
 				IngressEgress::process_vault_swap_request_full_witness(

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1427,7 +1427,7 @@ mod delayed_boosting {
 					DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 						.unwrap()
 						.boost_status,
-					BoostStatus::BoostPending
+					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
 				deposit_address
@@ -1504,7 +1504,7 @@ mod delayed_boosting {
 					DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 						.unwrap()
 						.boost_status,
-					BoostStatus::BoostPending
+					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
 				witness_deposit(deposit_address, INPUT_ASSET.into(), DEPOSIT_AMOUNT);
@@ -1600,7 +1600,7 @@ mod delayed_boosting {
 
 				assert_eq!(
 					BoostedVaultTransactions::<Test, Instance1>::get(&TX_ID),
-					BoostStatus::BoostPending
+					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
 				// EDGE CASE: full witness arrives before the delayed prewitness is processed,
@@ -1674,7 +1674,7 @@ mod delayed_boosting {
 
 				assert_eq!(
 					BoostedVaultTransactions::<Test, Instance1>::get(&tx_id),
-					BoostStatus::BoostPending
+					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
 				(deposit, tx_id)

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -1410,16 +1410,16 @@ mod delayed_boosting {
 
 				assert_ok!(EthereumIngressEgress::add_boost_funds(
 					RuntimeOrigin::signed(BOOSTER_1),
-					INPUT_ASSET.into(),
+					INPUT_ASSET,
 					DEPOSIT_AMOUNT,
 					TIER_5_BPS
 				));
 
 				let (_, deposit_address) = request_deposit_address_eth(LP_ACCOUNT, 5);
-				let _ = prewitness_deposit(deposit_address, INPUT_ASSET.into(), DEPOSIT_AMOUNT);
+				let _ = prewitness_deposit(deposit_address, INPUT_ASSET, DEPOSIT_AMOUNT);
 
 				assert_eq!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK).len(),
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK).len(),
 					1
 				);
 
@@ -1439,24 +1439,24 @@ mod delayed_boosting {
 				);
 
 				assert_eq!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK).len(),
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK).len(),
 					0
 				);
 
 				assert!(
 					matches!(
-						DepositChannelLookup::<Test, Instance1>::get(&deposit_address)
+						DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 							.unwrap()
 							.boost_status,
 						BoostStatus::Boosted { .. }
 					),
 					"Expected tx to be marked as boosted, got: {:#?}",
-					DepositChannelLookup::<Test, Instance1>::get(&deposit_address)
+					DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 						.unwrap()
 						.boost_status
 				);
 
-				witness_deposit(deposit_address, INPUT_ASSET.into(), DEPOSIT_AMOUNT);
+				witness_deposit(deposit_address, INPUT_ASSET, DEPOSIT_AMOUNT);
 
 				assert_has_matching_event!(
 					Test,
@@ -1464,7 +1464,7 @@ mod delayed_boosting {
 				);
 
 				assert_eq!(
-					DepositChannelLookup::<Test, Instance1>::get(&deposit_address)
+					DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 						.unwrap()
 						.boost_status,
 					BoostStatus::NotBoosted
@@ -1487,16 +1487,16 @@ mod delayed_boosting {
 
 				assert_ok!(EthereumIngressEgress::add_boost_funds(
 					RuntimeOrigin::signed(BOOSTER_1),
-					INPUT_ASSET.into(),
+					INPUT_ASSET,
 					DEPOSIT_AMOUNT,
 					TIER_5_BPS
 				));
 
 				let (_, deposit_address) = request_deposit_address_eth(LP_ACCOUNT, 5);
-				let _ = prewitness_deposit(deposit_address, INPUT_ASSET.into(), DEPOSIT_AMOUNT);
+				let _ = prewitness_deposit(deposit_address, INPUT_ASSET, DEPOSIT_AMOUNT);
 
 				assert_eq!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK).len(),
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK).len(),
 					1
 				);
 
@@ -1507,7 +1507,7 @@ mod delayed_boosting {
 					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
-				witness_deposit(deposit_address, INPUT_ASSET.into(), DEPOSIT_AMOUNT);
+				witness_deposit(deposit_address, INPUT_ASSET, DEPOSIT_AMOUNT);
 
 				assert_has_matching_event!(
 					Test,
@@ -1515,7 +1515,7 @@ mod delayed_boosting {
 				);
 
 				assert_eq!(
-					DepositChannelLookup::<Test, Instance1>::get(&deposit_address)
+					DepositChannelLookup::<Test, Instance1>::get(deposit_address)
 						.unwrap()
 						.boost_status,
 					BoostStatus::NotBoosted
@@ -1523,7 +1523,7 @@ mod delayed_boosting {
 			})
 			.then_execute_at_block(PROCESSED_AT_BLOCK, |_| {
 				assert!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK)
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK)
 						.is_empty(),
 					"Pending prewitnessed deposits should have been cleared"
 				);
@@ -1551,7 +1551,7 @@ mod delayed_boosting {
 				ForeignChainAddress::Eth([1; 20].into()),
 			),
 			deposit_metadata: None,
-			tx_id: TX_ID.clone(),
+			tx_id: TX_ID,
 			broker_fee: Some(Beneficiary { account: BROKER, bps: 5 }),
 			affiliate_fees: Default::default(),
 			refund_params: ChannelRefundParameters {
@@ -1594,12 +1594,12 @@ mod delayed_boosting {
 				);
 
 				assert_eq!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK).len(),
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK).len(),
 					1
 				);
 
 				assert_eq!(
-					BoostedVaultTransactions::<Test, Instance1>::get(&TX_ID),
+					BoostedVaultTransactions::<Test, Instance1>::get(TX_ID),
 					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
@@ -1619,7 +1619,7 @@ mod delayed_boosting {
 			})
 			.then_execute_at_block(PROCESSED_AT_BLOCK, |_| {
 				assert!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK)
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK)
 						.is_empty(),
 					"Pending prewitnessed deposits should have been cleared"
 				);
@@ -1641,7 +1641,6 @@ mod delayed_boosting {
 		// it the finalised deposit arrives and processed an not boosted.
 		// Importantly, we cancel the processing of the prewitnessed deposit.
 
-		const CHANNEL_ID: ChannelId = 1;
 		const DEPOSIT_BLOCK_HEIGHT: u64 = 10;
 
 		new_test_ext()
@@ -1668,12 +1667,12 @@ mod delayed_boosting {
 				);
 
 				assert_eq!(
-					PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK).len(),
+					PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK).len(),
 					1
 				);
 
 				assert_eq!(
-					BoostedVaultTransactions::<Test, Instance1>::get(&tx_id),
+					BoostedVaultTransactions::<Test, Instance1>::get(tx_id),
 					BoostStatus::BoostPending { amount: DEPOSIT_AMOUNT }
 				);
 
@@ -1685,16 +1684,16 @@ mod delayed_boosting {
 					RuntimeEvent::EthereumIngressEgress(Event::DepositBoosted { .. }),
 				);
 
-				assert!(PendingPrewitnessedDeposits::<Test, Instance1>::get(&PROCESSED_AT_BLOCK)
+				assert!(PendingPrewitnessedDeposits::<Test, Instance1>::get(PROCESSED_AT_BLOCK)
 					.is_empty());
 
 				assert!(
 					matches!(
-						BoostedVaultTransactions::<Test, Instance1>::get(&tx_id),
+						BoostedVaultTransactions::<Test, Instance1>::get(tx_id),
 						BoostStatus::Boosted { .. }
 					),
 					"Expected tx to be marked as boosted, got: {:#?}",
-					BoostedVaultTransactions::<Test, Instance1>::get(&tx_id)
+					BoostedVaultTransactions::<Test, Instance1>::get(tx_id)
 				);
 
 				EthereumIngressEgress::process_vault_swap_request_full_witness(

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -21,7 +21,8 @@ use cf_amm::{
 };
 use cf_primitives::{chains::assets::any::Asset, AssetAmount};
 use cf_test_utilities::{
-	assert_events_eq, assert_events_match, assert_has_matching_event, last_event,
+	assert_events_eq, assert_events_match, assert_has_matching_event, assert_matching_event_count,
+	last_event,
 };
 use cf_traits::{mocks::balance_api::MockBalance, BalanceApi, PoolApi, SwappingApi};
 use frame_support::{assert_noop, assert_ok, traits::Hooks};
@@ -223,27 +224,28 @@ fn pallet_limit_order_is_in_sync_with_pool() {
 		assert_eq!(pallet_limit_orders.base.get(&ALICE), None);
 		assert_eq!(pallet_limit_orders.base.get(&BOB).unwrap().get(&0), Some(&tick));
 
-		assert_has_matching_event!(
+		// Expect two events: one event for creation, one for sweeping.
+		assert_matching_event_count!(
 			Test,
 			RuntimeEvent::LiquidityPools(Event::LimitOrderUpdated {
 				lp: ALICE,
 				side: Side::Sell,
 				..
-			}),
+			}) => 2
 		);
 
-		assert_has_matching_event!(
+		assert_matching_event_count!(
 			Test,
-			RuntimeEvent::LiquidityPools(Event::LimitOrderUpdated { lp: BOB, side: Side::Buy, .. }),
+			RuntimeEvent::LiquidityPools(Event::LimitOrderUpdated { lp: BOB, side: Side::Buy, .. }) => 2
 		);
 
-		assert_has_matching_event!(
+		assert_matching_event_count!(
 			Test,
 			RuntimeEvent::LiquidityPools(Event::LimitOrderUpdated {
 				lp: BOB,
 				side: Side::Sell,
 				..
-			})
+			}) => 2
 		);
 	});
 }

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -21,8 +21,7 @@ use cf_amm::{
 };
 use cf_primitives::{chains::assets::any::Asset, AssetAmount};
 use cf_test_utilities::{
-	assert_events_eq, assert_events_match, assert_has_matching_event, assert_matching_event_count,
-	last_event,
+	assert_events_eq, assert_events_match, assert_matching_event_count, last_event,
 };
 use cf_traits::{mocks::balance_api::MockBalance, BalanceApi, PoolApi, SwappingApi};
 use frame_support::{assert_noop, assert_ok, traits::Hooks};


### PR DESCRIPTION
# Pull Request

Closes: PRO-2212

## Summary

- Prewitnessed deposits are now delayed by `BoostDelayBlocks` blocks before being processed. If `BoostDelayBlocks` is 0 (the current default), they are processed immediately as before.
- If a deposit is finalised before it is "prewitness" is processed (e.g. the delay is too long), the deposit is processed as not boosted.
- `BoostDelayBlocks` is configurable by governance