### PR TITLE
feat: precise bitcoin mempool fee estimations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8564,7 +8564,7 @@ dependencies = [
  "pallet-cf-reputation",
  "pallet-session",
  "parity-scale-codec",
- "proptest 1.6.0",
+ "proptest",
  "proptest-derive",
  "scale-info",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ proptest-derive = { version = "0.5.1" }
 quickcheck = { version = "1.0.3" }
 quickcheck_macros = { version = "1" }
 quote = { version = "1.0.35" }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.8.5", default-features = false}
 rayon = { version = "1.7.0" }
 redis = { version = "0.27.5" }
 regex = { version = "1.10.2" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -59,7 +59,7 @@ curve25519-dalek = { workspace = true, default-features = true, features = [
 ] }
 ed25519-dalek = { workspace = true }
 pin-project = { workspace = true }
-rand = { workspace = true, default-features = true }
+rand = { workspace = true, default-features = true, features = ["alloc"]}
 reqwest = { workspace = true, features = ["rustls-tls"] }
 tracing = { workspace = true }
 x25519-dalek = { workspace = true, features = ["serde"] }

--- a/engine/src/btc/retry_rpc.rs
+++ b/engine/src/btc/retry_rpc.rs
@@ -179,7 +179,7 @@ impl BtcRpcApi for BtcRetryRpcClient {
 				RequestLog::new("mempool_info".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
-					Box::pin(async move { Ok(client.mempool_info().await?) })
+					Box::pin(async move { client.mempool_info().await })
 				}),
 				2,
 			)
@@ -192,7 +192,7 @@ impl BtcRpcApi for BtcRetryRpcClient {
 				RequestLog::new("raw_mempool".to_string(), None),
 				Box::pin(move |client| {
 					#[allow(clippy::redundant_async_block)]
-					Box::pin(async move { Ok(client.raw_mempool().await?) })
+					Box::pin(async move { client.raw_mempool().await })
 				}),
 				2,
 			)
@@ -206,7 +206,7 @@ impl BtcRpcApi for BtcRetryRpcClient {
 				Box::pin(move |client| {
 					let txids = txids.clone();
 					#[allow(clippy::redundant_async_block)]
-					Box::pin(async move { Ok(client.mempool_entries(txids).await?) })
+					Box::pin(async move { client.mempool_entries(txids).await })
 				}),
 				2,
 			)

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod deposits;
+pub mod fees;
 pub mod source;
 pub mod vault_swaps;
 

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -274,7 +274,8 @@ impl VoterApi<BitcoinFeeTracking> for BitcoinFeeVoter {
 	) -> Result<Option<VoteOf<BitcoinFeeTracking>>, anyhow::Error> {
 		if settings.tx_sample_count_per_mempool_block > 0 {
 			match predict_fees(&self.client, settings.tx_sample_count_per_mempool_block).await {
-				Ok(fee) => return Ok(Some(fee)),
+				Ok(fee) =>
+					return Ok(Some(fee + settings.fixed_median_fee_adjustement_sat_per_vkilobyte)),
 				Err(err) => {
 					tracing::debug!("Could not estimate median mempool fees due to err: {err}. Falling back to native rpc call.");
 				},

--- a/engine/src/witness/btc/fees.rs
+++ b/engine/src/witness/btc/fees.rs
@@ -29,8 +29,7 @@ pub async fn predict_fees(
 	let info = client.mempool_info().await?;
 
 	if info.size == 0 || info.bytes == 0 {
-		tracing::debug!("mempool is empty, assuming fee = 0");
-		return Ok(0);
+		return Err(anyhow!("mempool is empty"));
 	}
 
 	// -- average vbytes per tx --

--- a/engine/src/witness/btc/fees.rs
+++ b/engine/src/witness/btc/fees.rs
@@ -1,0 +1,115 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cmp, time::Duration};
+
+use crate::{
+	btc::rpc::{BtcRpcApi, BtcRpcClient},
+	settings::HttpBasicAuthEndpoint,
+};
+use bitcoin::Txid;
+use cf_chains::btc::BtcAmount;
+use pallet_cf_elections::electoral_systems::oracle_price::primitives::compute_aggregated;
+use tokio::time::sleep;
+
+pub async fn predict_fees(
+	client: &impl BtcRpcApi,
+	target_tx_sample_count_per_block: u32,
+) -> anyhow::Result<BtcAmount> {
+	let info = client.mempool_info().await?;
+
+	if info.size == 0 || info.bytes == 0 {
+		return Ok(0);
+	}
+
+	// -- average vbytes per tx --
+	let vbytes_per_tx = (info.bytes as f64) / (info.size as f64);
+	println!("average vbytes/tx: {vbytes_per_tx}");
+
+	// -- number of blocks in the mempool --
+	let blocks_in_mempool = (info.bytes as f64) / 1000000.0;
+	let txs_per_block = 1000000.0 / vbytes_per_tx;
+	println!("there are ~{blocks_in_mempool} blocks in the mempool, with average {txs_per_block} txs per block");
+
+	// -- calculate sample target --
+	let sample_size = (target_tx_sample_count_per_block as f64) * blocks_in_mempool;
+	println!("we have to download {sample_size} txs to have an average sample size of {target_tx_sample_count_per_block} per block");
+
+	// ----------------------------------
+	// downloading txs
+
+	let tx_hashes: Vec<Txid> = client.raw_mempool().await?;
+	println!("Got {} hashes.", tx_hashes.len());
+
+	use rand::seq::SliceRandom;
+	let sub_tx_hashes: Vec<Txid> = tx_hashes
+		.choose_multiple(&mut rand::thread_rng(), sample_size as usize)
+		.cloned()
+		.collect();
+	println!("Selected a subset of size {}", sub_tx_hashes.len());
+
+	let tx_data = client.mempool_entries(sub_tx_hashes).await?;
+	println!("Got data for {} txs", tx_data.len());
+
+	let mut fees: Vec<_> = tx_data
+		.into_iter()
+		.filter_map(|a| {
+			if a.vsize == 0 {
+				return None;
+			}
+			Some((a.fees.base.to_sat() * 1000) / (a.vsize as u64))
+		})
+		.collect();
+	fees.sort_unstable_by(|a, b| b.cmp(a)); // sort in descending order, we don't care about object identities
+	let fees_next_block = &fees[0..cmp::min(target_tx_sample_count_per_block as usize, fees.len())];
+
+	let fee_stats = compute_aggregated(fees_next_block.into_iter().cloned().collect());
+	println!(
+		"Got {} fees for the next block. Max: {}, min: {}, stats: {:?}",
+		fees_next_block.len(),
+		fees_next_block[0],
+		fees_next_block[fees_next_block.len() - 1],
+		fee_stats
+	);
+
+	Ok(0)
+}
+
+#[test]
+fn mytestt() {
+	let x = [0, 2];
+	let y = &x[1..5];
+	println!("{y:?}");
+}
+
+#[tokio::test]
+async fn track_btc_fees() {
+	let client = BtcRpcClient::new(
+		HttpBasicAuthEndpoint {
+			http_endpoint: "http://localhost:8332".into(),
+			basic_auth_user: "flip".to_string(),
+			basic_auth_password: "flip".to_string(),
+		},
+		None,
+	)
+	.unwrap()
+	.await;
+
+	loop {
+		predict_fees(&client, 60).await.unwrap();
+		sleep(Duration::from_secs(20)).await;
+	}
+}

--- a/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/primitives.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/oracle_price/primitives.rs
@@ -108,6 +108,12 @@ pub fn select_nth_unstable_checked<A: Ord>(
 	Some(values.select_nth_unstable(index))
 }
 
+pub fn compute_median<A: Ord>(values: &mut [A]) -> Option<&mut A> {
+	let half = (values.len().saturating_sub(1)) / 2;
+	let (_first_half, median, _second_half) = select_nth_unstable_checked(values, half)?;
+	Some(median)
+}
+
 pub fn compute_aggregated<A: AggregationValue>(mut values: Vec<A>) -> Option<Aggregated<A>> {
 	let quarter = values.len().saturating_sub(1) / 4;
 	let half = (values.len().saturating_sub(1)) / 2;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/unsafe_median.rs
@@ -69,7 +69,10 @@ impl<
 	type ElectionIdentifierExtra = ();
 	type ElectionProperties = ();
 	type ElectionState = ();
-	type VoteStorage = vote_storage::bitmap_numerical::BitmapNoHash<Value>;
+	type VoteStorage = vote_storage::individual::Individual<
+		(),
+		vote_storage::individual::identity::Identity<Value>,
+	>;
 	type Consensus = Value;
 	type OnFinalizeContext = StateChainBlockNumber;
 	type OnFinalizeReturn = ();

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -465,7 +465,8 @@ impl UpdateFeeHook<BtcAmount> for BitcoinFeeUpdateHook {
 derive_common_traits! {
 	#[derive(TypeInfo)]
 	pub struct BitcoinFeeSettings {
-		pub tx_sample_count_per_mempool_block: u32
+		pub tx_sample_count_per_mempool_block: u32,
+		pub fixed_median_fee_adjustement_sat_per_vkilobyte: BtcAmount,
 	}
 }
 pub type BitcoinFeeTracking = UnsafeMedian<
@@ -627,7 +628,10 @@ pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 			Default::default(),
 			Default::default(),
 			Default::default(),
-			BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 },
+			BitcoinFeeSettings {
+				tx_sample_count_per_mempool_block: 20,
+				fixed_median_fee_adjustement_sat_per_vkilobyte: 1000,
+			},
 			LIVENESS_CHECK_DURATION,
 		),
 		shared_data_reference_lifetime: 8,

--- a/state-chain/runtime/src/chainflip/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_elections.rs
@@ -18,6 +18,7 @@ use cf_chains::{
 use cf_primitives::{AccountId, ChannelId};
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::Chainflip;
+use cf_utilities::derive_common_traits;
 use core::ops::RangeInclusive;
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_cf_broadcast::{TransactionConfirmation, TransactionOutIdToBroadcastId};
@@ -54,6 +55,7 @@ use pallet_cf_elections::{
 };
 use pallet_cf_ingress_egress::{DepositWitness, ProcessedUpTo, VaultDepositWitness};
 use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
 use sp_core::{Decode, Encode, Get, MaxEncodedLen};
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
@@ -460,9 +462,15 @@ impl UpdateFeeHook<BtcAmount> for BitcoinFeeUpdateHook {
 		}
 	}
 }
+derive_common_traits! {
+	#[derive(TypeInfo)]
+	pub struct BitcoinFeeSettings {
+		pub tx_sample_count_per_mempool_block: u32
+	}
+}
 pub type BitcoinFeeTracking = UnsafeMedian<
 	<Bitcoin as Chain>::ChainAmount,
-	(),
+	BitcoinFeeSettings,
 	BitcoinFeeUpdateHook,
 	<Runtime as Chainflip>::ValidatorId,
 	BlockNumberFor<Runtime>,
@@ -619,7 +627,7 @@ pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 			Default::default(),
 			Default::default(),
 			Default::default(),
-			Default::default(),
+			BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 },
 			LIVENESS_CHECK_DURATION,
 		),
 		shared_data_reference_lifetime: 8,

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -451,7 +451,17 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 			for (id, (a, b, c, d, (), f)) in settings_entries {
 				pallet_cf_elections::ElectoralSettings::<Runtime, BitcoinInstance>::insert(
 					id,
-					(a, b, c, d, BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 }, f),
+					(
+						a,
+						b,
+						c,
+						d,
+						BitcoinFeeSettings {
+							tx_sample_count_per_mempool_block: 20,
+							fixed_median_fee_adjustement_sat_per_vkilobyte: 1000,
+						},
+						f,
+					),
 				);
 			}
 		}
