### PR TITLE
chore: add oracle swaps FoK bouncer test

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -198,6 +198,7 @@ jobs:
           git rev-parse HEAD
           cd bouncer
           pnpm install --frozen-lockfile
+          ./commands/setup_elections.ts
           ./commands/update_price_feeds.ts ALL
 
       - name: Run bouncer on upgrade-from version 🙅‍♂️

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -198,11 +198,7 @@ jobs:
           git rev-parse HEAD
           cd bouncer
           pnpm install --frozen-lockfile
-          ./commands/update_price_feeds.ts BTC 10000
-          ./commands/update_price_feeds.ts ETH 1000
-          ./commands/update_price_feeds.ts SOL 100
-          ./commands/update_price_feeds.ts USDC 1
-          ./commands/update_price_feeds.ts USDT 1
+          ./commands/update_price_feeds.ts ALL
 
       - name: Run bouncer on upgrade-from version 🙅‍♂️
         if: inputs.run-job

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -190,17 +190,6 @@ jobs:
           ./commands/force_sol_nonces.ts
           ./commands/set_sol_alt.ts
 
-      # TODO: This is a temporary workaround to do the initial price feed setup. Remove after 1.11 is released.
-      - name: Setup price feeds
-        if: inputs.run-job
-        run: |
-          git checkout ${{ github.sha }}
-          git rev-parse HEAD
-          cd bouncer
-          pnpm install --frozen-lockfile
-          ./commands/setup_elections.ts
-          ./commands/update_price_feeds.ts ALL
-
       - name: Run bouncer on upgrade-from version 🙅‍♂️
         if: inputs.run-job
         id: pre-upgrade-bouncer
@@ -229,6 +218,17 @@ jobs:
             --bins ./../upgrade-to-bins \
             --localnet_init ./../localnet/init \
             --oldVersion "${{ env.OLD_BIN_VERSION }}"
+
+      # TODO: This is a temporary workaround to do the initial price feed setup. Remove after 1.11 is released.
+      - name: Setup price feeds
+        if: inputs.run-job
+        run: |
+          git checkout ${{ github.sha }}
+          git rev-parse HEAD
+          cd bouncer
+          pnpm install --frozen-lockfile
+          ./commands/setup_elections.ts
+          ./commands/update_price_feeds.ts ALL
 
       - name: Run bouncer after upgrade 🙅‍♂️
         if: inputs.run-job

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -32,8 +32,7 @@ import {
   DisposableApiPromise,
 } from 'shared/utils/substrate';
 import { brokerApiEndpoint, lpApiEndpoint } from 'shared/json_rpc';
