### PR TITLE
feat: bouncer smaller timeouts and improvements

### DIFF
--- a/bouncer/commands/run_test.ts
+++ b/bouncer/commands/run_test.ts
@@ -77,5 +77,5 @@ if (!matchingTestName) {
   console.error('No matching test function found');
   process.exit(1);
 } else {
-  execSync(`pnpm vitest --maxConcurrency=100 run -t "${matchingTestName}"`, { stdio: 'inherit' });
+  execSync(`pnpm vitest --maxConcurrency=500 run -t "${matchingTestName}"`, { stdio: 'inherit' });
 }

--- a/bouncer/fast_bouncer.sh
+++ b/bouncer/fast_bouncer.sh
@@ -2,4 +2,4 @@
 set -e
 ./commands/observe_block.ts 5
 ./setup_for_test.sh
-NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest --maxConcurrency=100 run -t "ConcurrentTests"
+NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest --maxConcurrency=500 run -t "ConcurrentTests"

--- a/bouncer/full_bouncer.sh
+++ b/bouncer/full_bouncer.sh
@@ -3,5 +3,5 @@ set -e
 echo "Running full bouncer 🧪"
 ./setup_for_test.sh
 NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest run -t "SerialTests1"
-NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest --maxConcurrency=100 run -t "ConcurrentTests"
+NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest --maxConcurrency=500 run -t "ConcurrentTests"
 NODE_COUNT=$1 LOCALNET=$LOCALNET pnpm vitest run -t "SerialTests2"

--- a/bouncer/shared/btc_vault_swap.ts
+++ b/bouncer/shared/btc_vault_swap.ts
@@ -10,6 +10,7 @@ import {
   decodeDotAddressForContract,
   fineAmountToAmount,
   handleSubstrateError,
+  sleep,
   stateChainAssetFromAsset,
 } from 'shared/utils';
 import { getChainflipApi, observeEvent } from 'shared/utils/substrate';
@@ -85,7 +86,7 @@ export async function buildAndSendBtcVaultSwap(
   return txid;
 }
 
-export async function openPrivateBtcChannel(logger: Logger, brokerUri: string): Promise<number> {
+async function openPrivateBtcChannel(logger: Logger, brokerUri: string): Promise<number> {
   // Check if the channel is already open
   const chainflip = await getChainflipApi();
   const broker = createStateChainKeypair(brokerUri);
@@ -117,6 +118,42 @@ export async function openPrivateBtcChannel(logger: Logger, brokerUri: string): 
       .signAndSend(broker, { nonce }, handleSubstrateError(chainflip));
   });
   return Number((await openedChannelEvent).data.channelId);
