### PR TITLE
feat: reorg-safe channel expiry

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -42,6 +42,7 @@ pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 	type ElectionProperties: MaybeArbitrary + CommonTraits + TestTraits;
 	type ElectionPropertiesHook: Hook<HookTypeFor<Self, ElectionPropertiesHook>> + CommonTraits;
 	type SafeModeEnabledHook: Hook<HookTypeFor<Self, SafeModeEnabledHook>> + CommonTraits;
+	type ProcessedUpToHook: Hook<HookTypeFor<Self, ProcessedUpToHook>> + CommonTraits;
 
 	type ElectionTrackerDebugEventHook: Hook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>
 		+ CommonTraits
@@ -77,6 +78,12 @@ impl<T: BWProcessorTypes> HookType for HookTypeFor<T, RulesHook> {
 pub struct ExecuteHook;
 impl<T: BWProcessorTypes> HookType for HookTypeFor<T, ExecuteHook> {
 	type Input = Vec<(ChainBlockNumberOf<T::Chain>, T::Event)>;
+	type Output = ();
+}
+
+pub struct ProcessedUpToHook;
+impl<T: BWProcessorTypes> HookType for HookTypeFor<T, ProcessedUpToHook> {
+	type Input = ChainBlockNumberOf<T::Chain>;
 	type Output = ();
 }
 
@@ -125,6 +132,7 @@ defx! {
 		pub generate_election_properties_hook: T::ElectionPropertiesHook,
 		pub safemode_enabled: T::SafeModeEnabledHook,
 		pub block_processor: BlockProcessor<T>,
+		pub processed_up_to: T::ProcessedUpToHook,
 	}
 	validate _this (else BlockWitnesserError) {}
 }
