### PR TITLE
refactor: return `Ok(None)` instead of error if sol egress witnessing cannot find a tx

### DIFF
--- a/engine/src/witness/sol/egress_witnessing.rs
+++ b/engine/src/witness/sol/egress_witnessing.rs
@@ -78,9 +78,11 @@ pub async fn get_finalized_fee_and_success_status(
 			);
 			Ok(None)
 		},
-		// TODO: Consider distinguishing this case as `Ok(None)` to indicate that the
-		// request returned a response, but the tx is not available yet.
-		None => Err(anyhow::anyhow!("Unknown Transaction.")),
+		None => {
+			// The request returned a response, but the the tx is not available yet.
+			tracing::debug!("Unknown Transaction ({signature:?})");
+			Ok(None)
+		},
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-1615

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Some time ago we've made the return value of the vote() function optional ([PRO-1979](https://linear.app/chainflip/issue/PRO-1979/make-return-value-of-voterapi-optional)). If the voter logic gets this value it doesn't vote for this election. It is going to try to vote again on the next SC block because is_vote_desired() returns Ok(true) for the ExactValue ES that's used by SolanaEgressWitnessing.