### PR TITLE
fix: API changes (increase/decrease; remove set_max_bid) & delegator account cleanup

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,10 +1,6 @@
 # This CI runs a lot of the jobs in parallel to speed up development time. We also run a simpler suite of bouncer tests.
 name: Release Chainflip Development
-on:
-  pull_request:
-    branches:
-      - main
-      - "release/*"
+on: pull_request
 concurrency:
   group: ${{ github.ref }}-release-development
   cancel-in-progress: true

--- a/bouncer/shared/utils/substrate.ts
+++ b/bouncer/shared/utils/substrate.ts
@@ -61,12 +61,7 @@ const getCachedDisposable = <T extends AsyncDisposable, F extends (...args: any[
   }) as F;
 };
 
-export interface CustomApi extends ApiPromise {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  raw_rpc(method: string, ...args: any[]): Promise<any>;
-}
-
-export type DisposableApiPromise = CustomApi & { [Symbol.asyncDispose](): Promise<void> };
+export type DisposableApiPromise = ApiPromise & { [Symbol.asyncDispose](): Promise<void> };
 
 // It is important to cache WS connections because nodes seem to have a
 // limit on how many can be opened at the same time (from the same IP presumably)
@@ -95,15 +90,6 @@ const getCachedSubstrateApi = (endpoint: string) =>
         if (prop === 'disconnect') {
           return async () => {
             // noop
-          };
-        }
-        if (prop === 'raw_rpc') {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return async (method: string, ...args: any[]) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const provider: WsProvider = (target as any)._rpcCore.provider;
-            const result = await provider.send(method, args);
-            return result;
           };
         }
 

