### PR TITLE
fix: boost details rpc incorporates network fee deduction

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -654,6 +654,8 @@ pub fn get_boost_pool_details<T: Config>(
 
 					let BoostPoolContribution { boosted_amount, network_fee, .. } = contribution;
 
+					let total_owed_amount = boosted_amount.saturating_sub(network_fee);
+
 					let boosters_fee = utils::fee_from_boosted_amount(boosted_amount, tier)
 						.saturating_sub(network_fee);
 
@@ -664,7 +666,7 @@ pub fn get_boost_pool_details<T: Config>(
 							(
 								acc_id.clone(),
 								OwedAmount {
-									total: *share * boosted_amount,
+									total: *share * total_owed_amount,
 									fee: *share * boosters_fee,
 								},
 							)

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -613,8 +613,9 @@ fn boost_pool_details() {
 				pending_boosts: BTreeMap::from_iter([(
 					DEPOSIT_ID,
 					BTreeMap::from_iter([
-						(BOOSTER_1, OwedAmount { total: 20_000, fee: 10 }),
-						(BOOSTER_2, OwedAmount { total: 10_000, fee: 5 })
+						// Note the network fee deduction:
+						(BOOSTER_1, OwedAmount { total: 20_000 - 10, fee: 10 }),
+						(BOOSTER_2, OwedAmount { total: 10_000 - 5, fee: 5 })
 					])
 				)]),
 				pending_withdrawals: BTreeMap::from_iter([(


### PR DESCRIPTION
# Pull Request

## Summary

The rpc only deducted network fee from `fee` field, but now it is also deducted from `total`.
(See the discussion on https://discord.com/channels/775961728608895008/1394651581953212496)