### PR TITLE
feat: swap aborted event

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -825,7 +825,7 @@ pub mod pallet {
 			broker_id: T::AccountId,
 			minimum_fee_bps: BasisPoints,
 		},
-		SwapCanceled {
+		SwapAborted {
 			swap_id: SwapId,
 		},
 	}
@@ -1800,6 +1800,8 @@ pub mod pallet {
 		fn refund_failed_swap(swap: Swap<T>) {
 			let swap_request_id = swap.swap_request_id;
 
+			Self::deposit_event(Event::<T>::SwapAborted { swap_id: swap.swap_id });
+
 			let Some(mut request) = SwapRequests::<T>::take(swap_request_id) else {
 				log_or_panic!("Swap request {swap_request_id} not found");
 				return;
@@ -1922,7 +1924,7 @@ pub mod pallet {
 		fn cancel_swap(swap_id: SwapId) -> AssetAmount {
 			ScheduledSwaps::<T>::mutate(|swaps| {
 				let amount = swaps.remove(&swap_id).map(|swap| {
-					Self::deposit_event(Event::<T>::SwapCanceled { swap_id: swap.swap_id });
+					Self::deposit_event(Event::<T>::SwapAborted { swap_id: swap.swap_id });
 					swap.input_amount
 				});
 				if amount.is_none() {

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -308,17 +308,17 @@ impl<T: Config> Swap<T> {
 
 #[derive(Debug, Decode, TypeInfo, Clone, PartialEq, Eq, Encode)]
 pub enum SwapFailureReason {
-	// Batch swap failed due to price impact limit,
+	/// Batch swap failed due to price impact limit
 	PriceImpactLimit,
-	// The minimum price limit was exceeded,
+	/// The minimum price limit was exceeded
 	MinPriceViolation,
-	// The oracle price slippage limit was exceeded,
+	/// The oracle price slippage limit was exceeded
 	OraclePriceSlippageExceeded,
-	// Unable to use oracle slippage parameter because the oracle price is stale,
+	/// Unable to use oracle slippage parameter because the oracle price is stale
 	OraclePriceStale,
-	// An earlier chunk for the same swap request was aborted or rescheduled
+	/// An earlier chunk for the same swap request was aborted or rescheduled
 	PredecessorSwapFailure,
-	// Swapping is disabled due to safe mode
+	/// Swapping is disabled due to safe mode
 	SafeModeActive,
 }
 
@@ -1706,12 +1706,12 @@ pub mod pallet {
 								MAX_BASIS_POINTS,
 							);
 							// Use the oracle price to calculate the minimum output needed
-							let output_amount = output_amount_floor(
+							let min_output_amount = output_amount_floor(
 								swap.swap.input_amount.into(),
 								min_oracle_price,
 							)
 							.unique_saturated_into();
-							if swap.final_output.unwrap() < output_amount {
+							if swap.final_output.unwrap() < min_output_amount {
 								return Err(SwapFailureReason::OraclePriceSlippageExceeded);
 							}
 						},

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1059,7 +1059,8 @@ fn swaps_get_retried_after_failure() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(1),
-					execute_at: RETRY_AT_BLOCK
+					execute_at: RETRY_AT_BLOCK,
+					reason: SwapFailureReason::PriceImpactLimit,
 				})
 			);
 
@@ -1067,7 +1068,8 @@ fn swaps_get_retried_after_failure() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(2),
-					execute_at: RETRY_AT_BLOCK
+					execute_at: RETRY_AT_BLOCK,
+					reason: SwapFailureReason::PriceImpactLimit,
 				})
 			);
 
@@ -1546,7 +1548,8 @@ mod swap_batching {
 					RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. }),
 					RuntimeEvent::Swapping(Event::SwapRescheduled {
 						swap_id: SwapId(1),
-						execute_at: SWAP_RESCHEDULED_BLOCK
+						execute_at: SWAP_RESCHEDULED_BLOCK,
+						reason: SwapFailureReason::PriceImpactLimit,
 					}),
 				);
 
@@ -1773,7 +1776,10 @@ mod internal_swaps {
 
 				assert_event_sequence!(
 					Test,
-					RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) }),
+					RuntimeEvent::Swapping(Event::SwapAborted {
+						swap_id: SwapId(2),
+						reason: SwapFailureReason::MinPriceViolation
+					}),
 					RuntimeEvent::Swapping(Event::SwapRequested {
 						request_type: SwapRequestTypeEncoded::NetworkFee,
 						input_amount: REFUND_FEE,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1773,6 +1773,7 @@ mod internal_swaps {
 
 				assert_event_sequence!(
 					Test,
+					RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) }),
 					RuntimeEvent::Swapping(Event::SwapRequested {
 						request_type: SwapRequestTypeEncoded::NetworkFee,
 						input_amount: REFUND_FEE,

--- a/state-chain/pallets/cf-swapping/src/tests/config.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/config.rs
@@ -350,6 +350,15 @@ fn cannot_swap_in_safe_mode() {
 		let retry_at_block = swaps_scheduled_at + SwapRetryDelay::<Test>::get();
 		assert_eq!(ScheduledSwaps::<Test>::get().len(), 4);
 
+		assert_has_matching_event!(
+			Test,
+			RuntimeEvent::Swapping(Event::SwapRescheduled {
+				swap_id: SwapId(1),
+				reason: SwapFailureReason::SafeModeActive,
+				..
+			})
+		);
+
 		<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_green();
 
 		// Swaps are processed

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -279,7 +279,8 @@ fn dca_with_fok_full_refund(is_ccm: bool) {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(1),
-					execute_at: REFUND_BLOCK
+					execute_at: REFUND_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				})
 			);
 
@@ -303,7 +304,10 @@ fn dca_with_fok_full_refund(is_ccm: bool) {
 
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(1),
+					reason: SwapFailureReason::MinPriceViolation
+				}),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					input_asset: INPUT_ASSET,
 					input_amount: REFUND_FEE,
@@ -377,7 +381,8 @@ fn dca_with_fok_partial_refund(is_ccm: bool) {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(2),
-					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK
+					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				})
 			);
 
