### PR TITLE
fix: change old_version to 1.9.7 for more reliable upgrade test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,7 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10470,7 +10470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14472,7 +14472,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix 0.38.43",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16052,7 +16052,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -31,10 +31,10 @@ assets = [
 	# The old version gets put into target/release/deps by the package github actions workflow.
 	# It downloads the correct version from the releases page.
 	[
-		"target/release/libchainflip_engine_v1_9_6.so",
+		"target/release/libchainflip_engine_v1_9_7.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_9_6.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_9_7.so",
 		"755",
 	],
 ]

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -19,7 +19,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.9.6")]
+	#[engine_proc_macros::link_engine_library_version("1.9.7")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -26,7 +26,7 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.9.6";
+pub const OLD_VERSION: &str = "1.9.7";
 pub const NEW_VERSION: &str = "1.10.0";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";


### PR DESCRIPTION
This should make the upgrade test more reliable. 