### PR TITLE
feat: Support for DCA 1 block interval

### DIFF
--- a/bouncer/tests/DCA_test.ts
+++ b/bouncer/tests/DCA_test.ts
@@ -16,21 +16,22 @@ import { DcaParams, FillOrKillParamsX128 } from 'shared/new_swap';
 import { TestContext } from 'shared/utils/test_context';
 import { Logger } from 'shared/utils/logger';
 
-// Requested number of blocks between each chunk
-const CHUNK_INTERVAL = 2;
-
 async function testDCASwap(
-  logger: Logger,
+  parentLogger: Logger,
   inputAsset: Asset,
   amount: number,
   numberOfChunks: number,
+  chunkIntervalBlocks: number,
   swapViaVault = false,
 ) {
-  assert(numberOfChunks > 1, 'Number of chunks must be greater than 1');
+  assert(numberOfChunks > 0, 'Number of chunks must be greater than 0');
+  const logger = parentLogger.child({
+    tag: `DCA_test_${inputAsset}_${numberOfChunks}_chunks_at_${chunkIntervalBlocks}_interval`,
+  });
 
   const dcaParams: DcaParams = {
     numberOfChunks,
-    chunkIntervalBlocks: CHUNK_INTERVAL,
+    chunkIntervalBlocks,
   };
   const fillOrKillParams: FillOrKillParamsX128 = {
     refundAddress: await newAssetAddress(inputAsset, randomBytes(32).toString('hex')),
@@ -49,7 +50,7 @@ async function testDCASwap(
 
   if (!swapViaVault) {
     const swapRequest = await requestNewSwap(
-      logger.child({ tag: `DCA_test_${inputAsset}` }),
+      logger,
       inputAsset,
       destAsset,
       destAddress,
@@ -110,7 +111,7 @@ async function testDCASwap(
   // Find the `SwapExecuted` events for this swap.
   const observeSwapExecutedEvents = await observeEvents(logger, `swapping:SwapExecuted`, {
     test: (event) => Number(event.data.swapRequestId.replaceAll(',', '')) === swapRequestId,
-    historicalCheckBlocks: numberOfChunks * CHUNK_INTERVAL + 10,
+    historicalCheckBlocks: numberOfChunks * chunkIntervalBlocks + 10,
   }).events;
 
   // Check that there were the correct number of SwapExecuted events, one for each chunk.
@@ -125,21 +126,23 @@ async function testDCASwap(
     const interval = observeSwapExecutedEvents[i].block - observeSwapExecutedEvents[i - 1].block;
     assert.strictEqual(
       interval,
-      CHUNK_INTERVAL,
+      chunkIntervalBlocks,
       `Unexpected chunk interval between chunk ${i - 1} & ${i}`,
     );
   }
 
-  logger.debug(`Chunk interval of ${CHUNK_INTERVAL} verified for all ${numberOfChunks} chunks`);
+  logger.debug(
+    `Chunk interval of ${chunkIntervalBlocks} verified for all ${numberOfChunks} chunks`,
+  );
 
   await observeBalanceIncrease(logger, destAsset, destAddress, destBalanceBefore);
 }
 
 export async function testDCASwaps(testContext: TestContext) {
   await Promise.all([
-    testDCASwap(testContext.logger, Assets.Eth, 1, 2),
-    testDCASwap(testContext.logger, Assets.ArbEth, 1, 2),
-    testDCASwap(testContext.logger, Assets.Sol, 1, 2, true),
-    testDCASwap(testContext.logger, Assets.SolUsdc, 1, 2, true),
+    testDCASwap(testContext.logger, Assets.Eth, 1, 2, 2),
+    testDCASwap(testContext.logger, Assets.ArbEth, 1, 4, 1),
+    testDCASwap(testContext.logger, Assets.Sol, 1, 2, 3, true),
+    testDCASwap(testContext.logger, Assets.SolUsdc, 1, 2, 1, true),
   ]);
 }

--- a/state-chain/pallets/cf-swapping/README.md
+++ b/state-chain/pallets/cf-swapping/README.md
@@ -38,7 +38,7 @@ CCM messages can be entered on-chain in the following ways:
 
 #### Processing
 
-Each Ccm can trigger up to 2 swap operations: one for the Principal amount and another for the Gas. The gas budget is defined in the Ccm message metadata, and the remaining deposited funds are used as Principal (Deposit amount must be >= GasBudget defined in the metadata). Each swap is batched with other swaps in the SwapQueue to avoid frontrunning. After all swaps are completed, the CCM message is egressed to the destination chain.
+Each Ccm can trigger up to 2 swap operations: one for the Principal amount and another for the Gas. The gas budget is defined in the Ccm message metadata, and the remaining deposited funds are used as Principal (Deposit amount must be >= GasBudget defined in the metadata). Each swap is batched with other swaps in the ScheduledSwaps to avoid frontrunning. After all swaps are completed, the CCM message is egressed to the destination chain.
 
 #### Egress
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -56,7 +56,11 @@ use sp_arithmetic::{
 	Rounding,
 };
 use sp_runtime::traits::TrailingZeroInput;
-use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+use sp_std::{
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	vec,
+	vec::Vec,
+};
 
 #[cfg(test)]
 mod mock;
@@ -70,7 +74,7 @@ pub mod migrations;
 pub mod weights;
 pub use weights::WeightInfo;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(12);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(13);
 
 pub(crate) const DEFAULT_SWAP_RETRY_DELAY_BLOCKS: u32 = 5;
 const DEFAULT_MAX_SWAP_RETRY_DURATION_BLOCKS: u32 = 3600 / SECONDS_PER_BLOCK as u32; // 1 hour
@@ -254,6 +258,7 @@ pub struct Swap<T: Config> {
 	input_amount: AssetAmount,
 	fees: Vec<FeeType<T>>,
 	refund_params: Option<SwapRefundParameters>,
+	execute_at: BlockNumberFor<T>,
 }
 
 pub struct DefaultBrokerBond<T>(PhantomData<T>);
@@ -286,6 +291,7 @@ impl<T: Config> Swap<T> {
 		input_amount: AssetAmount,
 		refund_params: Option<SwapRefundParameters>,
 		fees: impl IntoIterator<Item = FeeType<T>>,
+		execute_at: BlockNumberFor<T>,
 	) -> Self {
 		Self {
 			swap_id,
@@ -295,6 +301,7 @@ impl<T: Config> Swap<T> {
 			input_amount,
 			fees: fees.into_iter().collect(),
 			refund_params,
+			execute_at,
 		}
 	}
 }
@@ -328,17 +335,9 @@ impl<T: Config> From<DispatchError> for BatchExecutionError<T> {
 	}
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Encode, Decode, TypeInfo)]
-pub enum DcaStatus {
-	ChunkToBeScheduled,
-	ChunkScheduled(SwapId),
-	AwaitingRefund,
-	Completed,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct DcaState {
-	status: DcaStatus,
+	scheduled_chunks: BTreeSet<SwapId>,
 	remaining_input_amount: AssetAmount,
 	remaining_chunks: u32,
 	chunk_interval: u32,
@@ -346,63 +345,59 @@ pub struct DcaState {
 }
 
 impl DcaState {
-	// Create initial DCA state and prepares the first chunk for scheduling; if no dca parameters
-	// provided (for non-DCA swaps), this creates state equivalent to 1 chunk DCA
-	fn create_with_first_chunk(
-		input_amount: AssetAmount,
-		params: Option<DcaParameters>,
-	) -> (DcaState, AssetAmount) {
-		let mut state = DcaState {
-			status: DcaStatus::ChunkToBeScheduled,
+	fn new(input_amount: AssetAmount, params: Option<DcaParameters>) -> DcaState {
+		DcaState {
 			remaining_input_amount: input_amount,
 			remaining_chunks: params.as_ref().map(|p| p.number_of_chunks).unwrap_or(1),
 			// Chunk interval won't be used for non-DCA swaps but seems nicer to
 			// set a reasonable default than unwrap Option when it is needed:
 			chunk_interval: params.as_ref().map(|p| p.chunk_interval).unwrap_or(SWAP_DELAY_BLOCKS),
 			accumulated_output_amount: 0,
-		};
-
-		let first_chunk_amount = state.prepare_next_chunk(None).unwrap_or_else(|| {
-			log_or_panic!("Invariant violation: initial DCA state must have at least one chunk!");
-			0
-		});
-
-		(state, first_chunk_amount)
+			scheduled_chunks: BTreeSet::new(),
+		}
 	}
 
-	fn prepare_next_chunk(
-		&mut self,
-		prev_chunk_and_output: Option<(SwapId, AssetAmount)>,
-	) -> Option<AssetAmount> {
-		if let Some((prev_chunk_swap_id, prev_chunk_output_amount)) = prev_chunk_and_output {
-			if let DcaStatus::ChunkScheduled(scheduled_swap_id) = self.status {
-				if scheduled_swap_id != prev_chunk_swap_id {
-					log_or_panic!(
-						"Invariant violation: the recorded chunk id {scheduled_swap_id} does not match executed {prev_chunk_swap_id}"
-					);
-				}
-			} else {
-				log_or_panic!(
-					"Invariant violation: attempting to get next chunk when no previous chunk is recorded"
-				);
-			}
-
-			self.status = DcaStatus::ChunkToBeScheduled;
-			self.accumulated_output_amount += prev_chunk_output_amount;
-		}
-
-		let chunk_input_amount = self
-			.remaining_input_amount
-			.checked_div(self.remaining_chunks as u128)
-			.unwrap_or(0);
-
+	/// Calculate the amount of the next chunk to be scheduled.
+	fn calculate_next_chunk(&self) -> Option<AssetAmount> {
 		if self.remaining_chunks > 0 {
-			self.remaining_chunks = self.remaining_chunks.saturating_sub(1);
-			self.remaining_input_amount =
-				self.remaining_input_amount.saturating_sub(chunk_input_amount);
+			let chunk_input_amount = self
+				.remaining_input_amount
+				.checked_div(self.remaining_chunks as u128)
+				.unwrap_or(0);
+
 			Some(chunk_input_amount)
 		} else {
 			None
+		}
+	}
+
+	/// Called directly after a chunk has been scheduled. Records the new swap in the DCA state.
+	fn next_chunk_scheduled(
+		&mut self,
+		scheduled_chunk_swap_id: SwapId,
+		scheduled_chunk_amount: AssetAmount,
+	) {
+		// Add the new chunk to the scheduled swaps.
+		self.scheduled_chunks.insert(scheduled_chunk_swap_id);
+
+		// Update the remaining values
+		self.remaining_chunks = self.remaining_chunks.saturating_sub(1);
+		self.remaining_input_amount =
+			self.remaining_input_amount.saturating_sub(scheduled_chunk_amount);
+	}
+
+	/// Remove the completed chunk from the DCA state and accumulate the output amount.
+	fn completed_chunk(
+		&mut self,
+		completed_chunk_swap_id: SwapId,
+		completed_chunk_output_amount: AssetAmount,
+	) {
+		if self.scheduled_chunks.remove(&completed_chunk_swap_id) {
+			self.accumulated_output_amount += completed_chunk_output_amount;
+		} else {
+			log_or_panic!(
+					"Invariant violation: the completed swap id {completed_chunk_swap_id} does not match a scheduled chunk."
+				);
 		}
 	}
 }
@@ -555,11 +550,8 @@ pub mod pallet {
 	pub(super) type SwapRequests<T: Config> =
 		StorageMap<_, Twox64Concat, SwapRequestId, SwapRequest<T>>;
 
-	/// Scheduled Swaps
 	#[pallet::storage]
-	#[pallet::getter(fn swap_queue)]
-	pub type SwapQueue<T: Config> =
-		StorageMap<_, Twox64Concat, BlockNumberFor<T>, Vec<Swap<T>>, ValueQuery>;
+	pub type ScheduledSwaps<T: Config> = StorageValue<_, BTreeMap<SwapId, Swap<T>>, ValueQuery>;
 
 	/// SwapId Counter
 	#[pallet::storage]
@@ -829,6 +821,12 @@ pub mod pallet {
 			broker_id: T::AccountId,
 			minimum_fee_bps: BasisPoints,
 		},
+		SwapCanceled {
+			swap_request_id: SwapRequestId,
+			swap_id: SwapId,
+			asset: Asset,
+			amount: AssetAmount,
+		},
 	}
 	#[pallet::error]
 	pub enum Error<T> {
@@ -942,15 +940,33 @@ pub mod pallet {
 			weight_used
 		}
 
-		/// Execute all swaps in the SwapQueue
+		/// Execute swaps in the ScheduledSwaps
 		fn on_finalize(current_block: BlockNumberFor<T>) {
-			let swaps_to_execute = SwapQueue::<T>::take(current_block);
-			let retry_block = current_block + max(SwapRetryDelay::<T>::get(), 1u32.into());
+			// Take all swaps that are scheduled to be executed at this block.
+			let swaps_to_execute = ScheduledSwaps::<T>::mutate(|swaps| {
+				let swap_ids_to_execute: BTreeSet<_> = swaps
+					.iter()
+					.filter_map(|(swap_id, swap)| {
+						if swap.execute_at <= current_block {
+							Some(*swap_id)
+						} else {
+							None
+						}
+					})
+					.collect();
+				swap_ids_to_execute
+					.iter()
+					.map(|swap_id| {
+						swaps.remove(swap_id).expect("Must be in map due to collect above")
+					})
+					.collect::<Vec<Swap<T>>>()
+			});
+			let retry_delay = max(SwapRetryDelay::<T>::get(), 1u32.into());
 
 			if !T::SafeMode::get().swaps_enabled {
 				// Since we won't be executing swaps at this block, we need to reschedule them:
 				for swap in swaps_to_execute {
-					Self::reschedule_swap(swap, retry_block);
+					Self::reschedule_swap(swap, retry_delay);
 				}
 
 				return
@@ -966,7 +982,8 @@ pub mod pallet {
 			for swap in failed_swaps {
 				match swap.refund_params {
 					Some(ref params)
-						if BlockNumberFor::<T>::from(params.refund_block) < retry_block =>
+						if BlockNumberFor::<T>::from(params.refund_block) <
+							current_block + retry_delay =>
 					{
 						// Reached refund block, process refund:
 						Self::refund_failed_swap(swap);
@@ -974,7 +991,7 @@ pub mod pallet {
 					_ => {
 						// Either refund parameters not set, or refund block not
 						// reached:
-						Self::reschedule_swap(swap, retry_block);
+						Self::reschedule_swap(swap, retry_delay);
 					},
 				}
 			}
@@ -1437,8 +1454,13 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		#[allow(clippy::result_unit_err)]
-		pub fn get_scheduled_swap_legs(swaps: Vec<Swap<T>>, base_asset: Asset) -> Vec<SwapLegInfo> {
-			let mut swaps: Vec<_> = swaps.into_iter().map(SwapState::new).collect();
+		pub fn get_scheduled_swap_legs(base_asset: Asset) -> Vec<(SwapLegInfo, BlockNumberFor<T>)> {
+			let mut swaps: Vec<_> = ScheduledSwaps::<T>::get()
+				.values()
+				.filter(|swap| swap.from == base_asset || swap.to == base_asset)
+				.cloned()
+				.map(SwapState::new)
+				.collect();
 
 			// Can ignore the result here because we use pool price fallback below
 			let _res = Self::swap_into_stable_taking_fees(&mut swaps);
@@ -1458,19 +1480,22 @@ pub mod pallet {
 						dca_state.map(|dca| dca.chunk_interval).unwrap_or(SWAP_DELAY_BLOCKS);
 
 					if state.input_asset() == base_asset {
-						Some(SwapLegInfo {
-							swap_id: state.swap_id(),
-							swap_request_id: state.swap_request_id(),
-							base_asset,
-							// All swaps from `base_asset` have to go through the stable asset:
-							quote_asset: STABLE_ASSET,
-							side: Side::Sell,
-							amount: state.input_amount(),
-							source_asset: None,
-							source_amount: None,
-							remaining_chunks,
-							chunk_interval,
-						})
+						Some((
+							SwapLegInfo {
+								swap_id: state.swap_id(),
+								swap_request_id: state.swap_request_id(),
+								base_asset,
+								// All swaps from `base_asset` have to go through the stable asset:
+								quote_asset: STABLE_ASSET,
+								side: Side::Sell,
+								amount: state.input_amount(),
+								source_asset: None,
+								source_amount: None,
+								remaining_chunks,
+								chunk_interval,
+							},
+							state.swap.execute_at,
+						))
 					} else if state.output_asset() == base_asset {
 						// In case the swap is "simulated", the amount is just an estimate,
 						// so we additionally include `source_asset` and `source_amount`:
@@ -1501,19 +1526,22 @@ pub mod pallet {
 							)
 						})?;
 
-						Some(SwapLegInfo {
-							swap_id: state.swap_id(),
-							swap_request_id: state.swap_request_id(),
-							base_asset,
-							// All swaps to `base_asset` have to go through the stable asset:
-							quote_asset: STABLE_ASSET,
-							side: Side::Buy,
-							amount,
-							source_asset,
-							source_amount,
-							remaining_chunks,
-							chunk_interval,
-						})
+						Some((
+							SwapLegInfo {
+								swap_id: state.swap_id(),
+								swap_request_id: state.swap_request_id(),
+								base_asset,
+								// All swaps to `base_asset` have to go through the stable asset:
+								quote_asset: STABLE_ASSET,
+								side: Side::Buy,
+								amount,
+								source_asset,
+								source_amount,
+								remaining_chunks,
+								chunk_interval,
+							},
+							state.swap.execute_at,
+						))
 					} else {
 						None
 					}
@@ -1734,18 +1762,25 @@ pub mod pallet {
 			};
 
 			match &mut request.state {
-				SwapRequestState::UserSwap {
-					output_action,
-					refund_params,
-					dca_state: DcaState { remaining_input_amount, accumulated_output_amount, .. },
-					..
-				} => {
+				SwapRequestState::UserSwap { output_action, refund_params, dca_state } => {
 					let Some(refund_params) = &refund_params else {
 						log_or_panic!("Trying to refund swap request {swap_request_id}, but missing refund parameters");
 						return;
 					};
 
-					let total_input_remaining = swap.input_amount + *remaining_input_amount;
+					// Cancel any other scheduled swaps for this swap request and add the amounts
+					// back to the input remaining.
+					let canceled_swaps_amount = dca_state
+						.scheduled_chunks
+						.iter()
+						.filter(|swap_id| *swap_id != &swap.swap_id)
+						.fold(0, |acc: u128, swap_id| {
+							acc.saturating_add(Self::cancel_swap(*swap_id).unwrap_or_default())
+						});
+
+					let total_input_remaining = swap.input_amount +
+						dca_state.remaining_input_amount +
+						canceled_swaps_amount;
 					let FeeTaken { remaining_amount: amount_to_refund, fee: refund_fee } =
 						match Self::take_refund_fee(
 							total_input_remaining,
@@ -1800,12 +1835,12 @@ pub mod pallet {
 
 					// In case of DCA we may have partially swapped and now have some output
 					// asset to egress to the output address:
-					if *accumulated_output_amount > 0 {
+					if dca_state.accumulated_output_amount > 0 {
 						match output_action {
 							SwapOutputAction::Egress { ccm_deposit_metadata, output_address } => {
 								Self::egress_for_swap(
 									swap_request_id,
-									*accumulated_output_amount,
+									dca_state.accumulated_output_amount,
 									request.output_asset,
 									output_address.clone(),
 									ccm_deposit_metadata.clone(),
@@ -1817,13 +1852,13 @@ pub mod pallet {
 									swap_request_id,
 									account_id: account_id.clone(),
 									asset: request.output_asset,
-									amount: *accumulated_output_amount,
+									amount: dca_state.accumulated_output_amount,
 								});
 
 								T::BalanceApi::credit_account(
 									account_id,
 									request.output_asset,
-									*accumulated_output_amount,
+									dca_state.accumulated_output_amount,
 								);
 							},
 						}
@@ -1835,8 +1870,27 @@ pub mod pallet {
 					);
 				},
 			};
-
 			Self::deposit_event(Event::<T>::SwapRequestCompleted { swap_request_id: request.id });
+		}
+
+		// Removes the swap from the scheduled swaps and returns the input amount of the canceled
+		// swap.
+		fn cancel_swap(swap_id: SwapId) -> Option<AssetAmount> {
+			ScheduledSwaps::<T>::mutate(|swaps| {
+				let amount = swaps.remove(&swap_id).map(|swap| {
+					Self::deposit_event(Event::<T>::SwapCanceled {
+						swap_request_id: swap.swap_request_id,
+						swap_id: swap.swap_id,
+						asset: swap.from,
+						amount: swap.input_amount,
+					});
+					swap.input_amount
+				});
+				if amount.is_none() {
+					log_or_panic!("Attempted to cancel swap {swap_id}, but it was not found in ScheduledSwaps");
+				}
+				amount
+			})
 		}
 
 		fn process_swap_outcome(swap: SwapState<T>) {
@@ -1876,9 +1930,7 @@ pub mod pallet {
 
 			let request_completed = match &mut request.state {
 				SwapRequestState::UserSwap { output_action, dca_state, refund_params, .. } =>
-					if let Some(chunk_input_amount) =
-						dca_state.prepare_next_chunk(Some((swap.swap_id(), output_amount)))
-					{
+					if let Some(chunk_input_amount) = dca_state.calculate_next_chunk() {
 						let swap_id = Self::schedule_swap(
 							request.input_asset,
 							request.output_asset,
@@ -1887,43 +1939,55 @@ pub mod pallet {
 							SwapType::Swap,
 							swap.swap.fees.clone(),
 							request.id,
-							dca_state.chunk_interval.into(),
+							// Schedule the next chunk to be after any currently scheduled chunks
+							(dca_state.scheduled_chunks.len() as u32)
+								.saturating_mul(dca_state.chunk_interval)
+								.into(),
 						);
 
-						dca_state.status = DcaStatus::ChunkScheduled(swap_id);
+						dca_state.next_chunk_scheduled(swap_id, chunk_input_amount);
+						dca_state.completed_chunk(swap.swap_id(), output_amount);
 
 						false
 					} else {
 						debug_assert!(dca_state.remaining_input_amount == 0);
 
-						match output_action {
-							SwapOutputAction::Egress { ccm_deposit_metadata, output_address } => {
-								Self::egress_for_swap(
-									swap_request_id,
-									dca_state.accumulated_output_amount,
-									swap.output_asset(),
-									output_address.clone(),
-									ccm_deposit_metadata.clone(),
-									EgressType::Regular,
-								);
-							},
-							SwapOutputAction::CreditOnChain { account_id } => {
-								Self::deposit_event(Event::<T>::CreditedOnChain {
-									swap_request_id,
-									account_id: account_id.clone(),
-									asset: request.output_asset,
-									amount: dca_state.accumulated_output_amount,
-								});
+						dca_state.completed_chunk(swap.swap_id(), output_amount);
 
-								T::BalanceApi::credit_account(
-									account_id,
-									request.output_asset,
-									dca_state.accumulated_output_amount,
-								);
-							},
+						if dca_state.scheduled_chunks.is_empty() {
+							match output_action {
+								SwapOutputAction::Egress {
+									ccm_deposit_metadata,
+									output_address,
+								} => {
+									Self::egress_for_swap(
+										swap_request_id,
+										dca_state.accumulated_output_amount,
+										swap.output_asset(),
+										output_address.clone(),
+										ccm_deposit_metadata.clone(),
+										EgressType::Regular,
+									);
+								},
+								SwapOutputAction::CreditOnChain { account_id } => {
+									Self::deposit_event(Event::<T>::CreditedOnChain {
+										swap_request_id,
+										account_id: account_id.clone(),
+										asset: request.output_asset,
+										amount: dca_state.accumulated_output_amount,
+									});
+
+									T::BalanceApi::credit_account(
+										account_id,
+										request.output_asset,
+										dca_state.accumulated_output_amount,
+									);
+								},
+							}
+							true
+						} else {
+							false
 						}
-
-						true
 					},
 				SwapRequestState::NetworkFee => {
 					if swap.output_asset() == Asset::Flip {
@@ -2079,18 +2143,21 @@ pub mod pallet {
 				)
 			});
 
-			SwapQueue::<T>::append(
-				execute_at,
-				Swap::new(
+			ScheduledSwaps::<T>::mutate(|swaps| {
+				swaps.insert(
 					swap_id,
-					swap_request_id,
-					input_asset,
-					output_asset,
-					input_amount,
-					refund_params,
-					fees,
-				),
-			);
+					Swap::new(
+						swap_id,
+						swap_request_id,
+						input_asset,
+						output_asset,
+						input_amount,
+						refund_params,
+						fees,
+						execute_at,
+					),
+				)
+			});
 
 			Self::deposit_event(Event::<T>::SwapScheduled {
 				swap_request_id,
@@ -2103,9 +2170,50 @@ pub mod pallet {
 			swap_id
 		}
 
-		fn reschedule_swap(swap: Swap<T>, execute_at: BlockNumberFor<T>) {
-			Self::deposit_event(Event::<T>::SwapRescheduled { swap_id: swap.swap_id, execute_at });
-			SwapQueue::<T>::append(execute_at, swap);
+		fn reschedule_swap(mut swap: Swap<T>, retry_delay: BlockNumberFor<T>) {
+			SwapRequests::<T>::mutate(swap.swap_request_id, |request| {
+				if let Some(request) = request {
+					if let SwapRequestState::UserSwap { dca_state, .. } = &mut request.state {
+						ScheduledSwaps::<T>::mutate(|swaps| {
+							// Reschedule the main swap that was taken from the storage.
+							let execute_at = swap.execute_at.saturating_add(retry_delay);
+							let main_swap_id = swap.swap_id;
+							swap.execute_at = execute_at;
+							swaps.insert(main_swap_id, swap);
+							Self::deposit_event(Event::<T>::SwapRescheduled {
+								swap_id: main_swap_id,
+								execute_at,
+							});
+							for swap_id in dca_state.scheduled_chunks.iter().cloned() {
+								if swap_id != main_swap_id {
+									// All other scheduled swaps for this request need to also be
+									// rescheduled.
+									if swaps.contains_key(&swap_id) {
+										swaps.entry(swap_id).and_modify(|s| {
+											let execute_at =
+												s.execute_at.saturating_add(retry_delay);
+											s.execute_at = execute_at;
+											Self::deposit_event(Event::<T>::SwapRescheduled {
+												swap_id,
+												execute_at,
+											});
+										});
+									} else {
+										log_or_panic!(
+											"Swap {swap_id} not found in ScheduledSwaps for rescheduling",
+										);
+									}
+								}
+							}
+						})
+					}
+				} else {
+					log_or_panic!(
+						"Swap request {} not found for rescheduling",
+						swap.swap_request_id
+					);
+				}
+			});
 		}
 
 		#[transactional]
@@ -2405,8 +2513,8 @@ pub mod pallet {
 					);
 				},
 				SwapRequestType::Regular { output_action } => {
-					let (mut dca_state, chunk_input_amount) =
-						DcaState::create_with_first_chunk(net_amount, dca_params);
+					let mut dca_state = DcaState::new(net_amount, dca_params.clone());
+					let chunk_input_amount = dca_state.calculate_next_chunk().unwrap_or_default();
 
 					// Choose correct network fee for the swap
 					let mut fees = vec![FeeType::NetworkFee(NetworkFeeTracker::new(
@@ -2428,12 +2536,36 @@ pub mod pallet {
 						chunk_input_amount,
 						refund_params.as_ref(),
 						SwapType::Swap,
-						fees,
+						fees.clone(),
 						request_id,
 						SWAP_DELAY_BLOCKS.into(),
 					);
 
-					dca_state.status = DcaStatus::ChunkScheduled(swap_id);
+					dca_state.next_chunk_scheduled(swap_id, chunk_input_amount);
+
+					if let Some(DcaParameters { chunk_interval, .. }) = dca_params {
+						// This assumes that the swap delay is 2, so we will only even schedule max
+						// of 2 chunks at a time.
+						if chunk_interval == 1 {
+							// Also schedule a second swap so we can have an chunk interval that is
+							// smaller than the swap delay.
+							let chunk_input_amount =
+								dca_state.calculate_next_chunk().unwrap_or_default();
+							if chunk_input_amount > 0 {
+								let swap_id = Self::schedule_swap(
+									input_asset,
+									output_asset,
+									chunk_input_amount,
+									refund_params.as_ref(),
+									SwapType::Swap,
+									fees,
+									request_id,
+									SWAP_DELAY_BLOCKS.saturating_add(chunk_interval).into(),
+								);
+								dca_state.next_chunk_scheduled(swap_id, chunk_input_amount);
+							}
+						}
+					}
 
 					SwapRequests::<T>::insert(
 						request_id,
@@ -2555,7 +2687,7 @@ impl<T: Config> SwapParameterValidation for Pallet<T> {
 			if params.number_of_chunks == 0 {
 				return Err(DispatchError::from(Error::<T>::ZeroNumberOfChunksNotAllowed));
 			}
-			if params.chunk_interval < SWAP_DELAY_BLOCKS {
+			if params.chunk_interval == 0 {
 				return Err(DispatchError::from(Error::<T>::ChunkIntervalTooLow));
 			}
 			if let Some(total_swap_request_duration) =

--- a/state-chain/pallets/cf-swapping/src/migrations.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations.rs
@@ -19,15 +19,23 @@ use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
 use frame_support::migrations::VersionedMigration;
 
-pub mod swap_request_ccm_refund;
+pub mod swap_queue_migration;
+pub mod swap_request_migration;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<
 		11,
 		12,
-		swap_request_ccm_refund::Migration<T>,
+		swap_request_migration::Migration<T>,
 		Pallet<T>,
 		<T as frame_system::Config>::DbWeight,
 	>,
-	PlaceholderMigration<12, Pallet<T>>,
+	VersionedMigration<
+		12,
+		13,
+		swap_queue_migration::Migration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<13, Pallet<T>>,
 );

--- a/state-chain/pallets/cf-swapping/src/migrations/swap_queue_migration.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations/swap_queue_migration.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+
+use crate::Config;
+
+use crate::*;
+use frame_support::pallet_prelude::Weight;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::DispatchError;
+
+use codec::{Decode, Encode};
+
+pub mod old {
+	use super::*;
+
+	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+	pub struct Swap<T: Config> {
+		pub swap_id: SwapId,
+		pub swap_request_id: SwapRequestId,
+		pub from: Asset,
+		pub to: Asset,
+		pub input_amount: AssetAmount,
+		pub fees: Vec<FeeType<T>>,
+		pub refund_params: Option<SwapRefundParameters>,
+		// Migration is adding an execute_at field here
+	}
+
+	#[frame_support::storage_alias]
+	// Migration is also renaming this storage item to ScheduledSwaps
+	pub type SwapQueue<T: Config> =
+		StorageMap<Pallet<T>, Twox64Concat, BlockNumberFor<T>, Vec<Swap<T>>, ValueQuery>;
+}
+use sp_std::collections::btree_map::BTreeMap;
+
+pub struct Migration<T: Config>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let swaps_count =
+			old::SwapQueue::<T>::iter().fold(0u32, |acc, (_, swaps)| acc + swaps.len() as u32);
+		Ok(swaps_count.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let swaps_map: BTreeMap<SwapId, Swap<T>> = <old::SwapQueue<T>>::iter()
+			.flat_map(|(block, swaps)| {
+				swaps.into_iter().map(move |swap| {
+					log::info!("🧜‍♂️ migrating swap with id {:?}, block {:?}", swap.swap_id, block);
+					let new_swap = Swap::new(
+						swap.swap_id,
+						swap.swap_request_id,
+						swap.from,
+						swap.to,
+						swap.input_amount,
+						swap.refund_params,
+						swap.fees,
+						block,
+					);
+					(swap.swap_id, new_swap)
+				})
+			})
+			.collect();
+
+		let _result = <old::SwapQueue<T>>::clear(u32::MAX, None);
+
+		crate::ScheduledSwaps::<T>::put(swaps_map);
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let pre_swaps_count = <u32>::decode(&mut state.as_slice())
+			.map_err(|_| DispatchError::from("Failed to decode state"))?;
+
+		let post_swaps_count = crate::ScheduledSwaps::<T>::get().len() as u32;
+
+		assert_eq!(pre_swaps_count, post_swaps_count);
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-swapping/src/migrations/swap_request_migration.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations/swap_request_migration.rs
@@ -27,16 +27,45 @@ use codec::{Decode, Encode};
 
 pub mod old {
 	use super::*;
-	use cf_chains::ForeignChainAddress;
-	use cf_primitives::{Asset, Price};
-	use frame_support::Twox64Concat;
+	use cf_primitives::Price;
+
+	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+	pub enum DcaStatus {
+		ChunkToBeScheduled,
+		ChunkScheduled(SwapId),
+		AwaitingRefund,
+		Completed,
+	}
+
+	impl DcaStatus {
+		pub fn scheduled_chunks(&self) -> BTreeSet<SwapId> {
+			match self {
+				DcaStatus::ChunkToBeScheduled => BTreeSet::new(),
+				DcaStatus::ChunkScheduled(chunk) => {
+					log::info!("🧜‍♂️ migrating status with a chunk, id {chunk}");
+					BTreeSet::from_iter([*chunk])
+				},
+				DcaStatus::AwaitingRefund | DcaStatus::Completed => BTreeSet::new(),
+			}
+		}
+	}
+
+	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+	pub struct DcaState {
+		// Replacing this status field with a BTreeSet of scheduled swaps
+		pub status: DcaStatus,
+		pub remaining_input_amount: AssetAmount,
+		pub remaining_chunks: u32,
+		pub chunk_interval: u32,
+		pub accumulated_output_amount: AssetAmount,
+	}
 
 	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
 	pub struct RefundParametersExtendedGeneric<Address, AccountId> {
 		pub retry_duration: cf_primitives::BlockNumber,
 		pub refund_destination: AccountOrAddress<AccountId, Address>,
 		pub min_price: Price,
-		// Migration will add a refund_ccm_metadata
+		// Migration will also add a refund_ccm_metadata field
 	}
 
 	pub type RefundParametersExtended<AccountId> =
@@ -72,7 +101,8 @@ pub struct Migration<T: Config>(PhantomData<T>);
 impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
-		Ok((old::SwapRequests::<T>::iter().count() as u64).encode())
+		let swap_request_count = old::SwapRequests::<T>::iter().count() as u64;
+		Ok(swap_request_count.encode())
 	}
 
 	fn on_runtime_upgrade() -> Weight {
@@ -82,19 +112,28 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 				input_asset: old_swap_request.input_asset,
 				output_asset: old_swap_request.output_asset,
 				state: match old_swap_request.state {
-					old::SwapRequestState::UserSwap { refund_params, output_action, dca_state } =>
-						SwapRequestState::UserSwap {
-							refund_params: refund_params.map(|params| {
-								cf_chains::ChannelRefundParametersChecked {
-									retry_duration: params.retry_duration,
-									refund_address: params.refund_destination,
-									min_price: params.min_price,
-									refund_ccm_metadata: None,
-								}
-							}),
-							output_action,
-							dca_state,
+					old::SwapRequestState::UserSwap {
+						refund_params,
+						output_action,
+						dca_state: old_dca_state,
+					} => SwapRequestState::UserSwap {
+						refund_params: refund_params.map(|params| {
+							cf_chains::ChannelRefundParametersChecked {
+								retry_duration: params.retry_duration,
+								refund_address: params.refund_destination,
+								min_price: params.min_price,
+								refund_ccm_metadata: None,
+							}
+						}),
+						output_action,
+						dca_state: DcaState {
+							scheduled_chunks: old_dca_state.status.scheduled_chunks(),
+							remaining_input_amount: old_dca_state.remaining_input_amount,
+							remaining_chunks: old_dca_state.remaining_chunks,
+							chunk_interval: old_dca_state.chunk_interval,
+							accumulated_output_amount: old_dca_state.accumulated_output_amount,
 						},
+					},
 					old::SwapRequestState::NetworkFee => SwapRequestState::NetworkFee,
 					old::SwapRequestState::IngressEgressFee => SwapRequestState::IngressEgressFee,
 				},

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -154,7 +154,7 @@ fn create_test_swap(
 	execute_at: u64,
 ) -> Swap<Test> {
 	let mut dca_state = DcaState::new(amount, dca_params);
-	dca_state.next_chunk_scheduled(id.into(), amount);
+	dca_state.record_scheduled_chunk(id.into(), amount);
 
 	SwapRequests::<Test>::insert(
 		SwapRequestId::from(id),
@@ -876,7 +876,7 @@ fn swap_excess_are_confiscated() {
 					MAX_SWAP,
 					None,
 					vec![ZERO_NETWORK_FEES],
-					System::block_number() + u64::from(SWAP_DELAY_BLOCKS)
+					System::block_number() + SWAP_DELAY_BLOCKS as u64
 				)
 			)])
 		);

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -25,8 +25,7 @@ use std::sync::LazyLock;
 use super::*;
 use crate::{
 	mock::{RuntimeEvent, *},
-	CollectedRejectedFunds, Error, Event, MaximumSwapAmount, Pallet, Swap, SwapOrigin, SwapQueue,
-	SwapType,
+	CollectedRejectedFunds, Error, Event, MaximumSwapAmount, Pallet, Swap, SwapOrigin, SwapType,
 };
 use cf_amm::math::PRICE_FRACTIONAL_BITS;
 use cf_chains::{
@@ -152,7 +151,11 @@ fn create_test_swap(
 	output_asset: Asset,
 	amount: AssetAmount,
 	dca_params: Option<DcaParameters>,
+	execute_at: u64,
 ) -> Swap<Test> {
+	let mut dca_state = DcaState::new(amount, dca_params);
+	dca_state.next_chunk_scheduled(id.into(), amount);
+
 	SwapRequests::<Test>::insert(
 		SwapRequestId::from(id),
 		SwapRequest {
@@ -165,12 +168,12 @@ fn create_test_swap(
 					ccm_deposit_metadata: None,
 					output_address: ForeignChainAddress::Eth(H160::zero()),
 				},
-				dca_state: DcaState::create_with_first_chunk(amount, dca_params).0,
+				dca_state,
 			},
 		},
 	);
 
-	Swap::new(id.into(), id.into(), input_asset, output_asset, amount, None, vec![])
+	Swap::new(id.into(), id.into(), input_asset, output_asset, amount, None, vec![], execute_at)
 }
 
 // Returns some test data
@@ -283,7 +286,7 @@ fn get_broker_balance<T: Config>(who: &T::AccountId, asset: Asset) -> AssetAmoun
 
 #[track_caller]
 fn assert_swaps_queue_is_empty() {
-	assert_eq!(SwapQueue::<Test>::iter_keys().count(), 0);
+	assert!(ScheduledSwaps::<Test>::get().is_empty());
 }
 
 #[track_caller]
@@ -315,6 +318,11 @@ fn swap_with_custom_broker_fee(
 			broker_id: BROKER,
 		},
 	);
+}
+
+#[track_caller]
+fn get_scheduled_swap_block(swap_id: SwapId) -> Option<BlockNumberFor<Test>> {
+	ScheduledSwaps::<Test>::get().get(&swap_id).map(|swap| swap.execute_at)
 }
 
 #[test]
@@ -528,16 +536,20 @@ fn swap_by_deposit_happy_path() {
 
 			// Verify this swap is accepted and scheduled
 			assert_eq!(
-				SwapQueue::<Test>::get(SWAP_BLOCK),
-				vec![Swap::new(
+				ScheduledSwaps::<Test>::get(),
+				BTreeMap::from([(
 					1.into(),
-					1.into(),
-					INPUT_ASSET,
-					OUTPUT_ASSET,
-					AMOUNT,
-					None,
-					vec![ZERO_NETWORK_FEES],
-				)]
+					Swap::new(
+						1.into(),
+						1.into(),
+						INPUT_ASSET,
+						OUTPUT_ASSET,
+						AMOUNT,
+						None,
+						vec![ZERO_NETWORK_FEES],
+						SWAP_BLOCK
+					)
+				)])
 			);
 
 			assert!(SwapRequests::<Test>::get(SWAP_REQUEST_ID).is_some());
@@ -595,49 +607,65 @@ fn process_all_into_stable_swaps_first() {
 			});
 
 		assert_eq!(
-			SwapQueue::<Test>::get(SWAP_EXECUTION_BLOCK),
-			vec![
-				Swap::new(
+			ScheduledSwaps::<Test>::get(),
+			BTreeMap::from([
+				(
 					1.into(),
-					1.into(),
-					Asset::Flip,
-					Asset::Eth,
-					AMOUNT,
-					None,
-					vec![NETWORK_FEE_DETAILS],
+					Swap::new(
+						1.into(),
+						1.into(),
+						Asset::Flip,
+						Asset::Eth,
+						AMOUNT,
+						None,
+						vec![NETWORK_FEE_DETAILS],
+						SWAP_EXECUTION_BLOCK
+					),
 				),
-				Swap::new(
+				(
 					2.into(),
-					2.into(),
-					Asset::Btc,
-					Asset::Eth,
-					AMOUNT,
-					None,
-					vec![NETWORK_FEE_DETAILS],
+					Swap::new(
+						2.into(),
+						2.into(),
+						Asset::Btc,
+						Asset::Eth,
+						AMOUNT,
+						None,
+						vec![NETWORK_FEE_DETAILS],
+						SWAP_EXECUTION_BLOCK
+					)
 				),
-				Swap::new(
+				(
 					3.into(),
-					3.into(),
-					Asset::Dot,
-					Asset::Eth,
-					AMOUNT,
-					None,
-					vec![NETWORK_FEE_DETAILS],
+					Swap::new(
+						3.into(),
+						3.into(),
+						Asset::Dot,
+						Asset::Eth,
+						AMOUNT,
+						None,
+						vec![NETWORK_FEE_DETAILS],
+						SWAP_EXECUTION_BLOCK
+					),
 				),
-				Swap::new(
+				(
 					4.into(),
-					4.into(),
-					Asset::Usdc,
-					Asset::Eth,
-					AMOUNT,
-					None,
-					vec![NETWORK_FEE_DETAILS],
-				),
-			]
+					Swap::new(
+						4.into(),
+						4.into(),
+						Asset::Usdc,
+						Asset::Eth,
+						AMOUNT,
+						None,
+						vec![NETWORK_FEE_DETAILS],
+						SWAP_EXECUTION_BLOCK
+					)
+				)
+			])
 		);
 
 		System::reset_events();
-		// All swaps in the SwapQueue are executed.
+		// All of the swaps in the ScheduledSwaps queue are executed.
 		Swapping::on_finalize(SWAP_EXECUTION_BLOCK);
 		assert_swaps_queue_is_empty();
 
@@ -837,8 +865,20 @@ fn swap_excess_are_confiscated() {
 		}));
 
 		assert_eq!(
-			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS)),
-			vec![Swap::new(1.into(), 1.into(), from, to, MAX_SWAP, None, vec![ZERO_NETWORK_FEES],)]
+			ScheduledSwaps::<Test>::get(),
+			BTreeMap::from([(
+				1.into(),
+				Swap::new(
+					1.into(),
+					1.into(),
+					from,
+					to,
+					MAX_SWAP,
+					None,
+					vec![ZERO_NETWORK_FEES],
+					System::block_number() + u64::from(SWAP_DELAY_BLOCKS)
+				)
+			)])
 		);
 		assert_eq!(CollectedRejectedFunds::<Test>::get(from), 900);
 	});
@@ -1026,7 +1066,8 @@ fn swaps_get_retried_after_failure() {
 				})
 			);
 
-			assert_eq!(SwapQueue::<Test>::get(RETRY_AT_BLOCK).len(), 2);
+			assert_eq!(get_scheduled_swap_block(SwapId(1)), Some(RETRY_AT_BLOCK));
+			assert_eq!(get_scheduled_swap_block(SwapId(2)), Some(RETRY_AT_BLOCK));
 		})
 		.then_execute_at_next_block(|_| {
 			assert_eq!(System::block_number(), 4);
@@ -1061,14 +1102,6 @@ fn swaps_get_retried_after_failure() {
 			// now be successful):
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
-				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
-					swap_request_id: SwapRequestId(2),
-					..
-				}),
-				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
-					swap_request_id: SwapRequestId(2)
-				}),
 				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(1), .. }),
 				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
 					swap_request_id: SwapRequestId(1),
@@ -1076,6 +1109,14 @@ fn swaps_get_retried_after_failure() {
 				}),
 				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
 					swap_request_id: SwapRequestId(1)
+				}),
+				RuntimeEvent::Swapping(Event::SwapExecuted { swap_id: SwapId(2), .. }),
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SwapRequestId(2),
+					..
+				}),
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SwapRequestId(2)
 				}),
 			);
 		});
@@ -1117,14 +1158,17 @@ fn deposit_address_ready_event_contains_correct_parameters() {
 fn test_get_scheduled_swap_legs() {
 	new_test_ext().execute_with(|| {
 		const INIT_AMOUNT: AssetAmount = 1000;
+		const BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 
-		let swaps = vec![
-			create_test_swap(1, Asset::Flip, Asset::Usdc, INIT_AMOUNT, None),
-			create_test_swap(2, Asset::Usdc, Asset::Flip, INIT_AMOUNT, None),
-			create_test_swap(3, Asset::Btc, Asset::Eth, INIT_AMOUNT, None),
-			create_test_swap(4, Asset::Flip, Asset::Btc, INIT_AMOUNT, None),
-			create_test_swap(5, Asset::Eth, Asset::Flip, INIT_AMOUNT, None),
-		];
+		ScheduledSwaps::<Test>::mutate(|swaps| {
+			swaps.extend(vec![
+				(1.into(), create_test_swap(1, Asset::Flip, Asset::Usdc, INIT_AMOUNT, None, BLOCK)),
+				(2.into(), create_test_swap(2, Asset::Usdc, Asset::Flip, INIT_AMOUNT, None, BLOCK)),
+				(3.into(), create_test_swap(3, Asset::Btc, Asset::Eth, INIT_AMOUNT, None, BLOCK)),
+				(4.into(), create_test_swap(4, Asset::Flip, Asset::Btc, INIT_AMOUNT, None, BLOCK)),
+				(5.into(), create_test_swap(5, Asset::Eth, Asset::Flip, INIT_AMOUNT, None, BLOCK)),
+			]);
+		});
 
 		SwapRate::set(2f64);
 		// The amount of USDC in the middle of swap (5):
@@ -1134,56 +1178,68 @@ fn test_get_scheduled_swap_legs() {
 		assert_ne!(INIT_AMOUNT, INTERMEDIATE_AMOUNT);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Flip),
+			Swapping::get_scheduled_swap_legs(Asset::Flip),
 			vec![
-				SwapLegInfo {
-					swap_id: SwapId(1),
-					swap_request_id: SwapRequestId(1),
-					base_asset: Asset::Flip,
-					quote_asset: Asset::Usdc,
-					side: Side::Sell,
-					amount: INIT_AMOUNT,
-					source_asset: None,
-					source_amount: None,
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				},
-				SwapLegInfo {
-					swap_id: SwapId(2),
-					swap_request_id: SwapRequestId(2),
-					base_asset: Asset::Flip,
-					quote_asset: Asset::Usdc,
-					side: Side::Buy,
-					amount: INIT_AMOUNT,
-					source_asset: None,
-					source_amount: None,
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				},
-				SwapLegInfo {
-					swap_id: SwapId(4),
-					swap_request_id: SwapRequestId(4),
-					base_asset: Asset::Flip,
-					quote_asset: Asset::Usdc,
-					side: Side::Sell,
-					amount: INIT_AMOUNT,
-					source_asset: None,
-					source_amount: None,
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				},
-				SwapLegInfo {
-					swap_id: SwapId(5),
-					swap_request_id: SwapRequestId(5),
-					base_asset: Asset::Flip,
-					quote_asset: Asset::Usdc,
-					side: Side::Buy,
-					amount: INTERMEDIATE_AMOUNT,
-					source_asset: Some(Asset::Eth),
-					source_amount: Some(INIT_AMOUNT),
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				},
+				(
+					SwapLegInfo {
+						swap_id: SwapId(1),
+						swap_request_id: SwapRequestId(1),
+						base_asset: Asset::Flip,
+						quote_asset: Asset::Usdc,
+						side: Side::Sell,
+						amount: INIT_AMOUNT,
+						source_asset: None,
+						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(2),
+						swap_request_id: SwapRequestId(2),
+						base_asset: Asset::Flip,
+						quote_asset: Asset::Usdc,
+						side: Side::Buy,
+						amount: INIT_AMOUNT,
+						source_asset: None,
+						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(4),
+						swap_request_id: SwapRequestId(4),
+						base_asset: Asset::Flip,
+						quote_asset: Asset::Usdc,
+						side: Side::Sell,
+						amount: INIT_AMOUNT,
+						source_asset: None,
+						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(5),
+						swap_request_id: SwapRequestId(5),
+						base_asset: Asset::Flip,
+						quote_asset: Asset::Usdc,
+						side: Side::Buy,
+						amount: INTERMEDIATE_AMOUNT,
+						source_asset: Some(Asset::Eth),
+						source_amount: Some(INIT_AMOUNT),
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
 			]
 		);
 	});
@@ -1194,11 +1250,14 @@ fn test_get_scheduled_swap_legs_fallback() {
 	new_test_ext().execute_with(|| {
 		const INIT_AMOUNT: AssetAmount = 1000000000000000000000;
 		const PRICE: u128 = 2;
+		const BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 
-		let swaps = vec![
-			create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, None),
-			create_test_swap(2, Asset::Eth, Asset::Usdc, INIT_AMOUNT, None),
-		];
+		ScheduledSwaps::<Test>::mutate(|swaps| {
+			swaps.extend(vec![
+				(1.into(), create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, None, BLOCK)),
+				(2.into(), create_test_swap(2, Asset::Eth, Asset::Usdc, INIT_AMOUNT, None, BLOCK)),
+			]);
+		});
 
 		// Setting the swap rate to something different from the price so that if the fallback is
 		// not used, it will give a different result, avoiding a false positive.
@@ -1216,32 +1275,38 @@ fn test_get_scheduled_swap_legs_fallback() {
 		);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth),
+			Swapping::get_scheduled_swap_legs(Asset::Eth),
 			vec![
-				SwapLegInfo {
-					swap_id: SwapId(1),
-					swap_request_id: SwapRequestId(1),
-					base_asset: Asset::Eth,
-					quote_asset: Asset::Usdc,
-					side: Side::Buy,
-					amount: INIT_AMOUNT * PRICE,
-					source_asset: Some(Asset::Flip),
-					source_amount: Some(INIT_AMOUNT),
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				},
-				SwapLegInfo {
-					swap_id: SwapId(2),
-					swap_request_id: SwapRequestId(2),
-					base_asset: Asset::Eth,
-					quote_asset: Asset::Usdc,
-					side: Side::Sell,
-					amount: INIT_AMOUNT,
-					source_asset: None,
-					source_amount: None,
-					remaining_chunks: 0,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				}
+				(
+					SwapLegInfo {
+						swap_id: SwapId(1),
+						swap_request_id: SwapRequestId(1),
+						base_asset: Asset::Eth,
+						quote_asset: Asset::Usdc,
+						side: Side::Buy,
+						amount: INIT_AMOUNT * PRICE,
+						source_asset: Some(Asset::Flip),
+						source_amount: Some(INIT_AMOUNT),
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(2),
+						swap_request_id: SwapRequestId(2),
+						base_asset: Asset::Eth,
+						quote_asset: Asset::Usdc,
+						side: Side::Sell,
+						amount: INIT_AMOUNT,
+						source_asset: None,
+						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				)
 			]
 		);
 	});
@@ -1253,29 +1318,37 @@ fn test_get_scheduled_swap_legs_for_dca() {
 		const INIT_AMOUNT: AssetAmount = 1000000000000000000000;
 		const NUMBER_OF_CHUNKS: u32 = 3;
 		const CHUNK_INTERVAL: u32 = 10;
+		const BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 		SwapRate::set(1_f64);
 
 		let dca_params =
 			DcaParameters { number_of_chunks: NUMBER_OF_CHUNKS, chunk_interval: CHUNK_INTERVAL };
 
-		let swaps =
-			vec![create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, Some(dca_params))];
+		ScheduledSwaps::<Test>::mutate(|swaps| {
+			swaps.extend(vec![(
+				1.into(),
+				create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, Some(dca_params), BLOCK),
+			)]);
+		});
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(swaps, Asset::Eth),
-			vec![SwapLegInfo {
-				swap_id: SwapId(1),
-				swap_request_id: SwapRequestId(1),
-				base_asset: Asset::Eth,
-				quote_asset: Asset::Usdc,
-				side: Side::Buy,
-				amount: INIT_AMOUNT,
-				source_asset: Some(Asset::Flip),
-				source_amount: Some(INIT_AMOUNT),
-				// This is the first chunk, so there are 2 remaining
-				remaining_chunks: NUMBER_OF_CHUNKS - 1,
-				chunk_interval: CHUNK_INTERVAL,
-			},]
+			Swapping::get_scheduled_swap_legs(Asset::Eth),
+			vec![(
+				SwapLegInfo {
+					swap_id: SwapId(1),
+					swap_request_id: SwapRequestId(1),
+					base_asset: Asset::Eth,
+					quote_asset: Asset::Usdc,
+					side: Side::Buy,
+					amount: INIT_AMOUNT,
+					source_asset: Some(Asset::Flip),
+					source_amount: Some(INIT_AMOUNT),
+					// This is the first chunk, so there are 2 remaining
+					remaining_chunks: NUMBER_OF_CHUNKS - 1,
+					chunk_interval: CHUNK_INTERVAL,
+				},
+				BLOCK
+			)]
 		);
 	});
 }
@@ -1359,7 +1432,7 @@ mod swap_batching {
 
 	#[test]
 	fn single_swap() {
-		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 1000, None, []);
+		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 1000, None, [], 1);
 		let mut swaps = vec![swap1.clone()];
 
 		let swap_states = vec![swap1.to_state(None)];
@@ -1377,9 +1450,9 @@ mod swap_batching {
 
 	#[test]
 	fn swaps_fail_into_stable() {
-		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 500, None, []);
-		let swap2 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1000, None, []);
-		let swap3 = Swap::new(2.into(), 2.into(), Asset::Eth, Asset::Usdc, 1000, None, []);
+		let swap1 = Swap::new(0.into(), 0.into(), Asset::Btc, Asset::Usdc, 500, None, [], 1);
+		let swap2 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1000, None, [], 1);
+		let swap3 = Swap::new(2.into(), 2.into(), Asset::Eth, Asset::Usdc, 1000, None, [], 1);
 
 		let mut swaps = vec![swap1.clone(), swap2.clone(), swap3.clone()];
 
@@ -1401,9 +1474,9 @@ mod swap_batching {
 	fn swaps_fail_from_stable() {
 		// BTC swap should be removed because it would result in a larger amount
 		// of USDC and thus will have higher impact on the Eth pool
-		let swap1 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1, None, []);
-		let swap2 = Swap::new(2.into(), 2.into(), Asset::Usdc, Asset::Eth, 1000, None, []);
-		let swap3 = Swap::new(3.into(), 3.into(), Asset::Eth, Asset::Usdc, 100, None, []);
+		let swap1 = Swap::new(1.into(), 1.into(), Asset::Btc, Asset::Eth, 1, None, [], 1);
+		let swap2 = Swap::new(2.into(), 2.into(), Asset::Usdc, Asset::Eth, 1000, None, [], 1);
+		let swap3 = Swap::new(3.into(), 3.into(), Asset::Eth, Asset::Usdc, 100, None, [], 1);
 
 		let mut swaps = vec![swap1.clone(), swap2.clone(), swap3.clone()];
 

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -150,16 +150,20 @@ fn can_process_ccms_via_swap_deposit_address() {
 
 			// Principal swap is scheduled first
 			assert_eq!(
-				SwapQueue::<Test>::get(PRINCIPAL_SWAP_BLOCK),
-				vec![Swap::new(
+				ScheduledSwaps::<Test>::get(),
+				BTreeMap::from_iter([(
 					1.into(),
-					1.into(),
-					Asset::Dot,
-					Asset::Eth,
-					DEPOSIT_AMOUNT,
-					None,
-					vec![ZERO_NETWORK_FEES],
-				),]
+					Swap::new(
+						1.into(),
+						1.into(),
+						Asset::Dot,
+						Asset::Eth,
+						DEPOSIT_AMOUNT,
+						None,
+						vec![ZERO_NETWORK_FEES],
+						PRINCIPAL_SWAP_BLOCK
+					)
+				)])
 			);
 		})
 		.then_process_blocks_until_block(PRINCIPAL_SWAP_BLOCK)
@@ -194,16 +198,20 @@ fn ccm_principal_swap_only() {
 
 			// Principal swap should be immediately scheduled
 			assert_eq!(
-				SwapQueue::<Test>::get(PRINCIPAL_SWAP_BLOCK),
-				vec![Swap::new(
+				ScheduledSwaps::<Test>::get(),
+				BTreeMap::from_iter([(
 					1.into(),
-					SWAP_REQUEST_ID,
-					INPUT_ASSET,
-					OUTPUT_ASSET,
-					SWAP_AMOUNT,
-					None,
-					vec![ZERO_NETWORK_FEES],
-				),]
+					Swap::new(
+						1.into(),
+						SWAP_REQUEST_ID,
+						INPUT_ASSET,
+						OUTPUT_ASSET,
+						SWAP_AMOUNT,
+						None,
+						vec![ZERO_NETWORK_FEES],
+						PRINCIPAL_SWAP_BLOCK
+					)
+				)])
 			);
 		})
 		.then_process_blocks_until_block(PRINCIPAL_SWAP_BLOCK)

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -176,7 +176,7 @@ fn max_swap_amount_can_be_removed() {
 
 		initiate_swap();
 
-		let execute_at = System::block_number() + u64::from(SWAP_DELAY_BLOCKS);
+		let execute_at = System::block_number() + SWAP_DELAY_BLOCKS as u64;
 
 		assert_eq!(
 			ScheduledSwaps::<Test>::get(),
@@ -284,7 +284,7 @@ fn can_swap_below_max_amount() {
 					amount,
 					None,
 					vec![ZERO_NETWORK_FEES],
-					System::block_number() + u64::from(SWAP_DELAY_BLOCKS)
+					System::block_number() + SWAP_DELAY_BLOCKS as u64
 				)
 			)])
 		);

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -1043,12 +1043,7 @@ fn dca_with_one_block_interval_fok() {
 			// Make sure that chunk 2 failing cancels chunk 3 that was already scheduled
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapCanceled {
-					swap_request_id: SWAP_REQUEST_ID,
-					swap_id: SwapId(3),
-					asset: INPUT_ASSET,
-					amount: CHUNK_AMOUNT,
-				})
+				RuntimeEvent::Swapping(Event::SwapCanceled { swap_id: SwapId(3) })
 			);
 			assert_swaps_queue_is_empty();
 
@@ -1059,6 +1054,15 @@ fn dca_with_one_block_interval_fok() {
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: SWAP_REQUEST_ID,
 					amount: REFUND_AMOUNT,
+					..
+				})
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapEgressScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					asset: OUTPUT_ASSET,
+					amount: CHUNK_OUTPUT,
 					..
 				})
 			);

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -66,7 +66,7 @@ fn setup_dca_swap(
 	assert_eq!(
 		get_dca_state(SWAP_REQUEST_ID),
 		DcaState {
-			status: DcaStatus::ChunkScheduled(1.into()),
+			scheduled_chunks: BTreeSet::from([(1.into())]),
 			remaining_input_amount: INPUT_AMOUNT - chunk_amount,
 			remaining_chunks: number_of_chunks - 1,
 			chunk_interval,
@@ -106,7 +106,7 @@ fn assert_chunk_1_executed(number_of_chunks: u32) {
 	assert_eq!(
 		get_dca_state(SWAP_REQUEST_ID),
 		DcaState {
-			status: DcaStatus::ChunkScheduled(2.into()),
+			scheduled_chunks: BTreeSet::from([(2.into())]),
 			remaining_input_amount: INPUT_AMOUNT - (chunk_amount * 2),
 			remaining_chunks: number_of_chunks - 2,
 			chunk_interval: CHUNK_INTERVAL,
@@ -287,7 +287,7 @@ fn dca_with_fok_full_refund(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1.into()),
+					scheduled_chunks: BTreeSet::from([(1.into())]),
 					remaining_input_amount: CHUNK_AMOUNT,
 					remaining_chunks: 1,
 					chunk_interval: CHUNK_INTERVAL,
@@ -384,7 +384,7 @@ fn dca_with_fok_partial_refund(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2.into()),
+					scheduled_chunks: BTreeSet::from([(2.into())]),
 					remaining_input_amount: INPUT_AMOUNT - CHUNK_AMOUNT * 2,
 					remaining_chunks: 2,
 					chunk_interval: CHUNK_INTERVAL,
@@ -491,7 +491,7 @@ fn dca_with_fok_fully_executed(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1.into()),
+					scheduled_chunks: BTreeSet::from([(1.into())]),
 					remaining_input_amount: CHUNK_AMOUNT,
 					remaining_chunks: 1,
 					chunk_interval: CHUNK_INTERVAL,
@@ -527,7 +527,7 @@ fn dca_with_fok_fully_executed(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2.into()),
+					scheduled_chunks: BTreeSet::from([(2.into())]),
 					remaining_input_amount: 0,
 					remaining_chunks: 0,
 					chunk_interval: CHUNK_INTERVAL,
@@ -632,7 +632,7 @@ fn can_handle_dca_chunk_size_of_zero(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(1.into()),
+					scheduled_chunks: BTreeSet::from([(1.into())]),
 					// Still the full amount remaining because the first chunk is 0
 					remaining_input_amount: INPUT_AMOUNT,
 					remaining_chunks: NUMBER_OF_CHUNKS - 1,
@@ -669,7 +669,7 @@ fn can_handle_dca_chunk_size_of_zero(is_ccm: bool) {
 			assert_eq!(
 				get_dca_state(SWAP_REQUEST_ID),
 				DcaState {
-					status: DcaStatus::ChunkScheduled(2.into()),
+					scheduled_chunks: BTreeSet::from([(2.into())]),
 					remaining_input_amount: INPUT_AMOUNT,
 					remaining_chunks: NUMBER_OF_CHUNKS - 2,
 					chunk_interval: CHUNK_INTERVAL,
@@ -712,6 +712,10 @@ fn test_minimum_chunk_size() {
 		expected_number_of_chunks: u32,
 		minimum_chunk_size: AssetAmount,
 	) {
+		println!(
+			"Testing with asset_amount: {}, number_of_chunks: {}, expected_number_of_chunks: {}, minimum_chunk_size: {}",
+			asset_amount, number_of_chunks, expected_number_of_chunks, minimum_chunk_size
+		);
 		// Update the minimum chunk size
 		assert_ok!(Swapping::update_pallet_config(
 			OriginTrait::root(),
@@ -777,7 +781,7 @@ fn test_dca_parameter_validation() {
 	}
 
 	new_test_ext().execute_with(|| {
-		const MIN_CHUNK_INTERVAL: u32 = SWAP_DELAY_BLOCKS;
+		const MIN_CHUNK_INTERVAL: u32 = 1;
 		let max_swap_request_duration_blocks = MaxSwapRequestDurationBlocks::<Test>::get();
 
 		// Trivially ok
@@ -810,7 +814,7 @@ fn test_dca_parameter_validation() {
 
 		// Below the minimum
 		assert_err!(
-			validate_dca_params(10, 1),
+			validate_dca_params(10, 0),
 			DispatchError::from(crate::Error::<Test>::ChunkIntervalTooLow)
 		);
 		assert_err!(
@@ -818,4 +822,245 @@ fn test_dca_parameter_validation() {
 			DispatchError::from(crate::Error::<Test>::ZeroNumberOfChunksNotAllowed)
 		);
 	});
+}
+
+#[test]
+fn dca_with_one_block_interval() {
+	const ONE_BLOCK_CHUNK_INTERVAL: u32 = 1;
+	const NUMBER_OF_CHUNKS: u32 = 4;
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / NUMBER_OF_CHUNKS as u128;
+	const CHUNK_1_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+	const CHUNK_2_BLOCK: u64 = CHUNK_1_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+	const CHUNK_3_BLOCK: u64 = CHUNK_2_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+	const CHUNK_4_BLOCK: u64 = CHUNK_3_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+
+	assert_eq!(
+		SWAP_DELAY_BLOCKS, 2,
+		"Tests and code in init_swap_request assumes the swap delay is 2 blocks, 
+			so only a max of 2 chunks can be scheduled at a time."
+	);
+
+	new_test_ext()
+		.execute_with(|| {
+			insert_swaps(&[TestSwapParams::new(
+				Some(DcaParameters {
+					number_of_chunks: NUMBER_OF_CHUNKS,
+					chunk_interval: ONE_BLOCK_CHUNK_INTERVAL,
+				}),
+				None,  // no refund params
+				false, // no ccm
+			)]);
+
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRequested {
+					swap_request_id: SWAP_REQUEST_ID,
+					input_amount: INPUT_AMOUNT,
+					dca_parameters: Some(DcaParameters {
+						number_of_chunks: NUMBER_OF_CHUNKS,
+						chunk_interval: ONE_BLOCK_CHUNK_INTERVAL
+					}),
+					..
+				})
+			);
+
+			// 2 chunks should be scheduled at the same time with a 1 block interval
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(1),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_1_BLOCK,
+					..
+				})
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(2),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_2_BLOCK,
+					..
+				})
+			);
+		})
+		.then_process_blocks_until_block(CHUNK_1_BLOCK)
+		.then_execute_with(|_| {
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapExecuted {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(1),
+					..
+				})
+			);
+
+			// Now the last chunk should be scheduled, but the execute_at should be 1 block after
+			// chunk 2 (instead of 1 block after the just completed chunk 1).
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(3),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_3_BLOCK,
+					..
+				})
+			);
+		})
+		.then_process_blocks_until_block(CHUNK_4_BLOCK)
+		.then_execute_with(|_| {
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
+					swap_request_id: SWAP_REQUEST_ID
+				}),
+			);
+		});
+}
+
+#[test]
+fn dca_with_one_block_interval_fok() {
+	const ONE_BLOCK_CHUNK_INTERVAL: u32 = 1;
+	const NUMBER_OF_CHUNKS: u32 = 4;
+	const CHUNK_AMOUNT: AssetAmount = INPUT_AMOUNT / NUMBER_OF_CHUNKS as u128;
+	const CHUNK_BROKER_FEE: AssetAmount = CHUNK_AMOUNT * BROKER_FEE_BPS as u128 / 10_000;
+	const CHUNK_AMOUNT_AFTER_FEE: AssetAmount = CHUNK_AMOUNT - CHUNK_BROKER_FEE;
+	const CHUNK_OUTPUT: AssetAmount = CHUNK_AMOUNT_AFTER_FEE * DEFAULT_SWAP_RATE;
+	const CHUNK_1_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+	const CHUNK_2_BLOCK: u64 = CHUNK_1_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+	const CHUNK_2_RESCHEDULED_AT_BLOCK: u64 =
+		CHUNK_2_BLOCK + (DEFAULT_SWAP_RETRY_DELAY_BLOCKS as u64);
+	const CHUNK_3_BLOCK: u64 = CHUNK_2_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+	const CHUNK_3_RESCHEDULED_AT_BLOCK: u64 =
+		CHUNK_2_RESCHEDULED_AT_BLOCK + ONE_BLOCK_CHUNK_INTERVAL as u64;
+
+	new_test_ext()
+		.execute_with(|| {
+			insert_swaps(&[TestSwapParams::new(
+				Some(DcaParameters {
+					number_of_chunks: NUMBER_OF_CHUNKS,
+					chunk_interval: ONE_BLOCK_CHUNK_INTERVAL,
+				}),
+				Some(TestRefundParams {
+					retry_duration: DEFAULT_SWAP_RETRY_DELAY_BLOCKS,
+					min_output: CHUNK_OUTPUT,
+				}),
+				false, // no ccm
+			)]);
+
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRequested {
+					swap_request_id: SWAP_REQUEST_ID,
+					input_amount: INPUT_AMOUNT,
+					dca_parameters: Some(DcaParameters {
+						number_of_chunks: NUMBER_OF_CHUNKS,
+						chunk_interval: ONE_BLOCK_CHUNK_INTERVAL
+					}),
+					..
+				})
+			);
+
+			// Both chunks should be scheduled at the same time with a 1 block interval
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(1),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_1_BLOCK,
+					..
+				})
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(2),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_2_BLOCK,
+					..
+				})
+			);
+		})
+		.then_process_blocks_until_block(CHUNK_1_BLOCK)
+		.then_execute_with(|_| {
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapExecuted {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(1),
+					..
+				})
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(3),
+					input_amount: CHUNK_AMOUNT,
+					execute_at: CHUNK_3_BLOCK,
+					..
+				})
+			);
+
+			// Make sure the swap queue is correct
+			assert!(get_scheduled_swap_block(SwapId(1)).is_none());
+			assert_eq!(get_scheduled_swap_block(SwapId(2)), Some(CHUNK_2_BLOCK));
+			assert_eq!(get_scheduled_swap_block(SwapId(3)), Some(CHUNK_3_BLOCK));
+			assert!(get_scheduled_swap_block(SwapId(4)).is_none());
+
+			// Change the swap rate so the second chunk fails
+			SwapRate::set((DEFAULT_SWAP_RATE / 10) as f64);
+		})
+		.then_process_blocks_until_block(CHUNK_2_BLOCK)
+		.then_execute_with(|_| {
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRescheduled {
+					swap_id: SwapId(2),
+					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK
+				})
+			);
+			// The 3rd chunk should be rescheduled as well
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapRescheduled {
+					swap_id: SwapId(3),
+					execute_at: CHUNK_3_RESCHEDULED_AT_BLOCK
+				})
+			);
+
+			// Make sure the old entry was removed from the swap queue and only the new one is there
+			assert_eq!(get_scheduled_swap_block(SwapId(2)), Some(CHUNK_2_RESCHEDULED_AT_BLOCK));
+			assert_eq!(get_scheduled_swap_block(SwapId(3)), Some(CHUNK_3_RESCHEDULED_AT_BLOCK));
+		})
+		.then_process_blocks_until_block(CHUNK_2_RESCHEDULED_AT_BLOCK)
+		.then_execute_with(|_| {
+			// Make sure that chunk 2 failing cancels chunk 3 that was already scheduled
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapCanceled {
+					swap_request_id: SWAP_REQUEST_ID,
+					swap_id: SwapId(3),
+					asset: INPUT_ASSET,
+					amount: CHUNK_AMOUNT,
+				})
+			);
+			assert_swaps_queue_is_empty();
+
+			// The refund amount should be for all 3 remaining chunks, including the canceled one.
+			const REFUND_AMOUNT: AssetAmount = CHUNK_AMOUNT * 3;
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
+					swap_request_id: SWAP_REQUEST_ID,
+					amount: REFUND_AMOUNT,
+					..
+				})
+			);
+		});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -119,7 +119,7 @@ fn test_buy_back_flip() {
 				NETWORK_FEE_AMOUNT,
 				None,
 				[],
-				System::block_number() + u64::from(SWAP_DELAY_BLOCKS)
+				System::block_number() + SWAP_DELAY_BLOCKS as u64
 			)
 		);
 	});

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -108,10 +108,19 @@ fn test_buy_back_flip() {
 
 		// Note that the network fee will not be charged in this case:
 		assert_eq!(
-			SwapQueue::<Test>::get(System::block_number() + u64::from(SWAP_DELAY_BLOCKS))
-				.first()
+			ScheduledSwaps::<Test>::get()
+				.get(&1.into())
 				.expect("Should have scheduled a swap usdc -> flip"),
-			&Swap::new(1.into(), 1.into(), STABLE_ASSET, Asset::Flip, NETWORK_FEE_AMOUNT, None, [],)
+			&Swap::new(
+				1.into(),
+				1.into(),
+				STABLE_ASSET,
+				Asset::Flip,
+				NETWORK_FEE_AMOUNT,
+				None,
+				[],
+				System::block_number() + u64::from(SWAP_DELAY_BLOCKS)
+			)
 		);
 	});
 }

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -180,7 +180,7 @@ fn price_limit_is_respected_in_fok_swap(is_ccm: bool) {
 				}),
 			);
 
