### PR TITLE
feat: print logs of failed test when error is thrown in bouncer test.

### DIFF
--- a/bouncer/shared/utils/logger.ts
+++ b/bouncer/shared/utils/logger.ts
@@ -49,13 +49,15 @@ function logMethod(
   }
   method.apply(this, newArgs);
 
-  // Append log line to file
-  const testLogFile = getTestLogFile(this);
-  if (!existsSync(dirname(testLogFile))) {
-    mkdirSync(dirname(testLogFile), { recursive: true });
+  // Append log line to file. We ignore log levels that are 'trace' or below.
+  if (level > this.levels.values.trace) {
+    const testLogFile = getTestLogFile(this);
+    if (!existsSync(dirname(testLogFile))) {
+      mkdirSync(dirname(testLogFile), { recursive: true });
+    }
+    const logLine = `[${getIsoTime()}] ${toUpperCase(this.levels.labels[level])}: ${newArgs}\n`;
+    appendFileSync(testLogFile, logLine);
   }
-  const logLine = `[${getIsoTime()}] ${toUpperCase(this.levels.labels[level])}: ${newArgs}\n`;
-  appendFileSync(testLogFile, logLine);
 }
 
 export const globalLogger: Logger = pino(

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -514,6 +514,7 @@ export function observeEvents<T = any>(
 
   const controller = abortable ? new AbortController() : undefined;
 
+  const logMessagePeriod: number = 5;
   let blocksChecked = 0;
   const findEvent = async () => {
     await using subscription = await subscribeHeads({ chain, finalized });
@@ -525,7 +526,11 @@ export function observeEvents<T = any>(
 
     const checkEvents = (events: Event[], log: string) => {
       blocksChecked += 1;
-      logger.trace(`Checking ${events.length} ${log} events for ${eventName}`);
+      if (blocksChecked % logMessagePeriod === 0) {
+        logger.trace(
+          `Checking ${events.length} ${log} events for ${eventName} (${blocksChecked}th block)`,
+        );
+      }
       let stop = false;
       const foundEvents: Event[] = [];
       for (const event of events) {
@@ -598,7 +603,7 @@ export function observeEvents<T = any>(
           )} seconds`,
         );
         break;
-      } else {
+      } else if (blocksChecked % logMessagePeriod === 0) {
         logger.trace(`No ${eventName} events found in subscription.`);
       }
     }

--- a/bouncer/shared/utils/vitest.ts
+++ b/bouncer/shared/utils/vitest.ts
@@ -38,8 +38,14 @@ function createTestFunction(name: string, testFunction: (context: TestContext) =
     // Run the test with the test context
     await testFunction(context.testContext).catch((error) => {
       // We must catch the error here to be able to log it
+
+      // get local logs from `logStorage` attribute and append them to the error
+      const logStorage = context.testContext.logger.bindings().logStorage;
+      const logs = logStorage || '<No logs available>';
       context.testContext.error(error);
-      throw error;
+
+      // re-throw error
+      throw new Error(`${error}\n\nhistory:\n${logs}`);
     });
     context.testContext.logger.info(`✅ Finished test ${name}`);
   };

--- a/bouncer/shared/utils/vitest.ts
+++ b/bouncer/shared/utils/vitest.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, stat, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { afterEach, beforeEach, it } from 'vitest';
 import { TestContext } from 'shared/utils/test_context';
 import { testInfoFile } from 'shared/utils';
@@ -35,15 +35,6 @@ function createTestFunction(name: string, testFunction: (context: TestContext) =
   return async (context: { testContext: TestContext }) => {
     // Attach the test name to the logger
     context.testContext.logger = context.testContext.logger.child({ test: name });
-
-    // The file where we will write test specific logs to
-    const testLogFileName = getTestLogFile(context.testContext.logger);
-
-    // Delete log file for this test if it already exists
-    stat(testLogFileName, (_err, _stats) => {
-      unlinkSync(testLogFileName);
-    });
-
     context.testContext.logger.info(`🧪 Starting test ${name}`);
 
     // Run the test with the test context
@@ -52,9 +43,10 @@ function createTestFunction(name: string, testFunction: (context: TestContext) =
       context.testContext.error(error);
 
       // get local logs from file and append them to the error
+      const testLogFileName = getTestLogFile(context.testContext.logger);
       const logs = readFileSync(testLogFileName);
 
-      // re-throw error
+      // re-throw error with logs
       throw new Error(`${error}\n\nhistory:\n${logs}`);
     });
     context.testContext.logger.info(`✅ Finished test ${name}`);


### PR DESCRIPTION
# Pull Request

Stores all logs of a logger in a custom `logStorage` attribute. If a test fails, we can print out all logs that *this* logger accumulated, giving more context into the reason for failure.

Example output:
```
...

   ↓ ConcurrentTests > BrokerLevelScreening
   ↓ ConcurrentTests > VaultSwaps
   × ConcurrentTests > SpecialBitcoinSwaps 23322ms
     → Error: something happened!

history:
[2025-08-27T08:13:10.736Z] INFO: 🧪 Starting test SpecialBitcoinSwaps
[2025-08-27T08:13:10.744Z] TRACE: Observing event swapping:SwapDepositAddressReady
[2025-08-27T08:13:11.080Z] TRACE: Found event 1 swapping:SwapDepositAddressReady events in block 28934
[2025-08-27T08:13:13.901Z] DEBUG: $Deposit address: bcrt1p8henkz3pfgks3r0w9g0r7hqcx82vagg2z2ul59heqtnr8am5g5gsm60m2e
[2025-08-27T08:13:13.901Z] DEBUG: Destination address is: 0x7b8e81adf4352e31cf52f49772fb4db1b49357f6 Channel ID is: 39
[2025-08-27T08:13:14.085Z] DEBUG: Sending bitcoin tx with multiple outputs: [object Object]
[2025-08-27T08:13:14.085Z] TRACE: Observing event bitcoinIngressEgress:DepositFinalised
[2025-08-27T08:13:14.085Z] TRACE: Observing event bitcoinIngressEgress:DepositFinalised
[2025-08-27T08:13:14.085Z] TRACE: Observing event bitcoinIngressEgress:DepositFinalised
[2025-08-27T08:13:14.085Z] TRACE: Observing event bitcoinIngressEgress:DepositFinalised
[2025-08-27T08:13:34.052Z] TRACE: Found event 1 bitcoinIngressEgress:DepositFinalised events in block 28957
[2025-08-27T08:13:34.052Z] TRACE: Found event 1 bitcoinIngressEgress:DepositFinalised events in block 28957
[2025-08-27T08:13:34.052Z] TRACE: Found event 1 bitcoinIngressEgress:DepositFinalised events in block 28957
[2025-08-27T08:13:34.053Z] TRACE: Found event 1 bitcoinIngressEgress:DepositFinalised events in block 28957
[2025-08-27T08:13:34.053Z] DEBUG: Deposit of 50,000,000 finalised for channel 39
[2025-08-27T08:13:34.053Z] DEBUG: Deposit of 30,000,000 finalised for channel 39
[2025-08-27T08:13:34.053Z] DEBUG: Deposit of 80,000,000 finalised for channel 39
[2025-08-27T08:13:34.053Z] DEBUG: Deposit of 1,000,000 finalised for channel 39

   ↓ ConcurrentTests > DelegateFlip
   ↓ ConcurrentTests > CheckSolEventAccountsClosure
...
```