### PR TITLE
feat: make safety buffer configurable

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -44,7 +44,7 @@ use sp_core::bounded::alloc::collections::VecDeque;
 use state_chain_runtime::{
 	chainflip::bitcoin_elections::{
 		BitcoinBlockHeightWitnesserES, BitcoinChain, BitcoinDepositChannelWitnessingES,
-		BitcoinElectoralSystemRunner, BitcoinLiveness,
+		BitcoinElectoralSystemRunner, BitcoinLiveness, BITCOIN_MAINNET_SAFETY_BUFFER,
 	},
 	BitcoinInstance,
 };
@@ -79,7 +79,7 @@ pub struct BitcoinBlockHeightWitnesserVoter {
 impl VoterApi<BitcoinBlockHeightWitnesserES> for BitcoinBlockHeightWitnesserVoter {
 	async fn vote(
 		&self,
-		_settings: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralSettings,
+		settings: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectionProperties,
 	) -> std::result::Result<Option<VoteOf<BitcoinBlockHeightWitnesserES>>, anyhow::Error> {
 		tracing::debug!("BTC BHW: Block height tracking called properties: {:?}", properties);
@@ -120,7 +120,7 @@ impl VoterApi<BitcoinBlockHeightWitnesserES> for BitcoinBlockHeightWitnesserVote
 				);
 				best_block_header
 					.block_height
-					.saturating_sub(BitcoinChain::SAFETY_BUFFER as u64)
+					.saturating_sub(BITCOIN_MAINNET_SAFETY_BUFFER as u64)
 			} else {
 				witness_from_index
 			};
@@ -130,7 +130,7 @@ impl VoterApi<BitcoinBlockHeightWitnesserES> for BitcoinBlockHeightWitnesserVote
 			// submitted in one vote. We're submitting at most SAFETY_BUFFER headers.
 			let highest_submitted_height = std::cmp::min(
 				best_block_header.block_height,
-				witness_from_index.saturating_forward(BitcoinChain::SAFETY_BUFFER + 1),
+				witness_from_index.saturating_forward(BITCOIN_MAINNET_SAFETY_BUFFER as usize + 1),
 			);
 
 			// request headers for at most SAFETY_BUFFER heights, in parallel

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -79,7 +79,7 @@ pub struct BitcoinBlockHeightWitnesserVoter {
 impl VoterApi<BitcoinBlockHeightWitnesserES> for BitcoinBlockHeightWitnesserVoter {
 	async fn vote(
 		&self,
-		settings: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralSettings,
+		_settings: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralSettings,
 		properties: <BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectionProperties,
 	) -> std::result::Result<Option<VoteOf<BitcoinBlockHeightWitnesserES>>, anyhow::Error> {
 		tracing::debug!("BTC BHW: Block height tracking called properties: {:?}", properties);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
@@ -89,7 +89,7 @@ def_derive! {
 		///
 		/// This setting determines the number of blocks we store in the BHW to infer the depth of reorgs.
 		///
-		/// If you change this value, consider also looking at the `safety_buffer` setting of the BlockWitnesser.
+		/// If you change this value, you should also look the `safety_buffer` setting of the BlockWitnesser.
 		///
 		/// Changing it at runtime is possible and should not have unintended consequences.
 		pub safety_buffer: u32

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
@@ -52,10 +52,6 @@ pub trait ChainTypes: Ord + Clone + Debug + 'static {
 	type ChainBlockNumber: ChainBlockNumberTrait;
 	type ChainBlockHash: ChainBlockHashTrait;
 
-	// /// IMPORTANT: this value must always be greater than the safety margin we use, and represent
-	// /// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and
-	// in /// the BlockProcessor
-	// const SAFETY_BUFFER: usize;
 	const NAME: &'static str;
 }
 pub type ChainBlockNumberOf<T> = <T as ChainTypes>::ChainBlockNumber;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
@@ -1,5 +1,7 @@
 use core::{iter::Step, ops::RangeInclusive};
 
+use crate::electoral_systems::state_machine::core::def_derive;
+
 use super::{
 	block_witnesser::state_machine::HookTypeFor,
 	state_machine::core::{defx, Hook, HookType, Serde, Validate},
@@ -50,10 +52,10 @@ pub trait ChainTypes: Ord + Clone + Debug + 'static {
 	type ChainBlockNumber: ChainBlockNumberTrait;
 	type ChainBlockHash: ChainBlockHashTrait;
 
-	/// IMPORTANT: this value must always be greater than the safety margin we use, and represent
-	/// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and in
-	/// the BlockProcessor
-	const SAFETY_BUFFER: usize;
+	// /// IMPORTANT: this value must always be greater than the safety margin we use, and represent
+	// /// the buffer of data we keep around (in number of blocks) both in the ElectionTracker and
+	// in /// the BlockProcessor
+	// const SAFETY_BUFFER: usize;
 	const NAME: &'static str;
 }
 pub type ChainBlockNumberOf<T> = <T as ChainTypes>::ChainBlockNumber;
@@ -80,6 +82,22 @@ defx! {
 		pub witness_from_index: <T::Chain as ChainTypes>::ChainBlockNumber,
 	}
 	validate _this (else HeightWitnesserPropertiesError) {}
+}
+
+def_derive! {
+	#[derive(TypeInfo)]
+	pub struct BlockHeightWitnesserSettings {
+		/// IMPORTANT: This value should always be greater than any reorg depth we expect to happen.
+		/// If we expect reorgs of at most depth 3, set this value to over 2 times that number, so let's
+		/// say 8.
+		///
+		/// This setting determines the number of blocks we store in the BHW to infer the depth of reorgs.
+		///
+		/// If you change this value, consider also looking at the `safety_buffer` setting of the BlockWitnesser.
+		///
+		/// Changing it at runtime is possible and should not have unintended consequences.
+		pub safety_buffer: u32
+	}
 }
 
 defx! {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
@@ -197,8 +197,6 @@ mod prop_tests {
 
 		type ChainBlockHash = bool;
 
-		const SAFETY_BUFFER: usize = 3;
-
 		const NAME: &'static str = "Mock";
 	}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -444,8 +444,8 @@ impl<T: BWTypes> Default for ElectionTracker<T> {
 			optimistic_block_cache: Default::default(),
 			debug_events: Default::default(),
 
-			// WARNING: This should never be zero when the system is running.
-			// This value should be set from the actual BW settings at the very
+			// WARNING: This should always be set to a correct value when the system
+			// is running. This value is set from the actual BW settings at the very
 			// beginning of the BW step function.
 			//
 			// For additional safety, we initialize with a high value here.

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -57,6 +57,14 @@ defx! {
 
 		/// debug hook
 		pub debug_events: T::ElectionTrackerDebugEventHook,
+
+		/// IMPORTANT: This value should always be greater than any reorg depth we expect to happen.
+		/// If we expect reorgs of at most depth 3, set this value to over 2 times that number, so let's
+		/// say 8.
+		///
+		/// This value is set from the BW statemachine implementation on every run of the step function,
+		/// following the same-named value in the BWSettings.
+		pub safety_buffer: u32,
 	}
 
 	validate this (else ElectionTrackerError) {
@@ -83,7 +91,7 @@ defx! {
 		//--- ensure that we delete old data ---
 		// We should only store data received from optimistic elections for at most SAFETY_BUFFER blocks.
 		optimistic_block_cache_is_cleared: this.optimistic_block_cache.iter().all(|(height, _block)|
-			height.saturating_forward(T::Chain::SAFETY_BUFFER) > this.seen_heights_below
+			height.saturating_forward(this.safety_buffer as usize) > this.seen_heights_below
 		),
 
 		//--- disjointness of all elections ---
@@ -120,12 +128,12 @@ defx! {
 
 		elections_queued_by_hash_are_inside_safety_buffer:
 			this.queued_hash_elections.keys().all(
-				|height| height.saturating_forward(T::Chain::SAFETY_BUFFER) >= this.seen_heights_below
+				|height| height.saturating_forward(this.safety_buffer as usize) >= this.seen_heights_below
 			),
 
 		elections_queued_by_safe_are_outside_safety_buffer:
 			this.queued_safe_elections.get_all_heights().iter().all(
-				|height| height.saturating_forward(T::Chain::SAFETY_BUFFER) < this.seen_heights_below
+				|height| height.saturating_forward(this.safety_buffer as usize) < this.seen_heights_below
 			)
 	}
 }
@@ -191,7 +199,7 @@ impl<T: BWTypes> ElectionTracker<T> {
 
 		// clean up the optimistic block cache
 		self.optimistic_block_cache.retain(|height, _| {
-			height.saturating_forward(T::Chain::SAFETY_BUFFER) > self.seen_heights_below
+			height.saturating_forward(self.safety_buffer as usize) > self.seen_heights_below
 		});
 	}
 
@@ -393,7 +401,7 @@ impl<T: BWTypes> ElectionTracker<T> {
 		self.queued_hash_elections.append(&mut remaining);
 
 		let is_safe_height = |height: &ChainBlockNumberOf<T::Chain>| {
-			height.saturating_forward(T::Chain::SAFETY_BUFFER) < self.seen_heights_below
+			height.saturating_forward(self.safety_buffer as usize) < self.seen_heights_below
 		};
 
 		// clean up the queue by removing old hashes
@@ -435,9 +443,22 @@ impl<T: BWTypes> Default for ElectionTracker<T> {
 			queued_safe_elections: Default::default(),
 			optimistic_block_cache: Default::default(),
 			debug_events: Default::default(),
+
+			// WARNING: This should never be zero when the system is running.
+			// This value should be set from the actual BW settings at the very
+			// beginning of the BW step function.
+			//
+			// For additional safety, we initialize with a high value here.
+			safety_buffer: 100,
 		}
 	}
 }
+
+/// Even though the safety buffer can be updated through the settings, doing so
+/// could break the validity conditions on the ElectionTracker. We can't simulate
+/// dynamic SAFETY_BUFFER values, so we make this a constant.
+#[cfg(test)]
+pub const STATIC_SAFETY_BUFFER_FOR_TESTS: usize = 8;
 
 #[cfg(test)]
 impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
@@ -457,6 +478,7 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 		};
 
 		prop_do!(
+			let safety_buffer in Just(STATIC_SAFETY_BUFFER_FOR_TESTS);
 			let ongoing_below in chain_block_number();
 			let highest_seen_delta in 1..1000usize;
 			let highest_ongoign_delta in 0..1000usize;
@@ -464,12 +486,13 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 			let currently_highest = heights.iter().max().cloned().unwrap_or(Default::default());
 			let seen_heights_below = currently_highest.saturating_forward(highest_seen_delta);
 			let highest_ever_ongoing = currently_highest.saturating_forward(highest_ongoign_delta);
-			let safe_elections_below = max(ongoing_below, seen_heights_below.saturating_backward(T::Chain::SAFETY_BUFFER));
+			let safe_elections_below = max(ongoing_below, seen_heights_below.saturating_backward(safety_buffer as usize));
 			let ongoing = heights.iter().filter(|h| **h < ongoing_below).cloned().collect::<BTreeSet<_>>();
 			let safe = heights.iter().filter(|h| (ongoing_below..safe_elections_below).contains(*h)).cloned().collect::<BTreeSet<_>>();
 			let hash = heights.iter().filter(|h| (safe_elections_below..seen_heights_below).contains(*h)).cloned().collect::<BTreeSet<_>>();
 
 			Self {
+				safety_buffer: Just(safety_buffer as u32),
 				seen_heights_below: Just(seen_heights_below),
 				highest_ever_ongoing_election: Just(highest_ever_ongoing),
 				ongoing: vec(any::<BWElectionType<T>>(), ongoing.len()..=ongoing.len())
@@ -497,7 +520,7 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 						any::<OptimisticBlock<T>>(),
 						0..10
 					).prop_map(move |mut blocks| {
-						blocks.retain(|height, _| height.saturating_forward(T::Chain::SAFETY_BUFFER) > seen_heights_below);
+						blocks.retain(|height, _| height.saturating_forward(safety_buffer as usize) > seen_heights_below);
 						blocks
 					}),
 				debug_events: Just(Default::default()),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_height_witnesser.rs
@@ -19,7 +19,6 @@ type BHTypes = TypesFor<BlockHeightWitnesserDefinition>;
 impl ChainTypes for BHTypes {
 	type ChainBlockNumber = u64;
 	type ChainBlockHash = u64;
-	const SAFETY_BUFFER: usize = 8;
 	const NAME: &'static str = "Mock";
 }
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -75,7 +75,6 @@ impl ChainTypes for Types {
 	type ChainBlockNumber = u64;
 	type ChainBlockHash = u64;
 
-	const SAFETY_BUFFER: usize = SAFETY_MARGIN * 2;
 	const NAME: &'static str = "Mock";
 }
 
@@ -212,6 +211,7 @@ fn create_votes_expectation(
 
 const MAX_CONCURRENT_ELECTIONS: ElectionCount = 5;
 const SAFETY_MARGIN: usize = 3;
+const SAFETY_BUFFER: usize = SAFETY_MARGIN * 2;
 const MOCK_BW_ELECTION_PROPERTIES: BWElectionProperties<Types> = BWElectionProperties {
 	election_type: state_machine::EngineElectionType::<Types>::BlockHeight { submit_hash: false },
 	block_height: 2,
@@ -250,6 +250,7 @@ fn election_starts_and_resolves_when_consensus_is_reached() {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			max_optimistic_elections: 0,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 		})
 		.build()
 		.test_on_finalize(
@@ -301,6 +302,7 @@ fn creates_multiple_elections_below_maximum_when_required() {
 		.with_unsynchronised_settings(BlockWitnesserSettings {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 			max_optimistic_elections: 0,
 		})
 		.build()
@@ -395,6 +397,7 @@ fn creates_multiple_elections_limited_by_maximum() {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			max_optimistic_elections: 0,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 		})
 		.build()
 		.test_on_finalize(
@@ -483,6 +486,7 @@ fn reorg_clears_on_going_elections_and_continues() {
 		.with_unsynchronised_settings(BlockWitnesserSettings {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 			max_optimistic_elections: 0,
 		})
 		.build()
@@ -588,6 +592,7 @@ fn elections_resolved_out_of_order_has_no_impact() {
 		.with_unsynchronised_settings(BlockWitnesserSettings {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 			max_optimistic_elections: 0,
 		})
 		.build()
@@ -727,6 +732,7 @@ fn optimistic_election_result_saved_and_used_or_discarded_correctly() {
 		.with_unsynchronised_settings(BlockWitnesserSettings {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 			max_optimistic_elections: 1,
 		})
 		.build()
@@ -895,6 +901,7 @@ fn with_safe_mode_enabled() {
 		.with_unsynchronised_settings(BlockWitnesserSettings {
 			max_ongoing_elections: MAX_CONCURRENT_ELECTIONS,
 			safety_margin: SAFETY_MARGIN as u32,
+			safety_buffer: SAFETY_BUFFER as u32,
 			max_optimistic_elections: 0,
 		})
 		.build()


### PR DESCRIPTION
# Pull Request

Closes: PRO-2360

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR makes the SAFETY_BUFFER configurable by putting it into the settings of both the BHW and the BW.

It *also* sets the default safety_margin for bitcoin to 1 block. This means that we will emit a full witness event when a deposit is of age 1.