### PR TITLE
fix: Don't filter affiliates with 0 BPS in events

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1176,14 +1176,6 @@ pub mod pallet {
 					dca_parameters.clone(),
 				)?;
 
-			// TODO: deduplicate this with assemble_and_validate_broker_fees
-			let affiliate_fees = affiliate_fees
-				.into_iter()
-				.filter(|beneficiary| beneficiary.bps > 0)
-				.collect::<Vec<_>>()
-				.try_into()
-				.expect("Filtering out will always fit");
-
 			Self::deposit_event(Event::<T>::SwapDepositAddressReady {
 				deposit_address: T::AddressConverter::to_encoded_address(deposit_address),
 				destination_address,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -1500,17 +1500,17 @@ pub mod pallet {
 			if total_fee_bps > MAX_BASIS_POINTS {
 				FeeTaken { remaining_amount: stable_amount, fee: 0 }
 			} else {
-				let total_fee = broker_fees.iter().fold(
-					0u128,
-					|fee_accumulator, Beneficiary { account, bps }| {
+				let total_fee = broker_fees
+					.iter()
+					.filter(|Beneficiary { account: _, bps }| *bps > 0)
+					.fold(0u128, |fee_accumulator, Beneficiary { account, bps }| {
 						let fee = Permill::from_parts(*bps as u32 * BASIS_POINTS_PER_MILLION) *
 							stable_amount;
 
 						T::BalanceApi::credit_account(account, STABLE_ASSET, fee);
 
 						fee_accumulator.saturating_add(fee)
-					},
-				);
+					});
 
 				assert!(total_fee <= stable_amount, "Broker fee cannot be more than the amount");
 
@@ -2269,15 +2269,6 @@ pub mod pallet {
 			let beneficiaries = [Beneficiary { account: broker_id, bps: broker_commission }]
 				.into_iter()
 				.chain(affiliate_fees.iter().cloned())
-				.filter_map(
-					|beneficiary| {
-						if beneficiary.bps > 0 {
-							Some(beneficiary)
-						} else {
-							None
-						}
-					},
-				)
 				.collect::<Vec<_>>()
 				.try_into()
 				.expect(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -392,11 +392,18 @@ fn cannot_swap_with_incorrect_destination_address_type() {
 }
 
 #[test]
-fn expect_swap_id_to_be_emitted() {
+fn affiliates_with_0_bps_and_swap_id_are_getting_emitted_in_events() {
 	const AMOUNT: AssetAmount = 500;
 
 	new_test_ext()
 		.then_execute_at_block(INIT_BLOCK, |_| {
+			let beneficiaries: Beneficiaries<u64> = bounded_vec![
+				Beneficiary { account: BROKER, bps: 0 },
+				Beneficiary { account: 123, bps: 0 },
+			];
+
+			let affiliates: Affiliates<u64> = bounded_vec![Beneficiary { account: 123, bps: 0 },];
+
 			// 1. Request a deposit address -> SwapDepositAddressReady
 			assert_ok!(Swapping::request_swap_deposit_address_with_affiliates(
 				RuntimeOrigin::signed(BROKER),
@@ -406,13 +413,13 @@ fn expect_swap_id_to_be_emitted() {
 				0,
 				None,
 				0,
-				Default::default(),
+				affiliates.clone(),
 				REFUND_PARAMS,
 				None,
 			));
 
 			// 2. Schedule the swap -> SwapScheduled
-			swap_with_custom_broker_fee(Asset::Eth, Asset::Usdc, AMOUNT, bounded_vec![]);
+			swap_with_custom_broker_fee(Asset::Eth, Asset::Usdc, AMOUNT, beneficiaries.clone());
 
 			// 3. Process swaps -> SwapExecuted, SwapEgressScheduled
 			assert_event_sequence!(
@@ -423,12 +430,14 @@ fn expect_swap_id_to_be_emitted() {
 					source_asset: Asset::Eth,
 					destination_asset: Asset::Usdc,
 					channel_id: 0,
+					ref affiliate_fees,
 					..
-				}),
+				}) if *affiliate_fees == affiliates,
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					swap_request_id: SwapRequestId(1),
+					ref broker_fees,
 					..
-				}),
+				}) if *broker_fees == beneficiaries,
 				RuntimeEvent::Swapping(Event::SwapScheduled {
 					swap_request_id: SwapRequestId(1),
 					swap_id: SwapId(1),


### PR DESCRIPTION
# Pull Request

Closes: PRO-2270

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- Removed explicit filter for SwapDepositAddressReady
- Moved filtering of beneficiaries into take_broker_fees fuction
