### PR TITLE
refactor: swap expiry enum

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -55,10 +55,10 @@ use cf_traits::{
 	lending::{BoostApi, BoostOutcome},
 	AccountRoleRegistry, AdjustedFeeEstimationApi, AffiliateRegistry, AssetConverter,
 	AssetWithholding, BalanceApi, Broadcaster, CcmAdditionalDataHandler, Chainflip,
-	ChannelIdAllocator, DepositApi, EgressApi, EpochInfo, FeePayment,
+	ChannelIdAllocator, DepositApi, EgressApi, EpochInfo, ExpiryBehaviour, FeePayment,
 	FetchesTransfersLimitProvider, GetBlockHeight, IngressEgressFeeApi, IngressSink, IngressSource,
-	NetworkEnvironmentProvider, OnDeposit, PoolApi, ScheduledEgressDetails, SwapOutputAction,
-	SwapParameterValidation, SwapRequestHandler, SwapRequestType,
+	NetworkEnvironmentProvider, OnDeposit, PoolApi, PriceLimitsAndExpiry, ScheduledEgressDetails,
+	SwapOutputAction, SwapParameterValidation, SwapRequestHandler, SwapRequestType,
 };
 use frame_support::{
 	pallet_prelude::{OptionQuery, *},
@@ -2084,7 +2084,15 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						},
 					},
 					broker_fees,
-					Some(refund_params),
+					Some(PriceLimitsAndExpiry {
+						expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
+							retry_duration: refund_params.retry_duration,
+							refund_address: refund_params.refund_address,
+							refund_ccm_metadata: refund_params.refund_ccm_metadata,
+						},
+						min_price: refund_params.min_price,
+						max_oracle_price_slippage: refund_params.max_oracle_price_slippage,
+					}),
 					dca_params.clone(),
 					origin.into(),
 				);

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -55,10 +55,10 @@ use cf_traits::{
 	lending::{BoostApi, BoostOutcome},
 	AccountRoleRegistry, AdjustedFeeEstimationApi, AffiliateRegistry, AssetConverter,
 	AssetWithholding, BalanceApi, Broadcaster, CcmAdditionalDataHandler, Chainflip,
-	ChannelIdAllocator, DepositApi, EgressApi, EpochInfo, ExpiryBehaviour, FeePayment,
+	ChannelIdAllocator, DepositApi, EgressApi, EpochInfo, FeePayment,
 	FetchesTransfersLimitProvider, GetBlockHeight, IngressEgressFeeApi, IngressSink, IngressSource,
-	NetworkEnvironmentProvider, OnDeposit, PoolApi, PriceLimitsAndExpiry, ScheduledEgressDetails,
-	SwapOutputAction, SwapParameterValidation, SwapRequestHandler, SwapRequestType,
+	NetworkEnvironmentProvider, OnDeposit, PoolApi, ScheduledEgressDetails, SwapOutputAction,
+	SwapParameterValidation, SwapRequestHandler, SwapRequestType,
 };
 use frame_support::{
 	pallet_prelude::{OptionQuery, *},
@@ -2084,15 +2084,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						},
 					},
 					broker_fees,
-					Some(PriceLimitsAndExpiry {
-						expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
-							retry_duration: refund_params.retry_duration,
-							refund_address: refund_params.refund_address,
-							refund_ccm_metadata: refund_params.refund_ccm_metadata,
-						},
-						min_price: refund_params.min_price,
-						max_oracle_price_slippage: refund_params.max_oracle_price_slippage,
-					}),
+					Some(refund_params.into()),
 					dca_params.clone(),
 					origin.into(),
 				);

--- a/state-chain/pallets/cf-swapping/src/migrations/swap_request_migration.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations/swap_request_migration.rs
@@ -23,6 +23,7 @@ use frame_support::pallet_prelude::Weight;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::DispatchError;
 
+use cf_traits::ExpiryBehaviour;
 use codec::{Decode, Encode};
 
 pub mod old {
@@ -117,14 +118,14 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 						output_action,
 						dca_state: old_dca_state,
 					} => SwapRequestState::UserSwap {
-						refund_params: refund_params.map(|params| {
-							cf_chains::ChannelRefundParametersChecked {
+						price_limits_and_expiry: refund_params.map(|params| PriceLimitsAndExpiry {
+							expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
 								retry_duration: params.retry_duration,
 								refund_address: params.refund_destination,
-								min_price: params.min_price,
 								refund_ccm_metadata: None,
-								max_oracle_price_slippage: None,
-							}
+							},
+							min_price: params.min_price,
+							max_oracle_price_slippage: None,
 						}),
 						output_action,
 						dca_state: DcaState {

--- a/state-chain/pallets/cf-swapping/src/tests/ccm.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/ccm.rs
@@ -60,7 +60,7 @@ fn init_ccm_swap_request(input_asset: Asset, output_asset: Asset, input_amount: 
 			},
 		},
 		dca_parameters: None,
-		refund_parameters: None,
+		price_limits_and_expiry: None,
 		broker_fees: Default::default(),
 		origin,
 	}));

