### PR TITLE
fix: ensure bond for managed validators is distributed correctly

### DIFF
--- a/engine/src/witness/common/epoch_source.rs
+++ b/engine/src/witness/common/epoch_source.rs
@@ -277,7 +277,7 @@ impl<
 						.await
 						.expect(STATE_CHAIN_CONNECTION)
 						.iter()
-						.any(|participating_epoch| *participating_epoch == epoch)
+						.any(|(participating_epoch, _)| *participating_epoch == epoch)
 					{
 						Some(info)
 					} else {

--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -47,6 +47,8 @@ use crate::Call;
 	<T::ElectoralSystemRunner as ElectoralSystemTypes>::ElectoralSettings: BenchmarkValue,
 )]
 mod benchmarks {
+	use sp_runtime::traits::Zero;
+
 	use super::*;
 
 	fn ready_validator_for_vote<T: crate::pallet::Config<I>, I: 'static>(
@@ -62,6 +64,7 @@ mod benchmarks {
 		T::EpochInfo::set_authorities(validators.clone().into_iter().map(|v| v.into()).collect());
 		T::EpochInfo::add_authority_info_for_epoch(
 			epoch,
+			Zero::zero(),
 			validators.clone().into_iter().map(|v| v.into()).collect(),
 		);
 
@@ -141,7 +144,7 @@ mod benchmarks {
 		let validator_id: T::ValidatorId = caller.clone().into();
 		let epoch = T::EpochInfo::epoch_index();
 
-		T::EpochInfo::add_authority_info_for_epoch(epoch, vec![validator_id.clone()]);
+		T::EpochInfo::add_authority_info_for_epoch(epoch, Zero::zero(), vec![validator_id.clone()]);
 
 		Status::<T, I>::put(ElectionPalletStatus::Running);
 
@@ -158,7 +161,7 @@ mod benchmarks {
 		let validator_id: T::ValidatorId = caller.clone().into();
 		let epoch = T::EpochInfo::epoch_index();
 
-		T::EpochInfo::add_authority_info_for_epoch(epoch, vec![validator_id.clone()]);
+		T::EpochInfo::add_authority_info_for_epoch(epoch, Zero::zero(), vec![validator_id.clone()]);
 
 		Status::<T, I>::put(ElectionPalletStatus::Running);
 

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -183,18 +183,18 @@ mod benchmarks {
 		const OLD_EPOCH: EpochIndex = 1;
 		const EPOCH_TO_EXPIRE: EpochIndex = OLD_EPOCH + 1;
 
-		let amount = T::Amount::from(1000u32);
+		let bond = T::Amount::from(1000u32);
 
-		HistoricalBonds::<T>::insert(OLD_EPOCH, amount);
-		HistoricalBonds::<T>::insert(EPOCH_TO_EXPIRE, amount);
+		HistoricalBonds::<T>::insert(OLD_EPOCH, bond);
+		HistoricalBonds::<T>::insert(EPOCH_TO_EXPIRE, bond);
 
 		let authorities: Vec<_> = (0..a).map(|id| account("hello", id, id)).collect();
 
 		HistoricalAuthorities::<T>::insert(OLD_EPOCH, authorities.clone());
 		HistoricalAuthorities::<T>::insert(EPOCH_TO_EXPIRE, authorities.clone());
 		for a in authorities {
-			EpochHistory::<T>::activate_epoch(&a, OLD_EPOCH);
-			EpochHistory::<T>::activate_epoch(&a, EPOCH_TO_EXPIRE);
+			EpochHistory::<T>::activate_epoch(&a, OLD_EPOCH, bond);
+			EpochHistory::<T>::activate_epoch(&a, EPOCH_TO_EXPIRE, bond);
 		}
 
 		// Ensure that we are expiring the expected number of authorities.

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -168,6 +168,22 @@ where
 		self.validators.keys().map(|validator| (validator.clone(), avg_bid)).collect()
 	}
 
+	/// Returns a mapping of the bond amounts for each validator such that
+	/// the full bond is accounted for.
+	pub fn validator_bond_distribution(&self, bond: Bid) -> BTreeMap<Account, Bid> {
+		let mut total_bond = bond * Bid::from(self.validators.len() as u32);
+		let mut validator_bids = self.validators.clone().into_iter().collect::<Vec<_>>();
+		validator_bids.sort_by_key(|(_, v)| *v);
+		validator_bids
+			.into_iter()
+			.map(|(id, bid)| {
+				let individual_bond = core::cmp::min(bid, total_bond);
+				total_bond.saturating_reduce(individual_bond);
+				(id, individual_bond)
+			})
+			.collect()
+	}
+
 	pub fn distribute<Amount>(
 		&self,
 		total: Amount,
@@ -394,12 +410,30 @@ mod tests {
 				let sum: u128 = distributions.iter().map(|(_, amount)| *amount).sum();
 
 				// Property: The sum of all distributed amounts equals the input total
-				assert_eq!(
+				prop_assert_eq!(
 					sum, total_to_distribute,
 					"Sum of distributions ({}) does not equal total ({})",
 					sum, total_to_distribute
 				);
+
+				Ok(())
 			});
 		}
+	}
+
+	#[test]
+	fn test_validator_bond_distribution() {
+		let snapshot = DelegationSnapshot::<u64, u128> {
+			operator: 1,
+			validators: [(100, 800), (101, 300), (102, 200)].into_iter().collect(),
+			..Default::default()
+		};
+
+		let bond = 400;
+		let distribution = snapshot.validator_bond_distribution(bond);
+
+		assert_eq!(distribution[&100], 700);
+		assert_eq!(distribution[&101], 300);
+		assert_eq!(distribution[&102], 200);
 	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -834,13 +834,10 @@ pub mod pallet {
 		#[pallet::weight(T::ValidatorWeightInfo::register_as_validator())]
 		pub fn register_as_validator(origin: OriginFor<T>) -> DispatchResult {
 			let account_id: T::AccountId = ensure_signed(origin)?;
-			if Self::current_authority_count() >= AuctionParameters::<T>::get().max_size {
-				ensure!(
-					T::FundingInfo::total_balance_of(&account_id) >=
-						MinimumValidatorStake::<T>::get(),
-					Error::<T>::NotEnoughFunds
-				);
-			}
+			ensure!(
+				T::FundingInfo::total_balance_of(&account_id) >= MinimumValidatorStake::<T>::get(),
+				Error::<T>::NotEnoughFunds
+			);
 			T::AccountRoleRegistry::register_as_validator(&account_id)
 		}
 

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -16,5 +16,11 @@
 
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
 
-pub type PalletMigration<T> = (PlaceholderMigration<6, Pallet<T>>,);
+mod v7;
+
+pub type PalletMigration<T> = (
+	VersionedMigration<6, 7, v7::Migration<T>, Pallet<T>, <T as frame_system::Config>::DbWeight>,
+	PlaceholderMigration<7, Pallet<T>>,
+);

--- a/state-chain/pallets/cf-validator/src/migrations/v7.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/v7.rs
@@ -16,7 +16,7 @@
 
 use cf_primitives::EpochIndex;
 use frame_support::traits::UncheckedOnRuntimeUpgrade;
-use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, vec::Vec};
 
 use crate::{Config, HistoricalActiveEpochs, HistoricalBonds};
 

--- a/state-chain/pallets/cf-validator/src/migrations/v7.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/v7.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use cf_primitives::EpochIndex;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData};
+
+use crate::{Config, HistoricalActiveEpochs, HistoricalBonds};
+
+#[cfg(feature = "try-runtime")]
+use frame_support::pallet_prelude::DispatchError;
+#[cfg(feature = "try-runtime")]
+use sp_std::prelude::*;
+
+pub struct Migration<T>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		let bonds = HistoricalBonds::<T>::iter().collect::<BTreeMap<EpochIndex, T::Amount>>();
+		HistoricalActiveEpochs::<T>::translate(|_k, v: Vec<EpochIndex>| {
+			Some(
+				v.into_iter()
+					.filter_map(|e| Some((e, *bonds.get(&e)?)))
+					.collect::<Vec<(EpochIndex, T::Amount)>>(),
+			)
+		});
+		Default::default()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		Ok(vec![])
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		use crate::CurrentAuthorities;
+		use sp_std::collections::btree_set::BTreeSet;
+
+		// There should be one entry per authority
+		let accounts_in_historical_active_epochs = HistoricalActiveEpochs::<T>::iter()
+			.map(|(account, _)| account)
+			.collect::<BTreeSet<_>>();
+		let authorities = CurrentAuthorities::<T>::get().into_iter().collect::<BTreeSet<_>>();
+		assert_eq!(accounts_in_historical_active_epochs, authorities);
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-witnesser/src/benchmarking.rs
+++ b/state-chain/pallets/cf-witnesser/src/benchmarking.rs
@@ -21,12 +21,13 @@ use super::*;
 use cf_primitives::AccountRole;
 use cf_traits::AccountRoleRegistry;
 use frame_benchmarking::v2::*;
-use frame_support::{assert_ok, traits::Hooks};
+use frame_support::{assert_ok, sp_runtime::traits::Zero, traits::Hooks};
 use frame_system::RawOrigin;
 use sp_std::boxed::Box;
 
 #[benchmarks]
 mod benchmarks {
+
 	use super::*;
 
 	#[benchmark]
@@ -37,7 +38,7 @@ mod benchmarks {
 		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 		let epoch = T::EpochInfo::epoch_index();
 
-		T::EpochInfo::add_authority_info_for_epoch(epoch, Vec::from([validator_id]));
+		T::EpochInfo::add_authority_info_for_epoch(epoch, Zero::zero(), Vec::from([validator_id]));
 
 		#[extrinsic_call]
 		witness_at_epoch(RawOrigin::Signed(caller.clone()), Box::new(call.clone()), epoch);

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -1725,7 +1725,7 @@ impl_runtime_apis! {
 			}
 		}
 		fn cf_validator_info(account_id: &AccountId) -> ValidatorInfo {
-			let key_holder_epochs = pallet_cf_validator::HistoricalActiveEpochs::<Runtime>::get(account_id);
+			let keyholder_epochs = pallet_cf_validator::HistoricalActiveEpochs::<Runtime>::get(account_id).into_iter().map(|(e, _)| e).collect();
 			let is_qualified = <<Runtime as pallet_cf_validator::Config>::KeygenQualification as QualifyNode<_>>::is_qualified(account_id);
 			let is_current_authority = pallet_cf_validator::CurrentAuthorities::<Runtime>::get().contains(account_id);
 			let is_bidding = Validator::is_bidding(account_id);
@@ -1742,7 +1742,7 @@ impl_runtime_apis! {
 				bond: account_info.bond(),
 				last_heartbeat: pallet_cf_reputation::LastHeartbeat::<Runtime>::get(account_id).unwrap_or(0),
 				reputation_points: reputation_info.reputation_points,
-				keyholder_epochs: key_holder_epochs,
+				keyholder_epochs,
 				is_current_authority,
 				is_current_backup: false,
 				is_qualified: is_bidding && is_qualified,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -159,6 +159,7 @@ pub trait EpochInfo {
 	#[cfg(feature = "runtime-benchmarks")]
 	fn add_authority_info_for_epoch(
 		epoch_index: EpochIndex,
+		bond: Self::Amount,
 		new_authorities: Vec<Self::ValidatorId>,
 	);
 
@@ -656,11 +657,12 @@ pub trait HistoricalEpoch {
 	/// The bond for an epoch
 	fn epoch_bond(epoch: Self::EpochIndex) -> Self::Amount;
 	/// The unexpired epochs for which a node was in the authority set.
-	fn active_epochs_for_authority(id: &Self::ValidatorId) -> Vec<Self::EpochIndex>;
+	fn active_epochs_for_authority(id: &Self::ValidatorId)
+		-> Vec<(Self::EpochIndex, Self::Amount)>;
 	/// Removes an epoch from an authority's list of active epochs.
-	fn deactivate_epoch(authority: &Self::ValidatorId, epoch: EpochIndex);
+	fn deactivate_epoch(authority: &Self::ValidatorId, epoch: Self::EpochIndex);
 	/// Add an epoch to an authority's list of active epochs.
-	fn activate_epoch(authority: &Self::ValidatorId, epoch: EpochIndex);
+	fn activate_epoch(authority: &Self::ValidatorId, epoch: Self::EpochIndex, bond: Self::Amount);
 	/// Returns the amount of a authority's funds that are currently bonded.
 	fn active_bond(authority: &Self::ValidatorId) -> Self::Amount;
 	/// Returns the number of active epochs a authority is still active in

--- a/state-chain/traits/src/mocks/epoch_info.rs
+++ b/state-chain/traits/src/mocks/epoch_info.rs
@@ -143,8 +143,13 @@ macro_rules! impl_mock_epoch_info {
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]
-			fn add_authority_info_for_epoch(epoch_index: $epoch_index, new_authorities: sp_std::vec::Vec<Self::ValidatorId>) {
+			fn add_authority_info_for_epoch(
+				epoch_index: $epoch_index,
+				bond: Self::Amount,
+				new_authorities: sp_std::vec::Vec<Self::ValidatorId>
+			) {
 				MockEpochInfo::inner_add_authority_info_for_epoch(epoch_index, new_authorities);
+				MockEpochInfo::set_bond(bond);
 			}
 
 			#[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
Previously it was possible for the total managed validator bonds to be set too low if any of the validators had more stake than the current bond. 

I also noticed that validators were able to register at lower than the min stake *if* the number of authorities were low. I removed this, it doesn't make much sense IMO.