+}
+
+enum PrivateChannelStatus {
+  None,
+  Pending,
+  Open,
+}
+const privateChannelStatusMap: Map<string, PrivateChannelStatus> = new Map();
+
+/// Ensures a private BTC channel is open for the broker.
+/// Waits for the channel to be open if already pending.
+export async function waitForPrivateBtcChannel(logger: Logger, brokerUri: string): Promise<void> {
+  let shouldOpenChannel = false;
+
+  await brokerMutex.runExclusive(async () => {
+    const status = privateChannelStatusMap.get(brokerUri) ?? PrivateChannelStatus.None;
+
+    if (status === PrivateChannelStatus.Open) {
+      return;
+    }
+
+    if (status === PrivateChannelStatus.None) {
+      privateChannelStatusMap.set(brokerUri, PrivateChannelStatus.Pending);
+      shouldOpenChannel = true;
+    }
+  });
+
+  if (shouldOpenChannel) {
+    await openPrivateBtcChannel(logger, brokerUri);
+    privateChannelStatusMap.set(brokerUri, PrivateChannelStatus.Open);
+  } else {
+    // Wait for the status to become Open
+    while (privateChannelStatusMap.get(brokerUri) !== PrivateChannelStatus.Open) {
+      await sleep(1000);
+    }
+  }
 }
 
 export async function registerAffiliate(

--- a/bouncer/shared/deposit_liquidity.ts
+++ b/bouncer/shared/deposit_liquidity.ts
@@ -81,7 +81,7 @@ export async function depositLiquidity(
         BigInt(amountToFineAmount(String(amount), assetDecimals(ccy))),
       ),
     finalized: waitForFinalization,
-    timeoutSeconds: 90,
+    timeoutSeconds: 120,
   }).event;
 
   const txHash = await runWithTimeout(

--- a/bouncer/shared/get_hub_balance.ts
+++ b/bouncer/shared/get_hub_balance.ts
@@ -1,6 +1,5 @@
 import { fineAmountToAmount, assetDecimals, HubAsset, getHubAssetId } from 'shared/utils';
 import { getAssethubApi } from 'shared/utils/substrate';
-import { globalLogger } from './utils/logger';
 
 export async function getHubDotBalance(address: string): Promise<string> {
   await using assethub = await getAssethubApi();
@@ -16,9 +15,6 @@ export async function getHubAssetBalance(asset: HubAsset, address: string): Prom
   const reply = await assethub.query.assets.account(getHubAssetId(asset), address);
 
   if (reply.isEmpty) {
-    globalLogger.warn(
-      `Empty reply from assetHub account query for asset ${asset}, address ${address}`,
-    );
     return '0';
   }
 

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -31,7 +31,7 @@ import { SwapContext, SwapStatus } from 'shared/utils/swap_context';
 import { getChainflipApi, observeEvent } from 'shared/utils/substrate';
 import { executeEvmVaultSwap } from 'shared/evm_vault_swap';
 import { executeSolVaultSwap } from 'shared/sol_vault_swap';
-import { buildAndSendBtcVaultSwap } from 'shared/btc_vault_swap';
+import { buildAndSendBtcVaultSwap, waitForPrivateBtcChannel } from 'shared/btc_vault_swap';
 import { Logger, throwError } from 'shared/utils/logger';
 
 function encodeDestinationAddress(address: string, destAsset: Asset): string {
@@ -120,8 +120,9 @@ export async function requestNewSwap(
   const channelDestAddress = res.destinationAddress[shortChainFromAsset(destAsset)];
   const channelId = Number(res.channelId.replaceAll(',', ''));
 
-  logger.debug(`$Deposit address: ${depositAddress}`);
-  logger.debug(`Destination address is: ${channelDestAddress} Channel ID is: ${channelId}`);
+  logger.debug(
+    `Deposit address: ${depositAddress}, Destination address: ${channelDestAddress}, Channel ID: ${channelId}`,
+  );
 
   return {
     sourceAsset,
@@ -282,6 +283,7 @@ export async function executeVaultSwap(
 
   const srcChain = chainFromAsset(sourceAsset);
 
+  const brokerUri = brokerFees ? undefined : '//BROKER_1';
   const brokerFeesValue = brokerFees ?? {
     account: new Keyring({ type: 'sr25519' }).createFromUri('//BROKER_1').address,
     commissionBps: 1,
@@ -315,6 +317,9 @@ export async function executeVaultSwap(
     transactionId = { type: TransactionOrigin.VaultSwapEvm, txHash };
     sourceAddress = wallet.address.toLowerCase();
   } else if (srcChain === 'Bitcoin') {
+    if (brokerUri) {
+      await waitForPrivateBtcChannel(logger, brokerUri);
+    }
     logger.trace('Executing BTC vault swap');
     const txId = await buildAndSendBtcVaultSwap(
       logger,

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -583,7 +583,7 @@ export async function observeSwapRequested(
   swapRequestType: SwapRequestType,
 ) {
   return observeEvent(logger, 'swapping:SwapRequested', {
-    timeoutSeconds: 90,
+    timeoutSeconds: 150,
     test: (event) => {
       const data = event.data;
 
@@ -716,7 +716,7 @@ export async function observeBalanceIncrease(
   dstCcy: Asset,
   address: string,
   oldBalance: string,
-  timeoutSeconds = 90,
+  timeoutSeconds = 120,
 ): Promise<number> {
   logger.trace(`Observing balance increase of ${dstCcy} at ${address}`);
   for (let i = 0; i < Math.max(timeoutSeconds / 3, 1); i++) {

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -416,6 +416,7 @@ export function observeEvents<T = any>(
   }: Options<T> | AbortableOptions<T> = {},
 ) {
   const [expectedSection, expectedMethod] = eventName.split(':');
+  const startTime = Date.now();
   logger.trace(`Observing event ${eventName}`);
 
   const controller = abortable ? new AbortController() : undefined;
@@ -438,7 +439,9 @@ export function observeEvents<T = any>(
     }
     if (foundEvents.length > 0) {
       logger.trace(
-        `Found event ${foundEvents.length} ${eventName} events in block ${foundEvents[0].block}`,
+        `Found ${foundEvents.length} ${eventName} events in block ${foundEvents[0].block}, took ${Math.round(
+          (Date.now() - startTime) / 1000,
+        )} seconds`,
       );
       // No need to continue if we found event(s) in the past
       return foundEvents;
@@ -463,7 +466,9 @@ export function observeEvents<T = any>(
         }
         if (foundEvents.length > 0) {
           logger.trace(
-            `Found event ${foundEvents.length} ${eventName} events in block ${foundEvents[0].block}`,
+            `Found ${foundEvents.length} ${eventName} events in block ${foundEvents[0].block}, took ${Math.round(
+              (Date.now() - startTime) / 1000,
+            )} seconds`,
           );
           return foundEvents;
         }

--- a/bouncer/test_commands/all_cuncurrent_tests.sh
+++ b/bouncer/test_commands/all_cuncurrent_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pnpm vitest --maxConcurrency=100 run -t "ConcurrentTests"
+pnpm vitest --maxConcurrency=500 run -t "ConcurrentTests"

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -1,5 +1,4 @@
 import { InternalAsset as Asset, InternalAssets as Assets } from '@chainflip/cli';
-import { describe } from 'vitest';
 import { SwapParams } from 'shared/perform_swap';
 import { newCcmMetadata, newVaultSwapCcmMetadata, testSwap, testVaultSwap } from 'shared/swapping';
 import { btcAddressTypes } from 'shared/new_btc_address';
@@ -9,9 +8,8 @@ import {
   VaultSwapParams,
   vaultSwapSupportedChains,
 } from 'shared/utils';
-import { openPrivateBtcChannel } from 'shared/btc_vault_swap';
 import { TestContext } from 'shared/utils/test_context';
-import { manuallyAddTestToList, concurrentTest, serialTest } from 'shared/utils/vitest';
+import { manuallyAddTestToList, concurrentTest } from 'shared/utils/vitest';
 
 export async function initiateSwap(
   testContext: TestContext,
@@ -113,19 +111,8 @@ export function testAllSwaps(timeoutPerSwap: number) {
   appendSwap('ArbEth', 'HubUsdc', testVaultSwap);
   appendSwap('ArbEth', 'HubUsdt', testVaultSwap);
 
-  describe('AllSwaps', () => {
-    manuallyAddTestToList('AllSwaps', 'testAllSwaps');
-    serialTest(
-      'OpenPrivateBtcChannel',
-      async (context) => {
-        await openPrivateBtcChannel(context.logger, '//BROKER_1');
-        context.logger.info(`🧪 Private broker channel opened`);
-      },
-      120,
-      true,
-    );
-    for (const swap of allSwaps) {
-      concurrentTest(swap.name, swap.test, timeoutPerSwap, true);
-    }
-  });
+  manuallyAddTestToList('AllSwaps', 'testAllSwaps');
+  for (const swap of allSwaps) {
+    concurrentTest(swap.name, swap.test, timeoutPerSwap, true);
+  }
 }

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -456,7 +456,7 @@ async function testEvmLiquidityDeposit(
 
     const amount = '3';
     const observeAccountCreditedEvent = observeEvent(logger, 'assetBalances:AccountCredited', {
-      timeoutSeconds: 90,
+      timeoutSeconds: 120,
       test: (event) =>
         event.data.asset === sourceAsset &&
         isWithinOnePercent(

--- a/bouncer/tests/evm_deposits.ts
+++ b/bouncer/tests/evm_deposits.ts
@@ -134,6 +134,7 @@ async function testTxMultipleVaultSwaps(
 
   let eventCounter = 0;
   const observingEvent = observeEvent(logger, 'swapping:SwapRequested', {
+    timeoutSeconds: 150,
     test: (event) => {
       if (
         typeof event.data.origin === 'object' &&

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -22,7 +22,7 @@ import { testAssethubXcm } from 'tests/assethub_xcm';
 // Tests that will run in parallel by both the ci-development and the ci-main-merge
 describe('ConcurrentTests', () => {
   // Specify the number of nodes via setting the env var.
-  // NODE_COUNT="3-node" pnpm vitest --maxConcurrency=100 run -t "ConcurrentTests"
+  // NODE_COUNT="3-node" pnpm vitest --maxConcurrency=500 run -t "ConcurrentTests"
   const match = process.env.NODE_COUNT ? process.env.NODE_COUNT.match(/\d+/) : null;
   const givenNumberOfNodes = match ? parseInt(match[0]) : null;
   const numberOfNodes = givenNumberOfNodes ?? 1;
@@ -30,7 +30,7 @@ describe('ConcurrentTests', () => {
   concurrentTest('SwapLessThanED', swapLessThanED, 180);
   testAllSwaps(numberOfNodes === 1 ? 180 : 240); // TODO: find out what the 3-node timeout should be
   concurrentTest('EvmDeposits', testEvmDeposits, 250);
-  concurrentTest('FundRedeem', testFundRedeem, 1000);
+  concurrentTest('FundRedeem', testFundRedeem, 600);
   concurrentTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);
   concurrentTest('LpApi', testLpApi, 240);
   concurrentTest('BrokerFeeCollection', testBrokerFeeCollection, 200);

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -22,6 +22,6 @@ describe('SerialTests2', () => {
   serialTest('SolanaVaultSettingsGovernance', testSolanaVaultSettingsGovernance, 120);
 
   if (process.env.LOCALNET) {
-    serialTest('SwapAfterDisconnection', testSwapAfterDisconnection, 1300);
+    serialTest('SwapAfterDisconnection', testSwapAfterDisconnection, 250);
   }
 });

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -122,7 +122,7 @@ async function testLiquidityDepositLegacy(logger: Logger) {
 
   // Send funds to the deposit address and watch for deposit event
   const observeAccountCreditedEvent = observeEvent(logger, 'assetBalances:AccountCredited', {
-    timeoutSeconds: 90,
+    timeoutSeconds: 120,
     test: (event) =>
       event.data.asset === testAsset &&
       isWithinOnePercent(
@@ -167,7 +167,7 @@ async function testLiquidityDeposit(logger: Logger) {
 
   // Send funds to the deposit address and watch for deposit event
   const observeAccountCreditedEvent = observeEvent(logger, 'assetBalances:AccountCredited', {
-    timeoutSeconds: 90,
+    timeoutSeconds: 120,
     test: (event) =>
       event.data.asset === testAsset &&
       isWithinOnePercent(

--- a/bouncer/tests/lp_api_test.ts
+++ b/bouncer/tests/lp_api_test.ts
@@ -122,6 +122,7 @@ async function testLiquidityDepositLegacy(logger: Logger) {
 
   // Send funds to the deposit address and watch for deposit event
   const observeAccountCreditedEvent = observeEvent(logger, 'assetBalances:AccountCredited', {
+    timeoutSeconds: 90,
     test: (event) =>
       event.data.asset === testAsset &&
       isWithinOnePercent(
@@ -166,6 +167,7 @@ async function testLiquidityDeposit(logger: Logger) {
 
   // Send funds to the deposit address and watch for deposit event
   const observeAccountCreditedEvent = observeEvent(logger, 'assetBalances:AccountCredited', {
+    timeoutSeconds: 90,
     test: (event) =>
       event.data.asset === testAsset &&
       isWithinOnePercent(

--- a/bouncer/tests/vault_swap_tests.ts
+++ b/bouncer/tests/vault_swap_tests.ts
@@ -10,7 +10,7 @@ import {
   sleep,
 } from 'shared/utils';
 import { getEarnedBrokerFees } from 'tests/broker_fee_collection';
-import { openPrivateBtcChannel, registerAffiliate } from 'shared/btc_vault_swap';
+import { registerAffiliate, waitForPrivateBtcChannel } from 'shared/btc_vault_swap';
 import { setupBrokerAccount } from 'shared/setup_account';
 import { executeVaultSwap, performVaultSwap } from 'shared/perform_swap';
 import { prepareSwap } from 'shared/swapping';
@@ -114,7 +114,7 @@ async function testFeeCollection(
   const refundAddress = await newAddress('Eth', 'BTC_VAULT_SWAP_REFUND' + Math.random() * 100);
   await Promise.all([setupBrokerAccount(logger, brokerUri)]);
   if (inputAsset === Assets.Btc) {
-    await openPrivateBtcChannel(logger, brokerUri);
+    await waitForPrivateBtcChannel(logger, brokerUri);
   }
 
   logger.debug('Registering affiliate');


### PR DESCRIPTION
# Pull Request

Closes: PRO-1997

## Summary

- Fixed the `allSwaps` tests not running at the same time as the rest of the tests. (This will almost halve the bouncer test execution time)
- Put a 90sec timeout on most observing of AccountCredited and SwapRequested events. (The main failure point of flaky tests)
- Created a `waitForPrivateBtcChannel` function to remove the need to open the channel before the AllSwaps test and any others that use it.
- Added logging of wait times for the observe events to help us choose timeouts
- Reduced the unnecessarily large timeouts on a few tests.
- put a proper timeout on `observeBalanceIncrease` (90sec by default) and logged wait time.
- Cleaned up some logging 
