### PR TITLE
feat: allow `lp_subscribe_order_fills` to return best blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "cf-primitives",
  "cf-rpc-types",
  "jsonrpsee 0.23.2",
+ "serde",
  "thiserror 1.0.69",
 ]
 

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -304,7 +304,11 @@ impl LpRpcApiServer for RpcServerImpl {
 			.tx_hash)
 	}
 
-	async fn subscribe_order_fills(&self, pending_sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
+	async fn subscribe_order_fills(
+		&self,
+		pending_sink: PendingSubscriptionSink,
+		wait_finalized: Option<bool>,
+	) {
 		// pipe results from custom-rpc subscription
 		match self.api.raw_client().cf_subscribe_lp_order_fills(wait_finalized).await {
 			Ok(subscription) => {

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -304,9 +304,9 @@ impl LpRpcApiServer for RpcServerImpl {
 			.tx_hash)
 	}
 
-	async fn subscribe_order_fills(&self, pending_sink: PendingSubscriptionSink) {
+	async fn subscribe_order_fills(&self, pending_sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
 		// pipe results from custom-rpc subscription
-		match self.api.raw_client().cf_subscribe_lp_order_fills().await {
+		match self.api.raw_client().cf_subscribe_lp_order_fills(wait_finalized).await {
 			Ok(subscription) => {
 				let stream = stream::unfold(subscription, move |mut sub| async move {
 					match sub.next().await {

--- a/api/bin/chainflip-lp-api/src/main.rs
+++ b/api/bin/chainflip-lp-api/src/main.rs
@@ -19,7 +19,9 @@ use cf_primitives::{
 	chains::{Arbitrum, Solana},
 	ApiWaitForResult, BasisPoints, BlockNumber, DcaParameters, EgressId, PriceLimits, WaitFor,
 };
-use cf_rpc_apis::{lp::LpRpcApiServer, ExtrinsicResponse, RpcApiError, RpcResult};
+use cf_rpc_apis::{
+	lp::LpRpcApiServer, ExtrinsicResponse, NotificationBehaviour, RpcApiError, RpcResult,
+};
 use cf_utilities::{
 	health::{self, HealthCheckOptions},
 	rpc::NumberOrHex,
@@ -307,10 +309,10 @@ impl LpRpcApiServer for RpcServerImpl {
 	async fn subscribe_order_fills(
 		&self,
 		pending_sink: PendingSubscriptionSink,
-		wait_finalized: Option<bool>,
+		notification_behaviour: Option<NotificationBehaviour>,
 	) {
 		// pipe results from custom-rpc subscription
-		match self.api.raw_client().cf_subscribe_lp_order_fills(wait_finalized).await {
+		match self.api.raw_client().cf_subscribe_lp_order_fills(notification_behaviour).await {
 			Ok(subscription) => {
 				let stream = stream::unfold(subscription, move |mut sub| async move {
 					match sub.next().await {

--- a/api/cf-rpc-apis/Cargo.toml
+++ b/api/cf-rpc-apis/Cargo.toml
@@ -18,3 +18,4 @@ jsonrpsee = { workspace = true, features = ["full"] }
 cf-chains = { workspace = true, default-features = true }
 cf-primitives = { workspace = true, default-features = true }
 cf-rpc-types = { workspace = true }
+serde = { workspace = true, default-features = true, features = ["derive"] }

--- a/api/cf-rpc-apis/src/lib.rs
+++ b/api/cf-rpc-apis/src/lib.rs
@@ -19,9 +19,23 @@ use jsonrpsee::{
 	tracing::log,
 	types::{error::ErrorObjectOwned, ErrorCode, ErrorObject},
 };
+use serde::{Deserialize, Serialize};
 
 pub mod broker;
 pub mod lp;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum NotificationBehaviour {
+	/// Subscription will return finalized blocks.
+	Finalized,
+	/// Subscription will return best blocks. In the case of a re-org it might drop events.
+	#[default]
+	Best,
+	/// Subscription will return all new blocks. In the case of a re-org it might duplicate events.
+	///
+	/// The caller is responsible for de-duplicating events.
+	New,
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum RpcApiError {

--- a/api/cf-rpc-apis/src/lp.rs
+++ b/api/cf-rpc-apis/src/lp.rs
@@ -139,7 +139,7 @@ pub trait LpRpcApi {
 	) -> RpcResult<Hash>;
 
 	#[subscription(name = "subscribe_order_fills", item = BlockUpdate<OrderFills>)]
-	async fn subscribe_order_fills(&self);
+	async fn subscribe_order_fills(&self, wait_finalized: Option<bool>);
 
 	#[method(name = "order_fills")]
 	async fn order_fills(&self, at: Option<Hash>) -> RpcResult<BlockUpdate<OrderFills>>;

--- a/api/cf-rpc-apis/src/lp.rs
+++ b/api/cf-rpc-apis/src/lp.rs
@@ -138,7 +138,7 @@ pub trait LpRpcApi {
 	) -> RpcResult<Hash>;
 
 	#[subscription(name = "subscribe_order_fills", item = BlockUpdate<OrderFills>)]
-	async fn subscribe_order_fills(&self, wait_finalized: Option<NotificationBehaviour>);
+	async fn subscribe_order_fills(&self, notification_behaviour: Option<NotificationBehaviour>);
 
 	#[method(name = "order_fills")]
 	async fn order_fills(&self, at: Option<Hash>) -> RpcResult<BlockUpdate<OrderFills>>;

--- a/api/cf-rpc-apis/src/lp.rs
+++ b/api/cf-rpc-apis/src/lp.rs
@@ -14,21 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::RpcResult;
+use crate::{NotificationBehaviour, RpcResult};
 
 use cf_chains::{address::AddressString, evm::U256};
 use cf_primitives::{
 	chains::assets::any::AssetMap, ApiWaitForResult, Asset, BasisPoints, BlockNumber,
 	DcaParameters, EgressId, ForeignChain, PriceLimits, WaitFor,
 };
+pub use cf_rpc_types::lp::*;
 use cf_rpc_types::{
 	AccountId32, BlockUpdate, BoundedVec, ConstU32, EthereumAddress, ExtrinsicResponse, Hash,
 	NumberOrHex, OrderFills,
 };
 use jsonrpsee::proc_macros::rpc;
 use std::ops::Range;
-
-pub use cf_rpc_types::lp::*;
 
 #[rpc(server, client, namespace = "lp")]
 pub trait LpRpcApi {
@@ -139,7 +138,7 @@ pub trait LpRpcApi {
 	) -> RpcResult<Hash>;
 
 	#[subscription(name = "subscribe_order_fills", item = BlockUpdate<OrderFills>)]
-	async fn subscribe_order_fills(&self, wait_finalized: Option<bool>);
+	async fn subscribe_order_fills(&self, wait_finalized: Option<NotificationBehaviour>);
 
 	#[method(name = "order_fills")]
 	async fn order_fills(&self, at: Option<Hash>) -> RpcResult<BlockUpdate<OrderFills>>;

--- a/state-chain/custom-rpc/src/backend.rs
+++ b/state-chain/custom-rpc/src/backend.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::CfApiError;
-use cf_rpc_apis::{call_error, internal_error, CfErrorCode, RpcApiError};
+use cf_rpc_apis::{call_error, internal_error, CfErrorCode, NotificationBehaviour, RpcApiError};
 use futures::{stream, stream::StreamExt, FutureExt};
 use jsonrpsee::{types::error::ErrorObjectOwned, PendingSubscriptionSink, RpcModule};
 
@@ -36,7 +36,7 @@ use state_chain_runtime::{
 	runtime_apis::CustomRuntimeApi,
 	Hash, Header,
 };
-use std::{fmt::Debug, marker::PhantomData, num::NonZero, sync::Arc};
+use std::{marker::PhantomData, num::NonZero, sync::Arc};
 
 /// The CustomRpcBackend struct provides common logic implementation for providing RPC endpoints.
 ///
@@ -99,19 +99,6 @@ where
 			Ok(f(api, hash, api_version)?)
 		})
 	}
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum NotificationBehaviour {
-	/// Subscription will return finalized blocks.
-	Finalized,
-	/// Subscription will return best blocks. In the case of a re-org it might drop events.
-	#[default]
-	Best,
-	/// Subscription will return all new blocks. In the case of a re-org it might duplicate events.
-	///
-	/// The caller is responsible for de-duplicating events.
-	New,
 }
 
 /// Number of pinned blocks before starting to unpin oldest block. Must be lower than

--- a/state-chain/custom-rpc/src/broker.rs
+++ b/state-chain/custom-rpc/src/broker.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-	backend::{CustomRpcBackend, NotificationBehaviour},
+	backend::CustomRpcBackend,
 	get_preallocated_channels,
 	pool_client::{is_transaction_status_error, PoolClientError, SignedPoolClient},
 	CfApiError,
@@ -32,7 +32,7 @@ use cf_rpc_apis::{
 		DcaParameters, GetOpenDepositChannelsQuery, RpcBytes, SwapDepositAddress, TransactionInId,
 		VaultSwapExtraParametersRpc, VaultSwapInputRpc, WithdrawFeesDetail,
 	},
-	RefundParametersRpc, RpcResult, H256,
+	NotificationBehaviour, RefundParametersRpc, RpcResult, H256,
 };
 use futures::StreamExt;
 use jsonrpsee::{core::async_trait, PendingSubscriptionSink};

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1871,10 +1871,18 @@ where
 			})
 	}
 
-	async fn cf_subscribe_lp_order_fills(&self, sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
+	async fn cf_subscribe_lp_order_fills(
+		&self,
+		sink: PendingSubscriptionSink,
+		wait_finalized: Option<bool>,
+	) {
 		self.rpc_backend
 			.new_subscription(
-				if wait_finalized.unwrap_or(true) { NotificationBehaviour::Finalized } else { NotificationBehaviour::Best },
+				if wait_finalized.unwrap_or(true) {
+					NotificationBehaviour::Finalized
+				} else {
+					NotificationBehaviour::Best
+				},
 				false,
 				true,
 				sink,

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -876,7 +876,7 @@ pub trait CustomApi {
 	async fn cf_subscribe_scheduled_swaps(&self, base_asset: Asset, quote_asset: Asset);
 
 	#[subscription(name = "subscribe_lp_order_fills", item = BlockUpdate<OrderFills>)]
-	async fn cf_subscribe_lp_order_fills(&self);
+	async fn cf_subscribe_lp_order_fills(&self, wait_finalized: Option<bool>);
 
 	#[subscription(name = "subscribe_transaction_screening_events", item = BlockUpdate<TransactionScreeningEvents>)]
 	async fn cf_subscribe_transaction_screening_events(&self);
@@ -1871,10 +1871,10 @@ where
 			})
 	}
 
-	async fn cf_subscribe_lp_order_fills(&self, sink: PendingSubscriptionSink) {
+	async fn cf_subscribe_lp_order_fills(&self, sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
 		self.rpc_backend
 			.new_subscription(
-				NotificationBehaviour::Finalized,
+				if wait_finalized.unwrap_or(true) { NotificationBehaviour::Finalized } else { NotificationBehaviour::Best },
 				false,
 				true,
 				sink,

--- a/state-chain/custom-rpc/src/lp.rs
+++ b/state-chain/custom-rpc/src/lp.rs
@@ -15,11 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-	backend::{CustomRpcBackend, NotificationBehaviour},
+	backend::CustomRpcBackend,
 	get_preallocated_channels, order_fills,
 	pool_client::{is_transaction_status_error, PoolClientError, SignedPoolClient},
 	CfApiError, RpcResult, StorageQueryApi,
 };
+
 use anyhow::anyhow;
 use cf_amm::{common::Side, math::Tick};
 use cf_chains::{
@@ -45,7 +46,7 @@ use cf_rpc_apis::{
 		LpRpcApiServer, OpenSwapChannels, OrderIdJson, RangeOrder, RangeOrderChange,
 		RangeOrderSizeJson, SwapRequestResponse,
 	},
-	ExtrinsicResponse, OrderFills, RedemptionAmount, SwapChannelInfo,
+	ExtrinsicResponse, NotificationBehaviour, OrderFills, RedemptionAmount, SwapChannelInfo,
 };
 use cf_utilities::{rpc::NumberOrHex, try_parse_number_or_hex};
 use frame_support::BoundedVec;
@@ -581,15 +582,11 @@ where
 	async fn subscribe_order_fills(
 		&self,
 		sink: PendingSubscriptionSink,
-		wait_finalized: Option<bool>,
+		notification_behaviour: Option<NotificationBehaviour>,
 	) {
 		self.rpc_backend
 			.new_subscription(
-				if wait_finalized.unwrap_or(true) {
-					NotificationBehaviour::Finalized
-				} else {
-					NotificationBehaviour::Best
-				},
+				notification_behaviour.unwrap_or(NotificationBehaviour::Finalized),
 				false,
 				true,
 				sink,

--- a/state-chain/custom-rpc/src/lp.rs
+++ b/state-chain/custom-rpc/src/lp.rs
@@ -578,10 +578,10 @@ where
 		Ok(tx_hash)
 	}
 
-	async fn subscribe_order_fills(&self, sink: PendingSubscriptionSink) {
+	async fn subscribe_order_fills(&self, sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
 		self.rpc_backend
 			.new_subscription(
-				NotificationBehaviour::Finalized,
+				if wait_finalized.unwrap_or(true) { NotificationBehaviour::Finalized } else { NotificationBehaviour::Best },
 				false,
 				true,
 				sink,

--- a/state-chain/custom-rpc/src/lp.rs
+++ b/state-chain/custom-rpc/src/lp.rs
@@ -578,10 +578,18 @@ where
 		Ok(tx_hash)
 	}
 
-	async fn subscribe_order_fills(&self, sink: PendingSubscriptionSink, wait_finalized: Option<bool>) {
+	async fn subscribe_order_fills(
+		&self,
+		sink: PendingSubscriptionSink,
+		wait_finalized: Option<bool>,
+	) {
 		self.rpc_backend
 			.new_subscription(
-				if wait_finalized.unwrap_or(true) { NotificationBehaviour::Finalized } else { NotificationBehaviour::Best },
+				if wait_finalized.unwrap_or(true) {
+					NotificationBehaviour::Finalized
+				} else {
+					NotificationBehaviour::Best
+				},
 				false,
 				true,
 				sink,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2444

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

Added optional parameter to the subscription to allow subscribing to best blocks instead of finalized only
