### PR TITLE
fix: only wait for balance increases, ignore `performSwap()` exceptions.

### DIFF
--- a/bouncer/tests/assethub_xcm.ts
+++ b/bouncer/tests/assethub_xcm.ts
@@ -15,14 +15,18 @@ export async function testAssethubXcm(testContext: TestContext, _seed?: string) 
     '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
   );
   const oldDotBalance = await getBalance('Dot', '12QPwzxiXa1UAsgeoeNvvPnJqCFE8SwDb4FVXWauYWCwRiHt');
+
+  performSwap(
+    testContext.logger,
+    'Eth',
+    'HubDot',
+    '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
+    metadata,
+  ).catch((reason) => {
+    testContext.warn(`Task waiting for Assethub XCM swap failed. Reason: ${reason}`);
+  });
+
   await Promise.all([
-    performSwap(
-      testContext.logger,
-      'Eth',
-      'HubDot',
-      '14iGgWDpriDToidv1GY28a8yGqF4DyR397euELCzQB87qbRM',
-      metadata,
-    ),
     observeBalanceIncrease(
       testContext.logger,
       'HubDot',


### PR DESCRIPTION
# Pull Request

Closes: PRO-2458

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Instead of waiting for the `performSwap()` promise to resolve, we merely log in case of failure. We only wait for balance increases on HubDot (due to the swap) and on Polkadot (due to XCM execution).

**NOTE:** This test has to be redone after we deprecate polkadot, at the latest in 1.12. 
