### PR TITLE
fix: bouncer boost tests improved diagnostics

### DIFF
--- a/bouncer/tests/boost.ts
+++ b/bouncer/tests/boost.ts
@@ -197,16 +197,11 @@ async function testBoostingForAsset(
     'DepositBoosted',
     'Expected DepositBoosted event, but got ' + boostEvent.name.method,
   );
-  const depositEvent = await runWithTimeout(
+  await runWithTimeout(
     observeDepositFinalised,
     60,
     logger,
     'Waiting for DepositFinalised event after boosting swap',
-  );
-  assert.strictEqual(
-    depositEvent.name.method,
-    'DepositFinalised',
-    'Expected DepositFinalised event, but got ' + depositEvent.name.method,
   );
 
   // Stop boosting

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -27,21 +27,21 @@ describe('ConcurrentTests', () => {
   const givenNumberOfNodes = match ? parseInt(match[0]) : null;
   const numberOfNodes = givenNumberOfNodes ?? 1;
 
-  concurrentTest('SwapLessThanED', swapLessThanED, 400);
+  concurrentTest('SwapLessThanED', swapLessThanED, 180);
   testAllSwaps(numberOfNodes === 1 ? 180 : 240); // TODO: find out what the 3-node timeout should be
   concurrentTest('EvmDeposits', testEvmDeposits, 250);
   concurrentTest('FundRedeem', testFundRedeem, 1000);
   concurrentTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);
-  concurrentTest('LpApi', testLpApi, 200);
+  concurrentTest('LpApi', testLpApi, 240);
   concurrentTest('BrokerFeeCollection', testBrokerFeeCollection, 200);
   concurrentTest('BoostingForAsset', testBoostingSwap, 200);
-  concurrentTest('FillOrKill', testFillOrKill, 800);
+  concurrentTest('FillOrKill', testFillOrKill, 300);
   concurrentTest('DCASwaps', testDCASwaps, 300);
-  concurrentTest('CancelOrdersBatch', testCancelOrdersBatch, 240);
-  concurrentTest('DepositChannelCreation', depositChannelCreation, 360);
-  concurrentTest('BrokerLevelScreening', testBrokerLevelScreening, 800);
-  concurrentTest('VaultSwaps', testVaultSwap, 800);
-  concurrentTest('AssethubXCM', testAssethubXcm, 360);
+  concurrentTest('CancelOrdersBatch', testCancelOrdersBatch, 120);
+  concurrentTest('DepositChannelCreation', depositChannelCreation, 30);
+  concurrentTest('BrokerLevelScreening', testBrokerLevelScreening, 600);
+  concurrentTest('VaultSwaps', testVaultSwap, 600);
+  concurrentTest('AssethubXCM', testAssethubXcm, 200);
 
   // Tests that only work if there is more than one node
   if (numberOfNodes > 1) {

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -55,5 +55,5 @@ describe('ConcurrentTests', () => {
 
 // Run only the broker level screening tests
 describe('BrokerLevelScreeningTest', () => {
-  concurrentTest('BrokerLevelScreening', (context) => testBrokerLevelScreening(context, true), 800);
+  concurrentTest('BrokerLevelScreening', (context) => testBrokerLevelScreening(context, true), 600);
 });

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -34,7 +34,7 @@ describe('ConcurrentTests', () => {
   concurrentTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);
   concurrentTest('LpApi', testLpApi, 200);
   concurrentTest('BrokerFeeCollection', testBrokerFeeCollection, 200);
-  concurrentTest('BoostingForAsset', testBoostingSwap, 120);
+  concurrentTest('BoostingForAsset', testBoostingSwap, 200);
   concurrentTest('FillOrKill', testFillOrKill, 800);
   concurrentTest('DCASwaps', testDCASwaps, 300);
   concurrentTest('CancelOrdersBatch', testCancelOrdersBatch, 240);


### PR DESCRIPTION
This adds some additional logging to the boost test in bouncer. 

Also structures the processes a bit differently: the test checks for when boost fails because of missing liquidity. 

It also fixes a potential issue where we were always checking for btc pools although the test takes an arbitrary asset as argument. 