### PR TITLE
chore: rename eth clients to name different to subscription request name

### DIFF
--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/arb.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/arb.rs
@@ -64,7 +64,7 @@ where
 			nodes,
 			env_params.arb_chain_id.into(),
 			"arb_rpc",
-			"arb_subscribe",
+			"arb_subscribe_client",
 			"Arbitrum",
 			Arbitrum::WITNESS_PERIOD,
 		)?

--- a/api/bin/chainflip-ingress-egress-tracker/src/witnessing/eth.rs
+++ b/api/bin/chainflip-ingress-egress-tracker/src/witnessing/eth.rs
@@ -67,7 +67,7 @@ where
 			nodes,
 			env_params.eth_chain_id.into(),
 			"eth_rpc",
-			"eth_subscribe",
+			"eth_subscribe_client",
 			"Ethereum",
 			Ethereum::WITNESS_PERIOD,
 		)?

--- a/engine/src/evm/retry_rpc.rs
+++ b/engine/src/evm/retry_rpc.rs
@@ -582,7 +582,7 @@ mod tests {
 					settings.eth.nodes,
 					U256::from(1337u64),
 					"eth_rpc",
-					"eth_subscribe",
+					"eth_subscribe_client",
 					"Ethereum",
 					Ethereum::WITNESS_PERIOD,
 				)

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -265,7 +265,7 @@ async fn run_main(
 					settings.eth.nodes,
 					expected_eth_chain_id,
 					"eth_rpc",
-					"eth_subscribe",
+					"eth_subscribe_client",
 					"Ethereum",
 					cf_chains::Ethereum::WITNESS_PERIOD,
 				)?
@@ -285,7 +285,7 @@ async fn run_main(
 					settings.arb.nodes,
 					expected_arb_chain_id,
 					"arb_rpc",
-					"arb_subscribe",
+					"arb_subscribe_client",
 					"Arbitrum",
 					cf_chains::Arbitrum::WITNESS_PERIOD,
 				)?

--- a/engine/src/witness/arb.rs
+++ b/engine/src/witness/arb.rs
@@ -318,7 +318,7 @@ mod tests {
 						NodeContainer { primary: WsHttpEndpoints { ws_endpoint: "ws://localhost:8548".into(), http_endpoint: "http://localhost:8547".into()}, backup: None },
 						expected_arb_chain_id,
 						"arb_rpc",
-						"arb_subscribe",
+						"arb_subscribe_client",
 						"Arbitrum",
 						Arbitrum::WITNESS_PERIOD,
 					).unwrap()

--- a/engine/src/witness/evm/evm_deposits.rs
+++ b/engine/src/witness/evm/evm_deposits.rs
@@ -418,7 +418,7 @@ mod tests {
 					settings.eth.nodes,
 					U256::from(1337u64),
 					"eth_rpc",
-					"eth_subscribe",
+					"eth_subscribe_client",
 					"Ethereum",
 					Ethereum::WITNESS_PERIOD,
 				)

--- a/engine/src/witness/evm/key_manager.rs
+++ b/engine/src/witness/evm/key_manager.rs
@@ -225,7 +225,7 @@ mod tests {
 					},
 					U256::from(1337u64),
 					"eth_rpc",
-					"eth_subscribe",
+					"eth_subscribe_client",
 					"Ethereum",
 					Ethereum::WITNESS_PERIOD,
 				)


### PR DESCRIPTION
# Pull Request

Closes: PRO-2277

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

`eth_subscribe` is the name of the subscription request, so calling the client the same thing can be confusing. Particularly when we also have `arb_subscribe` and an `arb_subscribe` request does not exist.