@@ -413,7 +418,10 @@ fn dca_with_fok_partial_refund(is_ccm: bool) {
 
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) }),
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(2),
+					reason: SwapFailureReason::MinPriceViolation
+				}),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					input_asset: INPUT_ASSET,
 					input_amount: REFUND_FEE,
@@ -486,6 +494,7 @@ fn dca_with_fok_fully_executed(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(1),
 					execute_at: CHUNK_1_RETRY_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				})
 			);
 
@@ -1020,7 +1029,8 @@ fn dca_with_one_block_interval_fok() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(2),
-					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK
+					execute_at: CHUNK_2_RESCHEDULED_AT_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				})
 			);
 			// The 3rd chunk should be rescheduled as well
@@ -1028,7 +1038,8 @@ fn dca_with_one_block_interval_fok() {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: SwapId(3),
-					execute_at: CHUNK_3_RESCHEDULED_AT_BLOCK
+					execute_at: CHUNK_3_RESCHEDULED_AT_BLOCK,
+					reason: SwapFailureReason::PredecessorSwapFailure,
 				})
 			);
 
@@ -1041,11 +1052,17 @@ fn dca_with_one_block_interval_fok() {
 			// Make sure that chunk 2 failing cancels chunk 3 that was already scheduled
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) })
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(2),
+					reason: SwapFailureReason::MinPriceViolation
+				})
 			);
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(3) })
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(3),
+					reason: SwapFailureReason::PredecessorSwapFailure,
+				})
 			);
 			assert_swaps_queue_is_empty();
 

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -303,6 +303,7 @@ fn dca_with_fok_full_refund(is_ccm: bool) {
 
 			assert_event_sequence!(
 				Test,
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					input_asset: INPUT_ASSET,
 					input_amount: REFUND_FEE,
@@ -412,6 +413,7 @@ fn dca_with_fok_partial_refund(is_ccm: bool) {
 
 			assert_event_sequence!(
 				Test,
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) }),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					input_asset: INPUT_ASSET,
 					input_amount: REFUND_FEE,
@@ -712,10 +714,6 @@ fn test_minimum_chunk_size() {
 		expected_number_of_chunks: u32,
 		minimum_chunk_size: AssetAmount,
 	) {
-		println!(
-			"Testing with asset_amount: {}, number_of_chunks: {}, expected_number_of_chunks: {}, minimum_chunk_size: {}",
-			asset_amount, number_of_chunks, expected_number_of_chunks, minimum_chunk_size
-		);
 		// Update the minimum chunk size
 		assert_ok!(Swapping::update_pallet_config(
 			OriginTrait::root(),
@@ -1043,7 +1041,11 @@ fn dca_with_one_block_interval_fok() {
 			// Make sure that chunk 2 failing cancels chunk 3 that was already scheduled
 			assert_has_matching_event!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapCanceled { swap_id: SwapId(3) })
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(2) })
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(3) })
 			);
 			assert_swaps_queue_is_empty();
 

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -271,6 +271,7 @@ fn fok_swap_gets_refunded_due_to_price_limit(is_ccm: bool) {
 			// to reaching expiry block
 			assert_event_sequence!(
 				Test,
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: FOK_SWAP_REQUEST_ID,
 					..
@@ -421,6 +422,7 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
 				// Non-fok swap will continue to be retried:
 				RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: REGULAR_SWAP_ID, .. }),
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: FOK_SWAP_REQUEST_ID,
 					..
