### PR TITLE
feat: timestamp in block update

### DIFF
--- a/state-chain/custom-rpc/src/backend.rs
+++ b/state-chain/custom-rpc/src/backend.rs
@@ -30,7 +30,11 @@ use sc_rpc_spec_v2::chain_head::{
 use serde::Serialize;
 use sp_api::CallApiAt;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
-use state_chain_runtime::{chainflip::BlockUpdate, runtime_apis::CustomRuntimeApi, Hash};
+use state_chain_runtime::{
+	chainflip::{get_header_timestamp, BlockUpdate},
+	runtime_apis::CustomRuntimeApi,
+	Hash,
+};
 use std::{fmt::Debug, marker::PhantomData, num::NonZero, sync::Arc};
 
 /// The CustomRpcBackend struct provides common logic implementation for providing RPC endpoints.
@@ -371,6 +375,7 @@ where
 								Ok(Some(header)) => Some(Ok(BlockUpdate {
 									block_hash: hash,
 									block_number: *header.number(),
+									timestamp: get_header_timestamp(&header).unwrap_or_default(),
 									data: new_item,
 								})),
 								Ok(None) =>

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -22,7 +22,7 @@ use cf_amm::input_amount_from_fee;
 use cf_primitives::AccountId;
 use cf_rpc_apis::{OrderFilled, OrderFills};
 use pallet_cf_pools::{AssetPair, OrderId, Pool};
-use state_chain_runtime::Runtime;
+use state_chain_runtime::{chainflip::get_header_timestamp, Runtime};
 
 pub(crate) fn order_fills_for_block<C, B, BE>(
 	client: &C,
@@ -63,6 +63,7 @@ where
 	Ok(BlockUpdate::<OrderFills> {
 		block_hash: hash,
 		block_number: header.number,
+		timestamp: get_header_timestamp(&header).unwrap_or_default(),
 		data: order_fills_from_block_updates(&prev_pools, &pools, lp_events),
 	})
 }

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -1007,6 +1007,7 @@ pub fn calculate_account_apy(account_id: &AccountId) -> Option<u32> {
 pub struct BlockUpdate<Data> {
 	pub block_hash: Hash,
 	pub block_number: BlockNumber,
+	pub timestamp: u64,
 	// NOTE: Flatten requires Data types to be struct or map
 	// Also flatten is incompatible with u128, so AssetAmounts needs to be String type.
 	#[serde(flatten)]
@@ -1133,4 +1134,14 @@ impl CallIndexer<RuntimeCall> for LpOrderCallIndexer {
 			_ => None,
 		}
 	}
+}
+
+// Timestamp of the header in seconds past the unix epoch.
+pub fn get_header_timestamp(header: &crate::Header) -> Option<u64> {
+	header
+		.digest
+		.logs()
+		.iter()
+		.find_map(missed_authorship_slots::extract_slot_from_digest_item)
+		.map(|slot| slot.saturating_mul(cf_primitives::SECONDS_PER_BLOCK))
 }

--- a/state-chain/runtime/src/chainflip/missed_authorship_slots.rs
+++ b/state-chain/runtime/src/chainflip/missed_authorship_slots.rs
@@ -25,7 +25,7 @@ use crate::System;
 type LastSeenSlot = StorageValue<AuraSlotExtraction, Slot>;
 
 // https://github.com/chainflip-io/substrate/blob/c172d0f683fab3792b90d876fd6ca27056af9fe9/frame/aura/src/lib.rs#L179
-fn extract_slot_from_digest_item(item: &DigestItem) -> Option<Slot> {
+pub fn extract_slot_from_digest_item(item: &DigestItem) -> Option<Slot> {
 	item.as_pre_runtime().and_then(|(id, mut data)| {
 		if id == AURA_ENGINE_ID {
 			Slot::decode(&mut data).ok()


### PR DESCRIPTION
# Pull Request

Closes: PRO-2018

## Checklist

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

Getting the timestamp from the header via the existing `extract_slot_from_digest_item` function.
I think this is not a breaking change because its just adding a field to the `BlockUpdate`.
Tested it on a few subscriptions and checked time is correct.