### PR TITLE
fix: better sampling of txs for btc fees if mempool is almost empty

### DIFF
--- a/engine/src/witness/btc/fees.rs
+++ b/engine/src/witness/btc/fees.rs
@@ -43,6 +43,7 @@ pub async fn predict_fees(
 
 	// -- calculate sample target --
 	let sample_size = (tx_sample_count_per_mempool_block as f64) * blocks_in_mempool;
+	let sample_size = cmp::max(sample_size, tx_sample_count_per_mempool_block);
 	tracing::debug!("we have to download {sample_size} txs to have an average sample size of {tx_sample_count_per_mempool_block} per block");
 
 	// ----------------------------------


### PR DESCRIPTION
Currently, if the mempool is almost empty, we're not sampling any transactions, due to rounding and the fact that the number of txs being sampled is scaled by the number of "mempool blocks" currently in the mempool.

With this fix, we will always try to sample at least `sample_size` txs, even if there are very few txs in the mempool.