### PR TITLE
refactor: concise fee estimation trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6220,7 +6220,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -9511,7 +9511,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -10065,7 +10065,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -10076,14 +10076,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ dependencies = [
  "cf-amm-math",
  "cf-primitives",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
@@ -1379,7 +1379,7 @@ version = "0.1.0"
 dependencies = [
  "cf-primitives",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "sp-core 34.0.0",
@@ -1417,8 +1417,8 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "proptest 1.6.0",
- "rand 0.8.5",
+ "proptest",
+ "rand",
  "rlp",
  "saturating_cast",
  "scale-info",
@@ -1498,7 +1498,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "secp256k1 0.29.1",
  "sp-block-builder",
@@ -1551,6 +1551,8 @@ dependencies = [
  "frame-support",
  "hex",
  "parity-scale-codec",
+ "proptest",
+ "proptest-derive",
  "scale-info",
  "serde",
  "serde_json",
@@ -1626,7 +1628,7 @@ dependencies = [
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "sp-runtime 39.0.0",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B4)",
 ]
@@ -1776,7 +1778,7 @@ dependencies = [
  "pallet-cf-threshold-signature",
  "pallet-cf-validator",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
@@ -1920,7 +1922,7 @@ dependencies = [
  "pallet-cf-witnesser",
  "parity-scale-codec",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "rlp",
@@ -2187,15 +2189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,7 +2234,7 @@ dependencies = [
  "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
@@ -2353,7 +2346,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "hex",
- "proptest 1.6.0",
+ "proptest",
  "serde",
 ]
 
@@ -3418,7 +3411,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "sha3",
@@ -3555,7 +3548,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand",
  "scrypt",
  "serde",
  "serde_json",
@@ -3736,7 +3729,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "serde_json",
@@ -3841,7 +3834,7 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
@@ -4039,7 +4032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -4182,7 +4175,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "sc-block-builder",
  "sc-chain-spec",
@@ -4458,12 +4451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4633,7 +4620,7 @@ dependencies = [
  "csv",
  "hex",
  "multisig",
- "rand 0.8.5",
+ "rand",
  "rocksdb",
  "serde",
  "serde_json",
@@ -4726,7 +4713,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
 ]
 
@@ -4834,7 +4821,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "spinning_top",
 ]
@@ -5563,7 +5550,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
- "rand 0.8.5",
+ "rand",
  "tokio",
  "url",
  "xmltree",
@@ -5974,7 +5961,7 @@ dependencies = [
  "jsonrpsee-types 0.23.2",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
@@ -6371,7 +6358,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "rw-stream-sink",
  "smallvec",
  "thiserror 1.0.69",
@@ -6429,7 +6416,7 @@ dependencies = [
  "hkdf",
  "multihash 0.19.3",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
@@ -6456,7 +6443,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "smallvec",
  "thiserror 1.0.69",
@@ -6478,7 +6465,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.5.8",
  "tokio",
@@ -6519,7 +6506,7 @@ dependencies = [
  "multihash 0.19.3",
  "once_cell",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -6542,7 +6529,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "void",
 ]
 
@@ -6562,7 +6549,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "quinn 0.10.2",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustls 0.21.12",
  "socket2 0.5.8",
@@ -6583,7 +6570,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "void",
 ]
@@ -6605,7 +6592,7 @@ dependencies = [
  "log",
  "multistream-select",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "tokio",
  "void",
@@ -6765,7 +6752,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -6900,7 +6887,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.11.9",
  "quinn 0.9.4",
- "rand 0.8.5",
+ "rand",
  "rcgen",
  "ring 0.16.20",
  "rustls 0.20.9",
@@ -7242,7 +7229,7 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_distr",
  "subtle 2.6.1",
@@ -7499,7 +7486,7 @@ dependencies = [
  "num-bigint",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "schnorrkel",
  "secp256k1 0.29.1",
@@ -7553,7 +7540,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -8038,7 +8025,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -8219,9 +8206,9 @@ dependencies = [
  "log",
  "nanorand",
  "parity-scale-codec",
- "proptest 1.6.0",
+ "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "serde_arrays",
@@ -8553,7 +8540,7 @@ dependencies = [
  "frame-system",
  "log",
  "parity-scale-codec",
- "proptest 0.8.7",
+ "proptest",
  "scale-info",
  "serde",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-1.15.2%2B4)",
@@ -8745,7 +8732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -8766,7 +8753,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "siphasher 0.3.11",
  "snap",
  "winapi",
@@ -9031,7 +9018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -9512,24 +9499,6 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d0604475349f463fe44130aae73f2294b5309ab2ca0310b998bd334ef191f"
-dependencies = [
- "bit-set 0.5.3",
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "num-traits",
- "quick-error",
- "rand 0.5.6",
- "regex-syntax 0.6.29",
- "rusty-fork 0.2.2",
- "tempfile",
-]
-
-[[package]]
-name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
@@ -9539,11 +9508,11 @@ dependencies = [
  "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.5",
- "rusty-fork 0.3.0",
+ "rusty-fork",
  "tempfile",
  "unarray",
 ]
@@ -9749,7 +9718,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -9806,7 +9775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash 1.1.0",
  "rustls 0.20.9",
@@ -9824,7 +9793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141bf7dfde2fbc246bfd3fe12f2455aa24b0fbd9af535d8c86c7bd1381ff2b1a"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash 1.1.0",
  "rustls 0.21.12",
@@ -9877,19 +9846,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -9908,21 +9864,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -9949,7 +9890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -10562,18 +10503,6 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty-fork"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
-name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
@@ -10758,7 +10687,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10905,7 +10834,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -11198,7 +11127,7 @@ dependencies = [
  "pin-project",
  "prost 0.12.6",
  "prost-build 0.12.6",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network-common",
  "sc-network-types",
@@ -11347,7 +11276,7 @@ dependencies = [
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.3",
- "rand 0.8.5",
+ "rand",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -11369,7 +11298,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
@@ -11482,7 +11411,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec",
  "sc-client-api",
  "sc-rpc",
@@ -11516,7 +11445,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -11585,7 +11514,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -11608,7 +11537,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-network",
  "sc-utils",
  "serde",
@@ -12006,7 +11935,7 @@ dependencies = [
  "crc",
  "fxhash",
  "log",
- "rand 0.8.5",
+ "rand",
  "slab",
  "thiserror 1.0.69",
 ]
@@ -12051,7 +11980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.14.0",
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -12509,7 +12438,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "pin-project",
  "poly1305",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "ruzstd",
  "schnorrkel",
@@ -12552,7 +12481,7 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "serde",
  "serde_json",
@@ -12617,7 +12546,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1 0.9.8",
 ]
 
@@ -12633,7 +12562,7 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1",
 ]
 
@@ -12919,7 +12848,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.12.2",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
@@ -12966,7 +12895,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.13.1",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel",
  "secp256k1 0.28.2",
@@ -13300,7 +13229,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -13328,7 +13257,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -13445,7 +13374,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
@@ -13466,7 +13395,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
@@ -13487,7 +13416,7 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sha2 0.10.8",
  "sp-api 34.0.0",
@@ -13607,7 +13536,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core 34.0.0",
@@ -13630,7 +13559,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core 35.0.0",
@@ -13864,7 +13793,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "paste",
- "proptest 1.6.0",
+ "proptest",
  "proptest-derive",
  "scale-info",
  "serde",
@@ -14582,7 +14511,7 @@ dependencies = [
  "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand",
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror 1.0.69",
@@ -14828,7 +14757,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -15013,7 +14942,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.10",
  "thiserror 1.0.69",
@@ -15039,7 +14968,7 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "thiserror 1.0.69",
  "tinyvec",
@@ -15060,7 +14989,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -15093,7 +15022,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
@@ -15113,7 +15042,7 @@ dependencies = [
  "http 1.2.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -15134,7 +15063,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -15391,7 +15320,7 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -15838,7 +15767,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.36.17",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -16417,7 +16346,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,8 @@ pin-project = { version = "1.1.3" }
 predicates = { version = "3.0" }
 proc-macro2 = { version = "1.0.79" }
 prometheus = { version = "0.13.0", default-features = false }
-proptest = { version = "0.8.7" }
+proptest = { version = "1.6" }
+proptest-derive = { version = "0.5.1" }
 quickcheck = { version = "1.0.3" }
 quickcheck_macros = { version = "1" }
 quote = { version = "1.0.35" }

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -42,7 +42,8 @@ use cf_chains::{
 };
 use cf_primitives::{
 	chains, AccountId, AccountRole, Asset, AssetAmount, AuthorityCount, Beneficiary, EgressId,
-	PriceLimits, SwapId, FLIPPERINOS_PER_FLIP, GENESIS_EPOCH, STABLE_ASSET, SWAP_DELAY_BLOCKS,
+	IngressOrEgress, PriceLimits, SwapId, FLIPPERINOS_PER_FLIP, GENESIS_EPOCH, STABLE_ASSET,
+	SWAP_DELAY_BLOCKS,
 };
 use cf_test_utilities::{assert_events_eq, assert_events_match, assert_has_matching_event};
 use cf_traits::{
@@ -155,7 +156,10 @@ pub fn do_eth_swap(
 	let ingress_fee = sp_std::cmp::min(
 		Swapping::calculate_input_for_gas_output::<Ethereum>(
 			from_eth_asset,
-			EthereumChainTracking::estimate_ingress_fee(from_eth_asset),
+			EthereumChainTracking::estimate_fee(
+				from_eth_asset,
+				IngressOrEgress::IngressDepositChannel,
+			),
 		),
 		u128::MAX,
 	);
@@ -488,7 +492,10 @@ fn can_process_ccm_via_swap_deposit_address() {
 		let ingress_fee = sp_std::cmp::min(
 			Swapping::calculate_input_for_gas_output::<Ethereum>(
 				EthAsset::Flip,
-				EthereumChainTracking::estimate_ingress_fee(EthAsset::Flip),
+				EthereumChainTracking::estimate_fee(
+					EthAsset::Flip,
+					IngressOrEgress::IngressDepositChannel,
+				),
 			),
 			u128::MAX,
 		);

--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -31,9 +31,11 @@ use arrayref::array_ref;
 use bech32::{self, u5, FromBase32, ToBase32, Variant};
 pub use cf_primitives::chains::Bitcoin;
 use cf_primitives::{
-	chains::assets, NetworkEnvironment, DEFAULT_FEE_SATS_PER_KILOBYTE, INPUT_UTXO_SIZE_IN_BYTES,
-	MINIMUM_BTC_TX_SIZE_IN_BYTES, OUTPUT_UTXO_SIZE_IN_BYTES, VAULT_UTXO_SIZE_IN_BYTES,
+	chains::assets, IngressOrEgress, NetworkEnvironment, DEFAULT_FEE_SATS_PER_KILOBYTE,
+	INPUT_UTXO_SIZE_IN_BYTES, MINIMUM_BTC_TX_SIZE_IN_BYTES, OUTPUT_UTXO_SIZE_IN_BYTES,
+	VAULT_UTXO_SIZE_IN_BYTES,
 };
+use cf_runtime_utilities::log_or_panic;
 use cf_utilities::SliceToArray;
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use core::{cmp::max, mem::size_of};
@@ -147,32 +149,36 @@ impl Default for BitcoinTrackedData {
 // A Bitcoin transaction consists of some base data, a list of input UTXOs and a list of output
 // UTXOs
 impl FeeEstimationApi<Bitcoin> for BitcoinTrackedData {
-	// When a user deposits some BTC, they create an input UTXO that we need to spend as part of a
-	// transaction some time in the future, so we charge them the costs of spending such an input
-	// UTXO
-	fn estimate_ingress_fee(
+	fn estimate_fee(
 		&self,
 		_asset: <Bitcoin as Chain>::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
 	) -> <Bitcoin as Chain>::ChainAmount {
-		self.btc_fee_info.fee_per_input_utxo()
-	}
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<<Bitcoin as Chain>::ChainAmount> {
-		Some(self.btc_fee_info.fee_per_input_utxo())
-	}
-
-	// When a user wants to receive some BTC, we need to create a transaction which typically spends
-	// a UTXO from the vault and creates two output UTXOs: One going to the user and one sending the
-	// remaining BTC back into the vault.
-	fn estimate_egress_fee(
-		&self,
-		_asset: <Bitcoin as Chain>::ChainAsset,
-	) -> <Bitcoin as Chain>::ChainAmount {
-		self.btc_fee_info
-			.min_fee_required_per_tx()
-			.saturating_add(self.btc_fee_info.fee_per_vault_utxo())
-			.saturating_add(self.btc_fee_info.fee_per_output_utxo())
-			.saturating_add(self.btc_fee_info.fee_per_output_utxo())
+		match ingress_or_egress {
+			IngressOrEgress::IngressDepositChannel => {
+				// When a user deposits some BTC, they create an input UTXO that we need to spend as
+				// part of a transaction some time in the future, so we charge them the costs of
+				// spending such an input UTXO
+				self.btc_fee_info.fee_per_input_utxo()
+			},
+			IngressOrEgress::IngressVaultSwap => self.btc_fee_info.fee_per_input_utxo(),
+			IngressOrEgress::Egress => {
+				// When a user wants to receive some BTC, we need to create a transaction which
+				// typically spends a UTXO from the vault and creates two output UTXOs: One
+				// going to the user and one sending the remaining BTC back into the vault.
+				self.btc_fee_info
+					.min_fee_required_per_tx()
+					.saturating_add(self.btc_fee_info.fee_per_vault_utxo())
+					.saturating_add(self.btc_fee_info.fee_per_output_utxo())
+					.saturating_add(self.btc_fee_info.fee_per_output_utxo())
+			},
+			IngressOrEgress::EgressCcm { .. } => {
+				log_or_panic!(
+					"Tried to get EgressCcm fees for bitcoin, but egress ccm is not supported."
+				);
+				0
+			},
+		}
 	}
 }
 

--- a/state-chain/chains/src/dot.rs
+++ b/state-chain/chains/src/dot.rs
@@ -23,6 +23,7 @@ pub mod benchmarking;
 #[cfg(feature = "std")]
 pub mod serializable_address;
 
+use cf_runtime_utilities::log_or_panic;
 use cf_utilities::SliceToArray;
 #[cfg(feature = "std")]
 pub use serializable_address::*;
@@ -306,26 +307,31 @@ pub mod fee_constants {
 }
 
 impl FeeEstimationApi<Polkadot> for PolkadotTrackedData {
-	fn estimate_ingress_fee(
+	fn estimate_fee(
 		&self,
 		_asset: <Polkadot as Chain>::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
 	) -> <Polkadot as Chain>::ChainAmount {
-		use fee_constants::fetch::*;
-
-		self.median_tip + fetch::EXTRINSIC_FEE
-	}
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<<Polkadot as Chain>::ChainAmount> {
-		None
-	}
-
-	fn estimate_egress_fee(
-		&self,
-		_asset: <Polkadot as Chain>::ChainAsset,
-	) -> <Polkadot as Chain>::ChainAmount {
-		use fee_constants::transfer::*;
-
-		self.median_tip + transfer::EXTRINSIC_FEE
+		match ingress_or_egress {
+			IngressOrEgress::IngressDepositChannel => {
+				use fee_constants::fetch::*;
+				self.median_tip + fetch::EXTRINSIC_FEE
+			},
+			IngressOrEgress::IngressVaultSwap => {
+				log_or_panic!("Tried to get IngressVaultSwap fees for Polkadot, but vault swaps are not supported.");
+				0
+			},
+			IngressOrEgress::Egress => {
+				use fee_constants::transfer::*;
+				self.median_tip + transfer::EXTRINSIC_FEE
+			},
+			IngressOrEgress::EgressCcm { .. } => {
+				log_or_panic!(
+					"Tried to get EgressCcm fees for Polkadot, but egress ccm is not supported."
+				);
+				0
+			},
+		}
 	}
 }
 
@@ -1139,13 +1145,13 @@ mod test_polkadot_extrinsics {
 			median_tip: Default::default(),
 			runtime_version: Default::default(),
 		}
-		.estimate_ingress_fee(assets::dot::Asset::Dot);
+		.estimate_fee(assets::dot::Asset::Dot, IngressOrEgress::IngressDepositChannel);
 
 		let egress_fee = PolkadotTrackedData {
 			median_tip: Default::default(),
 			runtime_version: Default::default(),
 		}
-		.estimate_egress_fee(assets::dot::Asset::Dot);
+		.estimate_fee(assets::dot::Asset::Dot, IngressOrEgress::Egress);
 
 		// The values are not important. This test serves more as a sanity check that
 		// the fees are valid, and a reference to compare against the actual fees. These values must

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -45,7 +45,7 @@ use address::{
 };
 use cf_primitives::{
 	Affiliates, Asset, AssetAmount, BasisPoints, BlockNumber, BroadcastId, ChannelId,
-	DcaParameters, EgressId, EthAmount, GasAmount, TxId,
+	DcaParameters, EgressId, EthAmount, GasAmount, IngressOrEgress, TxId,
 };
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use frame_support::{
@@ -1322,42 +1322,20 @@ pub struct ChainState<C: Chain> {
 }
 
 pub trait FeeEstimationApi<C: Chain> {
-	fn estimate_ingress_fee(&self, asset: C::ChainAsset) -> C::ChainAmount;
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<C::ChainAmount>;
-
-	fn estimate_egress_fee(&self, asset: C::ChainAsset) -> C::ChainAmount;
-
-	fn estimate_ccm_fee(
+	fn estimate_fee(
 		&self,
-		_asset: C::ChainAsset,
-		_gas_budget: GasAmount,
-		_message_length: usize,
-	) -> Option<C::ChainAmount> {
-		None
-	}
+		asset: C::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
+	) -> C::ChainAmount;
 }
 
 impl<C: Chain> FeeEstimationApi<C> for () {
-	fn estimate_ingress_fee(&self, _asset: C::ChainAsset) -> C::ChainAmount {
-		Default::default()
-	}
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<C::ChainAmount> {
-		Default::default()
-	}
-
-	fn estimate_egress_fee(&self, _asset: C::ChainAsset) -> C::ChainAmount {
-		Default::default()
-	}
-
-	fn estimate_ccm_fee(
+	fn estimate_fee(
 		&self,
 		_asset: C::ChainAsset,
-		_gas_budget: GasAmount,
-		_message_length: usize,
-	) -> Option<C::ChainAmount> {
-		None
+		_ingress_or_egress: IngressOrEgress,
+	) -> C::ChainAmount {
+		Default::default()
 	}
 }
 

--- a/state-chain/chains/src/mocks.rs
+++ b/state-chain/chains/src/mocks.rs
@@ -197,30 +197,11 @@ impl BenchmarkValue for MockTrackedData {
 }
 
 impl FeeEstimationApi<MockEthereum> for MockTrackedData {
-	fn estimate_ingress_fee(
+	fn estimate_fee(
 		&self,
 		_asset: <MockEthereum as Chain>::ChainAsset,
+		_ingress_or_egress: IngressOrEgress,
 	) -> <MockEthereum as Chain>::ChainAmount {
-		unimplemented!("Unused for now.")
-	}
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<<MockEthereum as Chain>::ChainAmount> {
-		unimplemented!("Unused for now.")
-	}
-
-	fn estimate_egress_fee(
-		&self,
-		_asset: <MockEthereum as Chain>::ChainAsset,
-	) -> <MockEthereum as Chain>::ChainAmount {
-		unimplemented!("Unused for now.")
-	}
-
-	fn estimate_ccm_fee(
-		&self,
-		_asset: <MockEthereum as Chain>::ChainAsset,
-		_gas_budget: GasAmount,
-		_message_length: usize,
-	) -> Option<<MockEthereum as Chain>::ChainAmount> {
 		unimplemented!("Unused for now.")
 	}
 }

--- a/state-chain/pallets/cf-chain-tracking/src/lib.rs
+++ b/state-chain/pallets/cf-chain-tracking/src/lib.rs
@@ -27,6 +27,7 @@ pub mod weights;
 pub use weights::WeightInfo;
 
 use cf_chains::{Chain, ChainState, FeeEstimationApi};
+use cf_primitives::IngressOrEgress;
 use cf_traits::{AdjustedFeeEstimationApi, Chainflip, GetBlockHeight};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
 use frame_system::pallet_prelude::*;
@@ -227,44 +228,15 @@ impl<T: Config<I>, I: 'static> GetBlockHeight<T::TargetChain> for Pallet<T, I> {
 }
 
 impl<T: Config<I>, I: 'static> AdjustedFeeEstimationApi<T::TargetChain> for Pallet<T, I> {
-	fn estimate_ingress_fee(
+	fn estimate_fee(
 		asset: <T::TargetChain as Chain>::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
 	) -> <T::TargetChain as Chain>::ChainAmount {
 		FeeMultiplier::<T, I>::get().saturating_mul_int(
 			CurrentChainState::<T, I>::get()
 				.expect(NO_CHAIN_STATE)
 				.tracked_data
-				.estimate_ingress_fee(asset),
+				.estimate_fee(asset, ingress_or_egress),
 		)
-	}
-
-	fn estimate_ingress_fee_vault_swap() -> Option<<T::TargetChain as Chain>::ChainAmount> {
-		CurrentChainState::<T, I>::get()
-			.expect(NO_CHAIN_STATE)
-			.tracked_data
-			.estimate_ingress_fee_vault_swap()
-	}
-
-	fn estimate_egress_fee(
-		asset: <T::TargetChain as Chain>::ChainAsset,
-	) -> <T::TargetChain as Chain>::ChainAmount {
-		FeeMultiplier::<T, I>::get().saturating_mul_int(
-			CurrentChainState::<T, I>::get()
-				.expect(NO_CHAIN_STATE)
-				.tracked_data
-				.estimate_egress_fee(asset),
-		)
-	}
-
-	fn estimate_ccm_fee(
-		asset: <T::TargetChain as Chain>::ChainAsset,
-		gas_budget: cf_primitives::GasAmount,
-		message_length: usize,
-	) -> Option<<T::TargetChain as Chain>::ChainAmount> {
-		CurrentChainState::<T, I>::get()
-			.expect(NO_CHAIN_STATE)
-			.tracked_data
-			.estimate_ccm_fee(asset, gas_budget, message_length)
-			.map(|ccm_fee| FeeMultiplier::<T, I>::get().saturating_mul_int(ccm_fee))
 	}
 }

--- a/state-chain/pallets/cf-elections/Cargo.toml
+++ b/state-chain/pallets/cf-elections/Cargo.toml
@@ -51,10 +51,11 @@ sp-runtime = { workspace = true }
 
 [dev-dependencies]
 cf-test-utilities = { workspace = true, default-features = true }
+cf-primitives = { workspace = true, features = ["test"] }
 cf-chains = { workspace = true, features = ["test", "mocks"] }
 rand = { workspace = true, features = ["std"] }
-proptest = { version = "1.6" }
-proptest-derive = { version = "0.5.1" }
+proptest = { workspace = true}
+proptest-derive = { workspace = true }
 
 [features]
 default = ["std"]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser.rs
@@ -4,7 +4,7 @@ use super::{
 	block_witnesser::state_machine::HookTypeFor,
 	state_machine::core::{defx, Hook, HookType, Validate},
 };
-use crate::{electoral_systems::state_machine::core::def_derive, generic_tools::*};
+use crate::generic_tools::*;
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
 use derive_where::derive_where;
@@ -86,7 +86,7 @@ defx! {
 	validate _this (else HeightWitnesserPropertiesError) {}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub struct BlockHeightWitnesserSettings {
 		/// IMPORTANT: This value should always be greater than any reorg depth we expect to happen.

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_height_witnesser/primitives.rs
@@ -1,4 +1,5 @@
 use cf_chains::witness_period::SaturatingStep;
+use cf_utilities::macros::*;
 use codec::{Decode, Encode};
 use core::iter;
 use generic_typeinfo_derive::GenericTypeInfo;
@@ -6,7 +7,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_std::collections::vec_deque::VecDeque;
 
-use crate::electoral_systems::state_machine::core::{def_derive, defx};
+use crate::electoral_systems::state_machine::core::defx;
 
 use super::{super::state_machine::core::Validate, ChainTypes};
 
@@ -137,7 +138,7 @@ impl<T: ChainTypes> NonemptyContinuousHeaders<T> {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	/// Information returned if the `merge` function for `NonEmptyContinuousHeaders` was successful.
 	#[derive(Ord, PartialOrd,)]
 	pub struct MergeInfo<T: ChainTypes> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -6,15 +6,16 @@ use core::{
 use crate::electoral_systems::{
 	block_height_witnesser::{ChainBlockNumberOf, ChainTypes},
 	block_witnesser::state_machine::BWProcessorTypes,
-	state_machine::core::{def_derive, Hook, Validate},
+	state_machine::core::{Hook, Validate},
 };
 use cf_chains::witness_period::SaturatingStep;
+use cf_utilities::macros::*;
 use codec::{Decode, Encode};
 use frame_support::{pallet_prelude::TypeInfo, Deserialize, Serialize};
 use generic_typeinfo_derive::GenericTypeInfo;
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, vec::Vec};
 
-def_derive! {
+derive_common_traits! {
 	///
 	/// BlockProcessor
 	/// ===================================
@@ -63,7 +64,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(GenericTypeInfo)]
 	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	pub struct BlockProcessingInfo<T: BWProcessorTypes> {
@@ -78,7 +79,7 @@ impl<T: BWProcessorTypes> BlockProcessingInfo<T> {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub enum BlockProcessorEvent<T: BWProcessorTypes> {
 		NewBlock {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/primitives.rs
@@ -1,4 +1,5 @@
 use cf_chains::witness_period::SaturatingStep;
+use cf_utilities::macros::*;
 use codec::{Decode, Encode};
 use core::{
 	cmp::min,
@@ -24,7 +25,7 @@ use proptest_derive::Arbitrary;
 
 use crate::electoral_systems::{
 	block_height_witnesser::{ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes},
-	state_machine::core::{def_derive, defx, Hook, Validate},
+	state_machine::core::{defx, Hook, Validate},
 };
 
 use super::state_machine::{BWElectionType, BWTypes, EngineElectionType};
@@ -531,7 +532,7 @@ impl<T: BWTypes> Arbitrary for ElectionTracker<T> {
 	type Strategy = impl Strategy<Value = Self> + Clone + Sync + Send;
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(GenericTypeInfo)]
 	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	#[cfg_attr(test, derive(Arbitrary))]
@@ -548,7 +549,7 @@ impl<T: BWTypes> Validate for OptimisticBlock<T> {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(GenericTypeInfo)]
 	#[expand_name_with(T::Chain::NAME)]
 	pub enum ElectionTrackerEvent<T: BWTypes> {
@@ -566,7 +567,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub enum UpdateSafeElectionsReason {
 		OutOfSafetyMargin,

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -5,16 +5,19 @@ use super::{
 };
 #[cfg(test)]
 use crate::electoral_systems::state_machine::state_machine::InputOf;
-use crate::electoral_systems::{
-	block_height_witnesser::{
-		ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes, CommonTraits,
-		MaybeArbitrary, TestTraits,
+use crate::{
+	electoral_systems::{
+		block_height_witnesser::{
+			ChainBlockHashOf, ChainBlockNumberOf, ChainProgress, ChainTypes, CommonTraits,
+			MaybeArbitrary, TestTraits,
+		},
+		block_witnesser::block_processor::BlockProcessor,
+		state_machine::{
+			core::Validate,
+			state_machine::{AbstractApi, Statemachine},
+		},
 	},
-	block_witnesser::block_processor::BlockProcessor,
-	state_machine::{
-		core::Validate,
-		state_machine::{AbstractApi, Statemachine},
-	},
+	generic_tools::*,
 };
 use cf_chains::witness_period::SaturatingStep;
 use codec::{Decode, Encode};
@@ -182,7 +185,7 @@ defx! {
 	validate _this (else BlockWitnesserError) {}
 }
 
-def_derive!(
+derive_common_traits!(
 	#[derive(GenericTypeInfo)]
 	#[expand_name_with(C::NAME)]
 	pub enum EngineElectionType<C: ChainTypes> {
@@ -190,8 +193,7 @@ def_derive!(
 		BlockHeight { submit_hash: bool },
 	}
 );
-def_derive! {
-	#[no_serde]
+derive_common_traits! {
 	#[derive(GenericTypeInfo)]
 	#[expand_name_with(scale_info::prelude::format!("{}{}", T::Chain::NAME, T::BWNAME))]
 	pub struct BWElectionProperties<T: BWTypes> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/chainlink.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/chainlink.rs
@@ -21,9 +21,10 @@ use crate::electoral_systems::{
 	state_machine::common_imports::*,
 };
 use cf_amm_math::Price;
+use cf_utilities::macros::*;
 use sp_std::iter;
 
-def_derive! {
+derive_common_traits! {
 	/// Representation of the asset pairs as returned in the `description` field of chainlink responses.
 	#[derive(TypeInfo, Sequence, PartialOrd, Ord, Copy)]
 	#[cfg_attr(test, derive(Arbitrary))]

--- a/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/price.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/price.rs
@@ -28,8 +28,6 @@ use cf_primitives::Price;
 use proptest::prelude::Strategy;
 use sp_core::U256;
 
-use crate::electoral_systems::state_machine::common_imports::*;
-
 #[derive(Clone)]
 pub struct PriceUnit {
 	pub base_asset: PriceAsset,
@@ -42,7 +40,7 @@ impl PriceUnit {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(Copy, PartialOrd, Ord, TypeInfo)]
 	pub enum PriceAsset {
 		Btc,
@@ -77,7 +75,7 @@ pub fn denom(d: Denom) -> U256 {
 	U256::from(d) + 1
 }
 
-def_derive! {
+derive_common_traits! {
 	/// Fixed-point fraction type with strongly typed denominator. The internal representation
 	/// of the value is a U256, the const parameter `U: u128` defines the how the integer should
 	/// be interpreted: as the numerator of a fraction with a denominator of `U + 1`.

--- a/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/primitives.rs
@@ -14,24 +14,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use core::ops::{Mul, RangeInclusive, Sub};
-use sp_std::ops::Add;
+use core::ops::RangeInclusive;
+
+use codec::MaxEncodedLen;
+#[cfg(test)]
+use proptest_derive::Arbitrary;
 
 use crate::{
 	electoral_systems::{oracle_price::price::Fraction, state_machine::common_imports::*},
 	generic_tools::*,
 };
 
-#[cfg(test)]
-use proptest_derive::Arbitrary;
-
-def_derive! {
-	#[cfg_attr(test, derive(Arbitrary))]
-	#[derive(TypeInfo, PartialOrd, Ord, Default, Copy)]
+derive_common_traits! {
+	#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+	#[derive(TypeInfo, PartialOrd, Ord, Default, Copy, MaxEncodedLen)]
 	pub struct UnixTime{ pub seconds: u64 }
 }
 
-impl Add<Seconds> for UnixTime {
+impl sp_std::ops::Add<Seconds> for UnixTime {
 	type Output = UnixTime;
 
 	fn add(self, rhs: Seconds) -> Self::Output {
@@ -39,7 +39,7 @@ impl Add<Seconds> for UnixTime {
 	}
 }
 
-impl Sub<Seconds> for UnixTime {
+impl sp_std::ops::Sub<Seconds> for UnixTime {
 	type Output = UnixTime;
 
 	fn sub(self, rhs: Seconds) -> Self::Output {
@@ -47,13 +47,13 @@ impl Sub<Seconds> for UnixTime {
 	}
 }
 
-def_derive! {
-	#[cfg_attr(test, derive(Arbitrary))]
+derive_common_traits! {
+	#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 	#[derive(TypeInfo, Copy, Default)]
 	pub struct Seconds(pub u64);
 }
 
-impl Mul<u64> for Seconds {
+impl sp_std::ops::Mul<u64> for Seconds {
 	type Output = Seconds;
 
 	fn mul(self, rhs: u64) -> Self::Output {
@@ -61,7 +61,7 @@ impl Mul<u64> for Seconds {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Copy, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct BasisPoints(pub u16);
@@ -75,7 +75,7 @@ impl BasisPoints {
 
 pub trait AggregationValue = Ord + CommonTraits + MaybeArbitrary + 'static;
 
-def_derive! {
+derive_common_traits! {
 	#[cfg_attr(test, derive(Arbitrary))]
 	#[derive(TypeInfo)]
 	pub struct Aggregated<A: AggregationValue> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/state_machine.rs
@@ -14,24 +14,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use core::ops::RangeInclusive;
+use enum_iterator::{all, Sequence};
+use itertools::{Either, Itertools};
+
+use crate::electoral_systems::oracle_price::primitives::{Seconds, UnixTime};
+
 use crate::{
 	electoral_systems::{
 		block_witnesser::{primitives::SafeModeStatus, state_machine::HookTypeFor},
 		oracle_price::{
 			price::PriceUnit,
-			primitives::{BasisPoints, Seconds, UnixTime},
+			primitives::{Aggregated, BasisPoints},
 		},
-		state_machine::common_imports::*,
+		state_machine::{
+			common_imports::*,
+			state_machine::{AbstractApi, Statemachine},
+		},
 	},
 	generic_tools::*,
-};
-use core::ops::RangeInclusive;
-use enum_iterator::{all, Sequence};
-use itertools::{Either, Itertools};
-
-use crate::electoral_systems::{
-	oracle_price::primitives::Aggregated,
-	state_machine::state_machine::{AbstractApi, Statemachine},
 };
 use sp_std::{
 	ops::{Index, IndexMut},
@@ -93,7 +94,7 @@ impl<T: OPTypes> HookType for HookTypeFor<T, EmitPricesUpdatedEvent> {
 
 //---------------- the primitives ------------------
 
-def_derive! {
+derive_common_traits! {
 	#[derive(Copy, Sequence, PartialOrd, Ord, TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub enum ExternalPriceChain {
@@ -102,7 +103,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Copy, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub enum PriceStatus {
@@ -113,7 +114,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive_where(Default;)]
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
@@ -126,7 +127,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct AssetResponse<T: OPTypes> {
@@ -135,7 +136,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive_where(Default;)]
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
@@ -144,7 +145,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct ExternalChainStateVote<T: OPTypes> {
@@ -227,7 +228,7 @@ impl<T: OPTypes> ExternalChainState<T> {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct ExternalChainStates<T: OPTypes> {
@@ -274,7 +275,7 @@ impl<T: OPTypes> IndexMut<ExternalPriceChain> for ExternalChainStates<T> {
 
 //---------------- the api ------------------
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub enum VotingCondition<T: OPTypes> {
@@ -288,7 +289,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct PriceQuery<T: OPTypes> {
@@ -297,7 +298,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct OraclePriceSettings {
@@ -317,7 +318,7 @@ impl Index<ExternalPriceChain> for OraclePriceSettings {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct ExternalChainSettings {
@@ -327,7 +328,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo, Default)]
 	#[cfg_attr(test, derive(Arbitrary))]
 	pub struct OraclePriceTracker<T: OPTypes> {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/core.rs
@@ -130,25 +130,6 @@ macro_rules! derive_validation_statements {
 }
 pub(crate) use derive_validation_statements;
 
-#[macro_export]
-macro_rules! def_derive {
-	(#[no_serde] $($Definition:tt)*) => {
-		#[derive(
-			Debug, Clone, PartialEq, Eq, Encode, Decode,
-		)]
-		$($Definition)*
-	};
-	($($Definition:tt)*) => {
-		#[derive(
-			Debug, Clone, PartialEq, Eq, Encode, Decode,
-		)]
-		#[derive(Deserialize, Serialize)]
-		#[serde(bound(deserialize = "", serialize = ""))]
-		$($Definition)*
-	};
-}
-pub use def_derive;
-
 /// Syntax sugar for adding validation code to types with validity requirements
 macro_rules! defx {
 	(
@@ -173,7 +154,7 @@ macro_rules! defx {
 		crate::electoral_systems::state_machine::core::derive_error_enum!{$Error [ $($ParamName: $($ParamType)?),* ], $def { $($Definition)* } { $($prop_name),* } }
 
 
-		crate::electoral_systems::state_machine::core::def_derive!{
+		cf_utilities::macros::derive_common_traits!{
 			$(
 				#[$($Attributes)*]
 			)*

--- a/state-chain/pallets/cf-elections/src/generic_tools/functor.rs
+++ b/state-chain/pallets/cf-elections/src/generic_tools/functor.rs
@@ -1,5 +1,5 @@
 pub use super::common_traits::*;
-use crate::def_derive;
+use cf_utilities::macros::*;
 
 use sp_std::vec::Vec;
 
@@ -12,7 +12,7 @@ pub trait Transformation<F: Container, G: Container> {
 }
 
 // ----- vector -----
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub struct VectorContainer;
 }
@@ -22,7 +22,7 @@ impl Container for VectorContainer {
 }
 
 // ----- array -----
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub struct Array<const N: usize, A: CommonTraits> {
 		#[serde(with = "serde_arrays")]
@@ -30,7 +30,7 @@ def_derive! {
 	}
 }
 
-def_derive! {
+derive_common_traits! {
 	pub struct ArrayContainer<const N: usize>;
 }
 

--- a/state-chain/pallets/cf-elections/src/generic_tools/mod.rs
+++ b/state-chain/pallets/cf-elections/src/generic_tools/mod.rs
@@ -2,5 +2,6 @@ pub mod common_traits;
 pub mod derive_macros;
 pub mod functor;
 
+pub use cf_utilities::macros::*;
 pub use common_traits::*;
 pub use functor::*;

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -17,7 +17,8 @@
 use super::*;
 use cf_chains::{DepositOriginType, FeeEstimationApi};
 use cf_primitives::{
-	AssetAmount, BasisPoints, PrewitnessedDepositId, SwapRequestId, MAX_BASIS_POINTS,
+	AssetAmount, BasisPoints, IngressOrEgress, PrewitnessedDepositId, SwapRequestId,
+	MAX_BASIS_POINTS,
 };
 use cf_traits::{
 	mocks::tracked_data_provider::TrackedDataProvider, BalanceApi, SafeMode, SetSafeMode,
@@ -121,7 +122,10 @@ fn setup() {
 	ChainTracker::<Ethereum>::set_fee(INGRESS_FEE);
 
 	TrackedDataProvider::<Ethereum>::set_tracked_data(tracked_data);
-	assert_eq!(tracked_data.estimate_ingress_fee(EthAsset::Eth), INGRESS_FEE);
+	assert_eq!(
+		tracked_data.estimate_fee(EthAsset::Eth, IngressOrEgress::IngressDepositChannel),
+		INGRESS_FEE
+	);
 }
 
 #[test]

--- a/state-chain/primitives/Cargo.toml
+++ b/state-chain/primitives/Cargo.toml
@@ -17,15 +17,18 @@ strum_macros = { workspace = true }
 sp-core = { workspace = true }
 sp-arithmetic = { workspace = true }
 
-
 frame-support = { workspace = true }
 sp-std = { workspace = true }
 
 codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 
-[dev-dependencies]
 cf-utilities = { workspace = true }
+
+proptest-derive = { workspace = true, optional = true}
+proptest = { workspace = true, optional = true}
+
+[dev-dependencies]
 sp-runtime = { workspace = true, default-features = true }
 serde_json = { workspace = true }
 
@@ -42,4 +45,8 @@ std = [
 	"serde/std",
 	"sp-std/std",
 	"strum/std",
+]
+test = [
+	"dep:proptest-derive",
+	"dep:proptest"
 ]

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -571,3 +571,11 @@ impl<T> ApiWaitForResult<T> {
 		}
 	}
 }
+
+/// Used in cf_ingress_egress and in cf_chains.
+pub enum IngressOrEgress {
+	IngressDepositChannel,
+	IngressVaultSwap,
+	Egress,
+	EgressCcm { gas_budget: GasAmount, message_length: usize },
+}

--- a/state-chain/runtime/src/chainflip/generic_elections.rs
+++ b/state-chain/runtime/src/chainflip/generic_elections.rs
@@ -16,6 +16,7 @@
 
 use cf_primitives::{chains::assets::any, Price};
 use cf_runtime_utilities::log_or_panic;
+use cf_utilities::macros::*;
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_core::{Get, RuntimeDebug, H160};
 use sp_std::vec::Vec;
@@ -30,6 +31,7 @@ use pallet_cf_elections::{
 				ChainlinkAssetpair, ChainlinkPrice,
 			},
 			price::PriceAsset,
+			primitives::{Seconds, UnixTime},
 			state_machine::OPTypes,
 		},
 	},
@@ -49,7 +51,7 @@ use pallet_cf_elections::{
 		},
 		oracle_price::{consensus::OraclePriceConsensus, primitives::*, state_machine::*},
 		state_machine::{
-			core::{def_derive, Hook},
+			core::Hook,
 			state_machine_es::{StatemachineElectoralSystem, StatemachineElectoralSystemTypes},
 		},
 	},
@@ -98,7 +100,7 @@ pub fn decode_and_get_latest_oracle_price<T: OPTypes>(asset: any::Asset) -> Opti
 
 //--------------- voter settings -------------
 
-def_derive! {
+derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub struct ChainlinkOraclePriceSettings<C: Container = VectorContainer> {
 		pub sol_oracle_program_id: SolAddress,

--- a/state-chain/runtime/src/chainflip/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/solana_elections.rs
@@ -37,7 +37,7 @@ use cf_chains::{
 	CcmDepositMetadataUnchecked, Chain, ChannelRefundParametersForChain, FeeEstimationApi,
 	FetchAndCloseSolanaVaultSwapAccounts, ForeignChainAddress, Solana,
 };
-use cf_primitives::{AffiliateShortId, Affiliates, Beneficiary, DcaParameters};
+use cf_primitives::{AffiliateShortId, Affiliates, Beneficiary, DcaParameters, IngressOrEgress};
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	AdjustedFeeEstimationApi, Broadcaster, Chainflip, ElectionEgressWitnesser, GetBlockHeight,
@@ -478,47 +478,13 @@ impl SolanaChainTrackingProvider {
 	}
 }
 impl AdjustedFeeEstimationApi<Solana> for SolanaChainTrackingProvider {
-	fn estimate_ingress_fee(
+	fn estimate_fee(
 		asset: <Solana as Chain>::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
 	) -> <Solana as Chain>::ChainAmount {
 		Self::with_tracked_data_then_apply_fee_multiplier(|tracked_data| {
-			tracked_data.estimate_ingress_fee(asset)
+			tracked_data.estimate_fee(asset, ingress_or_egress)
 		})
-	}
-
-	fn estimate_ingress_fee_vault_swap() -> Option<<Solana as Chain>::ChainAmount> {
-		Some(Self::with_tracked_data_then_apply_fee_multiplier(|tracked_data| {
-			// TODO: These should be untangled?
-			tracked_data.estimate_ingress_fee_vault_swap().unwrap_or_else(|| {
-				log_or_panic!(
-					"Obtained None when estimating Solana Ingress Vault Swap fee. This should not happen"
-				);
-				Default::default()
-			})
-		}))
-	}
-
-	fn estimate_egress_fee(asset: <Solana as Chain>::ChainAsset) -> <Solana as Chain>::ChainAmount {
-		Self::with_tracked_data_then_apply_fee_multiplier(|tracked_data| {
-			tracked_data.estimate_egress_fee(asset)
-		})
-	}
-
-	fn estimate_ccm_fee(
-		asset: <Solana as Chain>::ChainAsset,
-		gas_budget: cf_primitives::GasAmount,
-		message_length: usize,
-	) -> Option<<Solana as Chain>::ChainAmount> {
-		Some(Self::with_tracked_data_then_apply_fee_multiplier(|tracked_data| {
-			tracked_data
-				.estimate_ccm_fee(asset, gas_budget, message_length)
-				.unwrap_or_else(|| {
-					log_or_panic!(
-						"Obtained None when estimating Solana Ccm fee. This should not happen"
-					);
-					Default::default()
-				})
-		}))
 	}
 }
 

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -82,7 +82,7 @@ use cf_chains::{
 };
 use cf_primitives::{
 	Affiliates, BasisPoints, Beneficiary, BroadcastId, ChannelId, DcaParameters, EpochIndex,
-	NetworkEnvironment, STABLE_ASSET,
+	IngressOrEgress, NetworkEnvironment, STABLE_ASSET,
 };
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, DummyEgressSuccessWitnesser,
@@ -99,7 +99,6 @@ use pallet_cf_elections::electoral_systems::oracle_price::{
 	price::PriceAsset,
 };
 use pallet_cf_governance::GovCallHash;
-use pallet_cf_ingress_egress::IngressOrEgress;
 use pallet_cf_pools::{
 	AskBidMap, HistoricalEarnedFees, PoolLiquidity, PoolOrderbook, PoolPriceV1, PoolPriceV2,
 	UnidirectionalPoolDepth,
@@ -2111,22 +2110,22 @@ impl_runtime_apis! {
 				ForeignChainAndAsset::Ethereum(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Ethereum>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, EthereumInstance>::estimate_ingress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, EthereumInstance>::estimate_fee(asset, IngressOrEgress::IngressDepositChannel)
 					))
 				},
-				ForeignChainAndAsset::Polkadot(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, PolkadotInstance>::estimate_ingress_fee(asset)),
-				ForeignChainAndAsset::Bitcoin(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, BitcoinInstance>::estimate_ingress_fee(asset).into()),
+				ForeignChainAndAsset::Polkadot(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, PolkadotInstance>::estimate_fee(asset, IngressOrEgress::IngressDepositChannel)),
+				ForeignChainAndAsset::Bitcoin(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, BitcoinInstance>::estimate_fee(asset, IngressOrEgress::IngressDepositChannel).into()),
 				ForeignChainAndAsset::Arbitrum(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Arbitrum>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, ArbitrumInstance>::estimate_ingress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, ArbitrumInstance>::estimate_fee(asset, IngressOrEgress::IngressDepositChannel)
 					))
 				},
-				ForeignChainAndAsset::Solana(asset) => Some(SolanaChainTrackingProvider::estimate_ingress_fee(asset).into()),
+				ForeignChainAndAsset::Solana(asset) => Some(SolanaChainTrackingProvider::estimate_fee(asset, IngressOrEgress::IngressDepositChannel).into()),
 				ForeignChainAndAsset::Assethub(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Assethub>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, AssethubInstance>::estimate_ingress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, AssethubInstance>::estimate_fee(asset, IngressOrEgress::IngressDepositChannel)
 					))
 				},
 			}
@@ -2137,22 +2136,22 @@ impl_runtime_apis! {
 				ForeignChainAndAsset::Ethereum(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Ethereum>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, EthereumInstance>::estimate_egress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, EthereumInstance>::estimate_fee(asset, IngressOrEgress::Egress)
 					))
 				},
-				ForeignChainAndAsset::Polkadot(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, PolkadotInstance>::estimate_egress_fee(asset)),
-				ForeignChainAndAsset::Bitcoin(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, BitcoinInstance>::estimate_egress_fee(asset).into()),
+				ForeignChainAndAsset::Polkadot(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, PolkadotInstance>::estimate_fee(asset, IngressOrEgress::Egress)),
+				ForeignChainAndAsset::Bitcoin(asset) => Some(pallet_cf_chain_tracking::Pallet::<Runtime, BitcoinInstance>::estimate_fee(asset, IngressOrEgress::Egress).into()),
 				ForeignChainAndAsset::Arbitrum(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Arbitrum>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, ArbitrumInstance>::estimate_egress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, ArbitrumInstance>::estimate_fee(asset, IngressOrEgress::Egress)
 					))
 				},
-				ForeignChainAndAsset::Solana(asset) => Some(SolanaChainTrackingProvider::estimate_egress_fee(asset).into()),
+				ForeignChainAndAsset::Solana(asset) => Some(SolanaChainTrackingProvider::estimate_fee(asset, IngressOrEgress::Egress).into()),
 				ForeignChainAndAsset::Assethub(asset) => {
 					Some(pallet_cf_swapping::Pallet::<Runtime>::calculate_input_for_gas_output::<Assethub>(
 						asset,
-						pallet_cf_chain_tracking::Pallet::<Runtime, AssethubInstance>::estimate_egress_fee(asset)
+						pallet_cf_chain_tracking::Pallet::<Runtime, AssethubInstance>::estimate_fee(asset, IngressOrEgress::Egress)
 					))
 				},
 			}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -961,17 +961,7 @@ pub trait AuthoritiesCfeVersions {
 }
 
 pub trait AdjustedFeeEstimationApi<C: Chain> {
-	fn estimate_ingress_fee(asset: C::ChainAsset) -> C::ChainAmount;
-
-	fn estimate_ingress_fee_vault_swap() -> Option<C::ChainAmount>;
-
-	fn estimate_egress_fee(asset: C::ChainAsset) -> C::ChainAmount;
-
-	fn estimate_ccm_fee(
-		asset: C::ChainAsset,
-		gas_budget: GasAmount,
-		message_length: usize,
-	) -> Option<C::ChainAmount>;
+	fn estimate_fee(asset: C::ChainAsset, ingress_or_egress: IngressOrEgress) -> C::ChainAmount;
 }
 
 pub trait CallDispatchFilter<RuntimeCall> {

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -48,7 +48,7 @@ use cf_chains::{
 use cf_primitives::{
 	AccountRole, AffiliateShortId, Asset, AssetAmount, AuthorityCount, BasisPoints, Beneficiaries,
 	BlockNumber, BroadcastId, ChannelId, DcaParameters, Ed25519PublicKey, EgressCounter, EgressId,
-	EpochIndex, ForeignChain, GasAmount, Ipv6Addr, NetworkEnvironment, Price, SemVer,
+	EpochIndex, ForeignChain, IngressOrEgress, Ipv6Addr, NetworkEnvironment, Price, SemVer,
 	ThresholdSignatureRequestId,
 };
 use codec::{Decode, Encode, MaxEncodedLen};

--- a/state-chain/traits/src/mocks/chain_tracking.rs
+++ b/state-chain/traits/src/mocks/chain_tracking.rs
@@ -17,6 +17,7 @@
 use super::MockPallet;
 use crate::mocks::MockPalletStorage;
 use cf_chains::Chain;
+use cf_primitives::IngressOrEgress;
 
 use crate::{AdjustedFeeEstimationApi, GetBlockHeight};
 
@@ -45,23 +46,7 @@ impl<C: Chain> GetBlockHeight<C> for ChainTracker<C> {
 }
 
 impl<C: Chain> AdjustedFeeEstimationApi<C> for ChainTracker<C> {
-	fn estimate_ingress_fee(_asset: C::ChainAsset) -> C::ChainAmount {
+	fn estimate_fee(_asset: C::ChainAsset, _ingress_or_egress: IngressOrEgress) -> C::ChainAmount {
 		Self::get_value(TRACKED_FEE_KEY).unwrap_or_default()
-	}
-
-	fn estimate_ingress_fee_vault_swap() -> Option<C::ChainAmount> {
-		Self::get_value(TRACKED_FEE_KEY)
-	}
-
-	fn estimate_egress_fee(_asset: C::ChainAsset) -> C::ChainAmount {
-		Self::get_value(TRACKED_FEE_KEY).unwrap_or_default()
-	}
-
-	fn estimate_ccm_fee(
-		_asset: C::ChainAsset,
-		_gas_budget: cf_primitives::GasAmount,
-		_message_length: usize,
-	) -> Option<C::ChainAmount> {
-		Self::get_value(TRACKED_FEE_KEY)
 	}
 }

--- a/state-chain/traits/src/mocks/tracked_data_provider.rs
+++ b/state-chain/traits/src/mocks/tracked_data_provider.rs
@@ -17,6 +17,7 @@
 use sp_std::marker::PhantomData;
 
 use cf_chains::{Chain, FeeEstimationApi};
+use cf_primitives::IngressOrEgress;
 
 use super::MockPallet;
 use crate::mocks::MockPalletStorage;
@@ -36,32 +37,13 @@ impl<C: Chain> TrackedDataProvider<C> {
 }
 
 impl<C: Chain> FeeEstimationApi<C> for TrackedDataProvider<C> {
-	fn estimate_ingress_fee(&self, asset: C::ChainAsset) -> C::ChainAmount {
-		Self::get_value::<C::TrackedData>(TRACKED_DATA_KEY)
-			.expect("TrackedData must be set explicitly in mocks")
-			.estimate_ingress_fee(asset)
-	}
-
-	fn estimate_ingress_fee_vault_swap(&self) -> Option<<C as Chain>::ChainAmount> {
-		Self::get_value::<C::TrackedData>(TRACKED_DATA_KEY)
-			.expect("TrackedData must be set explicitly in mocks")
-			.estimate_ingress_fee_vault_swap()
-	}
-
-	fn estimate_egress_fee(&self, asset: C::ChainAsset) -> C::ChainAmount {
-		Self::get_value::<C::TrackedData>(TRACKED_DATA_KEY)
-			.expect("TrackedData must be set explicitly in mocks")
-			.estimate_egress_fee(asset)
-	}
-
-	fn estimate_ccm_fee(
+	fn estimate_fee(
 		&self,
-		asset: <C as Chain>::ChainAsset,
-		gas_budget: cf_primitives::GasAmount,
-		message_length: usize,
-	) -> Option<<C as Chain>::ChainAmount> {
+		asset: C::ChainAsset,
+		ingress_or_egress: IngressOrEgress,
+	) -> C::ChainAmount {
 		Self::get_value::<C::TrackedData>(TRACKED_DATA_KEY)
 			.expect("TrackedData must be set explicitly in mocks")
-			.estimate_ccm_fee(asset, gas_budget, message_length)
+			.estimate_fee(asset, ingress_or_egress)
 	}
 }

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -31,6 +31,8 @@ pub use without_std::*;
 #[cfg(any(feature = "test-utils", test))]
 pub mod testing;
 
+pub mod macros;
+
 pub type Port = u16;
 
 /// Simply unwraps the value. Advantage of this is to make it clear in tests

--- a/utilities/src/macros.rs
+++ b/utilities/src/macros.rs
@@ -1,0 +1,14 @@
+/// Adds #[derive] statements for commonly used traits. These are currently: Debug, Clone,
+/// PartialEq, Eq, Encode, Decode, Serialize, Deserialize
+#[macro_export]
+macro_rules! derive_common_traits {
+	($($Definition:tt)*) => {
+		#[derive(
+			Debug, Clone, PartialEq, Eq, Encode, Decode,
+		)]
+		#[derive(Deserialize, Serialize)]
+		#[serde(bound(deserialize = "", serialize = ""))]
+		$($Definition)*
+	};
+}
+pub use derive_common_traits;


### PR DESCRIPTION
# Pull Request

Part of: PRO-2441

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR was part of my work to get better bitcoin fees. Since these are a few things that are standalone refactors, and the direction of the bitcoin fee estimation problem changed a bit, it seems useful to get these merged independently.

In particular:
 - This PR changes the `FeeEstimationApi` and `AdjustedFeeEstimationApi` such as to be easier extendable in the future. 
Instead of 4 separate functions, the api now has a single `estimate_fee()` which takes an additional parameter of type `IngressOrEgress`. Its 4 cases represent exactly the same information that the 4 functions' input types carried previously.
 - By doing this, it also fixes an inconsistency, where one of the 4 functions previously didn't apply the fee multiplier (`estimate_ingress_fee_vault_swap()`).
 - Accordingly, the definition of `IngressOrEgress` is moved to the `cf_primitives` crate.
 - The macro `def_derive!{}` that was previously only used in the `cf_elections` pallet is renamed to `derive_common_traits!{}` and moved to `cf_utilities::macros`.