### PR TITLE
refactor: solana alt auction uses a BTreeSet instead of Vec as key

### DIFF
--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -228,12 +228,15 @@ impl VoterApi<SolanaAltWitnessing> for SolanaAltWitnessingVoter {
 		_settings: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectoralSettings,
 		alt_witnessing_identifier: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectionProperties,
 	) -> Result<Option<VoteOf<SolanaAltWitnessing>>, anyhow::Error> {
-		lookup_table_witnessing::get_lookup_table_state(&self.client, alt_witnessing_identifier.0)
-			.await
-			// We wrap the vote in a Some here since the vote is always valid if there was no error
-			// in rpc while querying. This is so we come to consensus on "None" if the lookup
-			// table is not found.
-			.map(Some)
+		lookup_table_witnessing::get_lookup_table_state(
+			&self.client,
+			alt_witnessing_identifier.0.into_iter().collect(),
+		)
+		.await
+		// We wrap the vote in a Some here since the vote is always valid if there was no error
+		// in rpc while querying. This is so we come to consensus on "None" if the lookup
+		// table is not found.
+		.map(Some)
 	}
 }
 

--- a/engine/src/witness/sol.rs
+++ b/engine/src/witness/sol.rs
@@ -228,15 +228,12 @@ impl VoterApi<SolanaAltWitnessing> for SolanaAltWitnessingVoter {
 		_settings: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectoralSettings,
 		alt_witnessing_identifier: <SolanaAltWitnessing as ElectoralSystemTypes>::ElectionProperties,
 	) -> Result<Option<VoteOf<SolanaAltWitnessing>>, anyhow::Error> {
-		lookup_table_witnessing::get_lookup_table_state(
-			&self.client,
-			alt_witnessing_identifier.0.into_iter().collect(),
-		)
-		.await
-		// We wrap the vote in a Some here since the vote is always valid if there was no error
-		// in rpc while querying. This is so we come to consensus on "None" if the lookup
-		// table is not found.
-		.map(Some)
+		lookup_table_witnessing::get_lookup_table_state(&self.client, alt_witnessing_identifier.0)
+			.await
+			// We wrap the vote in a Some here since the vote is always valid if there was no error
+			// in rpc while querying. This is so we come to consensus on "None" if the lookup
+			// table is not found.
+			.map(Some)
 	}
 }
 

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -16,6 +16,8 @@
 
 #![cfg(test)]
 
+use std::collections::BTreeSet;
+
 use crate::{self as pallet_cf_environment, Decode, Encode, TypeInfo};
 use cf_chains::{
 	btc::{BitcoinCrypto, BitcoinFeeInfo},
@@ -216,12 +218,12 @@ impl RecoverDurableNonce for MockSolEnvironment {
 
 impl
 	ChainEnvironment<
-		Vec<SolAddress>,
+		BTreeSet<SolAddress>,
 		AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>,
 	> for MockSolEnvironment
 {
 	fn lookup(
-		_alts: Vec<SolAddress>,
+		_alts: BTreeSet<SolAddress>,
 	) -> Option<AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>> {
 		None
 	}

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -114,7 +114,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 pub use signer_nomination::RandomSignerNomination;
 use sp_core::U256;
-use sp_std::prelude::*;
+use sp_std::{collections::btree_set::BTreeSet, prelude::*};
 
 impl Chainflip for Runtime {
 	type RuntimeCall = RuntimeCall;
@@ -687,12 +687,12 @@ impl RecoverDurableNonce for SolEnvironment {
 
 impl
 	ChainEnvironment<
-		Vec<SolAddress>,
+		BTreeSet<SolAddress>,
 		AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>,
 	> for SolEnvironment
 {
 	fn lookup(
-		alts: Vec<SolAddress>,
+		alts: BTreeSet<SolAddress>,
 	) -> Option<AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>> {
 		solana_elections::solana_alt_result(alts)
 	}
@@ -1167,7 +1167,9 @@ impl CcmAdditionalDataHandler for CfCcmAdditionalDataHandler {
 			DecodedCcmAdditionalData::NotRequired => {},
 			DecodedCcmAdditionalData::Solana(versioned_solana_ccm_additional_data) => {
 				versioned_solana_ccm_additional_data.alt_addresses().inspect(|alt_addresses| {
-					solana_elections::initiate_solana_alt_election(alt_addresses.clone())
+					solana_elections::initiate_solana_alt_election(BTreeSet::from_iter(
+						alt_addresses.clone(),
+					))
 				});
 			},
 		}

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -200,7 +200,7 @@ pub type SolanaVaultSwapTracking =
 	Ord,
 	PartialOrd,
 )]
-pub struct SolanaAltWitnessingIdentifier(pub Vec<SolAddress>);
+pub struct SolanaAltWitnessingIdentifier(pub BTreeSet<SolAddress>);
 
 pub type SolanaAltWitnessing = electoral_systems::exact_value::ExactValue<
 	SolanaAltWitnessingIdentifier,
@@ -212,7 +212,7 @@ pub type SolanaAltWitnessing = electoral_systems::exact_value::ExactValue<
 >;
 
 pub fn solana_alt_result(
-	alts: Vec<SolAddress>,
+	alts: BTreeSet<SolAddress>,
 ) -> Option<AltWitnessingConsensusResult<Vec<SolAddressLookupTableAccount>>> {
 	SolanaAltWitnessing::take_election_result::<
 		DerivedElectoralAccess<
@@ -714,7 +714,7 @@ impl FromSolOrNot for SolanaVaultSwapDetails {
 	}
 }
 
-pub(crate) fn initiate_solana_alt_election(alts: Vec<SolAddress>) {
+pub(crate) fn initiate_solana_alt_election(alts: BTreeSet<SolAddress>) {
 	if alts.is_empty() {
 		return
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2261

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Refactored the Solana ALT auction's key to a BTreeSet.
This orders and dedups the alt addresses