-import { updatePriceFeed } from 'shared/update_price_feed';
-import { price } from 'shared/setup_swaps';
+import { updateDefaultPriceFeeds } from 'shared/update_price_feed';
 
 export async function createPolkadotVault(api: DisposableApiPromise) {
   const { promise, resolve } = deferredPromise<{
@@ -244,12 +243,7 @@ async function main(): Promise<void> {
 
   // Step 8
   logger.info('Setting up price feeds');
-  await updatePriceFeed(logger, 'Ethereum', 'BTC', price.get('Btc')!.toString());
-  await updatePriceFeed(logger, 'Ethereum', 'ETH', price.get('Eth')!.toString());
-  await updatePriceFeed(logger, 'Ethereum', 'SOL', price.get('Sol')!.toString());
-  await updatePriceFeed(logger, 'Solana', 'BTC', price.get('Btc')!.toString());
-  await updatePriceFeed(logger, 'Solana', 'ETH', price.get('Eth')!.toString());
-  await updatePriceFeed(logger, 'Solana', 'SOL', price.get('Sol')!.toString());
+  await updateDefaultPriceFeeds(logger);
 
   // Confirmation
   logger.info('Waiting for new epoch...');

--- a/bouncer/commands/update_price_feeds.ts
+++ b/bouncer/commands/update_price_feeds.ts
@@ -1,21 +1,31 @@
 #!/usr/bin/env -S pnpm tsx
 // INSTRUCTIONS
 //
-// This command takes two argument.
-// It will update the on-chain price feed for that asset.
+// This command takes two arguments.
+// The first argument is the asset to update the price feed for, or "ALL" to update all default price feeds.
+// The second argument is the price (optional when asset is "ALL").
 //
 // For example: ./commands/update_price_feeds.ts BTC 123456
+// Or: ./commands/update_price_feeds.ts ALL
 
 import { Asset } from '@chainflip/cli';
-import { updatePriceFeed } from '../shared/update_price_feed';
+import { updatePriceFeed, updateDefaultPriceFeeds } from '../shared/update_price_feed';
 import { runWithTimeoutAndExit } from '../shared/utils';
 import { globalLogger } from '../shared/utils/logger';
 
-export async function updatePriceFeeds(asset: string, price: string) {
-  await updatePriceFeed(globalLogger, 'Ethereum', asset as Asset, price);
-  await updatePriceFeed(globalLogger, 'Solana', asset as Asset, price);
+export async function updatePriceFeeds(asset: string, price?: string) {
+  if (asset.toUpperCase() === 'ALL') {
+    await updateDefaultPriceFeeds(globalLogger);
+  } else {
+    if (price === undefined) {
+      throw new Error('Price argument is required to set the price feed of a specific asset.');
+    }
+    await updatePriceFeed(globalLogger, 'Ethereum', asset as Asset, price);
+    await updatePriceFeed(globalLogger, 'Solana', asset as Asset, price);
+  }
 }
 
 const asset = process.argv[2];
-const price = process.argv[3].trim();
-await runWithTimeoutAndExit(updatePriceFeeds(asset, price), 20);
+const price = process.argv[3]?.trim();
+
+await runWithTimeoutAndExit(updatePriceFeeds(asset, price), 100);

--- a/bouncer/commands/update_price_feeds.ts
+++ b/bouncer/commands/update_price_feeds.ts
@@ -20,8 +20,10 @@ export async function updatePriceFeeds(asset: string, price?: string) {
     if (price === undefined) {
       throw new Error('Price argument is required to set the price feed of a specific asset.');
     }
-    await updatePriceFeed(globalLogger, 'Ethereum', asset as Asset, price);
-    await updatePriceFeed(globalLogger, 'Solana', asset as Asset, price);
+    await Promise.all([
+      updatePriceFeed(globalLogger, 'Ethereum', asset as Asset, price),
+      updatePriceFeed(globalLogger, 'Solana', asset as Asset, price),
+    ]);
   }
 }
 

--- a/bouncer/package.json
+++ b/bouncer/package.json
@@ -7,7 +7,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@chainflip/cli": "1.9.0-assethub.0-ccm-refunds",
+    "@chainflip/cli": "1.9.0-assethub.0-ccm-refunds-oracle-swaps",
     "@chainflip/utils": "^0.4.16",
     "@coral-xyz/anchor": "^0.30.1",
     "@iarna/toml": "^2.2.5",

--- a/bouncer/pnpm-lock.yaml
+++ b/bouncer/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@chainflip/cli':
-        specifier: 1.9.0-assethub.0-ccm-refunds
-        version: 1.9.0-assethub.0-ccm-refunds(axios@1.10.0)(bufferutil@4.0.8)(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 1.9.0-assethub.0-ccm-refunds-oracle-swaps
+        version: 1.9.0-assethub.0-ccm-refunds-oracle-swaps(axios@1.10.0)(bufferutil@4.0.8)(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@chainflip/utils':
         specifier: ^0.4.16
         version: 0.4.16
@@ -154,8 +154,8 @@ packages:
   '@chainflip/bitcoin@1.2.4':
     resolution: {integrity: sha512-bAVP4GSPnAOLWc0XVMXV4Mn5bsOlaa2KKhQCd7XKCYy4+e8JawZFxECywGQFCg8ZVeJMqy54RFGyLsMIx74+Iw==}
 
-  '@chainflip/cli@1.9.0-assethub.0-ccm-refunds':
-    resolution: {integrity: sha512-APmlkIoOO+ZdkGW5oNvGJ+F3wdHLVL5PljNQM8nmfXcUsb5iRTEartW5qUII//iGFwgYKPTzBREpuzGwrBG58A==}
+  '@chainflip/cli@1.9.0-assethub.0-ccm-refunds-oracle-swaps':
+    resolution: {integrity: sha512-ZVyrLdlmAgZPtB9cvaV4X/KxDaOI6lk+XokIhkPTSCzwbi3MlCcpwVqHQ7SOUSw4tDs/SV3UsalzNANdYsI3fg==}
     hasBin: true
     peerDependencies:
       axios: ^1.x
@@ -4040,7 +4040,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@chainflip/cli@1.9.0-assethub.0-ccm-refunds(axios@1.10.0)(bufferutil@4.0.8)(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@chainflip/cli@1.9.0-assethub.0-ccm-refunds-oracle-swaps(axios@1.10.0)(bufferutil@4.0.8)(ethers@6.13.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@chainflip/bitcoin': 1.2.4(typescript@5.8.3)
       '@chainflip/extrinsics': 1.6.1

--- a/bouncer/shared/new_swap.ts
+++ b/bouncer/shared/new_swap.ts
@@ -39,6 +39,7 @@ export async function newSwap(
     refundAddress: defaultRefundAddress,
     minPriceX128: '0',
     refundCcmMetadata: undefined,
+    maxOraclePriceSlippage: undefined,
   };
 
   // If the dry_run of the extrinsic fails on the broker-api then it won't retry. So we retry here to

--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -34,4 +34,25 @@ export async function setupElections(logger: Logger): Promise<void> {
   } else {
     logger.info('Ignoring bitcoin elections setup as bitcoinElections pallet is not available.');
   }
+
+  if (chainflip.query.genericElections) {
+    const upToDateTimeout = 86400;
+
+    const response = JSON.parse(
+      (await chainflip.query.genericElections.electoralUnsynchronisedSettings()) as any,
+    );
+
+    // Set large timeouts for oracle elections so all oracle prices are seen as up to date
+    response.solana.upToDateTimeout = upToDateTimeout;
+    response.ethereum.upToDateTimeout = upToDateTimeout;
+
+    // update election settings
+    await submitGovernanceExtrinsic((api) =>
+      api.tx.genericElections.updateSettings(response, null, 'Heed'),
+    );
+
+    logger.info(`Oracle elections timeout set to ${upToDateTimeout}.`);
+  } else {
+    logger.info('Ignoring Oracle elections setup as genericElections pallet is not available.');
+  }
 }

--- a/bouncer/shared/sol_vault_swap.ts
+++ b/bouncer/shared/sol_vault_swap.ts
@@ -108,6 +108,7 @@ export async function executeSolVaultSwap(
 
   await using chainflip = await getChainflipApi();
 
+  // This will be replaced in PRO-2228 when the SDK is used
   const refundParams: ChannelRefundParameters = {
     retry_duration: fillOrKillParams?.retryDurationBlocks ?? 0,
     refund_address: decodeSolAddress(
@@ -119,7 +120,7 @@ export async function executeSolVaultSwap(
       gas_budget: fillOrKillParams?.refundCcmMetadata.gasBudget,
       ccm_additional_data: fillOrKillParams?.refundCcmMetadata.ccmAdditionalData,
     },
-    max_oracle_price_slippage: undefined, // TODO: update FillOrKillParamsX128 with max_oracle_price_slippage
+    max_oracle_price_slippage: undefined,
   };
   const extraParameters: SolanaVaultSwapExtraParameters = {
     chain: 'Solana',

--- a/bouncer/shared/update_price_feed.ts
+++ b/bouncer/shared/update_price_feed.ts
@@ -139,21 +139,16 @@ export async function updatePriceFeed(logger: Logger, chain: Chain, asset: Asset
 }
 
 export async function updateDefaultPriceFeeds(logger: Logger) {
-  const ethereumUpdates = async () => {
-    await updatePriceFeed(logger, 'Ethereum', 'BTC', defaultPrice.get('Btc')!.toString());
-    await updatePriceFeed(logger, 'Ethereum', 'ETH', defaultPrice.get('Eth')!.toString());
-    await updatePriceFeed(logger, 'Ethereum', 'SOL', defaultPrice.get('Sol')!.toString());
-    await updatePriceFeed(logger, 'Ethereum', 'USDC', defaultPrice.get('Usdc')!.toString());
-    await updatePriceFeed(logger, 'Ethereum', 'USDT', defaultPrice.get('Usdt')!.toString());
-  };
-
-  const solanaUpdates = async () => {
-    await updatePriceFeed(logger, 'Solana', 'BTC', defaultPrice.get('Btc')!.toString());
-    await updatePriceFeed(logger, 'Solana', 'ETH', defaultPrice.get('Eth')!.toString());
-    await updatePriceFeed(logger, 'Solana', 'SOL', defaultPrice.get('Sol')!.toString());
-    await updatePriceFeed(logger, 'Solana', 'USDC', defaultPrice.get('Usdc')!.toString());
-    await updatePriceFeed(logger, 'Solana', 'USDT', defaultPrice.get('Usdt')!.toString());
-  };
-
-  await Promise.all([ethereumUpdates(), solanaUpdates()]);
+  await Promise.all([
+    updatePriceFeed(logger, 'Ethereum', 'BTC', defaultPrice.get('Btc')!.toString()),
+    updatePriceFeed(logger, 'Ethereum', 'ETH', defaultPrice.get('Eth')!.toString()),
+    updatePriceFeed(logger, 'Ethereum', 'SOL', defaultPrice.get('Sol')!.toString()),
+    updatePriceFeed(logger, 'Ethereum', 'USDC', defaultPrice.get('Usdc')!.toString()),
+    updatePriceFeed(logger, 'Ethereum', 'USDT', defaultPrice.get('Usdt')!.toString()),
+    updatePriceFeed(logger, 'Solana', 'BTC', defaultPrice.get('Btc')!.toString()),
+    updatePriceFeed(logger, 'Solana', 'ETH', defaultPrice.get('Eth')!.toString()),
+    updatePriceFeed(logger, 'Solana', 'SOL', defaultPrice.get('Sol')!.toString()),
+    updatePriceFeed(logger, 'Solana', 'USDC', defaultPrice.get('Usdc')!.toString()),
+    updatePriceFeed(logger, 'Solana', 'USDT', defaultPrice.get('Usdt')!.toString()),
+  ]);
 }

--- a/bouncer/shared/update_price_feed.ts
+++ b/bouncer/shared/update_price_feed.ts
@@ -6,6 +6,7 @@ import { signAndSendTxEvm } from '../shared/send_evm';
 import { amountToFineAmount, getContractAddress, getEvmEndpoint } from '../shared/utils';
 import { Logger } from '../shared/utils/logger';
 import { signAndSendTxSol } from './send_sol';
+import { price as defaultPrice } from './setup_swaps';
 
 // All price feeds are using 8 decimals
 const PRICE_FEED_DECIMALS = 8;
@@ -135,4 +136,24 @@ export async function updatePriceFeed(logger: Logger, chain: Chain, asset: Asset
     default:
       throw new Error(`Unsupported chain for price feed update: ${chain}`);
   }
+}
+
+export async function updateDefaultPriceFeeds(logger: Logger) {
+  const ethereumUpdates = async () => {
+    await updatePriceFeed(logger, 'Ethereum', 'BTC', defaultPrice.get('Btc')!.toString());
+    await updatePriceFeed(logger, 'Ethereum', 'ETH', defaultPrice.get('Eth')!.toString());
+    await updatePriceFeed(logger, 'Ethereum', 'SOL', defaultPrice.get('Sol')!.toString());
+    await updatePriceFeed(logger, 'Ethereum', 'USDC', defaultPrice.get('Usdc')!.toString());
+    await updatePriceFeed(logger, 'Ethereum', 'USDT', defaultPrice.get('Usdt')!.toString());
+  };
+
+  const solanaUpdates = async () => {
+    await updatePriceFeed(logger, 'Solana', 'BTC', defaultPrice.get('Btc')!.toString());
+    await updatePriceFeed(logger, 'Solana', 'ETH', defaultPrice.get('Eth')!.toString());
+    await updatePriceFeed(logger, 'Solana', 'SOL', defaultPrice.get('Sol')!.toString());
+    await updatePriceFeed(logger, 'Solana', 'USDC', defaultPrice.get('Usdc')!.toString());
+    await updatePriceFeed(logger, 'Solana', 'USDT', defaultPrice.get('Usdt')!.toString());
+  };
+
+  await Promise.all([ethereumUpdates(), solanaUpdates()]);
 }

--- a/bouncer/tests/evm_deposits.ts
+++ b/bouncer/tests/evm_deposits.ts
@@ -287,6 +287,7 @@ async function testEncodeCfParameters(parentLogger: Logger, sourceAsset: Asset, 
   const logger = parentLogger.child({ tag });
   await using chainflip = await getChainflipApi();
 
+  // This will be replaced in PRO-2228 when the SDK is used
   const refundParams: ChannelRefundParameters = {
     retry_duration: 10,
     refund_address: newEvmAddress('refund_eth'),

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -27,7 +27,7 @@ async function testMinPriceRefund(
   amount: number,
   swapViaVault = false,
   ccmRefund = false,
-  maxOraclePriceSlippage?: number,
+  oracleSwap = false,
 ) {
   const logger = parentLogger.child({ tag: `FoK_${sourceAsset}_${amount}` });
   const destAsset = sourceAsset === Assets.Usdc ? Assets.Flip : Assets.Usdc;
@@ -53,13 +53,11 @@ async function testMinPriceRefund(
       sourceAsset === Assets.Dot ? decodeDotAddressForContract(refundAddress) : refundAddress,
     // Unrealistic min price
     minPriceX128: amountToFineAmount(
-      maxOraclePriceSlippage === undefined
-        ? '99999999999999999999999999999999999999999999999999999'
-        : '0',
+      !oracleSwap ? '99999999999999999999999999999999999999999999999999999' : '0',
       assetDecimals(sourceAsset),
     ),
     refundCcmMetadata,
-    maxOraclePriceSlippage,
+    maxOraclePriceSlippage: oracleSwap ? 0 : undefined,
   };
 
   let swapRequestedHandle;
@@ -162,7 +160,7 @@ export async function testFillOrKill(testContext: TestContext) {
     testMinPriceRefund(testContext.logger, Assets.Sol, 10, true, true),
     testMinPriceRefund(testContext.logger, Assets.Usdc, 10, true, true),
     // Large oracle swaps with small oracle slippage will be refunded
-    testMinPriceRefund(testContext.logger, Assets.Eth, 50, false, false, 0),
-    testMinPriceRefund(testContext.logger, Assets.Btc, 2, false, false, 0),
+    testMinPriceRefund(testContext.logger, Assets.Eth, 50, false, false, true),
+    testMinPriceRefund(testContext.logger, Assets.Btc, 2, false, false, true),
   ]);
 }

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -160,7 +160,7 @@ export async function testFillOrKill(testContext: TestContext) {
     testMinPriceRefund(testContext.logger, Assets.Sol, 10, true, true),
     testMinPriceRefund(testContext.logger, Assets.Usdc, 10, true, true),
     // Large oracle swaps with small oracle slippage will be refunded
-    testMinPriceRefund(testContext.logger, Assets.Eth, 50, false, false, true),
-    testMinPriceRefund(testContext.logger, Assets.Btc, 2, false, false, true),
+    testMinPriceRefund(testContext.logger, Assets.Eth, 100, false, false, true),
+    testMinPriceRefund(testContext.logger, Assets.Btc, 10, false, false, true),
   ]);
 }

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -27,6 +27,7 @@ async function testMinPriceRefund(
   amount: number,
   swapViaVault = false,
   ccmRefund = false,
+  maxOraclePriceSlippage?: number,
 ) {
   const logger = parentLogger.child({ tag: `FoK_${sourceAsset}_${amount}` });
   const destAsset = sourceAsset === Assets.Usdc ? Assets.Flip : Assets.Usdc;
@@ -52,10 +53,13 @@ async function testMinPriceRefund(
       sourceAsset === Assets.Dot ? decodeDotAddressForContract(refundAddress) : refundAddress,
     // Unrealistic min price
     minPriceX128: amountToFineAmount(
-      '99999999999999999999999999999999999999999999999999999',
+      maxOraclePriceSlippage === undefined
+        ? '99999999999999999999999999999999999999999999999999999'
+        : '0',
       assetDecimals(sourceAsset),
     ),
     refundCcmMetadata,
+    maxOraclePriceSlippage,
   };
 
   let swapRequestedHandle;
@@ -157,5 +161,8 @@ export async function testFillOrKill(testContext: TestContext) {
     testMinPriceRefund(testContext.logger, Assets.ArbEth, 5, true, true),
     testMinPriceRefund(testContext.logger, Assets.Sol, 10, true, true),
     testMinPriceRefund(testContext.logger, Assets.Usdc, 10, true, true),
+    // Large oracle swaps with small oracle slippage will be refunded
+    testMinPriceRefund(testContext.logger, Assets.Eth, 50, false, false, 0),
+    testMinPriceRefund(testContext.logger, Assets.Btc, 2, false, false, 0),
   ]);
 }

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -77,6 +77,10 @@ async function testMinPriceRefund(
     maxOraclePriceSlippage: oracleSwap ? 0 : undefined,
   };
 
+  logger.info(
+    `Fok swap started from ${sourceAsset} to ${destAsset} with unrealistic min price${swapViaVault ? ' swapViaVault' : ''}${ccmRefund ? ' ccmRefund' : ''}${oracleSwap ? ' oracleSwap' : ''}`,
+  );
+
   let swapRequestedHandle;
 
   if (!swapViaVault) {
@@ -151,6 +155,10 @@ async function testMinPriceRefund(
     observeBalanceIncrease(logger, sourceAsset, refundAddress, refundBalanceBefore),
     ccmEventEmitted,
   ]);
+
+  logger.info(
+    `Fok swap complete from ${sourceAsset} to ${destAsset} with unrealistic min price${swapViaVault ? ' swapViaVault' : ''}${ccmRefund ? ' ccmRefund' : ''}${oracleSwap ? ' oracleSwap' : ''}`,
+  );
 }
 
 export async function testFillOrKill(testContext: TestContext) {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2460

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Add Oracle Swaps to FoK bouncer test.
Increase timeout for Oracle price elections as part of the election setup so the oracle prices are up to date for the whole duration of the bouncer run without needing to update it periodically.
