### PR TITLE
[RELEASE CANDIDATE] 1.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [1.11.6] - 2025-10-01
+
+### Fixes
+
+- Correctly update exceptions list with existing delegators
+- Ensure bond for managed validators is distributed correctly
+
 ## [1.11.5] - 2025-09-24
 
 ## Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -13736,7 +13736,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.11.5"
+version = "1.11.6"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.11.5"
+version = "1.11.6"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.11.5"
+version = "1.11.6"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.11.5"
+version = "1.11.6"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.11.5"
+version = "1.11.6"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_11_5"
+name = "chainflip_engine_v1_11_6"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.11.5"
+version = "1.11.6"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.11.5"
+version = "1.11.6"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v1_11_5.so",
+		"target/release/libchainflip_engine_v1_11_6.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_5.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_6.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.11.5")]
+	#[engine_proc_macros::link_engine_library_version("1.11.6")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -27,7 +27,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.10.4";
-pub const NEW_VERSION: &str = "1.11.5";
+pub const NEW_VERSION: &str = "1.11.6";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.11.5"
+version = "1.11.6"
 license = "Apache-2.0"
 
 [lib]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.11.5"
+version = "1.11.6"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -994,8 +994,23 @@ pub mod pallet {
 			ensure!(settings.fee_bps <= MAX_OPERATOR_FEE, Error::<T>::OperatorFeeTooHigh);
 
 			if let Some(current_settings) = OperatorSettingsLookup::<T>::get(&operator) {
-				if current_settings.delegation_acceptance != settings.delegation_acceptance {
-					Exceptions::<T>::remove(&operator);
+				match (current_settings.delegation_acceptance, settings.delegation_acceptance) {
+					(DelegationAcceptance::Allow, DelegationAcceptance::Deny) => {
+						Exceptions::<T>::mutate(&operator, |allowed| {
+							allowed.clear();
+							// Any existing delegators need be added to the allowed list.
+							for (delegator, (assigned_operator, _)) in DelegationChoice::<T>::iter()
+							{
+								if assigned_operator == operator {
+									allowed.insert(delegator.clone());
+								}
+							}
+						});
+					},
+					(DelegationAcceptance::Deny, DelegationAcceptance::Allow) => {
+						Exceptions::<T>::remove(&operator);
+					},
+					_ => {},
 				}
 			}
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1705,8 +1705,31 @@ mod operator {
 					settings: OPERATOR_SETTINGS,
 				}),
 			);
+			// Delegator delegates to ALICE
+			const BID: u128 = 1_000;
+			MockFlip::credit_funds(&BOB, BID);
+			assert_ok!(ValidatorPallet::delegate(
+				OriginTrait::signed(BOB),
+				ALICE,
+				DelegationAmount::Max
+			));
+			assert_eq!(DelegationChoice::<Test>::get(BOB), Some((ALICE, BID)));
+			// Update operator settings to DENY delegation acceptance.
+			const NEW_OPERATOR_SETTINGS: OperatorSettings = OperatorSettings {
+				fee_bps: DEFAULT_MIN_OPERATOR_FEE,
+				delegation_acceptance: DelegationAcceptance::Deny,
+			};
+			assert!(Exceptions::<Test>::get(ALICE).is_empty());
+			assert_ok!(ValidatorPallet::update_operator_settings(
+				OriginTrait::signed(ALICE),
+				NEW_OPERATOR_SETTINGS,
+			));
+			assert_eq!(OperatorSettingsLookup::<Test>::get(ALICE), Some(NEW_OPERATOR_SETTINGS));
+			// BOB should be added to exceptions list because he was already a delegator.
+			assert!(Exceptions::<Test>::get(ALICE).contains(&BOB));
 		});
 	}
+
 	#[test]
 	fn can_claim_by_operator_and_accept_by_validator() {
 		const OP_1: u64 = 1001;

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.11.5"
+version = "1.11.6"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -243,7 +243,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 1_11_05,
+	spec_version: 1_11_06,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
Contains some runtime-only fixes to delegation.

From these PRs:
- #6148 
- #6142 

One of the commits from the second PR was left out ([this](https://github.com/chainflip-io/chainflip-backend/pull/6142/commits/be71505da50c50faee83c57fca04e86c472882c6) one) - it was a non-functional refactor of the storage items. This would have broken engine compatibility, so I saved it for the next release.