### PR TITLE
feat: oracle swap refund params validation

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -999,7 +999,10 @@ pub trait CustomApi {
 	#[method(name = "validate_refund_params")]
 	fn cf_validate_refund_params(
 		&self,
+		input_asset: Asset,
+		output_asset: Asset,
 		retry_duration: BlockNumber,
+		max_oracle_price_slippage: Option<BasisPoints>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<()>;
 
@@ -1373,7 +1376,12 @@ where
 			liquidity: Liquidity,
 		) -> PoolPairsMap<AmmAmount>,
 		cf_validate_dca_params(number_of_chunks: u32, chunk_interval: u32) -> (),
-		cf_validate_refund_params(retry_duration: BlockNumber) -> (),
+		cf_validate_refund_params(
+			input_asset: Asset,
+			output_asset: Asset,
+			retry_duration: BlockNumber,
+			max_oracle_price_slippage: Option<BasisPoints>,
+		) -> (),
 	}
 
 	fn cf_current_compatibility_version(&self) -> RpcResult<SemVer> {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2728,6 +2728,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		vault_deposit_witness: VaultDepositWitness<T, I>,
 	) -> Result<ValidatedVaultSwapParams<T::AccountId>, RefundReason> {
 		let VaultDepositWitness {
+			input_asset: source_asset,
 			output_asset: destination_asset,
 			destination_address,
 			deposit_metadata,
@@ -2772,8 +2773,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			(None, None)
 		};
 
-		T::SwapParameterValidation::validate_refund_params(refund_params.retry_duration)
-			.map_err(|_| RefundReason::InvalidRefundParameters)?;
+		T::SwapParameterValidation::validate_refund_params(
+			source_asset.into(),
+			destination_asset,
+			refund_params.retry_duration,
+			refund_params.max_oracle_price_slippage,
+		)
+		.map_err(|_| RefundReason::InvalidRefundParameters)?;
 
 		if let Some(params) = &dca_params {
 			if T::SwapParameterValidation::validate_dca_params(params).is_err() {
@@ -3345,7 +3351,12 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 		(ChannelId, ForeignChainAddress, <T::TargetChain as Chain>::ChainBlockNumber, Self::Amount),
 		DispatchError,
 	> {
-		T::SwapParameterValidation::validate_refund_params(refund_params.retry_duration)?;
+		T::SwapParameterValidation::validate_refund_params(
+			source_asset.into(),
+			destination_asset,
+			refund_params.retry_duration,
+			refund_params.max_oracle_price_slippage,
+		)?;
 
 		if let Some(params) = &dca_params {
 			T::SwapParameterValidation::validate_dca_params(params)?;

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2796,7 +2796,7 @@ impl<T: Config> SwapParameterValidation for Pallet<T> {
 			return Err(DispatchError::from(Error::<T>::RetryDurationTooHigh));
 		}
 
-		// Check that the oracle price's are available for the assets.
+		// Check that the oracle prices are available for the assets.
 		if let Some(_max_oracle_price_slippage) = max_oracle_price_slippage {
 			if T::PriceFeedApi::get_price(input_asset).is_none() ||
 				T::PriceFeedApi::get_price(output_asset).is_none()

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -123,7 +123,7 @@ pub type BroadcastId = u32;
 /// This is the ratio of equivalently valued amounts of asset One and asset Zero.
 ///
 /// The price is always measured in amount of asset One per unit of asset Zero. Therefore as asset
-/// zero becomes more valuable relative to asset one the price's literal value goes up, and vice
+/// zero becomes more valuable relative to asset one the prices literal value goes up, and vice
 /// versa. This ratio is represented as a fixed point number with `PRICE_FRACTIONAL_BITS` fractional
 /// bits.
 pub type Price = U256;

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -600,7 +600,10 @@ decl_runtime_apis!(
 			chunk_interval: u32,
 		) -> Result<(), DispatchErrorWithMessage>;
 		fn cf_validate_refund_params(
+			input_asset: Asset,
+			output_asset: Asset,
 			retry_duration: BlockNumber,
+			max_oracle_price_slippage: Option<BasisPoints>,
 		) -> Result<(), DispatchErrorWithMessage>;
 		fn cf_request_swap_parameter_encoding(
 			broker: AccountId32,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1054,7 +1054,12 @@ pub trait SwapParameterValidation {
 
 	fn get_swap_limits() -> SwapLimits;
 	fn validate_dca_params(dca_params: &DcaParameters) -> Result<(), DispatchError>;
-	fn validate_refund_params(retry_duration: BlockNumber) -> Result<(), DispatchError>;
+	fn validate_refund_params(
+		input_asset: Asset,
+		output_asset: Asset,
+		retry_duration: BlockNumber,
+		max_oracle_price_slippage: Option<BasisPoints>,
+	) -> Result<(), DispatchError>;
 	fn validate_broker_fees(
 		broker_fees: &Beneficiaries<Self::AccountId>,
 	) -> Result<(), DispatchError>;

--- a/state-chain/traits/src/mocks/swap_parameter_validation.rs
+++ b/state-chain/traits/src/mocks/swap_parameter_validation.rs
@@ -16,7 +16,7 @@
 
 use sp_std::collections::btree_map::BTreeMap;
 
-use cf_primitives::{BasisPoints, BlockNumber};
+use cf_primitives::{Asset, BasisPoints, BlockNumber};
 use frame_support::sp_runtime::DispatchError;
 
 use crate::{SwapLimits, SwapParameterValidation};
@@ -54,11 +54,17 @@ impl SwapParameterValidation for MockSwapParameterValidation {
 		}
 	}
 
-	fn validate_refund_params(retry_duration: BlockNumber) -> Result<(), DispatchError> {
+	fn validate_refund_params(
+		_input_asset: Asset,
+		_output_asset: Asset,
+		retry_duration: BlockNumber,
+		_max_oracle_price_slippage: Option<BasisPoints>,
+	) -> Result<(), DispatchError> {
 		let limits = Self::get_swap_limits();
 		if retry_duration > limits.max_swap_retry_duration_blocks {
 			return Err(DispatchError::Other("Retry duration too high"));
 		}
+		// Note: ignoring oracle slippage validation for mock
 		Ok(())
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2482

## Checklist

- [x] I am confident that the code works.
- [x] I have written sufficient tests.
- [ ] I have updated documentation where appropriate.

## Summary

We already had a system for refund params validation, so i added the oracle slippage to that.
If either asset returns None from the price feed, the validation will return an error.
**Breaking change**: added params to the `cf_validate_refund_params` RPC. @dandanlen lmk if that's not ok.
