### PR TITLE
chore: map boost pool error

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool.rs
@@ -106,6 +106,11 @@ pub struct OwedAmount<AmountT> {
 	pub fee: AmountT,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Error {
+	AccountNotFoundInBoostPool,
+}
+
 /// Boosted amount is the amount provided by the pool plus boost fee,
 /// (and the sum of all boosted amounts from each participating pool
 /// must be equal the deposit amount being boosted). The fee is payed
@@ -446,9 +451,9 @@ where
 	pub fn stop_boosting(
 		&mut self,
 		booster_id: AccountId,
-	) -> Result<(C::ChainAmount, BTreeSet<PrewitnessedDepositId>), &'static str> {
+	) -> Result<(C::ChainAmount, BTreeSet<PrewitnessedDepositId>), Error> {
 		let Some(booster_active_amount) = self.amounts.remove(&booster_id) else {
-			return Err("Account not found in boost pool")
+			return Err(Error::AccountNotFoundInBoostPool);
 		};
 
 		self.available_amount.saturating_reduce(booster_active_amount);

--- a/state-chain/pallets/cf-ingress-egress/src/boost_pool/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/boost_pool/tests.rs
@@ -163,7 +163,7 @@ fn withdrawing_twice_is_no_op() {
 
 	check_pool(&pool, [(BOOSTER_2, AMOUNT_2)]);
 
-	assert!(pool.stop_boosting(BOOSTER_1).is_err());
+	assert_eq!(pool.stop_boosting(BOOSTER_1), Err(Error::AccountNotFoundInBoostPool));
 
 	// No changes:
 	check_pool(&pool, [(BOOSTER_2, AMOUNT_2)]);

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1468,8 +1468,10 @@ pub mod pallet {
 			let (unlocked_amount, pending_boosts) =
 				BoostPools::<T, I>::mutate(asset, pool_tier, |pool| {
 					let pool = pool.as_mut().ok_or(Error::<T, I>::BoostPoolDoesNotExist)?;
-					pool.stop_boosting(booster.clone())
-						.map_err(|_| Error::<T, I>::AccountNotFoundInBoostPool)
+					pool.stop_boosting(booster.clone()).map_err(|e| match e {
+						boost_pool::Error::AccountNotFoundInBoostPool =>
+							Error::<T, I>::AccountNotFoundInBoostPool,
+					})
 				})?;
 
 			T::Balance::credit_account(&booster, asset.into(), unlocked_amount.into());

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -998,6 +998,8 @@ pub mod pallet {
 		TransactionAlreadyPrewitnessed,
 		/// Assethub's Vault Account does not exist in storage.
 		MissingAssethubVault,
+		/// The account id is not a member of the boost pool.
+		AccountNotFoundInBoostPool,
 	}
 
 	#[pallet::hooks]
@@ -1467,6 +1469,7 @@ pub mod pallet {
 				BoostPools::<T, I>::mutate(asset, pool_tier, |pool| {
 					let pool = pool.as_mut().ok_or(Error::<T, I>::BoostPoolDoesNotExist)?;
 					pool.stop_boosting(booster.clone())
+						.map_err(|_| Error::<T, I>::AccountNotFoundInBoostPool)
 				})?;
 
 			T::Balance::credit_account(&booster, asset.into(), unlocked_amount.into());


### PR DESCRIPTION
# Pull Request

Closes: PRO-1958

## Checklist

- [x] I am confident that the code works.

## Summary

Simple mapping of the error to a pallet error so we can see the error message though an RPC/extrinsic. 
