### PR TITLE
chore: optimize encode/decode/typeinfo bounds

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -33,7 +33,7 @@ use pallet_cf_elections::{
 	electoral_systems::{
 		block_height_tracking::{
 			primitives::{Header, NonemptyContinuousHeaders},
-			ChainTypes, HWTypes, HeightWitnesserProperties,
+			BHWTypes, ChainTypes, HeightWitnesserProperties,
 		},
 		block_witnesser::state_machine::{BWElectionProperties, BWElectionType},
 	},

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -33,7 +33,7 @@ use pallet_cf_elections::{
 	electoral_systems::{
 		block_height_tracking::{
 			primitives::{Header, NonemptyContinuousHeaders},
-			BHWTypes, ChainTypes, HeightWitnesserProperties,
+			ChainTypes, HeightWitnesserProperties,
 		},
 		block_witnesser::state_machine::{BWElectionProperties, BWElectionType},
 	},
@@ -127,9 +127,9 @@ impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter 
 					"bht: election_property=0, best_block_height={}, submitting last 6 blocks.",
 					best_block_header.block_height
 				);
-				best_block_header.block_height.saturating_sub(
-					TypesFor::<BitcoinBlockHeightTracking>::BLOCK_BUFFER_SIZE as u64,
-				)
+				best_block_header
+					.block_height
+					.saturating_sub(BitcoinChain::SAFETY_BUFFER as u64)
 			} else {
 				latest_block_height
 			};

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -43,7 +43,7 @@ use sp_core::bounded::alloc::collections::VecDeque;
 use state_chain_runtime::{
 	chainflip::{
 		bitcoin_elections::{
-			BitcoinBlockHeightTracking, BitcoinBlockHeightTrackingES,
+			BitcoinBlockHeightTracking, BitcoinBlockHeightTrackingES, BitcoinChain,
 			BitcoinDepositChannelWitnessingES, BitcoinElectoralSystemRunner, BitcoinLiveness,
 		},
 		elections::TypesFor,
@@ -90,18 +90,17 @@ impl VoterApi<BitcoinBlockHeightTrackingES> for BitcoinBlockHeightTrackingVoter 
 
 		let mut headers = VecDeque::new();
 
-		let header_from_btc_header =
-			|header: BlockHeader| -> anyhow::Result<Header<TypesFor<BitcoinBlockHeightTracking>>> {
-				Ok(Header {
-					block_height: header.height,
-					hash: header.hash.to_byte_array().into(),
-					parent_hash: header
-						.previous_block_hash
-						.ok_or_else(|| anyhow::anyhow!("No parent hash"))?
-						.to_byte_array()
-						.into(),
-				})
-			};
+		let header_from_btc_header = |header: BlockHeader| -> anyhow::Result<Header<BitcoinChain>> {
+			Ok(Header {
+				block_height: header.height,
+				hash: header.hash.to_byte_array().into(),
+				parent_hash: header
+					.previous_block_hash
+					.ok_or_else(|| anyhow::anyhow!("No parent hash"))?
+					.to_byte_array()
+					.into(),
+			})
+		};
 
 		let get_header = |index: BlockNumber| {
 			async move {

--- a/state-chain/pallets/cf-elections/src/electoral_system.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_system.rs
@@ -54,9 +54,9 @@ impl<ES: ElectoralSystemTypes> ConsensusVotes<ES> {
 
 /// A trait for defining all relevant types of an electoral system.
 pub trait ElectoralSystemTypes: 'static + Sized {
-	type ValidatorId: Parameter + Member + MaybeSerializeDeserialize;
+	type ValidatorId: Parameter + Member;
 
-	type StateChainBlockNumber: Parameter + Member + Ord + MaybeSerializeDeserialize;
+	type StateChainBlockNumber: Parameter + Member + Ord;
 
 	/// This is intended for storing any internal state of the ElectoralSystem. It is not
 	/// synchronised and therefore should only be used by the ElectoralSystem, and not be consumed
@@ -64,6 +64,9 @@ pub trait ElectoralSystemTypes: 'static + Sized {
 	///
 	/// Also note that if this state is changed that will not cause election's consensus to be
 	/// retested.
+	///
+	/// Note: This has the `MaybeSerializeDeserialize` bound because it appears in the genesis
+	/// config of the elections pallet, which has to be (de-)serializable.
 	type ElectoralUnsynchronisedState: Parameter + Member + MaybeSerializeDeserialize;
 	/// This is intended for storing any internal state of the ElectoralSystem. It is not
 	/// synchronised and therefore should only be used by the ElectoralSystem, and not be consumed
@@ -87,11 +90,17 @@ pub trait ElectoralSystemTypes: 'static + Sized {
 	///
 	/// Also note that if these settings are changed that will not cause election's consensus to be
 	/// retested.
+	///
+	/// Note: This has the `MaybeSerializeDeserialize` bound because it appears in the genesis
+	/// config of the elections pallet, which has to be (de-)serializable.
 	type ElectoralUnsynchronisedSettings: Parameter + Member + MaybeSerializeDeserialize;
 
 	/// Settings of the electoral system. These settings are synchronised with
 	/// elections, so all engines will have a consistent view of the electoral settings to use for a
 	/// given election.
+	///
+	/// Note: This has the `MaybeSerializeDeserialize` bound because it appears in the genesis
+	/// config of the elections pallet, which has to be (de-)serializable.
 	type ElectoralSettings: Parameter + Member + MaybeSerializeDeserialize + Eq;
 
 	/// Extra data stored along with the UniqueMonotonicIdentifier as part of the

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -32,7 +32,7 @@ pub trait ChainTypes: Ord + Clone + Debug + 'static {
 	/// IMPORTANT: this value must always be greater than the safety margin we use, and represent
 	/// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and in
 	/// the BlockProcessor
-	const SAFETY_BUFFER: u32;
+	const SAFETY_BUFFER: usize;
 }
 pub type ChainBlockNumberOf<T> = <T as ChainTypes>::ChainBlockNumber;
 pub type ChainBlockHashOf<T> = <T as ChainTypes>::ChainBlockHash;
@@ -40,9 +40,6 @@ pub type ChainBlockHashOf<T> = <T as ChainTypes>::ChainBlockHash;
 pub trait BHWTypes: Ord + Clone + Debug + Sized + 'static {
 	type Chain: ChainTypes;
 	type BlockHeightChangeHook: Hook<HookTypeFor<Self, BlockHeightChangeHook>> + CommonTraits;
-
-	// TODO remove this one, replace by SAFETY_MARGIN
-	const BLOCK_BUFFER_SIZE: usize;
 }
 
 pub struct BlockHeightChangeHook;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -19,7 +19,7 @@ pub mod consensus;
 pub mod primitives;
 pub mod state_machine;
 
-pub trait CommonTraits = Debug + Clone + Serde;
+pub trait CommonTraits = Debug + Clone + Serde + Encode + Decode;
 
 pub trait ChainBlockNumberTrait =
 	CommonTraits + SaturatingStep + Step + BlockZero + Copy + Ord + 'static + Sized + Validate;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -37,7 +37,7 @@ pub trait ChainTypes: Ord + Clone + Debug + 'static {
 pub type ChainBlockNumberOf<T> = <T as ChainTypes>::ChainBlockNumber;
 pub type ChainBlockHashOf<T> = <T as ChainTypes>::ChainBlockHash;
 
-pub trait HWTypes: Ord + Clone + Debug + Sized + 'static {
+pub trait BHWTypes: Ord + Clone + Debug + Sized + 'static {
 	type Chain: ChainTypes;
 	type BlockHeightChangeHook: Hook<HookTypeFor<Self, BlockHeightChangeHook>> + CommonTraits;
 
@@ -46,14 +46,14 @@ pub trait HWTypes: Ord + Clone + Debug + Sized + 'static {
 }
 
 pub struct BlockHeightChangeHook;
-impl<T: HWTypes> HookType for HookTypeFor<T, BlockHeightChangeHook> {
+impl<T: BHWTypes> HookType for HookTypeFor<T, BlockHeightChangeHook> {
 	type Input = ChainBlockNumberOf<T::Chain>;
 	type Output = ();
 }
 
 defx! {
 	#[cfg_attr(test, derive(Arbitrary))]
-	pub struct HeightWitnesserProperties[T: HWTypes] {
+	pub struct HeightWitnesserProperties[T: BHWTypes] {
 		/// An election starts with a given block number,
 		/// meaning that engines have to submit all blocks they know of starting with this height.
 		pub witness_from_index: <T::Chain as ChainTypes>::ChainBlockNumber,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -2,12 +2,12 @@ use core::{iter::Step, ops::RangeInclusive};
 
 use super::{
 	block_witnesser::state_machine::HookTypeFor,
-	state_machine::core::{Hook, HookType, Serde, Validate},
+	state_machine::core::{defx, Hook, HookType, Serde, Validate},
 };
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
 use derive_where::derive_where;
-use frame_support::ensure;
+use primitives::{Header, NonemptyContinuousHeaders};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug};
@@ -19,100 +19,68 @@ pub mod consensus;
 pub mod primitives;
 pub mod state_machine;
 
+trait CommonTraits = Debug + Clone + Serde;
+
+pub trait ChainBlockNumberTrait =
+	SaturatingStep + Step + BlockZero + Debug + Copy + Ord + Serde + 'static + Sized + Validate;
+pub trait ChainBlockHashTrait = Validate + Serde + Ord + Clone + Debug + 'static;
+
 pub trait ChainTypes: Ord + Clone + Debug + 'static {
-	type ChainBlockNumber: SaturatingStep
-		+ Step
-		+ BlockZero
-		+ Debug
-		+ Copy
-		+ Ord
-		+ Serde
-		+ 'static
-		+ Sized
-		+ Validate;
-	type ChainBlockHash: Validate + Serde + Ord + Clone + Debug + 'static;
+	type ChainBlockNumber: ChainBlockNumberTrait;
+	type ChainBlockHash: ChainBlockHashTrait;
 
 	/// IMPORTANT: this value must always be greater than the safety margin we use, and represent
 	/// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and in
 	/// the BlockProcessor
 	const SAFETY_BUFFER: u32;
 }
+pub type ChainBlockNumberOf<T: ChainTypes> = T::ChainBlockNumber;
+pub type ChainBlockHashOf<T: ChainTypes> = T::ChainBlockHash;
 
-pub trait HWTypes: ChainTypes {
+pub trait HWTypes: Ord + Clone + Debug + Sized + 'static {
+	type Chain: ChainTypes;
+	type BlockHeightChangeHook: Hook<HookTypeFor<Self, BlockHeightChangeHook>> + CommonTraits;
+
+	// TODO remove this one, replace by SAFETY_MARGIN
 	const BLOCK_BUFFER_SIZE: usize;
-
-	type BlockHeightChangeHook: Hook<HookTypeFor<Self, BlockHeightChangeHook>>;
 }
 
 pub struct BlockHeightChangeHook;
 impl<T: HWTypes> HookType for HookTypeFor<T, BlockHeightChangeHook> {
-	type Input = T::ChainBlockNumber;
+	type Input = ChainBlockNumberOf<T::Chain>;
 	type Output = ();
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive_where(
 	Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd;
-	T::ChainBlockNumber: Debug + Clone + Copy + Eq + Ord
 )]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub struct HeightWitnesserProperties<T: ChainTypes> {
+pub struct HeightWitnesserProperties<T: HWTypes> {
 	/// An election starts with a given block number,
 	/// meaning that engines have to submit all blocks they know of starting with this height.
-	pub witness_from_index: T::ChainBlockNumber,
+	pub witness_from_index: <T::Chain as ChainTypes>::ChainBlockNumber,
 }
 
-#[derive(
-	Debug,
-	Clone,
-	PartialEq,
-	Eq, // T::ChainBlockNumber: Debug + Clone + Ord
-	Encode,
-	Decode,
-	TypeInfo,
-	Deserialize,
-	Serialize,
-)]
-pub enum ChainProgress<ChainBlockNumber: Ord, ChainBlockHash> {
-	// Range of new block heights witnessed. If this is not consecutive, it means that
-	Range(BTreeMap<ChainBlockNumber, ChainBlockHash>, RangeInclusive<ChainBlockNumber>),
-	Reorg(BTreeMap<ChainBlockNumber, ChainBlockHash>, RangeInclusive<ChainBlockNumber>),
-	// Range of new block heights, only emitted when there is a consensus for the first time after
-	// being started.
-	// FirstConsensus(BTreeMap<T::ChainBlockNumber, T::ChainBlockHash>,
-	// RangeInclusive<T::ChainBlockNumber>), there was no update to the witnessed block headers
-	None,
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
+pub enum ChainProgressType {
+	Continous,
+	Reorg,
 }
-pub type ChainProgressFor<T> =
-	ChainProgress<<T as ChainTypes>::ChainBlockNumber, <T as ChainTypes>::ChainBlockHash>;
 
-impl<ChainBlockNumber: Ord + Step, ChainBlockHash> Validate
-	for ChainProgress<ChainBlockNumber, ChainBlockHash>
-{
-	type Error = &'static str;
-
-	fn is_valid(&self) -> Result<(), Self::Error> {
-		use ChainProgress::*;
-		match self {
-			Range(hashes, range) | Reorg(hashes, range) => {
-				ensure!(
-					range.start() <= range.end(),
-					"range a..=b in ChainProgress should have a <= b"
-				);
-				ensure!(
-					hashes.keys().all(|key| range.contains(key)),
-					"hashes should all be inside the range"
-				);
-				ensure!(
-					range.clone().all(|key| hashes.contains_key(&key)),
-					"all heights should have an attached hash"
-				);
-				Ok(())
-			},
-			None => Ok(()),
-		}
+defx! {
+	pub struct ChainProgress[T: ChainTypes] {
+		pub headers: NonemptyContinuousHeaders<T>,
+		pub removed: Option<RangeInclusive<ChainBlockNumberOf<T>>>,
 	}
+
+	validate _this (else ChainProgressError) {
+		// TODO: ensure that the defx macro calls the is_valid
+		// on `headers` automatically!
+	}
+
 }
+pub type ChainProgressFor<T> = ChainProgress<T>;
 
 //-------- implementation of block height tracking as a state machine --------------
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -7,6 +7,7 @@ use super::{
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
 use derive_where::derive_where;
+use frame_support::pallet_prelude::MaybeSerializeDeserialize;
 use primitives::{Header, NonemptyContinuousHeaders};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
@@ -19,7 +20,7 @@ pub mod consensus;
 pub mod primitives;
 pub mod state_machine;
 
-pub trait CommonTraits = Debug + Clone + Serde + Encode + Decode;
+pub trait CommonTraits = Debug + Clone + Encode + Decode + MaybeSerializeDeserialize + Eq;
 
 pub trait ChainBlockNumberTrait =
 	CommonTraits + SaturatingStep + Step + BlockZero + Copy + Ord + 'static + Sized + Validate;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/consensus.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/consensus.rs
@@ -7,7 +7,7 @@ use crate::electoral_systems::state_machine::consensus::{
 };
 
 pub struct BlockHeightTrackingConsensus<T: HWTypes> {
-	votes: Vec<NonemptyContinuousHeaders<T>>,
+	votes: Vec<NonemptyContinuousHeaders<T::Chain>>,
 }
 
 impl<T: HWTypes> Default for BlockHeightTrackingConsensus<T> {
@@ -17,8 +17,8 @@ impl<T: HWTypes> Default for BlockHeightTrackingConsensus<T> {
 }
 
 impl<T: HWTypes> ConsensusMechanism for BlockHeightTrackingConsensus<T> {
-	type Vote = NonemptyContinuousHeaders<T>;
-	type Result = NonemptyContinuousHeaders<T>;
+	type Vote = NonemptyContinuousHeaders<T::Chain>;
+	type Result = NonemptyContinuousHeaders<T::Chain>;
 	type Settings = (Threshold, HeightWitnesserProperties<T>);
 
 	fn insert_vote(&mut self, vote: Self::Vote) {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/consensus.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/consensus.rs
@@ -1,22 +1,22 @@
 use cf_chains::witness_period::BlockZero;
 use sp_std::{collections::vec_deque::VecDeque, vec::Vec};
 
-use super::{primitives::NonemptyContinuousHeaders, HWTypes, HeightWitnesserProperties};
+use super::{primitives::NonemptyContinuousHeaders, BHWTypes, HeightWitnesserProperties};
 use crate::electoral_systems::state_machine::consensus::{
 	ConsensusMechanism, MultipleVotes, StagedConsensus, SupermajorityConsensus, Threshold,
 };
 
-pub struct BlockHeightTrackingConsensus<T: HWTypes> {
+pub struct BlockHeightTrackingConsensus<T: BHWTypes> {
 	votes: Vec<NonemptyContinuousHeaders<T::Chain>>,
 }
 
-impl<T: HWTypes> Default for BlockHeightTrackingConsensus<T> {
+impl<T: BHWTypes> Default for BlockHeightTrackingConsensus<T> {
 	fn default() -> Self {
 		Self { votes: Default::default() }
 	}
 }
 
-impl<T: HWTypes> ConsensusMechanism for BlockHeightTrackingConsensus<T> {
+impl<T: BHWTypes> ConsensusMechanism for BlockHeightTrackingConsensus<T> {
 	type Vote = NonemptyContinuousHeaders<T::Chain>;
 	type Result = NonemptyContinuousHeaders<T::Chain>;
 	type Settings = (Threshold, HeightWitnesserProperties<T>);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
@@ -4,7 +4,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::collections::vec_deque::VecDeque;
 
-use crate::electoral_systems::state_machine::core::{both, defx};
+use crate::electoral_systems::state_machine::core::{both, def_derive, defx};
 
 use super::{super::state_machine::core::Validate, ChainProgress, ChainTypes};
 
@@ -100,14 +100,13 @@ impl<T: ChainTypes> NonemptyContinuousHeaders<T> {
 	}
 }
 
-/// Information returned if the `merge` function for `NonEmptyContinuousHeaders` was successful.
-#[derive(
-	// Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize, Ord, PartialOrd,
-	Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Ord, PartialOrd,
-)]
-pub struct MergeInfo<T: ChainTypes> {
-	pub removed: VecDeque<Header<T>>,
-	pub added: VecDeque<Header<T>>,
+def_derive! {
+	/// Information returned if the `merge` function for `NonEmptyContinuousHeaders` was successful.
+	#[derive(Ord, PartialOrd,)]
+	pub struct MergeInfo<T: ChainTypes> {
+		pub removed: VecDeque<Header<T>>,
+		pub added: VecDeque<Header<T>>,
+	}
 }
 impl<T: ChainTypes> MergeInfo<T> {
 	pub fn into_chain_progress(&self) -> Option<ChainProgress<T>> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
@@ -102,7 +102,8 @@ impl<T: ChainTypes> NonemptyContinuousHeaders<T> {
 
 /// Information returned if the `merge` function for `NonEmptyContinuousHeaders` was successful.
 #[derive(
-	Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize, Ord, PartialOrd,
+	// Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize, Ord, PartialOrd,
+	Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Ord, PartialOrd,
 )]
 pub struct MergeInfo<T: ChainTypes> {
 	pub removed: VecDeque<Header<T>>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
@@ -8,7 +8,7 @@ use sp_std::collections::vec_deque::VecDeque;
 
 use crate::electoral_systems::state_machine::core::{both, defx};
 
-use super::{super::state_machine::core::Validate, ChainProgress, ChainProgressFor, ChainTypes};
+use super::{super::state_machine::core::Validate, ChainProgress, ChainTypes};
 
 //------------------------ inputs ---------------------------
 
@@ -99,7 +99,7 @@ pub struct MergeInfo<T: ChainTypes> {
 }
 
 impl<T: ChainTypes> MergeInfo<T> {
-	pub fn into_chain_progress(&self) -> Option<ChainProgressFor<T>> {
+	pub fn into_chain_progress(&self) -> Option<ChainProgress<T>> {
 		if self.added.is_empty() {
 			None
 		} else {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/primitives.rs
@@ -1,4 +1,4 @@
-use core::ops::{Range, RangeInclusive};
+use core::ops::Range;
 
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
@@ -8,9 +8,7 @@ use sp_std::collections::vec_deque::VecDeque;
 
 use crate::electoral_systems::state_machine::core::defx;
 
-use super::{
-	super::state_machine::core::Validate, ChainProgress, ChainProgressFor, ChainTypes, HWTypes,
-};
+use super::{super::state_machine::core::Validate, ChainProgress, ChainProgressFor, ChainTypes};
 
 //------------------------ inputs ---------------------------
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -1,8 +1,8 @@
 use super::{
-	super::state_machine::{
-		core::Validate, state_machine::Statemachine, state_machine_es::SMInput,
+	super::state_machine::{core::Validate, state_machine::Statemachine},
+	primitives::{
+		trim_to_length, MergeFailure, NonemptyContinuousHeaders, NonemptyContinuousHeadersError,
 	},
-	primitives::{trim_to_length, Header, MergeFailure, NonemptyContinuousHeaders},
 	ChainProgress, ChainProgressFor, HWTypes, HeightWitnesserProperties,
 };
 use crate::electoral_systems::state_machine::{
@@ -14,10 +14,15 @@ use codec::{Decode, Encode};
 use itertools::Either;
 use scale_info::{prelude::format, TypeInfo};
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::vec_deque::VecDeque, fmt::Debug, vec::Vec};
+use sp_std::{fmt::Debug, vec::Vec};
+
+#[derive(Debug, PartialEq)]
+pub enum VoteValidationError<T: HWTypes> {
+	BlockNotMatchingRequestedHeight,
+	NonemptyContinuousHeadersError(NonemptyContinuousHeadersError<T>),
+}
 
 //------------------------ state ---------------------------
-
 defx! {
 
 	pub enum BHWState[T: HWTypes] {
@@ -39,14 +44,8 @@ defx! {
 	}
 }
 
-#[derive(Debug, PartialEq)]
-pub enum VoteValidationError<T: HWTypes> {
-	BlockNotMatchingRequestedHeight,
-	NonemptyContinuousHeadersError(NonemptyContinuousHeadersError<T>),
-}
-
+//------------------------ state machine ---------------------------
 defx! {
-
 	#[derive(Default)]
 	pub struct BlockHeightWitnesser[T: HWTypes] {
 		pub state: BHWState<T>,
@@ -54,170 +53,153 @@ defx! {
 	}
 
 	validate _this (else BlockHeightWitnesserError) {}
-
-	impl AbstractApi {
-		type Query = HeightWitnesserProperties<T>;
-		type Response = NonemptyContinuousHeaders<T>;
-		type Error = VoteValidationError<T>;
-
-		fn validate(
-			base: &HeightWitnesserProperties<T>,
-			this: &NonemptyContinuousHeaders<T>,
-		) -> Result<(), Self::Error> {
-			this.is_valid().map_err(VoteValidationError::NonemptyContinuousHeadersError)?;
-
-			if base.witness_from_index.is_zero() {
+}
+impl<T: HWTypes> AbstractApi for BlockHeightWitnesser<T> {
+	type Query = HeightWitnesserProperties<T>;
+	type Response = NonemptyContinuousHeaders<T>;
+	type Error = VoteValidationError<T>;
+	fn validate(
+		base: &HeightWitnesserProperties<T>,
+		this: &NonemptyContinuousHeaders<T>,
+	) -> Result<(), Self::Error> {
+		this.is_valid().map_err(VoteValidationError::NonemptyContinuousHeadersError)?;
+		if base.witness_from_index.is_zero() {
+			Ok(())
+		} else {
+			if this.first().block_height == base.witness_from_index {
 				Ok(())
 			} else {
-				if this.first().block_height == base.witness_from_index {
-					Ok(())
-				} else {
-					Err(VoteValidationError::BlockNotMatchingRequestedHeight)
+				Err(VoteValidationError::BlockNotMatchingRequestedHeight)
+			}
+		}
+	}
+}
+impl<T: HWTypes> Statemachine for BlockHeightWitnesser<T> {
+	type State = BlockHeightWitnesser<T>;
+	type Context = ();
+	type Settings = ();
+	type Output = Result<ChainProgressFor<T>, &'static str>;
+	fn input_index(s: &mut Self::State) -> Vec<Self::Query> {
+		let witness_from_index = match s.state {
+			BHWState::Starting => T::ChainBlockNumber::zero(),
+			BHWState::Running { headers: _, witness_from } => witness_from,
+		};
+		Vec::from([HeightWitnesserProperties { witness_from_index }])
+	}
+	#[cfg(test)]
+	fn step_specification(
+		before: &mut Self::State,
+		input: &crate::electoral_systems::state_machine::state_machine::InputOf<Self>,
+		_output: &Self::Output,
+		_settings: &Self::Settings,
+		after: &Self::State,
+	) {
+		use cf_chains::witness_period::SaturatingStep;
+		use BHWState::*;
+		match (&before.state, &after.state) {
+			(Starting, Starting) => assert!(
+				*input == Either::Left(()),
+				"BHW should remain in Starting state only if it doesn't get a vote as input."
+			),
+
+			(Starting, Running { .. }) => (),
+
+			(Running { .. }, Starting) =>
+				panic!("BHW should never transit into Starting state once its running."),
+
+			(
+				Running { headers: headers0, witness_from: from0 },
+				Running { headers: headers1, witness_from: from1 },
+			) => {
+				assert!(
+					// there are two different cases:
+					// - in case of a reorg, the `witness_from` is reset to the beginning of the
+					//   headers we have:
+					(*from1 == headers0.first().block_height)
+					||
+					// - in the normal case, the `witness_from` should always be the next
+					//   height after the last header that we have
+					(*from1 == headers1.last().block_height.saturating_forward(1)),
+					"witness_from should be either next height, or height of first header"
+				);
+
+				assert!(
+					// if the input is *not* the empty context, then `witness_from` should
+					// always change after running the transition function.
+					// This ensures that we always have "fresh" election properties,
+					// and are thus deleting/recreating elections as expected.
+					(*input == Either::Left(())) || (*from1 != *from0),
+					"witness_from should always change, except when we get a non-vote input"
+				);
+			},
+		}
+	}
+	fn step(
+		s: &mut Self::State,
+		input: Either<Self::Context, (Self::Query, Self::Response)>,
+		_settings: &(),
+	) -> Self::Output {
+		let new_headers = match input {
+			Either::Left(_) => return Ok(ChainProgress::None),
+			Either::Right((_properties, consensus)) => consensus,
+		};
+		match &mut s.state {
+			BHWState::Starting => {
+				let first = new_headers.headers.front().unwrap().block_height;
+				let last = new_headers.headers.back().unwrap().block_height;
+				s.state = BHWState::Running {
+					headers: new_headers.clone(),
+					witness_from: last.saturating_forward(1),
+				};
+				let hashes = new_headers
+					.headers
+					.into_iter()
+					.map(|hash| (hash.block_height, hash.hash))
+					.collect();
+				Ok(ChainProgress::Range(hashes, first..=last))
+			},
+			BHWState::Running { headers, witness_from } => {
+				let mut chainblocks = headers.clone();
+				match chainblocks.merge(new_headers) {
+					Ok(merge_info) => {
+						log::info!(
+							"added new blocks: {:?}, replacing these blocks: {:?}",
+							merge_info.added,
+							merge_info.removed
+						);
+
+						let _ = trim_to_length(&mut chainblocks.headers, T::BLOCK_BUFFER_SIZE);
+
+						*headers = chainblocks;
+						*witness_from =
+							headers.headers.back().unwrap().block_height.saturating_forward(1);
+
+						let highest_seen = headers.headers.back().unwrap().block_height;
+						s.block_height_update.run(highest_seen);
+
+						// if we merge after a reorg, and the blocks we got are the same
+						// as the ones we previously had, then `into_chain_progress` might
+						// return `None`. In that case we return our current state.
+						Ok(merge_info.into_chain_progress().unwrap_or(ChainProgress::None))
+					},
+					Err(MergeFailure::ReorgWithUnknownRoot {
+						new_block,
+						existing_wrong_parent,
+					}) => {
+						log::info!("detected a reorg: got block {new_block:?} whose parent hash does not match the parent block we have recorded: {existing_wrong_parent:?}");
+						*witness_from = headers.headers.front().unwrap().block_height;
+						Ok(ChainProgress::None)
+					},
+
+					Err(MergeFailure::InternalError(reason)) => {
+						let str = format!("internal error in block height tracker: {reason}");
+						log::error!("internal error in block height tracker: {reason}");
+						Err(str.leak())
+					},
 				}
-			}
+			},
 		}
 	}
-
-	impl Statemachine {
-		type State = BlockHeightWitnesser<T>;
-		type Context = ();
-		type Settings = ();
-		type Output = Result<ChainProgressFor<T>, &'static str>;
-
-		fn input_index(s: &mut Self::State) -> Vec<Self::Query> {
-			let witness_from_index = match s.state {
-				BHWState::Starting => T::ChainBlockNumber::zero(),
-				BHWState::Running { headers: _, witness_from } => witness_from,
-			};
-			Vec::from([HeightWitnesserProperties { witness_from_index }])
-		}
-
-		/*
-
-		// specification for step function
-		#[cfg(test)]
-		fn step_specification(
-			before: &mut Self::State,
-			input: &Self::Input,
-			_output: &Self::Output,
-			_settings: &Self::Settings,
-			after: &Self::State,
-		) {
-			use cf_chains::witness_period::SaturatingStep;
-
-			use BHWState::*;
-
-			match (&before.state, &after.state) {
-				(Starting, Starting) => assert!(
-					*input == SMInput::Context(()),
-					"BHW should remain in Starting state only if it doesn't get a vote as input."
-				),
-
-				(Starting, Running { .. }) => (),
-
-				(Running { .. }, Starting) =>
-					panic!("BHW should never transit into Starting state once its running."),
-
-				(
-					Running { headers: headers0, witness_from: from0 },
-					Running { headers: headers1, witness_from: from1 },
-				) => {
-					assert!(
-						// there are two different cases:
-						// - in case of a reorg, the `witness_from` is reset to the beginning of the
-						//   headers we have:
-						(*from1 == headers0.front().unwrap().block_height)
-						||
-						// - in the normal case, the `witness_from` should always be the next
-						//   height after the last header that we have
-						(*from1 == headers1.back().unwrap().block_height.saturating_forward(1)),
-						"witness_from should be either next height, or height of first header"
-					);
-
-					assert!(
-						// if the input is *not* the empty context, then `witness_from` should
-						// always change after running the transition function.
-						// This ensures that we always have "fresh" election properties,
-						// and are thus deleting/recreating elections as expected.
-						(*input == SMInput::Context(())) || (*from1 != *from0),
-						"witness_from should always change, except when we get a non-vote input"
-					);
-				},
-			}
-		}
-
-		*/
-
-		fn step(
-			s: &mut Self::State,
-			input: Either<Self::Context, (Self::Query, Self::Response)>,
-			_settings: &(),
-		) -> Self::Output {
-			let new_headers = match input {
-				Either::Left(_) => return Ok(ChainProgress::None),
-				Either::Right((_properties, consensus)) => consensus,
-			};
-
-			match &mut s.state {
-				BHWState::Starting => {
-					let first = new_headers.headers.front().unwrap().block_height;
-					let last = new_headers.headers.back().unwrap().block_height;
-					s.state = BHWState::Running {
-						headers: new_headers.clone(),
-						witness_from: last.saturating_forward(1),
-					};
-					let hashes = new_headers
-						.headers
-						.into_iter()
-						.map(|hash| (hash.block_height, hash.hash))
-						.collect();
-					Ok(ChainProgress::Range(hashes, first..=last))
-				},
-
-				BHWState::Running { headers, witness_from } => {
-					let mut chainblocks = headers.clone();
-
-					match chainblocks.merge(new_headers) {
-						Ok(merge_info) => {
-							log::info!(
-								"added new blocks: {:?}, replacing these blocks: {:?}",
-								merge_info.added,
-								merge_info.removed
-							);
-
-							let _ = trim_to_length(&mut chainblocks.headers, T::BLOCK_BUFFER_SIZE);
-
-							*headers = chainblocks;
-							*witness_from = headers.headers.back().unwrap().block_height.saturating_forward(1);
-
-							let highest_seen = headers.headers.back().unwrap().block_height;
-							s.block_height_update.run(highest_seen);
-
-							// if we merge after a reorg, and the blocks we got are the same
-							// as the ones we previously had, then `into_chain_progress` might
-							// return `None`. In that case we return our current state.
-							Ok(merge_info.into_chain_progress().unwrap_or(ChainProgress::None))
-						},
-						Err(MergeFailure::ReorgWithUnknownRoot {
-							new_block,
-							existing_wrong_parent,
-						}) => {
-							log::info!("detected a reorg: got block {new_block:?} whose parent hash does not match the parent block we have recorded: {existing_wrong_parent:?}");
-							*witness_from = headers.headers.front().unwrap().block_height;
-							Ok(ChainProgress::None)
-						},
-
-						Err(MergeFailure::InternalError(reason)) => {
-							let str = format!("internal error in block height tracker: {reason}");
-							log::error!("internal error in block height tracker: {reason}");
-							Err(str.leak())
-						},
-					}
-				},
-			}
-		}
-	}
-
 }
 
 //------------------------ state machine ---------------------------

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -2,9 +2,7 @@ use super::{
 	super::state_machine::{
 		core::Validate, state_machine::Statemachine, state_machine_es::SMInput,
 	},
-	primitives::{
-		trim_to_length, Header, MergeFailure, NonemptyContinuousHeaders, VoteValidationError,
-	},
+	primitives::{trim_to_length, Header, MergeFailure, NonemptyContinuousHeaders},
 	ChainProgress, ChainProgressFor, HWTypes, HeightWitnesserProperties,
 };
 use crate::electoral_systems::state_machine::{
@@ -13,7 +11,6 @@ use crate::electoral_systems::state_machine::{
 };
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
-use frame_support::pallet_prelude::MaxEncodedLen;
 use itertools::Either;
 use scale_info::{prelude::format, TypeInfo};
 use serde::{Deserialize, Serialize};
@@ -42,6 +39,11 @@ defx! {
 	}
 }
 
+#[derive(Debug, PartialEq)]
+pub enum VoteValidationError<T: HWTypes> {
+	BlockNotMatchingRequestedHeight,
+	NonemptyContinuousHeadersError(NonemptyContinuousHeadersError<T>),
+}
 
 defx! {
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -194,11 +194,12 @@ pub enum VoteValidationError<C: ChainTypes> {
 
 #[cfg(test)]
 pub mod tests {
+
 	use crate::{
 		electoral_systems::{
 			block_height_tracking::{
 				primitives::NonemptyContinuousHeaders, BlockHeightChangeHook, ChainBlockHashOf,
-				ChainBlockNumberOf, ChainTypes,
+				ChainBlockHashTrait, ChainBlockNumberOf, ChainBlockNumberTrait, ChainTypes,
 			},
 			block_witnesser::state_machine::HookTypeFor,
 			state_machine::core::{hook_test_utils::MockHook, Serde, TypesFor, Validate},
@@ -215,7 +216,7 @@ pub mod tests {
 		prop_oneof,
 	};
 	use serde::{Deserialize, Serialize};
-	use sp_std::{fmt::Debug, iter::Step};
+	use sp_std::{fmt::Debug, vec::Vec};
 
 	use super::{
 		super::{
@@ -276,20 +277,8 @@ pub mod tests {
 		})
 	}
 
-	impl<
-			N: Validate
-				+ Serde
-				+ Copy
-				+ Ord
-				+ SaturatingStep
-				+ Step
-				+ BlockZero
-				+ Debug
-				+ Default
-				+ 'static,
-			H: Validate + Serde + Ord + Clone + Debug + 'static,
-			D: Validate + Serde + Ord + Clone + Debug + 'static,
-		> ChainTypes for TypesFor<(N, H, D)>
+	impl<N: ChainBlockNumberTrait, H: ChainBlockHashTrait, D: 'static> ChainTypes
+		for TypesFor<(N, H, D)>
 	{
 		type ChainBlockNumber = N;
 		type ChainBlockHash = H;
@@ -298,20 +287,8 @@ pub mod tests {
 		const SAFETY_BUFFER: usize = 16;
 	}
 
-	impl<
-			N: Validate
-				+ Serde
-				+ Copy
-				+ Ord
-				+ SaturatingStep
-				+ Step
-				+ BlockZero
-				+ sp_std::fmt::Debug
-				+ Default
-				+ 'static,
-			H: Validate + Serde + Ord + Clone + Debug + 'static,
-			D: Validate + Serde + Ord + Clone + Debug + 'static,
-		> BHWTypes for TypesFor<(N, H, D)>
+	impl<N: ChainBlockNumberTrait, H: ChainBlockHashTrait, D: 'static> BHWTypes
+		for TypesFor<(N, H, D)>
 	{
 		type BlockHeightChangeHook = MockHook<HookTypeFor<Self, BlockHeightChangeHook>>;
 		type Chain = Self;
@@ -319,7 +296,7 @@ pub mod tests {
 
 	#[test]
 	pub fn test_dsm() {
-		BlockHeightWitnesser::<TypesFor<(u32, Vec<char>, ())>>::test(
+		BlockHeightWitnesser::<TypesFor<(u32, Vec<u8>, ())>>::test(
 			module_path!(),
 			generate_state(),
 			Just(()),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -1,8 +1,7 @@
 use super::{
 	super::state_machine::{core::Validate, state_machine::Statemachine},
 	primitives::{MergeFailure, NonemptyContinuousHeaders, NonemptyContinuousHeadersError},
-	ChainBlockNumberOf, ChainProgress, ChainProgressFor, ChainTypes, HWTypes,
-	HeightWitnesserProperties,
+	ChainBlockNumberOf, ChainProgress, ChainTypes, HWTypes, HeightWitnesserProperties,
 };
 use crate::electoral_systems::state_machine::{
 	core::{defx, Hook},

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -202,9 +202,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	///   - `BPChainProgress::reorg(range)` for a reorganization event, where `range` defines the
 	///     blocks affected.
 	pub fn process_chain_progress(&mut self, progress: BPChainProgress<T::Chain>) {
-		let expiry = progress
-			.highest_block_height
-			.saturating_forward(T::Chain::SAFETY_BUFFER as usize);
+		let expiry = progress.highest_block_height.saturating_forward(T::Chain::SAFETY_BUFFER);
 
 		if let Some(heights) = progress.removed_block_heights.clone() {
 			for n in heights {
@@ -323,7 +321,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// Removes old block data and events based on the SAFETY_BUFFER
 	fn clean_old(&mut self, last_height: ChainBlockNumberOf<T::Chain>) {
 		let removed_blocks = self.blocks_data.extract_if(|block_number, _| {
-			block_number.saturating_forward(T::Chain::SAFETY_BUFFER as usize) <= last_height
+			block_number.saturating_forward(T::Chain::SAFETY_BUFFER) <= last_height
 		});
 		let removed_events =
 			self.processed_events.extract_if(|_, expiry_block| *expiry_block <= last_height);
@@ -513,7 +511,7 @@ pub(crate) mod tests {
 		);
 		assert_eq!(
 			processor.blocks_data.len(),
-			Types::SAFETY_BUFFER as usize,
+			Types::SAFETY_BUFFER,
 			"Max Types::SAFETY_BUFFER (16) blocks stored at any time"
 		);
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -6,7 +6,7 @@ use core::{
 use crate::electoral_systems::{
 	block_height_tracking::{ChainBlockNumberOf, ChainProgress, ChainTypes},
 	block_witnesser::{primitives::ChainProgressInner, state_machine::BWProcessorTypes},
-	state_machine::core::{Hook, Validate},
+	state_machine::core::{def_derive, Hook, Validate},
 };
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
@@ -74,30 +74,31 @@ impl<BlockData> BlockProcessingInfo<BlockData> {
 		BlockProcessingInfo { block_data, next_age_to_process: Default::default(), safety_margin }
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
-pub enum BlockProcessorEvent<T: BWProcessorTypes> {
-	NewBlock {
-		height: ChainBlockNumberOf<T::Chain>,
-		data: T::BlockData,
-	},
-	ProcessingBlockForAges {
-		height: ChainBlockNumberOf<T::Chain>,
-		ages: Range<u32>,
-	},
-	DeleteBlock((ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>)),
-	DeleteEvents(Vec<T::Event>),
-	StoreReorgedEvents {
-		block: (ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>),
-		events: Vec<T::Event>,
-		new_block_number: ChainBlockNumberOf<T::Chain>,
-	},
-	UpdatingExpiry {
-		event: T::Event,
-		from: ChainBlockNumberOf<T::Chain>,
-		to: ChainBlockNumberOf<T::Chain>,
-		safety_margin: u32,
-		range: RangeInclusive<ChainBlockNumberOf<T::Chain>>,
-	},
+def_derive! {
+	pub enum BlockProcessorEvent<T: BWProcessorTypes> {
+		NewBlock {
+			height: ChainBlockNumberOf<T::Chain>,
+			data: T::BlockData,
+		},
+		ProcessingBlockForAges {
+			height: ChainBlockNumberOf<T::Chain>,
+			ages: Range<u32>,
+		},
+		DeleteBlock((ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>)),
+		DeleteEvents(Vec<T::Event>),
+		StoreReorgedEvents {
+			block: (ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>),
+			events: Vec<T::Event>,
+			new_block_number: ChainBlockNumberOf<T::Chain>,
+		},
+		UpdatingExpiry {
+			event: T::Event,
+			from: ChainBlockNumberOf<T::Chain>,
+			to: ChainBlockNumberOf<T::Chain>,
+			safety_margin: u32,
+			range: RangeInclusive<ChainBlockNumberOf<T::Chain>>,
+		},
+	}
 }
 
 pub struct BPChainProgress<T: ChainTypes> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -5,19 +5,13 @@ use core::{
 
 use crate::electoral_systems::{
 	block_witnesser::{primitives::ChainProgressInner, state_machine::BWProcessorTypes},
-	state_machine::core::{hook_test_utils::MockHook, Hook, Validate},
+	state_machine::core::{Hook, Validate},
 };
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
 use derive_where::derive_where;
 use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
-use sp_std::{
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-	fmt::Debug,
-	marker::PhantomData,
-	vec,
-	vec::Vec,
-};
+use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, marker::PhantomData, vec, vec::Vec};
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -49,7 +49,7 @@ use proptest_derive::Arbitrary;
 ///     - `Execute`: A hook to dedup and execute generated events.
 /// 	- `LogEventHook`: A hook to log events, used for testing
 #[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize)]
 pub struct BlockProcessor<T: BWProcessorTypes> {
 	/// A mapping from block numbers to their corresponding BlockInfo (block data, the next age to
 	/// be processed and the safety margin). The "age" represents the block height difference
@@ -74,7 +74,7 @@ impl<BlockData> BlockProcessingInfo<BlockData> {
 		BlockProcessingInfo { block_data, next_age_to_process: Default::default(), safety_margin }
 	}
 }
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub enum BlockProcessorEvent<T: BWProcessorTypes> {
 	NewBlock {
 		height: ChainBlockNumberOf<T::Chain>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -4,6 +4,7 @@ use core::{
 };
 
 use crate::electoral_systems::{
+	block_height_tracking::{ChainBlockNumberOf, ChainProgress, ChainTypes},
 	block_witnesser::{primitives::ChainProgressInner, state_machine::BWProcessorTypes},
 	state_machine::core::{Hook, Validate},
 };
@@ -48,7 +49,7 @@ use proptest_derive::Arbitrary;
 ///     - `Execute`: A hook to dedup and execute generated events.
 /// 	- `LogEventHook`: A hook to log events, used for testing
 #[derive_where(Debug, Clone, PartialEq, Eq;
-	T::ChainBlockNumber: Debug + Clone + Eq,
+	ChainBlockNumberOf<T::Chain>: Debug + Clone + Eq,
 	T::BlockData: Debug + Clone + Eq,
 	T::Event: Debug + Clone + Eq,
 	T::Rules: Debug + Clone + Eq,
@@ -57,7 +58,7 @@ use proptest_derive::Arbitrary;
 )]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
 #[codec(encode_bound(
-	T::ChainBlockNumber: Encode,
+	ChainBlockNumberOf<T::Chain>: Encode,
 	T::BlockData: Encode,
 	T::Event: Encode,
 	T::Rules: Encode,
@@ -69,10 +70,10 @@ pub struct BlockProcessor<T: BWProcessorTypes> {
 	/// be processed and the safety margin). The "age" represents the block height difference
 	/// between head of the chain and block that we are processing, and it's used to know what
 	/// rules have already been processed for such block
-	pub blocks_data: BTreeMap<T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>>,
+	pub blocks_data: BTreeMap<ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>>,
 	/// A mapping from event to their corresponding expiration block_number (which is defined as
 	/// block_number + safety margin)
-	pub processed_events: BTreeMap<T::Event, T::ChainBlockNumber>,
+	pub processed_events: BTreeMap<T::Event, ChainBlockNumberOf<T::Chain>>,
 	pub rules: T::Rules,
 	pub execute: T::Execute,
 	pub log_event: T::LogEventHook,
@@ -91,27 +92,43 @@ impl<BlockData> BlockProcessingInfo<BlockData> {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
 pub enum BlockProcessorEvent<T: BWProcessorTypes> {
 	NewBlock {
-		height: T::ChainBlockNumber,
+		height: ChainBlockNumberOf<T::Chain>,
 		data: T::BlockData,
 	},
 	ProcessingBlockForAges {
-		height: T::ChainBlockNumber,
+		height: ChainBlockNumberOf<T::Chain>,
 		ages: Range<u32>,
 	},
-	DeleteBlock((T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>)),
+	DeleteBlock((ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>)),
 	DeleteEvents(Vec<T::Event>),
 	StoreReorgedEvents {
-		block: (T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>),
+		block: (ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>),
 		events: Vec<T::Event>,
-		new_block_number: T::ChainBlockNumber,
+		new_block_number: ChainBlockNumberOf<T::Chain>,
 	},
 	UpdatingExpiry {
 		event: T::Event,
-		from: T::ChainBlockNumber,
-		to: T::ChainBlockNumber,
+		from: ChainBlockNumberOf<T::Chain>,
+		to: ChainBlockNumberOf<T::Chain>,
 		safety_margin: u32,
-		range: RangeInclusive<T::ChainBlockNumber>,
+		range: RangeInclusive<ChainBlockNumberOf<T::Chain>>,
 	},
+}
+
+pub struct BPChainProgress<T: ChainTypes> {
+	pub highest_block_height: T::ChainBlockNumber,
+	pub removed_block_heights: Option<RangeInclusive<T::ChainBlockNumber>>,
+}
+impl<T: ChainTypes> BPChainProgress<T> {
+	fn up_to(highest_block_height: T::ChainBlockNumber) -> Self {
+		Self { highest_block_height, removed_block_heights: None }
+	}
+	fn reorg(
+		highest_block_height: T::ChainBlockNumber,
+		removed_block_heights: RangeInclusive<T::ChainBlockNumber>,
+	) -> Self {
+		Self { highest_block_height, removed_block_heights: Some(removed_block_heights) }
+	}
 }
 
 impl<BlockWitnessingProcessorDefinition: BWProcessorTypes> Default
@@ -131,11 +148,11 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// Processes incoming block data and chain progress updates.
 	pub fn process_block_data_and_chain_progress(
 		&mut self,
-		chain_progress: ChainProgressInner<T::ChainBlockNumber>,
-		block_data: (T::ChainBlockNumber, T::BlockData, u32),
+		progress: BPChainProgress<T::Chain>,
+		block_data: (ChainBlockNumberOf<T::Chain>, T::BlockData, u32),
 	) {
 		self.process_block_data(block_data);
-		self.process_chain_progress(chain_progress);
+		self.process_chain_progress(progress);
 	}
 
 	/// This method adds new Block Data to the BlockProcessor
@@ -145,7 +162,11 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// - `block_data`: A tuple `(block_number, block_data, safety_margin)`
 	pub fn process_block_data(
 		&mut self,
-		(block_number, block_data, safety_margin): (T::ChainBlockNumber, T::BlockData, u32),
+		(block_number, block_data, safety_margin): (
+			ChainBlockNumberOf<T::Chain>,
+			T::BlockData,
+			u32,
+		),
 	) {
 		self.log_event.run(BlockProcessorEvent::NewBlock {
 			height: block_number.clone(),
@@ -177,41 +198,44 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// # Parameters
 	///
 	/// - `chain_progress`: Indicates the current state of the blockchain. It can either be:
-	///   - `ChainProgressInner::Progress(last_height)` for a simple progress update.
-	///   - `ChainProgressInner::Reorg(range)` for a reorganization event, where `range` defines the
+	///   - `BPChainProgress::up_to(last_height)` for a simple progress update.
+	///   - `BPChainProgress::reorg(range)` for a reorganization event, where `range` defines the
 	///     blocks affected.
-	pub fn process_chain_progress(
-		&mut self,
-		chain_progress: ChainProgressInner<T::ChainBlockNumber>,
-	) {
-		let last_block: T::ChainBlockNumber;
-		match chain_progress {
-			ChainProgressInner::Progress(last_height) => {
-				last_block = last_height;
-			},
-			ChainProgressInner::Reorg(range) => {
-				last_block = *range.start();
-				let expiry = range.end().saturating_forward(T::SAFETY_BUFFER as usize);
-				for n in range.clone() {
-					if let Some(block_info) = self.blocks_data.remove(&n) {
-						let age_range: Range<u32> = 0..block_info.next_age_to_process;
-						self.process_rules_for_ages_and_block(
-							n,
-							age_range,
-							&block_info.block_data,
-							block_info.safety_margin,
-						)
-						.iter()
-						.for_each(|(_, event)| {
-							self.processed_events.insert(event.clone(), expiry);
-						});
-					}
+	pub fn process_chain_progress(&mut self, progress: BPChainProgress<T::Chain>) {
+		let expiry = progress
+			.highest_block_height
+			.saturating_forward(T::Chain::SAFETY_BUFFER as usize);
+
+		if let Some(heights) = progress.removed_block_heights.clone() {
+			for n in heights {
+				self.blocks_data.remove(&n);
+				if let Some(block_info) = self.blocks_data.remove(&n) {
+					let age_range: Range<u32> = 0..block_info.next_age_to_process;
+					self.process_rules_for_ages_and_block(
+						n,
+						age_range,
+						&block_info.block_data,
+						block_info.safety_margin,
+					)
+					.iter()
+					.for_each(|(_, event)| {
+						self.processed_events.insert(event.clone(), expiry);
+					});
 				}
-			},
+			}
 		}
-		let events = self.process_rules(last_block);
+
+		let events = self.process_rules(progress.highest_block_height);
 		self.execute.run(events);
-		self.clean_old(last_block);
+		self.clean_old(progress.highest_block_height);
+	}
+
+	fn process_reorg(removed_block_heights: RangeInclusive<ChainBlockNumberOf<T::Chain>>) {}
+
+	fn process_up_to(&mut self, highest_block_height: ChainBlockNumberOf<T::Chain>) {
+		let events = self.process_rules(highest_block_height);
+		self.execute.run(events);
+		self.clean_old(highest_block_height);
 	}
 
 	/// Processes the stored block data to generate events by applying the provided rules.
@@ -230,11 +254,12 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// A vector of (block height, events (`T::Event`)) generated during the processing rules.
 	fn process_rules(
 		&mut self,
-		last_height: T::ChainBlockNumber,
-	) -> Vec<(T::ChainBlockNumber, T::Event)> {
-		let mut last_events: Vec<(T::ChainBlockNumber, T::Event)> = vec![];
+		last_height: ChainBlockNumberOf<T::Chain>,
+	) -> Vec<(ChainBlockNumberOf<T::Chain>, T::Event)> {
+		let mut last_events: Vec<(ChainBlockNumberOf<T::Chain>, T::Event)> = vec![];
 		for (block_height, mut block_info) in self.blocks_data.clone() {
-			let new_age = T::ChainBlockNumber::steps_between(&block_height, &last_height).0;
+			let new_age =
+				ChainBlockNumberOf::<T::Chain>::steps_between(&block_height, &last_height).0;
 			// We ensure that we don't break anything in case the new age < next_age_to_process
 			if new_age as u32 >= block_info.next_age_to_process {
 				let age_range: Range<u32> =
@@ -281,12 +306,12 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	/// any event already processed.
 	fn process_rules_for_ages_and_block(
 		&mut self,
-		block_number: T::ChainBlockNumber,
+		block_number: ChainBlockNumberOf<T::Chain>,
 		age: Range<u32>,
 		data: &T::BlockData,
 		safety_margin: u32,
-	) -> Vec<(T::ChainBlockNumber, T::Event)> {
-		let events: Vec<(T::ChainBlockNumber, T::Event)> =
+	) -> Vec<(ChainBlockNumberOf<T::Chain>, T::Event)> {
+		let events: Vec<(ChainBlockNumberOf<T::Chain>, T::Event)> =
 			self.rules.run((block_number, age, data.clone(), safety_margin));
 
 		events
@@ -296,9 +321,9 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 	}
 
 	/// Removes old block data and events based on the SAFETY_BUFFER
-	fn clean_old(&mut self, last_height: T::ChainBlockNumber) {
+	fn clean_old(&mut self, last_height: ChainBlockNumberOf<T::Chain>) {
 		let removed_blocks = self.blocks_data.extract_if(|block_number, _| {
-			block_number.saturating_forward(T::SAFETY_BUFFER as usize) <= last_height
+			block_number.saturating_forward(T::Chain::SAFETY_BUFFER as usize) <= last_height
 		});
 		let removed_events =
 			self.processed_events.extract_if(|_, expiry_block| *expiry_block <= last_height);
@@ -316,9 +341,9 @@ pub(crate) mod tests {
 
 	use crate::{
 		electoral_systems::{
-			block_height_tracking::ChainTypes,
+			block_height_tracking::{ChainBlockNumberOf, ChainTypes},
 			block_witnesser::{
-				block_processor::BlockProcessor,
+				block_processor::{BPChainProgress, BlockProcessor},
 				primitives::ChainProgressInner,
 				state_machine::{
 					BWProcessorTypes, ExecuteHook, HookTypeFor, LogEventHook, RulesHook,
@@ -361,13 +386,13 @@ pub(crate) mod tests {
 		fn run(
 			&mut self,
 			(block, age, block_data, safety_margin): (
-				Types::ChainBlockNumber,
+				ChainBlockNumberOf<Types::Chain>,
 				Range<u32>,
 				Vec<E>,
 				u32,
 			),
-		) -> Vec<(Types::ChainBlockNumber, MockBtcEvent<E>)> {
-			let mut results: Vec<(Types::ChainBlockNumber, MockBtcEvent<E>)> = vec![];
+		) -> Vec<(ChainBlockNumberOf<Types::Chain>, MockBtcEvent<E>)> {
+			let mut results: Vec<(ChainBlockNumberOf<Types::Chain>, MockBtcEvent<E>)> = vec![];
 			if age.contains(&0u32) {
 				results.extend(
 					block_data
@@ -397,8 +422,9 @@ pub(crate) mod tests {
 			E: Clone + Ord,
 		> Hook<HookTypeFor<Types, ExecuteHook>> for Types
 	{
-		fn run(&mut self, events: Vec<(Types::ChainBlockNumber, Types::Event)>) {
-			let mut chosen: BTreeMap<E, (Types::ChainBlockNumber, Types::Event)> = BTreeMap::new();
+		fn run(&mut self, events: Vec<(ChainBlockNumberOf<Types::Chain>, Types::Event)>) {
+			let mut chosen: BTreeMap<E, (ChainBlockNumberOf<Types::Chain>, Types::Event)> =
+				BTreeMap::new();
 
 			for (block, event) in events {
 				let deposit: E = event.deposit_witness().clone();
@@ -441,6 +467,7 @@ pub(crate) mod tests {
 			D: Validate + Serde + Ord + Clone + Debug + Default + 'static,
 		> BWProcessorTypes for TypesFor<(N, H, Vec<D>)>
 	{
+		type Chain = Self;
 		type BlockData = Vec<D>;
 		type Event = MockBtcEvent<D>;
 		type Rules = TypesFor<(N, H, Vec<D>)>;
@@ -457,31 +484,31 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(11),
+			BPChainProgress::up_to(11),
 			(9, vec![1], SAFETY_MARGIN),
 		);
 		assert_eq!(processor.blocks_data.len(), 1, "Only one blockdata added to the processor");
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(11),
+			BPChainProgress::up_to(11),
 			(10, vec![4], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(11),
+			BPChainProgress::up_to(11),
 			(11, vec![7], SAFETY_MARGIN),
 		);
 		assert_eq!(processor.blocks_data.len(), 3, "Only three blockdata added to the processor");
 		for i in 0..Types::SAFETY_BUFFER as u8 {
 			processor.process_block_data_and_chain_progress(
-				ChainProgressInner::Progress(i),
+				BPChainProgress::up_to(i),
 				(i, vec![i], SAFETY_MARGIN),
 			);
 		}
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(16),
+			BPChainProgress::up_to(16),
 			(16, vec![7], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(17),
+			BPChainProgress::up_to(17),
 			(17, vec![7], SAFETY_MARGIN),
 		);
 		assert_eq!(
@@ -497,18 +524,18 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(9),
+			BPChainProgress::up_to(9),
 			(9, vec![1, 2, 3], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(10),
+			BPChainProgress::up_to(10),
 			(10, vec![4, 5, 6], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(11),
+			BPChainProgress::up_to(11),
 			(11, vec![7, 8, 9], SAFETY_MARGIN),
 		);
-		processor.process_chain_progress(ChainProgressInner::Reorg(RangeInclusive::new(9, 11)));
+		processor.process_chain_progress(BPChainProgress::reorg(11, RangeInclusive::new(9, 11)));
 		assert!(!processor.blocks_data.contains_key(&9));
 		assert!(!processor.blocks_data.contains_key(&10));
 		assert!(!processor.blocks_data.contains_key(&11));
@@ -521,19 +548,19 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 		// We processed pre-witnessing (boost) for the followings deposit
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(9),
+			BPChainProgress::up_to(9),
 			(9, vec![1, 2, 3], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(10),
+			BPChainProgress::up_to(10),
 			(10, vec![4, 5, 6], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(11),
+			BPChainProgress::up_to(11),
 			(11, vec![7, 8, 9], SAFETY_MARGIN),
 		);
 
-		processor.process_chain_progress(ChainProgressInner::Reorg(9..=11));
+		processor.process_chain_progress(BPChainProgress::reorg(11, 9..=11));
 
 		// We reprocessed the reorged blocks, now all the deposit end up in block 11
 		let result = processor.process_rules_for_ages_and_block(
@@ -554,15 +581,16 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(101),
+			BPChainProgress::up_to(101),
 			(101, vec![1], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(102),
+			BPChainProgress::up_to(102),
 			(102, vec![2], SAFETY_MARGIN),
 		);
 		assert_eq!(processor.processed_events.len(), 0);
-		processor.process_chain_progress(ChainProgressInner::Reorg(RangeInclusive::new(101, 103)));
+		processor
+			.process_chain_progress(BPChainProgress::reorg(103, RangeInclusive::new(101, 103)));
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
 			Some(103u8.saturating_add((Types::SAFETY_BUFFER as u8).into())).as_ref(),
@@ -580,15 +608,16 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(101),
+			BPChainProgress::up_to(101),
 			(101, vec![1], SAFETY_MARGIN),
 		);
-		processor.process_chain_progress(ChainProgressInner::Reorg(RangeInclusive::new(101, 101)));
+		processor
+			.process_chain_progress(BPChainProgress::reorg(101, RangeInclusive::new(101, 101)));
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::PreWitness(1)),
 			Some(101u8.saturating_add(Types::SAFETY_BUFFER as u8)).as_ref(),
 		);
-		processor.process_chain_progress(ChainProgressInner::Progress(
+		processor.process_chain_progress(BPChainProgress::up_to(
 			101u8.saturating_add(Types::SAFETY_BUFFER as u8),
 		));
 		assert_eq!(processor.processed_events.get(&MockBtcEvent::PreWitness(1)), None,);
@@ -600,17 +629,18 @@ pub(crate) mod tests {
 		let mut processor = BlockProcessor::<Types>::default();
 
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(101),
+			BPChainProgress::up_to(101),
 			(101, vec![1], SAFETY_MARGIN),
 		);
 		processor.process_block_data_and_chain_progress(
-			ChainProgressInner::Progress(102),
+			BPChainProgress::up_to(102),
 			(102, vec![2], SAFETY_MARGIN * 2),
 		);
-		processor.process_chain_progress(ChainProgressInner::Progress(106u8));
+		processor.process_chain_progress(BPChainProgress::up_to(106u8));
 		//At this point we dispatch full witness only for deposit 1(safety margin 3) and not
 		// 2(safety margin 6) to check it we simulate a reorg to check which events get saved
-		processor.process_chain_progress(ChainProgressInner::Reorg(RangeInclusive::new(101, 106)));
+		processor
+			.process_chain_progress(BPChainProgress::reorg(106, RangeInclusive::new(101, 106)));
 		assert_eq!(
 			processor.processed_events.get(&MockBtcEvent::Witness(1)),
 			Some(106u8.saturating_add(Types::SAFETY_BUFFER as u8)).as_ref(),
@@ -624,8 +654,12 @@ pub(crate) mod tests {
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum SMBlockProcessorInput<T: BWProcessorTypes> {
-	NewBlockData(T::ChainBlockNumber, T::ChainBlockNumber, T::BlockData),
-	ChainProgress(ChainProgressInner<T::ChainBlockNumber>),
+	NewBlockData(
+		<T::Chain as ChainTypes>::ChainBlockNumber,
+		<T::Chain as ChainTypes>::ChainBlockNumber,
+		T::BlockData,
+	),
+	ChainProgress(ChainProgressInner<ChainBlockNumberOf<T::Chain>>),
 }
 
 impl<T: BWProcessorTypes> Validate for BlockProcessor<T> {
@@ -636,9 +670,9 @@ impl<T: BWProcessorTypes> Validate for BlockProcessor<T> {
 }
 #[allow(dead_code)]
 pub struct SMBlockProcessorOutput<T: BWProcessorTypes> {
-	events: Vec<(T::ChainBlockNumber, T::Event)>,
-	deleted_data: BTreeMap<T::ChainBlockNumber, BlockProcessingInfo<T::BlockData>>,
-	deleted_events: Vec<(T::ChainBlockNumber, (Vec<T::Event>, u32))>,
+	events: Vec<(ChainBlockNumberOf<T::Chain>, T::Event)>,
+	deleted_data: BTreeMap<ChainBlockNumberOf<T::Chain>, BlockProcessingInfo<T::BlockData>>,
+	deleted_events: Vec<(ChainBlockNumberOf<T::Chain>, (Vec<T::Event>, u32))>,
 }
 impl<T: BWProcessorTypes> Validate for SMBlockProcessorOutput<T> {
 	type Error = ();
@@ -654,11 +688,11 @@ pub struct SMBlockProcessor<T: BWProcessorTypes> {
 /*
 use crate::electoral_systems::state_machine::core::IndexedValidate;
 impl<T: BWProcessorTypes + 'static + Debug>
-	IndexedValidate<BTreeSet<T::ChainBlockNumber>, SMBlockProcessorInput<T>> for SMBlockProcessor<T>
+	IndexedValidate<BTreeSet<ChainBlockNumberOf<T::Chain>>, SMBlockProcessorInput<T>> for SMBlockProcessor<T>
 {
 	type Error = ();
 	fn validate(
-		index: &BTreeSet<T::ChainBlockNumber>,
+		index: &BTreeSet<ChainBlockNumberOf<T::Chain>>,
 		value: &SMBlockProcessorInput<T>,
 	) -> Result<(), Self::Error> {
 		match value {
@@ -691,7 +725,7 @@ impl<
 	> Statemachine for SMBlockProcessor<T>
 {
 	type Input = SMBlockProcessorInput<T>;
-	type InputIndex = BTreeSet<T::ChainBlockNumber>;
+	type InputIndex = BTreeSet<ChainBlockNumberOf<T::Chain>>;
 	type Settings = u32;
 	type Output = ();
 	type State = BlockProcessor<T>;
@@ -704,7 +738,7 @@ impl<
 		match i {
 			SMBlockProcessorInput::NewBlockData(last_height, n, deposits) => s
 				.process_block_data_and_chain_progress(
-					ChainProgressInner::Progress(last_height),
+					BPChainProgress::up_to(last_height),
 					(n, deposits, *set),
 				),
 			SMBlockProcessorInput::ChainProgress(inner) => s.process_chain_progress(inner),
@@ -782,7 +816,7 @@ impl<
 		};
 
 		let reorg =
-			matches!(input, SMBlockProcessorInput::ChainProgress(ChainProgressInner::Reorg(_)));
+			matches!(input, SMBlockProcessorInput::ChainProgress(BPChainProgress::reorg(_)));
 		let blocks = |d: &BlocksData<T>| {
 			d.values()
 				.map(|block_info| block_info.block_data.clone())

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/consensus.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/consensus.rs
@@ -1,6 +1,7 @@
 use crate::{
-	electoral_systems::state_machine::consensus::{
-		ConsensusMechanism, SupermajorityConsensus, Threshold,
+	electoral_systems::{
+		block_height_tracking::ChainBlockHashOf,
+		state_machine::consensus::{ConsensusMechanism, SupermajorityConsensus, Threshold},
 	},
 	SharedDataHash,
 };
@@ -11,7 +12,7 @@ use super::state_machine::{BWElectionProperties, BWTypes};
 
 pub struct BWConsensus<T: BWTypes> {
 	pub consensus: SupermajorityConsensus<SharedDataHash>,
-	pub data: BTreeMap<SharedDataHash, (T::BlockData, Option<T::ChainBlockHash>)>,
+	pub data: BTreeMap<SharedDataHash, (T::BlockData, Option<ChainBlockHashOf<T::Chain>>)>,
 	pub _phantom: sp_std::marker::PhantomData<T>,
 }
 
@@ -27,10 +28,10 @@ impl<T: BWTypes> Default for BWConsensus<T> {
 
 impl<T: BWTypes> ConsensusMechanism for BWConsensus<T>
 where
-	(T::BlockData, Option<T::ChainBlockHash>): Hashable,
+	(T::BlockData, Option<ChainBlockHashOf<T::Chain>>): Hashable,
 {
-	type Vote = (T::BlockData, Option<T::ChainBlockHash>);
-	type Result = (T::BlockData, Option<T::ChainBlockHash>);
+	type Vote = (T::BlockData, Option<ChainBlockHashOf<T::Chain>>);
+	type Result = (T::BlockData, Option<ChainBlockHashOf<T::Chain>>);
 	type Settings = (Threshold, BWElectionProperties<T>);
 
 	fn insert_vote(&mut self, vote: Self::Vote) {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -25,12 +25,6 @@ use crate::electoral_systems::{
 use super::state_machine::{BWElectionType, BWTypes};
 
 defx! {
-	#[codec(encode_bound(
-		ChainBlockNumberOf<T::Chain>: Encode,
-		ChainBlockHashOf<T::Chain>: Encode,
-		T::BlockData: Encode,
-		T::ElectionTrackerEventHook: Encode
-	))]
 	pub struct ElectionTracker2[T: BWTypes] {
 		/// The lowest block we haven't seen yet. I.e., we have seen blocks below.
 		pub seen_heights_below: ChainBlockNumberOf<T::Chain>,
@@ -317,11 +311,6 @@ impl<T: BWTypes> Default for ElectionTracker2<T> {
 
 #[derive_where(Debug, Clone, PartialEq, Eq;)]
 #[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[codec(encode_bound(
-	ChainBlockNumberOf<T::Chain>: Encode,
-	ChainBlockHashOf<T::Chain>: Encode,
-	T::BlockData: Encode,
-))]
 pub struct OptimisticBlock<T: BWTypes> {
 	pub hash: ChainBlockHashOf<T::Chain>,
 	pub data: T::BlockData,
@@ -336,7 +325,7 @@ impl<T: BWTypes> Validate for OptimisticBlock<T> {
 }
 
 #[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
+#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize)]
 pub enum ElectionTrackerEvent<T: BWTypes> {
 	ComparingBlocks {
 		height: ChainBlockNumberOf<T::Chain>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -19,7 +19,7 @@ use proptest_derive::Arbitrary;
 
 use crate::electoral_systems::{
 	block_height_tracking::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress},
-	state_machine::core::{defx, fst, Hook, Validate},
+	state_machine::core::{def_derive, defx, fst, Hook, Validate},
 };
 
 use super::state_machine::{BWElectionType, BWTypes};
@@ -309,13 +309,12 @@ impl<T: BWTypes> Default for ElectionTracker2<T> {
 	}
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub struct OptimisticBlock<T: BWTypes> {
-	pub hash: ChainBlockHashOf<T::Chain>,
-	pub data: T::BlockData,
+def_derive! {
+	pub struct OptimisticBlock<T: BWTypes> {
+		pub hash: ChainBlockHashOf<T::Chain>,
+		pub data: T::BlockData,
+	}
 }
-
 impl<T: BWTypes> Validate for OptimisticBlock<T> {
 	type Error = ();
 
@@ -324,28 +323,29 @@ impl<T: BWTypes> Validate for OptimisticBlock<T> {
 	}
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize)]
-pub enum ElectionTrackerEvent<T: BWTypes> {
-	ComparingBlocks {
-		height: ChainBlockNumberOf<T::Chain>,
-		hash: Option<ChainBlockHashOf<T::Chain>>,
-		received: BWElectionType<T::Chain>,
-		current: BWElectionType<T::Chain>,
-	},
-	UpdateSafeElections {
-		old: CompactHeightTracker<ChainBlockNumberOf<T::Chain>>,
-		new: CompactHeightTracker<ChainBlockNumberOf<T::Chain>>,
-		reason: UpdateSafeElectionsReason,
-	},
+def_derive! {
+	pub enum ElectionTrackerEvent<T: BWTypes> {
+		ComparingBlocks {
+			height: ChainBlockNumberOf<T::Chain>,
+			hash: Option<ChainBlockHashOf<T::Chain>>,
+			received: BWElectionType<T::Chain>,
+			current: BWElectionType<T::Chain>,
+		},
+		UpdateSafeElections {
+			old: CompactHeightTracker<ChainBlockNumberOf<T::Chain>>,
+			new: CompactHeightTracker<ChainBlockNumberOf<T::Chain>>,
+			reason: UpdateSafeElectionsReason,
+		},
+	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize)]
-pub enum UpdateSafeElectionsReason {
-	OutOfSafetyMargin,
-	SafeElectionScheduled,
-	GotOptimisticBlock,
-	ReorgReceived,
+def_derive! {
+	pub enum UpdateSafeElectionsReason {
+		OutOfSafetyMargin,
+		SafeElectionScheduled,
+		GotOptimisticBlock,
+		ReorgReceived,
+	}
 }
 
 #[derive_where(Default; )]
@@ -353,7 +353,6 @@ pub enum UpdateSafeElectionsReason {
 pub struct CompactHeightTracker<N> {
 	elections: VecDeque<Range<N>>,
 }
-
 impl<N> Validate for CompactHeightTracker<N> {
 	type Error = ();
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -4,7 +4,9 @@ use super::{
 	primitives::{ElectionTracker2, ElectionTrackerEvent, SafeModeStatus},
 };
 use crate::electoral_systems::{
-	block_height_tracking::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes, CommonTraits},
+	block_height_tracking::{
+		ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes, CommonTraits,
+	},
 	block_witnesser::block_processor::BlockProcessor,
 	state_machine::{
 		core::Validate,
@@ -37,7 +39,9 @@ pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>> + CommonTraits;
 	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>> + CommonTraits;
 
-	type ElectionTrackerEventHook: Hook<HookTypeFor<Self, ElectionTrackerEventHook>> + CommonTraits + Default;
+	type ElectionTrackerEventHook: Hook<HookTypeFor<Self, ElectionTrackerEventHook>>
+		+ CommonTraits
+		+ Default;
 }
 
 // hook types
@@ -79,7 +83,7 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, LogEventHook> {
 
 pub trait BWProcessorTypes: Sized + Debug + Clone + Eq {
 	type Chain: ChainTypes;
-	type BlockData: CommonTraits + Ord + 'static;
+	type BlockData: Validate + CommonTraits + Ord + 'static;
 
 	type Event: CommonTraits + Ord + Encode;
 	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + CommonTraits;
@@ -143,7 +147,6 @@ defx! {
 	}
 	validate _this (else BWElectionTypeError) {}
 }
-
 
 #[derive(Debug)]
 pub struct BWStatemachine<Types: BWTypes> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -84,9 +84,9 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, LogEventHook> {
 
 pub trait BWProcessorTypes: Sized + Debug + Clone + Eq {
 	type Chain: ChainTypes;
-	type BlockData: PartialEq + Clone + Debug + Eq + Ord + Serde + 'static;
+	type BlockData: PartialEq + Clone + Debug + Eq + Ord + Serde + Encode + 'static;
 
-	type Event: Serde + Debug + Clone + Eq + Ord;
+	type Event: Serde + Debug + Clone + Eq + Ord + Encode;
 	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + Serde + Debug + Clone + Eq;
 	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + Serde + Debug + Clone + Eq;
 
@@ -464,7 +464,10 @@ pub mod tests {
 	};
 
 	use super::*;
-	use crate::prop_do;
+	use crate::{
+		electoral_systems::block_height_tracking::{ChainBlockHashTrait, ChainBlockNumberTrait},
+		prop_do,
+	};
 	use hook_test_utils::*;
 	use proptest::collection::*;
 
@@ -557,18 +560,9 @@ pub mod tests {
 	// }
 
 	impl<
-			N: Validate
-				+ Serde
-				+ Copy
-				+ Ord
-				+ SaturatingStep
-				+ Step
-				+ BlockZero
-				+ Debug
-				+ Default
-				+ 'static,
-			H: Validate + Serde + Ord + Clone + Debug + Default + 'static,
-			D: Validate + Serde + Ord + Clone + Debug + Default + 'static,
+			N: ChainBlockNumberTrait,
+			H: ChainBlockHashTrait,
+			D: Validate + Serde + Ord + Clone + Debug + Default + Encode + Decode + 'static,
 		> BWTypes for TypesFor<(N, H, Vec<D>)>
 	{
 		type ElectionProperties = ();

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -4,10 +4,8 @@ use super::{
 	primitives::{ElectionTracker2, ElectionTrackerEvent, SafeModeStatus},
 };
 use crate::electoral_systems::{
-	block_height_tracking::{
-		ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainProgressFor, ChainTypes,
-	},
-	block_witnesser::{block_processor::BlockProcessor, primitives::ChainProgressInner},
+	block_height_tracking::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes},
+	block_witnesser::block_processor::BlockProcessor,
 	state_machine::{
 		core::Validate,
 		state_machine::{AbstractApi, Statemachine},
@@ -226,7 +224,7 @@ impl<T: BWTypes> AbstractApi for BWStatemachine<T> {
 }
 
 impl<T: BWTypes> Statemachine for BWStatemachine<T> {
-	type Context = Option<ChainProgressFor<T::Chain>>;
+	type Context = Option<ChainProgress<T::Chain>>;
 	type Settings = BlockWitnesserSettings;
 	type Output = Result<(), &'static str>;
 	type State = BlockWitnesserState<T>;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -4,7 +4,7 @@ use super::{
 	primitives::{ElectionTracker2, ElectionTrackerEvent, SafeModeStatus},
 };
 use crate::electoral_systems::{
-	block_height_tracking::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes},
+	block_height_tracking::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes, CommonTraits},
 	block_witnesser::block_processor::BlockProcessor,
 	state_machine::{
 		core::Validate,
@@ -33,16 +33,11 @@ pub struct HookTypeFor<Tag1, Tag2> {
 }
 
 pub trait BWTypes: 'static + Sized + BWProcessorTypes {
-	type ElectionProperties: PartialEq + Clone + Eq + Debug + 'static;
-	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>>;
-	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>>;
+	type ElectionProperties: Validate + CommonTraits + 'static;
+	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>> + CommonTraits;
+	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>> + CommonTraits;
 
-	type ElectionTrackerEventHook: Hook<HookTypeFor<Self, ElectionTrackerEventHook>>
-		+ Default
-		+ Serde
-		+ Debug
-		+ Clone
-		+ Eq;
+	type ElectionTrackerEventHook: Hook<HookTypeFor<Self, ElectionTrackerEventHook>> + CommonTraits + Default;
 }
 
 // hook types
@@ -84,13 +79,13 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, LogEventHook> {
 
 pub trait BWProcessorTypes: Sized + Debug + Clone + Eq {
 	type Chain: ChainTypes;
-	type BlockData: PartialEq + Clone + Debug + Eq + Ord + Serde + Encode + 'static;
+	type BlockData: CommonTraits + Ord + 'static;
 
-	type Event: Serde + Debug + Clone + Eq + Ord + Encode;
-	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + Serde + Debug + Clone + Eq;
-	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + Serde + Debug + Clone + Eq;
+	type Event: CommonTraits + Ord + Encode;
+	type Rules: Hook<HookTypeFor<Self, RulesHook>> + Default + CommonTraits;
+	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + CommonTraits;
 
-	type LogEventHook: Hook<HookTypeFor<Self, LogEventHook>> + Default + Serde + Debug + Clone + Eq;
+	type LogEventHook: Hook<HookTypeFor<Self, LogEventHook>> + Default + CommonTraits;
 }
 
 #[derive(
@@ -112,93 +107,43 @@ pub struct BlockWitnesserSettings {
 	pub safety_margin: u32,
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq;
-	T::SafeModeEnabledHook: Debug + Clone + Eq,
-	T::ElectionPropertiesHook: Debug + Clone + Eq,
-	BlockProcessor<T>: Debug + Clone + Eq,
-)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[codec(encode_bound(
-	ChainBlockNumberOf<T::Chain>: Encode,
-	ChainBlockHashOf<T::Chain>: Encode,
-	T::ElectionPropertiesHook: Encode,
-	T::SafeModeEnabledHook: Encode,
-	T::BlockData: Encode,
-	T::ElectionTrackerEventHook: Encode,
-
-	BlockProcessor<T>: Encode,
-))]
-pub struct BlockWitnesserState<T: BWTypes> {
-	pub elections: ElectionTracker2<T>,
-	pub generate_election_properties_hook: T::ElectionPropertiesHook,
-	pub safemode_enabled: T::SafeModeEnabledHook,
-	pub block_processor: BlockProcessor<T>,
-	pub _phantom: sp_std::marker::PhantomData<T>,
-}
-
-impl<T: BWTypes> Validate for BlockWitnesserState<T> {
-	type Error = &'static str;
-
-	fn is_valid(&self) -> Result<(), Self::Error> {
-		Ok(())
+defx! {
+	#[derive(Default)]
+	pub struct BlockWitnesserState[T: BWTypes] {
+		pub elections: ElectionTracker2<T>,
+		pub generate_election_properties_hook: T::ElectionPropertiesHook,
+		pub safemode_enabled: T::SafeModeEnabledHook,
+		pub block_processor: BlockProcessor<T>,
+		pub _phantom: sp_std::marker::PhantomData<T>,
 	}
+	validate _this (else BlockWitnesserError) {}
 }
 
-impl<T: BWTypes> Default for BlockWitnesserState<T>
-where
-	T::ElectionPropertiesHook: Default,
-	T::SafeModeEnabledHook: Default,
-{
-	fn default() -> Self {
-		Self {
-			elections: Default::default(),
-			generate_election_properties_hook: Default::default(),
-			safemode_enabled: Default::default(),
-			block_processor: Default::default(),
-			_phantom: Default::default(),
-		}
+defx! {
+	pub struct BWElectionProperties[T: BWTypes] {
+		pub election_type: BWElectionType<T::Chain>,
+		pub block_height: ChainBlockNumberOf<T::Chain>,
+		pub properties: T::ElectionProperties,
 	}
+	validate _this (else BWElectionPropertiesError) {}
 }
 
-#[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[codec(encode_bound(
-	ChainBlockHashOf<T::Chain>: Encode,
-	ChainBlockNumberOf<T::Chain>: Encode,
-	T::ElectionProperties: Encode,
-))]
-pub struct BWElectionProperties<T: BWTypes> {
-	pub election_type: BWElectionType<T::Chain>,
-	pub block_height: ChainBlockNumberOf<T::Chain>,
-	pub properties: T::ElectionProperties,
-}
+defx! {
+	#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+	pub enum BWElectionType[C: ChainTypes] {
+		/// Querying blocks we haven't received a hash for yet
+		Optimistic,
 
-#[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Deserialize, Serialize)]
-#[codec(encode_bound(
-	ChainBlockHashOf<C>: Encode,
-	ChainBlockNumberOf<C>: Encode,
-))]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub enum BWElectionType<C: ChainTypes> {
-	/// Querying blocks we haven't received a hash for yet
-	Optimistic,
+		/// Querying blocks by hash
+		ByHash(C::ChainBlockHash),
 
-	/// Querying blocks by hash
-	ByHash(C::ChainBlockHash),
-
-	/// Querying "old" blocks that are below the safety margin,
-	/// and thus we don't care about the hash anymore
-	SafeBlockHeight,
-}
-
-impl<T: ChainTypes> Validate for BWElectionType<T> {
-	type Error = ();
-
-	fn is_valid(&self) -> Result<(), Self::Error> {
-		Ok(())
+		/// Querying "old" blocks that are below the safety margin,
+		/// and thus we don't care about the hash anymore
+		SafeBlockHeight,
 	}
+	validate _this (else BWElectionTypeError) {}
 }
+
 
 #[derive(Debug)]
 pub struct BWStatemachine<Types: BWTypes> {
@@ -479,6 +424,7 @@ pub mod tests {
 		ChainBlockNumberOf<T::Chain>: Arbitrary,
 		ChainBlockHashOf<T::Chain>: Arbitrary,
 		T::ElectionPropertiesHook: Default + Clone + Debug + Eq,
+		T::ElectionTrackerEventHook: Default + Clone + Debug + Eq,
 		T::BlockData: Default + Clone + Debug + Eq,
 	{
 		prop_do! {
@@ -562,7 +508,7 @@ pub mod tests {
 	impl<
 			N: ChainBlockNumberTrait,
 			H: ChainBlockHashTrait,
-			D: Validate + Serde + Ord + Clone + Debug + Default + Encode + Decode + 'static,
+			D: Validate + Ord + Default + CommonTraits + 'static,
 		> BWTypes for TypesFor<(N, H, Vec<D>)>
 	{
 		type ElectionProperties = ();

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -1,7 +1,7 @@
 use core::ops::RangeInclusive;
 
 use cf_chains::{witness_period::BlockWitnessRange, ChainWitnessConfig};
-use sp_std::collections::{btree_map::BTreeMap, vec_deque::VecDeque};
+use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque};
 
 use codec::{Decode, Encode};
 use derive_where::derive_where;
@@ -128,6 +128,18 @@ macro_rules! derive_validation_statements {
 }
 pub(crate) use derive_validation_statements;
 
+macro_rules! def_derive {
+	($($Definition:tt)*) => {
+		#[derive(
+			Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo,
+		)]
+		#[cfg_attr(feature = "std", derive(Deserialize, Serialize))]
+		#[cfg_attr(feature = "std", serde(bound(deserialize = "", serialize = "")))]
+		$($Definition)*
+	};
+}
+pub(crate) use def_derive;
+
 /// Syntax sugar for adding validation code to types with validity requirements
 macro_rules! defx {
 	(
@@ -152,17 +164,13 @@ macro_rules! defx {
 		crate::electoral_systems::state_machine::core::derive_error_enum!{$Error [ $($ParamName: $($ParamType)?),* ], $def { $($Definition)* } { $($prop_name),* } }
 
 
-		#[derive(
-			// Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo,
-			Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize,
-		)]
-		// #[cfg_attr(test, derive(Deserialize, Serialize))]
-		// #[cfg_attr(test, serde(bound(deserialize = "", serialize = "")))]
-		$(
-			#[$($Attributes)*]
-		)*
-		pub $def $Name<$($ParamName: $($ParamType)?),*> {
-			$($Definition)*
+		crate::electoral_systems::state_machine::core::def_derive!{
+			$(
+				#[$($Attributes)*]
+			)*
+			pub $def $Name<$($ParamName: $($ParamType)?),*> {
+				$($Definition)*
+			}
 		}
 
 		impl<$($ParamName: $($ParamType)?),*> Validate for $Name<$($ParamName),*> {
@@ -358,6 +366,14 @@ impl<A: Validate, B: Validate> Validate for BTreeMap<A, B> {
 	}
 }
 
+impl<A: Validate> Validate for BTreeSet<A> {
+	type Error = A::Error;
+
+	fn is_valid(&self) -> Result<(), Self::Error> {
+		self.iter().map(|a| a.is_valid()).collect()
+	}
+}
+
 impl<A: Validate> Validate for Vec<A> {
 	type Error = A::Error;
 
@@ -421,6 +437,14 @@ impl Validate for bool {
 }
 
 impl Validate for u8 {
+	type Error = ();
+
+	fn is_valid(&self) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}
+
+impl Validate for u16 {
 	type Error = ();
 
 	fn is_valid(&self) -> Result<(), Self::Error> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -153,10 +153,11 @@ macro_rules! defx {
 
 
 		#[derive(
+			// Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo,
 			Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Deserialize, Serialize,
 		)]
-		#[serde(bound(deserialize = "", serialize = ""))]
-
+		// #[cfg_attr(test, derive(Deserialize, Serialize))]
+		// #[cfg_attr(test, serde(bound(deserialize = "", serialize = "")))]
 		$(
 			#[$($Attributes)*]
 		)*
@@ -333,6 +334,14 @@ pub trait Validate {
 }
 
 impl Validate for () {
+	type Error = ();
+
+	fn is_valid(&self) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}
+
+impl<T> Validate for sp_std::marker::PhantomData<T> {
 	type Error = ();
 
 	fn is_valid(&self) -> Result<(), Self::Error> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -131,7 +131,7 @@ pub(crate) use derive_validation_statements;
 /// Syntax sugar for adding validation code to types with validity requirements
 macro_rules! defx {
 	(
-		$(#[$($Attributes:tt)*])?
+		$(#[$($Attributes:tt)*])*
 		pub $def:tt $Name:tt [$($ParamName:ident $(: $ParamType:tt)?),*] {
 			$($Definition:tt)*
 		}
@@ -159,7 +159,7 @@ macro_rules! defx {
 
 		$(
 			#[$($Attributes)*]
-		)?
+		)*
 		pub $def $Name<$($ParamName: $($ParamType)?),*> {
 			$($Definition)*
 		}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine_es.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine_es.rs
@@ -1,5 +1,4 @@
 use cf_utilities::success_threshold_from_share_count;
-use derive_where::derive_where;
 use itertools::Either;
 use sp_std::{fmt::Debug, vec::Vec};
 
@@ -11,7 +10,6 @@ use crate::{
 
 use super::{
 	consensus::{ConsensusMechanism, Threshold},
-	core::Validate,
 	state_machine::{AbstractApi, Statemachine},
 };
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
@@ -26,11 +26,11 @@ type BHTypes = TypesFor<BlockHeightWitnesserDefinition>;
 impl ChainTypes for BHTypes {
 	type ChainBlockNumber = u64;
 	type ChainBlockHash = u64;
-	const SAFETY_BUFFER: u32 = 8;
+	const SAFETY_BUFFER: usize = 8;
 }
 
 impl BHWTypes for BHTypes {
-	const BLOCK_BUFFER_SIZE: usize = 6;
+	type Chain = BHTypes;
 	type BlockHeightChangeHook = EmptyHook;
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
@@ -1,10 +1,8 @@
 use crate::electoral_systems::{
 	block_height_tracking::{
 		consensus::BlockHeightTrackingConsensus,
-		primitives::{
-			Header, NonemptyContinuousHeaders, NonemptyContinuousHeadersError, VoteValidationError,
-		},
-		state_machine::BlockHeightWitnesser,
+		primitives::{Header, NonemptyContinuousHeaders, NonemptyContinuousHeadersError},
+		state_machine::{BlockHeightWitnesser, VoteValidationError},
 		ChainTypes, HWTypes, HeightWitnesserProperties,
 	},
 	state_machine::{

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_tracking.rs
@@ -3,7 +3,7 @@ use crate::electoral_systems::{
 		consensus::BlockHeightTrackingConsensus,
 		primitives::{Header, NonemptyContinuousHeaders, NonemptyContinuousHeadersError},
 		state_machine::{BlockHeightWitnesser, VoteValidationError},
-		ChainTypes, HWTypes, HeightWitnesserProperties,
+		BHWTypes, ChainTypes, HeightWitnesserProperties,
 	},
 	state_machine::{
 		consensus::{ConsensusMechanism, Threshold},
@@ -29,7 +29,7 @@ impl ChainTypes for BHTypes {
 	const SAFETY_BUFFER: u32 = 8;
 }
 
-impl HWTypes for BHTypes {
+impl BHWTypes for BHTypes {
 	const BLOCK_BUFFER_SIZE: usize = 6;
 	type BlockHeightChangeHook = EmptyHook;
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -70,10 +70,11 @@ impl ChainTypes for Types {
 	type ChainBlockNumber = u64;
 	type ChainBlockHash = u64;
 
-	const SAFETY_BUFFER: u32 = SAFETY_MARGIN;
+	const SAFETY_BUFFER: usize = SAFETY_MARGIN;
 }
 
 impl BWProcessorTypes for Types {
+	type Chain = Types;
 	type BlockData = Vec<u8>;
 	type Event = ();
 	type Rules = MockHook<HookTypeFor<Self, RulesHook>, "rules">;
@@ -105,14 +106,14 @@ impl ElectoralSystemTypes for Types {
 	type VoteStorage =
 		vote_storage::bitmap::Bitmap<(BlockData, Option<<Self as ChainTypes>::ChainBlockHash>)>;
 	type Consensus = (BlockData, Option<<Self as ChainTypes>::ChainBlockHash>);
-	type OnFinalizeContext = Vec<ChainProgress<Self>>;
+	type OnFinalizeContext = Vec<Option<ChainProgress<Self>>>;
 	type OnFinalizeReturn = Vec<()>;
 }
 
 /// Associating the state machine and consensus mechanism to the struct
 impl StatemachineElectoralSystemTypes for Types {
 	// both context and return have to be vectors, these are the item types
-	type OnFinalizeContextItem = ChainProgress<Self>;
+	type OnFinalizeContextItem = Option<ChainProgress<Self>>;
 	type OnFinalizeReturnItem = ();
 
 	// the actual state machine and consensus mechanisms of this ES
@@ -209,7 +210,7 @@ fn create_votes_expectation(
 }
 
 const MAX_CONCURRENT_ELECTIONS: ElectionCount = 5;
-const SAFETY_MARGIN: u32 = 3;
+const SAFETY_MARGIN: usize = 3;
 const MOCK_BW_ELECTION_PROPERTIES: BWElectionProperties<Types> = BWElectionProperties {
 	election_type: BWElectionType::<Types>::SafeBlockHeight,
 	block_height: 2,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -20,7 +20,7 @@ use super::{mocks::Check, register_checks};
 use crate::{
 	electoral_system::{ConsensusVote, ConsensusVotes, ElectoralSystemTypes},
 	electoral_systems::{
-		block_height_tracking::{ChainProgressFor, ChainTypes},
+		block_height_tracking::{ChainProgress, ChainTypes},
 		block_witnesser::{
 			state_machine::{
 				BWElectionProperties, BWElectionType, BWProcessorTypes, ElectionPropertiesHook,
@@ -105,14 +105,14 @@ impl ElectoralSystemTypes for Types {
 	type VoteStorage =
 		vote_storage::bitmap::Bitmap<(BlockData, Option<<Self as ChainTypes>::ChainBlockHash>)>;
 	type Consensus = (BlockData, Option<<Self as ChainTypes>::ChainBlockHash>);
-	type OnFinalizeContext = Vec<ChainProgressFor<Self>>;
+	type OnFinalizeContext = Vec<ChainProgress<Self>>;
 	type OnFinalizeReturn = Vec<()>;
 }
 
 /// Associating the state machine and consensus mechanism to the struct
 impl StatemachineElectoralSystemTypes for Types {
 	// both context and return have to be vectors, these are the item types
-	type OnFinalizeContextItem = ChainProgressFor<Self>;
+	type OnFinalizeContextItem = ChainProgress<Self>;
 	type OnFinalizeReturnItem = ();
 
 	// the actual state machine and consensus mechanisms of this ES

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -17,7 +17,7 @@ use crate::electoral_systems::{
 	block_height_tracking::{
 		primitives::NonemptyContinuousHeaders,
 		state_machine::{tests::*, BHWState, BlockHeightWitnesser},
-		HWTypes, HeightWitnesserProperties,
+		BHWTypes, HeightWitnesserProperties,
 	},
 	block_witnesser::{
 		block_processor::{
@@ -173,7 +173,7 @@ pub fn test_all() {
         };
 
         #[derive(Clone, Debug)]
-        enum BWTrace<T: BWTypes, T0: HWTypes> {
+        enum BWTrace<T: BWTypes, T0: BHWTypes> {
             Input(InputOf<BWStatemachine<T>>),
             InputBHW(InputOf<BlockHeightWitnesser<T0>>),
             Output(Vec<(T::ChainBlockNumber, T::Event)>),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -16,7 +16,7 @@ use proptest::test_runner::{Config, FileFailurePersistence, TestRunner};
 use crate::electoral_systems::{
 	block_height_tracking::{
 		primitives::NonemptyContinuousHeaders,
-		state_machine::{tests::*, BHWState, BlockHeightWitnesser},
+		state_machine::{tests::*, BHWPhase, BlockHeightWitnesser},
 		BHWTypes, HeightWitnesserProperties,
 	},
 	block_witnesser::{
@@ -150,7 +150,7 @@ pub fn test_all() {
 
         // prepare the state machines
         let mut bhw_state: BlockHeightWitnesser<Types> = BlockHeightWitnesser {
-            state: BHWState::Starting,
+            phase: BHWPhase::Starting,
             block_height_update: MockHook::new(())
         };
         let block_processor: BlockProcessor<Types> = BlockProcessor {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -3,21 +3,22 @@
 
 pub mod chainstate_simulation;
 
-use core::marker::PhantomData;
+use codec::{EncodeLike, WrapperTypeDecode, WrapperTypeEncode};
+use core::{fmt::Display, marker::PhantomData, ops::Deref};
+use itertools::{Either, Itertools};
+use proptest::test_runner::{Config, FileFailurePersistence, TestRunner};
+use serde::{Deserialize, Serialize};
+use sp_std::{fmt::Debug, vec::Vec};
 use std::{
 	collections::{BTreeMap, BTreeSet, VecDeque},
 	hash::DefaultHasher,
 };
 
-use frame_support::ensure;
-use itertools::{Either, Itertools};
-use proptest::test_runner::{Config, FileFailurePersistence, TestRunner};
-
 use crate::electoral_systems::{
 	block_height_tracking::{
 		primitives::NonemptyContinuousHeaders,
 		state_machine::{tests::*, BHWPhase, BlockHeightWitnesser},
-		BHWTypes, HeightWitnesserProperties,
+		BHWTypes, ChainBlockNumberOf, HeightWitnesserProperties,
 	},
 	block_witnesser::{
 		block_processor::{
@@ -37,6 +38,43 @@ use crate::electoral_systems::{
 	},
 };
 use chainstate_simulation::*;
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
+struct EncodableChar(u8);
+impl Deref for EncodableChar {
+	type Target = u8;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+impl From<u8> for EncodableChar {
+	fn from(value: u8) -> Self {
+		Self(value)
+	}
+}
+impl WrapperTypeDecode for EncodableChar {
+	type Wrapped = u8;
+}
+impl WrapperTypeEncode for EncodableChar {}
+impl EncodeLike<u8> for EncodableChar {}
+impl Debug for EncodableChar {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
+impl Display for EncodableChar {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
+impl Validate for EncodableChar {
+	type Error = ();
+
+	fn is_valid(&self) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}
 
 macro_rules! if_matches {
     ($($tt:tt)+) => {
@@ -59,7 +97,7 @@ pub trait AbstractVoter<M: Statemachine> {
 
 #[test]
 pub fn test_all() {
-	type Types = TypesFor<(u8, usize, Vec<char>)>;
+	type Types = TypesFor<(u8, u32, Vec<EncodableChar>)>;
 	type BW = BWStatemachine<Types>;
 	type BHW = BlockHeightWitnesser<Types>;
 
@@ -114,15 +152,27 @@ pub fn test_all() {
 					Optimistic =>
 						if let Some(block_data) = chain.get_block_by_height(index.block_height) {
 							let header = chain.get_block_header(index.block_height).unwrap();
-							inputs.push(Either::Right((index, (block_data, Some(header.hash)))));
+							inputs.push(Either::Right((
+								index,
+								(
+									block_data.into_iter().map(|c| (c as u8).into()).collect(),
+									Some(header.hash),
+								),
+							)));
 						},
 					ByHash(hash) =>
 						if let Some(block_data) = chain.get_block_by_hash(hash) {
-							inputs.push(Either::Right((index, (block_data, None))));
+							inputs.push(Either::Right((
+								index,
+								(block_data.into_iter().map(|c| (c as u8).into()).collect(), None),
+							)));
 						},
 					SafeBlockHeight =>
 						if let Some(block_data) = chain.get_block_by_height(index.block_height) {
-							inputs.push(Either::Right((index, (block_data, None))));
+							inputs.push(Either::Right((
+								index,
+								(block_data.into_iter().map(|c| (c as u8).into()).collect(), None),
+							)));
 						},
 				}
 			}
@@ -176,7 +226,7 @@ pub fn test_all() {
         enum BWTrace<T: BWTypes, T0: BHWTypes> {
             Input(InputOf<BWStatemachine<T>>),
             InputBHW(InputOf<BlockHeightWitnesser<T0>>),
-            Output(Vec<(T::ChainBlockNumber, T::Event)>),
+            Output(Vec<(ChainBlockNumberOf<T::Chain>, T::Event)>),
             Event(BlockProcessorEvent<T>),
             ET(ElectionTrackerEvent<T>)
         }
@@ -291,15 +341,15 @@ pub fn test_all() {
             }
             for (height, event) in output {
                 let event = match event {
-                    MockBtcEvent::PreWitness(data) => format!("Pre {}", data as char),
-                    MockBtcEvent::Witness(data) => format!("Wit {}", data as char),
+                    MockBtcEvent::PreWitness(data) => format!("Pre {}", data),
+                    MockBtcEvent::Witness(data) => format!("Wit {}", data),
                 };
                 write!(printed, "{height}: {}, ", event).unwrap();
             }
             writeln!(printed, "").unwrap();
         }
 
-        let counted_events : Container<BTreeMultiSet<(u8, MockBtcEvent<char>)>> = total_outputs.into_iter().flatten().collect();
+        let counted_events : Container<BTreeMultiSet<(u8, MockBtcEvent<EncodableChar>)>> = total_outputs.into_iter().flatten().collect();
 
         // verify that each event was emitted only one time 
         for (event, count) in counted_events.0.0.clone() {
@@ -311,7 +361,7 @@ pub fn test_all() {
         }
 
         // ensure that we only emit witness events that are on the final chain
-        let emitted_witness_events : BTreeSet<_> = counted_events.0.0.keys().map(|(a,b)|b).filter_map(try_get!(MockBtcEvent::Witness)).map(|event| *event as char).collect();
+        let emitted_witness_events : BTreeSet<_> = counted_events.0.0.keys().map(|(a,b)|b).filter_map(try_get!(MockBtcEvent::Witness)).map(|event| event.0 as char).collect();
         let expected_witness_events : BTreeSet<_> = finalized_events.into_iter().cloned().collect();
         assert!(emitted_witness_events == expected_witness_events,
             "got witness events: {emitted_witness_events:?}, expected_witness_events: {expected_witness_events:?}, bw_input_history: {}",

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline/chainstate_simulation.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline/chainstate_simulation.rs
@@ -13,6 +13,8 @@ use core::{
 use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use proptest::{collection::*, prelude::*};
 
+type BlockId = u32;
+
 /// The basic data structure involved is an ordered tree which:
 ///  - a leaf represents a single block
 ///  - a branch represents a forked
@@ -131,7 +133,7 @@ pub struct Consumer {
 }
 
 pub struct FilledBlock<E> {
-	block_id: usize,
+	block_id: BlockId,
 	data: Vec<E>,
 	data_delays: Vec<usize>,
 }
@@ -139,7 +141,7 @@ pub struct FilledBlock<E> {
 pub fn fill_block<E: Clone>(
 	input: ForkedBlock<Consumer>,
 	events: &mut Vec<E>,
-	block_id: &mut usize,
+	block_id: &mut BlockId,
 ) -> ForkedBlock<FilledBlock<E>> {
 	use ForkedBlock::*;
 	match input {
@@ -163,7 +165,7 @@ pub fn fill_block<E: Clone>(
 pub fn fill_chain<E: Clone>(
 	chain: ForkedChain<Consumer>,
 	events: &mut Vec<E>,
-	block_id: &mut usize,
+	block_id: &mut BlockId,
 ) -> ForkedChain<FilledBlock<E>> {
 	chain.into_iter().map(|block| fill_block(block, events, block_id)).collect()
 }
@@ -201,7 +203,7 @@ pub fn create_time_steps<E: Clone>(chain: &ForkedChain<FilledBlock<E>>) -> Vec<F
 #[derive(Debug, Clone)]
 pub struct FlatBlock<E> {
 	pub events: Vec<E>,
-	pub block_id: usize,
+	pub block_id: BlockId,
 }
 
 // Temp
@@ -307,7 +309,7 @@ pub fn blocks_into_chain_progression(
 	FlatChainProgression { chains: time_steps, age: 0 }
 }
 
-pub struct MockChain<E, T: ChainTypes<ChainBlockHash = usize>> {
+pub struct MockChain<E, T: ChainTypes<ChainBlockHash = BlockId>> {
 	// heights and blocks
 	pub chain: Vec<(T::ChainBlockNumber, FlatBlock<E>)>,
 	pub _phantom: std::marker::PhantomData<T>,
@@ -318,7 +320,7 @@ use sp_std::iter::Step;
 // type MockChain<E> = Vec<FlatBlock<E>>;
 type N = u8;
 
-impl<E: Clone + PartialEq + Debug, T: ChainTypes<ChainBlockHash = usize>> MockChain<E, T> {
+impl<E: Clone + PartialEq + Debug, T: ChainTypes<ChainBlockHash = BlockId>> MockChain<E, T> {
 	pub fn new_with_offset(offset: usize, blocks: Vec<FlatBlock<E>>) -> MockChain<E, T> {
 		Self {
 			chain: blocks
@@ -332,7 +334,7 @@ impl<E: Clone + PartialEq + Debug, T: ChainTypes<ChainBlockHash = usize>> MockCh
 		}
 	}
 
-	pub fn get_hash_by_height(&self, height: T::ChainBlockNumber) -> Option<usize> {
+	pub fn get_hash_by_height(&self, height: T::ChainBlockNumber) -> Option<BlockId> {
 		self.chain
 			.iter()
 			.find(|(h, block)| *h == height)

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -41,7 +41,7 @@ use pallet_cf_elections::{
 		},
 		liveness::Liveness,
 		state_machine::{
-			core::{hook_test_utils::EmptyHook, Hook, Validate},
+			core::{hook_test_utils::EmptyHook, Hook},
 			state_machine_es::{StatemachineElectoralSystem, StatemachineElectoralSystemTypes},
 		},
 		unsafe_median::{UnsafeMedian, UpdateFeeHook},

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -23,8 +23,8 @@ use pallet_cf_elections::{
 	electoral_systems::{
 		block_height_tracking::{
 			consensus::BlockHeightTrackingConsensus, primitives::NonemptyContinuousHeaders,
-			state_machine::BlockHeightWitnesser, BlockHeightChangeHook, ChainProgressFor,
-			ChainTypes, HWTypes, HeightWitnesserProperties,
+			state_machine::BlockHeightWitnesser, BlockHeightChangeHook, ChainProgress, ChainTypes,
+			HWTypes, HeightWitnesserProperties,
 		},
 		block_witnesser::{
 			consensus::BWConsensus,
@@ -117,7 +117,7 @@ impls! {
 		type VoteStorage = vote_storage::bitmap::Bitmap<NonemptyContinuousHeaders<BitcoinChain>>;
 		type Consensus = NonemptyContinuousHeaders<BitcoinChain>;
 		type OnFinalizeContext = Vec<()>;
-		type OnFinalizeReturn = Vec<Option<ChainProgressFor<BitcoinChain>>>;
+		type OnFinalizeReturn = Vec<Option<ChainProgress<BitcoinChain>>>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
 
@@ -125,7 +125,7 @@ impls! {
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
 		type OnFinalizeContextItem = ();
-		type OnFinalizeReturnItem = Option<ChainProgressFor<BitcoinChain>>;
+		type OnFinalizeReturnItem = Option<ChainProgress<BitcoinChain>>;
 
 		// the actual state machine and consensus mechanisms of this ES
 		type ConsensusMechanism = BlockHeightTrackingConsensus<Self>;
@@ -191,7 +191,7 @@ impls! {
 		type ElectionState = ();
 		type VoteStorage = vote_storage::bitmap::Bitmap<(BlockDataDepositChannel, Option<btc::Hash>)>;
 		type Consensus = (BlockDataDepositChannel, Option<btc::Hash>);
-		type OnFinalizeContext = Vec<Option<ChainProgressFor<BitcoinChain>>>;
+		type OnFinalizeContext = Vec<Option<ChainProgress<BitcoinChain>>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -199,7 +199,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = Option<ChainProgressFor<BitcoinChain>>;
+		type OnFinalizeContextItem = Option<ChainProgress<BitcoinChain>>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES
@@ -282,7 +282,7 @@ impls! {
 		type ElectionState = ();
 		type VoteStorage = vote_storage::bitmap::Bitmap<(BlockDataVaultDeposit, Option<btc::Hash>)>;
 		type Consensus = (BlockDataVaultDeposit, Option<btc::Hash>);
-		type OnFinalizeContext = Vec<Option<ChainProgressFor<BitcoinChain>>>;
+		type OnFinalizeContext = Vec<Option<ChainProgress<BitcoinChain>>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -290,7 +290,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = Option<ChainProgressFor<BitcoinChain>>;
+		type OnFinalizeContextItem = Option<ChainProgress<BitcoinChain>>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES
@@ -381,7 +381,7 @@ impls! {
 		type ElectionState = ();
 		type VoteStorage = vote_storage::bitmap::Bitmap<(EgressBlockData, Option<btc::Hash>)>;
 		type Consensus = (EgressBlockData, Option<btc::Hash>);
-		type OnFinalizeContext = Vec<Option<ChainProgressFor<BitcoinChain>>>;
+		type OnFinalizeContext = Vec<Option<ChainProgress<BitcoinChain>>>;
 		type OnFinalizeReturn = Vec<()>;
 		type StateChainBlockNumber = BlockNumberFor<Runtime>;
 	}
@@ -389,7 +389,7 @@ impls! {
 	/// Associating the state machine and consensus mechanism to the struct
 	StatemachineElectoralSystemTypes {
 		// both context and return have to be vectors, these are the item types
-		type OnFinalizeContextItem = Option<ChainProgressFor<BitcoinChain>>;
+		type OnFinalizeContextItem = Option<ChainProgress<BitcoinChain>>;
 		type OnFinalizeReturnItem = ();
 
 		// the actual state machine and consensus mechanisms of this ES

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -79,14 +79,14 @@ pub struct OpenChannelDetails<ChainBlockNumber> {
 	pub close_block: ChainBlockNumber,
 }
 
-const SAFETY_BUFFER: u32 = 8;
+const SAFETY_BUFFER: usize = 8;
 
 pub struct BitcoinChainTag;
 pub type BitcoinChain = TypesFor<BitcoinChainTag>;
 impl ChainTypes for BitcoinChain {
 	type ChainBlockNumber = btc::BlockNumber;
 	type ChainBlockHash = btc::Hash;
-	const SAFETY_BUFFER: u32 = SAFETY_BUFFER;
+	const SAFETY_BUFFER: usize = SAFETY_BUFFER;
 }
 
 // ------------------------ block height tracking ---------------------------
@@ -98,7 +98,6 @@ impls! {
 
 	/// Associating the SM related types to the struct
 	BHWTypes {
-		const BLOCK_BUFFER_SIZE: usize = SAFETY_BUFFER as usize;
 		type BlockHeightChangeHook = Self;
 		type Chain = BitcoinChain;
 	}

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -23,8 +23,8 @@ use pallet_cf_elections::{
 	electoral_systems::{
 		block_height_tracking::{
 			consensus::BlockHeightTrackingConsensus, primitives::NonemptyContinuousHeaders,
-			state_machine::BlockHeightWitnesser, BlockHeightChangeHook, ChainProgress, ChainTypes,
-			HWTypes, HeightWitnesserProperties,
+			state_machine::BlockHeightWitnesser, BHWTypes, BlockHeightChangeHook, ChainProgress,
+			ChainTypes, HeightWitnesserProperties,
 		},
 		block_witnesser::{
 			consensus::BWConsensus,
@@ -97,7 +97,7 @@ impls! {
 	for TypesFor<BitcoinBlockHeightTracking>:
 
 	/// Associating the SM related types to the struct
-	HWTypes {
+	BHWTypes {
 		const BLOCK_BUFFER_SIZE: usize = SAFETY_BUFFER as usize;
 		type BlockHeightChangeHook = Self;
 		type Chain = BitcoinChain;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2283

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Uses a macro to attach `derive(...)` attributes to most structs, instead of having to add them manually. Also updates and unifies the bounds of the various `BW`/`BHW`-`Types` traits.
