### PR TITLE
fix: remove race condition in bouncer observe event

### DIFF
--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -339,7 +339,7 @@ const subscribeHeads = getCachedDisposable(
       cache.addEvents(header.hash.toString(), mappedEvents, finalized);
       subject.next({
         blockHash: header.hash.toString(),
-        blockNumber: header.number,
+        blockNumber: header.number.toNumber(),
         events: mappedEvents,
       });
     });


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

* Fixes a race condition in bouncer's `observeEvent` function between checking for the event in historic blocks and in the  new block from a subscription
