### PR TITLE
feat: cli validator commands for operator  acceptance/removal

### DIFF
--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -38,7 +38,7 @@ use chainflip_api::{
 use clap::Parser;
 use futures::FutureExt;
 use serde::Serialize;
-use std::{io::Write, path::PathBuf, sync::Arc};
+use std::{io::Write, path::PathBuf, str::FromStr, sync::Arc};
 
 mod settings;
 
@@ -139,6 +139,17 @@ async fn run_cli() -> Result<()> {
 					ValidatorSubcommands::StartBidding {} => {
 						let tx_hash = api.validator_api().start_bidding().await?;
 						println!("Account started bidding at tx {tx_hash:#x}.");
+					},
+					ValidatorSubcommands::AcceptOperator { operator_id } => {
+						let operator_account = AccountId32::from_str(&operator_id)
+							.map_err(|err| anyhow::anyhow!("Failed to parse AccountId: {}", err))
+							.context("Invalid account ID provided")?;
+						let events = api.validator_api().accept_operator(operator_account).await?;
+						println!("Operator accepted. Events: {:#?}", events);
+					},
+					ValidatorSubcommands::RemoveOperator => {
+						let events = api.validator_api().remove_operator().await?;
+						println!("Operator removed. Events: {:#?}", events);
 					},
 				},
 				Redeem { amount, eth_address, executor_address } => {

--- a/api/bin/chainflip-cli/src/settings.rs
+++ b/api/bin/chainflip-cli/src/settings.rs
@@ -133,6 +133,13 @@ pub enum ValidatorSubcommands {
 	StartBidding,
 	/// Stop bidding, thereby stopping participation in auctions.
 	StopBidding,
+	/// Accept an operator's claim to manage this validator.
+	AcceptOperator {
+		/// The operator account ID to accept
+		operator_id: String,
+	},
+	/// Remove the operator from managing this validator.
+	RemoveOperator,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/api/lib/src/lib.rs
+++ b/api/lib/src/lib.rs
@@ -238,6 +238,27 @@ pub trait ValidatorApi: SimpleSubmissionApi {
 		self.simple_submission_with_dry_run(pallet_cf_validator::Call::start_bidding {})
 			.await
 	}
+	async fn accept_operator(&self, operator_id: AccountId32) -> Result<Vec<RuntimeEvent>> {
+		let extrinsic_data = self
+			.submit_signed_extrinsic_with_dry_run(pallet_cf_validator::Call::accept_operator {
+				operator_id,
+			})
+			.await?
+			.until_finalized()
+			.await?;
+		Ok(extrinsic_data.events)
+	}
+	async fn remove_operator(&self) -> Result<Vec<RuntimeEvent>> {
+		let validator_account = self.account_id();
+		let extrinsic_data = self
+			.submit_signed_extrinsic_with_dry_run(pallet_cf_validator::Call::remove_validator {
+				validator: validator_account,
+			})
+			.await?
+			.until_finalized()
+			.await?;
+		Ok(extrinsic_data.events)
+	}
 }
 
 #[async_trait]


### PR DESCRIPTION
# Pull Request

Closes: PRO-2413

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

Adds the following commands: 

```
➜  chainflip-backend git:(main) ✗ ./target/release/chainflip-cli validator accept-operator --help
Accept an operator's claim to manage this validator

Usage: chainflip-cli validator accept-operator <OPERATOR_ID>

Arguments:
  <OPERATOR_ID>  The operator account ID to accept

Options:
  -h, --help  Print help
➜  chainflip-backend git:(main) ✗ ./target/release/chainflip-cli validator remove-operator --help
Remove the operator from managing this validator

Usage: chainflip-cli validator remove-operator

Options:
  -h, --help  Print help
```
