### PR TITLE
chore: add timeout for writing chain explorer to file

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -145,6 +145,7 @@ jobs:
       - name: Write chain explorer to file 📝
         if: failure()
         continue-on-error: true
+        timeout-minutes: 10
         working-directory: bouncer
         run: |
           BLOCK_HEIGHT=$(curl -s -H "Content-Type: application/json" \

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -295,6 +295,7 @@ jobs:
       - name: Write chain explorer to file 📝
         if: failure()
         continue-on-error: true
+        timeout-minutes: 10
         working-directory: bouncer
         run: |
           BLOCK_HEIGHT=$(curl -s -H "Content-Type: application/json" \


### PR DESCRIPTION
# Pull Request

Closes: PRO-2218

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

The writing to chain explorer can last the duration of the whole maximum job time just because it can't connect. Better to exit early, shouldn't take more than 10 minutes to write the file.