### PR TITLE
test: reenable BW proptests

### DIFF
--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -304,9 +304,10 @@ pub mod witness_period {
 	impl<C: ChainWitnessConfig> Arbitrary for BlockWitnessRange<C>
 	where
 		C::ChainBlockNumber: Arbitrary,
+		<C::ChainBlockNumber as Arbitrary>::Strategy: Clone + Send + Sync,
 	{
 		type Parameters = ();
-		type Strategy = impl Strategy<Value = Self>;
+		type Strategy = impl Strategy<Value = Self> + Clone + Sync + Send;
 
 		fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
 			any::<C::ChainBlockNumber>().prop_map(|height| {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -10,12 +10,11 @@ use derive_where::derive_where;
 use primitives::NonemptyContinuousHeaders;
 #[cfg(test)]
 use proptest::prelude::Arbitrary;
+#[cfg(test)]
+use proptest_derive::Arbitrary;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::fmt::Debug;
-
-#[cfg(test)]
-use proptest_derive::Arbitrary;
 
 pub mod consensus;
 pub mod primitives;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -1,5 +1,3 @@
-#[cfg(not(test))]
-use core::any::Any;
 use core::{iter::Step, ops::RangeInclusive};
 
 use super::{
@@ -26,13 +24,13 @@ pub mod state_machine;
 #[cfg(test)]
 pub trait TestTraits = Send + Sync;
 #[cfg(not(test))]
-pub trait TestTraits = Any;
+pub trait TestTraits = core::any::Any;
 
 #[cfg(test)]
 pub trait MaybeArbitrary = proptest::prelude::Arbitrary + Send + Sync
 where <Self as Arbitrary>::Strategy: Clone + Sync + Send;
 #[cfg(not(test))]
-pub trait MaybeArbitrary = Any;
+pub trait MaybeArbitrary = core::any::Any;
 
 pub trait CommonTraits = Debug + Clone + Encode + Decode + Serde + Eq;
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking.rs
@@ -1,3 +1,5 @@
+#[cfg(not(test))]
+use core::any::Any;
 use core::{iter::Step, ops::RangeInclusive};
 
 use super::{
@@ -8,6 +10,8 @@ use cf_chains::witness_period::{BlockZero, SaturatingStep};
 use codec::{Decode, Encode};
 use derive_where::derive_where;
 use primitives::NonemptyContinuousHeaders;
+#[cfg(test)]
+use proptest::prelude::Arbitrary;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::fmt::Debug;
@@ -18,6 +22,17 @@ use proptest_derive::Arbitrary;
 pub mod consensus;
 pub mod primitives;
 pub mod state_machine;
+
+#[cfg(test)]
+pub trait TestTraits = Send + Sync;
+#[cfg(not(test))]
+pub trait TestTraits = Any;
+
+#[cfg(test)]
+pub trait MaybeArbitrary = proptest::prelude::Arbitrary + Send + Sync
+where <Self as Arbitrary>::Strategy: Clone + Sync + Send;
+#[cfg(not(test))]
+pub trait MaybeArbitrary = Any;
 
 pub trait CommonTraits = Debug + Clone + Encode + Decode + Serde + Eq;
 
@@ -30,8 +45,9 @@ pub trait ChainBlockNumberTrait = CommonTraits
 	+ Ord
 	+ 'static
 	+ Sized
-	+ Validate;
-pub trait ChainBlockHashTrait = CommonTraits + Validate + Ord + 'static;
+	+ Validate
+	+ MaybeArbitrary;
+pub trait ChainBlockHashTrait = CommonTraits + Validate + Ord + 'static + MaybeArbitrary;
 
 pub trait ChainTypes: Ord + Clone + Debug + 'static {
 	type ChainBlockNumber: ChainBlockNumberTrait;
@@ -67,9 +83,10 @@ defx! {
 }
 
 defx! {
+	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct ChainProgress[T: ChainTypes] {
 		pub headers: NonemptyContinuousHeaders<T>,
-		pub removed: Option<RangeInclusive<ChainBlockNumberOf<T>>>,
+		pub removed: Option<RangeInclusive<<T as ChainTypes>::ChainBlockNumber>>,
 	}
 	validate _this (else ChainProgressError) {}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_tracking/state_machine.rs
@@ -321,7 +321,7 @@ pub mod tests {
 				}
 				.boxed()
 			},
-			Just(()),
+			|_| Just(()).boxed(),
 		);
 	}
 
@@ -358,7 +358,7 @@ pub mod tests {
 				}
 				.boxed()
 			},
-			Just(()),
+			|_| Just(()).boxed(),
 		);
 	}
 }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -261,9 +261,7 @@ pub(crate) mod tests {
 
 	use crate::{
 		electoral_systems::{
-			block_height_tracking::{
-				ChainBlockHashTrait, ChainBlockNumberTrait, ChainTypes, CommonTraits, TestTraits,
-			},
+			block_height_tracking::{ChainBlockHashTrait, ChainBlockNumberTrait, ChainTypes},
 			block_witnesser::{
 				block_processor::BlockProcessor,
 				state_machine::{

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -232,7 +232,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 		let deleted_blocks = self
 			.blocks_data
 			.extract_if(|block_number, _| {
-				block_number.saturating_forward(T::Chain::SAFETY_BUFFER) < seen_heights_below
+				block_number.saturating_forward(T::Chain::SAFETY_BUFFER) < lowest_in_progress_height
 			})
 			.collect();
 
@@ -267,7 +267,8 @@ pub(crate) mod tests {
 			block_witnesser::{
 				block_processor::BlockProcessor,
 				state_machine::{
-					BWProcessorTypes, DebugEventHook, ExecuteHook, HookTypeFor, RulesHook,
+					BWProcessorTypes, BlockDataTrait, DebugEventHook, ExecuteHook, HookTypeFor,
+					RulesHook,
 				},
 			},
 			state_machine::core::{hook_test_utils::MockHook, Hook, TypesFor, Validate},
@@ -329,11 +330,8 @@ pub(crate) mod tests {
 		}
 	}
 
-	impl<
-			N: ChainBlockNumberTrait,
-			H: ChainBlockHashTrait,
-			D: CommonTraits + TestTraits + Validate + Ord + Default + 'static,
-		> BWProcessorTypes for TypesFor<(N, H, Vec<D>)>
+	impl<N: ChainBlockNumberTrait, H: ChainBlockHashTrait, D: BlockDataTrait> BWProcessorTypes
+		for TypesFor<(N, H, Vec<D>)>
 	{
 		type Chain = Self;
 		type BlockData = Vec<D>;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -262,8 +262,7 @@ pub(crate) mod tests {
 	use crate::{
 		electoral_systems::{
 			block_height_tracking::{
-				ChainBlockHashTrait, ChainBlockNumberOf, ChainBlockNumberTrait, ChainTypes,
-				CommonTraits, TestTraits,
+				ChainBlockHashTrait, ChainBlockNumberTrait, ChainTypes, CommonTraits, TestTraits,
 			},
 			block_witnesser::{
 				block_processor::BlockProcessor,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -262,7 +262,8 @@ pub(crate) mod tests {
 	use crate::{
 		electoral_systems::{
 			block_height_tracking::{
-				ChainBlockHashTrait, ChainBlockNumberTrait, ChainTypes, CommonTraits,
+				ChainBlockHashTrait, ChainBlockNumberOf, ChainBlockNumberTrait, ChainTypes,
+				CommonTraits, TestTraits,
 			},
 			block_witnesser::{
 				block_processor::BlockProcessor,
@@ -332,7 +333,7 @@ pub(crate) mod tests {
 	impl<
 			N: ChainBlockNumberTrait,
 			H: ChainBlockHashTrait,
-			D: CommonTraits + Validate + Ord + Default + 'static,
+			D: CommonTraits + TestTraits + Validate + Ord + Default + 'static,
 		> BWProcessorTypes for TypesFor<(N, H, Vec<D>)>
 	{
 		type Chain = Self;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
@@ -60,6 +60,15 @@ macro_rules! prop_do {
     (return $($rest:tt)+) => {
         Just($($rest)+)
     };
+	($ctor:ident {
+		$($field:ident : $strat:expr,)*
+	}) => {
+		( $($strat,)* ).prop_map(
+			|($($field,)*)| $ctor {
+				$($field,)*
+			}
+		)
+	};
     ($expr:expr) => {$expr};
     (let $var:pat = $expr:expr; $($expr2:tt)+ ) => {
         {
@@ -70,6 +79,19 @@ macro_rules! prop_do {
     ($var:ident <<= $expr:expr; $($expr2:tt)+) => {
         $expr.prop_flat_map(move |$var| prop_do!($($expr2)+))
     };
+}
+
+#[macro_export]
+macro_rules! prop_construct {
+	($ctor:ident {
+		$($field:ident : $strat:expr,)*
+	}) => {
+		( $($strat,)* ).prop_map(
+			|($($field,)*)| $ctor {
+				$($field,)*
+			}
+		)
+	};
 }
 
 #[macro_export]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/helpers.rs
@@ -82,19 +82,6 @@ macro_rules! prop_do {
 }
 
 #[macro_export]
-macro_rules! prop_construct {
-	($ctor:ident {
-		$($field:ident : $strat:expr,)*
-	}) => {
-		( $($strat,)* ).prop_map(
-			|($($field,)*)| $ctor {
-				$($field,)*
-			}
-		)
-	};
-}
-
-#[macro_export]
 macro_rules! asserts {
 	($description:tt in $expr:expr; $($tail:tt)*) => {
 		assert!($expr, $description);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use sp_std::{
 	cmp::max,
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-	iter,
 	vec::Vec,
 };
 
@@ -619,7 +618,7 @@ pub struct CompactHeightTrackerExtract<'a, N: Ord> {
 	tracker: &'a mut CompactHeightTracker<N>,
 }
 
-impl<N: Step> Iterator for CompactHeightTrackerExtract<'_, N> {
+impl<N: SaturatingStep + Ord + Clone> Iterator for CompactHeightTrackerExtract<'_, N> {
 	type Item = N;
 
 	fn next(&mut self) -> Option<Self::Item> {
@@ -636,7 +635,6 @@ impl<N: Step> Iterator for CompactHeightTrackerExtract<'_, N> {
 		}
 	}
 }
-
 
 #[test]
 pub fn test_compact_height() {
@@ -668,7 +666,6 @@ pub fn test_compact_height() {
 	tracker.remove(1..6);
 	assert_eq!(tracker.elections, [].into_iter().collect());
 }
-
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -67,7 +67,7 @@ defx! {
 			.chain(this.ongoing.iter().filter(|(_, election_type)| **election_type != BWElectionType::Optimistic).map(|(height, _)| height))
 			.max()
 			.cloned()
-			.map(|max_height| max_height < this.seen_heights_below)
+			.map(|max_height| max_height.saturating_forward(1) <= this.seen_heights_below)
 			.unwrap_or(true)
 		},
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -439,11 +439,17 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 			prelude::Just,
 		};
 
+		let chain_block_number = || {
+			(0..(u32::MAX / 2) as usize).prop_map(|delta| {
+				<ChainBlockNumberOf<T::Chain> as Default>::default().saturating_forward(delta)
+			})
+		};
+
 		prop_do!(
-			let ongoing_below in any::<ChainBlockNumberOf<T::Chain>>();
-			let highest_seen_delta in any::<usize>();
-			let highest_ongoign_delta in any::<usize>();
-			let heights in btree_set(any::<ChainBlockNumberOf<T::Chain>>(), 0..40);
+			let ongoing_below in chain_block_number();
+			let highest_seen_delta in 1..1000usize;
+			let highest_ongoign_delta in 0..1000usize;
+			let heights in btree_set(chain_block_number(), 0..40);
 			let currently_highest = heights.iter().max().cloned().unwrap_or(Default::default());
 			let seen_heights_below = currently_highest.saturating_forward(highest_seen_delta);
 			let highest_ever_ongoing = currently_highest.saturating_forward(highest_ongoign_delta);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -10,7 +10,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::{
 	cmp::max,
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque},
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	iter,
 	vec::Vec,
 };

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -300,6 +300,11 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 		use cf_chains::witness_period::SaturatingStep;
 		use std::collections::BTreeSet;
 
+		assert!(
+			before.elections.seen_heights_below <= after.elections.seen_heights_below,
+			"`seen_heights_below` should be monotonically increasing"
+		);
+
 		// there should always be at most as many elections as given in the settings
 		// or more if we had more elections previously
 		assert!(
@@ -399,7 +404,7 @@ pub mod tests {
 			BlockWitnesserState {
 				elections,
 				generate_election_properties_hook: Default::default(),
-				safemode_enabled: MockHook::new(safemode),
+				safemode_enabled: MockHook::new(ConstantHook::new(safemode)),
 				block_processor: Default::default(),
 			}
 		})
@@ -438,9 +443,11 @@ pub mod tests {
 	fn generate_settings(
 	) -> impl Strategy<Value = BlockWitnesserSettings> + Clone + Debug + Sync + Send {
 		prop_do! {
-			let max_ongoing_elections in 1..10u16;
-			let safety_margin in 1..5u32;
-			return BlockWitnesserSettings { safety_margin, max_ongoing_elections }
+			BlockWitnesserSettings {
+				safety_margin: 1..5u32,
+				max_ongoing_elections: 1..10u16,
+				max_optimistic_elections: 0..3u8,
+			}
 		}
 	}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -377,27 +377,13 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 
 #[cfg(test)]
 pub mod tests {
-	use core::ops::RangeInclusive;
-
-	use proptest::{
-		arbitrary::{self, arbitrary, arbitrary_with},
-		prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy},
-		prop_oneof,
-		strategy::LazyJust,
-	};
+	use proptest::{arbitrary::arbitrary_with, prelude::*, prop_oneof};
 
 	use super::*;
 	use crate::{
-		electoral_systems::{
-			block_height_tracking::{
-				self, primitives::NonemptyContinuousHeaders, BHWTypes, ChainBlockHashTrait,
-				ChainBlockNumberTrait, HeightWitnesserProperties,
-			},
-			block_witnesser::primitives::CompactHeightTracker,
-		},
+		electoral_systems::block_height_tracking::{ChainBlockHashTrait, ChainBlockNumberTrait},
 		prop_do,
 	};
-	use frame_support::sp_runtime::offchain::http::Response;
 	use hook_test_utils::*;
 
 	fn generate_state<

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -294,6 +294,7 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 		after: &Self::State,
 	) {
 		use crate::electoral_systems::state_machine::test_utils::{BTreeMultiSet, Container};
+		use cf_chains::witness_period::SaturatingStep;
 		use std::collections::BTreeSet;
 
 		// there should always be at most as many elections as given in the settings

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -1,6 +1,8 @@
 use core::ops::RangeInclusive;
 
 use cf_chains::{witness_period::BlockWitnessRange, ChainWitnessConfig};
+#[cfg(test)]
+use proptest::prelude::{Arbitrary, Strategy};
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::VecDeque};
 
 use codec::{Decode, Encode};
@@ -224,6 +226,18 @@ impl<Tag> Validate for TypesFor<Tag> {
 	fn is_valid(&self) -> Result<(), Self::Error> {
 		Ok(())
 	}
+}
+
+#[cfg(test)]
+impl<Tag: Sync + Send> Arbitrary for TypesFor<Tag> {
+	type Parameters = ();
+
+	fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+		use proptest::prelude::Just;
+		Just(TypesFor { _phantom: Default::default() })
+	}
+
+	type Strategy = impl Strategy<Value = Self> + Debug + Clone + Sync + Send;
 }
 
 pub trait HookType {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -8,7 +8,7 @@ use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet, vec_deque::V
 use codec::{Decode, Encode};
 use derive_where::derive_where;
 use itertools::Either;
-use scale_info::{prelude::string::String, TypeInfo};
+use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_std::{fmt::Debug, vec::Vec};

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -193,7 +193,7 @@ pub trait Statemachine: AbstractApi + 'static {
 		states: impl Strategy<Value = Self::State>,
 		settings: impl Strategy<Value = Self::Settings>,
 		inputs: impl Fn(Self::Query) -> BoxedStrategy<Self::Response>,
-		context: impl Strategy<Value = Self::Context> + Clone,
+		context: impl Fn(&Self::State) -> BoxedStrategy<Self::Context>,
 	) where
 		Self::Query: sp_std::fmt::Debug + Clone + Send + PartialEq,
 		Self::Response: sp_std::fmt::Debug + Clone + Send,
@@ -230,7 +230,7 @@ pub trait Statemachine: AbstractApi + 'static {
 							let weight =
 								if Self::input_index(&mut state).is_empty() { 0 } else { 1 };
 							prop_oneof![
-								1 => context.clone().prop_map(Either::Left),
+								1 => context(&state).prop_map(Either::Left),
 								weight => select(Self::input_index(&mut state))
 									.prop_flat_map(|index| (Just(index.clone()), inputs(index)))
 									.prop_map(Either::Right),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -213,7 +213,7 @@ pub trait Statemachine: AbstractApi + 'static {
 			failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
 				"proptest-regressions",
 			))),
-			cases: 256 * 16, // 256 is the default
+			cases: 256 * 10 * 16, // 256 is the default
 			..Default::default()
 		});
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -125,7 +125,11 @@ pub trait Statemachine: AbstractApi + 'static {
 	/// The state transition function, it takes the state, and an input,
 	/// and assumes that both state and index are valid, and furthermore
 	/// that the input has the index `input_index(s)`.
-	fn step(s: &mut Self::State, input: InputOf<Self>, set: &Self::Settings) -> Self::Output;
+	fn step(
+		state: &mut Self::State,
+		input: InputOf<Self>,
+		settings: &Self::Settings,
+	) -> Self::Output;
 
 	/// Contains an optional specification of the `step` function.
 	/// Takes a state, input and next state as arguments. During testing it is verified
@@ -138,6 +142,46 @@ pub trait Statemachine: AbstractApi + 'static {
 		_settings: &Self::Settings,
 		_after: &Self::State,
 	) {
+	}
+
+	/// Runs the step function and validates the input and state both before and after, as well as
+	/// the output. This does *not* check that the input is valid for the given state because if
+	/// the SM is run as part of an electoral system this might not always be the case.
+	#[cfg(test)]
+	fn step_and_validate(
+		mut state: &mut Self::State,
+		input: InputOf<Self>,
+		settings: &Self::Settings,
+	) -> Self::Output
+	where
+		Self::Query: sp_std::fmt::Debug + Clone + Send + PartialEq,
+		Self::Response: sp_std::fmt::Debug + Clone + Send,
+		Self::State: sp_std::fmt::Debug + Clone + Send,
+		Self::Context: sp_std::fmt::Debug + Clone + Send,
+		Self::Settings: sp_std::fmt::Debug + Clone + Send,
+		Self::Error: sp_std::fmt::Debug,
+	{
+		// ensure that inputs are well formed
+		assert!(state.is_valid().is_ok(), "input state not valid {:?}", state.is_valid());
+		// backup state
+		let mut prev_state = state.clone();
+
+		// run step function and ensure that output is valid
+		let output = Self::step(&mut state, input.clone(), &settings);
+		assert!(output.is_valid().is_ok(), "step function failed");
+
+		// ensure that state is still well formed
+		assert!(
+			state.is_valid().is_ok(),
+			"state after step function is not valid ({:#?}), reason: {:?}",
+			state,
+			state.is_valid()
+		);
+
+		// ensure that step function computed valid state
+		Self::step_specification(&mut prev_state, &input, &output, &settings, &state);
+
+		output
 	}
 
 	/// Given strategies `states` and `inputs` for generating arbitrary, valid values, runs the step
@@ -178,61 +222,41 @@ pub trait Statemachine: AbstractApi + 'static {
 				&((states, settings).prop_flat_map(|(mut state, settings)| {
 					(
 						Just(state.clone()),
-						prop_oneof![
-							context.clone().prop_map(Either::Left),
-							select(Self::input_index(&mut state))
-								.prop_flat_map(|index| (Just(index.clone()), inputs(index)))
-								.prop_map(Either::Right),
-						],
+						{
+							// If there are no input indices we don't want to take
+							// the branch that selects an input index. This code is
+							// a bit convoluted, but it was the most convenient way
+							// to select between two different strategies.
+							let weight =
+								if Self::input_index(&mut state).is_empty() { 0 } else { 1 };
+							prop_oneof![
+								1 => context.clone().prop_map(Either::Left),
+								weight => select(Self::input_index(&mut state))
+									.prop_flat_map(|index| (Just(index.clone()), inputs(index)))
+									.prop_map(Either::Right),
+							]
+						},
 						Just(settings),
 					)
 				})),
 				#[allow(clippy::type_complexity)]
-				run_with_timeout(
-					10,
-					|(mut state, input, settings): (
-						Self::State,
-						Either<Self::Context, (Self::Query, Self::Response)>,
-						Self::Settings,
-					)| {
-						// ensure that inputs are well formed
-						assert!(
-							state.is_valid().is_ok(),
-							"input state not valid {:?}",
-							state.is_valid()
-						);
+				// run_with_timeout(
+				// 	500,
+				|(mut state, input, settings): (
+					Self::State,
+					Either<Self::Context, (Self::Query, Self::Response)>,
+					Self::Settings,
+				)| {
+					// ensure input has correct index
+					Self::validate_input(&Self::input_index(&mut state), &input)
+						.unwrap_or_else(|_| panic!("input has wrong index: {input:?}"));
 
-						// ensure input has correct index
-						Self::validate_input(&Self::input_index(&mut state), &input)
-							.unwrap_or_else(|_| panic!("input has wrong index: {input:?}"));
+					// run step and verify all other properties
+					let _output = Self::step_and_validate(&mut state, input, &settings);
 
-						// backup state
-						let mut prev_state = state.clone();
-
-						// run step function and ensure that output is valid
-						let output = Self::step(&mut state, input.clone(), &settings);
-						assert!(output.is_valid().is_ok(), "step function failed");
-
-						// ensure that state is still well formed
-						assert!(
-							state.is_valid().is_ok(),
-							"state after step function is not valid ({:?})",
-							state
-						);
-
-						// ensure that step function computed valid state
-						Self::step_specification(
-							&mut prev_state,
-							&input,
-							&output,
-							&settings,
-							&state,
-						);
-
-						println!("done test");
-						Ok(())
-					},
-				),
+					Ok(())
+				},
+				// ),
 			)
 			.unwrap();
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -58,7 +58,6 @@ type ElectionCount = u16;
 struct MockBlockProcessorDefinition;
 type Types = TypesFor<MockBlockProcessorDefinition>;
 
-
 impl Hook<HookTypeFor<Types, RulesHook>> for Types {
 	fn run(
 		&mut self,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -57,7 +57,7 @@ type ElectionProperties = BTreeSet<u16>;
 struct MockBlockProcessorDefinition;
 type Types = TypesFor<MockBlockProcessorDefinition>;
 
-impl Hook<HookTypeFor<(), SafeModeEnabledHook>> for Types {
+impl Hook<HookTypeFor<Self, SafeModeEnabledHook>> for Types {
 	fn run(&mut self, _input: ()) -> SafeModeStatus {
 		SafeModeStatus::Disabled
 	}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -92,7 +92,7 @@ impl BWTypes for Types {
 	type ElectionProperties = ElectionProperties;
 	type ElectionPropertiesHook =
 		MockHook<HookTypeFor<Self, ElectionPropertiesHook>, "generate_election_properties">;
-	type SafeModeEnabledHook = MockHook<HookTypeFor<(), SafeModeEnabledHook>, "safe_mode">;
+	type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>, "safe_mode">;
 	type ElectionTrackerDebugEventHook = MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -253,7 +253,8 @@ fn run_simulation(blocks: ForkedFilledChain) {
 					)
 				});
 
-				BW::step(&mut bw_state, Either::Left(bhw_output), &bw_settings).unwrap();
+				BW::step_and_validate(&mut bw_state, Either::Left(bhw_output), &bw_settings)
+					.unwrap();
 
 				history.extend(
 					bw_state.elections.debug_events.take_history().into_iter().map(BWTrace::ET),
@@ -285,7 +286,7 @@ fn run_simulation(blocks: ForkedFilledChain) {
 					)
 				});
 
-				BW::step(&mut bw_state, input, &bw_settings).unwrap();
+				BW::step_and_validate(&mut bw_state, input, &bw_settings).unwrap();
 
 				history.extend(
 					bw_state.elections.debug_events.take_history().into_iter().map(BWTrace::ET),

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -52,7 +52,6 @@ use pallet_cf_elections::{
 };
 use pallet_cf_ingress_egress::{DepositWitness, PalletSafeMode, VaultDepositWitness};
 use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
 use sp_core::{Decode, Encode, Get, MaxEncodedLen};
 use sp_std::vec::Vec;
 

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -132,46 +132,6 @@ impls! {
 pub type BitcoinBlockHeightTrackingES =
 	StatemachineElectoralSystem<TypesFor<BitcoinBlockHeightTracking>>;
 
-#[derive(
-	Clone,
-	PartialEq,
-	Eq,
-	PartialOrd,
-	Ord,
-	Debug,
-	Encode,
-	Decode,
-	TypeInfo,
-	MaxEncodedLen,
-	Serialize,
-	Deserialize,
-	Default,
-)]
-pub struct DepositSafeModeHook {}
-
-impl Hook<HookTypeFor<(), SafeModeEnabledHook>> for DepositSafeModeHook {
-	fn run(&mut self, _input: ()) -> SafeModeStatus {
-		if <<Runtime as pallet_cf_ingress_egress::Config<BitcoinInstance>>::SafeMode as Get<
-			PalletSafeMode<BitcoinInstance>,
-		>>::get()
-		.deposits_enabled
-		{
-			SafeModeStatus::Disabled
-		} else {
-			SafeModeStatus::Enabled
-		}
-	}
-}
-
-use pallet_cf_elections::electoral_systems::state_machine::core::Validate;
-impl Validate for DepositSafeModeHook {
-	type Error = ();
-
-	fn is_valid(&self) -> Result<(), Self::Error> {
-		Ok(())
-	}
-}
-
 // ------------------------ deposit channel witnessing ---------------------------
 /// The electoral system for deposit channel witnessing
 pub struct BitcoinDepositChannelWitnessing;
@@ -197,7 +157,7 @@ impls! {
 	BWTypes {
 		type ElectionProperties = ElectionPropertiesDepositChannel;
 		type ElectionPropertiesHook = Self;
-		type SafeModeEnabledHook = DepositSafeModeHook;
+		type SafeModeEnabledHook = Self;
 		type ElectionTrackerDebugEventHook = EmptyHook;
 	}
 
@@ -227,6 +187,19 @@ impls! {
 		}
 	}
 
+	Hook<HookTypeFor<Self, SafeModeEnabledHook>> {
+		fn run(&mut self, _input: ()) -> SafeModeStatus {
+			if <<Runtime as pallet_cf_ingress_egress::Config<BitcoinInstance>>::SafeMode as Get<
+				PalletSafeMode<BitcoinInstance>,
+			>>::get()
+			.deposits_enabled
+			{
+				SafeModeStatus::Disabled
+			} else {
+				SafeModeStatus::Enabled
+			}
+		}
+	}
 }
 /// Generating the state machine-based electoral system
 pub type BitcoinDepositChannelWitnessingES =
@@ -259,7 +232,7 @@ impls! {
 	BWTypes {
 		type ElectionProperties = ElectionPropertiesVaultDeposit;
 		type ElectionPropertiesHook = Self;
-		type SafeModeEnabledHook = DepositSafeModeHook;
+		type SafeModeEnabledHook = Self;
 		type ElectionTrackerDebugEventHook = EmptyHook;
 	}
 
@@ -291,6 +264,20 @@ impls! {
 						.map(move |address| (address, broker_id.clone(), channel_id))
 				})
 				.collect::<Vec<_>>()
+		}
+	}
+
+	Hook<HookTypeFor<Self, SafeModeEnabledHook>> {
+		fn run(&mut self, _input: ()) -> SafeModeStatus {
+			if <<Runtime as pallet_cf_ingress_egress::Config<BitcoinInstance>>::SafeMode as Get<
+				PalletSafeMode<BitcoinInstance>,
+			>>::get()
+			.deposits_enabled
+			{
+				SafeModeStatus::Disabled
+			} else {
+				SafeModeStatus::Enabled
+			}
 		}
 	}
 
@@ -345,7 +332,7 @@ impls! {
 	}
 
 	/// implementation of safe mode reading hook
-	Hook<HookTypeFor<(), SafeModeEnabledHook>> {
+	Hook<HookTypeFor<Self, SafeModeEnabledHook>> {
 		fn run(&mut self, _input: ()) -> SafeModeStatus {
 			// TODO: Add egress witnessing safe mode: PRO-2311
 			SafeModeStatus::Disabled


### PR DESCRIPTION
# Pull Request

Closes: PRO-2321

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This re-enables the (statemachine) (unit-) proptests for the BW. They've been disabled a long time due to refactorings.

This surfaced a few bugs, so in particular this commit includes the following changes:
 - fix: expire optimistic blocks.
 - fix: forward Governance election block data to BP.
 - fix: only mutate ongoing ByHash elections to BySafeHeight, don't do anything with Optimistic.
 - test: remove the requirement for safeheight elections to be lower than ongoing. This is because in certain cases (impossible with the current BHW) we can't guarantee it.
 - test: add an alternative requirement for safeheight and ongoing elections to be disjoint.
 - fix: rewrite the CompactHeightTracker to use a BTreeMap internally. This also fixes a few bugs in its behaviour.