### PR TITLE
fix: bouncer oracle price submission

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -190,7 +190,7 @@ jobs:
           ./commands/force_sol_nonces.ts
           ./commands/set_sol_alt.ts
 
-        # TODO: This is a temporary workaround to do the initial price feed setup. Remove after 1.10 is released.
+        # TODO: This is a temporary workaround to do the initial price feed setup. Remove after 1.11 is released.
       - name: Setup price feeds
         if: inputs.run-job
         run: |


### PR DESCRIPTION
# Pull Request


## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Update the mock price feeds using submit instead of update_price to get around the fact that the timestamps are wrong (old) after starting the old Solana images.