### PR TITLE
feat: limit number of validators per operator to 20

### DIFF
--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -57,7 +57,7 @@ fn setup_delegation(
 	));
 
 	assert_eq!(
-		pallet_cf_validator::ManagedValidators::<Runtime>::get(&validator),
+		pallet_cf_validator::OperatorChoice::<Runtime>::get(&validator),
 		Some(operator.clone())
 	);
 	assert!(pallet_cf_validator::OperatorSettingsLookup::<Runtime>::get(operator.clone()).is_some());

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -441,7 +441,7 @@ mod benchmarks {
 		#[extrinsic_call]
 		accept_operator(RawOrigin::Signed(validator.clone()), operator.clone());
 
-		assert!(ManagedValidators::<T>::get(validator).is_some());
+		assert!(OperatorChoice::<T>::get(validator).is_some());
 	}
 
 	#[benchmark]
@@ -456,12 +456,12 @@ mod benchmarks {
 		)
 		.unwrap();
 
-		ManagedValidators::<T>::insert(validator.clone(), operator.clone());
+		OperatorChoice::<T>::insert(validator.clone(), operator.clone());
 
 		#[extrinsic_call]
 		remove_validator(RawOrigin::Signed(validator.clone()), validator.clone());
 
-		assert!(ManagedValidators::<T>::get(validator).is_none());
+		assert!(OperatorChoice::<T>::get(validator).is_none());
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -19,6 +19,8 @@ use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
 /// The minimum delegation fee that can be charged, in basis points.
 pub const MIN_OPERATOR_FEE: u32 = 200;
 
+pub const MAX_VALIDATORS_PER_OPERATOR: usize = 20;
+
 pub enum AssociationToOperator {
 	Validator,
 	Delegator,

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -335,7 +335,7 @@ pub mod pallet {
 	pub type Exceptions<T: Config> =
 		StorageMap<_, Identity, T::AccountId, BTreeSet<T::AccountId>, ValueQuery>;
 
-	/// Maps a managed validator to its operator.
+	/// Maps operators to a list of their managed validators.
 	#[pallet::storage]
 	pub type ManagedValidators<T: Config> =
 		StorageMap<_, Identity, T::AccountId, BTreeSet<T::AccountId>, ValueQuery>;

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1808,7 +1808,7 @@ mod operator {
 				OriginTrait::signed(ALICE),
 				OPERATOR_SETTINGS
 			));
-			OperatorChoice::<Test>::insert(BOB, ALICE);
+			assert_ok!(ValidatorPallet::delegate(OriginTrait::signed(BOB), ALICE));
 
 			// Should succeed - validators are automatically removed during deregistration
 			assert_ok!(ValidatorPallet::deregister_as_operator(OriginTrait::signed(ALICE)));

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2574,13 +2574,13 @@ pub mod auction_optimization {
 		for bid in op_1_bids {
 			assert_ok!(ValidatorPallet::claim_validator(OriginTrait::signed(OP_1), bid.bidder_id));
 			assert_ok!(ValidatorPallet::accept_operator(OriginTrait::signed(bid.bidder_id), OP_1));
-			assert!(ManagedValidators::<Test>::get(bid.bidder_id).is_some());
+			assert!(OperatorChoice::<Test>::get(bid.bidder_id).is_some());
 		}
 
 		for bid in op_2_bids {
 			assert_ok!(ValidatorPallet::claim_validator(OriginTrait::signed(OP_2), bid.bidder_id));
 			assert_ok!(ValidatorPallet::accept_operator(OriginTrait::signed(bid.bidder_id), OP_2));
-			assert!(ManagedValidators::<Test>::get(bid.bidder_id).is_some());
+			assert!(OperatorChoice::<Test>::get(bid.bidder_id).is_some());
 		}
 	}
 
@@ -2761,7 +2761,7 @@ pub mod auction_optimization {
 									snapshot.operator
 								);
 								assert_eq!(
-									ManagedValidators::<Test>::get(val).unwrap(),
+									OperatorChoice::<Test>::get(val).unwrap(),
 									snapshot.operator
 								)
 							})

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1808,7 +1808,11 @@ mod operator {
 				OriginTrait::signed(ALICE),
 				OPERATOR_SETTINGS
 			));
