### PR TITLE
chore: better typeinfo for bitcoin elections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "ethereum-types",
  "frame-support",
  "generic-array 1.2.0",
+ "generic-typeinfo-derive",
  "hex",
  "hex-literal",
  "itertools 0.13.0",

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -14,6 +14,7 @@ cf-amm-math = { workspace = true }
 cf-primitives = { workspace = true }
 cf-utilities = { workspace = true }
 cf-runtime-utilities = { workspace = true }
+generic-typeinfo-derive = { workspace = true }
 
 # Cryptography
 digest = { workspace = true }

--- a/state-chain/chains/src/deposit_channel.rs
+++ b/state-chain/chains/src/deposit_channel.rs
@@ -15,10 +15,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use generic_typeinfo_derive::GenericTypeInfo;
+use scale_info::prelude::format;
 
 #[derive(
-	Clone, Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	Serialize,
+	Deserialize,
+	GenericTypeInfo,
 )]
+#[expand_name_with(C::NAME)]
 pub struct DepositChannel<C: Chain> {
 	// TODO: also add pending deposits into this as a Deque.
 	pub channel_id: ChannelId,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
@@ -7,6 +7,7 @@ use super::{
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
 use derive_where::derive_where;
+use generic_typeinfo_derive::GenericTypeInfo;
 use primitives::NonemptyContinuousHeaders;
 #[cfg(test)]
 use proptest::prelude::Arbitrary;
@@ -31,7 +32,7 @@ where <Self as Arbitrary>::Strategy: Clone + Sync + Send;
 #[cfg(not(test))]
 pub trait MaybeArbitrary = core::any::Any;
 
-pub trait CommonTraits = Debug + Clone + Encode + Decode + Serde + Eq;
+pub trait CommonTraits = Debug + Clone + Encode + Decode + Serde + Eq + TypeInfo;
 
 pub trait ChainBlockNumberTrait = CommonTraits
 	+ SaturatingStep
@@ -53,6 +54,7 @@ pub trait ChainTypes: Ord + Clone + Debug + 'static {
 	/// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and in
 	/// the BlockProcessor
 	const SAFETY_BUFFER: usize;
+	const NAME: &'static str;
 }
 pub type ChainBlockNumberOf<T> = <T as ChainTypes>::ChainBlockNumber;
 pub type ChainBlockHashOf<T> = <T as ChainTypes>::ChainBlockHash;
@@ -69,6 +71,8 @@ impl<T: BHWTypes> HookType for HookTypeFor<T, BlockHeightChangeHook> {
 }
 
 defx! {
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::Chain::NAME)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct HeightWitnesserProperties[T: BHWTypes] {
 		/// An election starts with a given block number,
@@ -79,6 +83,8 @@ defx! {
 }
 
 defx! {
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::NAME)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct ChainProgress[T: ChainTypes] {
 		pub headers: NonemptyContinuousHeaders<T>,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
@@ -1,5 +1,6 @@
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
+use generic_typeinfo_derive::GenericTypeInfo;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::collections::vec_deque::VecDeque;
@@ -20,6 +21,8 @@ defx! {
 	///
 	/// These properties are verified as part of the `Validate` implementation derived by the `defx` macro.
 	#[derive(Ord, PartialOrd)]
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::NAME)]
 	pub struct NonemptyContinuousHeaders[T: ChainTypes] {
 		pub(crate) headers: VecDeque<Header<T>>,
 	}
@@ -133,6 +136,8 @@ pub enum MergeFailure<T: ChainTypes> {
 defx! {
 	/// Block header for a given chain `C` as used by the BHW.
 	#[derive(Ord, PartialOrd)]
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(C::NAME)]
 	pub struct Header[C: ChainTypes] {
 		pub block_height: C::ChainBlockNumber,
 		pub hash: C::ChainBlockHash,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -12,6 +12,7 @@ use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
 use derive_where::derive_where;
 use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
+use generic_typeinfo_derive::GenericTypeInfo;
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, vec::Vec};
 
 ///
@@ -46,7 +47,8 @@ use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, vec::Vec};
 ///     - `Execute`: A hook to dedup and execute generated events.
 /// 	- `DebugEventHook`: A hook to log events, used for testing
 #[derive_where(Debug, Clone, PartialEq, Eq;)]
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize)]
+#[derive(Encode, Decode, Serialize, Deserialize, GenericTypeInfo)]
+#[expand_name_with(T::Chain::NAME)]
 pub struct BlockProcessor<T: BWProcessorTypes> {
 	/// A mapping from block numbers to their corresponding BlockInfo (block data, the next age to
 	/// be processed and the safety margin). The "age" represents the block height difference
@@ -73,6 +75,7 @@ impl<BlockData> BlockProcessingInfo<BlockData> {
 }
 
 def_derive! {
+	#[derive(TypeInfo)]
 	pub enum BlockProcessorEvent<T: BWProcessorTypes> {
 		NewBlock {
 			height: ChainBlockNumberOf<T::Chain>,
@@ -292,6 +295,7 @@ pub(crate) mod tests {
 		Arbitrary,
 		Encode,
 		Decode,
+		TypeInfo,
 	)]
 	pub enum MockBtcEvent<E> {
 		PreWitness(E),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -6,6 +6,7 @@ use core::{
 	ops::{Range, RangeInclusive},
 };
 use derive_where::derive_where;
+use generic_typeinfo_derive::GenericTypeInfo;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::{
@@ -27,6 +28,8 @@ use crate::electoral_systems::{
 use super::state_machine::{BWElectionType, BWTypes, EngineElectionType};
 
 defx! {
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::Chain::NAME)]
 	pub struct ElectionTracker[T: BWTypes] {
 		/// The lowest block we haven't seen yet. I.e., we have seen blocks below.
 		pub seen_heights_below: ChainBlockNumberOf<T::Chain>,
@@ -504,6 +507,8 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 }
 
 def_derive! {
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::Chain::NAME)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct OptimisticBlock<T: BWTypes> {
 		pub hash: <T::Chain as ChainTypes>::ChainBlockHash,
@@ -519,6 +524,8 @@ impl<T: BWTypes> Validate for OptimisticBlock<T> {
 }
 
 def_derive! {
+	#[derive(GenericTypeInfo)]
+	#[expand_name_with(T::Chain::NAME)]
 	pub enum ElectionTrackerEvent<T: BWTypes> {
 		ComparingBlocks {
 			height: ChainBlockNumberOf<T::Chain>,
@@ -535,6 +542,7 @@ def_derive! {
 }
 
 def_derive! {
+	#[derive(TypeInfo)]
 	pub enum UpdateSafeElectionsReason {
 		OutOfSafetyMargin,
 		SafeElectionScheduled,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -131,13 +131,13 @@ pub(crate) use derive_validation_statements;
 macro_rules! def_derive {
 	(#[no_serde] $($Definition:tt)*) => {
 		#[derive(
-			Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo,
+			Debug, Clone, PartialEq, Eq, Encode, Decode,
 		)]
 		$($Definition)*
 	};
 	($($Definition:tt)*) => {
 		#[derive(
-			Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo,
+			Debug, Clone, PartialEq, Eq, Encode, Decode,
 		)]
 		#[derive(Deserialize, Serialize)]
 		#[serde(bound(deserialize = "", serialize = ""))]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_witnesser.rs
@@ -20,6 +20,7 @@ impl ChainTypes for BHTypes {
 	type ChainBlockNumber = u64;
 	type ChainBlockHash = u64;
 	const SAFETY_BUFFER: usize = 8;
+	const NAME: &'static str = "Mock";
 }
 
 impl BHWTypes for BHTypes {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -76,6 +76,7 @@ impl ChainTypes for Types {
 	type ChainBlockHash = u64;
 
 	const SAFETY_BUFFER: usize = SAFETY_MARGIN * 2;
+	const NAME: &'static str = "Mock";
 }
 
 impl BWProcessorTypes for Types {
@@ -95,6 +96,8 @@ impl BWTypes for Types {
 	type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>, "safe_mode">;
 	type ProcessedUpToHook = MockHook<HookTypeFor<Self, ProcessedUpToHook>, "processed_up_to">;
 	type ElectionTrackerDebugEventHook = MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
+
+	const BWNAME: &'static str = "GenericBW";
 }
 
 /// Associating the state machine and consensus mechanism to the struct

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -433,13 +433,14 @@ pub mod pallet {
 		Eq,
 		Encode,
 		Decode,
-		TypeInfo,
 		MaxEncodedLen,
 		Serialize,
 		Deserialize,
 		Ord,
 		PartialOrd,
+		GenericTypeInfo,
 	)]
+	#[expand_name_with(C::NAME)]
 	pub struct DepositWitness<C: Chain> {
 		pub deposit_address: C::ChainAccount,
 		pub asset: C::ChainAsset,
@@ -520,7 +521,9 @@ pub mod pallet {
 	)]
 	#[expand_name_with(<T::TargetChain as PalletInstanceAlias>::TYPE_INFO_SUFFIX)]
 	pub enum DepositFailedDetails<T: Config<I>, I: 'static> {
+		#[replace_typename_with(DepositFailedDepositChannelVariant)]
 		DepositChannel { deposit_witness: DepositWitness<T::TargetChain> },
+		#[replace_typename_with(DepositFailedVaultVariant)]
 		Vault { vault_witness: Box<VaultDepositWitness<T, I>> },
 	}
 

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -87,6 +87,7 @@ impl ChainTypes for BitcoinChain {
 	type ChainBlockNumber = btc::BlockNumber;
 	type ChainBlockHash = btc::Hash;
 	const SAFETY_BUFFER: usize = SAFETY_BUFFER;
+	const NAME: &'static str = "Bitcoin";
 }
 
 // ------------------------ block height tracking ---------------------------
@@ -157,6 +158,8 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = Self;
 		type ElectionTrackerDebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "DepositChannel";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct
@@ -295,6 +298,8 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = EmptyHook;
 		type ElectionTrackerDebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "VaultDeposit";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct
@@ -378,6 +383,8 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = EmptyHook;
 		type ElectionTrackerDebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "Egress";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct


### PR DESCRIPTION
# Pull Request

Closes: PRO-2335

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR switches most types over to use the new `GenericTypeInfo` derive macro to generate TypeInfo implementations that properly take into account generics. This fixes a few issues with polkadot.js.

In order to generate non-overlapping names for all instantiations, this PR adds:
 - a `const NAME: &'static str` constant to the `ChainTypes` trait
 - a `const BWNAME: &'static str` constant to the `BWTypes` trait

Also it was necessary to change the TypeInfo name of the cases of the `DepositFailedDetails` enumeration, since they overlapped with the TypeInfo name of the `DepositDetails` struct.
