### PR TITLE
fix: skip elections setup if pallet not found

### DIFF
--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -7,8 +7,6 @@ export async function setupElections(logger: Logger): Promise<void> {
 
   const chainflip = await getChainflipApi();
 
-  const ingressSafetyMargin = 3;
-
   // get current bitcoin electoral settings
   // This is an array containing settings for
   // 1. BHW
@@ -16,18 +14,24 @@ export async function setupElections(logger: Logger): Promise<void> {
   // 3. VaultSwapWitnessing BW
   // 4. EgressWitnessing BW
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  const response = JSON.parse(
-    (await chainflip.query.bitcoinElections.electoralUnsynchronisedSettings()) as any,
-  );
+  if (chainflip.query.bitcoinElections) {
+    const ingressSafetyMargin = 3;
 
-  // set higher safety margin for ingresses so that we don't miss boosts
-  response[1].safetyMargin = ingressSafetyMargin;
-  response[2].safetyMargin = ingressSafetyMargin;
+    const response = JSON.parse(
+      (await chainflip.query.bitcoinElections.electoralUnsynchronisedSettings()) as any,
+    );
 
-  // update election settings
-  await submitGovernanceExtrinsic((api) =>
-    api.tx.bitcoinElections.updateSettings(response, null, 'Heed'),
-  );
+    // set higher safety margin for ingresses so that we don't miss boosts
+    response[1].safetyMargin = ingressSafetyMargin;
+    response[2].safetyMargin = ingressSafetyMargin;
 
-  logger.info(`Ingress safety margin for bitcoin elections set to ${ingressSafetyMargin}.`);
+    // update election settings
+    await submitGovernanceExtrinsic((api) =>
+      api.tx.bitcoinElections.updateSettings(response, null, 'Heed'),
+    );
+
+    logger.info(`Ingress safety margin for bitcoin elections set to ${ingressSafetyMargin}.`);
+  } else {
+    logger.info('Ignoring bitcoin elections setup as bitcoinElections pallet is not available.');
+  }
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Fix the bitcoin elections setup step in the bouncer. Should ignore setting up when the pallet is not found.