### PR TITLE
fix: [pick] always create price elections for eth and arb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [1.11.11] - 2025-10-07
+
+- Always create oracle price elections for both Eth and Arb. ([#6153](https://github.com/chainflip-io/chainflip-backend/issues/6153))
+
 ## [1.11.10] - 2025-10-02
 
 - Prevent duplication of polkadot rpc client.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "cf-primitives",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -13736,7 +13736,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-chain-runtime"
-version = "1.11.10"
+version = "1.11.11"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "1.11.10"
+version = "1.11.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "1.11.10"
+version = "1.11.11"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "1.11.10"
+version = "1.11.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "1.11.10"
+version = "1.11.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "1.11.10"
+version = "1.11.11"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v1_11_10"
+name = "chainflip_engine_v1_11_11"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "1.11.10"
+version = "1.11.11"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "1.11.10"
+version = "1.11.11"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v1_11_10.so",
+		"target/release/libchainflip_engine_v1_11_11.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_10.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v1_11_11.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("1.11.10")]
+	#[engine_proc_macros::link_engine_library_version("1.11.11")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -27,7 +27,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "1.10.4";
-pub const NEW_VERSION: &str = "1.11.10";
+pub const NEW_VERSION: &str = "1.11.11";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "1.11.10"
+version = "1.11.11"
 license = "Apache-2.0"
 
 [lib]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "1.11.10"
+version = "1.11.11"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/oracle_price.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/oracle_price.rs
@@ -262,7 +262,7 @@ fn election_lifecycle() {
 			|_| {},
 			vec![
 				election_for_chain_with_all_assets(Arbitrum, Some(UpToDate)),
-				election_for_chain_with_all_assets(Ethereum, None),
+				election_for_chain_with_all_assets(Ethereum, Some(UpToDate)),
 				current_prices_are(&prices2, UpToDate),
 			],
 		)
@@ -278,7 +278,7 @@ fn election_lifecycle() {
 			|_| {},
 			vec![
 				election_for_chain_with_all_assets(Arbitrum, Some(UpToDate)),
-				election_for_chain_with_all_assets(Ethereum, None),
+				election_for_chain_with_all_assets(Ethereum, Some(MaybeStale)),
 				current_prices_are(&prices2, UpToDate),
 			],
 		)
@@ -342,7 +342,7 @@ fn election_lifecycle() {
 			|_| {},
 			vec![
 				election_for_chain_with_all_assets(Arbitrum, Some(UpToDate)),
-				election_for_chain_with_all_assets(Ethereum, None),
+				election_for_chain_with_all_assets(Ethereum, Some(Stale)),
 				current_prices_are(&prices3, UpToDate),
 			],
 		);
@@ -430,7 +430,7 @@ fn election_lifecycles_handles_missing_assets_and_disparate_timestamps() {
 				)),
 			),
 		])
