### PR TITLE
fix: parallelize waiting for promises in AssethubXcm test

### DIFF
--- a/bouncer/tests/assethub_xcm.ts
+++ b/bouncer/tests/assethub_xcm.ts
@@ -15,14 +15,14 @@ export async function testAssethubXcm(testContext: TestContext, _seed?: string) 
     '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
   );
   const oldDotBalance = await getBalance('Dot', '12QPwzxiXa1UAsgeoeNvvPnJqCFE8SwDb4FVXWauYWCwRiHt');
-  await performSwap(
-    testContext.logger,
-    'Btc',
-    'HubDot',
-    '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
-    metadata,
-  );
   await Promise.all([
+    performSwap(
+      testContext.logger,
+      'Btc',
+      'HubDot',
+      '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
+      metadata,
+    ),
     observeBalanceIncrease(
       testContext.logger,
       'HubDot',


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.

## Summary

Instead of waiting for the swap promise, and then waiting for the balance to increase, we do both in parallel.
