### PR TITLE
refactor: non-const code red and green

### DIFF
--- a/state-chain/pallets/cf-asset-balances/src/tests.rs
+++ b/state-chain/pallets/cf-asset-balances/src/tests.rs
@@ -56,7 +56,7 @@ fn skip_refunding_if_safe_mode_is_enabled() {
 		assert_eq!(WithheldAssets::<Test>::get(ForeignChain::Ethereum.gas_asset()), 100);
 
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			refunding: crate::PalletSafeMode::CODE_RED,
+			refunding: crate::PalletSafeMode::code_red(),
 		});
 
 		Pallet::<Test>::trigger_reconciliation();

--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -37,7 +37,7 @@ mod benchmarks {
 			assert_ok!(call.dispatch_bypass_filter(origin));
 		}
 
-		assert_eq!(RuntimeSafeMode::<T>::get(), SafeMode::CODE_RED);
+		assert_eq!(RuntimeSafeMode::<T>::get(), SafeMode::code_red());
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -403,8 +403,8 @@ pub mod pallet {
 			T::EnsureGovernance::ensure_origin(origin)?;
 
 			RuntimeSafeMode::<T>::put(match update.clone() {
-				SafeModeUpdate::CodeGreen => SafeMode::CODE_GREEN,
-				SafeModeUpdate::CodeRed => SafeMode::CODE_RED,
+				SafeModeUpdate::CodeGreen => SafeMode::code_green(),
+				SafeModeUpdate::CodeRed => SafeMode::code_red(),
 				SafeModeUpdate::CodeAmber(safe_mode) => safe_mode,
 			});
 

--- a/state-chain/pallets/cf-environment/src/tests.rs
+++ b/state-chain/pallets/cf-environment/src/tests.rs
@@ -150,15 +150,15 @@ fn updating_consolidation_parameters() {
 fn update_safe_mode() {
 	new_test_ext().execute_with(|| {
 		// Default to GREEN
-		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::CODE_GREEN);
+		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::code_green());
 		assert_ok!(Environment::update_safe_mode(OriginTrait::root(), SafeModeUpdate::CodeRed));
-		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::CODE_RED);
+		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::code_red());
 		System::assert_last_event(RuntimeEvent::Environment(Event::RuntimeSafeModeUpdated {
 			safe_mode: SafeModeUpdate::CodeRed,
 		}));
 
 		assert_ok!(Environment::update_safe_mode(OriginTrait::root(), SafeModeUpdate::CodeGreen,));
-		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::CODE_GREEN);
+		assert_eq!(RuntimeSafeMode::<Test>::get(), SafeMode::code_green());
 		System::assert_last_event(RuntimeEvent::Environment(Event::RuntimeSafeModeUpdated {
 			safe_mode: SafeModeUpdate::CodeGreen,
 		}));

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -2017,9 +2017,9 @@ fn safe_mode_prevents_deposit_channel_creation() {
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
 			ingress_egress_ethereum: PalletSafeMode {
 				deposit_channel_creation_enabled: false,
-				..PalletSafeMode::CODE_GREEN
+				..PalletSafeMode::code_green()
 			},
-			..MockRuntimeSafeMode::CODE_GREEN
+			..MockRuntimeSafeMode::code_green()
 		});
 
 		assert_err!(

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -435,7 +435,7 @@ fn boosting_with_safe_mode(enable: bool) {
 		<MockRuntimeSafeMode as sp_core::Get<PalletSafeMode<Instance1>>>::get()
 	}
 
-	let boost_mode = if enable { PalletSafeMode::CODE_GREEN } else { PalletSafeMode::CODE_RED };
+	let boost_mode = if enable { PalletSafeMode::code_green() } else { PalletSafeMode::code_red() };
 
 	let new_mode = PalletSafeMode {
 		deposit_channel_creation_enabled: get_safe_mode().deposit_channel_creation_enabled,

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -366,7 +366,7 @@ fn add_boost_funds_is_disabled_by_safe_mode() {
 
 		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode {
 			add_boost_funds_enabled: false,
-			..PalletSafeMode::CODE_GREEN
+			..PalletSafeMode::code_green()
 		});
 
 		// Should not be able to add funds to the boost pool
@@ -382,7 +382,7 @@ fn add_boost_funds_is_disabled_by_safe_mode() {
 
 		assert_eq!(get_available_amount_for_booster(Asset::Eth, TIER_5_BPS, BOOSTER_1), None);
 
-		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode::CODE_GREEN);
+		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode::code_green());
 
 		// Should be able to add funds to the boost pool now that the safe mode is turned off
 		assert_ok!(LendingPools::add_boost_funds(
@@ -414,7 +414,7 @@ fn stop_boosting_is_disabled_by_safe_mode() {
 
 		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode {
 			stop_boosting_enabled: false,
-			..PalletSafeMode::CODE_GREEN
+			..PalletSafeMode::code_green()
 		});
 
 		// Should not be able to stop boosting
@@ -428,7 +428,7 @@ fn stop_boosting_is_disabled_by_safe_mode() {
 			Some(BOOST_FUNDS)
 		);
 
-		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode::CODE_GREEN);
+		MockRuntimeSafeMode::set_safe_mode(PalletSafeMode::code_green());
 
 		// Should be able to stop boosting now that the safe mode is turned off
 		assert_ok!(LendingPools::stop_boosting(

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -516,7 +516,7 @@ fn safe_mode_prevents_internal_swaps() {
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
 			liquidity_provider: PalletSafeMode {
 				internal_swaps_enabled: false,
-				..PalletSafeMode::CODE_GREEN
+				..PalletSafeMode::code_green()
 			},
 		});
 
@@ -524,7 +524,7 @@ fn safe_mode_prevents_internal_swaps() {
 
 		// As soon as we enable internal swaps the LP should be able to schedule a swap:
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			liquidity_provider: PalletSafeMode::CODE_GREEN,
+			liquidity_provider: PalletSafeMode::code_green(),
 		});
 
 		assert_ok!(schedule_swap());

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -935,7 +935,7 @@ mod safe_mode {
 
 			<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(PalletSafeMode {
 				strategy_updates_enabled: false,
-				..PalletSafeMode::CODE_GREEN
+				..PalletSafeMode::code_green()
 			});
 
 			assert_err!(
@@ -970,7 +970,7 @@ mod safe_mode {
 				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
 					PalletSafeMode {
 						strategy_updates_enabled: false,
-						..PalletSafeMode::CODE_GREEN
+						..PalletSafeMode::code_green()
 					},
 				);
 
@@ -1001,7 +1001,7 @@ mod safe_mode {
 				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
 					PalletSafeMode {
 						strategy_closure_enabled: false,
-						..PalletSafeMode::CODE_GREEN
+						..PalletSafeMode::code_green()
 					},
 				);
 
@@ -1028,7 +1028,7 @@ mod safe_mode {
 				<MockRuntimeSafeMode as SetSafeMode<PalletSafeMode>>::set_safe_mode(
 					PalletSafeMode {
 						strategy_execution_enabled: false,
-						..PalletSafeMode::CODE_GREEN
+						..PalletSafeMode::code_green()
 					},
 				);
 			})

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -277,8 +277,8 @@ mod benchmarks {
 			Pallet::<T>::start_authority_rotation();
 		}
 
-		assert_matches!(<T as Config>::SafeMode::get(), SafeMode::CODE_RED);
-		assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::Idle);
+		assert_eq!(<T as Config>::SafeMode::get(), PalletSafeMode::code_red());
+		assert_eq!(CurrentRotationPhase::<T>::get(), RotationPhase::Idle);
 	}
 
 	/**** 2. RotationPhase::KeygensInProgress *** */

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -627,7 +627,7 @@ fn no_validator_rotation_when_disabled_by_safe_mode() {
 	new_test_ext().then_execute_with_checks(|| {
 		// Activate Safe Mode: CODE RED
 		<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_red();
-		assert!(<MockRuntimeSafeMode as Get<PalletSafeMode>>::get() == PalletSafeMode::CODE_RED);
+		assert!(<MockRuntimeSafeMode as Get<PalletSafeMode>>::get() == PalletSafeMode::code_red());
 
 		// Try to start a rotation.
 		ValidatorPallet::start_authority_rotation();
@@ -640,7 +640,9 @@ fn no_validator_rotation_when_disabled_by_safe_mode() {
 
 		// Change safe mode to CODE GREEN
 		<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_green();
-		assert!(<MockRuntimeSafeMode as Get<PalletSafeMode>>::get() == PalletSafeMode::CODE_GREEN);
+		assert!(
+			<MockRuntimeSafeMode as Get<PalletSafeMode>>::get() == PalletSafeMode::code_green()
+		);
 
 		// Try to start a rotation.
 		set_default_test_bids();

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -136,8 +136,12 @@ pub enum MockRuntimeSafeMode {
 }
 
 impl SafeMode for MockRuntimeSafeMode {
-	const CODE_GREEN: Self = MockRuntimeSafeMode::CodeGreen;
-	const CODE_RED: Self = MockRuntimeSafeMode::CodeRed;
+	fn code_green() -> Self {
+		MockRuntimeSafeMode::CodeGreen
+	}
+	fn code_red() -> Self {
+		MockRuntimeSafeMode::CodeRed
+	}
 }
 
 thread_local! {

--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -82,13 +82,17 @@ impl<C, CallPermission: CallDispatchFilter<C>> CallDispatchFilter<C>
 
 impl<CallPermission> Default for PalletSafeMode<CallPermission> {
 	fn default() -> Self {
-		<PalletSafeMode<CallPermission> as SafeMode>::CODE_GREEN
+		<PalletSafeMode<CallPermission> as SafeMode>::code_green()
 	}
 }
 
 impl<CallPermission> SafeMode for PalletSafeMode<CallPermission> {
-	const CODE_RED: Self = PalletSafeMode::CodeRed;
-	const CODE_GREEN: Self = PalletSafeMode::CodeGreen;
+	fn code_red() -> Self {
+		PalletSafeMode::CodeRed
+	}
+	fn code_green() -> Self {
+		PalletSafeMode::CodeGreen
+	}
 }
 
 pub trait WitnessDataExtraction {
@@ -205,7 +209,7 @@ pub mod pallet {
 			let mut used_weight = Weight::zero();
 
 			let safe_mode = T::SafeMode::get();
-			if safe_mode != SafeMode::CODE_RED {
+			if safe_mode != SafeMode::code_red() {
 				let last_expired_epoch = T::EpochInfo::last_expired_epoch();
 				let current_epoch = T::EpochInfo::epoch_index();
 				WitnessedCallsScheduledForDispatch::<T>::mutate(|witnessed_calls_storage| {

--- a/state-chain/pallets/cf-witnesser/src/tests.rs
+++ b/state-chain/pallets/cf-witnesser/src/tests.rs
@@ -368,7 +368,7 @@ fn can_purge_stale_storage() {
 fn test_safe_mode() {
 	new_test_ext().execute_with(|| {
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			witnesser: PalletSafeMode::CODE_RED,
+			witnesser: PalletSafeMode::code_red(),
 		});
 
 		let call = Box::new(RuntimeCall::Dummy(pallet_dummy::Call::<Test>::increment_value {}));
@@ -398,7 +398,7 @@ fn test_safe_mode() {
 		assert!(!WitnessedCallsScheduledForDispatch::<Test>::get().is_empty());
 
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			witnesser: PalletSafeMode::CODE_GREEN,
+			witnesser: PalletSafeMode::code_green(),
 		});
 
 		// the call should now be able to dispatch since we now deactivated the safe mode but wont
@@ -455,7 +455,7 @@ fn safe_mode_code_amber_can_filter_calls() {
 fn safe_mode_recovery_ignores_duplicates() {
 	new_test_ext().execute_with(|| {
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			witnesser: PalletSafeMode::CODE_RED,
+			witnesser: PalletSafeMode::code_red(),
 		});
 
 		let call = Box::new(RuntimeCall::Dummy(pallet_dummy::Call::<Test>::increment_value {}));
@@ -489,7 +489,7 @@ fn safe_mode_recovery_ignores_duplicates() {
 		assert_eq!(WitnessedCallsScheduledForDispatch::<Test>::get().len(), 2);
 
 		MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
-			witnesser: PalletSafeMode::CODE_GREEN,
+			witnesser: PalletSafeMode::code_green(),
 		});
 		Witnesser::on_idle(1, Weight::zero().set_ref_time(1_000_000_000_000u64));
 

--- a/state-chain/runtime/src/migrations/safe_mode.rs
+++ b/state-chain/runtime/src/migrations/safe_mode.rs
@@ -76,7 +76,7 @@ impl UncheckedOnRuntimeUpgrade for SafeModeMigration {
                     ingress_egress_arbitrum: old.ingress_egress_arbitrum,
                     ingress_egress_solana: old.ingress_egress_solana,
                     ingress_egress_assethub: old.ingress_egress_assethub,
-                    elections_generic: GenericElectionsSafeMode::CODE_GREEN,
+                    elections_generic: GenericElectionsSafeMode::code_green(),
 				})
 			},
 		).map_err(|_| {

--- a/state-chain/traits/src/mocks/safe_mode.rs
+++ b/state-chain/traits/src/mocks/safe_mode.rs
@@ -50,35 +50,35 @@ mod test {
 			assert!(
 				<MockRuntimeSafeMode as Get<MockRuntimeSafeMode>>::get() ==
 					MockRuntimeSafeMode {
-						a: ExampleSafeModeA::CODE_GREEN,
-						b: ExampleSafeModeB::CODE_GREEN,
+						a: ExampleSafeModeA::code_green(),
+						b: ExampleSafeModeB::code_green(),
 					}
 			);
 			assert!(
 				<MockRuntimeSafeMode as Get<ExampleSafeModeA>>::get() ==
-					ExampleSafeModeA::CODE_GREEN
+					ExampleSafeModeA::code_green()
 			);
 			assert!(
 				<MockRuntimeSafeMode as Get<ExampleSafeModeB>>::get() ==
-					ExampleSafeModeB::CODE_GREEN
+					ExampleSafeModeB::code_green()
 			);
 
-			MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode::CODE_RED);
+			MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode::code_red());
 
 			assert!(
 				<MockRuntimeSafeMode as Get<MockRuntimeSafeMode>>::get() ==
 					MockRuntimeSafeMode {
-						a: ExampleSafeModeA::CODE_RED,
-						b: ExampleSafeModeB::CODE_RED,
+						a: ExampleSafeModeA::code_red(),
+						b: ExampleSafeModeB::code_red(),
 					}
 			);
 			assert_eq!(
 				<MockRuntimeSafeMode as Get<ExampleSafeModeA>>::get(),
-				ExampleSafeModeA::CODE_RED
+				ExampleSafeModeA::code_red()
 			);
 			assert_eq!(
 				<MockRuntimeSafeMode as Get<ExampleSafeModeB>>::get(),
-				ExampleSafeModeB::CODE_RED
+				ExampleSafeModeB::code_red()
 			);
 		});
 	}

--- a/state-chain/traits/src/safe_mode.rs
+++ b/state-chain/traits/src/safe_mode.rs
@@ -15,18 +15,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub trait SafeMode {
-	const CODE_RED: Self;
-	const CODE_GREEN: Self;
+	fn code_red() -> Self;
+	fn code_green() -> Self;
 }
 
 /// Trait for setting the value of current runtime Safe Mode.
 pub trait SetSafeMode<SafeModeType: SafeMode> {
 	fn set_safe_mode(mode: SafeModeType);
 	fn set_code_red() {
-		Self::set_safe_mode(SafeModeType::CODE_RED);
+		Self::set_safe_mode(SafeModeType::code_red());
 	}
 	fn set_code_green() {
-		Self::set_safe_mode(SafeModeType::CODE_GREEN);
+		Self::set_safe_mode(SafeModeType::code_green());
 	}
 }
 
@@ -85,17 +85,22 @@ macro_rules! impl_runtime_safe_mode {
 
 			impl Default for $runtime_safe_mode {
 				fn default() -> Self {
-					<Self as SafeMode>::CODE_GREEN
+					<Self as SafeMode>::code_green()
 				}
 			}
 
 			impl SafeMode for $runtime_safe_mode {
-				const CODE_RED: Self = Self {
-					$( $name: <$pallet_safe_mode as SafeMode>::CODE_RED ),*
-				};
-				const CODE_GREEN: Self = Self {
-					$( $name: <$pallet_safe_mode as SafeMode>::CODE_GREEN ),*
-				};
+				fn code_red() -> Self {
+					Self {
+						$( $name: <$pallet_safe_mode as SafeMode>::code_red()),*
+					}
+				}
+
+				fn code_green() -> Self {
+					Self {
+						$( $name: <$pallet_safe_mode as SafeMode>::code_green()),*
+					}
+				}
 			}
 
 			impl SetSafeMode<$runtime_safe_mode> for $runtime_safe_mode {
@@ -160,21 +165,25 @@ macro_rules! impl_pallet_safe_mode {
 
         impl Default for $pallet_safe_mode {
             fn default() -> Self {
-                <Self as $crate::SafeMode>::CODE_GREEN
+                <Self as $crate::SafeMode>::code_green()
             }
         }
 
         impl $crate::SafeMode for $pallet_safe_mode {
-            const CODE_RED: Self = Self {
-                $(
-                    $flag: false,
-                )+
-            };
-            const CODE_GREEN: Self = Self {
-                $(
-                    $flag: true,
-                )+
-            };
+            fn code_red() -> Self {
+	            Self {
+	                $(
+	                    $flag: false,
+	                )+
+	            }
+            }
+            fn code_green() -> Self {
+	            Self {
+	                $(
+	                    $flag: true,
+	                )+
+	            }
+            }
         }
     };
 
@@ -196,23 +205,27 @@ macro_rules! impl_pallet_safe_mode {
 
         impl<$generic> Default for $pallet_safe_mode<$generic> {
             fn default() -> Self {
-                <Self as $crate::SafeMode>::CODE_GREEN
+                <Self as $crate::SafeMode>::code_green()
             }
         }
 
         impl<$generic> $crate::SafeMode for $pallet_safe_mode<$generic> {
-            const CODE_RED: Self = Self {
-                $(
-                    $flag: false,
-                )+
-                _phantom: ::core::marker::PhantomData,
-            };
-            const CODE_GREEN: Self = Self {
-                $(
-                    $flag: true,
-                )+
-                _phantom: ::core::marker::PhantomData,
-            };
+        	fn code_red() -> Self {
+         		Self {
+         			$(
+         				$flag: false,
+         			)+
+         			_phantom: ::core::marker::PhantomData,
+         		}
+            }
+            fn code_green() -> Self {
+         		Self {
+         			$(
+         				$flag: true,
+         			)+
+         			_phantom: ::core::marker::PhantomData,
+         		}
+            }
         }
     };
 }
@@ -262,13 +275,21 @@ pub(crate) mod test {
 	}
 
 	impl SafeMode for ExampleSafeModeA {
-		const CODE_RED: Self = Self { safe: false };
-		const CODE_GREEN: Self = Self { safe: true };
+		fn code_red() -> Self {
+			Self { safe: false }
+		}
+		fn code_green() -> Self {
+			Self { safe: true }
+		}
 	}
 
 	impl SafeMode for ExampleSafeModeB {
-		const CODE_RED: Self = Self::NotSafe;
-		const CODE_GREEN: Self = Self::Safe;
+		fn code_red() -> Self {
+			Self::NotSafe
+		}
+		fn code_green() -> Self {
+			Self::Safe
+		}
 	}
 
 	// Use this macro to define a basic safe mode struct with a list of bool flags.
@@ -294,23 +315,23 @@ pub(crate) mod test {
 			assert!(
 				<TestRuntimeSafeMode as Get<TestRuntimeSafeMode>>::get() ==
 					TestRuntimeSafeMode {
-						example_a: ExampleSafeModeA::CODE_GREEN,
-						example_b: ExampleSafeModeB::CODE_GREEN,
-						pallet: SafeMode::CODE_GREEN,
-						pallet_2: SafeMode::CODE_GREEN,
+						example_a: ExampleSafeModeA::code_green(),
+						example_b: ExampleSafeModeB::code_green(),
+						pallet: SafeMode::code_green(),
+						pallet_2: SafeMode::code_green(),
 					}
 			);
 			assert!(
 				<TestRuntimeSafeMode as Get<ExampleSafeModeA>>::get() ==
-					ExampleSafeModeA::CODE_GREEN
+					ExampleSafeModeA::code_green()
 			);
 			assert!(
 				<TestRuntimeSafeMode as Get<ExampleSafeModeB>>::get() ==
-					ExampleSafeModeB::CODE_GREEN
+					ExampleSafeModeB::code_green()
 			);
 			assert!(
 				<TestRuntimeSafeMode as Get<TestPalletSafeMode>>::get() ==
-					TestPalletSafeMode::CODE_GREEN
+					TestPalletSafeMode::code_green()
 			);
 
 			// Activate Code Red for all
@@ -319,29 +340,29 @@ pub(crate) mod test {
 			assert!(
 				<TestRuntimeSafeMode as Get<TestRuntimeSafeMode>>::get() ==
 					TestRuntimeSafeMode {
-						example_a: ExampleSafeModeA::CODE_RED,
-						example_b: ExampleSafeModeB::CODE_RED,
-						pallet: SafeMode::CODE_RED,
-						pallet_2: SafeMode::CODE_RED,
+						example_a: ExampleSafeModeA::code_red(),
+						example_b: ExampleSafeModeB::code_red(),
+						pallet: SafeMode::code_red(),
+						pallet_2: SafeMode::code_red(),
 					}
 			);
 			assert_eq!(
 				<TestRuntimeSafeMode as Get<ExampleSafeModeA>>::get(),
-				ExampleSafeModeA::CODE_RED
+				ExampleSafeModeA::code_red()
 			);
 			assert_eq!(
 				<TestRuntimeSafeMode as Get<ExampleSafeModeB>>::get(),
-				ExampleSafeModeB::CODE_RED
+				ExampleSafeModeB::code_red()
 			);
 			assert!(
 				<TestRuntimeSafeMode as Get<TestPalletSafeMode>>::get() ==
-					TestPalletSafeMode::CODE_RED
+					TestPalletSafeMode::code_red()
 			);
 
 			// Code Amber
 			TestRuntimeSafeMode::set_safe_mode(TestRuntimeSafeMode {
-				example_a: ExampleSafeModeA::CODE_RED,
-				example_b: ExampleSafeModeB::CODE_RED,
+				example_a: ExampleSafeModeA::code_red(),
+				example_b: ExampleSafeModeB::code_red(),
 				pallet: TestPalletSafeMode { flag_1: true, flag_2: false },
 				pallet_2: TestPalletSafeMode2 { flag_1: false, flag_2: true },
 			});
@@ -357,7 +378,7 @@ pub(crate) mod test {
 			<TestRuntimeSafeMode as SetSafeMode<ExampleSafeModeA>>::set_code_green();
 			assert!(
 				<TestRuntimeSafeMode as Get<ExampleSafeModeA>>::get() ==
-					ExampleSafeModeA::CODE_GREEN,
+					ExampleSafeModeA::code_green(),
 			);
 		});
 	}


### PR DESCRIPTION
# Pull Request

As discussed with @dandanlen, since we are introducing per asset safe mode in the upcoming lending pallet, we need to be able to support containers (e.g. BTreeSet) as part of SafeMode structs, which makes it tricky to continue using const `CODE_GREEN` and `CODE_RED`. In this PR I'm changing these into `code_green()` and `code_red()` functions. This shouldn't really affect performance as we don't use these in performance critical sections.