### PR TITLE
feat: configurable poll intervall for unsafe median

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8299,6 +8299,7 @@ dependencies = [
  "serde",
  "serde_arrays",
  "sp-core 34.0.0",
+ "sp-runtime 39.0.0",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B4)",
  "utilities",
 ]

--- a/state-chain/pallets/cf-elections/Cargo.toml
+++ b/state-chain/pallets/cf-elections/Cargo.toml
@@ -47,6 +47,7 @@ frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive", "bit-vec"] }
 sp-core = { workspace = true }
 sp-std = { workspace = true }
+sp-runtime = { workspace = true }
 
 [dev-dependencies]
 cf-test-utilities = { workspace = true, default-features = true }

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/unsafe_median.rs
@@ -26,10 +26,10 @@ pub struct FeeHook;
 impl UpdateFeeHook<u64> for FeeHook {
 	fn update_fee(_fee: u64) {}
 }
-type SimpleUnsafeMedian = UnsafeMedian<u64, (), (), FeeHook, (), u32>;
+type SimpleUnsafeMedian = UnsafeMedian<u64, (), FeeHook, (), u32>;
 
-const INIT_UNSYNCHRONISED_STATE: u64 = 22;
-const NEW_UNSYNCHRONISED_STATE: u64 = 33;
+const INIT_UNSYNCHRONISED_STATE: (u64, u32) = (22, 0);
+const NEW_UNSYNCHRONISED_STATE: (u64, u32) = (33, 123);
 
 fn with_default_setup() -> TestSetup<SimpleUnsafeMedian> {
 	TestSetup::<_>::default().with_unsynchronised_state(INIT_UNSYNCHRONISED_STATE)
@@ -70,10 +70,10 @@ fn if_consensus_update_unsynchronised_state() {
 	with_default_context()
 		.force_consensus_update(ConsensusStatus::Gained {
 			most_recent: None,
-			new: NEW_UNSYNCHRONISED_STATE,
+			new: NEW_UNSYNCHRONISED_STATE.0,
 		})
 		.test_on_finalize(
-			&(),
+			&NEW_UNSYNCHRONISED_STATE.1,
 			|_| {},
 			vec![
 				Check::started_at_initial_state(),
@@ -89,7 +89,7 @@ fn if_no_consensus_do_not_update_unsynchronised_state() {
 	with_default_context()
 		.force_consensus_update(ConsensusStatus::None)
 		.test_on_finalize(
-			&(),
+			&0,
 			|_| {},
 			vec![
 				Check::started_at_initial_state(),

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -28,6 +28,7 @@ use frame_support::{
 	Parameter,
 };
 use itertools::Itertools;
+use sp_runtime::traits::Saturating;
 use sp_std::vec::Vec;
 
 pub trait UpdateFeeHook<Value> {
@@ -42,41 +43,28 @@ pub trait UpdateFeeHook<Value> {
 ///
 /// `Settings` can be used by governance to provide information to authorities about exactly how
 /// they should `vote`.
-pub struct UnsafeMedian<
-	Value,
-	UnsynchronisedSettings,
-	Settings,
-	Hook,
-	ValidatorId,
-	StateChainBlockNumber,
-> {
-	_phantom: core::marker::PhantomData<(
-		Value,
-		UnsynchronisedSettings,
-		Settings,
-		Hook,
-		ValidatorId,
-		StateChainBlockNumber,
-	)>,
+pub struct UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber> {
+	_phantom:
+		core::marker::PhantomData<(Value, Settings, Hook, ValidatorId, StateChainBlockNumber)>,
 }
 impl<
 		Value: Member + Parameter + MaybeSerializeDeserialize + Ord + BenchmarkValue,
-		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: UpdateFeeHook<Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
+		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize + Default + Saturating,
 	> ElectoralSystemTypes
-	for UnsafeMedian<Value, UnsynchronisedSettings, Settings, Hook, ValidatorId, StateChainBlockNumber>
+	for UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	type ValidatorId = ValidatorId;
 	type StateChainBlockNumber = StateChainBlockNumber;
 
-	type ElectoralUnsynchronisedState = Value;
+	// (the current value, last statechain block when it was updated)
+	type ElectoralUnsynchronisedState = (Value, StateChainBlockNumber);
 	type ElectoralUnsynchronisedStateMapKey = ();
 	type ElectoralUnsynchronisedStateMapValue = ();
 
-	type ElectoralUnsynchronisedSettings = UnsynchronisedSettings;
+	type ElectoralUnsynchronisedSettings = StateChainBlockNumber;
 	type ElectoralSettings = Settings;
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = ();
@@ -84,19 +72,17 @@ impl<
 	type VoteStorage =
 		vote_storage::individual::Individual<(), vote_storage::individual::shared::Shared<Value>>;
 	type Consensus = Value;
-	type OnFinalizeContext = ();
+	type OnFinalizeContext = StateChainBlockNumber;
 	type OnFinalizeReturn = ();
 }
 
 impl<
 		Value: Member + Parameter + MaybeSerializeDeserialize + Ord + BenchmarkValue,
-		UnsynchronisedSettings: Member + Parameter + MaybeSerializeDeserialize,
 		Settings: Member + Parameter + MaybeSerializeDeserialize + Eq,
 		Hook: UpdateFeeHook<Value> + 'static,
 		ValidatorId: Member + Parameter + Ord + MaybeSerializeDeserialize,
-		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize,
-	> ElectoralSystem
-	for UnsafeMedian<Value, UnsynchronisedSettings, Settings, Hook, ValidatorId, StateChainBlockNumber>
+		StateChainBlockNumber: Member + Parameter + Ord + MaybeSerializeDeserialize + Default + Saturating,
+	> ElectoralSystem for UnsafeMedian<Value, Settings, Hook, ValidatorId, StateChainBlockNumber>
 {
 	fn generate_vote_properties(
 		_election_identifier: ElectionIdentifier<Self::ElectionIdentifierExtra>,
@@ -108,8 +94,13 @@ impl<
 
 	fn on_finalize<ElectoralAccess: ElectoralWriteAccess<ElectoralSystem = Self> + 'static>(
 		election_identifiers: Vec<ElectionIdentifier<Self::ElectionIdentifierExtra>>,
-		_context: &Self::OnFinalizeContext,
+		current_statechain_block: &Self::OnFinalizeContext,
 	) -> Result<Self::OnFinalizeReturn, CorruptStorageError> {
+		let (_current_value, last_updated_statechain_block) =
+			ElectoralAccess::unsynchronised_state()?;
+
+		let update_period = ElectoralAccess::unsynchronised_settings()?;
+
 		if let Some(election_identifier) = election_identifiers
 			.into_iter()
 			.at_most_one()
@@ -118,11 +109,20 @@ impl<
 			let election_access = ElectoralAccess::election_mut(election_identifier);
 			if let Some(consensus) = election_access.check_consensus()?.has_consensus() {
 				election_access.delete();
-				ElectoralAccess::set_unsynchronised_state(consensus.clone())?;
+				ElectoralAccess::set_unsynchronised_state((
+					consensus.clone(),
+					current_statechain_block.clone(),
+				))?;
 				Hook::update_fee(consensus);
-				ElectoralAccess::new_election((), (), ())?;
+
+				// we have to immediately create a new election if we want one on every SC block
+				if update_period == Default::default() {
+					ElectoralAccess::new_election((), (), ())?;
+				}
 			}
-		} else {
+		} else if current_statechain_block.clone().saturating_sub(last_updated_statechain_block) >=
+			update_period
+		{
 			ElectoralAccess::new_election((), (), ())?;
 		}
 

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -157,7 +157,7 @@ use frame_system::pallet_prelude::*;
 
 pub use pallet::*;
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(7);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(8);
 
 pub use pallet::UniqueMonotonicIdentifier;
 

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -462,7 +462,6 @@ impl UpdateFeeHook<BtcAmount> for BitcoinFeeUpdateHook {
 }
 pub type BitcoinFeeTracking = UnsafeMedian<
 	<Bitcoin as Chain>::ChainAmount,
-	BtcAmount,
 	(),
 	BitcoinFeeUpdateHook,
 	<Runtime as Chainflip>::ValidatorId,
@@ -515,6 +514,8 @@ impl
 			>,
 		),
 	) -> Result<(), CorruptStorageError> {
+		let current_sc_block_number = crate::System::block_number();
+
 		let chain_progress = BitcoinBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,
@@ -553,7 +554,7 @@ impl
 				BitcoinFeeTracking,
 				RunnerStorageAccess<Runtime, BitcoinInstance>,
 			>,
-		>(fee_identifiers, &())?;
+		>(fee_identifiers, &current_sc_block_number)?;
 
 		BitcoinLiveness::on_finalize::<
 			DerivedElectoralAccess<
@@ -610,7 +611,7 @@ pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 				safety_margin: 0,
 				safety_buffer: BITCOIN_MAINNET_SAFETY_BUFFER,
 			},
-			Default::default(),
+			10, // wait 10 SC blocks until reopening fee election
 			(),
 		),
 		settings: (

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1453,6 +1453,13 @@ type AllMigrations = (
 	migrations::housekeeping::Migration,
 	migrations::bitcoin_elections::Migration,
 	migrations::generic_elections::Migration,
+	VersionedMigration<
+		7,
+		8,
+		NoopMigration,
+		pallet_cf_elections::Pallet<Runtime, SolanaInstance>,
+		DbWeight,
+	>,
 	MigrationsForV1_11,
 );
 

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -39,13 +39,13 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 pub type Migration = (
 	VersionedMigration<
-		6,
 		7,
+		8,
 		BitcoinElectionMigration,
 		pallet_cf_elections::Pallet<Runtime, BitcoinInstance>,
 		<Runtime as frame_system::Config>::DbWeight,
 	>,
-	PlaceholderMigration<7, Pallet<Runtime, BitcoinInstance>>,
+	PlaceholderMigration<8, Pallet<Runtime, BitcoinInstance>>,
 );
 
 pub struct BitcoinElectionMigration;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2443

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Since 1.10 we use the `UnsafeMedian` electoral system for witnessing bitcoin fees. This creates new elections on every SC block. Unfortunately, the bitcoin rpc call that we use to get fees (`estimate_smart_fee`) only very rarely updates it's value (every 2 btc blocks or so), so it doesn't make sense to query the rpc and vote on every SC block.

This PR adds a new (unsynchronised) setting to the UnsafeMedian ES that lets us specify the number of SC blocks to wait until the next election is created.
