### PR TITLE
fix: merge boost migrations for bitcoin_ingress_egress

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/migrations.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations.rs
@@ -29,4 +29,5 @@ pub type PalletMigration<T, I> = (
 		<T as frame_system::Config>::DbWeight,
 	>,
 	PlaceholderMigration<24, Pallet<T, I>>,
+	/* a migration from 24 to 25 is in state-chain/runtime/src/migrations/boost_refactor.rs */
 );

--- a/state-chain/runtime/src/migrations/boost_refactor.rs
+++ b/state-chain/runtime/src/migrations/boost_refactor.rs
@@ -218,22 +218,6 @@ impl UncheckedOnRuntimeUpgrade for BoostRefactorMigration {
 			},
 		);
 
-		pallet_cf_ingress_egress::DepositChannelLookup::<Runtime, BitcoinInstance>::translate_values(
-			|old_details : old::DepositChannelDetails<Runtime, BitcoinInstance>| {
-
-				Some(pallet_cf_ingress_egress::DepositChannelDetails {
-					owner: old_details.owner,
-					deposit_channel: old_details.deposit_channel,
-					opened_at: old_details.opened_at,
-					expires_at: old_details.expires_at,
-					action: old_details.action,
-					boost_fee: old_details.boost_fee,
-					boost_status: migrate_boost_status(old_details.boost_status),
-				})
-
-			},
-		);
-
 		old::NetworkFeeDeductionFromBoostPercent::<Runtime, EthereumInstance>::kill();
 		old::NetworkFeeDeductionFromBoostPercent::<Runtime, PolkadotInstance>::kill();
 		old::NetworkFeeDeductionFromBoostPercent::<Runtime, BitcoinInstance>::kill();

--- a/state-chain/runtime/src/migrations/boost_refactor.rs
+++ b/state-chain/runtime/src/migrations/boost_refactor.rs
@@ -135,6 +135,8 @@ struct PreUpgradeData {
 	boost_balances: BTreeMap<AccountId, ScaledAmount>,
 }
 
+// Migrating BoostStatus here because the migration collides with the
+// `CcmAdditionalDataToCheckedMigration` migration.
 fn migrate_boost_status<AccountId, BlockNumber>(
 	status: old::BoostStatus<AccountId, BlockNumber>,
 ) -> pallet_cf_ingress_egress::BoostStatus<AccountId, BlockNumber> {


### PR DESCRIPTION
The migrations for ccm_add_data_to_decoded and for the boost refactor clashed, because they both tried to migrate some data. I merged the critical part into the ccm_add_data_to_decoded migration.