### PR TITLE
tests

### DIFF
--- a/state-chain/pallets/cf-account-roles/src/benchmarking.rs
+++ b/state-chain/pallets/cf-account-roles/src/benchmarking.rs
@@ -44,15 +44,19 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn derive_sub_account() {
+	fn spawn_sub_account() {
 		const SUB_ACCOUNT_INDEX: SubAccountIndex = 1;
-		const FLIP_BALANCE: u128 = 1000;
+		const FLIP_BALANCE: u128 = 1000 * FLIPPERINOS_PER_FLIP;
 		let caller: T::AccountId = whitelisted_caller();
 
-		T::FeePayment::mint_to_account(&caller, (FLIP_BALANCE * FLIPPERINOS_PER_FLIP).into());
+		T::FeePayment::mint_to_account(&caller, (FLIP_BALANCE * 2).into());
 
 		#[extrinsic_call]
-		derive_sub_account(RawOrigin::Signed(caller.clone()), SUB_ACCOUNT_INDEX, None);
+		spawn_sub_account(
+			RawOrigin::Signed(caller.clone()),
+			SUB_ACCOUNT_INDEX,
+			FLIP_BALANCE.into(),
+		);
 	}
 
 	#[benchmark]
@@ -62,12 +66,12 @@ mod benchmarks {
 		let caller: T::AccountId = whitelisted_caller();
 		let call = Box::new(frame_system::Call::remark { remark: vec![] }.into());
 
-		T::FeePayment::mint_to_account(&caller, (FLIP_BALANCE * FLIPPERINOS_PER_FLIP).into());
+		T::FeePayment::mint_to_account(&caller, (FLIP_BALANCE * 2).into());
 
-		assert_ok!(Pallet::<T>::derive_sub_account(
+		assert_ok!(Pallet::<T>::spawn_sub_account(
 			RawOrigin::Signed(caller.clone()).into(),
 			SUB_ACCOUNT_INDEX,
-			None,
+			FLIP_BALANCE.into(),
 		));
 
 		#[extrinsic_call]

--- a/state-chain/pallets/cf-account-roles/src/benchmarking.rs
+++ b/state-chain/pallets/cf-account-roles/src/benchmarking.rs
@@ -25,7 +25,10 @@ use cf_traits::FeePayment;
 
 use cf_primitives::FLIPPERINOS_PER_FLIP;
 
-#[benchmarks]
+#[benchmarks(
+    where
+        <T as Config>::RuntimeCall: From<frame_system::Call<T>>
+)]
 mod benchmarks {
 	use super::*;
 

--- a/state-chain/pallets/cf-account-roles/src/lib.rs
+++ b/state-chain/pallets/cf-account-roles/src/lib.rs
@@ -28,11 +28,6 @@ use sp_std::boxed::Box;
 
 use cf_traits::Chainflip;
 
-#[cfg(not(feature = "runtime-benchmarks"))]
-use cf_traits::FeePayment;
-
-use sp_runtime::{codec::Decode, DispatchError};
-
 use cf_primitives::AccountRole;
 use cf_traits::{AccountRoleRegistry, DeregistrationCheck, SpawnAccount};
 use frame_support::{
@@ -40,11 +35,9 @@ use frame_support::{
 	error::BadOrigin,
 	pallet_prelude::{DispatchResult, StorageVersion},
 	traits::{EnsureOrigin, HandleLifetime, IsType, OnKilledAccount, OnNewAccount, OriginTrait},
-	BoundedVec, Hashable,
+	BoundedVec,
 };
 use sp_core::ConstU32;
-
-use sp_runtime::traits::TrailingZeroInput;
 
 use sp_runtime::traits::Dispatchable;
 
@@ -62,7 +55,10 @@ type VanityName = BoundedVec<u8, ConstU32<MAX_LENGTH_FOR_VANITY_NAME>>;
 pub mod pallet {
 	use super::*;
 	use cf_traits::DeregistrationCheck;
-	use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
+	use frame_support::{
+		dispatch::{DispatchResultWithPostInfo, PostDispatchInfo},
+		pallet_prelude::*,
+	};
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + cf_traits::Chainflip {
@@ -72,11 +68,12 @@ pub mod pallet {
 			AccountId = <Self as frame_system::Config>::AccountId,
 		>;
 		type RuntimeCall: Parameter
-			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>
 			+ GetDispatchInfo;
 		type SpawnAccount: SpawnAccount<
 			AccountId = <Self as frame_system::Config>::AccountId,
 			Amount = <Self as Chainflip>::Amount,
+			Index = SubAccountIndex,
 		>;
 		#[cfg(feature = "runtime-benchmarks")]
 		type FeePayment: cf_traits::FeePayment<
@@ -193,31 +190,26 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Derives a sub-account by the given origin account id and a sub-account index.
-		/// Stores the account id against the sub-account index and origin account id.
+		/// Spawns a sub-account by the given origin account id and a sub-account index.
 		///
-		/// The sub account is unmutual associated with the origin/parent account and the creation
-		/// fails if the sub-account already exists for the given index. It's possible to derive 256
-		/// sub-accounts per parent account. The parent account can execute calls on behalf of the
-		/// sub-account (see as_sub_account).
+		/// The sub account is dependent on the original parent account. Calls can be dispatched by
+		/// the parent account on behalf of the sub-account using [`Call::as_sub_account`].
+		/// Creation requires an initial balance of at least the minimum funding amount.
 		///
-		/// Events:
-		/// - `SubAccountCreated` if the sub-account is created.
+		/// All sub-accounts must be closed before the parent account can be closed.
 		///
-		/// Errors:
-		/// - `SubAccountAlreadyExists` if the sub-account already exists for the given index.
-		/// - `SubAccountIdDerivationFailed` if the sub-account id derivation fails.
+		/// The maximum number of sub-accounts is limited by the runtime's configured
+		/// [frame_system::Config::MaxConsumers] (default is 128).
 		#[pallet::call_index(1)]
-		#[pallet::weight(T::WeightInfo::derive_sub_account())]
-		pub fn derive_sub_account(
+		#[pallet::weight(T::WeightInfo::spawn_sub_account())]
+		pub fn spawn_sub_account(
 			origin: OriginFor<T>,
 			sub_account_index: SubAccountIndex,
-			amount: Option<T::Amount>,
+			initial_amount: T::Amount,
 		) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
 			let sub_account_id =
-				Self::derive_sub_account_id(account_id.clone(), sub_account_index)?;
-			T::SpawnAccount::spawn_sub_account(account_id.clone(), sub_account_id.clone(), amount)?;
+				T::SpawnAccount::spawn_sub_account(&account_id, sub_account_index, initial_amount)?;
 			Self::deposit_event(Event::SubAccountCreated {
 				account_id: account_id.clone(),
 				sub_account_id,
@@ -226,17 +218,11 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Executes a call on behalf of a sub-account. The account is getting identified by the
-		/// passed sub-account index.
+		/// Executes a call on behalf of a sub-account, as identified by the provided
+		/// `sub_account_index`. Fees are paid by the parent account.
 		///
 		/// The call is executed with the sub-account's account id as the dispatch origin.
-		///
-		/// Events:
-		/// - `SubAccountCallExecuted` if the call is executed.
-		///
-		/// Errors:
-		/// - `UnknownAccount` if the sub-account is not found.
-		/// - `FailedToExecuteCallOnBehalfOfSubAccount` if the call fails.
+		#[allow(clippy::useless_conversion)]
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::as_sub_account().saturating_add(call.get_dispatch_info().weight))]
 		pub fn as_sub_account(
@@ -247,7 +233,7 @@ pub mod pallet {
 			let mut origin = origin;
 			let account_id = ensure_signed(origin.clone())?;
 			let sub_account_id =
-				Self::derive_sub_account_id(account_id.clone(), sub_account_index)?;
+				T::SpawnAccount::derive_sub_account_id(&account_id, sub_account_index)?;
 			ensure!(
 				frame_system::Pallet::<T>::account_exists(&sub_account_id),
 				Error::<T>::UnknownAccount
@@ -261,20 +247,6 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-	}
-}
-
-impl<T: Config> Pallet<T> {
-	pub fn derive_sub_account_id(
-		parent_account_id: T::AccountId,
-		sub_account_index: SubAccountIndex,
-	) -> Result<T::AccountId, DispatchError> {
-		Ok(Decode::decode(&mut TrailingZeroInput::new(
-			(*b"chainflip/subaccount", parent_account_id.clone(), sub_account_index)
-				.blake2_256()
-				.as_ref(),
-		))
-		.map_err(|_| Error::<T>::SubAccountIdDerivationFailed)?)
 	}
 }
 

--- a/state-chain/pallets/cf-account-roles/src/mock.rs
+++ b/state-chain/pallets/cf-account-roles/src/mock.rs
@@ -59,10 +59,6 @@ impl SpawnAccount for MockSpawnAccount {
 	) -> Result<(), DispatchError> {
 		Ok(())
 	}
-
-	fn does_account_exist(_account_id: &Self::AccountId) -> bool {
-		true
-	}
 }
 
 impl Config for Test {

--- a/state-chain/pallets/cf-account-roles/src/tests.rs
+++ b/state-chain/pallets/cf-account-roles/src/tests.rs
@@ -205,16 +205,17 @@ fn deregistration_checks() {
 }
 
 #[test]
-fn derive_sub_account() {
+fn spawn_sub_account() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(AccountRolesPallet::derive_sub_account(RuntimeOrigin::signed(ALICE), 0, None));
+		const SUB_ACCOUNT_INDEX: u8 = 0;
+		assert_ok!(AccountRolesPallet::spawn_sub_account(RuntimeOrigin::signed(ALICE), SUB_ACCOUNT_INDEX, 0));
 		assert_has_matching_event!(
 			Test,
 			RuntimeEvent::MockAccountRoles(Event::SubAccountCreated {
 				account_id: ALICE,
-				sub_account_id: _,
-				sub_account_index: _,
-			})
+				sub_account_id,
+				sub_account_index: SUB_ACCOUNT_INDEX,
+			}) if *sub_account_id == MockSpawnAccount::derive_sub_account_id(&ALICE, SUB_ACCOUNT_INDEX).unwrap()
 		);
 	});
 }
@@ -224,14 +225,8 @@ fn execute_as_sub_account() {
 	new_test_ext().execute_with(|| {
 		const SUB_ACCOUNT_INDEX: u8 = 1;
 
-		let sub_account_id =
-			AccountRolesPallet::derive_sub_account_id(ALICE, SUB_ACCOUNT_INDEX).unwrap();
-
-		assert_ok!(AccountRolesPallet::derive_sub_account(
-			RuntimeOrigin::signed(ALICE),
-			SUB_ACCOUNT_INDEX,
-			None,
-		));
+		let sub_account_id = MockSpawnAccount::spawn_sub_account(&ALICE, SUB_ACCOUNT_INDEX, 0)
+			.expect("Sub-account ID derivation should not fail");
 		assert_ok!(AccountRolesPallet::as_sub_account(
 			RuntimeOrigin::signed(ALICE),
 			SUB_ACCOUNT_INDEX,

--- a/state-chain/pallets/cf-account-roles/src/weights.rs
+++ b/state-chain/pallets/cf-account-roles/src/weights.rs
@@ -49,7 +49,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_cf_account_roles.
 pub trait WeightInfo {
 	fn set_vanity_name() -> Weight;
-	fn derive_sub_account() -> Weight;
+	fn spawn_sub_account() -> Weight;
 	fn as_sub_account() -> Weight;
 }
 
@@ -68,7 +68,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-	fn derive_sub_account() -> Weight {
+	fn spawn_sub_account() -> Weight {
 		Weight::from_parts(0, 0)
 			.saturating_add(T::DbWeight::get().reads(0_u64))
 			.saturating_add(T::DbWeight::get().writes(0_u64))
@@ -95,7 +95,7 @@ impl WeightInfo for () {
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 
-	fn derive_sub_account() -> Weight {
+	fn spawn_sub_account() -> Weight {
 		Weight::from_parts(0, 0)
 			.saturating_add(ParityDbWeight::get().reads(0_u64))
 			.saturating_add(ParityDbWeight::get().writes(0_u64))

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1265,10 +1265,15 @@ pub trait CcmAdditionalDataHandler {
 pub trait SpawnAccount {
 	type AccountId;
 	type Amount;
+	type Index;
 
 	fn spawn_sub_account(
-		parent_account_id: Self::AccountId,
-		account_id: Self::AccountId,
-		initial_balance: Option<Self::Amount>,
-	) -> Result<(), DispatchError>;
+		parent_account_id: &Self::AccountId,
+		index: Self::Index,
+		initial_balance: Self::Amount,
+	) -> Result<Self::AccountId, DispatchError>;
+	fn derive_sub_account_id(
+		parent_account_id: &Self::AccountId,
+		index: Self::Index,
+	) -> Result<Self::AccountId, DispatchError>;
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1271,6 +1271,4 @@ pub trait SpawnAccount {
 		account_id: Self::AccountId,
 		initial_balance: Option<Self::Amount>,
 	) -> Result<(), DispatchError>;
-
-	fn does_account_exist(account_id: &Self::AccountId) -> bool;
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2361

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have updated documentation where appropriate.

## Summary

Ensures correct lifecycle tracking of sub-accounts using FRAME reference counting. In particular, increments/decrements the  'consumer' count of the parent when the sub-account is created/killed. This prevents the parent account from being reaped if any sub-accounts are still active. 