### PR TITLE
fix: expire blockdata based on `seen_heights_below`.

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -235,7 +235,7 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 		let deleted_blocks = self
 			.blocks_data
 			.extract_if(|block_number, _| {
-				block_number.saturating_forward(T::Chain::SAFETY_BUFFER) < lowest_in_progress_height
+				block_number.saturating_forward(T::Chain::SAFETY_BUFFER) < seen_heights_below
 			})
 			.collect();
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -233,29 +233,26 @@ pub trait Statemachine: AbstractApi + 'static {
 						Just(settings),
 					)
 				})),
-				#[allow(clippy::type_complexity)]
-				run_with_timeout(
-					500,
-					|(mut state, input, settings): (
-						Self::State,
-						Either<Self::Context, (Self::Query, Self::Response)>,
-						Self::Settings,
-					)| {
-						// ensure input matches with the current queries
-						Self::validate_input(&mut state, &input)
-							.unwrap_or_else(|_| panic!("input has wrong index: {input:?}"));
+				|(mut state, input, settings): (
+					Self::State,
+					Either<Self::Context, (Self::Query, Self::Response)>,
+					Self::Settings,
+				)| {
+					// ensure input matches with the current queries
+					Self::validate_input(&mut state, &input)
+						.unwrap_or_else(|_| panic!("input has wrong index: {input:?}"));
 
-						// run step and verify all other properties
-						let _output = Self::step_and_validate(&mut state, input, &settings);
+					// run step and verify all other properties
+					let _output = Self::step_and_validate(&mut state, input, &settings);
 
-						Ok(())
-					},
-				),
+					Ok(())
+				},
 			)
 			.unwrap();
 	}
 }
 
+#[allow(unused)]
 #[cfg(test)]
 pub fn run_with_timeout<
 	A: Send + Clone + Debug + 'static,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2350

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Previously, blockdata wouldn't be expired during safemode because we expired based on `lowest_in_progress_height` which doesn't move during safemode.

We now use `seen_heights_below`. An update to the `step_specification` of the BW was required.