@@ -522,7 +532,10 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 			|(_id, settings)| {
 				assert_eq!(
 					settings.4,
-					BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 }
+					BitcoinFeeSettings {
+						tx_sample_count_per_mempool_block: 20,
+						fixed_median_fee_adjustement_sat_per_vkilobyte: 1000
+					}
 				);
 			},
 		);

--- a/state-chain/runtime/src/migrations/bitcoin_elections.rs
+++ b/state-chain/runtime/src/migrations/bitcoin_elections.rs
@@ -15,13 +15,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-	chainflip,
 	chainflip::{
+		self,
 		bitcoin_block_processor::BtcEvent,
 		bitcoin_elections::{
 			BitcoinBlockHeightWitnesserES, BitcoinDepositChannelWitnessingES,
-			BitcoinEgressWitnessingES, BitcoinLiveness, BitcoinVaultDepositWitnessing,
-			BitcoinVaultDepositWitnessingES,
+			BitcoinEgressWitnessingES, BitcoinFeeSettings, BitcoinLiveness,
+			BitcoinVaultDepositWitnessing, BitcoinVaultDepositWitnessingES,
 		},
 		elections::TypesFor,
 	},
@@ -54,13 +54,13 @@ mod old {
 
 	use super::*;
 	use cf_chains::btc::{self};
-	use frame_support::pallet_prelude::OptionQuery;
+	use frame_support::{pallet_prelude::OptionQuery, Twox64Concat};
 	use pallet_cf_elections::{
 		electoral_systems::{
 			block_witnesser::{primitives::CompactHeightTracker, state_machine::BWElectionType},
 			state_machine::core::hook_test_utils::EmptyHook,
 		},
-		Config,
+		Config, UniqueMonotonicIdentifier,
 	};
 
 	use sp_std::collections::btree_map::BTreeMap;
@@ -159,6 +159,15 @@ mod old {
 		<BitcoinLiveness as ElectoralSystemTypes>::ElectoralUnsynchronisedSettings,
 	);
 
+	pub type CompositeElectoralSettings = (
+		<BitcoinBlockHeightWitnesserES as ElectoralSystemTypes>::ElectoralSettings,
+		<BitcoinDepositChannelWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		<BitcoinVaultDepositWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		<BitcoinEgressWitnessingES as ElectoralSystemTypes>::ElectoralSettings,
+		(),
+		<BitcoinLiveness as ElectoralSystemTypes>::ElectoralSettings,
+	);
+
 	#[frame_support::storage_alias]
 	pub type ElectoralUnsynchronisedState<T: Config<I>, I: 'static> =
 		StorageValue<Pallet<T, I>, CompositeElectoralUnsynchronisedState, OptionQuery>;
@@ -166,6 +175,15 @@ mod old {
 	#[frame_support::storage_alias]
 	pub type ElectoralUnsynchronisedSettings<T: Config<I>, I: 'static> =
 		StorageValue<Pallet<T, I>, CompositeElectoralUnsynchronisedSettings, OptionQuery>;
+
+	#[frame_support::storage_alias]
+	pub type ElectoralSettings<T: Config<I>, I: 'static> = StorageMap<
+		Pallet<T, I>,
+		Twox64Concat,
+		UniqueMonotonicIdentifier,
+		CompositeElectoralSettings,
+		OptionQuery,
+	>;
 }
 
 impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
@@ -419,10 +437,23 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 
 			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::put(
 				(
-					a, b, c, d, 10u32, // fee witnessing should happen every 10 SC blocks
+					a, b, c, d, 20u32, // fee witnessing should happen every 20 SC blocks
 					f,
 				),
 			);
+		}
+
+		// migrating settings
+		{
+			let settings_entries: Vec<_> =
+				old::ElectoralSettings::<Runtime, BitcoinInstance>::drain().collect();
+
+			for (id, (a, b, c, d, (), f)) in settings_entries {
+				pallet_cf_elections::ElectoralSettings::<Runtime, BitcoinInstance>::insert(
+					id,
+					(a, b, c, d, BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 }, f),
+				);
+			}
 		}
 
 		log::info!("🍩 Migration for BTC Election completed");
