### PR TITLE
fix: make voting for optimistic elections work independently of best_block_height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [1.11.5] - 2025-09-24
+
+## Fixes
+
+- Make voting for optimistic elections work independently of best_block_height ([#5995](https://github.com/chainflip-io/chainflip-backend/issues/5995)).
+
 ## [1.11.4] - 2025-09-23
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -13736,7 +13736,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.11.4"
+version = "1.11.5"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.11.4"
+version = "1.11.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.11.4"
+version = "1.11.5"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.11.4"
+version = "1.11.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.11.4"
+version = "1.11.5"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.11.4"
+version = "1.11.5"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_11_4"
+name = "chainflip_engine_v1_11_5"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.11.4"
+version = "1.11.5"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.11.4"
+version = "1.11.5"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v1_11_4.so",
+		"target/release/libchainflip_engine_v1_11_5.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_4.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_5.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.11.4")]
+	#[engine_proc_macros::link_engine_library_version("1.11.5")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -27,7 +27,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.10.4";
-pub const NEW_VERSION: &str = "1.11.4";
+pub const NEW_VERSION: &str = "1.11.5";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.11.4"
+version = "1.11.5"
 license = "Apache-2.0"
 
 [lib]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.11.4"
+version = "1.11.5"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.11.4"
+version = "1.11.5"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -243,7 +243,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 1_11_04,
+	spec_version: 1_11_05,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
## Summary

Cherry-pick of PR #5995 that was against `release/1.10` and wasn't picked until now.