--- a/state-chain/pallets/cf-swapping/src/tests/dca.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/dca.rs
@@ -598,7 +598,7 @@ fn can_handle_dca_chunk_size_of_zero(is_ccm: bool) {
 				input_asset: INPUT_ASSET,
 				output_asset: OUTPUT_ASSET,
 				input_amount: INPUT_AMOUNT,
-				refund_params: None,
+				price_limits_and_expiry: None,
 				dca_params: Some(dca_params.clone()),
 				output_address: (*EVM_OUTPUT_ADDRESS).clone(),
 				is_ccm,
@@ -836,7 +836,7 @@ fn dca_with_one_block_interval() {
 
 	assert_eq!(
 		SWAP_DELAY_BLOCKS, 2,
-		"Tests and code in init_swap_request assumes the swap delay is 2 blocks, 
+		"Tests and code in init_swap_request assumes the swap delay is 2 blocks,
 			so only a max of 2 chunks can be scheduled at a time."
 	);
 

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -67,9 +67,9 @@ fn both_fok_and_regular_swaps_succeed_first_try(is_ccm: bool) {
 				Test,
 				RuntimeEvent::Swapping(Event::SwapRequested {
 					swap_request_id: FOK_REQUEST_ID,
-					refund_parameters,
+					price_limits_and_expiry,
 					..
-				}) if refund_parameters.as_ref() == Some(&refund_parameters_encoded),
+				}) if price_limits_and_expiry.as_ref() == Some(&refund_parameters_encoded),
 			);
 
 			assert_swaps_scheduled_for_block(

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -26,8 +26,8 @@ pub mod lending;
 mod swapping;
 
 pub use swapping::{
-	SwapOutputAction, SwapOutputActionEncoded, SwapRequestHandler, SwapRequestType,
-	SwapRequestTypeEncoded, SwapType,
+	ExpiryBehaviour, PriceLimitsAndExpiry, SwapOutputAction, SwapOutputActionEncoded,
+	SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
 };
 
 pub mod mocks;

--- a/state-chain/traits/src/mocks/swap_request_api.rs
+++ b/state-chain/traits/src/mocks/swap_request_api.rs
@@ -15,10 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-	swapping::{SwapOutputAction, SwapRequestType},
+	swapping::{PriceLimitsAndExpiry, SwapOutputAction, SwapRequestType},
 	EgressApi, SwapRequestHandler,
 };
-use cf_chains::{Chain, ChannelRefundParametersCheckedInternal, SwapOrigin};
+use cf_chains::{Chain, SwapOrigin};
 use cf_primitives::{Asset, AssetAmount, Beneficiaries, DcaParameters, SwapRequestId};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -64,7 +64,7 @@ where
 		output_asset: Asset,
 		swap_type: SwapRequestType<Self::AccountId>,
 		broker_fees: Beneficiaries<Self::AccountId>,
