### PR TITLE
chore: Make Missing TSS key log as error

### DIFF
--- a/engine/multisig/src/client.rs
+++ b/engine/multisig/src/client.rs
@@ -393,7 +393,7 @@ impl<C: ChainSigning, KeyStore: KeyStoreAPI<C>> MultisigClientApi<C::CryptoSchem
 			// No key was found for the given key_id
 			self.update_latest_ceremony_id(ceremony_id);
 			let reported_parties = Default::default();
-			let failure_reason = SigningFailureReason::UnknownKey;
+			let failure_reason = SigningFailureReason::MissingKey;
 			failure_reason.log(&reported_parties);
 			futures::future::ready(Err((reported_parties, failure_reason))).boxed()
 		}

--- a/engine/multisig/src/client/common/failure_reason.rs
+++ b/engine/multisig/src/client/common/failure_reason.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use state_chain_runtime::AccountId;
-use tracing::warn;
+use tracing::{error, warn};
 
 use std::collections::BTreeSet;
 
@@ -48,8 +48,8 @@ pub enum SigningFailureReason {
 	InvalidSigShare,
 	#[error("Not Enough Signers")]
 	NotEnoughSigners,
-	#[error("Unknown Key")]
-	UnknownKey,
+	#[error("Missing Threshold Key")]
+	MissingKey,
 	#[error("Invalid Number of Payloads")]
 	InvalidNumberOfPayloads,
 	#[error("Deserialization Error")]
@@ -121,8 +121,8 @@ impl CeremonyFailureReason for SigningFailureReason {
 			SigningFailureReason::DeveloperError(_) |
 			SigningFailureReason::InvalidParticipants |
 			SigningFailureReason::NotEnoughSigners |
-			SigningFailureReason::UnknownKey => {
-				warn!(tag = REQUEST_TO_SIGN_IGNORED, "{REQUEST_TO_SIGN_IGNORED_PREFIX}: {self}",);
+			SigningFailureReason::MissingKey => {
+				error!(tag = REQUEST_TO_SIGN_IGNORED, "{REQUEST_TO_SIGN_IGNORED_PREFIX}: {self}",);
 			},
 		}
 	}

--- a/engine/multisig/src/client/multisig_client_tests.rs
+++ b/engine/multisig/src/client/multisig_client_tests.rs
@@ -62,7 +62,7 @@ async fn should_ignore_rts_for_unknown_key() {
 
 	// Check that the signing request fails immediately with an "unknown key" error
 	let (_, failure_reason) = assert_err!(assert_future_can_complete(signing_request_fut));
-	assert_eq!(failure_reason, SigningFailureReason::UnknownKey);
+	assert_eq!(failure_reason, SigningFailureReason::MissingKey);
 	assert_matches!(
 		assert_ok!(assert_future_can_complete(ceremony_request_receiver.recv())),
 		CeremonyRequest { ceremony_id: DEFAULT_SIGNING_CEREMONY_ID, details: None }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2351

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Improved error message to be logged as ERROR instead of WARN.
Make the error more explicit since the key should always exist.
