### PR TITLE
chore: box extrinsic types to reduce RuntimeCall enum size

### DIFF
--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -194,7 +194,7 @@ where
 						}
 						// TODO: Use block hash you got this vote tasks details from as the based of the mortal of the extrinsic
 						state_chain_client.submit_signed_extrinsic(pallet_cf_elections::Call::<state_chain_runtime::Runtime, Instance>::vote {
-							authority_votes: BTreeMap::from_iter(votes).try_into().unwrap(/*Safe due to chunking*/),
+							authority_votes: Box::new(BTreeMap::from_iter(votes).try_into().unwrap(/*Safe due to chunking*/)),
 						}).await;
 					}
 				}).await;
@@ -279,7 +279,7 @@ where
 								// which keeps decreasing exponentially (i.e. with the current values => 2 blocks delay: 1 in 40k, 3 blocks delay: 1 in 4million ...)
 								if (reference_details.created..reference_details.expires).contains(&block_info.number) && rng.gen_bool(required_full_vote_probability(authority_count, 0.01)) {
 									self.state_chain_client.submit_signed_extrinsic(pallet_cf_elections::Call::<state_chain_runtime::Runtime, Instance>::provide_shared_data {
-										shared_data: shared_data.clone(),
+										shared_data: Box::new(shared_data.clone()),
 									}).await;
 								}
 							}

--- a/state-chain/cf-integration-tests/src/solana.rs
+++ b/state-chain/cf-integration-tests/src/solana.rs
@@ -196,7 +196,7 @@ fn vote_for_alt_election(
 			Runtime,
 			SolanaInstance,
 		>::vote {
-			authority_votes: vote.clone()
+			authority_votes: Box::new(vote.clone())
 		})
 		.dispatch_bypass_filter(RuntimeOrigin::signed(id)));
 	});
@@ -1043,7 +1043,7 @@ fn solana_ccm_execution_error_can_trigger_fallback() {
 
 				assert_ok!(SolanaElections::vote(
 					RuntimeOrigin::signed(v),
-					vote.clone()
+					Box::new(vote.clone())
 				));
 			}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/mocks/access.rs
@@ -438,7 +438,6 @@ impl MockStorageAccess {
 		key: ES::ElectoralUnsynchronisedStateMapKey,
 		value: Option<ES::ElectoralUnsynchronisedStateMapValue>,
 	) {
-		println!("Setting unsynced state map for key: {:?}", key);
 		ELECTORAL_UNSYNCHRONISED_STATE_MAP.with(|old_state_map| {
 			let mut state_map_ref = old_state_map.borrow_mut();
 			match value {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -120,6 +120,7 @@ impl<
 				election_access.delete();
 				ElectoralAccess::set_unsynchronised_state(consensus.clone())?;
 				Hook::update_fee(consensus);
+				ElectoralAccess::new_election((), (), ())?;
 			}
 		} else {
 			ElectoralAccess::new_election((), (), ())?;

--- a/state-chain/pallets/cf-elections/src/tests.rs
+++ b/state-chain/pallets/cf-elections/src/tests.rs
@@ -43,7 +43,7 @@ fn votes_not_provided_until_shared_data_is_provided() {
 		.new_election()
 		.assert_calls_noop(
 			&authorities[..],
-			|_| Call::<_, _>::provide_shared_data { shared_data: () },
+			|_| Call::<_, _>::provide_shared_data { shared_data: Box::new(()) },
 			Error::<Test, _>::UnreferencedSharedData,
 		)
 		.assume_consensus()
@@ -70,7 +70,7 @@ fn votes_not_provided_until_shared_data_is_provided() {
 	// Case 1: Provide Shared Data through provide_shared_data extrinsic:
 	let case_1 = TestRunner::from_snapshot(initial_test_state.clone())
 		.assert_calls_ok(&authorities[..1], |_| Call::<Test, Instance1>::provide_shared_data {
-			shared_data: (),
+			shared_data: Box::new(()),
 		});
 
 	// Case 2: Provide Shared Data through vote extrinsic:
@@ -206,17 +206,21 @@ impl ElectoralSystemRunnerTestExt for TestRunner<TestContext> {
 							(
 								OriginTrait::signed(*id),
 								Call::<Test, I>::vote {
-									authority_votes: BoundedBTreeMap::try_from(
-										sp_std::iter::once((
-											ElectionIdentifierOf::<MockElectoralSystemRunner>::new(
-												*umi,
-												(),
-											),
-											vote.clone(),
-										))
-										.collect::<BTreeMap<_, _>>(),
-									)
-									.unwrap(),
+									authority_votes:
+										Box::new(
+											BoundedBTreeMap::try_from(
+												sp_std::iter::once(
+													(
+														ElectionIdentifierOf::<
+															MockElectoralSystemRunner,
+														>::new(*umi, ()),
+														vote.clone(),
+													),
+												)
+												.collect::<BTreeMap<_, _>>(),
+											)
+											.unwrap(),
+										),
 								},
 								expected_outcome.clone().map_err(Into::into),
 							)

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -3260,11 +3260,12 @@ mod test {
 	// Introduced from polkadot
 	#[test]
 	fn call_size() {
+		let call_size = core::mem::size_of::<RuntimeCall>();
 		assert!(
-			core::mem::size_of::<RuntimeCall>() <= CALL_ENUM_MAX_SIZE,
+			call_size <= CALL_ENUM_MAX_SIZE,
 			r"
-			Polkadot suggests a 230 byte limit for the size of the Call type. We use {} but this runtime's call size
-			is {}. If this test fails then you have just added a call variant that exceed the limit.
+			Polkadot suggests a 230 byte limit for the size of the Call type. We use {CALL_ENUM_MAX_SIZE} but this runtime's call size
+			is {call_size}. If this test fails then you have just added a call variant that exceed the limit.
 
 			Congratulations!
 
@@ -3276,9 +3277,7 @@ mod test {
 			  - https://github.com/paritytech/substrate/pull/9418
 			  - https://rust-lang.github.io/rust-clippy/master/#large_enum_variant
 			  - https://fasterthanli.me/articles/peeking-inside-a-rust-enum
-			",
-			CALL_ENUM_MAX_SIZE,
-			core::mem::size_of::<RuntimeCall>(),
+			"
 		);
 	}
 }


### PR DESCRIPTION
The `call_size()` test is to restrict the enum size, we were hitting this. So introducing a Box to the extrinsics with the biggest types to resolve this.
