### PR TITLE
fix: M2 build should use old cmake

### DIFF
--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install Rust Requirements 💿
         run: |
           brew install protobuf
+          wget https://raw.githubusercontent.com/Homebrew/homebrew-core/b4e46db74e74a8c1650b38b1da222284ce1ec5ce/Formula/c/cmake.rb -O ~/cmake.rb
+          brew unlink cmake
+          brew install -s ~/cmake.rb
 
       # This is a workaround for the issue with Git ownership that prevents cargo from executing git commands to get commit hash for `--version`
       - name: Configure Git 🛠️


### PR DESCRIPTION
some features were deprecated in the newest cmake version. This change explicitly uses an old version.