### PR TITLE
chore: rename sold_amounts -> bought_amounts

### DIFF
--- a/api/cf-rpc-types/src/lib.rs
+++ b/api/cf-rpc-types/src/lib.rs
@@ -69,7 +69,7 @@ pub enum OrderFilled {
 		quote_asset: Asset,
 		id: U256,
 		range: Range<Tick>,
-		sold_amounts: PoolPairsMap<U256>,
+		bought_amounts: PoolPairsMap<U256>,
 		fees: PoolPairsMap<U256>,
 		liquidity: U256,
 	},

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -1081,7 +1081,7 @@ fn order_fills_subscription() {
 						quote_asset: Asset::Usdc,
 						id: ORDER_ID.into(),
 						range: RANGE,
-						sold_amounts: PoolPairsMap {
+						bought_amounts: PoolPairsMap {
 							base: 5_000 * DECIMALS - 1000,  // rounding error (amplified)
 							quote: 2_000 * DECIMALS - 1000  // rounding error (amplified)
 						}

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -165,7 +165,7 @@ fn order_fills_for_pool<'a>(
 						base_asset: asset_pair.assets().base,
 						quote_asset: asset_pair.assets().quote,
 						id: id.into(),
-						sold_amounts: fees.map(|amount| {
+						bought_amounts: fees.map(|amount| {
 							input_amount_from_fee(amount, fee_hundredth_pips).unwrap_or_default()
 						}),
 						range: range.clone(),


### PR DESCRIPTION
# Pull Request

## Summary

As @niklasnatter correctly pointed out, the amount we are exposing here is the *bought* amount, thus renaming the field.
