### PR TITLE
test: improve bouncer speed

### DIFF
--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -28,7 +28,6 @@ describe('ConcurrentTests', () => {
   const givenNumberOfNodes = match ? parseInt(match[0]) : null;
   const numberOfNodes = givenNumberOfNodes ?? 1;
 
-  concurrentTest('SwapLessThanED', swapLessThanED, 180);
   testAllSwaps(numberOfNodes === 1 ? 180 : 240); // TODO: find out what the 3-node timeout should be
   concurrentTest('EvmDeposits', testEvmDeposits, 250);
   concurrentTest('FundRedeem', testFundRedeem, 1000);
@@ -44,6 +43,7 @@ describe('ConcurrentTests', () => {
   concurrentTest('VaultSwaps', testVaultSwap, 600);
   concurrentTest('AssethubXCM', testAssethubXcm, 200);
   concurrentTest('DelegateFlip', testDelegateFlip, 360);
+  concurrentTest('SwapLessThanED', swapLessThanED, 180);
 
   // Tests that only work if there is more than one node
   if (numberOfNodes > 1) {


### PR DESCRIPTION
# Pull Request


## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

I noticed that for some reason the `SwapLessThanED` is blocking the other tests from starting when running the bouncer. You can see it in any of the runs from the timestamps. e.g.
https://github.com/chainflip-io/chainflip-backend/actions/runs/17128788352/job/48587651646#step:16:74

This simple change reduces bouncer runs by 2-3 min.