-			assert_eq!(SwapQueue::<Test>::get(SWAP_RETRIED_AT_BLOCK).len(), 1);
+			assert_eq!(ScheduledSwaps::<Test>::get().len(), 1);
 		})
 		.then_execute_at_block(SWAP_RETRIED_AT_BLOCK, |_| {
 			// Changing the swap rate to allow the FoK swap to be executed
@@ -199,7 +199,7 @@ fn price_limit_is_respected_in_fok_swap(is_ccm: bool) {
 				}),
 			);
 
-			assert_eq!(SwapQueue::<Test>::get(SWAP_RETRIED_AT_BLOCK).len(), 0);
+			assert_swaps_queue_is_empty();
 		});
 }
 
@@ -419,6 +419,8 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 				Test,
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
+				// Non-fok swap will continue to be retried:
+				RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: REGULAR_SWAP_ID, .. }),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: FOK_SWAP_REQUEST_ID,
 					..
@@ -426,8 +428,6 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::SwapRequestCompleted {
 					swap_request_id: FOK_SWAP_REQUEST_ID
 				}),
-				// Non-fok swap will continue to be retried:
-				RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: REGULAR_SWAP_ID, .. }),
 			);
 		});
 }

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -132,7 +132,7 @@ pub type Price = U256;
 /// in units of asset One.
 pub type Tick = i32;
 
-define_wrapper_type!(SwapId, u64, extra_derives: Serialize, Deserialize);
+define_wrapper_type!(SwapId, u64, extra_derives: Serialize, Deserialize, PartialOrd, Ord);
 
 define_wrapper_type!(SwapRequestId, u64, extra_derives: Serialize, Deserialize, PartialOrd, Ord);
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2354

## Checklist

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [x] I have updated documentation where appropriate.

## Summary

- Refactored the dca state to hold a List of scheduled swap ids instead of just one.
- Refactored the swap queue so we do not need to know the block a swap is in to reschedule/cancel it.
- Refunding a failed swap will also cancel any other swaps that are scheduled for that swap request.
   - New event `SwapCanceled`.
- Rescheduling a swap will also reschedule any other swaps that are scheduled for that swap request.
- Refactored the dca state functions to split them up for more control.
- Init swap request now schedules 2 chunks if the interval is 1.
- When a swap completes it schedules the next chunk for the swap request, not necessarily a consecutive chunk.
- Added tests to cover the new 1 block interval.
- Changed the dca test in the bouncer to cover the 1 block interval.
- Refactored `cf_scheduled_swaps` rpc.
- Added migrations for the swap queue and the dca state