### PR TITLE
feat: Make transaction building transactional

### DIFF
--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -44,8 +44,8 @@ impl<E> SetAggKeyWithAggKey<EvmCrypto> for ArbitrumApi<E>
 where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
-	fn new_unsigned(
-		_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
+	fn new_unsigned_impl(
+		maybe_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
 		new_key: <EvmCrypto as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
 		Ok(Some(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(

--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -45,7 +45,7 @@ where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
 	fn new_unsigned_impl(
-		maybe_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
+		_maybe_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
 		new_key: <EvmCrypto as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
 		Ok(Some(Self::SetAggKeyWithAggKey(EvmTransactionBuilder::new_unsigned(

--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -80,7 +80,7 @@ impl<E> ExecutexSwapAndCall<Arbitrum> for ArbitrumApi<E>
 where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Arbitrum>,
 		source_chain: ForeignChain,
 		source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -59,7 +59,7 @@ impl<E> AllBatch<Arbitrum> for ArbitrumApi<E>
 where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Arbitrum>>,
 		transfer_params: Vec<(TransferAssetParams<Arbitrum>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/arb/api.rs
+++ b/state-chain/chains/src/arb/api.rs
@@ -112,7 +112,7 @@ impl<E> TransferFallback<Arbitrum> for ArbitrumApi<E>
 where
 	E: EvmEnvironmentProvider<Arbitrum> + ReplayProtectionProvider<Arbitrum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Arbitrum>,
 	) -> Result<Self, TransferFallbackError> {
 		let transfer_param = EncodableTransferAssetParams {

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -132,7 +132,7 @@ impl<E> SetAggKeyWithAggKey<BitcoinCrypto> for BitcoinApi<E>
 where
 	E: ChainEnvironment<UtxoSelectionType, SelectedUtxosAndChangeAmount>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_maybe_old_key: Option<<BitcoinCrypto as ChainCrypto>::AggKey>,
 		_new_key: <BitcoinCrypto as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -151,7 +151,7 @@ impl<E> From<batch_transfer::BatchTransfer> for BitcoinApi<E> {
 
 // TODO: Implement transfer / transfer and call for Bitcoin.
 impl<E: ReplayProtectionProvider<Bitcoin>> ExecutexSwapAndCall<Bitcoin> for BitcoinApi<E> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Bitcoin>,
 		_source_chain: ForeignChain,
 		_source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -186,7 +186,7 @@ where
 
 // transfer_fallback is unsupported for Bitcoin.
 impl<E: ReplayProtectionProvider<Bitcoin>> TransferFallback<Bitcoin> for BitcoinApi<E> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Bitcoin>,
 	) -> Result<Self, TransferFallbackError> {
 		Err(TransferFallbackError::Unsupported)

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -78,7 +78,7 @@ where
 	E: ChainEnvironment<UtxoSelectionType, SelectedUtxosAndChangeAmount>
 		+ ChainEnvironment<(), AggKey>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_fetch_params: Vec<FetchAssetParams<Bitcoin>>,
 		transfer_params: Vec<(TransferAssetParams<Bitcoin>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -138,7 +138,7 @@ impl<E> ExecutexSwapAndCall<Polkadot> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Polkadot>,
 		_source_chain: ForeignChain,
 		_source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -77,7 +77,7 @@ impl<E> AllBatch<Polkadot> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Polkadot>>,
 		transfer_params: Vec<(TransferAssetParams<Polkadot>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -154,7 +154,7 @@ impl<E> TransferFallback<Polkadot> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Polkadot>,
 	) -> Result<Self, TransferFallbackError> {
 		Err(TransferFallbackError::Unsupported)

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -118,7 +118,7 @@ impl<E> SetAggKeyWithAggKey<PolkadotCrypto> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -103,7 +103,7 @@ where
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
 	) -> Result<Self, SetGovKeyWithAggKeyError> {
-		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::Failed)?;
+		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::VaultAccountNotSet)?;
 
 		Ok(Self::ChangeGovKey(rotate_vault_proxy::extrinsic_builder(
 			E::replay_protection(false),

--- a/state-chain/chains/src/dot/api.rs
+++ b/state-chain/chains/src/dot/api.rs
@@ -99,11 +99,11 @@ impl<E> SetGovKeyWithAggKey<PolkadotCrypto> for PolkadotApi<E>
 where
 	E: PolkadotEnvironment + ReplayProtectionProvider<Polkadot>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
-	) -> Result<Self, ()> {
-		let vault = E::try_vault_account().ok_or(())?;
+	) -> Result<Self, SetGovKeyWithAggKeyError> {
+		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::Failed)?;
 
 		Ok(Self::ChangeGovKey(rotate_vault_proxy::extrinsic_builder(
 			E::replay_protection(false),

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -237,7 +237,7 @@ impl<E> TransferFallback<Ethereum> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Ethereum>,
 	) -> Result<Self, TransferFallbackError> {
 		let transfer_param = EncodableTransferAssetParams {

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -183,7 +183,7 @@ impl<E> AllBatch<Ethereum> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Ethereum>>,
 		transfer_params: Vec<(TransferAssetParams<Ethereum>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -111,10 +111,10 @@ impl<E> SetGovKeyWithAggKey<EvmCrypto> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_maybe_old_key: Option<<EvmCrypto as ChainCrypto>::GovKey>,
 		new_gov_key: <EvmCrypto as ChainCrypto>::GovKey,
-	) -> Result<Self, ()> {
+	) -> Result<Self, SetGovKeyWithAggKeyError> {
 		Ok(Self::SetGovKeyWithAggKey(EvmTransactionBuilder::new_unsigned(
 			E::replay_protection(E::key_manager_address()),
 			set_gov_key_with_agg_key::SetGovKeyWithAggKey::new(new_gov_key),

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -205,7 +205,7 @@ impl<E> ExecutexSwapAndCall<Ethereum> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Ethereum>,
 		source_chain: ForeignChain,
 		source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/eth/api.rs
+++ b/state-chain/chains/src/eth/api.rs
@@ -96,7 +96,7 @@ impl<E> SetAggKeyWithAggKey<EvmCrypto> for EthereumApi<E>
 where
 	E: EvmEnvironmentProvider<Ethereum> + ReplayProtectionProvider<Ethereum>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_old_key: Option<<EvmCrypto as ChainCrypto>::AggKey>,
 		new_key: <EvmCrypto as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {

--- a/state-chain/chains/src/evm/api/all_batch.rs
+++ b/state-chain/chains/src/evm/api/all_batch.rs
@@ -222,24 +222,27 @@ mod test_all_batch {
 
 	#[test]
 	fn batch_all_fetches() {
-		let all_batch: Vec<(EthereumApi<MockEnvironment>, Vec<EgressId>)> = AllBatch::new_unsigned(
-			vec![
-				FetchAssetParams {
-					deposit_fetch_id: EvmFetchId::Fetch(eth::Address::from_low_u64_be(CHANNEL_ID)),
-					asset: assets::eth::Asset::Usdc,
-				},
-				FetchAssetParams {
-					deposit_fetch_id: EvmFetchId::DeployAndFetch(CHANNEL_ID),
-					asset: assets::eth::Asset::Eth,
-				},
-				FetchAssetParams {
-					deposit_fetch_id: EvmFetchId::NotRequired,
-					asset: assets::eth::Asset::Eth,
-				},
-			],
-			vec![],
-		)
-		.unwrap();
+		let all_batch: Vec<(EthereumApi<MockEnvironment>, Vec<EgressId>)> =
+			AllBatch::new_unsigned_impl(
+				vec![
+					FetchAssetParams {
+						deposit_fetch_id: EvmFetchId::Fetch(eth::Address::from_low_u64_be(
+							CHANNEL_ID,
+						)),
+						asset: assets::eth::Asset::Usdc,
+					},
+					FetchAssetParams {
+						deposit_fetch_id: EvmFetchId::DeployAndFetch(CHANNEL_ID),
+						asset: assets::eth::Asset::Eth,
+					},
+					FetchAssetParams {
+						deposit_fetch_id: EvmFetchId::NotRequired,
+						asset: assets::eth::Asset::Eth,
+					},
+				],
+				vec![],
+			)
+			.unwrap();
 
 		assert_eq!(all_batch.len(), 1usize);
 		assert_matches!(all_batch[0].0, EthereumApi::AllBatch(..));

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -130,7 +130,7 @@ impl<E> SetAggKeyWithAggKey<PolkadotCrypto> for AssethubApi<E>
 where
 	E: AssethubEnvironment + ReplayProtectionProvider<Assethub>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -150,7 +150,7 @@ impl<E> ExecutexSwapAndCall<Assethub> for AssethubApi<E>
 where
 	E: AssethubEnvironment + ReplayProtectionProvider<Assethub>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Assethub>,
 		_source_chain: ForeignChain,
 		_source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -89,7 +89,7 @@ impl<E> AllBatch<Assethub> for AssethubApi<E>
 where
 	E: AssethubEnvironment + ReplayProtectionProvider<Assethub>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Assethub>>,
 		transfer_params: Vec<(TransferAssetParams<Assethub>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -111,11 +111,11 @@ impl<E> SetGovKeyWithAggKey<PolkadotCrypto> for AssethubApi<E>
 where
 	E: AssethubEnvironment + ReplayProtectionProvider<Assethub>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
-	) -> Result<Self, ()> {
-		let vault = E::try_vault_account().ok_or(())?;
+	) -> Result<Self, SetGovKeyWithAggKeyError> {
+		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::Failed)?;
 
 		Ok(Self::ChangeGovKey(rotate_vault_proxy::extrinsic_builder(
 			E::replay_protection(false),

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -179,7 +179,7 @@ impl<E> TransferFallback<Assethub> for AssethubApi<E>
 where
 	E: AssethubEnvironment + ReplayProtectionProvider<Assethub>,
 {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Assethub>,
 	) -> Result<Self, TransferFallbackError> {
 		Err(TransferFallbackError::Unsupported)

--- a/state-chain/chains/src/hub/api.rs
+++ b/state-chain/chains/src/hub/api.rs
@@ -115,7 +115,7 @@ where
 		maybe_old_key: Option<PolkadotPublicKey>,
 		new_key: PolkadotPublicKey,
 	) -> Result<Self, SetGovKeyWithAggKeyError> {
-		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::Failed)?;
+		let vault = E::try_vault_account().ok_or(SetGovKeyWithAggKeyError::VaultAccountNotSet)?;
 
 		Ok(Self::ChangeGovKey(rotate_vault_proxy::extrinsic_builder(
 			E::replay_protection(false),

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 use ccm_checker::{CcmValidityChecker, CcmValidityError, DecodedCcmAdditionalData};
 use core::{fmt::Display, iter::Step};
+use frame_support::storage::transactional;
 use sol::api::VaultSwapAccountAndSender;
 use sp_std::marker::PhantomData;
 
@@ -597,10 +598,16 @@ pub trait RejectCall<C: Chain>: ApiCall<C::ChainCrypto> {
 }
 
 pub trait AllBatch<C: Chain>: ApiCall<C::ChainCrypto> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<C>>,
 		transfer_params: Vec<(TransferAssetParams<C>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError>;
+	fn new_unsigned(
+		fetch_params: Vec<FetchAssetParams<C>>,
+		transfer_params: Vec<(TransferAssetParams<C>, EgressId)>,
+	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {
+		transactional::with_storage_layer(|| Self::new_unsigned_impl(fetch_params, transfer_params))
+	}
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -560,6 +560,12 @@ impl From<DispatchError> for AllBatchError {
 	}
 }
 
+impl From<DispatchError> for ExecutexSwapAndCallError {
+	fn from(e: DispatchError) -> Self {
+		ExecutexSwapAndCallError::DispatchError(e)
+	}
+}
+
 #[derive(Debug)]
 pub enum ConsolidationError {
 	NotRequired,
@@ -626,6 +632,26 @@ pub enum ExecutexSwapAndCallError {
 
 pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
 	fn new_unsigned(
+		transfer_param: TransferAssetParams<C>,
+		source_chain: ForeignChain,
+		source_address: Option<ForeignChainAddress>,
+		gas_budget: GasAmount,
+		message: Vec<u8>,
+		ccm_additional_data: DecodedCcmAdditionalData,
+	) -> Result<Self, ExecutexSwapAndCallError> {
+		transactional::with_storage_layer(|| {
+			Self::new_unsigned_impl(
+				transfer_param,
+				source_chain,
+				source_address,
+				gas_budget,
+				message,
+				ccm_additional_data,
+			)
+		})
+	}
+
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<C>,
 		source_chain: ForeignChain,
 		source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -486,11 +486,19 @@ pub trait ChainEnvironment<
 pub enum SetAggKeyWithAggKeyError {
 	Failed,
 	FinalTransactionExceededMaxLength,
+	DispatchError(DispatchError),
 }
 
 /// Constructs the `SetAggKeyWithAggKey` api call.
 pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 	fn new_unsigned(
+		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
+		new_key: <C as ChainCrypto>::AggKey,
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
+		transactional::with_storage_layer(|| Self::new_unsigned_impl(maybe_old_key, new_key))
+	}
+
+	fn new_unsigned_impl(
 		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
 		new_key: <C as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, SetAggKeyWithAggKeyError>;
@@ -563,6 +571,12 @@ impl From<DispatchError> for AllBatchError {
 impl From<DispatchError> for ExecutexSwapAndCallError {
 	fn from(e: DispatchError) -> Self {
 		ExecutexSwapAndCallError::DispatchError(e)
+	}
+}
+
+impl From<DispatchError> for SetAggKeyWithAggKeyError {
+	fn from(e: DispatchError) -> Self {
+		SetAggKeyWithAggKeyError::DispatchError(e)
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -548,6 +548,12 @@ pub trait RegisterRedemption: ApiCall<<Ethereum as Chain>::ChainCrypto> {
 pub trait FetchAndCloseSolanaVaultSwapAccounts: ApiCall<<Solana as Chain>::ChainCrypto> {
 	fn new_unsigned(
 		accounts: Vec<VaultSwapAccountAndSender>,
+	) -> Result<Self, SolanaTransactionBuildingError> {
+		transactional::with_storage_layer(|| Self::new_unsigned_impl(accounts))
+	}
+
+	fn new_unsigned_impl(
+		accounts: Vec<VaultSwapAccountAndSender>,
 	) -> Result<Self, SolanaTransactionBuildingError>;
 }
 
@@ -596,6 +602,12 @@ impl From<DispatchError> for SetAggKeyWithAggKeyError {
 impl From<DispatchError> for SetGovKeyWithAggKeyError {
 	fn from(e: DispatchError) -> Self {
 		SetGovKeyWithAggKeyError::DispatchError(e)
+	}
+}
+
+impl From<DispatchError> for SolanaTransactionBuildingError {
+	fn from(e: DispatchError) -> Self {
+		SolanaTransactionBuildingError::DispatchError(e)
 	}
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -491,7 +491,14 @@ pub enum SetAggKeyWithAggKeyError {
 
 #[derive(RuntimeDebug, Clone, PartialEq, Eq)]
 pub enum SetGovKeyWithAggKeyError {
-	Failed,
+	FailedToBuildAPICall,
+	VaultAccountNotSet,
+	CurrentAggKeyUnavailable,
+	NonceUnavailable,
+	ComputePriceUnavailable,
+	SolApiEnvironmentUnavailable,
+	FailedToDecodeKey,
+	UnsupportedChain,
 	DispatchError(DispatchError),
 }
 

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -504,6 +504,12 @@ pub enum SetGovKeyWithAggKeyError {
 
 /// Constructs the `SetAggKeyWithAggKey` api call.
 pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned(
 		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
 		new_key: <C as ChainCrypto>::AggKey,
@@ -511,6 +517,8 @@ pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 		transactional::with_storage_layer(|| Self::new_unsigned_impl(maybe_old_key, new_key))
 	}
 
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned_impl(
 		maybe_old_key: Option<<C as ChainCrypto>::AggKey>,
 		new_key: <C as ChainCrypto>::AggKey,
@@ -519,6 +527,12 @@ pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 
 #[allow(clippy::result_unit_err)]
 pub trait SetGovKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned(
 		maybe_old_key: Option<<C as ChainCrypto>::GovKey>,
 		new_key: <C as ChainCrypto>::GovKey,
@@ -526,6 +540,8 @@ pub trait SetGovKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 		transactional::with_storage_layer(|| Self::new_unsigned_impl(maybe_old_key, new_key))
 	}
 
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned_impl(
 		maybe_old_key: Option<<C as ChainCrypto>::GovKey>,
 		new_key: <C as ChainCrypto>::GovKey,
@@ -553,12 +569,20 @@ pub trait RegisterRedemption: ApiCall<<Ethereum as Chain>::ChainCrypto> {
 }
 
 pub trait FetchAndCloseSolanaVaultSwapAccounts: ApiCall<<Solana as Chain>::ChainCrypto> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned(
 		accounts: Vec<VaultSwapAccountAndSender>,
 	) -> Result<Self, SolanaTransactionBuildingError> {
 		transactional::with_storage_layer(|| Self::new_unsigned_impl(accounts))
 	}
 
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned_impl(
 		accounts: Vec<VaultSwapAccountAndSender>,
 	) -> Result<Self, SolanaTransactionBuildingError>;
@@ -662,10 +686,19 @@ pub trait RejectCall<C: Chain>: ApiCall<C::ChainCrypto> {
 }
 
 pub trait AllBatch<C: Chain>: ApiCall<C::ChainCrypto> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<C>>,
 		transfer_params: Vec<(TransferAssetParams<C>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError>;
+
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned(
 		fetch_params: Vec<FetchAssetParams<C>>,
 		transfer_params: Vec<(TransferAssetParams<C>, EgressId)>,
@@ -689,6 +722,12 @@ pub enum ExecutexSwapAndCallError {
 }
 
 pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned(
 		transfer_param: TransferAssetParams<C>,
 		source_chain: ForeignChain,
@@ -709,6 +748,8 @@ pub trait ExecutexSwapAndCall<C: Chain>: ApiCall<C::ChainCrypto> {
 		})
 	}
 
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<C>,
 		source_chain: ForeignChain,
@@ -730,10 +771,18 @@ pub enum TransferFallbackError {
 }
 
 pub trait TransferFallback<C: Chain>: ApiCall<C::ChainCrypto> {
+	/// DO NOT OVERRIDE THIS METHOD.
+	///
+	/// Instead implement the `new_unsigned_impl` method.
+	///
+	/// This method is executing `new_unsigned_impl` transactional to avoid undefined on-chain
+	/// storage by rolling back all changes if the transaction fails.
 	fn new_unsigned(transfer_param: TransferAssetParams<C>) -> Result<Self, TransferFallbackError> {
 		transactional::with_storage_layer(|| Self::new_unsigned_impl(transfer_param))
 	}
 
+	/// This needs to be implemented for each chain and includes the logic for building the
+	/// transaction. It should return an error if the transaction building has failed.
 	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<C>,
 	) -> Result<Self, TransferFallbackError>;

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -489,6 +489,12 @@ pub enum SetAggKeyWithAggKeyError {
 	DispatchError(DispatchError),
 }
 
+#[derive(RuntimeDebug, Clone, PartialEq, Eq)]
+pub enum SetGovKeyWithAggKeyError {
+	Failed,
+	DispatchError(DispatchError),
+}
+
 /// Constructs the `SetAggKeyWithAggKey` api call.
 pub trait SetAggKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 	fn new_unsigned(
@@ -509,7 +515,14 @@ pub trait SetGovKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
 	fn new_unsigned(
 		maybe_old_key: Option<<C as ChainCrypto>::GovKey>,
 		new_key: <C as ChainCrypto>::GovKey,
-	) -> Result<Self, ()>;
+	) -> Result<Self, SetGovKeyWithAggKeyError> {
+		transactional::with_storage_layer(|| Self::new_unsigned_impl(maybe_old_key, new_key))
+	}
+
+	fn new_unsigned_impl(
+		maybe_old_key: Option<<C as ChainCrypto>::GovKey>,
+		new_key: <C as ChainCrypto>::GovKey,
+	) -> Result<Self, SetGovKeyWithAggKeyError>;
 }
 
 pub trait SetCommKeyWithAggKey<C: ChainCrypto>: ApiCall<C> {
@@ -577,6 +590,12 @@ impl From<DispatchError> for ExecutexSwapAndCallError {
 impl From<DispatchError> for SetAggKeyWithAggKeyError {
 	fn from(e: DispatchError) -> Self {
 		SetAggKeyWithAggKeyError::DispatchError(e)
+	}
+}
+
+impl From<DispatchError> for SetGovKeyWithAggKeyError {
+	fn from(e: DispatchError) -> Self {
+		SetGovKeyWithAggKeyError::DispatchError(e)
 	}
 }
 

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -725,7 +725,7 @@ impl<Env: 'static + SolanaEnvironment> ExecutexSwapAndCall<Solana> for SolanaApi
 }
 
 impl<Env: 'static + SolanaEnvironment> AllBatch<Solana> for SolanaApi<Env> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Solana>>,
 		transfer_params: Vec<(TransferAssetParams<Solana>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -740,7 +740,7 @@ impl<Env: 'static + SolanaEnvironment> AllBatch<Solana> for SolanaApi<Env> {
 }
 
 impl<Env: 'static> TransferFallback<Solana> for SolanaApi<Env> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Solana>,
 	) -> Result<Self, TransferFallbackError> {
 		Err(TransferFallbackError::Unsupported)

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -489,7 +489,6 @@ impl<Environment: SolanaEnvironment> SolanaApi<Environment> {
 					transfer_param,
 					durable_nonce
 				);
-				Environment::recover_durable_nonce(durable_nonce.0);
 			})?,
 			signer: None,
 			_phantom: Default::default(),

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -22,6 +22,7 @@ use frame_support::{CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
+use sp_runtime::DispatchError;
 use sp_std::{collections::btree_set::BTreeSet, vec, vec::Vec};
 
 use crate::{
@@ -154,6 +155,7 @@ pub enum SolanaTransactionBuildingError {
 	InvalidCcm(CcmValidityError),
 	FailedToSerializeFinalTransaction,
 	FinalTransactionExceededMaxLength(u32),
+	DispatchError(DispatchError),
 	AltsNotYetWitnessed,
 	AltsInvalid,
 }
@@ -746,7 +748,7 @@ impl<Env: 'static> TransferFallback<Solana> for SolanaApi<Env> {
 }
 
 impl<Env: 'static + SolanaEnvironment> FetchAndCloseSolanaVaultSwapAccounts for SolanaApi<Env> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		accounts: Vec<VaultSwapAccountAndSender>,
 	) -> Result<Self, SolanaTransactionBuildingError> {
 		Self::fetch_and_batch_close_vault_swap_accounts(accounts)

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -691,7 +691,7 @@ impl<Env: 'static + SolanaEnvironment> SetAggKeyWithAggKey<SolanaCrypto> for Sol
 }
 
 impl<Env: 'static + SolanaEnvironment> ExecutexSwapAndCall<Solana> for SolanaApi<Env> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Solana>,
 		source_chain: cf_primitives::ForeignChain,
 		_source_address: Option<ForeignChainAddress>,

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -373,7 +373,6 @@ impl<Environment: SolanaEnvironment> SolanaApi<Environment> {
 				new_agg_key,
 				durable_nonce
 			);
-			Environment::recover_durable_nonce(durable_nonce.0);
 		})?;
 
 		Ok(Self {
@@ -678,7 +677,7 @@ impl<Env: 'static> ConsolidateCall<Solana> for SolanaApi<Env> {
 }
 
 impl<Env: 'static + SolanaEnvironment> SetAggKeyWithAggKey<SolanaCrypto> for SolanaApi<Env> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_maybe_old_key: Option<<SolanaCrypto as ChainCrypto>::AggKey>,
 		new_key: <SolanaCrypto as ChainCrypto>::AggKey,
 	) -> Result<Option<Self>, crate::SetAggKeyWithAggKeyError> {

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -761,14 +761,14 @@ impl<Environment: SolanaEnvironment> SetGovKeyWithAggKey<SolanaCrypto> for Solan
 		new_gov_key: <SolanaCrypto as ChainCrypto>::GovKey,
 	) -> Result<Self, SetGovKeyWithAggKeyError> {
 		// Lookup environment variables, such as aggkey and durable nonce.
-		let agg_key =
-			Environment::current_agg_key().map_err(|_e| SetGovKeyWithAggKeyError::Failed)?;
-		let sol_api_environment =
-			Environment::api_environment().map_err(|_e| SetGovKeyWithAggKeyError::Failed)?;
-		let compute_price =
-			Environment::compute_price().map_err(|_e| SetGovKeyWithAggKeyError::Failed)?;
-		let durable_nonce =
-			Environment::nonce_account().map_err(|_e| SetGovKeyWithAggKeyError::Failed)?;
+		let agg_key = Environment::current_agg_key()
+			.map_err(|_e| SetGovKeyWithAggKeyError::CurrentAggKeyUnavailable)?;
+		let sol_api_environment = Environment::api_environment()
+			.map_err(|_e| SetGovKeyWithAggKeyError::SolApiEnvironmentUnavailable)?;
+		let compute_price = Environment::compute_price()
+			.map_err(|_e| SetGovKeyWithAggKeyError::ComputePriceUnavailable)?;
+		let durable_nonce = Environment::nonce_account()
+			.map_err(|_e| SetGovKeyWithAggKeyError::NonceUnavailable)?;
 
 		// Build the transaction
 		let transaction = SolanaTransactionBuilder::set_gov_key_with_agg_key(
@@ -790,7 +790,7 @@ impl<Environment: SolanaEnvironment> SetGovKeyWithAggKey<SolanaCrypto> for Solan
 				e,
 				durable_nonce
 			);
-			SetGovKeyWithAggKeyError::Failed
+			SetGovKeyWithAggKeyError::FailedToBuildAPICall
 		})?;
 
 		Ok(Self {

--- a/state-chain/chains/src/sol/api.rs
+++ b/state-chain/chains/src/sol/api.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{RejectCall, SetGovKeyWithAggKeyError};
+use crate::{ccm_checker::VersionedSolanaCcmAdditionalData, RejectCall, SetGovKeyWithAggKeyError};
 use cf_runtime_utilities::log_or_panic;
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::marker::PhantomData;

--- a/state-chain/pallets/cf-tokenholder-governance/src/mock.rs
+++ b/state-chain/pallets/cf-tokenholder-governance/src/mock.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{self as pallet_cf_tokenholder_governance};
-use cf_chains::{Chain, ChainCrypto, Ethereum, ForeignChain};
+use cf_chains::{Chain, ChainCrypto, Ethereum, ForeignChain, SetGovKeyWithAggKeyError};
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_on_account_funded, impl_mock_waived_fees,
 	mocks::fee_payment::MockFeePayment, BroadcastAnyChainGovKey, CommKeyBroadcaster, WaivedFees,
@@ -103,12 +103,12 @@ impl BroadcastAnyChainGovKey for MockBroadcaster {
 		chain: cf_chains::ForeignChain,
 		old_key: Option<Vec<u8>>,
 		new_key: Vec<u8>,
-	) -> Result<(), ()> {
+	) -> Result<(), SetGovKeyWithAggKeyError> {
 		if Self::broadcast_success() {
 			GovKeyBroadcasted::put((chain, old_key, new_key));
 			Ok(())
 		} else {
-			Err(())
+			Err(SetGovKeyWithAggKeyError::Failed)
 		}
 	}
 

--- a/state-chain/pallets/cf-tokenholder-governance/src/mock.rs
+++ b/state-chain/pallets/cf-tokenholder-governance/src/mock.rs
@@ -108,7 +108,7 @@ impl BroadcastAnyChainGovKey for MockBroadcaster {
 			GovKeyBroadcasted::put((chain, old_key, new_key));
 			Ok(())
 		} else {
-			Err(SetGovKeyWithAggKeyError::Failed)
+			Err(SetGovKeyWithAggKeyError::FailedToBuildAPICall)
 		}
 	}
 

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -78,6 +78,13 @@ impl SetAggKeyWithAggKey<MockEthereumChainCrypto> for MockSetAggKeyWithAggKey {
 
 		Ok(Some(Self { old_key: old_key.ok_or(SetAggKeyWithAggKeyError::Failed)?, new_key }))
 	}
+
+	fn new_unsigned_impl(
+		old_key: Option<<<MockEthereum as Chain>::ChainCrypto as ChainCrypto>::AggKey>,
+		new_key: <<MockEthereum as Chain>::ChainCrypto as ChainCrypto>::AggKey,
+	) -> Result<Option<Self>, SetAggKeyWithAggKeyError> {
+		Self::new_unsigned(old_key, new_key)
+	}
 }
 
 impl ApiCall<MockEthereumChainCrypto> for MockSetAggKeyWithAggKey {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -715,13 +715,17 @@ impl TokenholderGovernanceBroadcaster {
 		<B as Broadcaster<C>>::ApiCall: cf_chains::SetGovKeyWithAggKey<C::ChainCrypto>,
 	{
 		let maybe_old_key = if let Some(old_key) = maybe_old_key {
-			Some(Decode::decode(&mut &old_key[..]).or(Err(SetGovKeyWithAggKeyError::Failed))?)
+			Some(
+				Decode::decode(&mut &old_key[..])
+					.or(Err(SetGovKeyWithAggKeyError::FailedToDecodeKey))?,
+			)
 		} else {
 			None
 		};
 		let api_call = SetGovKeyWithAggKey::<C::ChainCrypto>::new_unsigned(
 			maybe_old_key,
-			Decode::decode(&mut &new_key[..]).or(Err(SetGovKeyWithAggKeyError::Failed))?,
+			Decode::decode(&mut &new_key[..])
+				.or(Err(SetGovKeyWithAggKeyError::FailedToDecodeKey))?,
 		)?;
 		B::threshold_sign_and_broadcast(api_call);
 		Ok(())
@@ -743,8 +747,8 @@ impl BroadcastAnyChainGovKey for TokenholderGovernanceBroadcaster {
 				Self::broadcast_gov_key::<Ethereum, EthereumBroadcaster>(maybe_old_key, new_key),
 			ForeignChain::Polkadot =>
 				Self::broadcast_gov_key::<Polkadot, PolkadotBroadcaster>(maybe_old_key, new_key),
-			ForeignChain::Bitcoin => Err(SetGovKeyWithAggKeyError::Failed),
-			ForeignChain::Arbitrum => Err(SetGovKeyWithAggKeyError::Failed),
+			ForeignChain::Bitcoin => Err(SetGovKeyWithAggKeyError::UnsupportedChain),
+			ForeignChain::Arbitrum => Err(SetGovKeyWithAggKeyError::UnsupportedChain),
 			ForeignChain::Solana =>
 				Self::broadcast_gov_key::<Solana, SolanaBroadcaster>(maybe_old_key, new_key),
 			ForeignChain::Assethub =>

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -24,6 +24,8 @@ pub mod safe_mode;
 pub use safe_mode::*;
 mod swapping;
 
+use cf_chains::SetGovKeyWithAggKeyError;
+
 pub use swapping::{
 	SwapOutputAction, SwapOutputActionEncoded, SwapRequestHandler, SwapRequestType,
 	SwapRequestTypeEncoded, SwapType,
@@ -927,7 +929,7 @@ pub trait BroadcastAnyChainGovKey {
 		chain: ForeignChain,
 		old_key: Option<Vec<u8>>,
 		new_key: Vec<u8>,
-	) -> Result<(), ()>;
+	) -> Result<(), SetGovKeyWithAggKeyError>;
 
 	fn is_govkey_compatible(chain: ForeignChain, key: &[u8]) -> bool;
 }

--- a/state-chain/traits/src/mocks/api_call.rs
+++ b/state-chain/traits/src/mocks/api_call.rs
@@ -198,7 +198,7 @@ pub struct MockEthTransferFallback<MockEvmEnvironment> {
 }
 
 impl TransferFallback<Ethereum> for MockEthereumApiCall<MockEvmEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Ethereum>,
 	) -> Result<Self, TransferFallbackError> {
 		if MockEvmEnvironment::lookup(transfer_param.asset).is_none() {
@@ -285,7 +285,7 @@ pub struct MockBtcTransferFallback<MockBtcEnvironment> {
 }
 
 impl TransferFallback<Bitcoin> for MockBitcoinApiCall<MockBtcEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		_transfer_param: TransferAssetParams<Bitcoin>,
 	) -> Result<Self, TransferFallbackError> {
 		Err(TransferFallbackError::Unsupported)

--- a/state-chain/traits/src/mocks/api_call.rs
+++ b/state-chain/traits/src/mocks/api_call.rs
@@ -115,7 +115,7 @@ thread_local! {
 }
 
 impl AllBatch<Ethereum> for MockEthereumApiCall<MockEvmEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Ethereum>>,
 		transfer_params: Vec<(TransferAssetParams<Ethereum>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {
@@ -340,7 +340,7 @@ impl MockBtcAllBatch<MockBtcEnvironment> {
 }
 
 impl AllBatch<Bitcoin> for MockBitcoinApiCall<MockBtcEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		fetch_params: Vec<FetchAssetParams<Bitcoin>>,
 		transfer_params: Vec<(TransferAssetParams<Bitcoin>, EgressId)>,
 	) -> Result<Vec<(Self, Vec<EgressId>)>, AllBatchError> {

--- a/state-chain/traits/src/mocks/api_call.rs
+++ b/state-chain/traits/src/mocks/api_call.rs
@@ -166,7 +166,7 @@ pub struct MockEthExecutexSwapAndCall<MockEvmEnvironment> {
 }
 
 impl ExecutexSwapAndCall<Ethereum> for MockEthereumApiCall<MockEvmEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Ethereum>,
 		source_chain: ForeignChain,
 		source_address: Option<ForeignChainAddress>,
@@ -303,7 +303,7 @@ pub struct MockBtcExecutexSwapAndCall<MockBtcEnvironment> {
 }
 
 impl ExecutexSwapAndCall<Bitcoin> for MockBitcoinApiCall<MockBtcEnvironment> {
-	fn new_unsigned(
+	fn new_unsigned_impl(
 		transfer_param: TransferAssetParams<Bitcoin>,
 		source_chain: ForeignChain,
 		source_address: Option<ForeignChainAddress>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2238

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Modifies the pattern of building a transaction to introduce a default function that automatically wraps the actual call functionality into a transactional wrapper
- This pattern applies only if the `new_unsigned` returns a Result type, since otherwise the call can not fail
- Added a test to verify the general storage rollback