-		_refund_params: Option<ChannelRefundParametersCheckedInternal<Self::AccountId>>,
+		_price_limits_and_expiry: Option<PriceLimitsAndExpiry<Self::AccountId>>,
 		_dca_params: Option<DcaParameters>,
 		origin: SwapOrigin<Self::AccountId>,
 	) -> SwapRequestId {

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -17,8 +17,8 @@
 use cf_chains::{
 	address::{AddressConverter, EncodedAddress},
 	ccm_checker::DecodedCcmAdditionalData,
-	AccountOrAddress, CcmDepositMetadata, CcmDepositMetadataChecked, Chain, ForeignChainAddress,
-	SwapOrigin,
+	AccountOrAddress, CcmDepositMetadata, CcmDepositMetadataChecked, Chain,
+	ChannelRefundParametersCheckedInternal, ForeignChainAddress, SwapOrigin,
 };
 use cf_primitives::{
 	Asset, AssetAmount, BasisPoints, Beneficiaries, BlockNumber, DcaParameters, Price, PriceLimits,
@@ -97,6 +97,22 @@ pub struct PriceLimitsAndExpiry<AccountId> {
 	pub expiry_behaviour: ExpiryBehaviour<AccountId>,
 	pub min_price: Price,
 	pub max_oracle_price_slippage: Option<BasisPoints>,
+}
+
+impl<AccountId> From<ChannelRefundParametersCheckedInternal<AccountId>>
+	for PriceLimitsAndExpiry<AccountId>
+{
+	fn from(params: ChannelRefundParametersCheckedInternal<AccountId>) -> Self {
+		Self {
+			expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
+				retry_duration: params.retry_duration,
+				refund_address: params.refund_address,
+				refund_ccm_metadata: params.refund_ccm_metadata,
+			},
+			min_price: params.min_price,
+			max_oracle_price_slippage: params.max_oracle_price_slippage,
+		}
+	}
 }
 
 pub trait SwapRequestHandler {

--- a/state-chain/traits/src/swapping.rs
+++ b/state-chain/traits/src/swapping.rs
@@ -17,11 +17,12 @@
 use cf_chains::{
 	address::{AddressConverter, EncodedAddress},
 	ccm_checker::DecodedCcmAdditionalData,
-	AccountOrAddress, CcmDepositMetadata, Chain, ChannelRefundParametersCheckedInternal,
-	ForeignChainAddress, SwapOrigin,
+	AccountOrAddress, CcmDepositMetadata, CcmDepositMetadataChecked, Chain, ForeignChainAddress,
+	SwapOrigin,
 };
 use cf_primitives::{
-	Asset, AssetAmount, Beneficiaries, BlockNumber, DcaParameters, PriceLimits, SwapRequestId,
+	Asset, AssetAmount, BasisPoints, Beneficiaries, BlockNumber, DcaParameters, Price, PriceLimits,
+	SwapRequestId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
@@ -78,6 +79,26 @@ pub enum SwapRequestTypeGeneric<Address, AccountId> {
 pub type SwapRequestType<AccountId> = SwapRequestTypeGeneric<ForeignChainAddress, AccountId>;
 pub type SwapRequestTypeEncoded<AccountId> = SwapRequestTypeGeneric<EncodedAddress, AccountId>;
 
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+#[scale_info(skip_type_params(AccountId))]
+pub enum ExpiryBehaviour<AccountId> {
+	NoExpiry,
+	RefundIfExpires {
+		retry_duration: cf_primitives::BlockNumber,
+		refund_address: AccountOrAddress<AccountId, ForeignChainAddress>,
+		refund_ccm_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
+	},
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+#[scale_info(skip_type_params(AccountId))]
+pub struct PriceLimitsAndExpiry<AccountId> {
+	pub expiry_behaviour: ExpiryBehaviour<AccountId>,
+	pub min_price: Price,
+	pub max_oracle_price_slippage: Option<BasisPoints>,
+}
+
 pub trait SwapRequestHandler {
 	type AccountId: Clone;
 
@@ -87,7 +108,7 @@ pub trait SwapRequestHandler {
 		output_asset: Asset,
 		request_type: SwapRequestType<Self::AccountId>,
 		broker_fees: Beneficiaries<Self::AccountId>,
-		refund_params: Option<ChannelRefundParametersCheckedInternal<Self::AccountId>>,
+		price_limits_and_expiry: Option<PriceLimitsAndExpiry<Self::AccountId>>,
 		dca_params: Option<DcaParameters>,
 		origin: SwapOrigin<Self::AccountId>,
 	) -> SwapRequestId;
@@ -141,11 +162,13 @@ pub trait SwapRequestHandler {
 				output_action: SwapOutputAction::CreditOnChain { account_id: account_id.clone() },
 			},
 			Default::default(), /* no broker fees */
-			Some(ChannelRefundParametersCheckedInternal {
-				retry_duration,
-				refund_address: AccountOrAddress::InternalAccount(account_id.clone()),
+			Some(PriceLimitsAndExpiry {
+				expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
+					retry_duration,
+					refund_address: AccountOrAddress::InternalAccount(account_id.clone()),
+					refund_ccm_metadata: None,
+				},
 				min_price: price_limits.min_price,
-				refund_ccm_metadata: None,
 				max_oracle_price_slippage: price_limits.max_oracle_price_slippage,
 			}),
 			dca_params,


### PR DESCRIPTION
# Pull Request

## Summary

In liquidation swaps (and I think this might apply to other types of new "system" swaps like the onces swapping collected interest) we want to be able to set an oracle price limit but no expiry time and no refund address (these swaps are never meant to expire and should always execute to completion unless they are explicitly cancelled). However, current types in the swapping pallet don't support this: if you provide any type of price limit, you have to provide other fields too (max duration could have a sensible `u32::MAX`, but there is no sensible default for the refund address), and it seems better to encode the intention of swaps never expiring but having an oracle price limit into the type system.

Here I added `PriceLimitsAndExpiry` replacing the use of `ChannelRefundParametersCheckedInternal` in the swapping pallet (the former is still used externally though since we still want to require refund address for external swaps). Part of the new type is `ExpiryBehaviour` which in the `NoExpiry` variant does not contain refund information (which isn't needed when swaps never expire).

I'm making this change in a separate PR as ideally we want to merge this into the upcoming release branch to reuse existing migration code.

@GabrielBuragev @zoheb391 I replaced `refund_paramters` with `price_limits_and_expiry` (it should still have all info you need). If this is a problem, we can consider reverting the change in the event for now, but keep in mind that we will still need to make this change by 1.12 where we will start creating swaps with no expiry (but with a price limit).