### PR TITLE
chore: increase stream timeout for hub

### DIFF
--- a/engine/src/witness/hub/hub_source.rs
+++ b/engine/src/witness/hub/hub_source.rs
@@ -101,7 +101,7 @@ impl<C> HubUnfinalisedSource<C> {
 	}
 }
 
-const TIMEOUT: Duration = Duration::from_secs(20);
+const TIMEOUT: Duration = Duration::from_secs(36);
 const RESTART_STREAM_DELAY: Duration = Duration::from_secs(6);
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

We just carried over the timeout from Polkadot, but we should increase it since an AssetHub block is 12 seconds. 
