### PR TITLE
feat: iteratively run auction to optimize operator bids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8564,7 +8564,7 @@ dependencies = [
  "pallet-cf-reputation",
  "pallet-session",
  "parity-scale-codec",
- "proptest 1.6.0",
+ "proptest",
  "proptest-derive",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8566,6 +8566,8 @@ dependencies = [
  "parity-scale-codec",
  "proptest 1.6.0",
  "proptest-derive",
+ "quickcheck",
+ "quickcheck_macros",
  "scale-info",
  "serde",
  "sp-application-crypto 38.0.0",

--- a/engine/src/witness/eth/sc_utils.rs
+++ b/engine/src/witness/eth/sc_utils.rs
@@ -198,7 +198,7 @@ mod tests {
 		let sc_call_delegate = EthereumSCApi::<FlipBalance>::Delegation {
 			call: DelegationApi::Delegate {
 				operator: AccountId32::new([0xF4; 32]),
-				increase: DelegationAmount::Max,
+				increase: DelegationAmount::<FlipBalance>::Max,
 			},
 		}
 		.encode();

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -222,7 +222,6 @@ impl ExtBuilder {
 					max_size: self.max_authorities,
 					max_expansion: self.max_authorities,
 				},
-				auction_bid_cutoff_percentage: Percent::from_percent(0),
 				max_authority_set_contraction_percentage: DEFAULT_MAX_AUTHORITY_SET_CONTRACTION,
 			},
 			ethereum_vault: EthereumVaultConfig {

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -472,7 +472,6 @@ pub fn inner_cf_development_config(
 			devnet::ETHEREUM_SAFETY_MARGIN,
 			devnet::ARBITRUM_SAFETY_MARGIN,
 			devnet::SOLANA_SAFETY_MARGIN,
-			devnet::AUCTION_BID_CUTOFF_PERCENTAGE,
 			SolanaElectionsConfig {
 				option_initial_state: Some(solana_elections::initial_state(
 					sol_vault_program,
@@ -664,7 +663,6 @@ macro_rules! network_spec {
 						ETHEREUM_SAFETY_MARGIN,
 						ARBITRUM_SAFETY_MARGIN,
 						SOLANA_SAFETY_MARGIN,
-						AUCTION_BID_CUTOFF_PERCENTAGE,
 						SolanaElectionsConfig {
 							option_initial_state: Some(solana_elections::initial_state(
 								sol_vault_program,
@@ -733,7 +731,6 @@ fn testnet_genesis(
 	ethereum_safety_margin: u64,
 	arbitrum_safety_margin: u64,
 	solana_safety_margin: u64,
-	auction_bid_cutoff_percentage: Percent,
 	solana_elections: state_chain_runtime::SolanaElectionsConfig,
 	bitcoin_elections: state_chain_runtime::BitcoinElectionsConfig,
 	generic_elections: state_chain_runtime::GenericElectionsConfig,
@@ -828,7 +825,6 @@ fn testnet_genesis(
 				.expect("At least one authority is required"),
 			authority_set_min_size: min_authorities,
 			auction_parameters,
-			auction_bid_cutoff_percentage,
 			max_authority_set_contraction_percentage,
 		},
 		session: state_chain_runtime::SessionConfig {

--- a/state-chain/node/src/chain_spec/common.rs
+++ b/state-chain/node/src/chain_spec/common.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cf_primitives::AuthorityCount;
-use sp_runtime::{Percent, Permill};
+use sp_runtime::Permill;
 pub use state_chain_runtime::constants::common::*;
 use state_chain_runtime::{chainflip::Offence, BlockNumber, FlipBalance, SetSizeParameters};
 
@@ -99,7 +99,5 @@ pub const REDEMPTION_TTL_SECS: u64 = 2 * 3600;
 
 /// Determines the expiry duration for governance proposals.
 pub const EXPIRY_SPAN_IN_SECONDS: u64 = 24 * 3600;
-
-pub const AUCTION_BID_CUTOFF_PERCENTAGE: Percent = Percent::from_percent(10);
 
 pub const SHARED_DATA_REFERENCE_LIFETIME: u32 = 8;

--- a/state-chain/pallets/cf-validator/Cargo.toml
+++ b/state-chain/pallets/cf-validator/Cargo.toml
@@ -48,6 +48,9 @@ sp-runtime = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
 lazy_static = { workspace = true }
 cf-traits = { workspace = true, features = ["mocks"] }
+# Note: we should agree on one property testing framework...
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
 proptest = { version = "1.6" }
 proptest-derive = { version = "0.5.1" }
 

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -112,8 +112,6 @@ pub fn try_start_keygen<T: RuntimeConfig>(
 
 	Pallet::<T>::try_start_keygen(RotationState::from_auction_outcome::<T>(AuctionOutcome {
 		winners: bidder_set::<T, ValidatorIdOf<T>, _>(primary_candidates, epoch).collect(),
-		losers: bidder_set::<T, ValidatorIdOf<T>, _>(secondary_candidates, epoch + LARGE_OFFSET)
-			.collect(),
 		bond: 100u32.into(),
 	}));
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1516,7 +1516,9 @@ impl<T: Config> Pallet<T> {
 			.collect::<BTreeMap<_, _>>();
 
 		for outgoing_delegator in outgoing_delegators {
-			if !new_delegator_bids.contains_key(&outgoing_delegator) {
+			if !new_delegator_bids.contains_key(&outgoing_delegator) &&
+				!new_authorities.contains(ValidatorIdOf::<T>::from_ref(&outgoing_delegator))
+			{
 				T::Bonder::update_bond(&outgoing_delegator.clone().into(), T::Amount::from(0_u128));
 				Self::deposit_event(Event::UnDelegationFinalized {
 					delegator: outgoing_delegator.clone(),

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -17,6 +17,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 #![doc = include_str!("../../cf-doc-head.md")]
+#![feature(extract_if)]
 
 mod mock;
 mod tests;

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1618,17 +1618,16 @@ impl<T: Config> Pallet<T> {
 		.map(|(auction_outcome, resolver)| {
 			let mut current_outcome = auction_outcome;
 			loop {
+				let old_snapshots = delegation_snapshots.clone();
 				for (_operator, snapshot) in delegation_snapshots.iter_mut() {
 					snapshot.maybe_optimize_bid(&current_outcome);
 				}
-				if let Ok(new_outcome) =
+				if delegation_snapshots == old_snapshots {
+					break;
+				} else if let Ok(new_outcome) =
 					resolver.resolve_auction(auction_bids(&delegation_snapshots))
 				{
-					if new_outcome == current_outcome {
-						break;
-					} else {
-						current_outcome = new_outcome;
-					}
+					current_outcome = new_outcome;
 				} else {
 					break;
 				}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1642,9 +1642,7 @@ impl<T: Config> Pallet<T> {
 			let mut current_outcome = auction_outcome;
 			loop {
 				for (_operator, snapshot) in delegation_snapshots.iter_mut() {
-					if snapshot.avg_bid() < current_outcome.bond {
-						snapshot.optimize_bid(current_outcome.bond);
-					}
+					snapshot.maybe_optimize_bid(&current_outcome);
 				}
 				if let Ok(new_outcome) = resolver.resolve_auction(
 					auction_bids(&delegation_snapshots),

--- a/state-chain/pallets/cf-validator/src/migrations/remove_backups.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/remove_backups.rs
@@ -30,6 +30,8 @@ mod old {
 	pub type Backups<T: Config> = StorageValue<Pallet<T>, ()>;
 	#[frame_support::storage_alias]
 	pub type BackupRewardNodePercentage<T: Config> = StorageValue<Pallet<T>, ()>;
+	#[frame_support::storage_alias]
+	pub type AuctionBidCutoffPercentage<T: Config> = StorageValue<Pallet<T>, ()>;
 }
 
 impl<T> UncheckedOnRuntimeUpgrade for Migration<T>
@@ -40,12 +42,14 @@ where
 	fn pre_upgrade() -> Result<Vec<u8>, frame_support::pallet_prelude::DispatchError> {
 		assert!(old::Backups::<T>::exists());
 		assert!(old::BackupRewardNodePercentage::<T>::exists());
+		assert!(old::AuctionBidCutoffPercentage::<T>::exists());
 		Ok(Default::default())
 	}
 
 	fn on_runtime_upgrade() -> frame_support::pallet_prelude::Weight {
 		old::Backups::<T>::kill();
 		old::BackupRewardNodePercentage::<T>::kill();
+		old::AuctionBidCutoffPercentage::<T>::kill();
 		Default::default()
 	}
 
@@ -53,6 +57,7 @@ where
 	fn post_upgrade(_: Vec<u8>) -> Result<(), frame_support::pallet_prelude::DispatchError> {
 		assert!(!old::Backups::<T>::exists());
 		assert!(!old::BackupRewardNodePercentage::<T>::exists());
+		assert!(!old::AuctionBidCutoffPercentage::<T>::exists());
 		Ok(())
 	}
 }

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -95,6 +95,13 @@ pub const LOSING_BIDS: [Bid<ValidatorId, FlipBalance>; 3] = [
 	Bid { bidder_id: 6, amount: 90 },
 	Bid { bidder_id: 7, amount: 74 },
 ];
+
+pub const OPERATOR_1_BIDS: [Bid<ValidatorId, FlipBalance>; 2] =
+	[Bid { bidder_id: 9, amount: 90 }, Bid { bidder_id: 10, amount: 95 }];
+
+pub const OPERATOR_2_BIDS: [Bid<ValidatorId, FlipBalance>; 2] =
+	[Bid { bidder_id: 11, amount: 50 }, Bid { bidder_id: 12, amount: 45 }];
+
 pub const UNQUALIFIED_BID: Bid<ValidatorId, FlipBalance> = Bid { bidder_id: 8, amount: 200 };
 
 pub const EXPECTED_BOND: Amount = WINNING_BIDS[WINNING_BIDS.len() - 1].amount;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -200,7 +200,6 @@ cf_test_utilities::impl_test_helpers! {
 				max_size: MAX_AUTHORITY_SIZE,
 				max_expansion: MAX_AUTHORITY_SET_EXPANSION,
 			},
-			auction_bid_cutoff_percentage: Percent::from_percent(0),
 			max_authority_set_contraction_percentage: DEFAULT_MAX_AUTHORITY_SET_CONTRACTION,
 		},
 	},

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -96,12 +96,6 @@ pub const LOSING_BIDS: [Bid<ValidatorId, FlipBalance>; 3] = [
 	Bid { bidder_id: 7, amount: 74 },
 ];
 
-pub const OPERATOR_1_BIDS: [Bid<ValidatorId, FlipBalance>; 2] =
-	[Bid { bidder_id: 9, amount: 90 }, Bid { bidder_id: 10, amount: 95 }];
-
-pub const OPERATOR_2_BIDS: [Bid<ValidatorId, FlipBalance>; 2] =
-	[Bid { bidder_id: 11, amount: 50 }, Bid { bidder_id: 12, amount: 45 }];
-
 pub const UNQUALIFIED_BID: Bid<ValidatorId, FlipBalance> = Bid { bidder_id: 8, amount: 200 };
 
 pub const EXPECTED_BOND: Amount = WINNING_BIDS[WINNING_BIDS.len() - 1].amount;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -95,7 +95,6 @@ pub const LOSING_BIDS: [Bid<ValidatorId, FlipBalance>; 3] = [
 	Bid { bidder_id: 6, amount: 90 },
 	Bid { bidder_id: 7, amount: 74 },
 ];
-
 pub const UNQUALIFIED_BID: Bid<ValidatorId, FlipBalance> = Bid { bidder_id: 8, amount: 200 };
 
 pub const EXPECTED_BOND: Amount = WINNING_BIDS[WINNING_BIDS.len() - 1].amount;

--- a/state-chain/pallets/cf-validator/src/rotation_state.rs
+++ b/state-chain/pallets/cf-validator/src/rotation_state.rs
@@ -20,8 +20,8 @@ use sp_std::collections::btree_set::BTreeSet;
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Default)]
 pub struct RotationState<Id, Amount> {
-	primary_candidates: Vec<Id>,
-	secondary_candidates: Vec<Id>,
+	pub primary_candidates: Vec<Id>,
+	pub secondary_candidates: Vec<Id>,
 	pub banned: BTreeSet<Id>,
 	pub bond: Amount,
 	pub new_epoch_index: EpochIndex,

--- a/state-chain/pallets/cf-validator/src/rotation_state.rs
+++ b/state-chain/pallets/cf-validator/src/rotation_state.rs
@@ -21,7 +21,6 @@ use sp_std::collections::btree_set::BTreeSet;
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Default)]
 pub struct RotationState<Id, Amount> {
 	pub primary_candidates: Vec<Id>,
-	pub secondary_candidates: Vec<Id>,
 	pub banned: BTreeSet<Id>,
 	pub bond: Amount,
 	pub new_epoch_index: EpochIndex,
@@ -29,11 +28,10 @@ pub struct RotationState<Id, Amount> {
 
 impl<Id: Ord + Clone, Amount: AtLeast32BitUnsigned + Copy> RotationState<Id, Amount> {
 	pub fn from_auction_outcome<T: Config>(
-		AuctionOutcome { winners, losers, bond }: AuctionOutcome<Id, Amount>,
+		AuctionOutcome { winners, bond, .. }: AuctionOutcome<Id, Amount>,
 	) -> Self {
 		RotationState {
 			primary_candidates: winners,
-			secondary_candidates: losers,
 			banned: Default::default(),
 			bond,
 			new_epoch_index: T::EpochInfo::epoch_index() + 1,
@@ -49,9 +47,7 @@ impl<Id: Ord + Clone, Amount: AtLeast32BitUnsigned + Copy> RotationState<Id, Amo
 	pub fn authority_candidates(&self) -> BTreeSet<Id> {
 		self.primary_candidates
 			.iter()
-			.chain(&self.secondary_candidates)
 			.filter(|id| !self.banned.contains(id))
-			.take(self.primary_candidates.len())
 			.cloned()
 			.collect()
 	}
@@ -81,7 +77,6 @@ mod rotation_state_tests {
 	fn banning_is_additive() {
 		let mut rotation_state = RotationState::<Id, Amount> {
 			primary_candidates: (0..10).collect(),
-			secondary_candidates: (20..30).collect(),
 			banned: Default::default(),
 			bond: 500,
 			new_epoch_index: 2,
@@ -103,7 +98,6 @@ mod rotation_state_tests {
 	fn authority_candidates_prefers_primaries_and_excludes_banned() {
 		let rotation_state = RotationState::<Id, Amount> {
 			primary_candidates: (0..10).collect(),
-			secondary_candidates: (20..30).collect(),
 			banned: BTreeSet::from([1, 2, 4]),
 			bond: 500,
 			new_epoch_index: 2,
@@ -111,6 +105,6 @@ mod rotation_state_tests {
 
 		let candidates = rotation_state.authority_candidates();
 
-		assert_eq!(candidates, BTreeSet::from([0, 3, 5, 6, 7, 8, 9, 20, 21, 22]));
+		assert_eq!(candidates, BTreeSet::from([0, 3, 5, 6, 7, 8, 9]));
 	}
 }

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2548,6 +2548,7 @@ mod delegation {
 	}
 }
 
+#[cfg(test)]
 pub mod auction_optimization {
 
 	use cf_primitives::FlipBalance;
@@ -2621,19 +2622,23 @@ pub mod auction_optimization {
 	#[test]
 	fn test_auction_optimization() {
 		let operator_bids_combinations = create_operator_bids_combinations(vec![
-			(vec![150, 140], vec![130, 100], vec![100, 101, 102, 0], 120), /* both validators
-			                                                                * from op 1 make it,
-			                                                                * only one from op 2 */
-			(vec![80, 90], vec![60, 70], vec![101, 103, 0, 1], 120), /* both ops combine into 1
-			                                                          * val to make it */
-			(vec![90, 95], vec![50, 45], vec![101, 0, 1, 2], 110), /* op 1 converts bid to one
-			                                                        * val to make it, op 2 can't
-			                                                        * make it even if he
-			                                                        * combines into 1 */
-			(vec![90, 95], vec![50, 45, 30], vec![101, 102, 0, 1], 120), /* op 2 can now combine
-			                                                              * 3 vals into 1 to
-			                                                              * make it into the set */
-			(vec![90, 95], vec![80, 90, 95], vec![101, 103, 104, 0], 120), // op 2 combines into 2
+			// both validators from op 1 make it, only one from op 2
+			(vec![150, 140], vec![130, 100], vec![100, 101, 102, 0], 120),
+			// both ops combine into 1 val to make it
+			(vec![80, 90], vec![60, 70], vec![101, 103, 0, 1], 120),
+			// op 1 converts bid to one val to make it, op 2 can't make it even if he combines into
+			// 1
+			(vec![90, 95], vec![50, 45], vec![101, 0, 1, 2], 110),
+			// both consolidate their vals when they have nodes at the boundary of cutoff such that
+			// some vaop 2 can now combine 3 vals into 1 to make it into the setls make it and some
+			// dont. We still consolidate the bids to increase the number of vals in the set
+			(vec![90, 95], vec![50, 45, 30], vec![101, 102, 0, 1], 120),
+			// op 2 combines into 2
+			(vec![90, 95], vec![80, 90, 95], vec![101, 103, 104, 0], 120),
+			// both consolidate their vals when they have nodes at the boundary of cutoff such that
+			// some vals make it and some dont. We still consolidate the bids to increase the
+			// number of vals in the set
+			(vec![220, 205, 200], vec![150, 140, 130], vec![100, 101, 103, 104], 210),
 		]);
 
 		for (op_1_bids, op_2_bids, expected_primary_candidates, expected_bond) in

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -850,7 +850,6 @@ fn failed_keygen_with_offenders(offenders: impl IntoIterator<Item = u64>) {
 	CurrentRotationPhase::<Test>::put(RotationPhase::KeygensInProgress(
 		RuntimeRotationState::<Test>::from_auction_outcome::<Test>(AuctionOutcome {
 			winners: CANDIDATES.collect(),
-			losers: Default::default(),
 			bond: Default::default(),
 		}),
 	));
@@ -921,7 +920,6 @@ mod key_handover {
 		CurrentRotationPhase::<Test>::put(RotationPhase::KeygensInProgress(
 			RuntimeRotationState::<Test>::from_auction_outcome::<Test>(AuctionOutcome {
 				winners: CANDIDATES.collect(),
-				losers: Default::default(),
 				bond: Default::default(),
 			}),
 		));
@@ -1464,7 +1462,6 @@ fn validator_set_change_propagates_to_session_pallet() {
 			CurrentRotationPhase::put(RotationPhase::<Test>::NewKeysActivated(
 				RuntimeRotationState::<Test>::from_auction_outcome::<Test>(AuctionOutcome {
 					winners: WINNING_BIDS.map(|bidder| bidder.bidder_id).to_vec(),
-					losers: vec![],
 					bond: EXPECTED_BOND,
 				}),
 			));
@@ -1478,7 +1475,6 @@ fn validator_set_change_propagates_to_session_pallet() {
 #[test]
 fn can_update_all_config_items() {
 	new_test_ext().execute_with(|| {
-		const NEW_AUCTION_BID_CUTOFF_PERCENTAGE: Percent = Percent::from_percent(10);
 		const NEW_REDEMPTION_PERIOD_AS_PERCENTAGE: Percent = Percent::from_percent(10);
 		const NEW_REGISTRATION_BOND_PERCENTAGE: Percent = Percent::from_percent(10);
 		const NEW_AUTHORITY_SET_MIN_SIZE: u32 = 0;
@@ -1490,7 +1486,6 @@ fn can_update_all_config_items() {
 		const NEW_DELEGATION_CAPACITY_FACTOR: Option<u32> = Some(5);
 
 		// Check that the default values are different from the new ones
-		assert_ne!(AuctionBidCutoffPercentage::<Test>::get(), NEW_AUCTION_BID_CUTOFF_PERCENTAGE);
 		assert_ne!(
 			RedemptionPeriodAsPercentage::<Test>::get(),
 			NEW_REDEMPTION_PERIOD_AS_PERCENTAGE
@@ -1508,9 +1503,6 @@ fn can_update_all_config_items() {
 
 		// Update all config items
 		let updates = vec![
-			PalletConfigUpdate::AuctionBidCutoffPercentage {
-				percentage: NEW_AUCTION_BID_CUTOFF_PERCENTAGE,
-			},
 			PalletConfigUpdate::RedemptionPeriodAsPercentage {
 				percentage: NEW_REDEMPTION_PERIOD_AS_PERCENTAGE,
 			},
@@ -1537,7 +1529,6 @@ fn can_update_all_config_items() {
 		}
 
 		// Check that the new values were set
-		assert_eq!(AuctionBidCutoffPercentage::<Test>::get(), NEW_AUCTION_BID_CUTOFF_PERCENTAGE);
 		assert_eq!(
 			RedemptionPeriodAsPercentage::<Test>::get(),
 			NEW_REDEMPTION_PERIOD_AS_PERCENTAGE
@@ -1557,8 +1548,8 @@ fn can_update_all_config_items() {
 		assert_noop!(
 			ValidatorPallet::update_pallet_config(
 				OriginTrait::signed(ALICE),
-				PalletConfigUpdate::AuctionBidCutoffPercentage {
-					percentage: NEW_AUCTION_BID_CUTOFF_PERCENTAGE,
+				PalletConfigUpdate::DelegationCapacityFactor {
+					factor: NEW_DELEGATION_CAPACITY_FACTOR
 				}
 			),
 			sp_runtime::traits::BadOrigin
@@ -2655,7 +2646,6 @@ pub mod auction_optimization {
 					new_phase:
 						RotationPhase::KeygensInProgress(RotationState {
 							primary_candidates,
-							secondary_candidates: _,
 							banned: _,
 							bond,
 							new_epoch_index: _,
@@ -2752,7 +2742,6 @@ pub mod auction_optimization {
 						new_phase:
 							RotationPhase::KeygensInProgress(RotationState {
 								primary_candidates: _,
-								secondary_candidates: _,
 								banned: _,
 								bond,
 								new_epoch_index: _,

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2622,9 +2622,8 @@ pub mod auction_optimization {
 			// op 1 converts bid to one val to make it, op 2 can't make it even if he combines into
 			// 1
 			(vec![90, 95], vec![50, 45], vec![101, 0, 1, 2], 110),
-			// both consolidate their vals when they have nodes at the boundary of cutoff such that
-			// some vaop 2 can now combine 3 vals into 1 to make it into the setls make it and some
-			// dont. We still consolidate the bids to increase the number of vals in the set
+			// op 2 can now make it by combining 3 vals into 1 to make it and op 1 combines 2 into
+			// 1.
 			(vec![90, 95], vec![50, 45, 30], vec![101, 102, 0, 1], 120),
 			// op 2 combines into 2
 			(vec![90, 95], vec![80, 90, 95], vec![101, 103, 104, 0], 120),
@@ -2748,6 +2747,21 @@ pub mod auction_optimization {
 							}),
 					}) = last_event::<Test>()
 					{
+						let future_epoch = CurrentEpoch::<Test>::get() + 1;
+						for snapshot in
+							DelegationSnapshots::<Test>::iter_prefix_values(future_epoch)
+						{
+							snapshot.validators.iter().for_each(|(val, _)| {
+								assert_eq!(
+									ValidatorToOperator::<Test>::get(future_epoch, val).unwrap(),
+									snapshot.operator
+								);
+								assert_eq!(
+									ManagedValidators::<Test>::get(val).unwrap(),
+									snapshot.operator
+								)
+							})
+						}
 						bond < single_auction_outcome.bond
 					} else {
 						true

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2680,7 +2680,7 @@ pub mod auction_optimization {
 							operator: OP_1,
 							validators: op_1_bids
 								.extract_if(.., |Bid { bidder_id, amount: _ }| {
-									expected_primary_candidates.contains(&bidder_id) ||
+									expected_primary_candidates.contains(bidder_id) ||
 										*bidder_id == max_op1_bidder
 								})
 								.map(|Bid { bidder_id, amount }| (bidder_id, amount))
@@ -2701,7 +2701,7 @@ pub mod auction_optimization {
 							operator: OP_2,
 							validators: op_2_bids
 								.extract_if(.., |Bid { bidder_id, amount: _ }| {
-									expected_primary_candidates.contains(&bidder_id) ||
+									expected_primary_candidates.contains(bidder_id) ||
 										*bidder_id == max_op2_bidder
 								})
 								.map(|Bid { bidder_id, amount }| (bidder_id, amount))

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1799,7 +1799,6 @@ impl_runtime_apis! {
 			.and_then(|resolver| {
 				resolver.resolve_auction(
 					Validator::get_qualified_bidders::<<Runtime as pallet_cf_validator::Config>::KeygenQualification>(),
-					Validator::auction_bid_cutoff_percentage(),
 				)
 			})
 			.ok()
@@ -2977,7 +2976,6 @@ impl_runtime_apis! {
 			.and_then(|resolver| {
 				resolver.resolve_auction(
 					Validator::get_qualified_bidders::<<Runtime as pallet_cf_validator::Config>::KeygenQualification>(),
-					Validator::auction_bid_cutoff_percentage(),
 				)
 			})
 			.ok()


### PR DESCRIPTION
# Pull Request

Closes: PRO-2440

## Checklist

Please conduct a thorough self-review before opening the PR.

- [ ] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

optimizes the operator bids automatically during the auction so that operators can make the set by increasing their average bid by converting one of their validator nodes to a delegator thereby reducing the number of validators and increasing the average bid.
