### PR TITLE
fix: better try-runtime logging in upgrade test

### DIFF
--- a/bouncer/commands/try_runtime_upgrade.ts
+++ b/bouncer/commands/try_runtime_upgrade.ts
@@ -59,11 +59,11 @@ async function main(): Promise<void> {
       block,
       path.dirname(process.cwd()),
       endpoint,
-      args.lastN,
+      args['last-n'],
     );
   } else {
     console.log('Try runtime using runtime at ' + args.runtime);
-    await tryRuntimeUpgrade(block, endpoint, args.runtime, args.lastN);
+    await tryRuntimeUpgrade(block, endpoint, args.runtime, args['last-n']);
   }
 }
 

--- a/bouncer/shared/try_runtime_upgrade.ts
+++ b/bouncer/shared/try_runtime_upgrade.ts
@@ -17,9 +17,10 @@ async function createSnapshotFile(networkUrl: string, blockHash: string): Promis
   logger.info('Writing snapshot to: ', snapshotOutputPath);
 
   return execWithRustLog(
-    `try-runtime create-snapshot ${blockParam} --uri ${networkUrl} ${snapshotOutputPath}`,
+    `try-runtime`,
+    `create-snapshot ${blockParam} --uri ${networkUrl} ${snapshotOutputPath}`.split(' '),
     `create-snapshot-${blockHash}`,
-    'runtime::executive=debug',
+    'info,runtime::executive=debug',
   );
 }
 
@@ -31,14 +32,15 @@ async function tryRuntimeCommand(
   const blockParam = blockHash === 'latest' ? 'live' : `live --at ${blockHash}`;
 
   const success = await execWithRustLog(
-    `try-runtime \
-        --runtime ${runtimePath} on-runtime-upgrade \
-        --blocktime 6000 \
-        --disable-spec-version-check \
-        --checks all ${blockParam} \
-        --uri ${networkUrl}`,
+    `try-runtime`,
+    `\
+--runtime ${runtimePath} on-runtime-upgrade \
+--blocktime 6000 \
+--disable-spec-version-check \
+--checks all ${blockParam} \
+--uri ${networkUrl}`.split(' '),
     `try-runtime-${blockHash}`,
-    'runtime::executive=debug',
+    'info,runtime::executive=debug',
   );
   if (!success) {
     await createSnapshotFile(networkUrl, blockHash);

--- a/bouncer/shared/upgrade_network.ts
+++ b/bouncer/shared/upgrade_network.ts
@@ -66,16 +66,22 @@ async function startBrokerAndLpApi(localnetInitPath: string, binaryPath: string,
   logger.info('Starting new broker and lp-api.');
 
   await execWithLog(
-    `${localnetInitPath}/scripts/start-broker-api.sh ${binaryPath}`,
+    `${localnetInitPath}/scripts/start-broker-api.sh`,
+    [`${binaryPath}`],
     'start-broker-api',
     {
       KEYS_DIR: keysDir,
     },
   );
 
-  await execWithLog(`${localnetInitPath}/scripts/start-lp-api.sh ${binaryPath}`, 'start-lp-api', {
-    KEYS_DIR: keysDir,
-  });
+  await execWithLog(
+    `${localnetInitPath}/scripts/start-lp-api.sh`,
+    [`${binaryPath}`],
+    'start-lp-api',
+    {
+      KEYS_DIR: keysDir,
+    },
+  );
 
   await sleep(10000);
 
@@ -98,6 +104,7 @@ async function startDepositMonitor(localnetInitPath: string) {
 
   await execWithLog(
     `${localnetInitPath}/scripts/start-deposit-monitor.sh`,
+    [],
     'start-deposit-monitor',
     {
       LOCALNET_INIT_DIR: `${localnetInitPath}`,
@@ -122,7 +129,7 @@ async function compatibleUpgrade(
 
   const { SELECTED_NODES, nodeCount } = await getNodesInfo(numberOfNodes);
 
-  await execWithLog(`${localnetInitPath}/scripts/start-all-nodes.sh`, 'start-all-nodes', {
+  await execWithLog(`${localnetInitPath}/scripts/start-all-nodes.sh`, [], 'start-all-nodes', {
     INIT_RPC_PORT: `9944`,
     KEYS_DIR,
     NODE_COUNT: nodeCount,
@@ -137,6 +144,7 @@ async function compatibleUpgrade(
   // engines crashed when node shutdown, so restart them.
   await execWithLog(
     `${localnetInitPath}/scripts/start-all-engines.sh`,
+    [],
     'start-all-engines-post-upgrade',
     {
       INIT_RUN: 'false',
@@ -202,7 +210,7 @@ async function incompatibleUpgradeNoBuild(
   const KEYS_DIR = `${localnetInitPath}/keys`;
 
   const { SELECTED_NODES, nodeCount } = await getNodesInfo(numberOfNodes);
-  await execWithLog(`${localnetInitPath}/scripts/start-all-nodes.sh`, 'start-all-nodes', {
+  await execWithLog(`${localnetInitPath}/scripts/start-all-nodes.sh`, [], 'start-all-nodes', {
     INIT_RPC_PORT: `9944`,
     KEYS_DIR,
     NODE_COUNT: nodeCount,
@@ -231,6 +239,7 @@ async function incompatibleUpgradeNoBuild(
   // Restart the engines
   await execWithLog(
     `${localnetInitPath}/scripts/start-all-engines.sh`,
+    [],
     'start-all-engines-post-upgrade',
     {
       INIT_RUN: 'false',

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -1292,6 +1292,7 @@ export async function startEngines(
   const { SELECTED_NODES, nodeCount } = await getNodesInfo(numberOfNodes);
   await execWithLog(
     `${localnetInitPath}/scripts/start-all-engines.sh`,
+    [],
     'start-all-engines-pre-upgrade',
     {
       INIT_RUN: 'false',


### PR DESCRIPTION
This improves the try-runtime command:
 - refactor: use `spawn` instead of `execAsync`. This lets us print the stdout and err while the upgrade test is running. Note, this requires us to pass the CLI-arguments as a `string[]`, instead of as a concatenated `string`, as we did until now.
 - fix: add `info` to rust loglevel. This makes `try-runtime` actually print the relevant logs.