@@ -206,10 +214,6 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			.clone()
 			.into_iter()
 			.map(|(block_height, election_type)| {
-				// We apply the SAFETY_BUFFER before we fetch the election_properties,
-				// this makes sure that if txs that have been submitted post channel creation,
-				// but due to reorg ended up in an external chain block that's below the channels `opened_at`,
-				// are still witnessed. (See PRO-2306).
 				let height_for_election_properties = block_height.saturating_forward(T::Chain::SAFETY_BUFFER);
 				match election_type {
 					BWElectionType::Governance(properties) => BWElectionProperties {
@@ -278,6 +282,8 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			},
 		};
 
+		let lowest_in_progress_height = state.elections.lowest_in_progress_height();
+
 		state.block_processor.process_blocks_up_to(
 			state.elections.seen_heights_below,
 			// NOTE: we use the lowest "in progress" height for expiring block and event
@@ -285,7 +291,7 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			// call), no event data is going to be deleted. That's why we can't use
 			// the `highest_seen` block height, because that one progresses always
 			// following data from the BHW, ignoring ongoing elections.
-			state.elections.lowest_in_progress_height(),
+			lowest_in_progress_height,
 		);
 
 		state.elections.start_more_elections(
@@ -293,6 +299,9 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 			settings.max_optimistic_elections,
 			state.safemode_enabled.run(()),
 		);
+
+		// We subtract 1 since that is the block that we have processed up to.
+		state.processed_up_to.run(lowest_in_progress_height.saturating_backward(1));
 
 		Ok(())
 	}
@@ -407,6 +416,7 @@ pub mod tests {
 	>() -> impl Strategy<Value = BlockWitnesserState<T>>
 	where
 		T::ElectionPropertiesHook: Default,
+		T::ProcessedUpToHook: Default,
 		T::BlockData: Default,
 	{
 		(any::<SafeModeStatus>(), any::<ElectionTracker<T>>()).prop_map(|(safemode, elections)| {
@@ -414,6 +424,7 @@ pub mod tests {
 				elections,
 				generate_election_properties_hook: Default::default(),
 				safemode_enabled: MockHook::new(ConstantHook::new(safemode)),
+				processed_up_to: Default::default(),
 				block_processor: Default::default(),
 			}
 		})
@@ -482,6 +493,8 @@ pub mod tests {
 		type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>>;
 		type ElectionTrackerDebugEventHook =
 			MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
+		type ProcessedUpToHook =
+			MockHook<HookTypeFor<Self, ProcessedUpToHook>>;
 	}
 
 	#[test]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -24,10 +24,7 @@ use crate::{
 		block_witnesser::{
 			primitives::ElectionTracker,
 			state_machine::{
-				BWElectionProperties, BWElectionType, BWProcessorTypes, BlockWitnesserSettings,
-				BlockWitnesserState, DebugEventHook, ElectionPropertiesHook,
-				ElectionTrackerDebugEventHook, ExecuteHook, HookTypeFor, RulesHook,
-				SafeModeEnabledHook,
+				BWElectionProperties, BWElectionType, BWProcessorTypes, BlockWitnesserSettings, BlockWitnesserState, DebugEventHook, ElectionPropertiesHook, ElectionTrackerDebugEventHook, ExecuteHook, HookTypeFor, ProcessedUpToHook, RulesHook, SafeModeEnabledHook
 			},
 			*,
 		},
@@ -93,6 +90,7 @@ impl BWTypes for Types {
 	type ElectionPropertiesHook =
 		MockHook<HookTypeFor<Self, ElectionPropertiesHook>, "generate_election_properties">;
 	type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>, "safe_mode">;
+	type ProcessedUpToHook = MockHook<HookTypeFor<Self, ProcessedUpToHook>, "processed_up_to">;
 	type ElectionTrackerDebugEventHook = MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -187,6 +187,7 @@ fn run_simulation(blocks: ForkedFilledChain) {
 		elections: Default::default(),
 		generate_election_properties_hook: Default::default(),
 		safemode_enabled: MockHook::new(ConstantHook::new(SafeModeStatus::Disabled)),
+		processed_up_to: Default::default(),
 		block_processor,
 	};
 	let bw_settings = BlockWitnesserSettings {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -3094,45 +3094,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	// This should only be used if we're using ProcessedUpTo to track the block height.
 	pub fn active_deposit_channels_at(
-		block_height: TargetChainBlockNumber<T, I>,
+		opened_at_or_before: TargetChainBlockNumber<T, I>,
+		expires_after: TargetChainBlockNumber<T, I>,
 	) -> Vec<DepositChannelDetails<T, I>> {
-		debug_assert!(<T::TargetChain as Chain>::is_block_witness_root(block_height));
+		debug_assert!(<T::TargetChain as Chain>::is_block_witness_root(opened_at_or_before));
 
 		DepositChannelLookup::<T, I>::iter_values()
-			.filter_map(|details| {
-				if details.opened_at <= block_height &&
-					(
-						block_height <= details.expires_at
-						// QUESTION: The following code should be discussed, I don't think we have
-						// to account for `ProcessedUpTo` in this place.
-						//
-						// &&
-						// // If we have not yet processed the expires_at block, then we shouldn't
-						// expire it yet. i.e. we should include it as an active channel.
-						// ProcessedUpTo::<T, I>::get() < details.expires_at)
-					) {
-					// TODO: Filter not filter_map
-					log::info!(
-						"Include channel: {:?} for height: {}",
-						details.deposit_channel,
-						block_height
-					);
-					Some(details)
-				} else {
-					log::info!(
-						"Don't include channel {:?} as it's not active at block height {:?}",
-						details.deposit_channel,
-						block_height
-					);
-					log::info!(
-						"Opened at: {:?}, Expires at: {:?}, Processed up to: {:?}",
-						details.opened_at,
-						details.expires_at,
-						ProcessedUpTo::<T, I>::get()
-					);
-					None
-				}
-			})
+			.filter(|details| 
+				details.opened_at <= opened_at_or_before &&
+					details.expires_at < expires_after
+			)
 			.collect()
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2345

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

- The `open_deposit_channels_at()` function now takes two arguments, since we have to distinguish between opening and closing heights for channels. There's a `T::Chain::SAFETY_BUFFER` difference between them, since we want to open channels by SAFETY_BUFFER blocks before their `opened_at` value. But we want to close them immediately when they reach `expire_at`.
- There's a new `ProcessedUpToHook` which is called from the BW statemachine with the `lowest_in_progress_height - 1`. The implementation of this hook for bitcoin deposit channels applies a SAFETY_BUFFER and sets the `ProcessedUpTo` value in the ingress egress pallet accordingly.