--- a/bouncer/tests/delegate_flip.ts
+++ b/bouncer/tests/delegate_flip.ts
@@ -177,7 +177,7 @@ async function testDelegate(parentLogger: Logger) {
   scCallExecutedEvent = observeEvent(logger, 'funding:SCCallExecuted', {
     test: (event) => event.data.ethTxHash === receipt.transactionHash,
   }).event;
-  const undelegatedEvent = observeEvent(logger, 'validator:UnDelegated', {
+  const undelegatedEvent = observeEvent(logger, 'validator:Undelegated', {
     test: (event) => {
       const delegatorMatch = event.data.delegator === evmToScAddress(whalePubkey);
       const operatorMatch = event.data.operator === operator.address;

--- a/bouncer/tests/delegate_flip.ts
+++ b/bouncer/tests/delegate_flip.ts
@@ -38,7 +38,7 @@ async function encodeAndSendDelegationApiCall(
 
   logger.info(`Requesting EVM encoding for ${caller} ${JSON.stringify(call)}`);
 
-  const payload = await chainflip.raw_rpc('cf_evm_calldata', caller, {
+  const payload = await chainflip.rpc('cf_evm_calldata', caller, {
     API: 'Delegation',
     call,
   });

--- a/bouncer/tests/delegate_flip.ts
+++ b/bouncer/tests/delegate_flip.ts
@@ -12,110 +12,66 @@ import {
   hexPubkeyToFlipAddress,
   newAddress,
 } from 'shared/utils';
-import { TestContext } from 'shared/utils/test_context';
 import { Logger } from 'shared/utils/logger';
-import { getEthScUtilsAbi } from 'shared/contract_interfaces';
 import { approveErc20 } from 'shared/approve_erc20';
 import { newStatechainAddress } from 'shared/new_statechain_address';
 import { getChainflipApi, observeEvent } from 'shared/utils/substrate';
 import { newCcmMetadata } from 'shared/swapping';
-import { Struct, Enum, Option, u128, Bytes as TsBytes } from 'scale-ts';
-import { hexToU8a, u8aToHex } from '@polkadot/util';
 import { requestNewSwap } from 'shared/perform_swap';
 import { send } from 'shared/send';
 import { setupOperatorAccount } from 'shared/setup_account';
+import z from 'zod';
 
-const cfScUtilsAbi = await getEthScUtilsAbi();
-
-// TODO: Update this with the rpc encoding once the logic is implemented in PRO-2439.
-const RedemptionAmountCodec = Enum({
-  Max: Struct({}),
-  Exact: u128,
-});
-export const ScCallsCodec = Enum({
-  Delegation: Enum({
-    Delegate: Struct({
-      operator: TsBytes(32),
-    }),
-    Undelegate: Struct({}),
-    SetMaxBid: Struct({
-      maybeMaxBid: Option(u128),
-    }),
-    Redeem: Struct({
-      amount: RedemptionAmountCodec,
-      address: TsBytes(20),
-      executor: Option(TsBytes(20)),
-    }),
-  }),
+const evmCallDetails = z.object({
+  calldata: z.string(),
+  value: z.string(),
+  to: z.string(),
+  source_token_address: z.string().optional(),
 });
 
-type ScCallPayload =
-  | { type: 'Delegate'; operatorId: string }
-  | { type: 'Undelegate' }
-  | { type: 'SetMaxBid'; maxBid?: bigint }
-  | {
-      type: 'Redeem';
-      amount: { Max: true } | { Exact: bigint };
-      address: string;
-      executor?: string;
-    };
+async function encodeAndSendDelegationApiCall(
+  logger: Logger,
+  caller: string,
+  call: DelegationApi,
+): Promise<string> {
+  await using chainflip = await getChainflipApi();
 
-function encodeToScCall(payload: ScCallPayload): string {
-  switch (payload.type) {
-    case 'Delegate':
-      return u8aToHex(
-        ScCallsCodec.enc({
-          tag: 'Delegation',
-          value: { tag: 'Delegate', value: { operator: hexToU8a(payload.operatorId) } },
-        }),
-      );
-    case 'Undelegate':
-      return u8aToHex(
-        ScCallsCodec.enc({
-          tag: 'Delegation',
-          value: { tag: 'Undelegate', value: {} },
-        }),
-      );
-    case 'SetMaxBid':
-      return u8aToHex(
-        ScCallsCodec.enc({
-          tag: 'Delegation',
-          value: { tag: 'SetMaxBid', value: { maybeMaxBid: payload.maxBid } },
-        }),
-      );
-    case 'Redeem':
-      return u8aToHex(
-        ScCallsCodec.enc({
-          tag: 'Delegation',
-          value: {
-            tag: 'Redeem',
-            value: {
-              amount:
-                'Max' in payload.amount
-                  ? { tag: 'Max', value: {} }
-                  : { tag: 'Exact', value: payload.amount.Exact },
-              address: hexToU8a(payload.address),
-              executor: payload.executor ? hexToU8a(payload.executor) : undefined,
-            },
-          },
-        }),
-      );
-    default:
-      throw new Error('Invalid payload type');
-  }
+  logger.info(`Requesting EVM encoding for ${caller} ${JSON.stringify(call)}`);
+
+  const payload = await chainflip.raw_rpc('cf_evm_calldata', caller, {
+    API: 'Delegation',
+    call,
+  });
+
+  logger.info(`EVM Call payload for ${caller} ${JSON.stringify(call)}: ${JSON.stringify(payload)}`);
+
+  const { calldata, value, to } = evmCallDetails.parse(payload);
+
+  const { transactionHash } = await signAndSendTxEvm(logger, 'Ethereum', to, value, calldata);
+
+  return transactionHash;
 }
+
+type DelegationApi =
+  | { Delegate: { operator: string; increase: { Some: string } | 'Max' } }
+  | { Undelegate: { decrease: { Some: string } | 'Max' } }
+  | {
+      Redeem: {
+        amount: { Max: true } | { Exact: string };
+        address: string;
+        executor?: string;
+      };
+    };
 
 // Left pad the EVM address to convert it to a Statechain address.
 function evmToScAddress(evmAddress: string) {
   return hexPubkeyToFlipAddress('0x' + evmAddress.slice(2).padStart(64, '0'));
 }
 
-async function testDelegate(parentLogger: Logger) {
-  const web3 = new Web3(getEvmEndpoint('Ethereum'));
+export async function testDelegate(logger: Logger) {
   const uri = '//Operator_0';
   const scUtilsAddress = getContractAddress('Ethereum', 'SC_UTILS');
-  const cfScUtilsContract = new web3.eth.Contract(cfScUtilsAbi, scUtilsAddress);
-  const logger = parentLogger.child({ tag: 'DelegateFlip' });
+  const { pubkey: whalePubkey } = getEvmWhaleKeypair('Ethereum');
 
   const amount = amountToFineAmountBigInt(defaultAssetAmounts('Flip'), 'Flip');
 
@@ -132,19 +88,14 @@ async function testDelegate(parentLogger: Logger) {
   await approveErc20(logger, 'Flip', scUtilsAddress, amount.toString());
 
   logger.info(`Delegating ${amount} Flip to operator ${operator.address}...`);
-  let scCall = encodeToScCall({
-    type: 'Delegate',
-    operatorId: operatorPubkey,
+  const delegateTxHash = await encodeAndSendDelegationApiCall(logger, whalePubkey, {
+    Delegate: { operator: operator.address, increase: { Some: '0x' + amount.toString(16) } },
   });
-  let txData = cfScUtilsContract.methods.depositToScGateway(amount.toString(), scCall).encodeABI();
+  logger.info('Delegate flip transaction sent ' + delegateTxHash);
 
-  let receipt = await signAndSendTxEvm(logger, 'Ethereum', scUtilsAddress, '0', txData);
-  logger.info('Delegate flip transaction sent ' + receipt.transactionHash);
-
-  const { pubkey: whalePubkey } = getEvmWhaleKeypair('Ethereum');
   const fundEvent = observeEvent(logger, 'funding:Funded', {
     test: (event) => {
-      const txMatch = event.data.txHash === receipt.transactionHash;
+      const txMatch = event.data.txHash === delegateTxHash;
       const amountMatch = event.data.fundsAdded.replace(/,/g, '') === amount.toString();
       const accountIdMatch = evmToScAddress(whalePubkey) === event.data.accountId;
       return txMatch && amountMatch && accountIdMatch;
@@ -152,13 +103,15 @@ async function testDelegate(parentLogger: Logger) {
   }).event;
   let scCallExecutedEvent = observeEvent(logger, 'funding:SCCallExecuted', {
     test: (event) => {
-      const txMatch = event.data.ethTxHash === receipt.transactionHash;
-      const operatorMatch = event.data.scCall.Delegation.Delegate.operator === operator.address;
+      const txMatch = event.data.ethTxHash === delegateTxHash;
+      const operatorMatch =
+        event.data.scCall.Delegation.call.Delegate.operator === operator.address;
       return txMatch && operatorMatch;
     },
   }).event;
   const delegatedEvent = observeEvent(logger, 'validator:Delegated', {
     test: (event) => {
+      logger.debug('Delegated event data: ' + JSON.stringify(event.data));
       const delegatorMatch = event.data.delegator === evmToScAddress(whalePubkey);
       const operatorMatch = event.data.operator === operator.address;
       return delegatorMatch && operatorMatch;
@@ -167,15 +120,13 @@ async function testDelegate(parentLogger: Logger) {
   await Promise.all([fundEvent, scCallExecutedEvent, delegatedEvent]);
 
   logger.info('Undelegating Flip from operator ' + operator.address + '...');
-  scCall = encodeToScCall({
-    type: 'Undelegate',
+  const undelegateTxHash = await encodeAndSendDelegationApiCall(logger, whalePubkey, {
+    Undelegate: { decrease: 'Max' },
   });
-  txData = cfScUtilsContract.methods.callSc(scCall).encodeABI();
-  receipt = await signAndSendTxEvm(logger, 'Ethereum', scUtilsAddress, '0', txData);
-  logger.info('Undelegate flip transaction sent ' + receipt.transactionHash);
+  logger.info('Undelegate flip transaction sent ' + undelegateTxHash);
 
   scCallExecutedEvent = observeEvent(logger, 'funding:SCCallExecuted', {
-    test: (event) => event.data.ethTxHash === receipt.transactionHash,
+    test: (event) => event.data.ethTxHash === undelegateTxHash,
   }).event;
   const undelegatedEvent = observeEvent(logger, 'validator:Undelegated', {
     test: (event) => {
@@ -185,28 +136,6 @@ async function testDelegate(parentLogger: Logger) {
     },
   }).event;
   await Promise.all([scCallExecutedEvent, undelegatedEvent]);
-
-  logger.info('Setting new max bid');
-  const maxBid = amount;
-  scCall = encodeToScCall({
-    type: 'SetMaxBid',
-    maxBid: BigInt(maxBid),
-  });
-  txData = cfScUtilsContract.methods.callSc(scCall).encodeABI();
-  receipt = await signAndSendTxEvm(logger, 'Ethereum', scUtilsAddress, '0', txData);
-  logger.info('Set Max Bid transaction sent ' + receipt.transactionHash);
-
-  scCallExecutedEvent = observeEvent(logger, 'funding:SCCallExecuted', {
-    test: (event) => event.data.ethTxHash === receipt.transactionHash,
-  }).event;
-  const maxBidEvent = observeEvent(logger, 'validator:MaxBidUpdated', {
-    test: (event) => {
-      const delegatorMatch = event.data.delegator === evmToScAddress(whalePubkey);
-      const maxBidMatch = event.data.maxBid.replace(/,/g, '') === maxBid.toString();
-      return delegatorMatch && maxBidMatch;
-    },
-  }).event;
-  await Promise.all([scCallExecutedEvent, maxBidEvent]);
 
   await using chainflip = await getChainflipApi();
   const pendingRedemption = await chainflip.query.flip.pendingRedemptionsReserve(
@@ -221,18 +150,13 @@ async function testDelegate(parentLogger: Logger) {
     const redeemAddress = await newAddress('Flip', randomBytes(32).toString('hex'));
     const redemAmount = amount / 2n; // Leave anough to pay fees
 
-    scCall = encodeToScCall({
-      type: 'Redeem',
-      amount: { Exact: redemAmount },
-      address: redeemAddress,
-      executor: undefined,
+    const redeemTxHash = await encodeAndSendDelegationApiCall(logger, whalePubkey, {
+      Redeem: { amount: { Exact: '0x' + redemAmount.toString(16) }, address: redeemAddress },
     });
-    txData = cfScUtilsContract.methods.callSc(scCall).encodeABI();
-    receipt = await signAndSendTxEvm(logger, 'Ethereum', scUtilsAddress, '0', txData);
-    logger.info('Redeem request transaction sent ' + receipt.transactionHash);
+    logger.info('Redeem request transaction sent ' + redeemTxHash);
 
     scCallExecutedEvent = observeEvent(logger, 'funding:SCCallExecuted', {
-      test: (event) => event.data.ethTxHash === receipt.transactionHash,
+      test: (event) => event.data.ethTxHash === redeemTxHash,
     }).event;
     const redeemEvent = observeEvent(logger, 'funding:RedemptionRequested', {
       test: (event) => {
@@ -247,7 +171,7 @@ async function testDelegate(parentLogger: Logger) {
   logger.info('Delegation test completed successfully!');
 }
 
-async function testCcmSwapFundAccount(logger: Logger) {
+export async function testCcmSwapFundAccount(logger: Logger) {
   const web3 = new Web3(getEvmEndpoint('Ethereum'));
   const scUtilsAddress = getContractAddress('Ethereum', 'SC_UTILS');
   const scAddress = await newStatechainAddress(randomBytes(32).toString('hex'));
@@ -270,8 +194,4 @@ async function testCcmSwapFundAccount(logger: Logger) {
   await send(logger, 'Btc', swapParams.depositAddress);
   await fundEvent;
   logger.info('Funding event witnessed succesfully!');
-}
-
-export async function testDelegateFlip(testContext: TestContext) {
-  await Promise.all([testDelegate(testContext.logger), testCcmSwapFundAccount(testContext.logger)]);
 }

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -17,7 +17,7 @@ import { depositChannelCreation } from 'tests/request_swap_deposit_address_with_
 import { testBrokerLevelScreening } from 'tests/broker_level_screening';
 import { testFundRedeem } from 'tests/fund_redeem';
 import { concurrentTest, serialTest } from 'shared/utils/vitest';
-import { testDelegateFlip } from './delegate_flip';
+import { testCcmSwapFundAccount, testDelegate } from './delegate_flip';
 import { testSpecialBitcoinSwaps } from './special_btc_swaps';
 
 // Tests that will run in parallel by both the ci-development and the ci-main-merge
@@ -45,7 +45,12 @@ describe('ConcurrentTests', () => {
   // WHEN CHANGING ANYTHING RELATED TO ASSETHUB OR XCM, run this test locally.
   // concurrentTest('AssethubXCM', testAssethubXcm, 200);
   concurrentTest('SpecialBitcoinSwaps', testSpecialBitcoinSwaps, 60);
-  concurrentTest('DelegateFlip', testDelegateFlip, 360);
+  concurrentTest('DelegateFlip', (context) => testDelegate(context.logger), 360);
+  concurrentTest(
+    'SwapAndFundAccountViaCCM',
+    (context) => testCcmSwapFundAccount(context.logger),
+    360,
+  );
 
   // Test this separately since some other tests rely on single member governance.
   serialTest('MultipleMembersGovernance', testMultipleMembersGovernance, 120);

--- a/engine/src/witness/eth/sc_utils.rs
+++ b/engine/src/witness/eth/sc_utils.rs
@@ -186,16 +186,21 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 
 #[cfg(test)]
 mod tests {
+	use cf_primitives::FlipBalance;
 	use codec::Encode;
 	use frame_support::sp_runtime::AccountId32;
-	use state_chain_runtime::chainflip::ethereum_sc_calls::{DelegationApi, EthereumSCApi};
+	use state_chain_runtime::chainflip::ethereum_sc_calls::{
+		DelegationAmount, DelegationApi, EthereumSCApi,
+	};
 
 	#[test]
 	fn test_sc_call_encode() {
-		let sc_call_delegate = EthereumSCApi::Delegation(DelegationApi::Delegate {
-			operator: AccountId32::new([0xF4; 32]),
-			increase: pallet_cf_validator::DelegationAmount::Max,
-		})
+		let sc_call_delegate = EthereumSCApi::<FlipBalance>::Delegation {
+			call: DelegationApi::Delegate {
+				operator: AccountId32::new([0xF4; 32]),
+				increase: DelegationAmount::Max,
+			},
+		}
 		.encode();
 		assert_eq!(
 			sc_call_delegate,

--- a/engine/src/witness/eth/sc_utils.rs
+++ b/engine/src/witness/eth/sc_utils.rs
@@ -194,6 +194,7 @@ mod tests {
 	fn test_sc_call_encode() {
 		let sc_call_delegate = EthereumSCApi::Delegation(DelegationApi::Delegate {
 			operator: AccountId32::new([0xF4; 32]),
+			increase: pallet_cf_validator::DelegationAmount::Max,
 		})
 		.encode();
 		assert_eq!(

--- a/engine/src/witness/eth/sc_utils.rs
+++ b/engine/src/witness/eth/sc_utils.rs
@@ -199,7 +199,7 @@ mod tests {
 		.encode();
 		assert_eq!(
 			sc_call_delegate,
-			hex::decode("0000f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4")
+			hex::decode("0000f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f400")
 				.unwrap()
 		);
 	}

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -250,13 +250,20 @@ fn slashings_are_distributed_among_delegators() {
 				delegators.keys().map(Flip::balance).sum();
 			let delegators_slash = total_delegators_pre_balance - total_delegators_post_balance;
 
-			assert!(auth_slash > 0u128);
-			assert!(delegators_slash > 0u128);
-			assert!(FlipBalance::abs_diff(op_slash * 19, delegators_slash) < 10); // 5/95 split
-
 			let total_pre_balance =
 				auth_pre_balance + total_delegators_pre_balance + op_pre_balance;
 			let total_slashing = auth_slash + delegators_slash + op_slash;
+
+			let epsilon = total_slashing / 10_000; // allow 0.01% error due to rounding
+
+			assert!(auth_slash > 0u128);
+			assert!(delegators_slash > 0u128);
+			assert!(
+				FlipBalance::abs_diff(op_slash * 19, delegators_slash) < epsilon,
+				"Expected to be within {} but got a diff of {}",
+				epsilon,
+				FlipBalance::abs_diff(op_slash * 19, delegators_slash)
+			); // 5/95 split
 
 			// Verify that slashings are distributed accordingly
 			assert_eq!(

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -88,19 +88,6 @@ fn setup_delegation(
 		.map(|(d, _)| d)
 		.collect::<BTreeSet<_>>();
 	assert_eq!(actual_delegator_set, delegators.keys().cloned().collect());
-
-	// Debug delegation setup
-	println!("Debug delegation setup:");
-	println!("  operator: {:?}", operator);
-	println!("  validator: {:?}", validator);
-	for (delegator, stake) in &delegators {
-		println!(
-			"  delegator: {:?}, stake: {}, max_bid: {:?}",
-			delegator,
-			stake,
-			pallet_cf_validator::MaxDelegationBid::<Runtime>::get(delegator)
-		);
-	}
 }
 
 #[test]
@@ -120,8 +107,6 @@ fn block_author_rewards_are_distributed_among_delegators() {
 				.into_iter()
 				.next()
 				.unwrap();
-
-			println!("Selected authority for test: {:?}", auth);
 
 			let operator = AccountId::from([0xe1; 32]);
 

--- a/state-chain/chains/src/evm/api.rs
+++ b/state-chain/chains/src/evm/api.rs
@@ -32,11 +32,13 @@ use super::{tokenizable::Tokenizable, EvmFetchId};
 pub mod all_batch;
 pub mod common;
 pub mod execute_x_swap_and_call;
+pub mod sc_utils;
 pub mod set_agg_key_with_agg_key;
 pub mod set_comm_key_with_agg_key;
 pub mod set_gov_key_with_agg_key;
 pub mod transfer_fallback;
 pub mod vault_swaps;
+
 pub use vault_swaps::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Default)]

--- a/state-chain/chains/src/evm/api/sc_utils.rs
+++ b/state-chain/chains/src/evm/api/sc_utils.rs
@@ -1,0 +1,2 @@
+pub mod deposit_flip_to_sc_gateway_and_call;
+pub mod sc_call;

--- a/state-chain/chains/src/evm/api/sc_utils/deposit_flip_to_sc_gateway_and_call.rs
+++ b/state-chain/chains/src/evm/api/sc_utils/deposit_flip_to_sc_gateway_and_call.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::evm::{api::EvmCall, tokenizable::Tokenizable};
+use cf_primitives::FlipBalance;
+use codec::{Decode, Encode};
+use ethabi::Token;
+use frame_support::sp_runtime::RuntimeDebug;
+use scale_info::TypeInfo;
+use sp_core::U256;
+use sp_std::{vec, vec::Vec};
+
+/// Represents all the arguments required to build the call to Vault's 'depositToScGateway'
+/// function.
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, PartialEq, Eq)]
+pub struct DepositToSCGatewayAndCall {
+	amount: U256,
+	sc_call: Vec<u8>,
+}
+
+impl DepositToSCGatewayAndCall {
+	pub fn new(amount: FlipBalance, sc_call: Vec<u8>) -> Self {
+		Self { amount: amount.into(), sc_call }
+	}
+}
+
+impl EvmCall for DepositToSCGatewayAndCall {
+	const FUNCTION_NAME: &'static str = "depositToScGateway";
+
+	fn function_params() -> Vec<(&'static str, ethabi::ParamType)> {
+		vec![("amount", U256::param_type()), ("scCall", <Vec<u8>>::param_type())]
+	}
+
+	fn function_call_args(&self) -> Vec<Token> {
+		vec![self.amount.tokenize(), self.sc_call.clone().tokenize()]
+	}
+}

--- a/state-chain/chains/src/evm/api/sc_utils/sc_call.rs
+++ b/state-chain/chains/src/evm/api/sc_utils/sc_call.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::evm::{api::EvmCall, tokenizable::Tokenizable};
+use codec::{Decode, Encode};
+use ethabi::Token;
+use frame_support::sp_runtime::RuntimeDebug;
+use scale_info::TypeInfo;
+use sp_std::{vec, vec::Vec};
+
+/// Represents all the arguments required to build the call to Vault's 'callSc'
+/// function.
+#[derive(Encode, Decode, TypeInfo, Clone, RuntimeDebug, PartialEq, Eq)]
+pub struct SCCall {
+	sc_call: Vec<u8>,
+}
+
+impl SCCall {
+	pub fn new(sc_call: Vec<u8>) -> Self {
+		Self { sc_call }
+	}
+}
+
+impl EvmCall for SCCall {
+	const FUNCTION_NAME: &'static str = "callSc";
+
+	fn function_params() -> Vec<(&'static str, ethabi::ParamType)> {
+		vec![("scCall", <Vec<u8>>::param_type())]
+	}
+
+	fn function_call_args(&self) -> Vec<Token> {
+		vec![self.sc_call.clone().tokenize()]
+	}
+}

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -80,11 +80,11 @@ use state_chain_runtime::{
 	constants::common::TX_FEE_MULTIPLIER,
 	runtime_apis::{
 		AuctionState, BoostPoolDepth, BoostPoolDetails, BrokerInfo, CcmData, ChainAccounts,
-		CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi, FailingWitnessValidators,
-		FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, NetworkFees,
-		OpenedDepositChannels, OperatorInfo, RuntimeApiPenalty, SimulatedSwapInformation,
-		TradingStrategyInfo, TradingStrategyLimits, TransactionScreeningEvents, ValidatorInfo,
-		VaultAddresses, VaultSwapDetails,
+		CustomRuntimeApi, DispatchErrorWithMessage, ElectoralRuntimeApi, EvmCallDetails,
+		FailingWitnessValidators, FeeTypes, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo,
+		NetworkFees, OpenedDepositChannels, OperatorInfo, RuntimeApiPenalty,
+		SimulatedSwapInformation, TradingStrategyInfo, TradingStrategyLimits,
+		TransactionScreeningEvents, ValidatorInfo, VaultAddresses, VaultSwapDetails,
 	},
 	safe_mode::RuntimeSafeMode,
 	FlipBalance, Hash,
@@ -1098,6 +1098,13 @@ pub trait CustomApi {
 		base_and_quote_asset: Option<(PriceAsset, PriceAsset)>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<OraclePrice>>;
+	#[method(name = "evm_calldata")]
+	fn cf_evm_calldata(
+		&self,
+		caller: EthereumAddress,
+		call: state_chain_runtime::chainflip::ethereum_sc_calls::EthereumSCApi<NumberOrHex>,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<EvmCallDetails>;
 }
 
 /// An RPC extension for the state chain node.
@@ -2113,6 +2120,41 @@ where
 			};
 
 			Ok::<_, CfApiError>(strategies)
+		})
+	}
+
+	fn cf_evm_calldata(
+		&self,
+		caller: EthereumAddress,
+		call: state_chain_runtime::chainflip::ethereum_sc_calls::EthereumSCApi<NumberOrHex>,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<EvmCallDetails> {
+		self.rpc_backend.with_runtime_api(at, |api, hash| {
+			let api_version = api
+				.api_version::<dyn CustomRuntimeApi<state_chain_runtime::Block>>(hash)
+				.map_err(CfApiError::from)?
+				.unwrap_or_default();
+
+			if api_version < 6 {
+				// sc calls via ethereum didn't exist before version 6
+				Err(CfApiError::ErrorObject(call_error(
+					"sc calls via ethereum are not supported for the current runtime api version",
+					CfErrorCode::RuntimeApiError,
+				)))
+			} else {
+				api.cf_evm_calldata(
+					hash,
+					caller,
+					call.try_fmap(TryInto::try_into).map_err(|s| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InvalidParams.code(),
+							format!("Failed to convert call parameters: {s}."),
+							None::<()>,
+						))
+					})?,
+				)?
+				.map_err(CfApiError::from)
+			}
 		})
 	}
 }

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -38,7 +38,7 @@ use cf_primitives::{
 
 use state_chain_runtime::{
 	runtime_apis::{
-		BrokerRejectionEventFor, ChannelActionType, EvmVaultSwapDetails, NetworkFeeDetails,
+		BrokerRejectionEventFor, ChannelActionType, EvmCallDetails, NetworkFeeDetails,
 		OpenedDepositChannels,
 	},
 	Runtime,
@@ -831,7 +831,7 @@ fn vault_swap_details_serialization() {
 		deposit_address: "1Pc9wMdCRguVVrZ9Paz8MSgUd47cYfyeQH".to_string().into(),
 	};
 	let eth = VaultSwapDetails::<AddressString>::Ethereum {
-		details: EvmVaultSwapDetails {
+		details: EvmCallDetails {
 			calldata: vec![0x11, 0x22, 0x33, 0x44],
 			value: 12345678.into(),
 			to: H160([0xdd; 20]),
@@ -839,7 +839,7 @@ fn vault_swap_details_serialization() {
 		},
 	};
 	let arb = VaultSwapDetails::<AddressString>::Arbitrum {
-		details: EvmVaultSwapDetails {
+		details: EvmCallDetails {
 			calldata: vec![0x11, 0x22, 0x33, 0x44],
 			value: 2345678.into(),
 			to: H160([0xcc; 20]),

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -27,6 +27,7 @@ pub mod migrations;
 pub mod weights;
 use core::marker::PhantomData;
 
+use frame_support::{Deserialize, Serialize};
 pub use weights::WeightInfo;
 
 #[cfg(test)]
@@ -333,14 +334,38 @@ pub mod pallet {
 	pub type EthTransactionHash = [u8; 32];
 
 	#[derive(
-		Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd,
+		Copy,
+		Clone,
+		Debug,
+		PartialEq,
+		Eq,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+		Ord,
+		PartialOrd,
+		Serialize,
+		Deserialize,
 	)]
-	pub enum RedemptionAmount<T: Parameter> {
+	pub enum RedemptionAmount<T> {
 		Max,
 		Exact(T),
 	}
 
-	impl<T: Parameter> From<T> for RedemptionAmount<T> {
+	impl<T> RedemptionAmount<T> {
+		pub fn try_fmap<B, E>(
+			self,
+			f: impl FnOnce(T) -> Result<B, E>,
+		) -> Result<RedemptionAmount<B>, E> {
+			match self {
+				RedemptionAmount::Max => Ok(RedemptionAmount::Max),
+				RedemptionAmount::Exact(amount) => Ok(RedemptionAmount::Exact(f(amount)?)),
+			}
+		}
+	}
+
+	impl<T> From<T> for RedemptionAmount<T> {
 		fn from(t: T) -> Self {
 			Self::Exact(t)
 		}
@@ -1203,7 +1228,7 @@ pub struct EthereumDepositAndSCCall {
 	pub call: Vec<u8>,
 }
 
-#[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, DebugNoBound)]
+#[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, DebugNoBound, Serialize, Deserialize)]
 pub enum EthereumDeposit {
 	FlipToSCGateway { amount: EthAmount },
 	Vault { asset: EthAsset, amount: EthAmount },

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -332,7 +332,9 @@ pub mod pallet {
 
 	pub type EthTransactionHash = [u8; 32];
 
-	#[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Ord, PartialOrd)]
+	#[derive(
+		Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Ord, PartialOrd,
+	)]
 	pub enum RedemptionAmount<T: Parameter> {
 		Max,
 		Exact(T),
@@ -376,11 +378,8 @@ pub mod pallet {
 
 		/// Calls that are dispatchable via ethereum contract
 		type EthereumSCApi: UnfilteredDispatchable<RuntimeOrigin = Self::RuntimeOrigin>
-			+ Decode
-			+ Clone
-			+ Ord
-			+ PartialOrd
-			+ Debug
+			+ Member
+			+ Parameter
 			+ GetDispatchInfo;
 
 		/// Safe Mode access.

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -550,7 +550,7 @@ mod benchmarks {
 		DelegationChoice::<T>::remove(&delegator);
 
 		#[extrinsic_call]
-		delegate(RawOrigin::Signed(delegator.clone()), operator.clone());
+		delegate(RawOrigin::Signed(delegator.clone()), operator.clone(), DelegationAmount::Max);
 
 		assert_eq!(DelegationChoice::<T>::get(delegator), Some(operator));
 	}
@@ -569,20 +569,8 @@ mod benchmarks {
 		DelegationChoice::<T>::insert(&delegator, operator);
 
 		#[extrinsic_call]
-		undelegate(RawOrigin::Signed(delegator.clone()));
+		undelegate(RawOrigin::Signed(delegator.clone()), DelegationAmount::Max);
 
 		assert!(DelegationChoice::<T>::get(&delegator).is_none());
-	}
-
-	#[benchmark]
-	fn set_max_bid() {
-		let caller: T::AccountId = whitelisted_caller();
-		frame_system::Pallet::<T>::inc_providers(&caller);
-		<T as frame_system::Config>::OnNewAccount::on_new_account(&caller);
-
-		#[extrinsic_call]
-		set_max_bid(RawOrigin::Signed(caller.clone()), Some(T::Amount::from(0u128)));
-
-		assert!(MaxDelegationBid::<T>::get(caller).is_some());
 	}
 }

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -24,11 +24,36 @@ pub enum AssociationToOperator {
 	Delegator,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Debug,
+	Default,
+	Clone,
+	Copy,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	Serialize,
+	Deserialize,
+	TypeInfo,
+	MaxEncodedLen,
+)]
 pub enum DelegationAmount<T> {
 	#[default]
 	Max,
 	Some(T),
+}
+
+impl<T> DelegationAmount<T> {
+	pub fn try_fmap<B, E>(
+		self,
+		f: impl FnOnce(T) -> Result<B, E>,
+	) -> Result<DelegationAmount<B>, E> {
+		match self {
+			DelegationAmount::Max => Ok(DelegationAmount::Max),
+			DelegationAmount::Some(amount) => Ok(DelegationAmount::Some(f(amount)?)),
+		}
+	}
 }
 
 /// Represents a validator's default stance on accepting delegations

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -24,6 +24,13 @@ pub enum AssociationToOperator {
 	Delegator,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum DelegationAmount<T> {
+	#[default]
+	Max,
+	Some(T),
+}
+
 /// Represents a validator's default stance on accepting delegations
 #[derive(
 	Copy,

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -443,7 +443,7 @@ pub mod pallet {
 		/// Operator settings have been updated.
 		OperatorSettingsUpdated { operator: T::AccountId, preferences: OperatorSettings },
 		/// An account has undelegated from an operator.
-		UnDelegated { delegator: T::AccountId, operator: T::AccountId },
+		Undelegated { delegator: T::AccountId, operator: T::AccountId },
 		/// An account has delegated to an operator.
 		Delegated { delegator: T::AccountId, operator: T::AccountId },
 		/// The undelegation process of an delegator has been finalized.
@@ -1016,7 +1016,7 @@ pub mod pallet {
 				DelegationChoice::<T>::try_mutate_exists(&delegator, |maybe_assigned_operator| {
 					if let Some(assigned_operator) = maybe_assigned_operator.take() {
 						if assigned_operator == operator {
-							Self::deposit_event(Event::UnDelegated {
+							Self::deposit_event(Event::Undelegated {
 								delegator: delegator.clone(),
 								operator: operator.clone(),
 							});
@@ -1141,7 +1141,7 @@ pub mod pallet {
 				|_| (),
 			) {
 				DelegationChoice::<T>::remove(&delegator);
-				Self::deposit_event(Event::UnDelegated { delegator, operator: operator.clone() });
+				Self::deposit_event(Event::Undelegated { delegator, operator: operator.clone() });
 			}
 
 			Exceptions::<T>::remove(&operator);
@@ -1192,7 +1192,7 @@ pub mod pallet {
 
 			DelegationChoice::<T>::mutate(&delegator, |maybe_operator| {
 				if let Some(previous_operator) = maybe_operator.replace(operator.clone()) {
-					Self::deposit_event(Event::UnDelegated {
+					Self::deposit_event(Event::Undelegated {
 						delegator: delegator.clone(),
 						operator: previous_operator,
 					});
@@ -1272,7 +1272,7 @@ pub mod pallet {
 				let operator = DelegationChoice::<T>::take(&delegator)
 					.expect("DelegationChoice existence was checked above");
 
-				Self::deposit_event(Event::UnDelegated { delegator, operator });
+				Self::deposit_event(Event::Undelegated { delegator, operator });
 			}
 
 			Ok(())
@@ -2059,7 +2059,7 @@ impl<T: Config> OnKilledAccount<T::AccountId> for DelegatedAccountCleanup<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
 		MaxDelegationBid::<T>::remove(account_id);
 		if let Some(operator) = DelegationChoice::<T>::take(account_id) {
-			Pallet::<T>::deposit_event(Event::UnDelegated {
+			Pallet::<T>::deposit_event(Event::Undelegated {
 				delegator: account_id.clone(),
 				operator,
 			});

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -210,8 +210,6 @@ cf_test_utilities::impl_test_helpers! {
 			frame_system::Provider::<Test>::created(&account_id).unwrap();
 			<<Test as Chainflip>::AccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_validator(&account_id).unwrap();
 		}
-		// Default to a high capacity factor for the tests.
-		DelegationCapacityFactor::<Test>::put(1000);
 		frame_system::Provider::<Test>::created(&ALICE).unwrap();
 		frame_system::Provider::<Test>::created(&BOB).unwrap();
 		// Account creation is necessary but it emits events. We clear them so that

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1915,16 +1915,33 @@ mod delegation {
 				ValidatorPallet::undelegate(OriginTrait::signed(ALICE), DelegationAmount::Max),
 				Error::<Test>::AccountIsNotDelegating
 			);
-			DelegationChoice::<Test>::insert(ALICE, BOB);
+			assert_ok!(ValidatorPallet::register_as_operator(
+				OriginTrait::signed(BOB),
+				OPERATOR_SETTINGS,
+			));
+			assert_ok!(ValidatorPallet::delegate(
+				OriginTrait::signed(ALICE),
+				BOB,
+				DelegationAmount::Max,
+			));
 			// Undelegate with None (undelegate completely)
 			assert_ok!(ValidatorPallet::undelegate(
 				OriginTrait::signed(ALICE),
-				DelegationAmount::Max
+				DelegationAmount::Max,
 			));
 			assert_eq!(DelegationChoice::<Test>::get(ALICE), None);
 			assert_eq!(MaxDelegationBid::<Test>::get(ALICE), None);
 			assert_event_sequence!(
 				Test,
+				RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
+					delegator: ALICE,
+					max_bid: Some(0),
+				}),
+				RuntimeEvent::ValidatorPallet(Event::Delegated { delegator: ALICE, operator: BOB }),
+				RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
+					delegator: ALICE,
+					max_bid: None,
+				}),
 				RuntimeEvent::ValidatorPallet(Event::Undelegated {
 					delegator: ALICE,
 					operator: BOB

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2151,6 +2151,26 @@ mod delegation {
 			assert_ok!(ValidatorPallet::set_max_bid(OriginTrait::signed(BOB), Some(100)));
 		});
 	}
+
+	#[test]
+	fn set_max_bid_only_delegators() {
+		new_test_ext().execute_with(|| {
+			const DELEGATOR: u64 = 5000;
+
+			// Not delegating -> should fail.
+			assert_noop!(
+				ValidatorPallet::set_max_bid(OriginTrait::signed(DELEGATOR), Some(100)),
+				Error::<Test>::AccountIsNotDelegating
+			);
+
+			// Simulate delegation to an operator (BOB).
+			DelegationChoice::<Test>::insert(DELEGATOR, BOB);
+
+			// Now it should succeed.
+			assert_ok!(ValidatorPallet::set_max_bid(OriginTrait::signed(DELEGATOR), Some(100)));
+			assert_eq!(MaxDelegationBid::<Test>::get(DELEGATOR), Some(100));
+		});
+	}
 }
 
 #[cfg(test)]

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1629,7 +1629,7 @@ mod operator {
 					max_bid: Some(0),
 				}),
 				RuntimeEvent::ValidatorPallet(Event::Delegated { operator: ALICE, delegator: BOB }),
-				RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+				RuntimeEvent::ValidatorPallet(Event::Undelegated {
 					operator: ALICE,
 					delegator: BOB,
 				}),
@@ -1690,7 +1690,7 @@ mod operator {
 					max_bid: Some(0),
 				}),
 				RuntimeEvent::ValidatorPallet(Event::Delegated { operator: ALICE, delegator: BOB }),
-				RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+				RuntimeEvent::ValidatorPallet(Event::Undelegated {
 					operator: ALICE,
 					delegator: BOB,
 				}),
@@ -1925,7 +1925,7 @@ mod delegation {
 			assert_eq!(MaxDelegationBid::<Test>::get(ALICE), None);
 			assert_event_sequence!(
 				Test,
-				RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+				RuntimeEvent::ValidatorPallet(Event::Undelegated {
 					delegator: ALICE,
 					operator: BOB
 				}),
@@ -2363,7 +2363,7 @@ mod delegation {
 				None,
 				"MaxDelegationBid should be None after decrementing to zero"
 			);
-			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
 				operator: BOB,
 			}));
@@ -2397,7 +2397,7 @@ mod delegation {
 			));
 			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), None);
 			assert_eq!(MaxDelegationBid::<Test>::get(DELEGATOR), None);
-			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
 				operator: BOB,
 			}));
@@ -2518,7 +2518,7 @@ mod delegation {
 			// Check that delegation data is cleaned up
 			assert_eq!(MaxDelegationBid::<Test>::get(DELEGATOR), None);
 			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), None);
-			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::UnDelegated {
+			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
 				operator: BOB,
 			}));

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2788,7 +2788,7 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		MockEpochInfo::set_epoch(EPOCH);
 
 		// Create a delegation snapshot
-		let snapshot = DelegationSnapshot::<Test> {
+		DelegationSnapshot::<Test> {
 			operator: OPERATOR,
 			validators: [(VALIDATOR, 1000000u128)].into_iter().collect(),
 			delegators: [(DELEGATOR1, 2000000u128), (DELEGATOR2, 3000000u128)]
@@ -2796,9 +2796,8 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 				.collect(),
 			delegation_fee_bps: 500, // 5% fee
 			capacity_factor: None,
-		};
-
-		snapshot.register_for_epoch(EPOCH);
+		}
+		.register_for_epoch(EPOCH);
 
 		// Distribute rewards to the validator.
 		DelegatedRewardsDistribution::<Test, MockIssuance>::distribute(REWARD_AMOUNT, &VALIDATOR);

--- a/state-chain/pallets/cf-validator/src/weights.rs
+++ b/state-chain/pallets/cf-validator/src/weights.rs
@@ -72,7 +72,6 @@ pub trait WeightInfo {
 	fn deregister_as_operator() -> Weight;
 	fn delegate() -> Weight;
 	fn undelegate() -> Weight;
-	fn set_max_bid() -> Weight;
 }
 
 /// Weights for pallet_cf_validator using the Substrate node and recommended hardware.
@@ -461,9 +460,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 		Weight::from_parts(0, 0)
 	}
 	fn undelegate() -> Weight {
-		Weight::from_parts(0, 0)
-	}
-	fn set_max_bid() -> Weight {
 		Weight::from_parts(0, 0)
 	}
 }
@@ -856,9 +852,6 @@ impl WeightInfo for () {
 		Weight::from_parts(0, 0)
 	}
 	fn undelegate() -> Weight {
-		Weight::from_parts(0, 0)
-	}
-	fn set_max_bid() -> Weight {
 		Weight::from_parts(0, 0)
 	}
 }

--- a/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
+++ b/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
@@ -5,8 +5,10 @@ use frame_support::{
 	traits::UnfilteredDispatchable,
 };
 use pallet_cf_funding::{Call as FundingCall, RedemptionAmount};
-use pallet_cf_validator::{Call as ValidatorCall, DelegationAmount};
+use pallet_cf_validator::Call as ValidatorCall;
 use sp_runtime::traits::Dispatchable;
+
+pub use pallet_cf_validator::DelegationAmount;
 
 #[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Debug)]
 pub enum DelegationApi {

--- a/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
+++ b/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
@@ -1,46 +1,86 @@
 use crate::{chainflip::TypeInfo, Decode, Encode, EthereumAddress, Runtime, RuntimeCall};
+use cf_primitives::FlipBalance;
 use codec::MaxEncodedLen;
 use frame_support::{
 	dispatch::{DispatchInfo, GetDispatchInfo},
 	traits::UnfilteredDispatchable,
+	Deserialize, Serialize,
 };
 use pallet_cf_funding::{Call as FundingCall, RedemptionAmount};
 use pallet_cf_validator::Call as ValidatorCall;
-use sp_runtime::traits::Dispatchable;
+use sp_runtime::{traits::Dispatchable, AccountId32};
 
+// Re-export here because it's need to construct the DelegationApi enum.
 pub use pallet_cf_validator::DelegationAmount;
 
-#[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Debug)]
-pub enum DelegationApi {
+pub struct EthereumAccount(pub EthereumAddress);
+
+impl EthereumAccount {
+	pub fn into_account_id(&self) -> <Runtime as frame_system::Config>::AccountId {
+		let mut data = [0u8; 32];
+		data[12..32].copy_from_slice(&self.0 .0);
+		AccountId32::new(data)
+	}
+}
+
+#[derive(
+	Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Debug, Serialize, Deserialize,
+)]
+pub enum DelegationApi<A> {
 	Delegate {
 		operator: <Runtime as frame_system::Config>::AccountId,
-		increase: DelegationAmount<<Runtime as cf_traits::Chainflip>::Amount>,
+		increase: DelegationAmount<A>,
 	},
 	Undelegate {
-		decrease: DelegationAmount<<Runtime as cf_traits::Chainflip>::Amount>,
+		decrease: DelegationAmount<A>,
 	},
 	Redeem {
-		amount: RedemptionAmount<<Runtime as cf_traits::Chainflip>::Amount>,
+		amount: RedemptionAmount<A>,
 		address: EthereumAddress,
 		executor: Option<EthereumAddress>,
 	},
 }
 
-#[derive(Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Debug)]
-pub enum EthereumSCApi {
-	Delegation(DelegationApi),
+impl<A> DelegationApi<A> {
+	pub fn try_fmap<B, E>(self, f: impl FnOnce(A) -> Result<B, E>) -> Result<DelegationApi<B>, E> {
+		match self {
+			DelegationApi::Delegate { operator, increase } =>
+				Ok(DelegationApi::Delegate { operator, increase: increase.try_fmap(f)? }),
+			DelegationApi::Undelegate { decrease } =>
+				Ok(DelegationApi::Undelegate { decrease: decrease.try_fmap(f)? }),
+			DelegationApi::Redeem { amount, address, executor } =>
+				Ok(DelegationApi::Redeem { amount: amount.try_fmap(f)?, address, executor }),
+		}
+	}
+}
+
+#[derive(
+	Clone, PartialEq, Eq, Encode, Decode, TypeInfo, MaxEncodedLen, Debug, Serialize, Deserialize,
+)]
+#[serde(tag = "API")]
+pub enum EthereumSCApi<A> {
+	Delegation { call: DelegationApi<A> },
 	// reserved for future Apis for example Loan(LoanApi)...
 	// This allows us to update the API without breaking the encoding.
 }
 
-impl UnfilteredDispatchable for EthereumSCApi {
+impl<A> EthereumSCApi<A> {
+	pub fn try_fmap<B, E>(self, f: impl FnOnce(A) -> Result<B, E>) -> Result<EthereumSCApi<B>, E> {
+		match self {
+			EthereumSCApi::Delegation { call } =>
+				Ok(EthereumSCApi::Delegation { call: call.try_fmap(f)? }),
+		}
+	}
+}
+
+impl UnfilteredDispatchable for EthereumSCApi<FlipBalance> {
 	type RuntimeOrigin = <Runtime as frame_system::Config>::RuntimeOrigin;
 	fn dispatch_bypass_filter(
 		self,
 		origin: Self::RuntimeOrigin,
 	) -> frame_support::dispatch::DispatchResultWithPostInfo {
 		match self {
-			EthereumSCApi::Delegation(delegation_api) => match delegation_api {
+			EthereumSCApi::Delegation { call } => match call {
 				DelegationApi::Delegate { operator, increase } =>
 					RuntimeCall::Validator(ValidatorCall::<Runtime>::delegate {
 						operator,
@@ -62,10 +102,10 @@ impl UnfilteredDispatchable for EthereumSCApi {
 	}
 }
 
-impl GetDispatchInfo for EthereumSCApi {
+impl GetDispatchInfo for EthereumSCApi<FlipBalance> {
 	fn get_dispatch_info(&self) -> DispatchInfo {
 		match self {
-			EthereumSCApi::Delegation(delegation_api) => match delegation_api {
+			EthereumSCApi::Delegation { call } => match call {
 				DelegationApi::Delegate { operator, increase } =>
 					RuntimeCall::Validator(ValidatorCall::<Runtime>::delegate {
 						operator: operator.clone(),

--- a/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
+++ b/state-chain/runtime/src/chainflip/ethereum_sc_calls.rs
@@ -41,10 +41,10 @@ impl UnfilteredDispatchable for EthereumSCApi {
 		match self {
 			EthereumSCApi::Delegation(delegation_api) => match delegation_api {
 				DelegationApi::Delegate { operator } =>
-					RuntimeCall::Validator(ValidatorCall::<Runtime>::delegate { operator })
+					RuntimeCall::Validator(ValidatorCall::<Runtime>::delegate { operator, max_bid: None })
 						.dispatch(origin),
 				DelegationApi::Undelegate =>
-					RuntimeCall::Validator(ValidatorCall::<Runtime>::undelegate {}).dispatch(origin),
+					RuntimeCall::Validator(ValidatorCall::<Runtime>::undelegate { decrement: None }).dispatch(origin),
 				DelegationApi::SetMaxBid { maybe_max_bid } =>
 					RuntimeCall::Validator(ValidatorCall::<Runtime>::set_max_bid {
 						max_bid: maybe_max_bid,
@@ -69,10 +69,11 @@ impl GetDispatchInfo for EthereumSCApi {
 				DelegationApi::Delegate { operator } =>
 					RuntimeCall::Validator(ValidatorCall::<Runtime>::delegate {
 						operator: operator.clone(),
+						max_bid: None,
 					})
 					.get_dispatch_info(),
 				DelegationApi::Undelegate {} =>
-					RuntimeCall::Validator(ValidatorCall::<Runtime>::undelegate {})
+					RuntimeCall::Validator(ValidatorCall::<Runtime>::undelegate { decrement: None })
 						.get_dispatch_info(),
 				DelegationApi::SetMaxBid { maybe_max_bid } =>
 					RuntimeCall::Validator(ValidatorCall::<Runtime>::set_max_bid {

--- a/state-chain/runtime/src/chainflip/vault_swaps.rs
+++ b/state-chain/runtime/src/chainflip/vault_swaps.rs
@@ -19,7 +19,7 @@ use crate::{
 		address_derivation::btc::derive_btc_vault_deposit_addresses, AddressConverter,
 		ChainAddressConverter, EvmEnvironment, SolEnvironment,
 	},
-	runtime_apis::{DispatchErrorWithMessage, EvmVaultSwapDetails, VaultSwapDetails},
+	runtime_apis::{DispatchErrorWithMessage, EvmCallDetails, VaultSwapDetails},
 	AccountId, BlockNumber, Environment, Runtime, Swapping,
 };
 
@@ -245,14 +245,14 @@ pub fn evm_vault_swap<A>(
 	}?;
 
 	match source_asset.into() {
-		ForeignChain::Ethereum => Ok(VaultSwapDetails::ethereum(EvmVaultSwapDetails {
+		ForeignChain::Ethereum => Ok(VaultSwapDetails::ethereum(EvmCallDetails {
 			calldata,
 			// Only return `amount` for native currently. 0 for Tokens
 			value: (source_asset == Asset::Eth).then_some(U256::from(amount)).unwrap_or_default(),
 			to: Environment::eth_vault_address(),
 			source_token_address,
 		})),
-		ForeignChain::Arbitrum => Ok(VaultSwapDetails::arbitrum(EvmVaultSwapDetails {
+		ForeignChain::Arbitrum => Ok(VaultSwapDetails::arbitrum(EvmCallDetails {
 			calldata,
 			// Only return `amount` for native currently. 0 for Tokens
 			value: (source_asset == Asset::ArbEth)

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -708,6 +708,7 @@ impl frame_system::Config for Runtime {
 		Reputation,
 		pallet_cf_pools::DeleteHistoricalEarnedFees<Self>,
 		pallet_cf_asset_balances::DeleteAccount<Self>,
+		pallet_cf_validator::DelegatedAccountCleanup<Self>,
 	);
 	/// The data to be stored in an account.
 	type AccountData = ();

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -69,11 +69,11 @@ pub enum VaultSwapDetails<BtcAddress> {
 	},
 	Ethereum {
 		#[serde(flatten)]
-		details: EvmVaultSwapDetails,
+		details: EvmCallDetails,
 	},
 	Arbitrum {
 		#[serde(flatten)]
-		details: EvmVaultSwapDetails,
+		details: EvmCallDetails,
 	},
 	Solana {
 		#[serde(flatten)]
@@ -82,7 +82,7 @@ pub enum VaultSwapDetails<BtcAddress> {
 }
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Serialize, Deserialize)]
-pub struct EvmVaultSwapDetails {
+pub struct EvmCallDetails {
 	/// The encoded calldata payload including function selector.
 	#[serde(with = "sp_core::bytes")]
 	pub calldata: Vec<u8>,
@@ -97,11 +97,11 @@ pub struct EvmVaultSwapDetails {
 }
 
 impl<BtcAddress> VaultSwapDetails<BtcAddress> {
-	pub fn ethereum(details: EvmVaultSwapDetails) -> Self {
+	pub fn ethereum(details: EvmCallDetails) -> Self {
 		VaultSwapDetails::Ethereum { details }
 	}
 
-	pub fn arbitrum(details: EvmVaultSwapDetails) -> Self {
+	pub fn arbitrum(details: EvmCallDetails) -> Self {
 		VaultSwapDetails::Arbitrum { details }
 	}
 
@@ -463,7 +463,7 @@ pub struct NetworkFees {
 //  - Handle the dummy method gracefully in the custom rpc implementation using
 //    runtime_api().api_version().
 decl_runtime_apis!(
-	#[api_version(5)]
+	#[api_version(6)]
 	pub trait CustomRuntimeApi {
 		/// Returns true if the current phase is the auction phase.
 		fn cf_is_auction_phase() -> bool;
@@ -653,6 +653,12 @@ decl_runtime_apis!(
 		fn cf_oracle_prices(
 			base_and_quote_asset: Option<(PriceAsset, PriceAsset)>,
 		) -> Vec<OraclePrice>;
+		fn cf_evm_calldata(
+			caller: EthereumAddress,
+			call: crate::chainflip::ethereum_sc_calls::EthereumSCApi<FlipBalance>,
+		) -> Result<EvmCallDetails, DispatchErrorWithMessage>;
+		#[changed_in(6)]
+		fn cf_evm_calldata();
 	}
 );
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -816,6 +816,27 @@ pub trait AccountRoleRegistry<T: frame_system::Config> {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
+	fn generate_whitelisted_callers(
+		roles: Vec<AccountRole>,
+	) -> Result<Vec<T::AccountId>, DispatchError> {
+		use frame_support::traits::OnNewAccount;
+		roles
+			.into_iter()
+			.enumerate()
+			.map(|(n, role)| {
+				let caller =
+					frame_benchmarking::account::<T::AccountId>("whitelisted_caller", n as u32, 0);
+				if frame_system::Pallet::<T>::providers(&caller) == 0u32 {
+					frame_system::Pallet::<T>::inc_providers(&caller);
+				}
+				<T as frame_system::Config>::OnNewAccount::on_new_account(&caller);
+				Self::register_account_role(&caller, role)?;
+				Ok(caller)
+			})
+			.collect::<Result<Vec<_>, DispatchError>>()
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
 	fn generate_whitelisted_callers_with_role(
 		role: AccountRole,
 		num: u32,


### PR DESCRIPTION
Fixes: PRO-2461

- `set_max_bid` didn't check that the account was delegating.
- added a test
- added `OnKilledAccount` implementation to ensure cleanup

ALSO: 

Changed the API: delegate and undelegate now take increase/decrease to update the max bid. 
Setting the max bid directly is no longer supported. 