-		// this means that we're now querying only arbitrum and all prices are up to date
+		// we're still querying Arb and Eth both
 		.test_on_finalize(
 			&vec![()],
 			|_| {},
@@ -440,7 +440,8 @@ fn election_lifecycles_handles_missing_assets_and_disparate_timestamps() {
 					Some(all::<ChainlinkAssetpair>().zip(repeat(UpToDate)).collect()),
 				)),
 				Check::<OraclePriceES>::election_for_chain_ongoing_with_asset_status((
-					Ethereum, None,
+					Ethereum,
+					Some(all::<ChainlinkAssetpair>().zip(repeat(MaybeStale)).collect()),
 				)),
 				Check::<OraclePriceES>::electoral_price_api_returns(
 					prices4assets

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -149,6 +149,27 @@ pub struct PriceLimits {
 	pub max_oracle_price_slippage: Option<BasisPoints>,
 }
 
+#[derive(
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
+	TypeInfo,
+	Serialize,
+	Deserialize,
+	MaxEncodedLen,
+	PartialOrd,
+	Ord,
+	Copy,
+	Default,
+)]
+pub struct Temp {
+	limits: PriceLimits,
+	other: u32,
+}
+
 /// The `log1.0001(price)` rounded to the nearest integer. Note [Price] is always
 /// in units of asset One.
 pub type Tick = i32;

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "1.11.10"
+version = "1.11.11"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/chainflip/generic_elections.rs
+++ b/state-chain/runtime/src/chainflip/generic_elections.rs
@@ -297,16 +297,16 @@ pub fn initial_state(
 		},),
 		unsynchronised_settings: (OraclePriceSettings {
 			arbitrum: ExternalChainSettings {
-				up_to_date_timeout: Seconds(60),
+				up_to_date_timeout: Seconds(60 * 60),
 				maybe_stale_timeout: Seconds(30),
-				minimal_price_deviation: BasisPoints(10),
+				minimal_price_deviation: BasisPoints(5),
 				up_to_date_timeout_overrides: up_to_date_timeout_overrides.clone(),
 				maybe_stale_timeout_overrides: maybe_stale_timeout_overrides.clone(),
 			},
 			ethereum: ExternalChainSettings {
-				up_to_date_timeout: Seconds(60),
+				up_to_date_timeout: Seconds(60 * 60),
 				maybe_stale_timeout: Seconds(30),
-				minimal_price_deviation: BasisPoints(10),
+				minimal_price_deviation: BasisPoints(5),
 				up_to_date_timeout_overrides: up_to_date_timeout_overrides.clone(),
 				maybe_stale_timeout_overrides: maybe_stale_timeout_overrides.clone(),
 			},

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -243,7 +243,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("chainflip-node"),
 	impl_name: create_runtime_str!("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 1_11_10,
+	spec_version: 1_11_11,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,

--- a/state-chain/runtime/src/migrations/generic_elections.rs
+++ b/state-chain/runtime/src/migrations/generic_elections.rs
@@ -16,6 +16,7 @@
 
 use crate::{chainflip::generic_elections::ChainlinkOraclePriceSettings, *};
 use frame_support::{pallet_prelude::Weight, traits::OnRuntimeUpgrade};
+use pallet_cf_elections::CorruptStorageAdherance;
 
 use crate::chainflip::generic_elections;
 #[cfg(feature = "try-runtime")]
@@ -30,119 +31,38 @@ impl OnRuntimeUpgrade for Migration {
 	}
 
 	fn on_runtime_upgrade() -> Weight {
-		let chainlink_oracle_price_settings =
-			match cf_runtime_utilities::genesis_hashes::genesis_hash::<Runtime>() {
-				cf_runtime_utilities::genesis_hashes::BERGHAIN => ChainlinkOraclePriceSettings {
-					arb_address_checker: hex_literal::hex!(
-						"69c700a0debab9e349dd1f52ed62eb253a3c9892"
+		if crate::VERSION.spec_version == 1_11_11 {
+			let result = pallet_cf_elections::Pallet::<Runtime, ()>::update_settings(
+				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
+				Some(
+					generic_elections::initial_state(
+						// It's not important what we pass in here, since we only want to extract
+						// the unsychronized settings
+						ChainlinkOraclePriceSettings {
+							arb_address_checker: Default::default(),
+							arb_oracle_feeds: Default::default(),
+							eth_address_checker: Default::default(),
+							eth_oracle_feeds: Default::default(),
+						},
 					)
-					.into(),
-					arb_oracle_feeds: vec![
-						hex_literal::hex!("6ce185860a4963106506C203335A2910413708e9").into(),
-						hex_literal::hex!("639Fe6ab55C921f74e7fac1ee960C0B6293ba612").into(),
-						hex_literal::hex!("24ceA4b8ce57cdA5058b924B9B9987992450590c").into(),
-						hex_literal::hex!("50834F3163758fcC1Df9973b6e91f0F0F0434aD3").into(),
-						hex_literal::hex!("3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7").into(),
-					],
-					eth_address_checker: hex_literal::hex!(
-						"1562Ad6bb0e68980A3111F24531c964c7e155611"
-					)
-					.into(),
-					eth_oracle_feeds: vec![
-						hex_literal::hex!("F4030086522a5bEEa4988F8cA5B36dbC97BeE88c").into(),
-						hex_literal::hex!("5f4eC3Df9cbd43714FE2740f5E3616155c5b8419").into(),
-						hex_literal::hex!("4ffC43a60e009B551865A93d232E33Fce9f01507").into(),
-						hex_literal::hex!("8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6").into(),
-						hex_literal::hex!("3E7d1eAB13ad0104d2750B8863b489D65364e32D").into(),
-					],
-				},
-				cf_runtime_utilities::genesis_hashes::PERSEVERANCE |
-				cf_runtime_utilities::genesis_hashes::SISYPHOS => ChainlinkOraclePriceSettings {
-					arb_address_checker: hex_literal::hex!(
-						"564e411634189E68ecD570400eBCF783b4aF8688"
-					)
-					.into(),
-					arb_oracle_feeds: vec![
-						hex_literal::hex!("56a43EB56Da12C0dc1D972ACb089c06a5dEF8e69").into(),
-						hex_literal::hex!("d30e2101a97dcbAeBCBC04F14C3f624E67A35165").into(),
-						hex_literal::hex!("32377717BC9F9bA8Db45A244bCE77e7c0Cc5A775").into(),
-						hex_literal::hex!("0153002d20B96532C639313c2d54c3dA09109309").into(),
-						hex_literal::hex!("80EDee6f667eCc9f63a0a6f55578F870651f06A4").into(),
-					],
+					.unsynchronised_settings,
+				),
+				None,
+				CorruptStorageAdherance::Heed,
+			);
 
-					eth_address_checker: hex_literal::hex!(
-						"26061f315570bddf11d9055411a3d811c5ff0148"
-					)
-					.into(),
-					eth_oracle_feeds: vec![
-						hex_literal::hex!("1b44F3514812d835EB1BDB0acB33d3fA3351Ee43").into(),
-						hex_literal::hex!("694AA1769357215DE4FAC081bf1f309aDC325306").into(),
-						// There is no SOL price feed in testnet - using ETH instead
-						hex_literal::hex!("694AA1769357215DE4FAC081bf1f309aDC325306").into(),
-						hex_literal::hex!("A2F78ab2355fe2f984D808B5CeE7FD0A93D5270E").into(),
-						// There is no USDT price feed in testnet - using USDC instead
-						hex_literal::hex!("A2F78ab2355fe2f984D808B5CeE7FD0A93D5270E").into(),
-					],
-				},
-				// localnet:
-				_ => ChainlinkOraclePriceSettings {
-					arb_address_checker: hex_literal::hex!(
-						"9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
-					)
-					.into(),
-					arb_oracle_feeds: vec![
-						hex_literal::hex!("a85233C63b9Ee964Add6F2cffe00Fd84eb32338f").into(),
-						hex_literal::hex!("4A679253410272dd5232B3Ff7cF5dbB88f295319").into(),
-						hex_literal::hex!("7a2088a1bFc9d81c55368AE168C2C02570cB814F").into(),
-						hex_literal::hex!("09635F643e140090A9A8Dcd712eD6285858ceBef").into(),
-						hex_literal::hex!("c5a5C42992dECbae36851359345FE25997F5C42d").into(),
-					],
-					eth_address_checker: hex_literal::hex!(
-						"e7f1725E7734CE288F8367e1Bb143E90bb3F0512"
-					)
-					.into(),
-					eth_oracle_feeds: vec![
-						hex_literal::hex!("322813Fd9A801c5507c9de605d63CEA4f2CE6c44").into(),
-						hex_literal::hex!("a85233C63b9Ee964Add6F2cffe00Fd84eb32338f").into(),
-						hex_literal::hex!("4A679253410272dd5232B3Ff7cF5dbB88f295319").into(),
-						hex_literal::hex!("7a2088a1bFc9d81c55368AE168C2C02570cB814F").into(),
-						hex_literal::hex!("09635F643e140090A9A8Dcd712eD6285858ceBef").into(),
-					],
-				},
-			};
+			match result {
+				Ok(()) => log::info!("successfully updated price oracle election settings"),
+				Err(err) =>
+					log::error!("error when updating price oracle election settings: {err:?}"),
+			}
+		}
 
-		// Before we initialize the pallet, we kill all `OptionQuery` storage entries. This is
-		// because we already released 1.11.x to sisy/persa and it contained a different version
-		// of the elections (with sol as extrenal price chain)
-		use pallet_cf_elections as elections;
-		let _ = elections::SharedDataReferenceCount::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::SharedData::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::BitmapComponents::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::IndividualComponents::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectoralUnsynchronisedStateMap::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectoralSettings::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectionProperties::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectionState::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectionConsensusHistory::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ElectionConsensusHistoryUpToDate::<Runtime, ()>::clear(u32::MAX, None);
-		let _ = elections::ContributingAuthorities::<Runtime, ()>::clear(u32::MAX, None);
-		elections::NextElectionIdentifier::<Runtime, ()>::kill();
-		elections::ElectoralUnsynchronisedSettings::<Runtime, ()>::kill();
-		elections::ElectoralUnsynchronisedState::<Runtime, ()>::kill();
-		elections::Status::<Runtime, ()>::kill();
-
-		let _result = pallet_cf_elections::Pallet::<Runtime, ()>::internally_initialize(
-			generic_elections::initial_state(chainlink_oracle_price_settings),
-		);
 		Weight::zero()
 	}
 
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
-		use pallet_cf_elections::SharedDataReferenceLifetime;
-
-		let lifetime = SharedDataReferenceLifetime::<Runtime, ()>::get();
-		assert_eq!(lifetime, 8);
 		Ok(())
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2560

## Checklist

Please conduct a thorough self-review before opening the PR.

- [x] I am confident that the code works.
- [ ] I have written sufficient tests.
- [ ] I have written and tested required migrations.
- [ ] I have updated documentation where appropriate.

## Summary

This is a pick of #6153. It additionally includes a runtime upgrade setting the oracle price election settings (increasing timeouts, lowering min price deviation parameter).

The new settings are: for both Eth and Arb the same:
 - `up_to_date_timeout: Seconds(60 * 60)` (1h)
 - `maybe_stale_timeout: Seconds(30)`
 - `minimal_price_deviation: BasisPoints(5)`