### PR TITLE
fix: reduce some more potential race conditions in bouncer

### DIFF
--- a/bouncer/shared/btc_vault_swap.ts
+++ b/bouncer/shared/btc_vault_swap.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { Chains } from '@chainflip/cli';
-import { waitForBtcTransaction, sendVaultTransaction } from 'shared/send_btc';
+import { sendVaultTransaction } from 'shared/send_btc';
 import {
   Asset,
   assetDecimals,
@@ -42,7 +42,6 @@ export async function buildAndSendBtcVaultSwap(
     account: string;
     bps: number;
   }[] = [],
-  confirmations: number = 1,
 ) {
   await using chainflip = await getChainflipApi();
 
@@ -78,9 +77,6 @@ export async function buildAndSendBtcVaultSwap(
     BtcVaultSwapDetails.deposit_address,
     refundAddress,
   );
-  if (confirmations > 0) {
-    await waitForBtcTransaction(logger, txid, confirmations);
-  }
 
   return txid;
 }

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -598,6 +598,9 @@ export async function observeSwapRequested(
       // Otherwise it was a swap scheduled by interacting with the Eth smart contract
       return false;
     },
+    // We assume that a swaprequest is uniquely identifiable by the `id: TransactionOriginId`.
+    // To reduce potential race conditions we always check the last 30 blocks.
+    historicalCheckBlocks: 30,
   }).event;
 }
 

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -243,7 +243,6 @@ async function brokerLevelScreeningTestBtcVaultSwap(
       commissionBps: 0,
     },
     [],
-    0,
   );
   await reportFunction(txId);
 }


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.

## Summary

 - don't wait for btc confirmations when sending btc vault vault swap
 - always check historical blocks when calling `observeSwapRequested`
