### PR TITLE
feat: Exclude nodes failing keygen from delegation snapshots

### DIFF
--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -121,10 +121,11 @@ pub fn try_start_keygen<T: RuntimeConfig>(
 	init_bidders::<T>(primary_candidates, epoch, 100_000u128);
 	init_bidders::<T>(secondary_candidates, epoch + LARGE_OFFSET, 90_000u128);
 
-	Pallet::<T>::try_start_keygen(RotationState::from_auction_outcome::<T>(AuctionOutcome {
+	Pallet::<T>::start_keygen_attempt(RotationState::from_auction_outcome::<T>(AuctionOutcome {
 		winners: bidder_set::<T, ValidatorIdOf<T>, _>(primary_candidates, epoch).collect(),
 		bond: 100u32.into(),
-	}));
+	}))
+	.unwrap();
 
 	assert_matches!(CurrentRotationPhase::<T>::get(), RotationPhase::KeygensInProgress(..));
 }

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -156,6 +156,13 @@ impl<Account: Ord + Clone + FullCodec + 'static, Bid: FullCodec + 'static>
 		}
 		DelegationSnapshots::<T>::insert(epoch_index, operator, self);
 	}
+
+	pub fn clear_epoch_registrations<T: Config<AccountId = Account, Amount = Bid>>(
+		epoch_index: EpochIndex,
+	) {
+		DelegationSnapshots::<T>::clear_prefix(epoch_index, u32::MAX, None);
+		ValidatorToOperator::<T>::clear_prefix(epoch_index, u32::MAX, None);
+	}
 }
 
 impl<Account, Bid> DelegationSnapshot<Account, Bid>

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -257,11 +257,23 @@ where
 	}
 
 	fn move_lowest_validator_to_delegator(&mut self) {
-		if let Some((validator, amount)) =
-			self.validators.clone().into_iter().min_by_key(|(_, v)| *v)
-		{
-			self.validators.remove(&validator);
-			self.delegators.insert(validator.into_ref().clone(), amount);
+		if let Some((validator, _)) = self.validators.iter().min_by_key(|(_, v)| *v) {
+			let _ = self.move_validator_to_delegator(validator.clone());
+		}
+	}
+
+	/// Moves a specific validator to delegators.
+	/// Returns true if the validator was found and moved.
+	pub fn move_validator_to_delegator(&mut self, validator: Account) -> bool {
+		if let Some(bid) = self.validators.remove(&validator) {
+			debug_assert!(
+				self.delegators.insert(validator, bid).is_none(),
+				"Validator being moved to delegator should not already be a delegator"
+			);
+
+			true
+		} else {
+			false
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -1,5 +1,6 @@
 use crate::{AuctionOutcome, Config, DelegationSnapshots, Pallet, ValidatorToOperator};
 use cf_primitives::EpochIndex;
+use cf_runtime_utilities::log_or_panic;
 use cf_traits::{EpochInfo, Issuance, RewardsDistribution, Slashing};
 use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;
@@ -273,11 +274,11 @@ where
 	/// Returns true if the validator was found and moved.
 	pub fn move_validator_to_delegator(&mut self, validator: Account) -> bool {
 		if let Some(bid) = self.validators.remove(&validator) {
-			debug_assert!(
-				self.delegators.insert(validator, bid).is_none(),
-				"Validator being moved to delegator should not already be a delegator"
-			);
-
+			if self.delegators.insert(validator, bid).is_some() {
+				log_or_panic!(
+					"Validator being moved to delegator should not already be a delegator"
+				)
+			}
 			true
 		} else {
 			false

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -160,8 +160,8 @@ impl<Account: Ord + Clone + FullCodec + 'static, Bid: FullCodec + 'static>
 	pub fn clear_epoch_registrations<T: Config<AccountId = Account, Amount = Bid>>(
 		epoch_index: EpochIndex,
 	) {
-		DelegationSnapshots::<T>::clear_prefix(epoch_index, u32::MAX, None);
-		ValidatorToOperator::<T>::clear_prefix(epoch_index, u32::MAX, None);
+		let _ = DelegationSnapshots::<T>::clear_prefix(epoch_index, u32::MAX, None);
+		let _ = ValidatorToOperator::<T>::clear_prefix(epoch_index, u32::MAX, None);
 	}
 }
 

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -265,14 +265,11 @@ where
 	}
 
 	fn move_lowest_validator_to_delegator(&mut self) {
-		if let Some((validator, _)) = self.validators.iter().min_by_key(|(_, v)| *v) {
-			let validator = validator.clone();
-			let bid = self.validators.remove(&validator).expect("just found it");
-			if self.delegators.insert(validator, bid).is_some() {
-				log_or_panic!(
-					"Validator being moved to delegator should not already be a delegator"
-				)
-			}
+		if let Some((validator, amount)) =
+			self.validators.clone().into_iter().min_by_key(|(_, v)| *v)
+		{
+			self.validators.remove(&validator);
+			self.delegators.insert(validator.into_ref().clone(), amount);
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -1,6 +1,5 @@
 use crate::{AuctionOutcome, Config, DelegationSnapshots, Pallet, ValidatorToOperator};
 use cf_primitives::EpochIndex;
-use cf_runtime_utilities::log_or_panic;
 use cf_traits::{EpochInfo, Issuance, RewardsDistribution, Slashing};
 use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -266,22 +266,13 @@ where
 
 	fn move_lowest_validator_to_delegator(&mut self) {
 		if let Some((validator, _)) = self.validators.iter().min_by_key(|(_, v)| *v) {
-			let _ = self.move_validator_to_delegator(validator.clone());
-		}
-	}
-
-	/// Moves a specific validator to delegators.
-	/// Returns true if the validator was found and moved.
-	pub fn move_validator_to_delegator(&mut self, validator: Account) -> bool {
-		if let Some(bid) = self.validators.remove(&validator) {
+			let validator = validator.clone();
+			let bid = self.validators.remove(&validator).expect("just found it");
 			if self.delegators.insert(validator, bid).is_some() {
 				log_or_panic!(
 					"Validator being moved to delegator should not already be a delegator"
 				)
 			}
-			true
-		} else {
-			false
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -176,15 +176,6 @@ enum RotationError {
 	DecodeWithMemTracking,
 	TypeInfo,
 	MaxEncodedLen,
-	Copy,
-	Clone,
-	Debug,
-	PartialEq,
-	Eq,
-	Encode,
-	Decode,
-	TypeInfo,
-	MaxEncodedLen,
 )]
 pub enum PalletOffence {
 	MissedAuthorshipSlot,

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -74,6 +74,14 @@ type Version = SemVer;
 
 type Ed25519Signature = ed25519::Signature;
 
+type AuctionOutcomeWithDelegators<T> = (
+	AuctionOutcome<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
+	BTreeMap<
+		<T as frame_system::Config>::AccountId,
+		DelegationSnapshot<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
+	>,
+);
+
 #[derive(
 	Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
@@ -583,7 +591,7 @@ pub mod pallet {
 						T::ValidatorWeightInfo::rotation_phase_idle()
 					}
 				},
-				RotationPhase::KeygensInProgress(mut rotation_state) => {
+				RotationPhase::KeygensInProgress( rotation_state) => {
 					let num_primary_candidates = rotation_state.num_primary_candidates();
 					match T::KeyRotator::status() {
 						AsyncResult::Ready(KeyRotationStatusOuter::KeygenComplete) => {
@@ -1756,13 +1764,7 @@ impl<T: Config> Pallet<T> {
 		auction_bids: impl Fn(
 			&BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
 		) -> Vec<Bid<T::AccountId, T::Amount>>,
-	) -> Result<
-		(
-			AuctionOutcome<T::AccountId, T::Amount>,
-			BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-		),
-		AuctionError,
-	> {
+	) -> Result<AuctionOutcomeWithDelegators<T>, AuctionError> {
 		let mut current_outcome = resolver.resolve_auction(auction_bids(&delegation_snapshots))?;
 		loop {
 			let old_snapshots = delegation_snapshots.clone();
@@ -1933,16 +1935,8 @@ impl<T: Config> Pallet<T> {
 		mut rotation_state: RuntimeRotationState<T>,
 		offenders: &BTreeSet<ValidatorIdOf<T>>,
 		context: &'static str,
-	) -> Result<
-		(
-			RuntimeRotationState<T>,
-			Option<(
-				AuctionOutcome<T::AccountId, T::Amount>,
-				BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-			)>,
-		),
-		RotationError,
-	> {
+	) -> Result<(RuntimeRotationState<T>, Option<AuctionOutcomeWithDelegators<T>>), RotationError>
+	{
 		rotation_state.ban(offenders.clone());
 		let mut delegation_snapshots: BTreeMap<
 			T::AccountId,
@@ -1973,13 +1967,7 @@ impl<T: Config> Pallet<T> {
 	fn re_resolve_auction_after_ban(
 		banned: &BTreeSet<ValidatorIdOf<T>>,
 		delegation_snapshots: BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-	) -> Result<
-		(
-			AuctionOutcome<T::AccountId, T::Amount>,
-			BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-		),
-		AuctionError,
-	> {
+	) -> Result<AuctionOutcomeWithDelegators<T>, AuctionError> {
 		// Get all validators that are in snapshots (as validators, not delegators)
 		let managed_validators: BTreeSet<_> = delegation_snapshots
 			.values()
@@ -2037,16 +2025,16 @@ impl<T: Config> Pallet<T> {
 				Self::current_authority_count(),
 		);
 
-		if (candidates.len() as u32) < min_size {
-			return Err(RotationError::NotEnoughCandidates {
-				candidates: candidates.len() as u32,
-				min_size,
-			})
-		} else {
+		if (candidates.len() as u32) >= min_size {
 			T::KeyRotator::keygen(candidates, rotation_state.new_epoch_index);
 			Self::set_rotation_phase(RotationPhase::KeygensInProgress(rotation_state));
 			log::info!(target: "cf-validator", "Vault rotation initiated.");
 			Ok(())
+		} else {
+			Err(RotationError::NotEnoughCandidates {
+				candidates: candidates.len() as u32,
+				min_size,
+			})
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1735,26 +1735,27 @@ impl<T: Config> Pallet<T> {
 		),
 		AuctionError,
 	> {
-		let (_auction_outcome, resolver, mut delegation_snapshots, auction_bids) =
-			Self::run_initial_auction(excluded)?;
-
-		let mut current_outcome = resolver.resolve_auction(auction_bids(&delegation_snapshots))?;
-		loop {
-			let old_snapshots = delegation_snapshots.clone();
-			for snapshot in delegation_snapshots.values_mut() {
-				snapshot.maybe_optimize_bid(&current_outcome);
-			}
-			if delegation_snapshots == old_snapshots {
-				break;
-			} else if let Ok(new_outcome) =
-				resolver.resolve_auction(auction_bids(&delegation_snapshots))
-			{
-				current_outcome = new_outcome;
-			} else {
-				break;
-			}
-		}
-		Ok((current_outcome, delegation_snapshots))
+		Self::run_initial_auction(excluded).map(
+			|(initial_outcome, resolver, mut delegation_snapshots, auction_bids)| {
+				let mut current_outcome = initial_outcome;
+				loop {
+					let old_snapshots = delegation_snapshots.clone();
+					for snapshot in delegation_snapshots.values_mut() {
+						snapshot.maybe_optimize_bid(&current_outcome);
+					}
+					if delegation_snapshots == old_snapshots {
+						break;
+					} else if let Ok(new_outcome) =
+						resolver.resolve_auction(auction_bids(&delegation_snapshots))
+					{
+						current_outcome = new_outcome;
+					} else {
+						break;
+					}
+				}
+				(current_outcome, delegation_snapshots)
+			},
+		)
 	}
 
 	fn start_authority_rotation() -> Weight {

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -151,6 +151,12 @@ impl<T: pallet::Config> RotationPhase<T> {
 }
 type ValidatorIdOf<T> = <T as Chainflip>::ValidatorId;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RotationError {
+	ReauctionFailed { context: &'static str, error: AuctionError },
+	NotEnoughCandidates { candidates: u32, min_size: u32 },
+}
+
 #[derive(
 	Copy,
 	Clone,
@@ -160,6 +166,15 @@ type ValidatorIdOf<T> = <T as Chainflip>::ValidatorId;
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
+	TypeInfo,
+	MaxEncodedLen,
+	Copy,
+	Clone,
+	Debug,
+	PartialEq,
+	Eq,
+	Encode,
+	Decode,
 	TypeInfo,
 	MaxEncodedLen,
 )]
@@ -575,16 +590,13 @@ pub mod pallet {
 							Self::try_start_key_handover(rotation_state, block_number);
 						},
 						AsyncResult::Ready(KeyRotationStatusOuter::Failed(offenders)) => {
-							if Self::maybe_reauction_after_ban(
-								&mut rotation_state,
-								&offenders,
-								"keygen failure",
-							)
-							.is_err()
+							if let Err(error) =
+								Self::try_restart_keygen(rotation_state, &offenders, "keygen failure")
 							{
+								Self::handle_rotation_error(error);
+								Self::abort_rotation();
 								return T::ValidatorWeightInfo::rotation_phase_keygen(num_primary_candidates)
 							}
-							Self::try_restart_keygen(rotation_state);
 						},
 						AsyncResult::Pending => {
 							log::debug!(target: "cf-validator", "awaiting keygen completion");
@@ -618,16 +630,13 @@ pub mod pallet {
 								log::warn!(
 									"{num_failed_candidates} authority candidate(s) failed to participate in key handover. Retrying from keygen.",
 								);
-								if Self::maybe_reauction_after_ban(
-									&mut rotation_state,
-									&offenders,
-									"handover failure",
-								)
-								.is_err()
+								if let Err(error) =
+									Self::try_restart_keygen(rotation_state, &offenders, "handover failure")
 								{
+									Self::handle_rotation_error(error);
+									Self::abort_rotation();
 									return T::ValidatorWeightInfo::rotation_phase_keygen(num_primary_candidates)
 								}
-								Self::try_restart_keygen(rotation_state);
 							} else {
 								log::warn!(
 									"Key handover attempt failed. Retrying with a new participant set.",
@@ -1732,44 +1741,45 @@ impl<T: Config> Pallet<T> {
 		AuctionError,
 	> {
 		Self::run_initial_auction().and_then(
-			|(_auction_outcome, resolver, mut delegation_snapshots, auction_bids)| {
-				Self::resolve_auction_with_snapshots(
-					&resolver,
-					&mut delegation_snapshots,
-					auction_bids,
-				)
-				.map(|outcome| (outcome, delegation_snapshots))
+			|(_auction_outcome, resolver, delegation_snapshots, auction_bids)| {
+				Self::resolve_auction_with_snapshots(&resolver, delegation_snapshots, auction_bids)
 			},
 		)
 	}
 
 	fn resolve_auction_with_snapshots(
 		resolver: &SetSizeMaximisingAuctionResolver,
-		delegation_snapshots: &mut BTreeMap<
+		mut delegation_snapshots: BTreeMap<
 			T::AccountId,
 			DelegationSnapshot<T::AccountId, T::Amount>,
 		>,
 		auction_bids: impl Fn(
 			&BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
 		) -> Vec<Bid<T::AccountId, T::Amount>>,
-	) -> Result<AuctionOutcome<T::AccountId, T::Amount>, AuctionError> {
-		let mut current_outcome = resolver.resolve_auction(auction_bids(delegation_snapshots))?;
+	) -> Result<
+		(
+			AuctionOutcome<T::AccountId, T::Amount>,
+			BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+		),
+		AuctionError,
+	> {
+		let mut current_outcome = resolver.resolve_auction(auction_bids(&delegation_snapshots))?;
 		loop {
 			let old_snapshots = delegation_snapshots.clone();
 			for snapshot in delegation_snapshots.values_mut() {
 				snapshot.maybe_optimize_bid(&current_outcome);
 			}
-			if delegation_snapshots == &old_snapshots {
+			if delegation_snapshots == old_snapshots {
 				break;
 			} else if let Ok(new_outcome) =
-				resolver.resolve_auction(auction_bids(delegation_snapshots))
+				resolver.resolve_auction(auction_bids(&delegation_snapshots))
 			{
 				current_outcome = new_outcome;
 			} else {
 				break;
 			}
 		}
-		Ok(current_outcome)
+		Ok((current_outcome, delegation_snapshots))
 	}
 
 	fn start_authority_rotation() -> Weight {
@@ -1818,7 +1828,14 @@ impl<T: Config> Pallet<T> {
 					snapshot.register_for_epoch::<T>(next_epoch_index);
 				}
 
-				Self::try_start_keygen(RotationState::from_auction_outcome::<T>(auction_outcome));
+				// This only errors if there are less than min_size candidates after the auction.
+				let rotation_state = RotationState::from_auction_outcome::<T>(auction_outcome);
+				if let Err(error) = Self::prepare_keygen_attempt(rotation_state, None)
+					.and_then(|rotation_state| Self::start_keygen_attempt(rotation_state))
+				{
+					Self::handle_rotation_error(error);
+					Self::abort_rotation();
+				}
 
 				weight
 			},
@@ -1834,9 +1851,42 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	fn try_restart_keygen(rotation_state: RuntimeRotationState<T>) {
-		T::KeyRotator::reset_key_rotation();
-		Self::try_start_keygen(rotation_state);
+	fn try_restart_keygen(
+		rotation_state: RuntimeRotationState<T>,
+		offenders: &BTreeSet<ValidatorIdOf<T>>,
+		context: &'static str,
+	) -> Result<(), RotationError> {
+		Self::prepare_keygen_attempt(rotation_state, Some((offenders, context)))
+			.and_then(|rotation_state| Self::start_keygen_attempt(rotation_state))
+	}
+
+	fn prepare_keygen_attempt(
+		rotation_state: RuntimeRotationState<T>,
+		offenders: Option<(&BTreeSet<ValidatorIdOf<T>>, &'static str)>,
+	) -> Result<RuntimeRotationState<T>, RotationError> {
+		let Some((offenders, context)) = offenders else { return Ok(rotation_state) };
+
+		let (mut rotation_state, reauction) =
+			Self::maybe_reauction_after_ban(rotation_state, offenders, context)?;
+
+		if let Some((new_outcome, new_snapshots)) = reauction {
+			let new_outcome = new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
+			log::info!(
+				target: "cf-validator",
+				"Re-resolved auction after {}. New bond: {:?}",
+				context,
+				new_outcome.bond
+			);
+			Self::persist_reauction_snapshots(rotation_state.new_epoch_index, new_snapshots);
+			Self::deposit_event(Event::AuctionCompleted(
+				new_outcome.winners.clone(),
+				new_outcome.bond,
+			));
+			rotation_state.primary_candidates = new_outcome.winners;
+			rotation_state.bond = new_outcome.bond;
+		}
+
+		Ok(rotation_state)
 	}
 
 	/// Updates delegation snapshots by moving banned validators to delegators.
@@ -1845,6 +1895,10 @@ impl<T: Config> Pallet<T> {
 	fn update_snapshots_for_banned(
 		banned: &BTreeSet<ValidatorIdOf<T>>,
 		next_epoch_index: EpochIndex,
+		delegation_snapshots: &mut BTreeMap<
+			T::AccountId,
+			DelegationSnapshot<T::AccountId, T::Amount>,
+		>,
 	) -> bool {
 		// Group banned validators by their operator
 		let mut operators_to_update: BTreeMap<T::AccountId, Vec<&ValidatorIdOf<T>>> =
@@ -1862,16 +1916,13 @@ impl<T: Config> Pallet<T> {
 		// Update each affected operator's snapshot once
 		let mut has_updates = false;
 		for (operator, banned_validators) in operators_to_update {
-			if let Some(mut snapshot) = DelegationSnapshots::<T>::get(next_epoch_index, &operator) {
+			if let Some(snapshot) = delegation_snapshots.get_mut(&operator) {
 				let mut snapshot_modified = false;
 				for banned_id in banned_validators {
 					snapshot_modified |=
 						snapshot.move_validator_to_delegator(banned_id.into_ref().clone());
 				}
-				if snapshot_modified {
-					DelegationSnapshots::<T>::insert(next_epoch_index, &operator, snapshot);
-					has_updates = true;
-				}
+				has_updates |= snapshot_modified;
 			}
 		}
 
@@ -1879,51 +1930,40 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn maybe_reauction_after_ban(
-		rotation_state: &mut RuntimeRotationState<T>,
+		mut rotation_state: RuntimeRotationState<T>,
 		offenders: &BTreeSet<ValidatorIdOf<T>>,
 		context: &'static str,
-	) -> Result<(), ()> {
+	) -> Result<
+		(
+			RuntimeRotationState<T>,
+			Option<(
+				AuctionOutcome<T::AccountId, T::Amount>,
+				BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+			)>,
+		),
+		RotationError,
+	> {
 		rotation_state.ban(offenders.clone());
+		let mut delegation_snapshots: BTreeMap<
+			T::AccountId,
+			DelegationSnapshot<T::AccountId, T::Amount>,
+		> = DelegationSnapshots::<T>::iter_prefix(rotation_state.new_epoch_index).collect();
 
-		let snapshots_modified =
-			Self::update_snapshots_for_banned(offenders, rotation_state.new_epoch_index);
+		let snapshots_modified = Self::update_snapshots_for_banned(
+			offenders,
+			rotation_state.new_epoch_index,
+			&mut delegation_snapshots,
+		);
 
 		if !snapshots_modified {
-			return Ok(())
+			return Ok((rotation_state, None))
 		}
 
-		match Self::re_resolve_auction_after_ban(
-			&rotation_state.banned,
-			rotation_state.new_epoch_index,
-		) {
-			Ok(new_outcome) => {
-				let new_outcome =
-					new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
-				log::info!(
-					target: "cf-validator",
-					"Re-resolved auction after {}. New bond: {:?}",
-					context,
-					new_outcome.bond
-				);
-				Self::deposit_event(Event::AuctionCompleted(
-					new_outcome.winners.clone(),
-					new_outcome.bond,
-				));
-				rotation_state.primary_candidates = new_outcome.winners;
-				rotation_state.bond = new_outcome.bond;
-				Ok(())
-			},
-			Err(e) => {
-				log::error!(
-					target: "cf-validator",
-					"Failed to re-resolve auction after {}: {:?}. Aborting rotation.",
-					context,
-					e
-				);
-				Self::abort_rotation();
-				Err(())
-			},
-		}
+		Self::re_resolve_auction_after_ban(&rotation_state.banned, delegation_snapshots)
+			.map(|(new_outcome, new_snapshots)| {
+				(rotation_state, Some((new_outcome, new_snapshots)))
+			})
+			.map_err(|error| RotationError::ReauctionFailed { context, error })
 	}
 
 	/// Re-resolves the auction after banning nodes.
@@ -1932,12 +1972,14 @@ impl<T: Config> Pallet<T> {
 	/// already handled by `update_snapshots_for_banned`).
 	fn re_resolve_auction_after_ban(
 		banned: &BTreeSet<ValidatorIdOf<T>>,
-		next_epoch_index: EpochIndex,
-	) -> Result<AuctionOutcome<T::AccountId, T::Amount>, AuctionError> {
-		// Collect current snapshots from storage
-		let mut delegation_snapshots: BTreeMap<T::AccountId, _> =
-			DelegationSnapshots::<T>::iter_prefix(next_epoch_index).collect();
-
+		delegation_snapshots: BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+	) -> Result<
+		(
+			AuctionOutcome<T::AccountId, T::Amount>,
+			BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+		),
+		AuctionError,
+	> {
 		// Get all validators that are in snapshots (as validators, not delegators)
 		let managed_validators: BTreeSet<_> = delegation_snapshots
 			.values()
@@ -1981,10 +2023,11 @@ impl<T: Config> Pallet<T> {
 			AuctionParameters::<T>::get(),
 		)?;
 
-		Self::resolve_auction_with_snapshots(&resolver, &mut delegation_snapshots, auction_bids)
+		Self::resolve_auction_with_snapshots(&resolver, delegation_snapshots, auction_bids)
 	}
 
-	fn try_start_keygen(rotation_state: RuntimeRotationState<T>) {
+	fn start_keygen_attempt(rotation_state: RuntimeRotationState<T>) -> Result<(), RotationError> {
+		T::KeyRotator::reset_key_rotation();
 		let candidates = rotation_state.authority_candidates();
 		let SetSizeParameters { min_size, .. } = AuctionParameters::<T>::get();
 
@@ -1995,17 +2038,46 @@ impl<T: Config> Pallet<T> {
 		);
 
 		if (candidates.len() as u32) < min_size {
-			log::error!(
-				target: "cf-validator",
-				"Only {:?} authority candidates available, not enough to satisfy the minimum set size of {:?}. - aborting rotation.",
-				candidates.len(),
-				min_size
-			);
-			Self::abort_rotation();
+			return Err(RotationError::NotEnoughCandidates {
+				candidates: candidates.len() as u32,
+				min_size,
+			})
 		} else {
 			T::KeyRotator::keygen(candidates, rotation_state.new_epoch_index);
 			Self::set_rotation_phase(RotationPhase::KeygensInProgress(rotation_state));
 			log::info!(target: "cf-validator", "Vault rotation initiated.");
+			Ok(())
+		}
+	}
+
+	fn persist_reauction_snapshots(
+		next_epoch_index: EpochIndex,
+		new_snapshots: BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+	) {
+		DelegationSnapshot::clear_epoch_registrations::<T>(next_epoch_index);
+		for snapshot in new_snapshots.into_values() {
+			snapshot.register_for_epoch::<T>(next_epoch_index);
+		}
+	}
+
+	fn handle_rotation_error(error: RotationError) {
+		match error {
+			RotationError::ReauctionFailed { context, error } => {
+				log::error!(
+					target: "cf-validator",
+					"Failed to re-resolve auction after {}: {:?}.",
+					context,
+					error
+				);
+			},
+			RotationError::NotEnoughCandidates { candidates, min_size } => {
+				log::error!(
+					target: "cf-validator",
+					"Only {:?} authority candidates available, not enough to satisfy the minimum set size of {:?}.",
+					candidates,
+					min_size
+				);
+			},
 		}
 	}
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -74,14 +74,6 @@ type Version = SemVer;
 
 type Ed25519Signature = ed25519::Signature;
 
-type AuctionOutcomeWithDelegators<T> = (
-	AuctionOutcome<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
-	BTreeMap<
-		<T as frame_system::Config>::AccountId,
-		DelegationSnapshot<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
-	>,
-);
-
 #[derive(
 	Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
@@ -1743,23 +1735,9 @@ impl<T: Config> Pallet<T> {
 		),
 		AuctionError,
 	> {
-		Self::run_initial_auction(excluded).and_then(
-			|(_auction_outcome, resolver, delegation_snapshots, auction_bids)| {
-				Self::resolve_auction_with_snapshots(&resolver, delegation_snapshots, auction_bids)
-			},
-		)
-	}
+		let (_auction_outcome, resolver, mut delegation_snapshots, auction_bids) =
+			Self::run_initial_auction(excluded)?;
 
-	fn resolve_auction_with_snapshots(
-		resolver: &SetSizeMaximisingAuctionResolver,
-		mut delegation_snapshots: BTreeMap<
-			T::AccountId,
-			DelegationSnapshot<T::AccountId, T::Amount>,
-		>,
-		auction_bids: impl Fn(
-			&BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-		) -> Vec<Bid<T::AccountId, T::Amount>>,
-	) -> Result<AuctionOutcomeWithDelegators<T>, AuctionError> {
 		let mut current_outcome = resolver.resolve_auction(auction_bids(&delegation_snapshots))?;
 		loop {
 			let old_snapshots = delegation_snapshots.clone();
@@ -2084,45 +2062,28 @@ impl<T: Config> Pallet<T> {
 		let mut snapshots = BTreeMap::new();
 
 		for Bid { bidder_id, amount } in Self::get_qualified_bidders::<Q>() {
-			if excluded.contains(&bidder_id) {
-				// `into_ref` is used to cast between AccountId and ValidatorId.
-				let bidder_id = bidder_id.into_ref();
-				if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
+			let is_excluded = excluded.contains(&bidder_id);
+			// `into_ref` is used to cast between AccountId and ValidatorId.
+			let bidder_id = bidder_id.into_ref();
+			if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
+				let snapshot = snapshots.entry(operator.clone()).or_insert_with(|| {
+					DelegationSnapshot::init(
+						&operator,
+						OperatorSettingsLookup::<T>::get(&operator)
+							.map(|settings| settings.fee_bps)
+							.unwrap_or(MinimumOperatorFee::<T>::get()),
+					)
+				});
+				if is_excluded {
 					// Excluded managed validator: still appears as a delegator so their
 					// stake contributes to the operator, but they cannot be selected.
-					snapshots
-						.entry(operator.clone())
-						.or_insert_with(|| {
-							DelegationSnapshot::init(
-								&operator,
-								OperatorSettingsLookup::<T>::get(&operator)
-									.map(|settings| settings.fee_bps)
-									.unwrap_or(MinimumOperatorFee::<T>::get()),
-							)
-						})
-						.delegators
-						.insert(bidder_id.clone(), amount);
-				}
-				// else: Excluded independent validator: does not appear at all in the auction.
-			} else {
-				// `into_ref` is used to cast between AccountId and ValidatorId.
-				let bidder_id = bidder_id.into_ref();
-				if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
-					snapshots
-						.entry(operator.clone())
-						.or_insert_with(|| {
-							DelegationSnapshot::init(
-								&operator,
-								OperatorSettingsLookup::<T>::get(&operator)
-									.map(|settings| settings.fee_bps)
-									.unwrap_or(MinimumOperatorFee::<T>::get()),
-							)
-						})
-						.validators
-						.insert(bidder_id.clone(), amount);
+					snapshot.delegators.insert(bidder_id.clone(), amount);
 				} else {
-					let _ = independent_bidders.insert(bidder_id.clone(), amount);
+					snapshot.validators.insert(bidder_id.clone(), amount);
 				}
+			} else if !is_excluded {
+				// Independent validator (excluded independents are dropped entirely).
+				let _ = independent_bidders.insert(bidder_id.clone(), amount);
 			}
 		}
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -575,7 +575,15 @@ pub mod pallet {
 							Self::try_start_key_handover(rotation_state, block_number);
 						},
 						AsyncResult::Ready(KeyRotationStatusOuter::Failed(offenders)) => {
-							rotation_state.ban(offenders);
+							if Self::maybe_reauction_after_ban(
+								&mut rotation_state,
+								&offenders,
+								"keygen failure",
+							)
+							.is_err()
+							{
+								return T::ValidatorWeightInfo::rotation_phase_keygen(num_primary_candidates)
+							}
 							Self::try_restart_keygen(rotation_state);
 						},
 						AsyncResult::Pending => {
@@ -606,16 +614,25 @@ pub mod pallet {
 							let num_failed_candidates = offenders.intersection(&rotation_state.authority_candidates()).count();
 							// TODO: Punish a bit more here? Some of these nodes are already an authority and have failed to participate in handover.
 							// So given they're already not going to be in the set, excluding them from the set may not be enough punishment.
-							rotation_state.ban(offenders);
 							if num_failed_candidates > 0 {
 								log::warn!(
 									"{num_failed_candidates} authority candidate(s) failed to participate in key handover. Retrying from keygen.",
 								);
+								if Self::maybe_reauction_after_ban(
+									&mut rotation_state,
+									&offenders,
+									"handover failure",
+								)
+								.is_err()
+								{
+									return T::ValidatorWeightInfo::rotation_phase_keygen(num_primary_candidates)
+								}
 								Self::try_restart_keygen(rotation_state);
 							} else {
 								log::warn!(
 									"Key handover attempt failed. Retrying with a new participant set.",
 								);
+								rotation_state.banned.extend(offenders);
 								Self::try_start_key_handover(rotation_state, block_number)
 							};
 						},
@@ -1714,39 +1731,57 @@ impl<T: Config> Pallet<T> {
 		),
 		AuctionError,
 	> {
-		Self::run_initial_auction().map(
-			|(auction_outcome, resolver, mut delegation_snapshots, auction_bids)| {
-				let mut current_outcome = auction_outcome;
-				loop {
-					let old_snapshots = delegation_snapshots.clone();
-					for (_operator, snapshot) in delegation_snapshots.iter_mut() {
-						snapshot.maybe_optimize_bid(&current_outcome);
-					}
-					if delegation_snapshots == old_snapshots {
-						break;
-					} else if let Ok(new_outcome) =
-						resolver.resolve_auction(auction_bids(&delegation_snapshots))
-					{
-						current_outcome = new_outcome;
-					} else {
-						break;
-					}
-				}
-				(current_outcome, delegation_snapshots)
+		Self::run_initial_auction().and_then(
+			|(_auction_outcome, resolver, mut delegation_snapshots, auction_bids)| {
+				Self::resolve_auction_with_snapshots(
+					&resolver,
+					&mut delegation_snapshots,
+					auction_bids,
+				)
+				.map(|outcome| (outcome, delegation_snapshots))
 			},
 		)
 	}
 
+	fn resolve_auction_with_snapshots(
+		resolver: &SetSizeMaximisingAuctionResolver,
+		delegation_snapshots: &mut BTreeMap<
+			T::AccountId,
+			DelegationSnapshot<T::AccountId, T::Amount>,
+		>,
+		auction_bids: impl Fn(
+			&BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
+		) -> Vec<Bid<T::AccountId, T::Amount>>,
+	) -> Result<AuctionOutcome<T::AccountId, T::Amount>, AuctionError> {
+		let mut current_outcome = resolver.resolve_auction(auction_bids(delegation_snapshots))?;
+		loop {
+			let old_snapshots = delegation_snapshots.clone();
+			for snapshot in delegation_snapshots.values_mut() {
+				snapshot.maybe_optimize_bid(&current_outcome);
+			}
+			if delegation_snapshots == &old_snapshots {
+				break;
+			} else if let Ok(new_outcome) =
+				resolver.resolve_auction(auction_bids(delegation_snapshots))
+			{
+				current_outcome = new_outcome;
+			} else {
+				break;
+			}
+		}
+		Ok(current_outcome)
+	}
+
 	fn start_authority_rotation() -> Weight {
 		if !T::SafeMode::get().authority_rotation_enabled {
-			log::warn!(
+			log::info!(
 				target: "cf-validator",
 				"Failed to start Authority Rotation: Disabled due to Runtime Safe Mode."
 			);
 			return T::ValidatorWeightInfo::start_authority_rotation_while_disabled_by_safe_mode()
 		}
 		if !matches!(CurrentRotationPhase::<T>::get(), RotationPhase::Idle) {
-			log::error!(
+			log::info!(
 				target: "cf-validator",
 				"Failed to start authority rotation: Authority rotation already in progress."
 			);
@@ -1804,6 +1839,151 @@ impl<T: Config> Pallet<T> {
 		Self::try_start_keygen(rotation_state);
 	}
 
+	/// Updates delegation snapshots by moving banned validators to delegators.
+	/// Uses ValidatorToOperator for efficient operator lookup.
+	/// Returns true if any snapshots were modified (i.e., a managed validator was banned).
+	fn update_snapshots_for_banned(
+		banned: &BTreeSet<ValidatorIdOf<T>>,
+		next_epoch_index: EpochIndex,
+	) -> bool {
+		// Group banned validators by their operator
+		let mut operators_to_update: BTreeMap<T::AccountId, Vec<&ValidatorIdOf<T>>> =
+			BTreeMap::new();
+
+		for banned_id in banned {
+			if let Some(operator) =
+				ValidatorToOperator::<T>::get(next_epoch_index, banned_id.into_ref())
+			{
+				operators_to_update.entry(operator).or_default().push(banned_id);
+			}
+			// If no operator mapping, validator is independent - no snapshot update needed
+		}
+
+		// Update each affected operator's snapshot once
+		let mut has_updates = false;
+		for (operator, banned_validators) in operators_to_update {
+			if let Some(mut snapshot) = DelegationSnapshots::<T>::get(next_epoch_index, &operator) {
+				let mut snapshot_modified = false;
+				for banned_id in banned_validators {
+					snapshot_modified |=
+						snapshot.move_validator_to_delegator(banned_id.into_ref().clone());
+				}
+				if snapshot_modified {
+					DelegationSnapshots::<T>::insert(next_epoch_index, &operator, snapshot);
+					has_updates = true;
+				}
+			}
+		}
+
+		has_updates
+	}
+
+	fn maybe_reauction_after_ban(
+		rotation_state: &mut RuntimeRotationState<T>,
+		offenders: &BTreeSet<ValidatorIdOf<T>>,
+		context: &'static str,
+	) -> Result<(), ()> {
+		rotation_state.ban(offenders.clone());
+
+		let snapshots_modified =
+			Self::update_snapshots_for_banned(offenders, rotation_state.new_epoch_index);
+
+		if !snapshots_modified {
+			return Ok(())
+		}
+
+		match Self::re_resolve_auction_after_ban(
+			&rotation_state.banned,
+			rotation_state.new_epoch_index,
+		) {
+			Ok(new_outcome) => {
+				let new_outcome =
+					new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
+				log::info!(
+					target: "cf-validator",
+					"Re-resolved auction after {}. New bond: {:?}",
+					context,
+					new_outcome.bond
+				);
+				Self::deposit_event(Event::AuctionCompleted(
+					new_outcome.winners.clone(),
+					new_outcome.bond,
+				));
+				rotation_state.primary_candidates = new_outcome.winners;
+				rotation_state.bond = new_outcome.bond;
+				Ok(())
+			},
+			Err(e) => {
+				log::error!(
+					target: "cf-validator",
+					"Failed to re-resolve auction after {}: {:?}. Aborting rotation.",
+					context,
+					e
+				);
+				Self::abort_rotation();
+				Err(())
+			},
+		}
+	}
+
+	/// Re-resolves the auction after banning nodes.
+	/// Uses the already-stored snapshots and recalculates independent bidders.
+	/// Banned nodes are excluded from independent bidders (managed validators are
+	/// already handled by `update_snapshots_for_banned`).
+	fn re_resolve_auction_after_ban(
+		banned: &BTreeSet<ValidatorIdOf<T>>,
+		next_epoch_index: EpochIndex,
+	) -> Result<AuctionOutcome<T::AccountId, T::Amount>, AuctionError> {
+		// Collect current snapshots from storage
+		let mut delegation_snapshots: BTreeMap<T::AccountId, _> =
+			DelegationSnapshots::<T>::iter_prefix(next_epoch_index).collect();
+
+		// Get all validators that are in snapshots (as validators, not delegators)
+		let managed_validators: BTreeSet<_> = delegation_snapshots
+			.values()
+			.flat_map(|s| s.validators.keys().cloned())
+			.collect();
+
+		// Independent bidders are qualified bidders NOT in any snapshot AND NOT banned
+		let independent_bids: BTreeMap<T::AccountId, T::Amount> =
+			Self::get_qualified_bidders::<T::KeygenQualification>()
+				.into_iter()
+				.filter(|bid| {
+					!managed_validators.contains(bid.bidder_id.into_ref()) &&
+						!banned.contains(&bid.bidder_id)
+				})
+				.map(|bid| (bid.bidder_id.into_ref().clone(), bid.amount))
+				.collect();
+
+		let minimum_auction_bid = MinimumAuctionBid::<T>::get();
+
+		let auction_bids = move |snapshots: &BTreeMap<
+			T::AccountId,
+			DelegationSnapshot<T::AccountId, T::Amount>,
+		>|
+		      -> Vec<Bid<T::AccountId, T::Amount>> {
+			snapshots
+				.values()
+				.flat_map(|snapshot| snapshot.effective_validator_bids())
+				.chain(independent_bids.clone())
+				.filter_map(|(bidder_id, amount)| {
+					if amount >= minimum_auction_bid {
+						Some(Bid { bidder_id, amount })
+					} else {
+						None
+					}
+				})
+				.collect()
+		};
+
+		let resolver = SetSizeMaximisingAuctionResolver::try_new(
+			T::EpochInfo::current_authority_count(),
+			AuctionParameters::<T>::get(),
+		)?;
+
+		Self::resolve_auction_with_snapshots(&resolver, &mut delegation_snapshots, auction_bids)
+	}
+
 	fn try_start_keygen(rotation_state: RuntimeRotationState<T>) {
 		let candidates = rotation_state.authority_candidates();
 		let SetSizeParameters { min_size, .. } = AuctionParameters::<T>::get();
@@ -1815,7 +1995,7 @@ impl<T: Config> Pallet<T> {
 		);
 
 		if (candidates.len() as u32) < min_size {
-			log::warn!(
+			log::error!(
 				target: "cf-validator",
 				"Only {:?} authority candidates available, not enough to satisfy the minimum set size of {:?}. - aborting rotation.",
 				candidates.len(),
@@ -1834,7 +2014,7 @@ impl<T: Config> Pallet<T> {
 		block_number: BlockNumberFor<T>,
 	) {
 		if !T::SafeMode::get().authority_rotation_enabled {
-			log::warn!(
+			log::info!(
 				target: "cf-validator",
 				"Failed to start Key Handover: Disabled due to Runtime Safe Mode. Aborting Authority rotation."
 			);
@@ -1856,7 +2036,7 @@ impl<T: Config> Pallet<T> {
 			);
 			Self::set_rotation_phase(RotationPhase::KeyHandoversInProgress(rotation_state));
 		} else {
-			log::warn!(
+			log::error!(
 				target: "cf-validator",
 				"Too many authorities have been banned from keygen. Key handover would fail. Aborting rotation."
 			);

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -82,6 +82,15 @@ type AuctionOutcomeWithDelegators<T> = (
 	>,
 );
 
+type ReauctionResult<T> = (
+	AuctionOutcome<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
+	BTreeMap<
+		<T as frame_system::Config>::AccountId,
+		DelegationSnapshot<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
+	>,
+	bool,
+);
+
 #[derive(
 	Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
@@ -1862,7 +1871,7 @@ impl<T: Config> Pallet<T> {
 		let (mut rotation_state, reauction) =
 			Self::maybe_reauction_after_ban(rotation_state, offenders, context)?;
 
-		if let Some(((new_outcome, new_snapshots), snapshots_changed)) = reauction {
+		if let Some((new_outcome, new_snapshots, snapshots_changed)) = reauction {
 			let new_outcome = new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
 			log::info!(
 				target: "cf-validator",
@@ -1928,10 +1937,7 @@ impl<T: Config> Pallet<T> {
 		mut rotation_state: RuntimeRotationState<T>,
 		offenders: &BTreeSet<ValidatorIdOf<T>>,
 		context: &'static str,
-	) -> Result<
-		(RuntimeRotationState<T>, Option<(AuctionOutcomeWithDelegators<T>, bool)>),
-		RotationError,
-	> {
+	) -> Result<(RuntimeRotationState<T>, Option<ReauctionResult<T>>), RotationError> {
 		rotation_state.ban(offenders.clone());
 		let mut delegation_snapshots: BTreeMap<
 			T::AccountId,
@@ -1955,7 +1961,7 @@ impl<T: Config> Pallet<T> {
 			.map(|(new_outcome, new_snapshots)| {
 				let snapshots_changed =
 					snapshots_modified || new_snapshots != snapshots_before_reauction;
-				(rotation_state, Some(((new_outcome, new_snapshots), snapshots_changed)))
+				(rotation_state, Some((new_outcome, new_snapshots, snapshots_changed)))
 			})
 			.map_err(|error| RotationError::ReauctionFailed { context, error })
 	}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -2000,10 +2000,10 @@ impl<T: Config> Pallet<T> {
 
 		for (delegator, (operator, max_bid)) in DelegationChoice::<T>::iter() {
 			if let Some(snapshot) = snapshots.get_mut(&operator) {
-				let delegator_balance = T::FundingInfo::balance(&delegator);
-				snapshot
-					.delegators
-					.insert(delegator.clone(), core::cmp::min(max_bid, delegator_balance));
+				let bid = core::cmp::min(max_bid, T::FundingInfo::balance(&delegator));
+				if bid > Zero::zero() {
+					snapshot.delegators.insert(delegator.clone(), bid);
+				}
 			}
 		}
 
@@ -2225,6 +2225,10 @@ impl<T: Config> RedemptionCheck for Pallet<T> {
 				Error::<T>::StillBidding
 			);
 		}
+		ensure!(
+			!DelegationChoice::<T>::contains_key(validator_id.into_ref()),
+			Error::<T>::StillBidding
+		);
 
 		Ok(())
 	}

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1862,7 +1862,7 @@ impl<T: Config> Pallet<T> {
 		let (mut rotation_state, reauction) =
 			Self::maybe_reauction_after_ban(rotation_state, offenders, context)?;
 
-		if let Some((new_outcome, new_snapshots)) = reauction {
+		if let Some(((new_outcome, new_snapshots), snapshots_changed)) = reauction {
 			let new_outcome = new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
 			log::info!(
 				target: "cf-validator",
@@ -1870,7 +1870,9 @@ impl<T: Config> Pallet<T> {
 				context,
 				new_outcome.bond
 			);
-			Self::persist_reauction_snapshots(rotation_state.new_epoch_index, new_snapshots);
+			if snapshots_changed {
+				Self::persist_reauction_snapshots(rotation_state.new_epoch_index, new_snapshots);
+			}
 			Self::deposit_event(Event::AuctionCompleted(
 				new_outcome.winners.clone(),
 				new_outcome.bond,
@@ -1926,8 +1928,10 @@ impl<T: Config> Pallet<T> {
 		mut rotation_state: RuntimeRotationState<T>,
 		offenders: &BTreeSet<ValidatorIdOf<T>>,
 		context: &'static str,
-	) -> Result<(RuntimeRotationState<T>, Option<AuctionOutcomeWithDelegators<T>>), RotationError>
-	{
+	) -> Result<
+		(RuntimeRotationState<T>, Option<(AuctionOutcomeWithDelegators<T>, bool)>),
+		RotationError,
+	> {
 		rotation_state.ban(offenders.clone());
 		let mut delegation_snapshots: BTreeMap<
 			T::AccountId,
@@ -1939,16 +1943,31 @@ impl<T: Config> Pallet<T> {
 			rotation_state.new_epoch_index,
 			&mut delegation_snapshots,
 		);
+		let has_banned_independent_candidates =
+			Self::has_banned_independent_primary_candidates(&rotation_state, offenders);
 
-		if !snapshots_modified {
+		if !snapshots_modified && !has_banned_independent_candidates {
 			return Ok((rotation_state, None))
 		}
 
+		let snapshots_before_reauction = delegation_snapshots.clone();
 		Self::re_resolve_auction_after_ban(&rotation_state.banned, delegation_snapshots)
 			.map(|(new_outcome, new_snapshots)| {
-				(rotation_state, Some((new_outcome, new_snapshots)))
+				let snapshots_changed =
+					snapshots_modified || new_snapshots != snapshots_before_reauction;
+				(rotation_state, Some(((new_outcome, new_snapshots), snapshots_changed)))
 			})
 			.map_err(|error| RotationError::ReauctionFailed { context, error })
+	}
+
+	fn has_banned_independent_primary_candidates(
+		rotation_state: &RuntimeRotationState<T>,
+		offenders: &BTreeSet<ValidatorIdOf<T>>,
+	) -> bool {
+		offenders.iter().any(|validator_id| {
+			rotation_state.primary_candidates.contains(validator_id) &&
+				!OperatorChoice::<T>::contains_key(validator_id.into_ref())
+		})
 	}
 
 	/// Re-resolves the auction after banning nodes.
@@ -2332,7 +2351,7 @@ impl<T: Config> pallet_session::SessionManager<ValidatorIdOf<T>> for Pallet<T> {
 		let genesis_authorities = Self::current_authorities();
 		if !genesis_authorities.is_empty() {
 			frame_support::print(
-				"No genesis authorities found! Make sure the Validator pallet is initialised before the Session pallet."
+				"No genesis authorities found! Make sure the Validator pallet is initialised before the Session pallet.",
 			);
 		};
 		Some(genesis_authorities.into_iter().collect())

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -82,15 +82,6 @@ type AuctionOutcomeWithDelegators<T> = (
 	>,
 );
 
-type ReauctionResult<T> = (
-	AuctionOutcome<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
-	BTreeMap<
-		<T as frame_system::Config>::AccountId,
-		DelegationSnapshot<<T as frame_system::Config>::AccountId, <T as Chainflip>::Amount>,
-	>,
-	bool,
-);
-
 #[derive(
 	Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
@@ -170,7 +161,7 @@ type ValidatorIdOf<T> = <T as Chainflip>::ValidatorId;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RotationError {
-	ReauctionFailed { context: &'static str, error: AuctionError },
+	AuctionFailed { context: &'static str, error: AuctionError },
 	NotEnoughCandidates { candidates: u32, min_size: u32 },
 }
 
@@ -1694,7 +1685,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	#[expect(clippy::type_complexity)]
-	pub fn run_initial_auction() -> Result<
+	pub fn run_initial_auction(
+		excluded: &BTreeSet<ValidatorIdOf<T>>,
+	) -> Result<
 		(
 			AuctionOutcome<T::AccountId, T::Amount>,
 			SetSizeMaximisingAuctionResolver,
@@ -1706,7 +1699,7 @@ impl<T: Config> Pallet<T> {
 		AuctionError,
 	> {
 		let (delegation_snapshots, independent_bids) =
-			Self::build_delegation_snapshots::<T::KeygenQualification>();
+			Self::build_delegation_snapshots::<T::KeygenQualification>(excluded);
 
 		let minimum_auction_bid = MinimumAuctionBid::<T>::get();
 
@@ -1741,14 +1734,16 @@ impl<T: Config> Pallet<T> {
 	}
 
 	#[expect(clippy::type_complexity)]
-	pub fn resolve_auction_iteratively() -> Result<
+	pub fn resolve_auction_iteratively(
+		excluded: &BTreeSet<ValidatorIdOf<T>>,
+	) -> Result<
 		(
 			AuctionOutcome<T::AccountId, T::Amount>,
 			BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
 		),
 		AuctionError,
 	> {
-		Self::run_initial_auction().and_then(
+		Self::run_initial_auction(excluded).and_then(
 			|(_auction_outcome, resolver, delegation_snapshots, auction_bids)| {
 				Self::resolve_auction_with_snapshots(&resolver, delegation_snapshots, auction_bids)
 			},
@@ -1801,7 +1796,7 @@ impl<T: Config> Pallet<T> {
 		}
 		log::info!(target: "cf-validator", "Starting rotation");
 
-		match Self::resolve_auction_iteratively() {
+		match Self::resolve_auction_iteratively(&BTreeSet::new()) {
 			Ok((auction_outcome, delegation_snapshots)) => {
 				let auction_outcome =
 					auction_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
@@ -1832,9 +1827,7 @@ impl<T: Config> Pallet<T> {
 
 				// This only errors if there are less than min_size candidates after the auction.
 				let rotation_state = RotationState::from_auction_outcome::<T>(auction_outcome);
-				if let Err(error) = Self::prepare_keygen_attempt(rotation_state, None)
-					.and_then(|rotation_state| Self::start_keygen_attempt(rotation_state))
-				{
+				if let Err(error) = Self::start_keygen_attempt(rotation_state) {
 					Self::handle_rotation_error(error);
 					Self::abort_rotation();
 				}
@@ -1854,180 +1847,41 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn try_restart_keygen(
-		rotation_state: RuntimeRotationState<T>,
-		offenders: &BTreeSet<ValidatorIdOf<T>>,
-		context: &'static str,
-	) -> Result<(), RotationError> {
-		Self::prepare_keygen_attempt(rotation_state, Some((offenders, context)))
-			.and_then(|rotation_state| Self::start_keygen_attempt(rotation_state))
-	}
-
-	fn prepare_keygen_attempt(
-		rotation_state: RuntimeRotationState<T>,
-		offenders: Option<(&BTreeSet<ValidatorIdOf<T>>, &'static str)>,
-	) -> Result<RuntimeRotationState<T>, RotationError> {
-		let Some((offenders, context)) = offenders else { return Ok(rotation_state) };
-
-		let (mut rotation_state, reauction) =
-			Self::maybe_reauction_after_ban(rotation_state, offenders, context)?;
-
-		if let Some((new_outcome, new_snapshots, snapshots_changed)) = reauction {
-			let new_outcome = new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
-			log::info!(
-				target: "cf-validator",
-				"Re-resolved auction after {}. New bond: {:?}",
-				context,
-				new_outcome.bond
-			);
-			if snapshots_changed {
-				Self::persist_reauction_snapshots(rotation_state.new_epoch_index, new_snapshots);
-			}
-			Self::deposit_event(Event::AuctionCompleted(
-				new_outcome.winners.clone(),
-				new_outcome.bond,
-			));
-			rotation_state.primary_candidates = new_outcome.winners;
-			rotation_state.bond = new_outcome.bond;
-		}
-
-		Ok(rotation_state)
-	}
-
-	/// Updates delegation snapshots by moving banned validators to delegators.
-	/// Uses ValidatorToOperator for efficient operator lookup.
-	/// Returns true if any snapshots were modified (i.e., a managed validator was banned).
-	fn update_snapshots_for_banned(
-		banned: &BTreeSet<ValidatorIdOf<T>>,
-		next_epoch_index: EpochIndex,
-		delegation_snapshots: &mut BTreeMap<
-			T::AccountId,
-			DelegationSnapshot<T::AccountId, T::Amount>,
-		>,
-	) -> bool {
-		// Group banned validators by their operator
-		let mut operators_to_update: BTreeMap<T::AccountId, Vec<&ValidatorIdOf<T>>> =
-			BTreeMap::new();
-
-		for banned_id in banned {
-			if let Some(operator) =
-				ValidatorToOperator::<T>::get(next_epoch_index, banned_id.into_ref())
-			{
-				operators_to_update.entry(operator).or_default().push(banned_id);
-			}
-			// If no operator mapping, validator is independent - no snapshot update needed
-		}
-
-		// Update each affected operator's snapshot once
-		let mut has_updates = false;
-		for (operator, banned_validators) in operators_to_update {
-			if let Some(snapshot) = delegation_snapshots.get_mut(&operator) {
-				let mut snapshot_modified = false;
-				for banned_id in banned_validators {
-					snapshot_modified |=
-						snapshot.move_validator_to_delegator(banned_id.into_ref().clone());
-				}
-				has_updates |= snapshot_modified;
-			}
-		}
-
-		has_updates
-	}
-
-	fn maybe_reauction_after_ban(
 		mut rotation_state: RuntimeRotationState<T>,
 		offenders: &BTreeSet<ValidatorIdOf<T>>,
 		context: &'static str,
-	) -> Result<(RuntimeRotationState<T>, Option<ReauctionResult<T>>), RotationError> {
+	) -> Result<(), RotationError> {
 		rotation_state.ban(offenders.clone());
-		let mut delegation_snapshots: BTreeMap<
-			T::AccountId,
-			DelegationSnapshot<T::AccountId, T::Amount>,
-		> = DelegationSnapshots::<T>::iter_prefix(rotation_state.new_epoch_index).collect();
 
-		let snapshots_modified = Self::update_snapshots_for_banned(
-			offenders,
-			rotation_state.new_epoch_index,
-			&mut delegation_snapshots,
+		let (new_outcome, new_snapshots) =
+			Self::resolve_auction_iteratively(&rotation_state.banned)
+				.map_err(|error| RotationError::AuctionFailed { context, error })?;
+
+		let new_outcome = new_outcome.map_ids(|id| ValidatorIdOf::<T>::from_ref(&id).clone());
+
+		log::info!(
+			target: "cf-validator",
+			"Re-resolved auction after {}. New bond: {:?}",
+			context,
+			new_outcome.bond
 		);
-		let has_banned_independent_candidates =
-			Self::has_banned_independent_primary_candidates(&rotation_state, offenders);
 
-		if !snapshots_modified && !has_banned_independent_candidates {
-			return Ok((rotation_state, None))
+		// Persist the new snapshots (clear old ones first)
+		DelegationSnapshot::clear_epoch_registrations::<T>(rotation_state.new_epoch_index);
+		for snapshot in new_snapshots.into_values() {
+			snapshot.register_for_epoch::<T>(rotation_state.new_epoch_index);
 		}
 
-		let snapshots_before_reauction = delegation_snapshots.clone();
-		Self::re_resolve_auction_after_ban(&rotation_state.banned, delegation_snapshots)
-			.map(|(new_outcome, new_snapshots)| {
-				let snapshots_changed =
-					snapshots_modified || new_snapshots != snapshots_before_reauction;
-				(rotation_state, Some((new_outcome, new_snapshots, snapshots_changed)))
-			})
-			.map_err(|error| RotationError::ReauctionFailed { context, error })
-	}
+		Self::deposit_event(Event::AuctionCompleted(new_outcome.winners.clone(), new_outcome.bond));
 
-	fn has_banned_independent_primary_candidates(
-		rotation_state: &RuntimeRotationState<T>,
-		offenders: &BTreeSet<ValidatorIdOf<T>>,
-	) -> bool {
-		offenders.iter().any(|validator_id| {
-			rotation_state.primary_candidates.contains(validator_id) &&
-				!OperatorChoice::<T>::contains_key(validator_id.into_ref())
-		})
-	}
+		rotation_state.primary_candidates = new_outcome.winners;
+		rotation_state.bond = new_outcome.bond;
 
-	/// Re-resolves the auction after banning nodes.
-	/// Uses the already-stored snapshots and recalculates independent bidders.
-	/// Banned nodes are excluded from independent bidders (managed validators are
-	/// already handled by `update_snapshots_for_banned`).
-	fn re_resolve_auction_after_ban(
-		banned: &BTreeSet<ValidatorIdOf<T>>,
-		delegation_snapshots: BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-	) -> Result<AuctionOutcomeWithDelegators<T>, AuctionError> {
-		// Get all validators that are in snapshots (as validators, not delegators)
-		let managed_validators: BTreeSet<_> = delegation_snapshots
-			.values()
-			.flat_map(|s| s.validators.keys().cloned())
-			.collect();
+		debug_assert!(rotation_state
+			.banned
+			.is_disjoint(&rotation_state.primary_candidates.iter().cloned().collect()));
 
-		// Independent bidders are qualified bidders NOT in any snapshot AND NOT banned
-		let independent_bids: BTreeMap<T::AccountId, T::Amount> =
-			Self::get_qualified_bidders::<T::KeygenQualification>()
-				.into_iter()
-				.filter(|bid| {
-					!managed_validators.contains(bid.bidder_id.into_ref()) &&
-						!banned.contains(&bid.bidder_id)
-				})
-				.map(|bid| (bid.bidder_id.into_ref().clone(), bid.amount))
-				.collect();
-
-		let minimum_auction_bid = MinimumAuctionBid::<T>::get();
-
-		let auction_bids = move |snapshots: &BTreeMap<
-			T::AccountId,
-			DelegationSnapshot<T::AccountId, T::Amount>,
-		>|
-		      -> Vec<Bid<T::AccountId, T::Amount>> {
-			snapshots
-				.values()
-				.flat_map(|snapshot| snapshot.effective_validator_bids())
-				.chain(independent_bids.clone())
-				.filter_map(|(bidder_id, amount)| {
-					if amount >= minimum_auction_bid {
-						Some(Bid { bidder_id, amount })
-					} else {
-						None
-					}
-				})
-				.collect()
-		};
-
-		let resolver = SetSizeMaximisingAuctionResolver::try_new(
-			T::EpochInfo::current_authority_count(),
-			AuctionParameters::<T>::get(),
-		)?;
-
-		Self::resolve_auction_with_snapshots(&resolver, delegation_snapshots, auction_bids)
+		Self::start_keygen_attempt(rotation_state)
 	}
 
 	fn start_keygen_attempt(rotation_state: RuntimeRotationState<T>) -> Result<(), RotationError> {
@@ -2054,19 +1908,9 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	fn persist_reauction_snapshots(
-		next_epoch_index: EpochIndex,
-		new_snapshots: BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
-	) {
-		DelegationSnapshot::clear_epoch_registrations::<T>(next_epoch_index);
-		for snapshot in new_snapshots.into_values() {
-			snapshot.register_for_epoch::<T>(next_epoch_index);
-		}
-	}
-
 	fn handle_rotation_error(error: RotationError) {
 		match error {
-			RotationError::ReauctionFailed { context, error } => {
+			RotationError::AuctionFailed { context, error } => {
 				log::error!(
 					target: "cf-validator",
 					"Failed to re-resolve auction after {}: {:?}.",
@@ -2225,8 +2069,14 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Return a tuple of the delegation snapshots and the independent bidders (standalone
 	/// validators).
+	///
+	/// Bidders in `excluded` are handled as follows:
+	/// - managed validators become delegators
+	/// - independent validators are dropped entirely.
 	#[expect(clippy::type_complexity)]
-	pub fn build_delegation_snapshots<Q: QualifyNode<ValidatorIdOf<T>>>() -> (
+	pub fn build_delegation_snapshots<Q: QualifyNode<ValidatorIdOf<T>>>(
+		excluded: &BTreeSet<ValidatorIdOf<T>>,
+	) -> (
 		BTreeMap<T::AccountId, DelegationSnapshot<T::AccountId, T::Amount>>,
 		BTreeMap<T::AccountId, T::Amount>,
 	) {
@@ -2234,23 +2084,45 @@ impl<T: Config> Pallet<T> {
 		let mut snapshots = BTreeMap::new();
 
 		for Bid { bidder_id, amount } in Self::get_qualified_bidders::<Q>() {
-			// `into_ref` is used to cast between AccountId and ValidatorId.
-			let bidder_id = bidder_id.into_ref();
-			if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
-				snapshots
-					.entry(operator.clone())
-					.or_insert_with(|| {
-						DelegationSnapshot::init(
-							&operator,
-							OperatorSettingsLookup::<T>::get(&operator)
-								.map(|settings| settings.fee_bps)
-								.unwrap_or(MinimumOperatorFee::<T>::get()),
-						)
-					})
-					.validators
-					.insert(bidder_id.clone(), amount);
+			if excluded.contains(&bidder_id) {
+				// `into_ref` is used to cast between AccountId and ValidatorId.
+				let bidder_id = bidder_id.into_ref();
+				if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
+					// Excluded managed validator: still appears as a delegator so their
+					// stake contributes to the operator, but they cannot be selected.
+					snapshots
+						.entry(operator.clone())
+						.or_insert_with(|| {
+							DelegationSnapshot::init(
+								&operator,
+								OperatorSettingsLookup::<T>::get(&operator)
+									.map(|settings| settings.fee_bps)
+									.unwrap_or(MinimumOperatorFee::<T>::get()),
+							)
+						})
+						.delegators
+						.insert(bidder_id.clone(), amount);
+				}
+				// else: Excluded independent validator: does not appear at all in the auction.
 			} else {
-				let _ = independent_bidders.insert(bidder_id.clone(), amount);
+				// `into_ref` is used to cast between AccountId and ValidatorId.
+				let bidder_id = bidder_id.into_ref();
+				if let Some(operator) = OperatorChoice::<T>::get(bidder_id) {
+					snapshots
+						.entry(operator.clone())
+						.or_insert_with(|| {
+							DelegationSnapshot::init(
+								&operator,
+								OperatorSettingsLookup::<T>::get(&operator)
+									.map(|settings| settings.fee_bps)
+									.unwrap_or(MinimumOperatorFee::<T>::get()),
+							)
+						})
+						.validators
+						.insert(bidder_id.clone(), amount);
+				} else {
+					let _ = independent_bidders.insert(bidder_id.clone(), amount);
+				}
 			}
 		}
 

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -293,6 +293,12 @@ macro_rules! assert_invariants {
 				snapshot,
 				System::block_number()
 			);
+			assert!(
+				CurrentAuthorities::<Test>::get().contains(&managed_validator),
+				"Managed validator {:?} in snapshot but not in current authorities at block {:?}",
+				managed_validator,
+				System::block_number()
+			);
 		}
 		for authority in ValidatorPallet::current_authorities() {
 			// Check if authority is managed by an operator

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -859,6 +859,20 @@ lazy_static::lazy_static! {
 }
 
 fn failed_keygen_with_offenders(offenders: impl IntoIterator<Item = u64>) {
+	AuctionParameters::<Test>::put(SetSizeParameters {
+		min_size: MIN_AUTHORITY_SIZE,
+		max_size: CANDIDATES.count() as u32,
+		max_expansion: CANDIDATES.count() as u32,
+	});
+	ActiveBidder::<Test>::set(Default::default());
+
+	for candidate in CANDIDATES {
+		MockFlip::credit_funds(&candidate, 100);
+		ActiveBidder::<Test>::mutate(|bidders| {
+			bidders.insert(candidate);
+		});
+	}
+
 	CurrentAuthorities::<Test>::set(AUTHORITIES.collect());
 	CurrentRotationPhase::<Test>::put(RotationPhase::KeygensInProgress(
 		RuntimeRotationState::<Test>::from_auction_outcome::<Test>(AuctionOutcome {
@@ -891,16 +905,23 @@ mod keygen {
 	}
 
 	#[test]
-	fn abort_on_keygen_failure_if_too_many_banned() {
+	fn aborts_if_reauction_still_cannot_meet_min_size() {
 		new_test_ext().execute_with(|| {
-			// Not enough unbanned nodes left after this failure, so we should abort
+			// Re-auction runs, but with too many banned candidates we still abort.
 			failed_keygen_with_offenders(CANDIDATES.take(*MAX_ALLOWED_KEYGEN_OFFENDERS + 1));
-			assert_rotation_aborted();
+			assert_rotation_phase_matches!(RotationPhase::Idle);
+			assert_eq!(<Test as Config>::KeyRotator::status(), AsyncResult::Void);
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			}));
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::RotationAborted))
+			}));
 		});
 	}
 
 	#[test]
-	fn rotation_aborts_if_candidates_below_min_percentage() {
+	fn rotation_aborts_if_reauction_cannot_recover_after_large_failure() {
 		new_test_ext().execute_with(|| {
 			// Ban half of the candidates:
 			let failing_count = CANDIDATES.count() / 2;
@@ -909,8 +930,8 @@ mod keygen {
 			// We still have enough candidates according to auction resolver parameters:
 			assert!(remaining_count > MIN_AUTHORITY_SIZE as usize);
 
-			// But the rotation should be aborted since authority count would drop too much
-			// compared to the previous set:
+			// Without a re-auction, authority count would drop too much compared to the previous
+			// set:
 			assert!(
 				remaining_count <
 					(Percent::one() - DEFAULT_MAX_AUTHORITY_SET_CONTRACTION) *
@@ -918,7 +939,14 @@ mod keygen {
 			);
 
 			failed_keygen_with_offenders(CANDIDATES.take(failing_count));
-			assert_rotation_aborted();
+			assert_rotation_phase_matches!(RotationPhase::Idle);
+			assert_eq!(<Test as Config>::KeyRotator::status(), AsyncResult::Void);
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			}));
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::RotationAborted))
+			}));
 		});
 	}
 }
@@ -929,6 +957,20 @@ mod key_handover {
 	use super::*;
 
 	fn failed_handover_with_offenders(offenders: impl IntoIterator<Item = u64>) {
+		AuctionParameters::<Test>::put(SetSizeParameters {
+			min_size: MIN_AUTHORITY_SIZE,
+			max_size: CANDIDATES.count() as u32,
+			max_expansion: CANDIDATES.count() as u32,
+		});
+		ActiveBidder::<Test>::set(Default::default());
+
+		for candidate in CANDIDATES {
+			MockFlip::credit_funds(&candidate, 100);
+			ActiveBidder::<Test>::mutate(|bidders| {
+				bidders.insert(candidate);
+			});
+		}
+
 		CurrentAuthorities::<Test>::set(AUTHORITIES.collect());
 		CurrentRotationPhase::<Test>::put(RotationPhase::KeygensInProgress(
 			RuntimeRotationState::<Test>::from_auction_outcome::<Test>(AuctionOutcome {
@@ -3615,7 +3657,7 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
-	fn independent_validator_failure_does_not_trigger_reauction() {
+	fn independent_validator_failure_triggers_reauction() {
 		new_test_ext().execute_with(|| {
 			// Setup independent validators (no operator) using add_bids
 			set_default_test_bids();
@@ -3628,22 +3670,33 @@ mod keygen_failure_with_delegation {
 			// Get current phase to verify keygen started
 			let phase = CurrentRotationPhase::<Test>::get();
 			assert!(matches!(phase, RotationPhase::KeygensInProgress(..)));
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			assert_eq!(DelegationSnapshots::<Test>::iter_prefix(next_epoch).count(), 0);
 
 			// Simulate keygen failure with independent validator
 			MockKeyRotatorA::failed([independent_validator]);
 			System::reset_events();
 			Pallet::<Test>::on_initialize(1);
 
-			// Should NOT emit AuctionCompleted (no re-auction for independent validators)
-			// The rotation should just proceed with retry (or abort depending on min size)
+			// Should emit AuctionCompleted (re-auction happened)
 			let auction_completed_emitted = System::events().iter().any(|record| {
 				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
 			});
 
 			assert!(
-				!auction_completed_emitted,
-				"AuctionCompleted should not be emitted for independent validator failure"
+				auction_completed_emitted,
+				"AuctionCompleted should be emitted for independent validator failure"
 			);
+			assert_eq!(DelegationSnapshots::<Test>::iter_prefix(next_epoch).count(), 0);
+
+			if let RotationPhase::KeygensInProgress(state) = CurrentRotationPhase::<Test>::get() {
+				assert!(
+					!state.primary_candidates.contains(&independent_validator),
+					"banned independent validator should be excluded from primary candidates"
+				);
+			} else {
+				panic!("unexpected rotation phase: {:?}", CurrentRotationPhase::<Test>::get());
+			}
 		});
 	}
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3283,6 +3283,10 @@ mod keygen_failure_with_delegation {
 	const VALIDATOR_1: u64 = 100;
 	const VALIDATOR_2: u64 = 101;
 	const VALIDATOR_3: u64 = 102;
+	const OPERATOR_2: u64 = 1001;
+	const VALIDATOR_4: u64 = 103;
+	const VALIDATOR_5: u64 = 104;
+	const VALIDATOR_6: u64 = 105;
 	const DELEGATOR: u64 = 200;
 
 	fn setup_operator_with_validators() {
@@ -3323,6 +3327,45 @@ mod keygen_failure_with_delegation {
 			OPERATOR,
 			DelegationAmount::Max
 		));
+	}
+
+	fn setup_two_operators_with_validators() {
+		MockEpochInfo::set_epoch(GENESIS_EPOCH);
+		set_default_test_bids();
+
+		for (operator, validators) in [
+			(OPERATOR, [VALIDATOR_1, VALIDATOR_2, VALIDATOR_3]),
+			(OPERATOR_2, [VALIDATOR_4, VALIDATOR_5, VALIDATOR_6]),
+		] {
+			MockFlip::credit_funds(&operator, 1000);
+			assert_ok!(ValidatorPallet::register_as_operator(
+				OriginTrait::signed(operator),
+				OPERATOR_SETTINGS,
+				vanity()
+			));
+
+			add_bids(
+				validators
+					.iter()
+					.enumerate()
+					.map(|(idx, validator)| Bid {
+						bidder_id: *validator,
+						amount: 600 - (idx as u128 * 50),
+					})
+					.collect(),
+			);
+
+			for validator in validators {
+				assert_ok!(ValidatorPallet::claim_validator(
+					OriginTrait::signed(operator),
+					validator
+				));
+				assert_ok!(ValidatorPallet::accept_operator(
+					OriginTrait::signed(validator),
+					operator
+				));
+			}
+		}
 	}
 
 	#[test]
@@ -3437,6 +3480,79 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
+	fn reauction_failure_aborts_rotation_without_persisting_snapshots() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let initial_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(initial_snapshot.validators.contains_key(&VALIDATOR_1));
+
+			// Force re-auction failure by invalidating parameters after rotation started.
+			AuctionParameters::<Test>::put(SetSizeParameters {
+				min_size: 0,
+				max_size: 0,
+				max_expansion: 0,
+			});
+
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			assert_rotation_aborted();
+
+			let post_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(post_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(!post_snapshot.delegators.contains_key(&VALIDATOR_1));
+		});
+	}
+
+	#[test]
+	fn handover_failure_with_candidate_updates_snapshots_and_restarts_keygen() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			MockKeyRotatorA::keygen_success();
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeyHandoversInProgress(..)
+			));
+
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(2);
+
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(!updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			}));
+		});
+	}
+
+	#[test]
 	fn independent_validator_failure_does_not_trigger_reauction() {
 		new_test_ext().execute_with(|| {
 			// Setup independent validators (no operator) using add_bids
@@ -3466,6 +3582,105 @@ mod keygen_failure_with_delegation {
 				!auction_completed_emitted,
 				"AuctionCompleted should not be emitted for independent validator failure"
 			);
+		});
+	}
+
+	#[test]
+	fn keygen_aborts_when_candidates_below_min_size() {
+		new_test_ext().execute_with(|| {
+			set_default_test_bids();
+
+			ValidatorPallet::start_authority_rotation();
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			// Make the minimum size unattainable to force NotEnoughCandidates.
+			AuctionParameters::<Test>::put(SetSizeParameters {
+				min_size: 100,
+				max_size: 100,
+				max_expansion: 0,
+			});
+
+			MockKeyRotatorA::failed([ALICE]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			assert_rotation_aborted();
+		});
+	}
+
+	#[test]
+	fn mixed_offenders_trigger_reauction_and_exclude_independent() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			// Add an independent validator (no operator).
+			let independent_validator = 555u64;
+			add_bids(vec![Bid { bidder_id: independent_validator, amount: 250 }]);
+
+			ValidatorPallet::start_authority_rotation();
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			MockKeyRotatorA::failed([VALIDATOR_1, independent_validator]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			// Managed validator should be moved into delegators.
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(!updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+
+			// Re-auction should be triggered.
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			}));
+
+			// Independent offender should not be selected as a primary candidate.
+			if let RotationPhase::KeygensInProgress(state) = CurrentRotationPhase::<Test>::get() {
+				assert!(
+					!state.primary_candidates.contains(&independent_validator),
+					"independent offender should be excluded from primary candidates"
+				);
+			} else {
+				panic!("unexpected rotation phase: {:?}", CurrentRotationPhase::<Test>::get());
+			}
+		});
+	}
+
+	#[test]
+	fn multi_operator_ban_updates_all_snapshots() {
+		new_test_ext().execute_with(|| {
+			setup_two_operators_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let op1_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			let op2_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR_2).unwrap();
+			assert!(op1_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(op2_snapshot.validators.contains_key(&VALIDATOR_4));
+
+			MockKeyRotatorA::failed([VALIDATOR_1, VALIDATOR_4]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			let updated_op1 = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			let updated_op2 = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR_2).unwrap();
+
+			assert!(!updated_op1.validators.contains_key(&VALIDATOR_1));
+			assert!(updated_op1.delegators.contains_key(&VALIDATOR_1));
+			assert!(!updated_op2.validators.contains_key(&VALIDATOR_4));
+			assert!(updated_op2.delegators.contains_key(&VALIDATOR_4));
 		});
 	}
 }

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3272,3 +3272,200 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		assert_eq!(total_minted, REWARD_AMOUNT);
 	});
 }
+
+#[cfg(test)]
+mod keygen_failure_with_delegation {
+	use super::*;
+	use crate::delegation::DelegationSnapshot;
+	use cf_traits::KeyRotationStatusOuter;
+
+	const OPERATOR: u64 = 1000;
+	const VALIDATOR_1: u64 = 100;
+	const VALIDATOR_2: u64 = 101;
+	const VALIDATOR_3: u64 = 102;
+	const DELEGATOR: u64 = 200;
+
+	fn setup_operator_with_validators() {
+		// Synchronize MockEpochInfo with the pallet's CurrentEpoch
+		// This is necessary because from_auction_outcome uses T::EpochInfo::epoch_index()
+		// which in tests returns MockEpochInfo's value, not CurrentEpoch storage
+		MockEpochInfo::set_epoch(GENESIS_EPOCH);
+
+		// Add default test bids first to ensure auction will succeed
+		set_default_test_bids();
+
+		// Register operator
+		MockFlip::credit_funds(&OPERATOR, 1000);
+		assert_ok!(ValidatorPallet::register_as_operator(
+			OriginTrait::signed(OPERATOR),
+			OPERATOR_SETTINGS,
+			vanity()
+		));
+
+		// Setup validators with high bids so they win the auction
+		// Default WINNING_BIDS are 120, 120, 110, 105 so we need higher amounts
+		add_bids(vec![
+			Bid { bidder_id: VALIDATOR_1, amount: 500 },
+			Bid { bidder_id: VALIDATOR_2, amount: 400 },
+			Bid { bidder_id: VALIDATOR_3, amount: 300 },
+		]);
+
+		// Claim and accept validators
+		for validator in [VALIDATOR_1, VALIDATOR_2, VALIDATOR_3] {
+			assert_ok!(ValidatorPallet::claim_validator(OriginTrait::signed(OPERATOR), validator));
+			assert_ok!(ValidatorPallet::accept_operator(OriginTrait::signed(validator), OPERATOR));
+		}
+
+		// Setup a delegator
+		MockFlip::credit_funds(&DELEGATOR, 500);
+		assert_ok!(ValidatorPallet::delegate(
+			OriginTrait::signed(DELEGATOR),
+			OPERATOR,
+			DelegationAmount::Max
+		));
+	}
+
+	#[test]
+	fn move_validator_to_delegator_works() {
+		new_test_ext().execute_with(|| {
+			let mut snapshot = DelegationSnapshot::<u64, u128> {
+				operator: OPERATOR,
+				validators: BTreeMap::from_iter([(VALIDATOR_1, 150), (VALIDATOR_2, 120)]),
+				delegators: BTreeMap::from_iter([(DELEGATOR, 500)]),
+				delegation_fee_bps: 2000,
+			};
+
+			// Move validator 1 to delegators
+			assert!(snapshot.move_validator_to_delegator(VALIDATOR_1));
+			assert!(!snapshot.validators.contains_key(&VALIDATOR_1));
+			assert_eq!(snapshot.delegators.get(&VALIDATOR_1), Some(&150));
+			assert_eq!(snapshot.validators.len(), 1);
+			assert_eq!(snapshot.delegators.len(), 2);
+
+			// Try to move a non-existent validator
+			assert!(!snapshot.move_validator_to_delegator(999));
+		});
+	}
+
+	#[test]
+	fn keygen_failure_updates_delegation_snapshot() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			// Start rotation - this will create delegation snapshots
+			ValidatorPallet::start_authority_rotation();
+
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+
+			// Verify initial snapshot has all 3 validators
+			let initial_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert_eq!(initial_snapshot.validators.len(), 3);
+			assert!(initial_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(initial_snapshot.validators.contains_key(&VALIDATOR_2));
+			assert!(initial_snapshot.validators.contains_key(&VALIDATOR_3));
+
+			// Verify ValidatorToOperator mapping exists
+			assert_eq!(
+				ValidatorToOperator::<Test>::get(next_epoch, VALIDATOR_1),
+				Some(OPERATOR),
+				"VALIDATOR_1 should be mapped to OPERATOR"
+			);
+
+			// Simulate keygen failure with VALIDATOR_1 as offender
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+
+			// Check key rotator status before on_initialize
+			let status = <Test as crate::Config>::KeyRotator::status();
+			assert!(
+				matches!(status, AsyncResult::Ready(KeyRotationStatusOuter::Failed(ref offenders)) if offenders.contains(&VALIDATOR_1)),
+				"Expected Failed status with VALIDATOR_1 as offender, got: {:?}",
+				status
+			);
+
+			// Check rotation phase
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			Pallet::<Test>::on_initialize(1);
+
+			// Verify snapshot was updated - VALIDATOR_1 moved to delegators
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert_eq!(
+				updated_snapshot.validators.len(),
+				2,
+				"Snapshot validators: {:?}, delegators: {:?}",
+				updated_snapshot.validators,
+				updated_snapshot.delegators
+			);
+			assert!(!updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(updated_snapshot.validators.contains_key(&VALIDATOR_2));
+			assert!(updated_snapshot.validators.contains_key(&VALIDATOR_3));
+
+			// VALIDATOR_1 should now be a delegator
+			assert!(updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+			assert_eq!(updated_snapshot.delegators.get(&VALIDATOR_1), Some(&500));
+		});
+	}
+
+	#[test]
+	fn keygen_failure_emits_auction_completed_when_snapshot_updated() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			// Start rotation
+			ValidatorPallet::start_authority_rotation();
+
+			// Verify we're in KeygensInProgress
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeygensInProgress(..)
+			));
+
+			// Simulate keygen failure
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			// Should emit AuctionCompleted event (re-auction happened)
+			assert!(System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			}));
+		});
+	}
+
+	#[test]
+	fn independent_validator_failure_does_not_trigger_reauction() {
+		new_test_ext().execute_with(|| {
+			// Setup independent validators (no operator) using add_bids
+			set_default_test_bids();
+			let independent_validator = 500u64;
+			add_bids(vec![Bid { bidder_id: independent_validator, amount: 200 }]);
+
+			// Start rotation
+			ValidatorPallet::start_authority_rotation();
+
+			// Get current phase to verify keygen started
+			let phase = CurrentRotationPhase::<Test>::get();
+			assert!(matches!(phase, RotationPhase::KeygensInProgress(..)));
+
+			// Simulate keygen failure with independent validator
+			MockKeyRotatorA::failed([independent_validator]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			// Should NOT emit AuctionCompleted (no re-auction for independent validators)
+			// The rotation should just proceed with retry (or abort depending on min size)
+			let auction_completed_emitted = System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			});
+
+			assert!(
+				!auction_completed_emitted,
+				"AuctionCompleted should not be emitted for independent validator failure"
+			);
+		});
+	}
+}

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -2970,7 +2970,8 @@ pub mod auction_optimization {
 				.then_execute_with_checks(|| -> bool {
 					setup_bids(op_1_bids, op_2_bids);
 
-					let single_auction_outcome = ValidatorPallet::run_initial_auction().unwrap().0;
+					let single_auction_outcome =
+						ValidatorPallet::run_initial_auction(&Default::default()).unwrap().0;
 
 					ValidatorPallet::start_authority_rotation();
 
@@ -3697,62 +3698,6 @@ mod keygen_failure_with_delegation {
 			} else {
 				panic!("unexpected rotation phase: {:?}", CurrentRotationPhase::<Test>::get());
 			}
-		});
-	}
-
-	#[test]
-	fn offender_already_delegator_does_not_trigger_reauction() {
-		new_test_ext().execute_with(|| {
-			setup_operator_with_validators();
-
-			ValidatorPallet::start_authority_rotation();
-			let next_epoch = CurrentEpoch::<Test>::get() + 1;
-			let mut snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
-			assert!(snapshot.move_validator_to_delegator(VALIDATOR_1));
-			DelegationSnapshots::<Test>::insert(next_epoch, OPERATOR, snapshot);
-
-			MockKeyRotatorA::failed([VALIDATOR_1]);
-			System::reset_events();
-			Pallet::<Test>::on_initialize(1);
-
-			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
-			assert!(!updated_snapshot.validators.contains_key(&VALIDATOR_1));
-			assert!(updated_snapshot.delegators.contains_key(&VALIDATOR_1));
-
-			let auction_completed_emitted = System::events().iter().any(|record| {
-				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
-			});
-			assert!(
-				!auction_completed_emitted,
-				"AuctionCompleted should not be emitted when offender already moved"
-			);
-		});
-	}
-
-	#[test]
-	fn missing_validator_to_operator_mapping_skips_snapshot_update() {
-		new_test_ext().execute_with(|| {
-			setup_operator_with_validators();
-
-			ValidatorPallet::start_authority_rotation();
-			let next_epoch = CurrentEpoch::<Test>::get() + 1;
-			ValidatorToOperator::<Test>::remove(next_epoch, VALIDATOR_1);
-
-			MockKeyRotatorA::failed([VALIDATOR_1]);
-			System::reset_events();
-			Pallet::<Test>::on_initialize(1);
-
-			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
-			assert!(updated_snapshot.validators.contains_key(&VALIDATOR_1));
-			assert!(!updated_snapshot.delegators.contains_key(&VALIDATOR_1));
-
-			let auction_completed_emitted = System::events().iter().any(|record| {
-				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
-			});
-			assert!(
-				!auction_completed_emitted,
-				"AuctionCompleted should not be emitted when validator-to-operator mapping is missing"
-			);
 		});
 	}
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3480,6 +3480,27 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
+	fn keygen_failure_excludes_banned_managed_from_primary_candidates() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			if let RotationPhase::KeygensInProgress(state) = CurrentRotationPhase::<Test>::get() {
+				assert!(
+					!state.primary_candidates.contains(&VALIDATOR_1),
+					"banned managed validator should be excluded from primary candidates"
+				);
+			} else {
+				panic!("unexpected rotation phase: {:?}", CurrentRotationPhase::<Test>::get());
+			}
+		});
+	}
+
+	#[test]
 	fn reauction_failure_aborts_rotation_without_persisting_snapshots() {
 		new_test_ext().execute_with(|| {
 			setup_operator_with_validators();
@@ -3553,6 +3574,47 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
+	fn handover_failure_with_non_candidate_does_not_reauction_or_update_snapshots() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			MockKeyRotatorA::keygen_success();
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeyHandoversInProgress(..)
+			));
+
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let initial_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(initial_snapshot.validators.contains_key(&VALIDATOR_1));
+
+			MockKeyRotatorA::failed([DELEGATOR]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(2);
+
+			assert!(matches!(
+				CurrentRotationPhase::<Test>::get(),
+				RotationPhase::KeyHandoversInProgress(..)
+			));
+
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(!updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+
+			let auction_completed_emitted = System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			});
+			assert!(
+				!auction_completed_emitted,
+				"AuctionCompleted should not be emitted for non-candidate handover failure"
+			);
+		});
+	}
+
+	#[test]
 	fn independent_validator_failure_does_not_trigger_reauction() {
 		new_test_ext().execute_with(|| {
 			// Setup independent validators (no operator) using add_bids
@@ -3581,6 +3643,62 @@ mod keygen_failure_with_delegation {
 			assert!(
 				!auction_completed_emitted,
 				"AuctionCompleted should not be emitted for independent validator failure"
+			);
+		});
+	}
+
+	#[test]
+	fn offender_already_delegator_does_not_trigger_reauction() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			let mut snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(snapshot.move_validator_to_delegator(VALIDATOR_1));
+			DelegationSnapshots::<Test>::insert(next_epoch, OPERATOR, snapshot);
+
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(!updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+
+			let auction_completed_emitted = System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			});
+			assert!(
+				!auction_completed_emitted,
+				"AuctionCompleted should not be emitted when offender already moved"
+			);
+		});
+	}
+
+	#[test]
+	fn missing_validator_to_operator_mapping_skips_snapshot_update() {
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+
+			ValidatorPallet::start_authority_rotation();
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+			ValidatorToOperator::<Test>::remove(next_epoch, VALIDATOR_1);
+
+			MockKeyRotatorA::failed([VALIDATOR_1]);
+			System::reset_events();
+			Pallet::<Test>::on_initialize(1);
+
+			let updated_snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(updated_snapshot.validators.contains_key(&VALIDATOR_1));
+			assert!(!updated_snapshot.delegators.contains_key(&VALIDATOR_1));
+
+			let auction_completed_emitted = System::events().iter().any(|record| {
+				matches!(record.event, RuntimeEvent::ValidatorPallet(Event::AuctionCompleted(..)))
+			});
+			assert!(
+				!auction_completed_emitted,
+				"AuctionCompleted should not be emitted when validator-to-operator mapping is missing"
 			);
 		});
 	}

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3412,24 +3412,24 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
-	fn move_validator_to_delegator_works() {
+	fn maybe_optimize_bid_moves_lowest_validator_to_delegator() {
 		new_test_ext().execute_with(|| {
 			let mut snapshot = DelegationSnapshot::<u64, u128> {
 				operator: OPERATOR,
 				validators: BTreeMap::from_iter([(VALIDATOR_1, 150), (VALIDATOR_2, 120)]),
-				delegators: BTreeMap::from_iter([(DELEGATOR, 500)]),
+				delegators: BTreeMap::new(),
 				delegation_fee_bps: 2000,
 			};
 
-			// Move validator 1 to delegators
-			assert!(snapshot.move_validator_to_delegator(VALIDATOR_1));
-			assert!(!snapshot.validators.contains_key(&VALIDATOR_1));
-			assert_eq!(snapshot.delegators.get(&VALIDATOR_1), Some(&150));
-			assert_eq!(snapshot.validators.len(), 1);
-			assert_eq!(snapshot.delegators.len(), 2);
+			// avg_bid = (150 + 120) / 2 = 135 which is below bond of 200,
+			// so maybe_optimize_bid should move the lowest (VALIDATOR_2) to delegators.
+			let outcome = AuctionOutcome { winners: vec![], bond: 200 };
+			snapshot.maybe_optimize_bid(&outcome);
 
-			// Try to move a non-existent validator
-			assert!(!snapshot.move_validator_to_delegator(999));
+			assert!(!snapshot.validators.contains_key(&VALIDATOR_2));
+			assert_eq!(snapshot.delegators.get(&VALIDATOR_2), Some(&120));
+			assert_eq!(snapshot.validators.len(), 1);
+			assert_eq!(snapshot.delegators.len(), 1);
 		});
 	}
 

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -475,7 +475,7 @@ impl_runtime_apis! {
 				epoch_duration: Validator::epoch_duration(),
 				current_epoch_started_at: Validator::current_epoch_started_at(),
 				current_epoch_index: Validator::current_epoch(),
-				min_active_bid: Validator::resolve_auction_iteratively()
+				min_active_bid: Validator::resolve_auction_iteratively(&Default::default())
 					.ok()
 					.map(|(auction_outcome, _)| auction_outcome.bond),
 				rotation_phase: Validator::current_rotation_phase().to_str().to_owned(),
@@ -608,7 +608,7 @@ impl_runtime_apis! {
 			DispatchErrorWithMessage
 		>
 		{
-			let next_auction = Validator::resolve_auction_iteratively()
+			let next_auction = Validator::resolve_auction_iteratively(&Default::default())
 				.map_err(|e| DispatchErrorWithMessage::from(<pallet_cf_validator::Error<Runtime>>::from(e)))?;
 			let next_set: BTreeSet<AccountId> = next_auction.0.winners.iter().cloned().collect();
 			let current_set: BTreeSet<AccountId> = Validator::current_authorities().into_iter().collect();
@@ -902,7 +902,7 @@ impl_runtime_apis! {
 				min_funding: MinimumFunding::<Runtime>::get().unique_saturated_into(),
 				min_bid: pallet_cf_validator::MinimumAuctionBid::<Runtime>::get().unique_saturated_into(),
 				auction_size_range: (auction_params.min_size, auction_params.max_size),
-				min_active_bid: Validator::resolve_auction_iteratively()
+				min_active_bid: Validator::resolve_auction_iteratively(&Default::default())
 				.ok()
 				.map(|(auction_outcome, _)| auction_outcome.bond)
 			}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2565 , PRO-2803

This fixes an issue where validator nodes failing keygen would still be included in the delegation snapshot when the keygen is retried. 

It also included a refactor of the logic to make the side-effects more explicit (functions return results and errors are handled at the call-site rather than deep inside the call stack). 