### PR TITLE
chore: bump docker build-push

### DIFF
--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -134,8 +134,6 @@ jobs:
           push: ${{ inputs.save_tags == '' }}
           load: ${{ inputs.save_tags != '' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           file: ${{ needs.set-dockerfile-name.outputs.dockerfile_path }}/${{ matrix.target }}.Dockerfile
           build-args: |
             BUILD_DATETIME=${{ needs.get-date-time.outputs.date }} ${{ needs.get-date-time.outputs.time }}
@@ -217,8 +215,6 @@ jobs:
           push: ${{ inputs.publish_public_images }}
           load: ${{ inputs.save_tags != '' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           file: ${{ needs.set-dockerfile-name.outputs.dockerfile_path }}/${{ matrix.target }}.Dockerfile
           build-args: |
             BUILD_DATETIME=${{ needs.get-date-time.outputs.date }} ${{ needs.get-date-time.outputs.time }}

--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -128,7 +128,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push 🏗️🫸
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
           push: ${{ inputs.save_tags == '' }}
@@ -211,7 +211,7 @@ jobs:
           password: ${{ secrets.CF_DOCKERHUB_TOKEN }}
 
       - name: Build and push 🏗️🫸
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
           push: ${{ inputs.publish_public_images }}

--- a/.github/workflows/_26_docker_external_networks.yml
+++ b/.github/workflows/_26_docker_external_networks.yml
@@ -65,8 +65,6 @@ jobs:
           push: true
           load: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           file: ./ci/docker/development/${{ inputs.network }}/Dockerfile
           build-args: |
             BUILD_DATETIME=${{ needs.get-date-time.outputs.date }} ${{ needs.get-date-time.outputs.time }}

--- a/.github/workflows/_26_docker_external_networks.yml
+++ b/.github/workflows/_26_docker_external_networks.yml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push 🏗️🫸
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: ./ci/docker/development/${{ inputs.network }}
           push: true

--- a/.github/workflows/docker-build-rust-base.yml
+++ b/.github/workflows/docker-build-rust-base.yml
@@ -55,7 +55,7 @@ jobs:
           tags: ${{ steps.image_tags.outputs.image_tag }}
 
       - name: Build and push 🏗️🫸
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4
         with:
           context: .
           push: true


### PR DESCRIPTION
Fix github docker cache issue, as github deprecated some older versions we were depending on.
We remove cache-from and cache-to as Namespace provides this already.
