### PR TITLE
fix: use fewer proptest iterations to decrease CI times.

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine.rs
@@ -208,7 +208,10 @@ pub trait Statemachine: AbstractApi + 'static {
 			failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
 				"proptest-regressions",
 			))),
-			cases: 256 * 10 * 16, // 256 is the default
+			// Default is: 256
+			// Value useful for development is: 256 * 10 * 16
+			// Value for quick CI: 200
+			cases: 200,
 			..Default::default()
 		});
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/statemachine_witnessing_pipeline.rs
@@ -379,10 +379,10 @@ fn run_simulation(blocks: ForkedFilledChain) {
 pub fn test_all() {
 	let mut runner = TestRunner::new(Config {
 		source_file: Some(file!()),
-		// TODO: we had previously a much higher number (256 * 256 * 4),
-		// but currently it takes a *very* long to test with this many iterations.
-		// Appearently due to having increased the empty block buffer on the main chain.
-		cases: 256 * 60,
+		// Default is: 256
+		// Value useful for development is: 256 * 60
+		// Value for quick CI: 100
+		cases: 100,
 		failure_persistence: Some(Box::new(FileFailurePersistence::SourceParallel(
 			"proptest-regressions-full-pipeline",
 		))),


### PR DESCRIPTION
# Pull Request

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

We had long runs of the coverage-check in CI (which of course runs all tests to compute the coverage), due to a high number of iterations set for the proptests. This PR lowers the number of proptest iterations. When changing existing proptest-tested statemachine code, **the iteration numbers should be temporarily increased**, to ensure full coverage.
