### PR TITLE
chore: add a command for setting minimum network fee

### DIFF
--- a/bouncer/commands/set_minimum_network_fee.ts
+++ b/bouncer/commands/set_minimum_network_fee.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S pnpm tsx
+import { submitGovernanceExtrinsic } from '../shared/cf_governance';
+import { runWithTimeoutAndExit } from '../shared/utils';
+
+async function main() {
+  const minFee = Number(process.argv[2] ?? 500_000);
+  await submitGovernanceExtrinsic((api) =>
+    api.tx.swapping.updatePalletConfig([
+      { SetMinimumNetworkFee: { minFee } },
+      { SetInternalSwapMinimumNetworkFee: { minFee } },
+    ]),
+  );
+}
+await runWithTimeoutAndExit(main(), 60);


### PR DESCRIPTION
## Summary

Adds another command that can be used for setting the min. network fee (for both internal/regular swaps)
