### PR TITLE
chore: remove duplicate/unused safe mode option

### DIFF
--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__runtime_safe_mode_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__runtime_safe_mode_serialization.snap
@@ -34,7 +34,6 @@ expression: val
     "strategy_execution_enabled": true
   },
   "lending_pools": {
-    "boost_deposits_enabled": true,
     "add_boost_funds_enabled": true,
     "stop_boosting_enabled": true
   },

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -67,7 +67,6 @@ pub const PALLET_VERSION: StorageVersion = StorageVersion::new(1);
 
 impl_pallet_safe_mode! {
 	PalletSafeMode;
-	boost_deposits_enabled,
 	add_boost_funds_enabled,
 	stop_boosting_enabled,
 }


### PR DESCRIPTION
# Pull Request

We already have `boost_deposits_enabled` in the ingress-egress pallet and this one was unused. No migration is needed since it is in the new pallet.