### PR TITLE
fix: use correct nonce for one of the sol localnet nonce accounts.

### DIFF
--- a/state-chain/node/src/chain_spec/testnet.rs
+++ b/state-chain/node/src/chain_spec/testnet.rs
@@ -141,7 +141,7 @@ pub const ENV: StateChainEnvironment = StateChainEnvironment {
 		),
 		(
 			const_address("3pGbKatko2ckoLEy139McfKiirNgy9brYxieNqFGdN1W"),
-			const_hash("EbWq3dgSjaa8pX3YeXVHopANoHCAsEkXrbALMjndbvr1"),
+			const_hash("64hFuYc2RjeDLWAatbnbD3XCWgRBgbHLxCjfeNxx1G5e"),
 		),
 		(
 			const_address("9Mcd8BTievK2yTvyiqG9Ft4HfDFf6mjGFBWMnCSRQP8S"),


### PR DESCRIPTION
### Summary

In localnet, when running the `AllSwaps` test, we had to restrict the max-concurrency to 100, since otherwise some solana egresses seemed to fail. The issue was exacerbated when attempting to run "fast bouncer".

Tracking down of this problem led me to discover that one of the nonce accounts was initialized with an incorrect nonce. To double check that this PR uses the correct value, you can do the following:

1. start a localnet
2. open the [sol explorer](https://explorer.solana.com/?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899)
3. search for `3pGbKatko2ckoLEy139McfKiirNgy9brYxieNqFGdN1W` (this account can be found in the `chain_spec/testnet.rs` file)
4. check the `blockhash` field. On a freshly started localnet it will say `64hFuYc2RjeDLWAatbnbD3XCWgRBgbHLxCjfeNxx1G5e`.
5. To double check, all other accounts mentioned in the spec file should have the same hash as the `block_hash` field shows in the sol explorer.