### PR TITLE
feat: bouncer deposit liquidity timeout

### DIFF
--- a/bouncer/shared/deposit_liquidity.ts
+++ b/bouncer/shared/deposit_liquidity.ts
@@ -30,7 +30,7 @@ export async function depositLiquidity(
   await using chainflip = await getChainflipApi();
   const chain = shortChainFromAsset(ccy);
 
-  const lp = createStateChainKeypair(lpUri ?? (process.env.LP_URI || '//LP_1'));
+  const lp = createStateChainKeypair(lpUri);
 
   // If no liquidity refund address is registered, then do that now
   if (

--- a/bouncer/shared/deposit_liquidity.ts
+++ b/bouncer/shared/deposit_liquidity.ts
@@ -11,22 +11,26 @@ import {
   decodeSolAddress,
   assetDecimals,
   createStateChainKeypair,
+  runWithTimeout,
 } from 'shared/utils';
 import { send } from 'shared/send';
 import { getChainflipApi, observeEvent } from 'shared/utils/substrate';
 import { Logger } from 'shared/utils/logger';
 
 export async function depositLiquidity(
-  logger: Logger,
+  parentLogger: Logger,
   ccy: Asset,
   amount: number,
   waitForFinalization = false,
-  lpKey?: string,
+  optionLpUri?: string,
 ) {
+  const lpUri = optionLpUri ?? (process.env.LP_URI || '//LP_1');
+  const logger = parentLogger.child({ ccy, amount, lpUri });
+
   await using chainflip = await getChainflipApi();
   const chain = shortChainFromAsset(ccy);
 
-  const lp = createStateChainKeypair(lpKey ?? (process.env.LP_URI || '//LP_1'));
+  const lp = createStateChainKeypair(lpUri ?? (process.env.LP_URI || '//LP_1'));
 
   // If no liquidity refund address is registered, then do that now
   if (
@@ -44,7 +48,7 @@ export async function depositLiquidity(
         : refundAddress;
     refundAddress = chain === 'Sol' ? decodeSolAddress(refundAddress) : refundAddress;
 
-    logger.debug('Registering Liquidity Refund Address for ' + ccy + ': ' + refundAddress);
+    logger.debug(`Registering Liquidity Refund Address for ${refundAddress}`);
     await lpMutex.runExclusive(async () => {
       const nonce = await chainflip.rpc.system.accountNextIndex(lp.address);
       await chainflip.tx.liquidityProvider
@@ -67,8 +71,7 @@ export async function depositLiquidity(
 
   const ingressAddress = (await eventHandle).data.depositAddress[chain];
 
-  logger.trace(`Received ${ccy} deposit address: ${ingressAddress}`);
-  logger.trace(`Initiating transfer of ${amount} ${ccy} to ${ingressAddress}`);
+  logger.trace(`Initiating transfer to ${ingressAddress}`);
   eventHandle = observeEvent(logger, 'assetBalances:AccountCredited', {
     test: (event) =>
       event.data.asset === ccy &&
@@ -78,10 +81,17 @@ export async function depositLiquidity(
         BigInt(amountToFineAmount(String(amount), assetDecimals(ccy))),
       ),
     finalized: waitForFinalization,
+    timeoutSeconds: 90,
   }).event;
 
-  await send(logger, ccy, ingressAddress, String(amount));
+  await runWithTimeout(
+    send(logger, ccy, ingressAddress, String(amount)),
+    30,
+    logger,
+    `sending liquidity ${amount} ${ccy}.`,
+  );
 
   await eventHandle;
-  logger.debug(`Liquidity deposited: ${amount} ${ccy} to ${ingressAddress}`);
+
+  logger.debug(`Liquidity deposited to ${ingressAddress}`);
 }

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -34,7 +34,7 @@ import { getChainflipApi, observeBadEvent, observeEvent } from 'shared/utils/sub
 import { execWithLog } from 'shared/utils/exec_with_log';
 import { send } from 'shared/send';
 import { TestContext } from 'shared/utils/test_context';
-import { Logger, throwError } from 'shared/utils/logger';
+import { Logger, loggerError, throwError } from 'shared/utils/logger';
 
 const cfTesterAbi = await getCFTesterAbi();
 const cfTesterIdl = await getCfTesterIdl();
@@ -306,15 +306,27 @@ export function stateChainAssetFromAsset(asset: Asset): string {
   throw new Error(`Unsupported asset: ${asset}`);
 }
 
-export const runWithTimeout = async <T>(promise: Promise<T>, seconds: number): Promise<T> =>
-  Promise.race([
+export async function runWithTimeout<T>(
+  promise: Promise<T>,
+  seconds: number,
+  logger?: Logger,
+  taskDescription?: string,
+): Promise<T> {
+  // Add the task description to the error message if provided
+  let error = new Error(
+    `Timed out after ${seconds}s.` + (taskDescription ? ` Waiting on: ${taskDescription}` : ''),
+  );
+  if (logger) {
+    // Add the logger info to the error message if a logger is provided
+    error = loggerError(logger, error);
+  }
+  return Promise.race([
     promise,
-    sleep(seconds * 1000, new Error(`Timed out after ${seconds}s.`), { ref: false }).then(
-      (error) => {
-        throw error;
-      },
-    ),
+    sleep(seconds * 1000, error, { ref: false }).then((e) => {
+      throw e;
+    }),
   ]);
+}
 
 /// Runs the given promise with a timeout and handles exiting the process. Used for running commands.
 export async function runWithTimeoutAndExit<T>(

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -1,7 +1,7 @@
 import 'disposablestack/auto';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { Observable, Subject } from 'rxjs';
-import { deferredPromise, sleep } from 'shared/utils';
+import { deferredPromise, runWithTimeout, sleep } from 'shared/utils';
 import { Logger } from 'shared/utils/logger';
 
 // @ts-expect-error polyfilling
@@ -358,6 +358,7 @@ interface BaseOptions<T> {
   test?: EventTest<T>;
   finalized?: boolean;
   historicalCheckBlocks?: number;
+  timeoutSeconds?: number;
 }
 
 interface Options<T> extends BaseOptions<T> {
@@ -399,6 +400,7 @@ export function observeEvents<T = any>(
     test = () => true,
     finalized = false,
     historicalCheckBlocks = 0,
+    timeoutSeconds = 0,
     abortable = false,
   }: Options<T> | AbortableOptions<T> = {},
 ) {
@@ -429,26 +431,41 @@ export function observeEvents<T = any>(
       return foundEvents;
     }
 
-    // Subscribe to new events and wait for the first match
-    await using subscription = await subscribeHeads({ chain, finalized });
-    const subscriptionIterator = observableToIterable(subscription.observable, controller?.signal);
-    for await (const events of subscriptionIterator) {
-      for (const event of events) {
-        if (
-          event.name.section.includes(expectedSection) &&
-          event.name.method.includes(expectedMethod) &&
-          test(event)
-        ) {
-          foundEvents.push(event);
-          logger.trace(`Found event ${eventName} in block ${event.block}`);
+    const findEventSubscription = async () => {
+      // Subscribe to new events and wait for the first match
+      await using subscription = await subscribeHeads({ chain, finalized });
+      const subscriptionIterator = observableToIterable(
+        subscription.observable,
+        controller?.signal,
+      );
+      for await (const events of subscriptionIterator) {
+        for (const event of events) {
+          if (
+            event.name.section.includes(expectedSection) &&
+            event.name.method.includes(expectedMethod) &&
+            test(event)
+          ) {
+            foundEvents.push(event);
+            logger.trace(`Found event ${eventName} in block ${event.block}`);
+          }
+        }
+        if (foundEvents.length > 0) {
+          return foundEvents;
         }
       }
-      if (foundEvents.length > 0) {
-        return foundEvents;
-      }
-    }
 
-    return null;
+      return null;
+    };
+
+    if (timeoutSeconds > 0) {
+      return runWithTimeout(
+        findEventSubscription(),
+        timeoutSeconds,
+        logger,
+        `observing event ${eventName}`,
+      );
+    }
+    return findEventSubscription();
   };
 
   if (!controller) return { events: findEvent() } as Observer<T>;
@@ -485,6 +502,7 @@ export function observeEvent<T = any>(
     test = () => true,
     finalized = false,
     historicalCheckBlocks = 0,
+    timeoutSeconds = 0,
     abortable = false,
   }: Options<T> | AbortableOptions<T> = {},
 ): SingleEventObserver<T> | SingleEventAbortableObserver<T> {
@@ -494,6 +512,7 @@ export function observeEvent<T = any>(
       test,
       finalized,
       historicalCheckBlocks,
+      timeoutSeconds,
       abortable,
     });
 
@@ -508,6 +527,7 @@ export function observeEvent<T = any>(
     test,
     finalized,
     historicalCheckBlocks,
+    timeoutSeconds,
     abortable,
   });
 

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -89,11 +89,13 @@ async function testRegisterLiquidityRefundAddress(parentLogger: Logger) {
 }
 
 async function testLiquidityDepositLegacy(logger: Logger) {
+  const lpAccount = createStateChainKeypair('//LP_API');
+
   const observeLiquidityDepositAddressReadyEvent = observeEvent(
     logger,
     'liquidityProvider:LiquidityDepositAddressReady',
     {
-      test: (event) => event.data.depositAddress.Eth,
+      test: (event) => event.data.depositAddress.Eth && event.data.accountId === lpAccount.address,
     },
   ).event;
 
@@ -137,11 +139,13 @@ async function testLiquidityDepositLegacy(logger: Logger) {
 }
 
 async function testLiquidityDeposit(logger: Logger) {
+  const lpAccount = createStateChainKeypair('//LP_API');
+
   const observeLiquidityDepositAddressReadyEvent = observeEvent(
     logger,
     'liquidityProvider:LiquidityDepositAddressReady',
     {
-      test: (event) => event.data.depositAddress.Eth,
+      test: (event) => event.data.depositAddress.Eth && event.data.accountId === lpAccount.address,
     },
   ).event;
 


### PR DESCRIPTION
# Pull Request

- Added a timeout feature to the observe event function.
- Added the option for the run with timeout function to use the logger and take a description of the task that its running.
- Used the features to add a 90sec timeout to the deposit liquidity function where it has been timing out on the "flaky" tests.
- Start of PRO-1997