### PR TITLE
fix: can close orders after sweeping

### DIFF
--- a/state-chain/amm/src/limit_orders.rs
+++ b/state-chain/amm/src/limit_orders.rs
@@ -787,10 +787,22 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			let positions = &mut self.positions[!SD::INPUT_SIDE];
 			let fixed_pools = &mut self.fixed_pools[!SD::INPUT_SIDE];
 
-			let position = positions
-				.get(&(sqrt_price, lp.clone()))
-				.ok_or(PositionError::NonExistent)?
-				.clone();
+			let position = match positions.get(&(sqrt_price, lp.clone())) {
+				Some(position) => position.clone(),
+				None =>
+					if amount == u128::MAX.into() {
+						// We are removing the order anyway so not being able to
+						// find it is not a problem (this happens if implicit sweeping
+						// pre-removes the order if it was fully executed).
+						return Ok((
+							Default::default(),
+							Default::default(),
+							PositionInfo::default(),
+						));
+					} else {
+						return Err(PositionError::NonExistent);
+					},
+			};
 			let option_fixed_pool = fixed_pools.get(&sqrt_price);
 
 			let (collected_amounts, option_position) =


### PR DESCRIPTION
# Pull Request

If a limit order if fully executed, explicitly closing it by reducing the amount by u128::MAX may result in an error due to the order already having been removed by sweeping. This PR fixes the problem by effectively ignoring the error of not being able to find the order if our intention is to remove it.

The integration test cover this case when ASS is used (the test would previously fail).
