### PR TITLE
fix: liveness ES to use SC block number

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/liveness.rs
@@ -46,8 +46,7 @@ impl MockHook {
 	}
 }
 
-type SimpleLiveness =
-	Liveness<ChainBlockHash, ChainBlockNumber, BlockNumber, MockHook, ValidatorId, u32>;
+type SimpleLiveness = Liveness<ChainBlockHash, ChainBlockNumber, MockHook, ValidatorId, u32>;
 
 register_checks! {
 	SimpleLiveness {

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -445,7 +445,6 @@ pub type BitcoinEgressWitnessingES = StatemachineElectoralSystem<TypesFor<Bitcoi
 pub type BitcoinLiveness = Liveness<
 	BlockNumber,
 	Hash,
-	cf_primitives::BlockNumber,
 	ReportFailedLivenessCheck<Bitcoin>,
 	<Runtime as Chainflip>::ValidatorId,
 	BlockNumberFor<Runtime>,

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -162,7 +162,6 @@ pub type SolanaEgressWitnessing = electoral_systems::exact_value::ExactValue<
 pub type SolanaLiveness = Liveness<
 	<Solana as Chain>::ChainBlockNumber,
 	SolHash,
-	cf_primitives::BlockNumber,
 	ReportFailedLivenessCheck<Solana>,
 	<Runtime as Chainflip>::ValidatorId,
 	BlockNumberFor<Runtime>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2401

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Fix Liveness ES to use the SC block as seed to generate the random blockheight.