### PR TITLE
feat: delegation capacity factor

### DIFF
--- a/state-chain/pallets/cf-funding/src/benchmarking.rs
+++ b/state-chain/pallets/cf-funding/src/benchmarking.rs
@@ -27,6 +27,7 @@ use frame_support::{
 	traits::{EnsureOrigin, UnfilteredDispatchable},
 };
 use frame_system::RawOrigin;
+use sp_std::vec;
 
 fn fund_with_minimum<T: Config>(account_id: &T::AccountId) {
 	assert_ok!(Call::<T>::funded {

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -102,6 +102,9 @@ pub enum PalletConfigUpdate {
 	MinimumAuctionBid {
 		minimum_flip_bid: u32,
 	},
+	DelegationCapacityFactor {
+		factor: u32,
+	},
 }
 
 type RuntimeRotationState<T> =
@@ -363,6 +366,14 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type MaxDelegationBid<T: Config> =
 		StorageMap<_, Identity, T::AccountId, T::Amount, OptionQuery>;
+
+	/// Determines the cap on the total delegation an operator can have relative to their managed
+	/// validators. For example, a factor of 5 means that the total delegation an operator can
+	/// have is capped at 5x the total stake of their managed validators.
+	///
+	/// Note that if this is unset, it defaults to zero, ie. delegation is ignored.
+	#[pallet::storage]
+	pub type DelegationCapacityFactor<T> = StorageValue<_, u32, ValueQuery>;
 
 	/// Stores delegation snapshots per epoch and operator.
 	#[pallet::storage]
@@ -666,6 +677,9 @@ pub mod pallet {
 					MinimumAuctionBid::<T>::set(
 						FLIPPERINOS_PER_FLIP.saturating_mul(minimum_flip_bid.into()).into(),
 					);
+				},
+				PalletConfigUpdate::DelegationCapacityFactor { factor } => {
+					DelegationCapacityFactor::<T>::set(factor);
 				},
 			}
 

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -206,6 +206,8 @@ cf_test_utilities::impl_test_helpers! {
 		{
 			<<Test as Chainflip>::AccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&account_id).unwrap();
 		}
+		// Default to a high capacity factor for the tests.
+		DelegationCapacityFactor::<Test>::put(1000);
 	},
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2434

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [x] I have written and tested required migrations. (none required)
- [ ] I have updated documentation where appropriate. (not yet)

## Summary

Caps the amount of delegated stake that can be deployed usefully by operators. 

It does so by adding a `DelegationCapacityFactor`. This determines how much delegation can be used for bidding by an operator. 

It also determines the maximum reward that is available to be distributed to delegators. 

Example:
If the factor is 4 and the operator has 100FLIP in its validators, any excess delegated stake above 400FLIP will be ignored.

Even if the operator attracts 10000FLIP, only 500 FLIP will be available to bid on authority slots. 

It follows that the Validator/Delegator reward split is calculated taking this cap into account. For example in the above scenario, with a 100 FLIP reward, the validators will never receive less than 20FLIP, no matter how much delegation. The remaining reward portion (after fees) will simply be diluted amongst the additional delegators. 

This creates an incentive for 'excess' delegators to defect to other operators and prevents operators from becoming 'over-staked' (ie. combats the nothing-at-stake scenario).