### PR TITLE
feat: Custom network for any asset

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -442,6 +442,12 @@ pub enum PalletConfigUpdate<T: Config> {
 	/// Set the network fee rate and minimum in USDC that will be used just for internal swaps
 	/// (credit on-chain swaps)
 	SetInternalSwapNetworkFee { rate: Option<Permill>, minimum: Option<AssetAmount> },
+	/// Set a custom network fee for a specific asset. Set to None to remove the custom network fee
+	/// rate for that asset and fallback to the standard network fee.
+	SetNetworkFeeForAsset { asset: Asset, rate: Option<Permill> },
+	/// Set a custom network fee for internal swaps for a specific asset. Set to None to remove the
+	/// custom network fee rate for that asset and fallback to the standard internal network fee.
+	SetInternalSwapNetworkFeeForAsset { asset: Asset, rate: Option<Permill> },
 }
 
 impl_pallet_safe_mode! {
@@ -644,6 +650,19 @@ pub mod pallet {
 	/// swaps).
 	#[pallet::storage]
 	pub type InternalSwapNetworkFee<T: Config> = StorageValue<_, FeeRateAndMinimum, ValueQuery>;
+
+	/// A custom network fee for a specific asset. A swap will use the highest fee rate (custom or
+	/// standard) between the input and output asset.
+	#[pallet::storage]
+	pub type NetworkFeeForAsset<T: Config> =
+		StorageMap<_, Twox64Concat, Asset, Permill, OptionQuery>;
+
+	/// A custom network fee for internal swaps for a specific asset.
+	/// A swap will use the highest fee rate (custom or standard) between the input and output
+	/// asset.
+	#[pallet::storage]
+	pub type InternalSwapNetworkFeeForAsset<T: Config> =
+		StorageMap<_, Twox64Concat, Asset, Permill, OptionQuery>;
 
 	/// Set by the broker, this is the minimum broker commission that the broker will accept for a
 	/// vault swap.
@@ -1021,7 +1040,7 @@ pub mod pallet {
 		#[pallet::weight(<T as frame_system::Config>::SystemWeightInfo::set_storage(updates.len() as u32))]
 		pub fn update_pallet_config(
 			origin: OriginFor<T>,
-			updates: BoundedVec<PalletConfigUpdate<T>, ConstU32<10>>,
+			updates: BoundedVec<PalletConfigUpdate<T>, ConstU32<20>>,
 		) -> DispatchResult {
 			T::EnsureGovernance::ensure_origin(origin)?;
 
@@ -1093,6 +1112,19 @@ pub mod pallet {
 							},
 						}
 					},
+					PalletConfigUpdate::SetNetworkFeeForAsset { asset, rate } => {
+						if let Some(rate) = rate {
+							NetworkFeeForAsset::<T>::insert(asset, rate);
+						} else {
+							NetworkFeeForAsset::<T>::remove(asset);
+						}
+					},
+					PalletConfigUpdate::SetInternalSwapNetworkFeeForAsset { asset, rate } =>
+						if let Some(rate) = rate {
+							InternalSwapNetworkFeeForAsset::<T>::insert(asset, rate);
+						} else {
+							InternalSwapNetworkFeeForAsset::<T>::remove(asset);
+						},
 				}
 				Self::deposit_event(Event::<T>::PalletConfigUpdated { update });
 			}
@@ -2216,6 +2248,31 @@ pub mod pallet {
 			Pallet::<T>::validate_broker_fees(&beneficiaries)?;
 			Ok(beneficiaries)
 		}
