### PR TITLE
feat: create different safe modes for different block-witnessers

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -62,6 +62,7 @@ type AggKey<T, I> =
 impl_pallet_safe_mode! {
 	PalletSafeMode<I>;
 	retry_enabled,
+	egress_witnessing_enabled
 }
 
 /// The number of broadcast attempts that were made before this one.

--- a/state-chain/pallets/cf-chain-tracking/src/lib.rs
+++ b/state-chain/pallets/cf-chain-tracking/src/lib.rs
@@ -168,6 +168,7 @@ pub mod pallet {
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	//TODO: to be removed once all chains are converted to election based witnessing
 	pub fn inner_update_chain_state(new_chain_state: ChainState<T::TargetChain>) -> DispatchResult {
 		CurrentChainState::<T, I>::try_mutate::<_, Error<T, I>, _>(|previous_chain_state| {
 			ensure!(

--- a/state-chain/pallets/cf-chain-tracking/src/lib.rs
+++ b/state-chain/pallets/cf-chain-tracking/src/lib.rs
@@ -185,6 +185,22 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
+	pub fn inner_update_chain_height(
+		new_height: <T::TargetChain as Chain>::ChainBlockNumber,
+	) -> DispatchResult {
+		CurrentChainState::<T, I>::try_mutate(|previous_chain_state| {
+			ensure!(
+				new_height > previous_chain_state.as_ref().expect(NO_CHAIN_STATE).block_height,
+				Error::<T, I>::StaleDataSubmitted
+			);
+			previous_chain_state.as_mut().expect(NO_CHAIN_STATE).block_height = new_height;
+
+			Ok::<(), DispatchError>(())
+		})?;
+
+		Ok(())
+	}
+
 	pub fn inner_update_fee(new_fee: <T::TargetChain as Chain>::TrackedData) -> DispatchResult {
 		CurrentChainState::<T, I>::mutate(|previous_chain_state| {
 			previous_chain_state.as_mut().expect(NO_CHAIN_STATE).tracked_data = new_fee;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -69,7 +69,7 @@ defx! {
 			.unwrap_or(true)
 		},
 
-		// The `highest_ever_ongoing_election` should always be updated when new elections are created. 
+		// The `highest_ever_ongoing_election` should always be updated when new elections are created.
 		highest_ever_ongoing_election_is_updated: {
 			this.ongoing.keys().all(|height| *height <= this.highest_ever_ongoing_election)
 		},

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -365,7 +365,9 @@ impl_pallet_safe_mode! {
 	boost_deposits_enabled,
 	add_boost_funds_enabled,
 	stop_boosting_enabled,
-	deposits_enabled,
+	deposit_channel_creation_enabled,
+	deposit_channel_witnessing_enabled,
+	vault_deposit_witnessing_enabled,
 }
 
 /// Calls to the external chains that has failed to be broadcast/accepted by the target chain.
@@ -3084,7 +3086,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		(ChannelId, TargetChainAccount<T, I>, TargetChainBlockNumber<T, I>, T::Amount),
 		DispatchError,
 	> {
-		ensure!(T::SafeMode::get().deposits_enabled, Error::<T, I>::DepositChannelCreationDisabled);
+		ensure!(
+			T::SafeMode::get().deposit_channel_creation_enabled,
+			Error::<T, I>::DepositChannelCreationDisabled
+		);
 
 		let channel_opening_fee = ChannelOpeningFee::<T, I>::get();
 		T::FeePayment::try_burn_fee(requester, channel_opening_fee)?;

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -1781,7 +1781,7 @@ fn safe_mode_prevents_deposit_channel_creation() {
 
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
 			ingress_egress_ethereum: PalletSafeMode {
-				deposits_enabled: false,
+				deposit_channel_creation_enabled: false,
 				..PalletSafeMode::CODE_GREEN
 			},
 			..MockRuntimeSafeMode::CODE_GREEN

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -839,8 +839,10 @@ fn boosting_with_safe_mode(enable: bool) {
 
 	let boost_mode = if enable { PalletSafeMode::CODE_GREEN } else { PalletSafeMode::CODE_RED };
 
-	let new_mode =
-		PalletSafeMode { deposits_enabled: get_safe_mode().deposits_enabled, ..boost_mode };
+	let new_mode = PalletSafeMode {
+		deposit_channel_creation_enabled: get_safe_mode().deposit_channel_creation_enabled,
+		..boost_mode
+	};
 
 	assert!(get_safe_mode() != new_mode, "Boosting is already in the requested mode");
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2311

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Added different safe modes for:
- deposit channel creation
- deposit channel witnessing
- vault deposit witnessing
- egress witnessing

+ introduced `inner_update_chain_height` to avoid setting the BTC fees to 0 when updating the chain height 
