### PR TITLE
feat: use correct origin to dispatch broadcastSuccessCallback for bitcoin

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -1072,23 +1072,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			PendingApiCalls::<T, I>::get(broadcast_id).map(|api_call| (broadcast_id, api_call))
 		})
 	}
-
-	pub fn broadcast_success(egress: TransactionConfirmation<T, I>) {
-		if let Err(err) = Self::egress_success(
-			OriginFor::<T>::none(),
-			egress.tx_out_id.clone(),
-			egress.signer_id,
-			egress.tx_fee,
-			egress.tx_metadata,
-			egress.transaction_ref,
-		) {
-			log::error!(
-				"Failed to execute egress success: TxOutId: {:?}, Error: {:?}",
-				egress.tx_out_id,
-				err
-			)
-		}
-	}
 }
 
 impl<T: Config<I>, I: 'static> Broadcaster<T::TargetChain> for Pallet<T, I> {

--- a/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
+++ b/state-chain/runtime/src/chainflip/bitcoin_block_processor.rs
@@ -118,7 +118,21 @@ impl Hook<HookTypeFor<TypesEgressWitnessing, ExecuteHook>> for TypesEgressWitnes
 			match event {
 				BtcEvent::PreWitness(_) => { /* We don't care about pre-witnessing an egress*/ },
 				BtcEvent::Witness(egress) => {
-					BitcoinBroadcaster::broadcast_success(egress.clone());
+					#[allow(clippy::unit_arg)]
+					if let Err(err) = BitcoinBroadcaster::egress_success(
+						pallet_cf_witnesser::RawOrigin::CurrentEpochWitnessThreshold.into(),
+						egress.tx_out_id,
+						egress.signer_id.clone(),
+						egress.tx_fee,
+						egress.tx_metadata,
+						egress.transaction_ref,
+					) {
+						log::error!(
+							"Failed to execute Bitcoin egress success: TxOutId: {:?}, Error: {:?}",
+							egress.tx_out_id,
+							err
+						)
+					}
 				},
 			}
 		}


### PR DESCRIPTION
# Pull Request

Closes: PRO-xxx

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary
Used correct origin to dispatch `BroadcastSuccessCallback` for Bitcoin.