### PR TITLE
fix: make multiple members gov test serial

### DIFF
--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -30,7 +30,6 @@ describe('ConcurrentTests', () => {
   testAllSwaps(numberOfNodes === 1 ? 180 : 240); // TODO: find out what the 3-node timeout should be
   concurrentTest('EvmDeposits', testEvmDeposits, 300);
   concurrentTest('FundRedeem', testFundRedeem, 600);
-  concurrentTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);
   concurrentTest('LpApi', testLpApi, 240);
   concurrentTest('BrokerFeeCollection', testBrokerFeeCollection, 200);
   concurrentTest('BoostingForAsset', testBoostingSwap, 200);
@@ -45,6 +44,9 @@ describe('ConcurrentTests', () => {
   // WHEN CHANGING ANYTHING RELATED TO ASSETHUB OR XCM, run this test locally.
   // concurrentTest('AssethubXCM', testAssethubXcm, 200);
   concurrentTest('DelegateFlip', testDelegateFlip, 360);
+
+  // Test this separately since some other tests rely on single member governance.
+  serialTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);
 
   // Tests that only work if there is more than one node
   if (numberOfNodes > 1) {


### PR DESCRIPTION

This was (I'm pretty sure) preventing boost pool creation - which relies on governance to create the pools. 