@@ -464,6 +466,7 @@ fn fok_test_zero_refund_duration(is_ccm: bool) {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: SwapRequestId(1),
 					..
@@ -521,6 +524,7 @@ fn test_zero_refund_amount_remaining() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					swap_request_id: SwapRequestId(2),
 					input_asset: Asset::Usdc,

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -176,7 +176,8 @@ fn price_limit_is_respected_in_fok_swap(is_ccm: bool) {
 				}),
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: FOK_SWAP_1_ID,
-					execute_at: SWAP_RETRIED_AT_BLOCK
+					execute_at: SWAP_RETRIED_AT_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				}),
 			);
 
@@ -260,6 +261,7 @@ fn fok_swap_gets_refunded_due_to_price_limit(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: FOK_SWAP_ID,
 					execute_at: SWAP_RETRIED_AT_BLOCK,
+					reason: SwapFailureReason::MinPriceViolation,
 				}),
 			);
 		})
@@ -271,7 +273,10 @@ fn fok_swap_gets_refunded_due_to_price_limit(is_ccm: bool) {
 			// to reaching expiry block
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(1),
+					reason: SwapFailureReason::MinPriceViolation
+				}),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: FOK_SWAP_REQUEST_ID,
 					..
@@ -403,10 +408,12 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: REGULAR_SWAP_ID,
 					execute_at: SWAP_RETRIED_AT_BLOCK,
+					reason: SwapFailureReason::PriceImpactLimit,
 				}),
 				RuntimeEvent::Swapping(Event::SwapRescheduled {
 					swap_id: FOK_SWAP_ID,
 					execute_at: SWAP_RETRIED_AT_BLOCK,
+					reason: SwapFailureReason::PriceImpactLimit,
 				}),
 			);
 		})
@@ -422,7 +429,10 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
 				// Non-fok swap will continue to be retried:
 				RuntimeEvent::Swapping(Event::SwapRescheduled { swap_id: REGULAR_SWAP_ID, .. }),
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(1),
+					reason: SwapFailureReason::PriceImpactLimit
+				}),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: FOK_SWAP_REQUEST_ID,
 					..
