### PR TITLE
feat: only run perseverance release job on x.y.z semver tag (no suffix)

### DIFF
--- a/.github/workflows/release-perseverance.yml
+++ b/.github/workflows/release-perseverance.yml
@@ -2,7 +2,7 @@ name: Release Chainflip Perseverance
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
+      - "[0-9]+.[0-9]+.[0-9]+"
 concurrency:
   group: ${{ github.ref }}-release-perseverance
   cancel-in-progress: true


### PR DESCRIPTION
Sometimes it can be useful to tag a release candidate without running the release jobs.