### PR TITLE
fix: use ci-benchmarks-release instead of ci-benchmarks

### DIFF
--- a/.github/workflows/_100_run_benchmarks.yml
+++ b/.github/workflows/_100_run_benchmarks.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Fetch chainflip-node with benchmarks from ${{ inputs.commit_sha }}
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
         with:
-          workflow: ci-benchmarks.yml
+          workflow: ci-benchmarks-release.yml
           workflow_conclusion: completed
           name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile }}
           commit: ${{ inputs.commit_sha }}


### PR DESCRIPTION
This appears to have changed (?) since the last release.

Seems to work, based on [this run](https://github.com/chainflip-io/chainflip-backend/actions/runs/14596896538/job/40945101442).