-			assert_ok!(ValidatorPallet::delegate(OriginTrait::signed(BOB), ALICE));
+			assert_ok!(ValidatorPallet::delegate(
+				OriginTrait::signed(BOB),
+				ALICE,
+				DelegationAmount::Max
+			));
 
 			// Should succeed - validators are automatically removed during deregistration
 			assert_ok!(ValidatorPallet::deregister_as_operator(OriginTrait::signed(ALICE)));

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2723,8 +2723,14 @@ pub mod auction_optimization {
 				.into_iter()
 				.map(|(b1, b2)| {
 					(
-						b1.into_iter().map(|b| b % FLIP_MAX_SUPPLY).collect(),
-						b2.into_iter().map(|b| b % FLIP_MAX_SUPPLY).collect(),
+						b1.into_iter()
+							.take(MAX_VALIDATORS_PER_OPERATOR)
+							.map(|b| b % FLIP_MAX_SUPPLY)
+							.collect(),
+						b2.into_iter()
+							.take(MAX_VALIDATORS_PER_OPERATOR)
+							.map(|b| b % FLIP_MAX_SUPPLY)
+							.collect(),
 						Default::default(),
 						Default::default(),
 					)

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1772,8 +1772,8 @@ mod operator {
 			);
 
 			// Expected end state:
-			assert_eq!(ManagedValidators::<Test>::get(V_1), Some(OP_2));
-			assert_eq!(ManagedValidators::<Test>::get(V_2), Some(OP_1));
+			assert_eq!(OperatorChoice::<Test>::get(V_1), Some(OP_2));
+			assert_eq!(OperatorChoice::<Test>::get(V_2), Some(OP_1));
 
 			assert_has_event::<Test>(RuntimeEvent::ValidatorPallet(
 				Event::OperatorAcceptedByValidator { validator: V_1, operator: OP_2 },
@@ -1786,10 +1786,10 @@ mod operator {
 	#[test]
 	fn validator_and_operator_can_remove_validator() {
 		new_test_ext().execute_with(|| {
-			ManagedValidators::<Test>::insert(BOB, ALICE);
+			OperatorChoice::<Test>::insert(BOB, ALICE);
 			// ALICE can remove BOB
 			assert_ok!(ValidatorPallet::remove_validator(OriginTrait::signed(ALICE), BOB));
-			ManagedValidators::<Test>::insert(BOB, ALICE);
+			OperatorChoice::<Test>::insert(BOB, ALICE);
 			// BOB can remove BOB
 			assert_ok!(ValidatorPallet::remove_validator(OriginTrait::signed(BOB), BOB));
 			assert_event_sequence!(
@@ -1808,13 +1808,13 @@ mod operator {
 				OriginTrait::signed(ALICE),
 				OPERATOR_SETTINGS
 			));
-			ManagedValidators::<Test>::insert(BOB, ALICE);
+			OperatorChoice::<Test>::insert(BOB, ALICE);
 
 			// Should succeed - validators are automatically removed during deregistration
 			assert_ok!(ValidatorPallet::deregister_as_operator(OriginTrait::signed(ALICE)));
 
 			// Verify validator was removed from operator
-			assert!(!ManagedValidators::<Test>::contains_key(BOB));
+			assert!(!OperatorChoice::<Test>::contains_key(BOB));
 		});
 	}
 
@@ -2047,7 +2047,7 @@ mod delegation {
 						OriginTrait::signed(bid.bidder_id),
 						OPERATOR
 					));
-					assert!(ManagedValidators::<Test>::get(bid.bidder_id).is_some());
+					assert!(OperatorChoice::<Test>::get(bid.bidder_id).is_some());
 				}
 
 				set_default_test_bids();

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1736,7 +1736,7 @@ impl_runtime_apis! {
 				apy_bp,
 				restricted_balances,
 				estimated_redeemable_balance,
-				operator: pallet_cf_validator::ManagedValidators::<Runtime>::get(account_id),
+				operator: pallet_cf_validator::OperatorChoice::<Runtime>::get(account_id),
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2516

Sets a limit to the number of validators per operator. 

I renamed ManagedValidators to OperatorChoice (this is similar to DelegationChoice for delegators).
This way I can use ManagedValidators for a map of Operator to all current validators. 