@@ -480,12 +511,21 @@ impl UncheckedOnRuntimeUpgrade for BitcoinElectionMigration {
 
 		assert_eq!(current_state.1, 0);
 
-		let current_settings =
+		let current_unsynchronised_settings =
 			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::get()
 				.unwrap()
 				.4;
 
-		assert_eq!(current_settings, 10);
+		assert_eq!(current_unsynchronised_settings, 10);
+
+		pallet_cf_elections::ElectoralSettings::<Runtime, BitcoinInstance>::iter().for_each(
+			|(_id, settings)| {
+				assert_eq!(
+					settings.4,
+					BitcoinFeeSettings { tx_sample_count_per_mempool_block: 20 }
+				);
+			},
+		);
 
 		Ok(())
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2431

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This PR:
 - Adds a new method for bitcoin fee witnessing to the engine: random transactions from the mempool are sampled and we calculate the median fee of transactions expected to be in the *next* block. This has to parameters configurable via `ElectoralSettings`: "target sample size of txs in the next block" and "fixed fee adjustment value" (added on top of the calculated median). If the target sample size is set to 0, it falls back to the previous witnessing method. It also does this if for any reason the amount of txs sampled is less than half the target sample size.
 - Changes the vote storage of `UnsafeMedian` to `Individual<Identity>` since now we don't expect any of the validators to vote with the same vote, and thus using bitmaps (in any form) doesn't have benefits.
