### PR TITLE
fix: print logs from all childloggers with a `tag` if the test itself has none

### DIFF
--- a/bouncer/shared/utils/logger.ts
+++ b/bouncer/shared/utils/logger.ts
@@ -1,6 +1,7 @@
 import { toUpperCase } from '@chainflip/utils/string';
-import { appendFileSync, existsSync, mkdirSync } from 'fs';
-import { dirname } from 'path';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { readdir } from 'fs/promises';
+import { dirname, parse } from 'path';
 import pino from 'pino';
 
 export type Logger = pino.Logger;
@@ -14,6 +15,36 @@ export function getTestLogFile(logger: Logger): string {
   const tag = logger.bindings().tag ?? '';
   const suffix = tag === '' ? '' : `-${tag}`;
   return `${testLogDir}/${startTime}/${testname}${suffix}.log`;
+}
+
+export async function getTestLogFilesForTaggedChildren(
+  logger: Logger,
+): Promise<{ tag: string; logs: string }[]> {
+  const startTime = logger.bindings().startTime ?? 'UnknownStartStime';
+  const testname = logger.bindings().test ?? 'UnknownTest';
+  const testDir = `${testLogDir}/${startTime}`;
+
+  const taggedLogs = [];
+
+  // get all files in test directory:
+  try {
+    const files = await readdir(testDir);
+    for (const file of files) {
+      const filename = parse(file).name;
+      if (filename !== testname && file.startsWith(testname)) {
+        taggedLogs.push({
+          tag: filename.slice(testname.length + 1), // since the filename is `{testname}-{tag}.log`, we extract the tag
+          logs: String(readFileSync(`${testDir}/${file}`)),
+        });
+      }
+    }
+    return taggedLogs;
+  } catch (err) {
+    logger.warn(
+      `Failed with ${err} when trying to get directory contents of test log directory (${testDir})`,
+    );
+    return [];
+  }
 }
 
 const logFileDestination = pino.destination({

--- a/bouncer/shared/utils/vitest.ts
+++ b/bouncer/shared/utils/vitest.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { afterEach, beforeEach, it } from 'vitest';
 import { TestContext } from 'shared/utils/test_context';
 import { runWithTimeout, testInfoFile } from 'shared/utils';
-import { getTestLogFile } from './logger';
+import { getTestLogFile, getTestLogFilesForTaggedChildren } from './logger';
 
 // Write the test name and function name to a file to be used by the `run_test.ts` command
 function writeTestInfoFile(name: string, functionName: string) {
@@ -41,17 +41,33 @@ function createTestFunction(
     context.testContext.logger = context.testContext.logger.child({ test: name });
     context.testContext.logger.info(`🧪 Starting test ${name}`);
 
+    // Check whether we currently have a tag, if we don't have one,
+    // we want to later include all the files created by child loggers that had a tag.
+    const tagExists = !!context.testContext.logger.bindings().tag;
+
     // Run the test with the test context
-    await runWithTimeout(testFunction(context.testContext), timeoutSeconds).catch((error) => {
+    await runWithTimeout(testFunction(context.testContext), timeoutSeconds).catch(async (error) => {
       // We must catch the error here to be able to log it
       context.testContext.error(error);
+
+      // get childLogs if we didn't have a tag. This operation might cause logging,
+      // and thus we want to run it before we get the logs for the test logger below.
+      let childLogs: { tag: string; logs: string }[] = [];
+      if (!tagExists) {
+        childLogs = await getTestLogFilesForTaggedChildren(context.testContext.logger);
+      }
 
       // get local logs from file and append them to the error
       const testLogFileName = getTestLogFile(context.testContext.logger);
       const logs = readFileSync(testLogFileName);
 
+      let fullLogs = `history\n${logs}`;
+      for (const child of childLogs) {
+        fullLogs += `\n\nhistory of child logger (tag: ${child.tag})\n${child.logs}`;
+      }
+
       // re-throw error with logs
-      throw new Error(`${error}\n\nhistory:\n${logs}`);
+      throw new Error(`${error}\n\n${fullLogs}`);
     });
     context.testContext.logger.info(`✅ Finished test ${name}`);
   };


### PR DESCRIPTION
Some tests have a list of subfunctions that test a given functionality with different inputs (e.g. the FillOrKill test checking that FoK paramers work for various assets). These tests create child loggers with a `{tag: ...}` binding. The previous implementation of test-local-logs did not collect the logs for tagged children when an error is thrown.

Changes:
 - When an error is thrown at the top level of a test, collect logs not only from the logfile of that test, but also try to get a list of all possibly tagged child log files.