### PR TITLE
feat: CFE check for CF chain node connection

### DIFF
--- a/engine/src/state_chain_observer/client.rs
+++ b/engine/src/state_chain_observer/client.rs
@@ -736,10 +736,19 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 		)?);
 		let signer = signer::PairSigner::<sp_core::sr25519::Pair>::new(pair.clone());
 
+		// Pre-check to verify if the correct chain is connected.
+		if base_rpc_client
+			.storage_value::<pallet_cf_environment::CurrentReleaseVersion<state_chain_runtime::Runtime>>(
+				finalized_block_stream.cache().hash,
+			)
+			.await? == Default::default()
+		{
+			bail!("Failed to retrieve compatible CFE version from Chainflip node. \nPlease ensure the Port you use points to a valid Chainflip Node");
+		}
+
 		let account_nonce = {
 			loop {
 				let block_hash = finalized_block_stream.cache().hash;
-
 				match base_rpc_client
 					.storage_map_entry::<pallet_cf_account_roles::AccountRoles<state_chain_runtime::Runtime>>(
 						block_hash,


### PR DESCRIPTION
# Pull Request

Closes: PRO-1953

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary
When CFE is launched, it will try to check for CFE version - something unique to CF nodes. This ensures Engine is connecting to a valid CF node, not other Substrate-based chains by mistake

If an invalid CFE version is returned, the CFE exits early.

To reproduce the error and test the fix, replace `$SC_RPC_PORT` with `9947` in `localnet/init/scripts/start-engine.sh`