@@ -466,7 +476,10 @@ fn fok_test_zero_refund_duration(is_ccm: bool) {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
+				RuntimeEvent::Swapping(Event::SwapAborted {
+					swap_id: SwapId(1),
+					reason: SwapFailureReason::PriceImpactLimit
+				}),
 				RuntimeEvent::Swapping(Event::RefundEgressScheduled {
 					swap_request_id: SwapRequestId(1),
 					..
@@ -524,7 +537,7 @@ fn test_zero_refund_amount_remaining() {
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::Swapping(Event::BatchSwapFailed { .. }),
-				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1) }),
+				RuntimeEvent::Swapping(Event::SwapAborted { swap_id: SwapId(1), reason: SwapFailureReason::PriceImpactLimit }),
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					swap_request_id: SwapRequestId(2),
 					input_asset: Asset::Usdc,
@@ -628,7 +641,10 @@ mod oracle_swaps {
 				// Chunk 2's output was below the price limit, so it will be retried.
 				assert_has_matching_event!(
 					Test,
-					RuntimeEvent::Swapping(Event::SwapRescheduled { .. })
+					RuntimeEvent::Swapping(Event::SwapRescheduled {
+						reason: SwapFailureReason::OraclePriceSlippageExceeded,
+						..
+					})
 				);
 
 				// Now drop the oracle price for input asset. It will once again match the swap
@@ -728,6 +744,71 @@ mod oracle_swaps {
 				assert_has_matching_event!(
 					Test,
 					RuntimeEvent::Swapping(Event::SwapExecuted { .. })
+				);
+
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::Swapping(Event::SwapRequestCompleted { .. })
+				);
+			});
+	}
+
+	#[test]
+	fn oracle_swap_aborts_if_price_stale() {
+		const SWAP_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+		const SWAP_RETRIED_AT_BLOCK: u64 = SWAP_BLOCK + (DEFAULT_SWAP_RETRY_DELAY_BLOCKS as u64);
+
+		new_test_ext()
+			.execute_with(|| {
+				assert_eq!(System::block_number(), INIT_BLOCK);
+
+				MockPriceFeedApi::set_price(
+					INPUT_ASSET,
+					Some(U256::from(2) << PRICE_FRACTIONAL_BITS),
+				);
+				MockPriceFeedApi::set_price(
+					OUTPUT_ASSET,
+					Some(U256::from(2) << PRICE_FRACTIONAL_BITS),
+				);
+
+				// Set one of the assets to stale
+				MockPriceFeedApi::set_stale(INPUT_ASSET, true);
+				MockPriceFeedApi::set_stale(OUTPUT_ASSET, false);
+
+				Swapping::init_internal_swap_request(
+					INPUT_ASSET,
+					INPUT_AMOUNT,
+					OUTPUT_ASSET,
+					DEFAULT_SWAP_RETRY_DELAY_BLOCKS,
+					// Set the oracle price slippage to a non-zero value
+					PriceLimits { min_price: 0.into(), max_oracle_price_slippage: Some(10) },
+					None,
+					LP_ACCOUNT,
+				);
+			})
+			.then_process_blocks_until_block(SWAP_BLOCK)
+			.then_execute_with(|_| {
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::Swapping(Event::SwapRescheduled {
+						swap_id: SwapId(1),
+						execute_at: SWAP_RETRIED_AT_BLOCK,
+						reason: SwapFailureReason::OraclePriceStale,
+					})
+				);
+
+				// Change to the other asset being stale
+				MockPriceFeedApi::set_stale(INPUT_ASSET, false);
+				MockPriceFeedApi::set_stale(OUTPUT_ASSET, true);
+			})
+			.then_process_blocks_until_block(SWAP_RETRIED_AT_BLOCK)
+			.then_execute_with(|_| {
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::Swapping(Event::SwapAborted {
+						swap_id: SwapId(1),
+						reason: SwapFailureReason::OraclePriceStale
+					})
 				);
 
 				assert_has_matching_event!(

--- a/state-chain/traits/src/mocks/price_feed_api.rs
+++ b/state-chain/traits/src/mocks/price_feed_api.rs
@@ -13,16 +13,22 @@ impl MockPallet for MockPriceFeedApi {
 }
 
 const ORACLE_PRICE: &[u8] = b"ORACLE_PRICE";
+const ORACLE_STALE: &[u8] = b"ORACLE_STALE";
 
 impl MockPriceFeedApi {
 	pub fn set_price(asset: cf_primitives::Asset, price: Option<Price>) {
 		Self::put_storage(ORACLE_PRICE, asset, price);
 	}
+
+	pub fn set_stale(asset: cf_primitives::Asset, stale: bool) {
+		Self::put_storage(ORACLE_STALE, asset, stale);
+	}
 }
 
 impl PriceFeedApi for MockPriceFeedApi {
 	fn get_price(asset: Asset) -> Option<OraclePrice> {
+		let stale = Self::get_storage::<_, bool>(ORACLE_STALE, asset).unwrap_or_default();
 		Self::get_storage::<_, Option<Price>>(ORACLE_PRICE, asset)
-			.and_then(|price| price.map(|price| OraclePrice { price, stale: false }))
+			.and_then(|price| price.map(|price| OraclePrice { price, stale }))
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2453

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have updated documentation where appropriate.

## Summary

- Changed the new swap canceled event to `SwapAborted`. 
- Emit the `SwapAborted` event both when a swap is canceled and when a swap fails.
- Added a new enum `SwapFailedReason`
- put the new reason enum in swap aborted event and swap rescheduled event.
