### PR TITLE
refactor: better channel action handling in ingress-egress pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ dependencies = [
  "itertools 0.13.0",
  "libsecp256k1",
  "log",
+ "n-functor",
  "parity-scale-codec",
  "proptest",
  "rand",
@@ -1550,6 +1551,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "hex",
+ "n-functor",
  "parity-scale-codec",
  "proptest",
  "proptest-derive",
@@ -7521,6 +7523,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "n-functor"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e279584350f406d0be657b1f66ed3450c2da43cfa154f8320470984e81b28b9d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "nalgebra"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8347,6 +8360,7 @@ dependencies = [
  "generic-typeinfo-derive",
  "hex-literal",
  "log",
+ "n-functor",
  "pallet-cf-governance",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,7 @@ web3 = { version = "0.19" }
 x25519-dalek = { version = "2.0" }
 zeroize = { version = "1.7.0" }
 zmq = { git = "https://github.com/chainflip-io/rust-zmq.git", tag = "chainflip-v0.9.2+1" }
+n-functor = "0.2.1"
 
 # subxt dependency (at the moment points to the commit hash of the PR fixing subxt macro wasm loading).
 # TODO: remove the commit hash when subxt is released > 0.41.0

--- a/engine/src/witness/btc/deposits.rs
+++ b/engine/src/witness/btc/deposits.rs
@@ -310,7 +310,7 @@ pub mod tests {
 				asset: btc::Asset::Btc,
 				state: deposit_address,
 			},
-			action: ChannelAction::<AccountId32, Bitcoin>::LiquidityProvision {
+			action: ChannelAction::<AccountId32, <Bitcoin as cf_chains::Chain>::ChainAccount>::LiquidityProvision {
 				lp_account: AccountId32::new([0xab; 32]),
 				refund_address: ForeignChainAddress::Btc(ScriptPubkey::P2PKH([0; 20])),
 			},

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -70,6 +70,7 @@ derive-where = "1.2.7"
 proptest = { version = "1.6", optional = true }
 duplicate = "2.0.0"
 saturating_cast = "0.1.0"
+n-functor = { workspace = true }
 
 # Substrate packages
 ss58-registry = { workspace = true, optional = true }

--- a/state-chain/chains/src/refund_parameters.rs
+++ b/state-chain/chains/src/refund_parameters.rs
@@ -34,6 +34,7 @@ use sp_std::{cmp::Ord, convert::Into, fmt::Debug, prelude::*};
 /// This is used to represent the destination address for an egress or an internal account
 /// to move funds internally.
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, PartialOrd, Ord)]
+#[n_functor::derive_n_functor]
 pub enum AccountOrAddress<AccountId, Address> {
 	InternalAccount(AccountId),
 	ExternalAddress(Address),
@@ -72,6 +73,7 @@ pub enum AccountOrAddress<AccountId, Address> {
 	PartialOrd,
 	Ord,
 )]
+#[n_functor::derive_n_functor(impl_map_res = true)]
 pub struct ChannelRefundParameters<A, CcmRefundDetails> {
 	pub retry_duration: cf_primitives::BlockNumber,
 	pub refund_address: A,
@@ -153,26 +155,14 @@ impl RpcChannelRefundParameters {
 }
 
 impl<A, D> ChannelRefundParameters<A, D> {
-	pub fn map_address<B, F: FnOnce(A) -> B>(self, f: F) -> ChannelRefundParameters<B, D> {
-		ChannelRefundParameters {
-			retry_duration: self.retry_duration,
-			refund_address: f(self.refund_address),
-			min_price: self.min_price,
-			refund_ccm_metadata: self.refund_ccm_metadata,
-			max_oracle_price_slippage: self.max_oracle_price_slippage,
-		}
+	pub fn map_address<B, F: Fn(A) -> B>(self, f: F) -> ChannelRefundParameters<B, D> {
+		self.map(f, |refund_metadata| refund_metadata)
 	}
-	pub fn try_map_address<B, E, F: FnOnce(A) -> Result<B, E>>(
+	pub fn try_map_address<B, E, F: Fn(A) -> Result<B, E>>(
 		self,
 		f: F,
 	) -> Result<ChannelRefundParameters<B, D>, E> {
-		Ok(ChannelRefundParameters {
-			retry_duration: self.retry_duration,
-			refund_address: f(self.refund_address)?,
-			min_price: self.min_price,
-			refund_ccm_metadata: self.refund_ccm_metadata,
-			max_oracle_price_slippage: self.max_oracle_price_slippage,
-		})
+		self.map_res(f, Result::Ok)
 	}
 }
 

--- a/state-chain/pallets/cf-ingress-egress/Cargo.toml
+++ b/state-chain/pallets/cf-ingress-egress/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 cf-chains = { workspace = true }
 cf-primitives = { workspace = true }
+cf-utilities = { workspace = true }
 cf-traits = { workspace = true }
 cf-runtime-utilities = { workspace = true, features = ["derive"] }
 generic-typeinfo-derive = { workspace = true }
@@ -24,6 +25,7 @@ log = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
+n-functor = { workspace = true }
 
 # ==== Parity deps ====
 codec = { workspace = true, features = ["derive"] }

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -111,22 +111,24 @@ mod benchmarks {
 			let source_asset: <<T as Config<I>>::TargetChain as Chain>::ChainAsset =
 				BenchmarkValue::benchmark_value();
 			let block_number = TargetChainBlockNumber::<T, I>::benchmark_value();
-			let mut channel =
-				DepositChannelDetails::<T, I> {
-					owner: account("doogle", 0, 0),
-					opened_at: block_number,
-					expires_at: block_number,
-					deposit_channel: DepositChannel::generate_new::<
-						<T as Config<I>>::AddressDerivation,
-					>(1, source_asset)
+			let mut channel = DepositChannelDetails::<T, I> {
+				owner: account("doogle", 0, 0),
+				opened_at: block_number,
+				expires_at: block_number,
+				deposit_channel:
+					DepositChannel::generate_new::<<T as Config<I>>::AddressDerivation>(
+						1,
+						source_asset,
+					)
 					.unwrap(),
-					action: ChannelAction::<T::AccountId, <T::TargetChain as Chain>::ChainAccount>::LiquidityProvision {
+				action:
+					ChannelAction::<T::AccountId, TargetChainAccount<T, I>>::LiquidityProvision {
 						lp_account: account("doogle", 0, 0),
 						refund_address: ForeignChainAddress::benchmark_value(),
 					},
-					boost_fee: 0,
-					boost_status: BoostStatus::NotBoosted,
-				};
+				boost_fee: 0,
+				boost_status: BoostStatus::NotBoosted,
+			};
 			channel.deposit_channel.state.on_fetch_scheduled();
 			DepositChannelLookup::<T, I>::insert(deposit_address.clone(), channel);
 			addresses.push(deposit_address);

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -76,10 +76,11 @@ mod benchmarks {
 						source_asset,
 					)
 					.unwrap(),
-				action: ChannelAction::<T::AccountId, <T::TargetChain as Chain>::ChainAccount>::LiquidityProvision {
-					lp_account: account("doogle", 0, 0),
-					refund_address: ForeignChainAddress::benchmark_value(),
-				},
+				action:
+					ChannelAction::<T::AccountId, TargetChainAccount<T, I>>::LiquidityProvision {
+						lp_account: account("doogle", 0, 0),
+						refund_address: ForeignChainAddress::benchmark_value(),
+					},
 				boost_fee: 0,
 				boost_status: BoostStatus::NotBoosted,
 			},

--- a/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/benchmarking.rs
@@ -76,7 +76,7 @@ mod benchmarks {
 						source_asset,
 					)
 					.unwrap(),
-				action: ChannelAction::<T::AccountId, T::TargetChain>::LiquidityProvision {
+				action: ChannelAction::<T::AccountId, <T::TargetChain as Chain>::ChainAccount>::LiquidityProvision {
 					lp_account: account("doogle", 0, 0),
 					refund_address: ForeignChainAddress::benchmark_value(),
 				},
@@ -119,7 +119,7 @@ mod benchmarks {
 						<T as Config<I>>::AddressDerivation,
 					>(1, source_asset)
 					.unwrap(),
-					action: ChannelAction::<T::AccountId, T::TargetChain>::LiquidityProvision {
+					action: ChannelAction::<T::AccountId, <T::TargetChain as Chain>::ChainAccount>::LiquidityProvision {
 						lp_account: account("doogle", 0, 0),
 						refund_address: ForeignChainAddress::benchmark_value(),
 					},

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -142,7 +142,6 @@ struct PendingPrewitnessedDeposit<T: Config<I>, I: 'static> {
 	asset: TargetChainAsset<T, I>,
 	deposit_details: <T::TargetChain as Chain>::DepositDetails,
 	deposit_address: Option<TargetChainAccount<T, I>>,
-	source_address: Option<ForeignChainAddress>,
 	action: ChannelAction<T::AccountId, T::TargetChain>,
 	boost_fee: u16,
 	channel_id: Option<u64>,
@@ -214,7 +213,6 @@ enum FullWitnessDepositOutcome {
 pub struct ValidatedVaultSwapParams<AccountId> {
 	pub broker_fees: BoundedVec<Beneficiary<AccountId>, ConstU32<6>>,
 	pub egress_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
-	pub source_address: Option<ForeignChainAddress>,
 	pub destination_address: ForeignChainAddress,
 }
 
@@ -396,9 +394,7 @@ pub enum PalletConfigUpdate<T: Config<I>, I: 'static> {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use cf_chains::{
-		address::EncodedAddress, CcmChannelMetadataChecked, ExecutexSwapAndCall, TransferFallback,
-	};
+	use cf_chains::{address::EncodedAddress, ExecutexSwapAndCall, TransferFallback};
 	use cf_primitives::{BroadcastId, EpochIndex};
 	use cf_traits::{OnDeposit, SwapParameterValidation};
 	use core::marker::PhantomData;
@@ -1995,7 +1991,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				asset,
 				deposit_details,
 				deposit_address: Some(deposit_address.clone()),
-				source_address: None,
 				action,
 				boost_fee,
 				channel_id: Some(deposit_channel.channel_id),
@@ -2034,7 +2029,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn perform_channel_action(
 		action: ChannelAction<T::AccountId, T::TargetChain>,
 		asset: TargetChainAsset<T, I>,
-		source_address: Option<ForeignChainAddress>,
 		amount_after_fees: TargetChainAmount<T, I>,
 		origin: DepositOrigin<T, I>,
 	) -> DepositAction<T, I> {
@@ -2141,7 +2135,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			*asset,
 			*amount,
 			deposit_details.clone(),
-			None, // source address is unknown
 			deposit_channel_details.boost_status,
 			deposit_channel_details.boost_fee,
 			Some(channel_id),
@@ -2266,7 +2259,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			asset,
 			deposit_details,
 			deposit_address,
-			source_address,
 			action,
 			boost_fee,
 			channel_id,
@@ -2352,7 +2344,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					let action = Self::perform_channel_action(
 						action,
 						asset,
-						source_address,
 						amount_after_fees,
 						origin.clone(),
 					);
@@ -2424,12 +2415,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				Err(_) => return,
 			};
 
-		if let Ok(ValidatedVaultSwapParams {
-			broker_fees,
-			egress_metadata,
-			source_address,
-			destination_address,
-		}) = Self::try_validate_vault_swap(vault_deposit_witness.clone())
+		if let Ok(ValidatedVaultSwapParams { broker_fees, egress_metadata, destination_address }) =
+			Self::try_validate_vault_swap(vault_deposit_witness.clone())
 		{
 			let action = ChannelAction::Swap {
 				destination_asset: output_asset,
@@ -2449,7 +2436,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					asset,
 					deposit_details,
 					deposit_address,
-					source_address,
 					action,
 					boost_fee,
 					channel_id,
@@ -2486,7 +2472,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		asset: TargetChainAsset<T, I>,
 		deposit_amount: TargetChainAmount<T, I>,
 		deposit_details: <T::TargetChain as Chain>::DepositDetails,
-		source_address: Option<ForeignChainAddress>,
 		boost_status: BoostStatus<TargetChainAmount<T, I>, BlockNumberFor<T>>,
 		max_boost_fee_bps: BasisPoints,
 		channel_id: Option<u64>,
@@ -2662,7 +2647,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					let action = Self::perform_channel_action(
 						action,
 						asset,
-						source_address,
 						amount_after_fees,
 						origin.clone(),
 					);
@@ -2721,7 +2705,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				},
 			};
 
-		let (egress_metadata, source_address) = if let Some(metadata) = deposit_metadata.clone() {
+		let egress_metadata = if let Some(metadata) = deposit_metadata.clone() {
 			let destination_chain: ForeignChain = (destination_asset).into();
 			if !destination_chain.ccm_support() {
 				return Err(RefundReason::CcmUnsupportedForTargetChain);
@@ -2731,17 +2715,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				.to_checked(destination_asset, destination_address_internal.clone())
 				.map_err(|_| RefundReason::CcmInvalidMetadata)
 				.map(|decoded| {
-					(
-						Some(CcmDepositMetadataChecked {
-							channel_metadata: decoded.channel_metadata,
-							source_chain: source_asset.into(),
-							source_address: decoded.source_address.clone(),
-						}),
-						decoded.source_address,
-					)
+					Some(CcmDepositMetadataChecked {
+						channel_metadata: decoded.channel_metadata,
+						source_chain: source_asset.into(),
+						source_address: decoded.source_address.clone(),
+					})
 				})?
 		} else {
-			(None, None)
+			None
 		};
 
 		T::SwapParameterValidation::validate_refund_params(
@@ -2761,7 +2742,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(ValidatedVaultSwapParams {
 			broker_fees,
 			egress_metadata,
-			source_address,
 			destination_address: destination_address_internal,
 		})
 	}
@@ -2796,48 +2776,36 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				Err(_) => return,
 			};
 
-		let (action, source_address) =
-			match Self::try_validate_vault_swap(vault_deposit_witness.clone()) {
-				Ok(ValidatedVaultSwapParams {
-					broker_fees,
-					egress_metadata,
-					source_address,
+		let action = match Self::try_validate_vault_swap(vault_deposit_witness.clone()) {
+			Ok(ValidatedVaultSwapParams { broker_fees, egress_metadata, destination_address }) =>
+				ChannelAction::Swap {
+					destination_asset,
 					destination_address,
-				}) => (
-					ChannelAction::Swap {
-						destination_asset,
-						destination_address,
-						broker_fees: broker_fees.clone(),
-						egress_metadata: egress_metadata.clone(),
-						refund_params: checked_refund_params,
-						dca_params: dca_params.clone(),
+					broker_fees: broker_fees.clone(),
+					egress_metadata: egress_metadata.clone(),
+					refund_params: checked_refund_params,
+					dca_params: dca_params.clone(),
+				},
+			Err(reason) => ChannelAction::Refund {
+				reason: reason.clone(),
+				refund_address,
+				refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.map(
+					|mut refund_ccm_metadata| {
+						// TODO: Check: @Albert is this intentional? setting the
+						// source_address to None is what implicitly happened in the
+						// refund flow until now
+						refund_ccm_metadata.source_address = None;
+						refund_ccm_metadata
 					},
-					source_address,
 				),
-				Err(reason) => (
-					ChannelAction::Refund {
-						reason: reason.clone(),
-						refund_address,
-						refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.map(
-							|mut refund_ccm_metadata| {
-								// TODO: Check: @Albert is this intentional? setting the
-								// source_address to None is what implicitly happened in the
-								// refund flow until now
-								refund_ccm_metadata.source_address = None;
-								refund_ccm_metadata
-							},
-						),
-					},
-					None,
-				),
-			};
+			},
+		};
 
 		match Self::process_full_witness_deposit_inner(
 			deposit_address.clone(),
 			source_asset,
 			deposit_amount,
 			deposit_details.clone(),
-			source_address,
 			BoostedVaultTransactions::<T, I>::get(&tx_id),
 			boost_fee,
 			channel_id,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2708,15 +2708,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let refund_action = |reason| ChannelAction::Refund {
 			reason,
 			refund_address,
-			refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.clone().map(
-				|mut refund_ccm_metadata| {
-					// TODO: Check: @Albert is this intentional? setting the
-					// source_address to None is what implicitly happened in the
-					// refund flow until now
-					refund_ccm_metadata.source_address = None;
-					refund_ccm_metadata
-				},
-			),
+			refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.clone(),
 		};
 
 		// ------ fees -----

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -57,7 +57,7 @@ use cf_traits::{
 	AssetWithholding, BalanceApi, Broadcaster, CcmAdditionalDataHandler, Chainflip,
 	ChannelIdAllocator, DepositApi, EgressApi, EpochInfo, FeePayment,
 	FetchesTransfersLimitProvider, GetBlockHeight, IngressEgressFeeApi, IngressSink, IngressSource,
-	NetworkEnvironmentProvider, OnDeposit, PoolApi, ScheduledEgressDetails, SwapOutputAction,
+	NetworkEnvironmentProvider, OnDeposit, ScheduledEgressDetails, SwapOutputAction,
 	SwapParameterValidation, SwapRequestHandler, SwapRequestType,
 };
 use frame_support::{
@@ -457,24 +457,7 @@ pub mod pallet {
 		PartialOrdNoBound,
 		GenericTypeInfo,
 	)]
-	#[serde(bound(
-		serialize = "
-		TargetChainAsset<T, I>: Serialize,
-		Option<TargetChainAccount<T, I>>: Serialize,
-		<T::TargetChain as Chain>::ChainAmount: Serialize,
-		<T::TargetChain as Chain>::DepositDetails: Serialize,
-		TransactionInIdFor<T, I>: Serialize,
-		Option<Beneficiary<T::AccountId>>: Serialize,
-	",
-		deserialize = "
-		TargetChainAsset<T, I>: Deserialize<'de>,
-		Option<TargetChainAccount<T, I>>: Deserialize<'de>,
-		<T::TargetChain as Chain>::ChainAmount: Deserialize<'de>,
-		<T::TargetChain as Chain>::DepositDetails: Deserialize<'de>,
-		TransactionInIdFor<T, I>: Deserialize<'de>,
-		Option<Beneficiary<T::AccountId>>: Deserialize<'de>,
-	"
-	))]
+	#[serde(bound(serialize = "", deserialize = ""))]
 	#[expand_name_with(<T::TargetChain as PalletInstanceAlias>::TYPE_INFO_SUFFIX)]
 	pub struct VaultDepositWitness<T: Config<I>, I: 'static> {
 		pub input_asset: TargetChainAsset<T, I>,
@@ -679,8 +662,6 @@ pub mod pallet {
 		type AddressConverter: AddressConverter;
 
 		type Balance: BalanceApi<AccountId = Self::AccountId>;
-
-		type PoolApi: PoolApi<AccountId = <Self as frame_system::Config>::AccountId>;
 
 		/// The type of the chain-native transaction.
 		type ChainApiCall: AllBatch<Self::TargetChain>

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -209,14 +209,6 @@ enum FullWitnessDepositOutcome {
 	BoostConsumed,
 	BoostNotConsumed,
 }
-
-#[derive(RuntimeDebug, Clone)]
-pub struct ValidatedVaultSwapParams<AccountId> {
-	pub broker_fees: BoundedVec<Beneficiary<AccountId>, ConstU32<6>>,
-	pub egress_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
-	pub destination_address: ForeignChainAddress,
-}
-
 mod deposit_origin {
 
 	use super::*;

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -562,6 +562,7 @@ pub mod pallet {
 			refund_address: C::ChainAccount,
 			refund_ccm_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
 		},
+		Unrefundable,
 	}
 
 	/// Contains identifying information about the particular actions that have occurred for a
@@ -2077,6 +2078,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				};
 				DepositAction::Refund { egress_id, amount: amount_after_fees, reason }
 			},
+			ChannelAction::Unrefundable => {
+				todo!()
+			},
 		}
 	}
 
@@ -2391,12 +2395,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			channel_id,
 			deposit_amount: amount,
 			deposit_details,
-			output_asset,
 			tx_id,
 			broker_fee,
-			dca_params,
 			boost_fee,
-			refund_params,
 			..
 		} = vault_deposit_witness.clone();
 
@@ -2405,65 +2406,50 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			broker_fee.as_ref().map(|Beneficiary { account, .. }| account.clone()),
 		);
 
-		let checked_refund_params =
-			match refund_params.map_refund_address_to_foreign_chain_address().into_checked(
-				deposit_address.clone().map(|addr| addr.into_foreign_chain_address()),
-				asset.into(),
-			) {
-				Ok(checked_refund_params) =>
-					checked_refund_params.map_address(AccountOrAddress::ExternalAddress),
-				Err(_) => return,
-			};
-
-		if let Ok(ValidatedVaultSwapParams { broker_fees, egress_metadata, destination_address }) =
-			Self::try_validate_vault_swap(vault_deposit_witness.clone())
+		match Self::derive_channel_action_from_vault_deposit_witness(vault_deposit_witness.clone())
 		{
-			let action = ChannelAction::Swap {
-				destination_asset: output_asset,
-				destination_address,
-				broker_fees,
-				refund_params: checked_refund_params,
-				dca_params,
-				egress_metadata,
-			};
+			action @ ChannelAction::Swap { .. } => {
+				let boost_status_lookup = BoostStatusLookup::Vault { tx_id: tx_id.clone() };
+				let boost_status = boost_status_lookup.resolve();
+				if boost_status == BoostStatus::NotBoosted {
+					let deposit = PendingPrewitnessedDeposit {
+						block_height,
+						amount,
+						asset,
+						deposit_details,
+						deposit_address,
+						action,
+						boost_fee,
+						channel_id,
+						origin,
+					};
 
-			let boost_status_lookup = BoostStatusLookup::Vault { tx_id: tx_id.clone() };
-			let boost_status = boost_status_lookup.resolve();
-			if boost_status == BoostStatus::NotBoosted {
-				let deposit = PendingPrewitnessedDeposit {
-					block_height,
-					amount,
-					asset,
-					deposit_details,
-					deposit_address,
-					action,
-					boost_fee,
-					channel_id,
-					origin,
-				};
+					let delay = BoostDelayBlocks::<T, I>::get();
 
-				let delay = BoostDelayBlocks::<T, I>::get();
+					let new_boost_status = if delay > 0u32.into() {
+						let process_at_block = frame_system::Pallet::<T>::block_number() + delay;
 
-				let new_boost_status = if delay > 0u32.into() {
-					let process_at_block = frame_system::Pallet::<T>::block_number() + delay;
+						PendingPrewitnessedDeposits::<T, I>::append(
+							process_at_block,
+							PendingPrewitnessedDepositEntry {
+								boost_status_lookup: boost_status_lookup.clone(),
+								deposit,
+							},
+						);
+						BoostStatus::BoostPending { amount, process_at_block }
+					} else {
+						// Process immediately
+						Self::process_prewitness_deposit_inner(deposit)
+					};
 
-					PendingPrewitnessedDeposits::<T, I>::append(
-						process_at_block,
-						PendingPrewitnessedDepositEntry {
-							boost_status_lookup: boost_status_lookup.clone(),
-							deposit,
-						},
-					);
-					BoostStatus::BoostPending { amount, process_at_block }
-				} else {
-					// Process immediately
-					Self::process_prewitness_deposit_inner(deposit)
-				};
-
-				if boost_status != new_boost_status {
-					boost_status_lookup.set(new_boost_status);
+					if boost_status != new_boost_status {
+						boost_status_lookup.set(new_boost_status);
+					}
 				}
-			}
+			},
+			_ => {
+				// we don't process refunds on prewitness
+			},
 		}
 	}
 
@@ -2530,6 +2516,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 								refund_address.clone().into_foreign_chain_address(),
 								refund_ccm_metadata.clone(),
 							),
+							ChannelAction::Unrefundable => {
+								// TODO: choose error to return in this case.
+								todo!()
+							},
 						};
 
 						ScheduledTransactionsForRejection::<T, I>::append(
@@ -2670,11 +2660,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	fn try_validate_vault_swap(
+	fn derive_channel_action_from_vault_deposit_witness(
 		vault_deposit_witness: VaultDepositWitness<T, I>,
-	) -> Result<ValidatedVaultSwapParams<T::AccountId>, RefundReason> {
+	) -> ChannelAction<T::AccountId, T::TargetChain> {
 		let VaultDepositWitness {
 			input_asset: source_asset,
+			deposit_address,
 			output_asset: destination_asset,
 			destination_address,
 			deposit_metadata,
@@ -2685,15 +2676,44 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			..
 		} = vault_deposit_witness.clone();
 
+		// ------ refund parameters -----
+
+		let refund_address = refund_params.refund_address.clone();
+		let checked_refund_params =
+			match refund_params.map_refund_address_to_foreign_chain_address().into_checked(
+				deposit_address.clone().map(|addr| addr.into_foreign_chain_address()),
+				source_asset.into(),
+			) {
+				Ok(checked_refund_params) =>
+					checked_refund_params.map_address(AccountOrAddress::ExternalAddress),
+				Err(_) => return ChannelAction::Unrefundable,
+			};
+
+		let refund_action = |reason| ChannelAction::Refund {
+			reason,
+			refund_address,
+			refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.clone().map(
+				|mut refund_ccm_metadata| {
+					// TODO: Check: @Albert is this intentional? setting the
+					// source_address to None is what implicitly happened in the
+					// refund flow until now
+					refund_ccm_metadata.source_address = None;
+					refund_ccm_metadata
+				},
+			),
+		};
+
+		// ------ fees -----
 		let Some(broker_fees) = Self::assemble_broker_fees(broker_fee, affiliate_fees.clone())
 		else {
-			return Err(RefundReason::InvalidBrokerFees);
+			return refund_action(RefundReason::InvalidBrokerFees);
 		};
 
 		if T::SwapParameterValidation::validate_broker_fees(&broker_fees).is_err() {
-			return Err(RefundReason::InvalidBrokerFees);
+			return refund_action(RefundReason::InvalidBrokerFees);
 		}
 
+		// ------ egress ccm metadata -----
 		let destination_address_internal =
 			match T::AddressConverter::decode_and_validate_address_for_asset(
 				destination_address.clone(),
@@ -2701,49 +2721,53 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			) {
 				Ok(address) => address,
 				Err(_) => {
-					return Err(RefundReason::InvalidDestinationAddress);
+					return refund_action(RefundReason::InvalidDestinationAddress);
 				},
 			};
 
 		let egress_metadata = if let Some(metadata) = deposit_metadata.clone() {
 			let destination_chain: ForeignChain = (destination_asset).into();
 			if !destination_chain.ccm_support() {
-				return Err(RefundReason::CcmUnsupportedForTargetChain);
+				return refund_action(RefundReason::CcmUnsupportedForTargetChain);
 			}
 
-			metadata
-				.to_checked(destination_asset, destination_address_internal.clone())
-				.map_err(|_| RefundReason::CcmInvalidMetadata)
-				.map(|decoded| {
-					Some(CcmDepositMetadataChecked {
-						channel_metadata: decoded.channel_metadata,
-						source_chain: source_asset.into(),
-						source_address: decoded.source_address.clone(),
-					})
-				})?
+			match metadata.to_checked(destination_asset, destination_address_internal.clone()) {
+				Ok(decoded) => Some(CcmDepositMetadataChecked {
+					channel_metadata: decoded.channel_metadata,
+					source_chain: source_asset.into(),
+					source_address: decoded.source_address.clone(),
+				}),
+				Err(_) => return refund_action(RefundReason::CcmInvalidMetadata),
+			}
 		} else {
 			None
 		};
 
-		T::SwapParameterValidation::validate_refund_params(
+		if T::SwapParameterValidation::validate_refund_params(
 			source_asset.into(),
 			destination_asset,
-			refund_params.retry_duration,
-			refund_params.max_oracle_price_slippage,
+			checked_refund_params.retry_duration,
+			checked_refund_params.max_oracle_price_slippage,
 		)
-		.map_err(|_| RefundReason::InvalidRefundParameters)?;
+		.is_err()
+		{
+			return refund_action(RefundReason::InvalidRefundParameters)
+		}
 
 		if let Some(params) = &dca_params {
 			if T::SwapParameterValidation::validate_dca_params(params).is_err() {
-				return Err(RefundReason::InvalidDcaParameters);
+				return refund_action(RefundReason::InvalidDcaParameters);
 			}
 		}
 
-		Ok(ValidatedVaultSwapParams {
+		ChannelAction::Swap {
+			destination_asset,
+			destination_address: destination_address_internal,
 			broker_fees,
 			egress_metadata,
-			destination_address: destination_address_internal,
-		})
+			refund_params: checked_refund_params,
+			dca_params,
+		}
 	}
 
 	pub fn process_vault_swap_request_full_witness(
@@ -2756,50 +2780,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			channel_id,
 			deposit_amount,
 			deposit_details,
-			output_asset: destination_asset,
 			tx_id,
 			broker_fee,
-			refund_params,
-			dca_params,
 			boost_fee,
 			..
 		} = vault_deposit_witness.clone();
 
-		let refund_address = refund_params.refund_address.clone();
-		let checked_refund_params =
-			match refund_params.map_refund_address_to_foreign_chain_address().into_checked(
-				deposit_address.clone().map(|addr| addr.into_foreign_chain_address()),
-				source_asset.into(),
-			) {
-				Ok(checked_refund_params) =>
-					checked_refund_params.map_address(AccountOrAddress::ExternalAddress),
-				Err(_) => return,
-			};
-
-		let action = match Self::try_validate_vault_swap(vault_deposit_witness.clone()) {
-			Ok(ValidatedVaultSwapParams { broker_fees, egress_metadata, destination_address }) =>
-				ChannelAction::Swap {
-					destination_asset,
-					destination_address,
-					broker_fees: broker_fees.clone(),
-					egress_metadata: egress_metadata.clone(),
-					refund_params: checked_refund_params,
-					dca_params: dca_params.clone(),
-				},
-			Err(reason) => ChannelAction::Refund {
-				reason: reason.clone(),
-				refund_address,
-				refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.map(
-					|mut refund_ccm_metadata| {
-						// TODO: Check: @Albert is this intentional? setting the
-						// source_address to None is what implicitly happened in the
-						// refund flow until now
-						refund_ccm_metadata.source_address = None;
-						refund_ccm_metadata
-					},
-				),
-			},
-		};
+		let action =
+			Self::derive_channel_action_from_vault_deposit_witness(vault_deposit_witness.clone());
 
 		match Self::process_full_witness_deposit_inner(
 			deposit_address.clone(),

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -324,7 +324,7 @@ impl<C: Chain> CrossChainMessage<C> {
 	}
 }
 
-pub const PALLET_VERSION: StorageVersion = StorageVersion::new(27);
+pub const PALLET_VERSION: StorageVersion = StorageVersion::new(28);
 
 impl_pallet_safe_mode! {
 	PalletSafeMode<I>;

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -142,7 +142,7 @@ struct PendingPrewitnessedDeposit<T: Config<I>, I: 'static> {
 	asset: TargetChainAsset<T, I>,
 	deposit_details: <T::TargetChain as Chain>::DepositDetails,
 	deposit_address: Option<TargetChainAccount<T, I>>,
-	action: ChannelActionForDeposit<T::AccountId, <T::TargetChain as Chain>::ChainAccount>,
+	action: ChannelActionForDeposit<T::AccountId, TargetChainAccount<T, I>>,
 	boost_fee: u16,
 	channel_id: Option<u64>,
 	origin: DepositOrigin<T, I>,
@@ -217,7 +217,7 @@ mod deposit_origin {
 	#[scale_info(skip_type_params(T, I))]
 	pub(super) enum DepositOrigin<T: Config<I>, I: 'static> {
 		DepositChannel {
-			deposit_address: <T::TargetChain as Chain>::ChainAccount,
+			deposit_address: TargetChainAccount<T, I>,
 			channel_id: ChannelId,
 			deposit_block_height: u64,
 			broker_id: T::AccountId,
@@ -230,7 +230,7 @@ mod deposit_origin {
 
 	impl<T: Config<I>, I: 'static> DepositOrigin<T, I> {
 		pub fn deposit_channel(
-			deposit_address: <T::TargetChain as Chain>::ChainAccount,
+			deposit_address: TargetChainAccount<T, I>,
 			channel_id: ChannelId,
 			deposit_block_height: <T::TargetChain as Chain>::ChainBlockNumber,
 			broker_id: T::AccountId,
@@ -511,7 +511,7 @@ pub mod pallet {
 		pub expires_at: TargetChainBlockNumber<T, I>,
 		/// The action to be taken when the DepositChannel is deposited to.
 		#[skip_name_expansion]
-		pub action: ChannelAction<T::AccountId, <T::TargetChain as Chain>::ChainAccount>,
+		pub action: ChannelAction<T::AccountId, TargetChainAccount<T, I>>,
 		/// The boost fee
 		#[skip_name_expansion]
 		pub boost_fee: BasisPoints,
@@ -1524,7 +1524,7 @@ pub mod pallet {
 }
 
 impl<T: Config<I>, I: 'static> IngressSink for Pallet<T, I> {
-	type Account = <T::TargetChain as Chain>::ChainAccount;
+	type Account = TargetChainAccount<T, I>;
 	type Asset = <T::TargetChain as Chain>::ChainAsset;
 	type Amount = <T::TargetChain as Chain>::ChainAmount;
 	type BlockNumber = <T::TargetChain as Chain>::ChainBlockNumber;
@@ -1579,7 +1579,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		});
 		Ok(())
 	}
-	fn recycle_channel(used_weight: &mut Weight, address: <T::TargetChain as Chain>::ChainAccount) {
+	fn recycle_channel(used_weight: &mut Weight, address: TargetChainAccount<T, I>) {
 		if let Some(DepositChannelDetails { deposit_channel, boost_status, .. }) =
 			DepositChannelLookup::<T, I>::take(address)
 		{
@@ -1616,7 +1616,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	// be retried).
 	fn try_broadcast_rejection_refund_or_store_tx_details(
 		tx: TransactionRejectionDetails<T, I>,
-		refund_address: <T::TargetChain as Chain>::ChainAccount,
+		refund_address: TargetChainAccount<T, I>,
 		deposit_fetch_id: Option<<T::TargetChain as Chain>::DepositFetchId>,
 	) {
 		let AmountAndFeesWithheld {
@@ -2040,7 +2040,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	fn perform_channel_action(
-		action: ChannelActionForDeposit<T::AccountId, <T::TargetChain as Chain>::ChainAccount>,
+		action: ChannelActionForDeposit<T::AccountId, TargetChainAccount<T, I>>,
 		asset: TargetChainAsset<T, I>,
 		amount_after_fees: TargetChainAmount<T, I>,
 		origin: DepositOrigin<T, I>,
@@ -2479,7 +2479,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		boost_status: BoostStatus<TargetChainAmount<T, I>, BlockNumberFor<T>>,
 		max_boost_fee_bps: BasisPoints,
 		channel_id: Option<u64>,
-		action: ChannelActionForDeposit<T::AccountId, <T::TargetChain as Chain>::ChainAccount>,
+		action: ChannelActionForDeposit<T::AccountId, TargetChainAccount<T, I>>,
 		block_height: TargetChainBlockNumber<T, I>,
 		origin: DepositOrigin<T, I>,
 	) -> Result<FullWitnessDepositOutcome, DepositFailedReason> {
@@ -2678,7 +2678,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	fn derive_channel_action_from_vault_deposit_witness(
 		vault_deposit_witness: VaultDepositWitness<T, I>,
-	) -> ChannelActionForDeposit<T::AccountId, <T::TargetChain as Chain>::ChainAccount> {
+	) -> ChannelActionForDeposit<T::AccountId, TargetChainAccount<T, I>> {
 		let VaultDepositWitness {
 			input_asset: source_asset,
 			deposit_address,
@@ -2912,7 +2912,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn open_channel(
 		requester: &T::AccountId,
 		source_asset: TargetChainAsset<T, I>,
-		action: ChannelAction<T::AccountId, <T::TargetChain as Chain>::ChainAccount>,
+		action: ChannelAction<T::AccountId, TargetChainAccount<T, I>>,
 		boost_fee: BasisPoints,
 	) -> Result<
 		(DepositChannel<T::TargetChain>, TargetChainBlockNumber<T, I>, T::Amount),

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -564,7 +564,7 @@ pub mod pallet {
 		Refund {
 			reason: RefundReason,
 			refund_address: C::ChainAccount,
-			refund_ccm_metadata: Option<CcmChannelMetadataChecked>,
+			refund_ccm_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
 		},
 	}
 
@@ -2080,11 +2080,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					asset,
 					amount_after_fees,
 					refund_address,
-					refund_ccm_metadata.as_ref().map(|metadata| CcmDepositMetadata {
-						channel_metadata: metadata.clone(),
-						source_chain: asset.into(),
-						source_address,
-					}),
+					refund_ccm_metadata,
 				) {
 					Ok(egress_details) => Some(egress_details.egress_id),
 					Err(e) => {
@@ -2542,13 +2538,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 								if let AccountOrAddress::ExternalAddress(refund_addr) =
 									refund_params.refund_address.clone()
 								{
-									Ok((
-										refund_addr,
-										refund_params
-											.refund_ccm_metadata
-											.clone()
-											.map(|refund| refund.channel_metadata),
-									))
+									Ok((refund_addr, refund_params.refund_ccm_metadata.clone()))
 								} else {
 									Err(DepositFailedReason::DepositWitnessRejected(
 										"Invalid Refund address".into(),
@@ -2571,13 +2561,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 								amount: deposit_amount,
 								asset,
 								deposit_details: deposit_details.clone(),
-								refund_ccm_metadata: refund_ccm_metadata.map(|metadata| {
-									CcmDepositMetadata {
-										channel_metadata: metadata,
-										source_chain: asset.into(),
-										source_address,
-									}
-								}),
+								refund_ccm_metadata,
 							},
 						);
 
@@ -2832,9 +2816,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					ChannelAction::Refund {
 						reason: reason.clone(),
 						refund_address,
-						refund_ccm_metadata: checked_refund_params
-							.refund_ccm_metadata
-							.map(|refund| refund.channel_metadata),
+						refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.map(
+							|mut refund_ccm_metadata| {
+								// TODO: Check: is this intentional? setting the source_address to
+								// None is what implicitly happened in the refund flow until now
+								refund_ccm_metadata.source_address = None;
+								refund_ccm_metadata
+							},
+						),
 					},
 					None,
 				),

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -213,7 +213,7 @@ enum FullWitnessDepositOutcome {
 #[derive(RuntimeDebug, Clone)]
 pub struct ValidatedVaultSwapParams<AccountId> {
 	pub broker_fees: BoundedVec<Beneficiary<AccountId>, ConstU32<6>>,
-	pub channel_metadata: Option<CcmChannelMetadataChecked>,
+	pub egress_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
 	pub source_address: Option<ForeignChainAddress>,
 	pub destination_address: ForeignChainAddress,
 }
@@ -553,7 +553,7 @@ pub mod pallet {
 			destination_asset: Asset,
 			destination_address: ForeignChainAddress,
 			broker_fees: Beneficiaries<AccountId>,
-			channel_metadata: Option<CcmChannelMetadataChecked>,
+			egress_metadata: Option<CcmDepositMetadataChecked<ForeignChainAddress>>,
 			refund_params: ChannelRefundParametersCheckedInternal<AccountId>,
 			dca_params: Option<DcaParameters>,
 		},
@@ -2047,24 +2047,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				destination_asset,
 				destination_address,
 				broker_fees,
-				channel_metadata,
+				egress_metadata,
 				refund_params,
 				dca_params,
 			} => {
-				let deposit_metadata =
-					channel_metadata.clone().map(|metadata| CcmDepositMetadataChecked {
-						channel_metadata: metadata,
-						source_chain: asset.into(),
-						source_address,
-					});
-
 				let swap_request_id = T::SwapRequestHandler::init_swap_request(
 					asset.into(),
 					amount_after_fees.into(),
 					destination_asset,
 					SwapRequestType::Regular {
 						output_action: SwapOutputAction::Egress {
-							ccm_deposit_metadata: deposit_metadata,
+							ccm_deposit_metadata: egress_metadata,
 							output_address: destination_address,
 						},
 					},
@@ -2433,7 +2426,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		if let Ok(ValidatedVaultSwapParams {
 			broker_fees,
-			channel_metadata,
+			egress_metadata,
 			source_address,
 			destination_address,
 		}) = Self::try_validate_vault_swap(vault_deposit_witness.clone())
@@ -2444,7 +2437,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				broker_fees,
 				refund_params: checked_refund_params,
 				dca_params,
-				channel_metadata,
+				egress_metadata,
 			};
 
 			let boost_status_lookup = BoostStatusLookup::Vault { tx_id: tx_id.clone() };
@@ -2728,7 +2721,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				},
 			};
 
-		let (channel_metadata, source_address) = if let Some(metadata) = deposit_metadata.clone() {
+		let (egress_metadata, source_address) = if let Some(metadata) = deposit_metadata.clone() {
 			let destination_chain: ForeignChain = (destination_asset).into();
 			if !destination_chain.ccm_support() {
 				return Err(RefundReason::CcmUnsupportedForTargetChain);
@@ -2737,7 +2730,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			metadata
 				.to_checked(destination_asset, destination_address_internal.clone())
 				.map_err(|_| RefundReason::CcmInvalidMetadata)
-				.map(|decoded| (Some(decoded.channel_metadata), decoded.source_address))?
+				.map(|decoded| {
+					(
+						Some(CcmDepositMetadataChecked {
+							channel_metadata: decoded.channel_metadata,
+							source_chain: source_asset.into(),
+							source_address: decoded.source_address.clone(),
+						}),
+						decoded.source_address,
+					)
+				})?
 		} else {
 			(None, None)
 		};
@@ -2758,7 +2760,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		Ok(ValidatedVaultSwapParams {
 			broker_fees,
-			channel_metadata,
+			egress_metadata,
 			source_address,
 			destination_address: destination_address_internal,
 		})
@@ -2798,7 +2800,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			match Self::try_validate_vault_swap(vault_deposit_witness.clone()) {
 				Ok(ValidatedVaultSwapParams {
 					broker_fees,
-					channel_metadata,
+					egress_metadata,
 					source_address,
 					destination_address,
 				}) => (
@@ -2806,7 +2808,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						destination_asset,
 						destination_address,
 						broker_fees: broker_fees.clone(),
-						channel_metadata: channel_metadata.clone(),
+						egress_metadata: egress_metadata.clone(),
 						refund_params: checked_refund_params,
 						dca_params: dca_params.clone(),
 					},
@@ -2818,8 +2820,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						refund_address,
 						refund_ccm_metadata: checked_refund_params.refund_ccm_metadata.map(
 							|mut refund_ccm_metadata| {
-								// TODO: Check: is this intentional? setting the source_address to
-								// None is what implicitly happened in the refund flow until now
+								// TODO: Check: @Albert is this intentional? setting the
+								// source_address to None is what implicitly happened in the
+								// refund flow until now
 								refund_ccm_metadata.source_address = None;
 								refund_ccm_metadata
 							},
@@ -3330,7 +3333,13 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 				destination_asset,
 				destination_address,
 				broker_fees,
-				channel_metadata,
+				egress_metadata: channel_metadata.clone().map(|metadata| {
+					CcmDepositMetadataChecked {
+						channel_metadata: metadata,
+						source_chain: source_asset.into(),
+						source_address: None,
+					}
+				}),
 				refund_params: refund_params
 					.map_refund_address_to_foreign_chain_address()
 					.into_checked(None, source_asset.into())?

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1994,12 +1994,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				deposit_details,
 				deposit_address: Some(deposit_address.clone()),
 				action: action.map(
-					|x| x,
-					|y| y,
+					|account_id| account_id,
+					|target_chain_account| target_chain_account,
 					|channel_metadata| CcmDepositMetadataChecked {
 						channel_metadata,
 						source_chain: asset.into(),
-						source_address: None, // TODO: Are we sure this is correct?
+						// For deposit channels we don't witness the source address
+						source_address: None,
 					},
 				),
 				boost_fee,
@@ -2154,12 +2155,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			deposit_channel_details.boost_fee,
 			Some(channel_id),
 			deposit_channel_details.action.map(
-				|x| x,
-				|y| y,
+				|account_id| account_id,
+				|target_chain_account| target_chain_account,
 				|channel_metadata| CcmDepositMetadataChecked {
 					channel_metadata,
 					source_chain: (*asset).into(),
-					source_address: None, // TODO: Are we sure this is correct?
+					// For deposit channels we don't witness the source address
+					source_address: None,
 				},
 			),
 			block_height,
@@ -3296,7 +3298,12 @@ impl<T: Config<I>, I: 'static> DepositApi<T::TargetChain> for Pallet<T, I> {
 					.into_checked(None, source_asset.into())?
 					// we map the CcmDepositMetadata to a CcmChannelMetadata, forgetting the other
 					// fields:
-					.map(|x| x, |y| y.map(|y| y.channel_metadata)),
+					.map(
+						|address| address,
+						|maybe_deposit_metadata| {
+							maybe_deposit_metadata.map(|metadata| metadata.channel_metadata)
+						},
+					),
 				dca_params,
 			},
 			boost_fee,

--- a/state-chain/pallets/cf-ingress-egress/src/migrations.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations.rs
@@ -16,5 +16,17 @@
 
 use crate::Pallet;
 use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
 
-pub type PalletMigration<T, I> = (PlaceholderMigration<27, Pallet<T, I>>,);
+mod channel_action_ccm_refund;
+
+pub type PalletMigration<T, I> = (
+	VersionedMigration<
+		27,
+		28,
+		channel_action_ccm_refund::ChannelActionCcmRefund<T, I>,
+		Pallet<T, I>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<28, Pallet<T, I>>,
+);

--- a/state-chain/pallets/cf-ingress-egress/src/migrations/channel_action_ccm_refund.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/migrations/channel_action_ccm_refund.rs
@@ -1,0 +1,167 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+#[cfg(feature = "try-runtime")]
+use sp_std::collections::btree_set::BTreeSet;
+
+use crate::Config;
+
+use crate::*;
+use frame_support::pallet_prelude::Weight;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::DispatchError;
+
+use codec::{Decode, Encode};
+
+use cf_chains::ChannelRefundParametersCheckedInternal;
+
+pub mod old {
+	use super::*;
+	// use cf_primitives::Price;
+
+	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+	pub struct DepositChannelDetails<T: Config<I>, I: 'static> {
+		pub owner: T::AccountId,
+		pub deposit_channel: DepositChannel<T::TargetChain>,
+		pub opened_at: TargetChainBlockNumber<T, I>,
+		pub expires_at: TargetChainBlockNumber<T, I>,
+		pub action: ChannelAction<T::AccountId, T::TargetChain>,
+		pub boost_fee: BasisPoints,
+		pub boost_status: BoostStatus<TargetChainAmount<T, I>, BlockNumberFor<T>>,
+	}
+
+	#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+	#[allow(clippy::large_enum_variant)]
+	pub enum ChannelAction<AccountId, C: Chain> {
+		Swap {
+			destination_asset: Asset,
+			destination_address: ForeignChainAddress,
+			broker_fees: Beneficiaries<AccountId>,
+			channel_metadata: Option<CcmChannelMetadataChecked>,
+			refund_params: ChannelRefundParametersCheckedInternal<AccountId>,
+			dca_params: Option<DcaParameters>,
+		},
+		LiquidityProvision {
+			lp_account: AccountId,
+			refund_address: ForeignChainAddress,
+		},
+		Refund {
+			reason: RefundReason,
+			refund_address: C::ChainAccount,
+			refund_ccm_metadata: Option<CcmChannelMetadataChecked>,
+		},
+	}
+
+	#[frame_support::storage_alias]
+	pub type DepositChannelLookup<T: Config<I>, I: 'static> = StorageMap<
+		Pallet<T, I>,
+		Twox64Concat,
+		TargetChainAccount<T, I>,
+		DepositChannelDetails<T, I>,
+		OptionQuery,
+	>;
+}
+
+pub struct ChannelActionCcmRefund<T: Config<I>, I: 'static>(PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> UncheckedOnRuntimeUpgrade for ChannelActionCcmRefund<T, I> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let deposit_channels =
+			old::DepositChannelLookup::<T, I>::iter_keys().collect::<BTreeSet<_>>();
+
+		Ok(deposit_channels.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("🍩 Running migration for Ingress-Egress pallet: Updating Refund Parameters.");
+		crate::DepositChannelLookup::<T, I>::translate_values::<old::DepositChannelDetails<T, I>, _>(
+			|old| {
+				Some(DepositChannelDetails {
+					owner: old.owner,
+					deposit_channel: old.deposit_channel,
+					opened_at: old.opened_at,
+					expires_at: old.expires_at,
+					action: match old.action {
+						old::ChannelAction::Swap {
+							destination_asset,
+							destination_address,
+							broker_fees,
+							channel_metadata,
+							refund_params:
+								ChannelRefundParametersCheckedInternal {
+									retry_duration,
+									refund_address,
+									min_price,
+									refund_ccm_metadata,
+									max_oracle_price_slippage,
+								},
+							dca_params,
+						} => ChannelAction::Swap {
+							destination_asset,
+							destination_address: destination_address.clone(),
+							broker_fees,
+							channel_metadata,
+							refund_params: ChannelRefundParameters {
+								retry_duration,
+								refund_address,
+								min_price,
+								refund_ccm_metadata: refund_ccm_metadata.map(|d| {
+									// extract the `CcmChannelMetadata` from `CcmDepositMetadata`
+									d.channel_metadata
+								}),
+								max_oracle_price_slippage,
+							},
+							dca_params,
+						},
+						old::ChannelAction::LiquidityProvision { lp_account, refund_address } =>
+							ChannelAction::LiquidityProvision { lp_account, refund_address },
+						old::ChannelAction::Refund {
+							reason,
+							refund_address,
+							refund_ccm_metadata,
+						} => ChannelAction::Refund { reason, refund_address, refund_ccm_metadata },
+					},
+					boost_fee: old.boost_fee,
+					boost_status: old.boost_status,
+				})
+			},
+		);
+		log::info!("🍩 Migration for Ingress-Egress pallet complete.");
+
+		Weight::zero()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let pre_deposit_channels =
+			<BTreeSet<TargetChainAccount<T, I>>>::decode(&mut state.as_slice())
+				.map_err(|_| DispatchError::from("Failed to decode state"))?;
+
+		let post_deposit_channels =
+			DepositChannelLookup::<T, I>::iter_keys().collect::<BTreeSet<_>>();
+		assert_eq!(
+			pre_deposit_channels,
+			post_deposit_channels,
+			"Deposit channels should remain the same after migration. Diff: {:?}",
+			pre_deposit_channels
+				.symmetric_difference(&post_deposit_channels)
+				.collect::<Vec<_>>()
+		);
+
+		Ok(())
+	}
+}

--- a/state-chain/pallets/cf-ingress-egress/src/mocks.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/mocks.rs
@@ -44,7 +44,6 @@ use cf_traits::{
 		fee_payment::MockFeePayment,
 		fetches_transfers_limit_provider::MockFetchesTransfersLimitProvider,
 		lending_pools::MockBoostApi,
-		pool_api::MockPoolApi,
 		swap_parameter_validation::MockSwapParameterValidation,
 		swap_request_api::MockSwapRequestHandler,
 	},
@@ -126,7 +125,6 @@ impl Config<Instance1> for Test {
 	type AddressDerivation = MockAddressDerivation;
 	type AddressConverter = MockAddressConverter;
 	type Balance = MockBalance;
-	type PoolApi = MockPoolApi;
 	type ChainApiCall = MockEthereumApiCall<MockEvmEnvironment>;
 	type Broadcaster = MockEgressBroadcasterEth;
 	type DepositHandler = MockDepositHandler;
@@ -157,7 +155,6 @@ impl Config<Instance2> for Test {
 	type AddressDerivation = MockAddressDerivation;
 	type AddressConverter = MockAddressConverter;
 	type Balance = MockBalance;
-	type PoolApi = MockPoolApi;
 	type ChainApiCall = MockBitcoinApiCall<MockBtcEnvironment>;
 	type Broadcaster = MockEgressBroadcasterBtc;
 	type DepositHandler = MockDepositHandler;

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -2746,7 +2746,6 @@ fn ignore_change_of_minimum_deposit_if_deposit_is_boosted() {
 		asset: EthAsset::Eth,
 		deposit_details: Default::default(),
 		deposit_address: None,
-		source_address: None,
 		action: ChannelAction::LiquidityProvision {
 			lp_account: 0,
 			refund_address: ForeignChainAddress::Eth(Default::default()),
@@ -2762,7 +2761,6 @@ fn ignore_change_of_minimum_deposit_if_deposit_is_boosted() {
 			deposit.asset,
 			deposit.amount,
 			deposit.deposit_details.clone(),
-			deposit.source_address.clone(),
 			boost_status,
 			deposit.boost_fee,
 			deposit.channel_id,

--- a/state-chain/primitives/Cargo.toml
+++ b/state-chain/primitives/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 workspace = true
 
 [dependencies]
+n-functor = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
 hex = { workspace = true, optional = true }
 strum = { workspace = true }

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -486,6 +486,7 @@ pub type Beneficiaries<Id> = BoundedVec<Beneficiary<Id>, ConstU32<MAX_BENEFICIAR
 	PartialOrd,
 	Ord,
 )]
+#[n_functor::derive_n_functor]
 pub struct Beneficiary<Id> {
 	pub account: Id,
 	pub bps: BasisPoints,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -433,7 +433,6 @@ impl pallet_cf_ingress_egress::Config<Instance1> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = eth::api::EthereumApi<EvmEnvironment>;
 	type Broadcaster = EthereumBroadcaster;
 	type DepositHandler = chainflip::DepositHandler;
@@ -464,7 +463,6 @@ impl pallet_cf_ingress_egress::Config<Instance2> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = dot::api::PolkadotApi<chainflip::DotEnvironment>;
 	type Broadcaster = PolkadotBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
@@ -495,7 +493,6 @@ impl pallet_cf_ingress_egress::Config<Instance3> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = cf_chains::btc::api::BitcoinApi<chainflip::BtcEnvironment>;
 	type Broadcaster = BitcoinBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
@@ -526,7 +523,6 @@ impl pallet_cf_ingress_egress::Config<Instance4> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = ArbitrumApi<EvmEnvironment>;
 	type Broadcaster = ArbitrumBroadcaster;
 	type DepositHandler = chainflip::DepositHandler;
@@ -557,7 +553,6 @@ impl pallet_cf_ingress_egress::Config<Instance5> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = cf_chains::sol::api::SolanaApi<SolEnvironment>;
 	type Broadcaster = SolanaBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;
@@ -588,7 +583,6 @@ impl pallet_cf_ingress_egress::Config<Instance6> for Runtime {
 	type AddressDerivation = AddressDerivation;
 	type AddressConverter = ChainAddressConverter;
 	type Balance = AssetBalances;
-	type PoolApi = LiquidityPools;
 	type ChainApiCall = hub::api::AssethubApi<chainflip::HubEnvironment>;
 	type Broadcaster = AssethubBroadcaster;
 	type WeightInfo = pallet_cf_ingress_egress::weights::PalletWeight<Runtime>;

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -430,7 +430,7 @@ pub enum ChannelActionType {
 	Unrefundable,
 }
 
-impl<AccountId, C: Chain> From<ChannelAction<AccountId, C>> for ChannelActionType {
+impl<AccountId, C> From<ChannelAction<AccountId, C>> for ChannelActionType {
 	fn from(action: ChannelAction<AccountId, C>) -> Self {
 		match action {
 			ChannelAction::Swap { .. } => ChannelActionType::Swap,

--- a/state-chain/runtime/src/runtime_apis.rs
+++ b/state-chain/runtime/src/runtime_apis.rs
@@ -427,6 +427,7 @@ pub enum ChannelActionType {
 	Swap,
 	LiquidityProvision,
 	Refund,
+	Unrefundable,
 }
 
 impl<AccountId, C: Chain> From<ChannelAction<AccountId, C>> for ChannelActionType {
@@ -435,6 +436,7 @@ impl<AccountId, C: Chain> From<ChannelAction<AccountId, C>> for ChannelActionTyp
 			ChannelAction::Swap { .. } => ChannelActionType::Swap,
 			ChannelAction::LiquidityProvision { .. } => ChannelActionType::LiquidityProvision,
 			ChannelAction::Refund { .. } => ChannelActionType::Refund,
+			ChannelAction::Unrefundable => ChannelActionType::Unrefundable,
 		}
 	}
 }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -33,7 +33,7 @@ regex = { workspace = true, optional = true }
 scale-info = { workspace = true, optional = true }
 scopeguard = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive", "alloc"] }
-sp-core = { workspace = true, optional = true }
+sp-core = { workspace = true, optional = false }
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["full"] }
@@ -76,8 +76,7 @@ std = [
 	"dep:tracing",
 	"dep:tracing-subscriber",
 	"dep:warp",
-	"dep:sp-core",
-	"sp-core?/std",
+	"sp-core/std",
 	"dep:num-traits",
 	"dep:regex",
 	"dep:url",

--- a/utilities/src/without_std.rs
+++ b/utilities/src/without_std.rs
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod bounded_vec;
 pub mod conditional;
 
 pub const fn bs58_array<const S: usize>(s: &'static str) -> [u8; S] {

--- a/utilities/src/without_std/bounded_vec.rs
+++ b/utilities/src/without_std/bounded_vec.rs
@@ -1,0 +1,8 @@
+use sp_core::{bounded::BoundedVec, Get};
+
+pub fn map_bounded_vec<S: Get<u32>, T0, T1>(
+	xs: BoundedVec<T0, S>,
+	f: impl Fn(T0) -> T1,
+) -> BoundedVec<T1, S> {
+	BoundedVec::truncate_from(xs.into_iter().map(f).collect())
+}


### PR DESCRIPTION
# Pull Request

Motivated as part of PRO-2451.

Closes: PRO-2553.

This extracts the ingress-egress pallet refactors of https://github.com/chainflip-io/chainflip-backend/pull/6038.

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

While working on the "refund undecodable bitcoin vault swaps"-PR (PRO-2451), I tried to understand the ingress-egress pallet, and in that process, came upon various places where the code could be improved. This PR is the result. It would be useful to merge this before working on PRO-2551.

### Refactors:
1. When constructing ChannelAction::Refund, directly include the CcmDepositMetadata with source_chain and source_address. Then in BLS of "full witness" uses that instead of reconstructing it.
2. Make the `ChannelAction` struct parametric over it's CcmMetadata. At channel construction time we don't have deposit data, so we want to use `CcmChannelMetadata`. When we have an actual deposit, we want to use `CcmDepositMetadata`.
3. Move the validation of vault swap refund parameters into `try_validate_vault_swap`. Previously this logic was duplicated between witness and prewitness.
4. Change the type of the refund address inside of the `refund_params` field of `ChannelAction::Swap` from AccountOrAddress to ForeignChainAddress. We never used the `AccountOrAddress::InternalAccount` variant and it seems like this change was more or less accidental.
 
### Question:
1.  @albert-llimos: The current behaviour (on main) is: If we have a Ccm refund due to failure of `try_validate_vault_swap`, then the `CcmDepositMetadata` when passing
 the refund to `Self::schedule_egress()` has `source_address == None` due to how we propagate the error. Is this intentional?
2. @albert-llimos @dandanlen: I'm motioning to rename the struct `ChannelRefundParameters<A, CcmRefundDetails>` to simply `RefundParameters<A, CcmRefundDetails>` because we use it in two different ways, we either insert either deposit or channel metadata into the `CcmRefundDetails` type parameter. I haven't done this yet, and of course we can do that in a later PR.


 ### Impact:
 Types that are changed and require migration:
  - [x] ChannelAction. Changed the type of `Swap { refund_params }`.
      - from: `ChannelRefundParameters<AccountOrAddress, Option<CcmDepositMetadataChecked<ForeignChainAddress>>>`
      - to : `ChannelRefundParameters<ForeignChainAddress, Option<CcmChannelMetadataChecked>>`