### PR TITLE
cherry-pick: Fix polkadot.js decoding for various bitcoin election types (#5972)

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -31,7 +31,7 @@ use super::state_machine::{BWElectionType, BWTypes, EngineElectionType};
 
 defx! {
 	#[derive(GenericTypeInfo)]
-	#[expand_name_with(T::Chain::NAME)]
+	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	pub struct ElectionTracker[T: BWTypes] {
 		/// The lowest block we haven't seen yet. I.e., we have seen blocks below.
 		pub seen_heights_below: ChainBlockNumberOf<T::Chain>,
@@ -533,7 +533,7 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 
 def_derive! {
 	#[derive(GenericTypeInfo)]
-	#[expand_name_with(T::Chain::NAME)]
+	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct OptimisticBlock<T: BWTypes> {
 		pub hash: <T::Chain as ChainTypes>::ChainBlockHash,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -48,8 +48,6 @@ pub trait BWTypes: 'static + Sized + BWProcessorTypes {
 		+ CommonTraits
 		+ TestTraits
 		+ Default;
-
-	const BWNAME: &'static str;
 }
 
 // hook types
@@ -105,6 +103,8 @@ pub trait BWProcessorTypes: Sized + 'static + Debug + Clone + Eq {
 	type Execute: Hook<HookTypeFor<Self, ExecuteHook>> + Default + CommonTraits;
 
 	type DebugEventHook: Hook<HookTypeFor<Self, DebugEventHook>> + Default + CommonTraits;
+
+	const BWNAME: &'static str;
 }
 
 #[derive(
@@ -156,7 +156,7 @@ pub struct BlockWitnesserSettings {
 
 defx! {
 	#[derive(GenericTypeInfo)]
-	#[expand_name_with(T::Chain::NAME)]
+	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	#[derive(Default)]
 	pub struct BlockWitnesserState[T: BWTypes] {
 		pub elections: ElectionTracker<T>,
@@ -568,8 +568,6 @@ pub mod tests {
 		type ElectionTrackerDebugEventHook =
 			MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
 		type ProcessedUpToHook = MockHook<HookTypeFor<Self, ProcessedUpToHook>>;
-
-		const BWNAME: &'static str = "GenericBW";
 	}
 
 	#[test]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -85,6 +85,8 @@ impl BWProcessorTypes for Types {
 	type Rules = MockHook<HookTypeFor<Self, RulesHook>, "rules", Self>;
 	type Execute = MockHook<HookTypeFor<Self, ExecuteHook>, "execute">;
 	type DebugEventHook = MockHook<HookTypeFor<Self, DebugEventHook>, "debug">;
+
+	const BWNAME: &'static str = "GenericBW";
 }
 
 /// Associating BW types to the struct
@@ -95,8 +97,6 @@ impl BWTypes for Types {
 	type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>, "safe_mode">;
 	type ProcessedUpToHook = MockHook<HookTypeFor<Self, ProcessedUpToHook>, "processed_up_to">;
 	type ElectionTrackerDebugEventHook = MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
-
-	const BWNAME: &'static str = "GenericBW";
 }
 
 /// Associating the state machine and consensus mechanism to the struct

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -163,6 +163,8 @@ impls! {
 		type Rules = Self;
 		type Execute = Self;
 		type DebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "DepositChannel";
 	}
 
 	/// Associating BW types to the struct
@@ -172,8 +174,6 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = Self;
 		type ElectionTrackerDebugEventHook = EmptyHook;
-
-		const BWNAME: &'static str = "DepositChannel";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct
@@ -303,6 +303,8 @@ impls! {
 		type Execute = Self;
 
 		type DebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "VaultDeposit";
 	}
 
 	/// Associating BW types to the struct
@@ -312,8 +314,6 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = EmptyHook;
 		type ElectionTrackerDebugEventHook = EmptyHook;
-
-		const BWNAME: &'static str = "VaultDeposit";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct
@@ -388,6 +388,8 @@ impls! {
 		type Execute = Self;
 
 		type DebugEventHook = EmptyHook;
+
+		const BWNAME: &'static str = "Egress";
 	}
 
 	/// Associating BW types to the struct
@@ -397,8 +399,6 @@ impls! {
 		type SafeModeEnabledHook = Self;
 		type ProcessedUpToHook = EmptyHook;
 		type ElectionTrackerDebugEventHook = EmptyHook;
-
-		const BWNAME: &'static str = "Egress";
 	}
 
 	/// Associating the state machine and consensus mechanism to the struct


### PR DESCRIPTION
Cherry-picks "Fix polkadot.js decoding for various bitcoin election types (#5972)" onto release/1.10
* fix: Fix polkadot.js decoding by attaching the BWName to typeinfo of various BW structs.
* chore: fix clippy / compilation of tests.
