### PR TITLE
fix: avoid logging Error in case of Optimistic Election

### DIFF
--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -173,17 +173,16 @@ where
 			Ok(Some((block.txdata, None)))
 		},
 		EngineElectionType::BlockHeight { submit_hash } => {
-			let block_hash = if submit_hash {
+			// check whether a block exists with the given height
+			if submit_hash {
 				let block_hash = client.best_block_hash().await?;
 				let best_block_header = client.block_header(block_hash).await?;
-				if best_block_header.height != block_height {
+				if best_block_header.height < block_height {
 					return Ok(None)
 				}
-				block_hash
-			} else {
-				client.block_hash(block_height).await?
-			};
+			}
 
+			let block_hash = client.block_hash(block_height).await?;
 			let block = client.block(block_hash).await?;
 			Ok(Some((
 				block.txdata,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2398

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

When querying for optimistic blocks the RPC will always fail for non-existing block, since we are querying optimistically this is expected to happen very often. Changed the logic to query only if the block is actually new and return None otherwise.
