### PR TITLE
feat: support for internal swaps and asset specific network fees in swap rate RPC

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -753,6 +753,7 @@ pub trait CustomApi {
 		ccm_data: Option<CcmData>,
 		exclude_fees: Option<BTreeSet<FeeTypes>>,
 		additional_orders: Option<Vec<SwapRateV2AdditionalOrder>>,
+		is_internal: Option<bool>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutputV2>;
 	#[method(name = "required_asset_ratio_for_range_order")]
@@ -1473,6 +1474,7 @@ where
 			None,
 			None,
 			additional_orders,
+			None,
 			at,
 		)
 	}
@@ -1487,6 +1489,7 @@ where
 		ccm_data: Option<CcmData>,
 		exclude_fees: Option<BTreeSet<FeeTypes>>,
 		additional_orders: Option<Vec<SwapRateV2AdditionalOrder>>,
+		is_internal: Option<bool>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<RpcSwapOutputV2> {
 		let amount = amount
@@ -1544,6 +1547,7 @@ where
 					ccm_data,
 					exclude_fees.unwrap_or_default(),
 					additional_orders,
+					is_internal,
 				)?
 				.map(|simulated_swap_info_v2| {
 					into_rpc_swap_output(simulated_swap_info_v2, from_asset, to_asset)

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2274,7 +2274,7 @@ pub mod pallet {
 			Ok(beneficiaries)
 		}
 
-		pub(super) fn get_network_fee_for_swap(
+		pub fn get_network_fee_for_swap(
 			input_asset: Asset,
 			output_asset: Asset,
 			is_internal_swap: bool,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1711,6 +1711,7 @@ impl_runtime_apis! {
 			ccm_data: Option<CcmData>,
 			exclude_fees: BTreeSet<FeeTypes>,
 			additional_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
+			is_internal: Option<bool>,
 		) -> Result<SimulatedSwapInformation, DispatchErrorWithMessage> {
 			if let Some(additional_orders) = additional_orders {
 				for (index, additional_order) in additional_orders.into_iter().enumerate() {
@@ -1811,7 +1812,11 @@ impl_runtime_apis! {
 
 			if include_fee(FeeTypes::Network) {
 				fees_vec.push(FeeType::NetworkFee(NetworkFeeTracker::new(
-					pallet_cf_swapping::NetworkFee::<Runtime>::get(),
+					pallet_cf_swapping::Pallet::<Runtime>::get_network_fee_for_swap(
+						input_asset,
+						output_asset,
+						is_internal.unwrap_or(false),
+					),
 				)));
 			}
 

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -459,6 +459,7 @@ decl_runtime_apis!(
 			ccm_data: Option<CcmData>,
 			exclude_fees: BTreeSet<FeeTypes>,
 			additional_limit_orders: Option<Vec<SimulateSwapAdditionalOrder>>,
+			is_internal: Option<bool>,
 		) -> Result<SimulatedSwapInformation, DispatchErrorWithMessage>;
 		fn cf_pool_info(
 			base_asset: Asset,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2281

## Checklist

- [x] I am confident that the code works.
- [ ] I have updated documentation where appropriate.

## Summary

- Added an optional `is_internal` param to the `cf_pool_swap_rate_v3`.
- Also now supports the new custom network fee rates for any asset.
