### PR TITLE
feat: configurable bitcoin fee polling interval [pick to 1.10]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8273,6 +8273,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B3)",
  "utilities",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -13854,7 +13854,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.10.1"
+version = "1.10.2"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.10.1"
+version = "1.10.2"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_10_1"
+name = "chainflip_engine_v1_10_2"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.10.1"
+version = "1.10.2"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -34,7 +34,7 @@ assets = [
 		"target/release/libchainflip_engine_v1_10_1.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_10_1.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_10_r.so",
 		"755",
 	],
 ]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.10.1"
+version = "1.10.2"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,19 +22,19 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v1_10_1.so",
+		"target/release/libchainflip_engine_v1_10_2.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_10_1.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_10_2.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.
 	# It downloads the correct version from the releases page.
 	[
-		"target/release/libchainflip_engine_v1_9_5.so",
+		"target/release/libchainflip_engine_v1_10_1.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_9_5.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_10_1.so",
 		"755",
 	],
 ]

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -19,7 +19,7 @@ use engine_upgrade_utils::{CStrArray, NEW_VERSION, OLD_VERSION};
 
 // Declare the entrypoints into each version of the engine
 mod old {
-	#[engine_proc_macros::link_engine_library_version("1.9.5")]
+	#[engine_proc_macros::link_engine_library_version("1.10.1")]
 	extern "C" {
 		pub fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.10.1")]
+	#[engine_proc_macros::link_engine_library_version("1.10.2")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -26,8 +26,8 @@ pub mod build_helpers;
 // rest of the places the version needs changing on build using the build scripts in each of the
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
-pub const OLD_VERSION: &str = "1.9.5";
-pub const NEW_VERSION: &str = "1.10.1";
+pub const OLD_VERSION: &str = "1.10.1";
+pub const NEW_VERSION: &str = "1.10.2";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.10.1"
+version = "1.10.2"
 license = "Apache-2.0"
 
 [lib]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.10.1"
+version = "1.10.2"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-elections/Cargo.toml
+++ b/state-chain/pallets/cf-elections/Cargo.toml
@@ -44,6 +44,7 @@ frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive", "bit-vec"] }
 sp-core = { workspace = true }
 sp-std = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
 cf-test-utilities = { workspace = true, default-features = true }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
@@ -26,10 +26,10 @@ pub struct FeeHook;
 impl UpdateFeeHook<u64> for FeeHook {
 	fn update_fee(_fee: u64) {}
 }
-type SimpleUnsafeMedian = UnsafeMedian<u64, (), (), FeeHook, (), u32>;
+type SimpleUnsafeMedian = UnsafeMedian<u64, (), FeeHook, (), u32>;
 
-const INIT_UNSYNCHRONISED_STATE: u64 = 22;
-const NEW_UNSYNCHRONISED_STATE: u64 = 33;
+const INIT_UNSYNCHRONISED_STATE: (u64, u32) = (22, 0);
+const NEW_UNSYNCHRONISED_STATE: (u64, u32) = (33, 123);
 
 fn with_default_setup() -> TestSetup<SimpleUnsafeMedian> {
 	TestSetup::<_>::default().with_unsynchronised_state(INIT_UNSYNCHRONISED_STATE)
@@ -70,10 +70,10 @@ fn if_consensus_update_unsynchronised_state() {
 	with_default_context()
 		.force_consensus_update(ConsensusStatus::Gained {
 			most_recent: None,
-			new: NEW_UNSYNCHRONISED_STATE,
+			new: NEW_UNSYNCHRONISED_STATE.0,
 		})
 		.test_on_finalize(
-			&(),
+			&NEW_UNSYNCHRONISED_STATE.1,
 			|_| {},
 			vec![
 				Check::started_at_initial_state(),
@@ -89,7 +89,7 @@ fn if_no_consensus_do_not_update_unsynchronised_state() {
 	with_default_context()
 		.force_consensus_update(ConsensusStatus::None)
 		.test_on_finalize(
-			&(),
+			&0,
 			|_| {},
 			vec![
 				Check::started_at_initial_state(),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -28,6 +28,7 @@ use frame_support::{
 	Parameter,
 };
 use itertools::Itertools;
+use sp_runtime::traits::Saturating;
 use sp_std::vec::Vec;
 
 pub trait UpdateFeeHook<Value> {
@@ -42,41 +43,28 @@ pub trait UpdateFeeHook<Value> {
 ///
 /// `Settings` can be used by governance to provide information to authorities about exactly how
 /// they should `vote`.
-pub struct UnsafeMedian<
-	Value,
-	UnsynchronisedSettings,
-	Settings,
-	Hook,
-	ValidatorId,
-	StateChainBlockNumber,
-> {
-	_phantom: core::marker::PhantomData<(
-		Value,
-		UnsynchronisedSettings,
-		Settings,
-		Hook,
-		ValidatorId,
-		StateChainBlockNumber,
-	)>,
+pub struct UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber> {
+	_phantom:
+		core::marker::PhantomData<(Value, Settings, Hook, ValidatorId, StateChainBlockNumber)>,
 }
 impl<
 		Value: Member + Parameter + MaybeSerializeDeserialize + Ord + BenchmarkValue,
-		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: UpdateFeeHook<Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
+		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize + Default + Saturating,
 	> ElectoralSystemTypes
-	for UnsafeMedian<Value, UnsynchronisedSettings, Settings, Hook, ValidatorId, StateChainBlockNumber>
+	for UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	type ValidatorId = ValidatorId;
 	type StateChainBlockNumber = StateChainBlockNumber;
 
-	type ElectoralUnsynchronisedState = Value;
+	// (the current value, last statechain block when it was updated)
+	type ElectoralUnsynchronisedState = (Value, StateChainBlockNumber);
 	type ElectoralUnsynchronisedStateMapKey = ();
 	type ElectoralUnsynchronisedStateMapValue = ();
 
-	type ElectoralUnsynchronisedSettings = UnsynchronisedSettings;
+	type ElectoralUnsynchronisedSettings = StateChainBlockNumber;
 	type ElectoralSettings = Settings;
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = ();
@@ -84,19 +72,17 @@ impl<
 	type VoteStorage =
 		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<Value>>;
 	type Consensus = Value;
-	type OnFinalizeContext = ();
+	type OnFinalizeContext = StateChainBlockNumber;
 	type OnFinalizeReturn = ();
 }
 
 impl<
 		Value: Member + Parameter + MaybeSerializeDeserialize + Ord + BenchmarkValue,
-		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: UpdateFeeHook<Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem
-	for UnsafeMedian<Value, UnsynchronisedSettings, Settings, Hook, ValidatorId, StateChainBlockNumber>
+		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize + Default + Saturating,
+	> ElectoralSystem for UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
@@ -108,8 +94,13 @@ impl<
 
 	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(
 		election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
-		_context: &Self::OnFinalizeContext,
+		current_statechain_block: &Self::OnFinalizeContext,
 	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
+		let (_current_value, last_updated_statechain_block) =
+			ElectoralAccess::unsynchronised_state()?;
+
+		let update_period = ElectoralAccess::unsynchronised_settings()?;
+
 		if let Some(election_identifier) = election_identifiers
 			.into_iter()
 			.at_most_one()
@@ -118,11 +109,20 @@ impl<
 			let election_access = ElectoralAccess::election_mut(election_identifier);
 			if let Some(consensus) = election_access.check_consensus()?.has_consensus() {
 				election_access.delete();
-				ElectoralAccess::set_unsynchronised_state(consensus.clone())?;
+				ElectoralAccess::set_unsynchronised_state((
+					consensus.clone(),
+					current_statechain_block.clone(),
+				))?;
 				Hook::update_fee(consensus);
-				ElectoralAccess::new_election((), (), ())?;
+
+				// we have to immediately create a new election if we want one on every SC block
+				if update_period == Default::default() {
+					ElectoralAccess::new_election((), (), ())?;
+				}
 			}
-		} else {
+		} else if current_statechain_block.clone().saturating_sub(last_updated_statechain_block) >=
+			update_period
+		{
 			ElectoralAccess::new_election((), (), ())?;
 		}
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -152,7 +152,7 @@ use frame_system::pallet_prelude::*;
 
 pub use pallet::*;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(6);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
 
 pub use pallet::UniqueMonotonicIdentifier;
 

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.10.1"
+version = "1.10.2"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -612,7 +612,7 @@ pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 				safety_margin: 0,
 				safety_buffer: BITCOIN_MAINNET_SAFETY_BUFFER,
 			},
-			2, // wait 2 SC blocks until reopening fee election
+			10, // wait 10 SC blocks until reopening fee election
 			(),
 		),
 		settings: (

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -463,7 +463,6 @@ impl UpdateFeeHook<BtcAmount> for BitcoinFeeUpdateHook {
 }
 pub type BitcoinFeeTracking = UnsafeMedian<
 	<Bitcoin as Chain>::ChainAmount,
-	BtcAmount,
 	(),
 	BitcoinFeeUpdateHook,
 	<Runtime as Chainflip>::ValidatorId,
@@ -516,6 +515,8 @@ impl
 			>,
 		),
 	) -> Result<(), CorruptStorageError> {
+		let current_sc_block_number = crate::System::block_number();
+
 		let chain_progress = BitcoinBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,
@@ -554,7 +555,7 @@ impl
 				BitcoinFeeTracking,
 				RunnerStorageAccess<Runtime, BitcoinInstance>,
 			>,
-		>(fee_identifiers, &())?;
+		>(fee_identifiers, &current_sc_block_number)?;
 
 		BitcoinLiveness::on_finalize::<
 			DerivedElectoralAccess<
@@ -611,7 +612,7 @@ pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 				safety_margin: 0,
 				safety_buffer: BITCOIN_MAINNET_SAFETY_BUFFER,
 			},
-			Default::default(),
+			2, // wait 2 SC blocks until reopening fee election
 			(),
 		),
 		settings: (

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -182,6 +182,7 @@ use chainflip::{
 };
 use safe_mode::{RuntimeSafeMode, WitnesserCallPermission};
 
+use crate::migrations::bitcoin_elections::MyDebugMigration;
 use constants::common::*;
 use pallet_cf_flip::{Bonder, FlipSlasher};
 pub use pallet_transaction_payment::ChargeTransactionPayment;
@@ -1423,6 +1424,8 @@ pub type PalletExecutionOrder = (
 ///   remove them when they are no longer needed.
 /// - Release-specific migrations: remove these if they are no longer needed.
 type AllMigrations = (
+	// MyDebugMigration,
+
 	// This ClearEvents should only be run at the start of all migrations. This is in case another
 	// migration needs to trigger an event like a Broadcast for example.
 	pallet_cf_cfe_interface::migrations::ClearEvents<Runtime>,
@@ -1434,6 +1437,14 @@ type AllMigrations = (
 	MigrationsForV1_10,
 	// migrations::btc_elections_migrations::Migration, no longer needed, since 1.10 is released
 	migrations::bitcoin_elections::Migration, // migration from 1.10.1 to 1.10.2
+	// migrating the solana elections pallet
+	VersionedMigration<
+		6,
+		7,
+		NoopMigration,
+		pallet_cf_elections::Pallet<Runtime, SolanaInstance>,
+		DbWeight,
+	>,
 );
 
 /// All the pallet-specific migrations and migrations that depend on pallet migration order. Do not

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1432,7 +1432,8 @@ type AllMigrations = (
 	PalletMigrations,
 	migrations::housekeeping::Migration,
 	MigrationsForV1_10,
-	migrations::btc_elections_migrations::Migration,
+	// migrations::btc_elections_migrations::Migration, no longer needed, since 1.10 is released
+	migrations::bitcoin_elections::Migration, // migration from 1.10.1 to 1.10.2
 );
 
 /// All the pallet-specific migrations and migrations that depend on pallet migration order. Do not

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -182,7 +182,6 @@ use chainflip::{
 };
 use safe_mode::{RuntimeSafeMode, WitnesserCallPermission};
 
-use crate::migrations::bitcoin_elections::MyDebugMigration;
 use constants::common::*;
 use pallet_cf_flip::{Bonder, FlipSlasher};
 pub use pallet_transaction_payment::ChargeTransactionPayment;

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1424,8 +1424,6 @@ pub type PalletExecutionOrder = (
 ///   remove them when they are no longer needed.
 /// - Release-specific migrations: remove these if they are no longer needed.
 type AllMigrations = (
-	// MyDebugMigration,
-
 	// This ClearEvents should only be run at the start of all migrations. This is in case another
 	// migration needs to trigger an event like a Broadcast for example.
 	pallet_cf_cfe_interface::migrations::ClearEvents<Runtime>,
@@ -1435,9 +1433,8 @@ type AllMigrations = (
 	PalletMigrations,
 	migrations::housekeeping::Migration,
 	MigrationsForV1_10,
-	// migrations::btc_elections_migrations::Migration, no longer needed, since 1.10 is released
 	migrations::bitcoin_elections::Migration, // migration from 1.10.1 to 1.10.2
-	// migrating the solana elections pallet
+	// no-op migration for the solana instance of elections pallet
 	VersionedMigration<
 		6,
 		7,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -236,7 +236,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 1_10_01,
+	spec_version: 1_10_02,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -16,7 +16,7 @@
 
 //! Chainflip runtime storage migrations.
 
-pub mod btc_elections_migrations;
+pub mod bitcoin_elections;
 pub mod housekeeping;
 
 pub mod boost_refactor;

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -80,7 +80,7 @@ mod old {
 impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-		Ok(vec![])
+		Ok(Vec::new())
 	}
 
 	fn on_runtime_upgrade() -> Weight {

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -23,9 +23,7 @@ use crate::{
 };
 use cf_runtime_utilities::PlaceholderMigration;
 use frame_support::{
-	migrations::VersionedMigration,
-	traits::{OnRuntimeUpgrade, UncheckedOnRuntimeUpgrade},
-	weights::Weight,
+	migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
 };
 use pallet_cf_elections::{ElectoralSystemTypes, Pallet};
 #[cfg(feature = "try-runtime")]

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -144,12 +144,3 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 		Ok(())
 	}
 }
-
-pub struct MyDebugMigration;
-impl OnRuntimeUpgrade for MyDebugMigration {
-	fn on_runtime_upgrade() -> Weight {
-		panic!("let's try to see if this can fail?");
-		log::info!("$$$ Running debug migration $$$$");
-		Weight::zero()
-	}
-}

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -23,7 +23,9 @@ use crate::{
 };
 use cf_runtime_utilities::PlaceholderMigration;
 use frame_support::{
-	migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
+	migrations::VersionedMigration,
+	traits::{OnRuntimeUpgrade, UncheckedOnRuntimeUpgrade},
+	weights::Weight,
 };
 use pallet_cf_elections::{ElectoralSystemTypes, Pallet};
 #[cfg(feature = "try-runtime")]
@@ -140,5 +142,14 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 		assert_eq!(current_settings, 10);
 
 		Ok(())
+	}
+}
+
+pub struct MyDebugMigration;
+impl OnRuntimeUpgrade for MyDebugMigration {
+	fn on_runtime_upgrade() -> Weight {
+		panic!("let's try to see if this can fail?");
+		log::info!("$$$ Running debug migration $$$$");
+		Weight::zero()
 	}
 }

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+	chainflip::bitcoin_elections::{
+		BitcoinBlockHeightWitnesserES, BitcoinDepositChannelWitnessingES,
+		BitcoinEgressWitnessingES, BitcoinLiveness, BitcoinVaultDepositWitnessingES,
+	},
+	BitcoinInstance, Runtime,
+};
+use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::{
+	migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
+};
+use pallet_cf_elections::{ElectoralSystemTypes, Pallet};
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+use sp_std::vec::Vec;
+
+pub type Migration = (
+	VersionedMigration<
+		6,
+		7,
+		BitcoinElectionMigration,
+		pallet_cf_elections::Pallet<Runtime, BitcoinInstance>,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<7, Pallet<Runtime, BitcoinInstance>>,
+);
+
+pub struct BitcoinElectionMigration;
+
+mod old {
+
+	use super::*;
+	use cf_chains::btc::BtcAmount;
+	use frame_support::pallet_prelude::OptionQuery;
+	use pallet_cf_elections::Config;
+
+	pub type CompositeElectoralUnsynchronisedSettings = (
+		<BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+		<BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+		<BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+		<BitcoinEgressWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+		BtcAmount,
+		<BitcoinLiveness as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
+	);
+
+	pub type CompositeElectoralUnsynchronisedState = (
+		<BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+		<BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+		<BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+		<BitcoinEgressWitnessingES as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+		BtcAmount,
+		<BitcoinLiveness as ElectoralSystemTypes>::ElectoralUnsynchronisedState,
+	);
+
+	#[frame_support::storage_alias]
+	pub type ElectoralUnsynchronisedSettings<T: Config<I>, I: 'static> =
+		StorageValue<Pallet<T, I>, CompositeElectoralUnsynchronisedSettings, OptionQuery>;
+
+	#[frame_support::storage_alias]
+	pub type ElectoralUnsynchronisedState<T: Config<I>, I: 'static> =
+		StorageValue<Pallet<T, I>, CompositeElectoralUnsynchronisedState, OptionQuery>;
+}
+
+impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		Ok(vec![])
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("🍩 Migration for BTC Election started");
+
+		// migrating unsynchronised state
+		{
+			let optional_storage =
+				old::ElectoralUnsynchronisedState::<Runtime, BitcoinInstance>::get();
+			let (a, b, c, d, current_btc_fee, f) =
+				optional_storage.expect("Should contain something");
+
+			pallet_cf_elections::ElectoralUnsynchronisedState::<Runtime, BitcoinInstance>::put((
+				a,
+				b,
+				c,
+				d,
+				(current_btc_fee, 0), // last election concluded at block 0
+				f,
+			));
+		}
+
+		// migrating unsynchronised settings
+		{
+			let optional_storage =
+				old::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::get();
+			let (a, b, c, d, _old_settings_amount, f) =
+				optional_storage.expect("Should contain something");
+
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::put(
+				(
+					a, b, c, d, 10u32, // fee witnessing should happen every 10 SC blocks
+					f,
+				),
+			);
+		}
+
+		log::info!("🍩 Migration for BTC Election completed");
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let current_state =
+			pallet_cf_elections::ElectoralUnsynchronisedState::<Runtime, BitcoinInstance>::get()
+				.unwrap()
+				.4;
+
+		assert_eq!(current_state.1, 0);
+
+		let current_settings =
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::get()
+				.unwrap()
+				.4;
+
+		assert_eq!(current_settings, 10);
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
# Pull Request

Related: PRO-2443

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Since 1.10 we use the `UnsafeMedian` electoral system for witnessing bitcoin fees. This creates new elections on every SC block. Unfortunately, the bitcoin rpc call that we use to get fees (`estimate_smart_fee`) only very rarely updates it's value (every 2 btc blocks or so), so it doesn't make sense to query the rpc and vote on every SC block.

This PR adds a new (unsynchronised) setting to the UnsafeMedian ES that lets us specify the number of SC blocks to wait until the next election is created.