+
+		pub(super) fn get_network_fee_for_swap(
+			input_asset: Asset,
+			output_asset: Asset,
+			is_internal_swap: bool,
+		) -> FeeRateAndMinimum {
+			let (input_asset_fee, output_asset_fee, minimum) = if is_internal_swap {
+				let default_fee = InternalSwapNetworkFee::<T>::get();
+				(
+					InternalSwapNetworkFeeForAsset::<T>::get(input_asset)
+						.unwrap_or(default_fee.rate),
+					InternalSwapNetworkFeeForAsset::<T>::get(output_asset)
+						.unwrap_or(default_fee.rate),
+					default_fee.minimum,
+				)
+			} else {
+				let default_fee = NetworkFee::<T>::get();
+				(
+					NetworkFeeForAsset::<T>::get(input_asset).unwrap_or(default_fee.rate),
+					NetworkFeeForAsset::<T>::get(output_asset).unwrap_or(default_fee.rate),
+					default_fee.minimum,
+				)
+			};
+			FeeRateAndMinimum { rate: input_asset_fee.max(output_asset_fee), minimum }
+		}
 	}
 
 	impl<T: Config> SwapRequestHandler for Pallet<T> {
@@ -2317,7 +2374,7 @@ pub mod pallet {
 				SwapRequestType::IngressEgressFee => {
 					// No minimum network fee for ingress/egress fee swaps
 					let fees = vec![FeeType::NetworkFee(NetworkFeeTracker::new_without_minimum(
-						NetworkFee::<T>::get(),
+						Pallet::<T>::get_network_fee_for_swap(input_asset, output_asset, false),
 					))];
 
 					Self::schedule_swap(
@@ -2347,13 +2404,13 @@ pub mod pallet {
 						DcaState::create_with_first_chunk(net_amount, dca_params);
 
 					// Choose correct network fee for the swap
-					let mut fees = vec![FeeType::NetworkFee(
-						if matches!(output_action, SwapOutputAction::CreditOnChain { .. }) {
-							NetworkFeeTracker::new(InternalSwapNetworkFee::<T>::get())
-						} else {
-							NetworkFeeTracker::new(NetworkFee::<T>::get())
-						},
-					)];
+					let mut fees = vec![FeeType::NetworkFee(NetworkFeeTracker::new(
+						Pallet::<T>::get_network_fee_for_swap(
+							input_asset,
+							output_asset,
+							matches!(output_action, SwapOutputAction::CreditOnChain { .. }),
+						),
+					))];
 
 					// Add broker fees if any
 					if !broker_fees.is_empty() {

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -1045,3 +1045,152 @@ fn gas_calculation_can_handle_extreme_swap_rate() {
 		);
 	});
 }
+
+#[test]
+fn test_get_network_fee() {
+	const REGULAR_NETWORK_FEE: u32 = 5;
+	const INTERNAL_SWAP_NETWORK_FEE: u32 = 6;
+	const MINIMUM_NETWORK_FEE: AssetAmount = 123;
+
+	fn test_get_fee(
+		input_asset_fee: (Asset, Option<u32>),
+		output_asset_fee: (Asset, Option<u32>),
+		is_internal: bool,
+		expected_fee: u32,
+	) {
+		new_test_ext().execute_with(|| {
+			// Set the standard network fee
+			if is_internal {
+				InternalSwapNetworkFee::<Test>::set(FeeRateAndMinimum {
+					rate: Permill::from_percent(INTERNAL_SWAP_NETWORK_FEE),
+					minimum: MINIMUM_NETWORK_FEE,
+				});
+			} else {
+				NetworkFee::<Test>::set(FeeRateAndMinimum {
+					rate: Permill::from_percent(REGULAR_NETWORK_FEE),
+					minimum: MINIMUM_NETWORK_FEE,
+				});
+			}
+
+			// Set the custom network fees for the assets
+			if let (asset, Some(fee)) = input_asset_fee {
+				if is_internal {
+					InternalSwapNetworkFeeForAsset::<Test>::insert(
+						asset,
+						Permill::from_percent(fee),
+					);
+				} else {
+					NetworkFeeForAsset::<Test>::insert(asset, Permill::from_percent(fee));
+				}
+			}
+			if let (asset, Some(fee)) = output_asset_fee {
+				if is_internal {
+					InternalSwapNetworkFeeForAsset::<Test>::insert(
+						asset,
+						Permill::from_percent(fee),
+					);
+				} else {
+					NetworkFeeForAsset::<Test>::insert(asset, Permill::from_percent(fee));
+				}
+			}
+
+			// Get the network fee for the swap
+			let fee = Pallet::<Test>::get_network_fee_for_swap(
+				input_asset_fee.0,
+				output_asset_fee.0,
+				is_internal,
+			);
+
+			// Check that the fee rate and minimum are as expected
+			assert_eq!(fee.minimum, MINIMUM_NETWORK_FEE);
+			assert_eq!(fee.rate, Permill::from_percent(expected_fee));
+		});
+	}
+
+	fn test_all(is_internal: bool) {
+		let network_fee = if is_internal { INTERNAL_SWAP_NETWORK_FEE } else { REGULAR_NETWORK_FEE };
+
+		// The normal network fee is used as fallback when no custom fee is set for either asset.
+		test_get_fee((Asset::Flip, None), (Asset::Eth, None), is_internal, network_fee);
+
+		// Test that the normal network fee is used if one asset is not set
+		test_get_fee(
+			(Asset::Flip, Some(network_fee - 1)),
+			(Asset::Eth, None),
+			is_internal,
+			network_fee,
+		);
+		test_get_fee(
+			(Asset::Flip, None),
+			(Asset::Eth, Some(network_fee - 2)),
+			is_internal,
+			network_fee,
+		);
+
+		// Test that the highest fee is always used
+		test_get_fee((Asset::Flip, Some(20)), (Asset::Eth, Some(25)), is_internal, 25);
+		test_get_fee((Asset::Flip, None), (Asset::Eth, Some(25)), is_internal, 25);
+		test_get_fee((Asset::Flip, Some(25)), (Asset::Eth, Some(20)), is_internal, 25);
+	}
+
+	// Run test for both internal and regular swaps
+	test_all(false);
+	test_all(true);
+}
+
+#[test]
+fn test_swap_with_custom_network_fee_for_asset() {
+	const FEE_RATE_FLIP: Permill = Permill::from_percent(10);
+	const FEE_RATE_ETH: Permill = Permill::from_percent(5);
+	const NETWORK_FEE: Permill = Permill::from_percent(1);
+
+	// We expect the higher fee rate to be used.
+	let expected_fee = FEE_RATE_FLIP * INPUT_AMOUNT;
+
+	const SWAP_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+
+	new_test_ext()
+		.execute_with(|| {
+			// Set the swap rate to 1 to make the test simple
+			SwapRate::set(1.0);
+
+			// Set the standard network fee
+			NetworkFee::<Test>::set(FeeRateAndMinimum { rate: NETWORK_FEE, minimum: 0 });
+
+			// Set custom network fees for specific assets
+			NetworkFeeForAsset::<Test>::insert(Asset::Flip, FEE_RATE_FLIP);
+			NetworkFeeForAsset::<Test>::insert(Asset::Eth, FEE_RATE_ETH);
+
+			// Now do a swap
+			Swapping::init_swap_request(
+				Asset::Flip,
+				INPUT_AMOUNT,
+				Asset::Eth,
+				SwapRequestType::Regular {
+					output_action: SwapOutputAction::Egress {
+						output_address: ForeignChainAddress::Eth([1; 20].into()),
+						ccm_deposit_metadata: None,
+					},
+				},
+				Default::default(),
+				None,
+				None,
+				SwapOrigin::Vault {
+					tx_id: TransactionInIdForAnyChain::Evm(H256::default()),
+					broker_id: Some(BROKER),
+				},
+			);
+		})
+		.then_process_blocks_until_block(SWAP_BLOCK)
+		.then_execute_with(|_| {
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapExecuted {
+					input_amount: INPUT_AMOUNT,
+					output_amount,
+					network_fee,
+					..
+				}) if *network_fee == expected_fee && *output_amount == INPUT_AMOUNT - expected_fee
+			);
+		});
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2262 & PRO-2255

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have updated documentation where appropriate.

## Summary

You can set a custom network fee rate (not minimum) for any asset. The swap with look at both the input and output assets network fee rate (custom or standard) and choose the highest.
So to get the desired behaviour of lower fees for internal stable coin swaps, we can send a pallet update gov extrinsic with 
``` ts
[SetInternalSwapNetworkFeeForAsset { asset:"Usdc", rate: 500 } ,
SetInternalSwapNetworkFeeForAsset { asset:"Usdt", rate: 500 } ,
// etc, for all stables
...]
```

- Added 2 new storage items that map a network fee rate to an asset. One for regular and one for internal.
- Added to the update pallet config to be able to set and remove them.
   - Changed the limit on how many updates can be put in a single extrinsic from 10 -> 20. Makes it easier for the unit test.
- Added 2 tests to cover the new behaviour


