### PR TITLE
feat: oracle delta

### DIFF
--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -89,14 +89,23 @@ pub fn bounded_sqrt_price(quote: Amount, base: Amount) -> SqrtPriceQ64F96 {
 	}
 }
 
-// Given prices of asset 1 and asset 2 (in terms of the same asset)
-// compute the price of asset 1 in terms of asset 2
+/// Given prices of asset 1 and asset 2 (in terms of the same asset)
+/// compute the price of asset 1 in terms of asset 2
 pub fn relative_price(price_1: Price, price_2: Price) -> Price {
 	mul_div_floor(price_1, U256::one() << PRICE_FRACTIONAL_BITS, price_2)
 }
 
 pub fn output_amount_floor(input: Amount, price: Price) -> Amount {
 	mul_div_floor(input, price, U256::one() << PRICE_FRACTIONAL_BITS)
+}
+
+/// Calculates the price of the input asset in terms of the output asset
+pub fn price_from_input_output(input: Amount, output: Amount) -> Option<Price> {
+	if input.is_zero() {
+		None
+	} else {
+		Some(mul_div_floor(output, U256::one() << PRICE_FRACTIONAL_BITS, input))
+	}
 }
 
 pub fn output_amount_ceil(input: Amount, price: Price) -> Amount {
@@ -631,6 +640,29 @@ mod test {
 				U256::from_dec_str("4567845678456784567845678456784567845678").unwrap()
 			),
 			U256::from_dec_str("91965187171920516035188920897262983721").unwrap()
+		);
+	}
+
+	#[test]
+	fn test_price_from_input_output() {
+		assert_eq!(
+			price_from_input_output(1.into(), 1.into()),
+			Some(U256::one() << PRICE_FRACTIONAL_BITS)
+		);
+		assert_eq!(
+			price_from_input_output(2.into(), 1.into()),
+			Some((U256::one() << PRICE_FRACTIONAL_BITS) / 2)
+		);
+		assert_eq!(
+			price_from_input_output(1.into(), 2.into()),
+			Some((U256::one() << PRICE_FRACTIONAL_BITS) * 2)
+		);
+		assert_eq!(
+			price_from_input_output(
+				1.into(),
+				output_amount_floor(1.into(), U256::from(2) << PRICE_FRACTIONAL_BITS)
+			),
+			Some((U256::one() << PRICE_FRACTIONAL_BITS) * 2)
 		);
 	}
 }

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -785,6 +785,7 @@ fn can_handle_ccm_with_zero_swap_outputs() {
 					output_asset: OUTPUT_ASSET,
 					output_amount: ZERO_AMOUNT,
 					intermediate_amount: None,
+					oracle_delta: None,
 				}),
 			);
 		})
@@ -1433,6 +1434,7 @@ mod swap_batching {
 				broker_fee_taken: None,
 				stable_amount,
 				final_output: None,
+				oracle_delta: None,
 			}
 		}
 	}

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -730,6 +730,7 @@ fn input_amount_excludes_network_fee() {
 				input_amount: expected_input_amount,
 				output_amount: expected_input_amount * DEFAULT_SWAP_RATE,
 				intermediate_amount: None,
+				oracle_delta: None,
 			}));
 		});
 }
@@ -820,6 +821,7 @@ fn expect_earned_fees_to_be_recorded() {
 				output_asset: Asset::Usdc,
 				output_amount: INTERMEDIATE_AMOUNT - NETWORK_FEE_1 - ALICE_FEE_1,
 				intermediate_amount: None,
+				oracle_delta: None,
 			}));
 
 			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), ALICE_FEE_1);
@@ -845,6 +847,7 @@ fn expect_earned_fees_to_be_recorded() {
 				output_asset: Asset::Flip,
 				output_amount: AMOUNT_AFTER_FEES * DEFAULT_SWAP_RATE,
 				intermediate_amount: None,
+				oracle_delta: None,
 			}));
 
 			assert_eq!(get_broker_balance::<Test>(&ALICE, Asset::Usdc), ALICE_FEE_1 + ALICE_FEE_2);
@@ -876,6 +879,7 @@ fn expect_earned_fees_to_be_recorded() {
 				output_asset: Asset::Flip,
 				output_amount: INTERMEDIATE_AMOUNT_AFTER_FEES * DEFAULT_SWAP_RATE,
 				intermediate_amount: Some(INTERMEDIATE_AMOUNT_AFTER_FEES),
+				oracle_delta: None,
 			}));
 
 			assert_eq!(


### PR DESCRIPTION
# Pull Request

Closes: PRO-2454

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have updated documentation where appropriate.

## Summary

- Calculating the new `oracle_delta` when we check for price violations (regardless of refund params)
- Added the new `oracle_delta` to the `SwapExecuted` Event
- Using a `Option<i16>` for the `oracle_delta`. Will be `None` if the oracle price is not supported for one of the assets.
- The delta is in basis points but most likely will be a negative number.
- Added some tests to cover the new calculations.