### PR TITLE
test: bouncer decode vault swaps as sanity check

### DIFF
--- a/bouncer/commands/run_test.ts
+++ b/bouncer/commands/run_test.ts
@@ -1,22 +1,46 @@
 #!/usr/bin/env -S pnpm tsx
 // INSTRUCTIONS
 //
-// This command takes one argument.
-// It will find and run the test function (using vitest) in the test file provided as an argument.
+// This command takes one argument: either a test file or a swap number.
 //
-// For example: ./commands/run_test.ts ./tests/boost.ts
-// This is the equivalent of running `BOUNCER_LOG_LEVEL=debug pnpm vitest --maxConcurrency=100 --hideSkippedTests run -t "BoostingForAsset"`
+// To run a test file:
+//   ./commands/run_test.ts ./tests/boost.ts
+//   This is the equivalent of running:
+//  `BOUNCER_LOG_LEVEL=debug pnpm vitest --maxConcurrency=100 --hideSkippedTests run -t "BoostingForAsset"`
+//
+// To run a single swap test by number:
+//   ./commands/run_test.ts 287
+//   This is the equivalent of running:
+// `BOUNCER_LOG_LEVEL=debug pnpm vitest --maxConcurrency=100 --hideSkippedTests run tests/fast_bouncer.test.ts -t "Swap 287:"`
 
 import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { testInfoFile } from 'shared/utils';
 
-// Check that a test file was provided as an argument
-const testFile = process.argv[2];
-if (!testFile) {
+const arg = process.argv[2];
+if (!arg) {
   console.error('Usage: ./commands/run_test.ts ./tests/<test_file>');
+  console.error('       ./commands/run_test.ts <swap_number>');
   process.exit(1);
-} else if (!existsSync(testFile)) {
+}
+
+// If a swap number is given, run just that single swap test directly.
+if (/^\d+$/.test(arg)) {
+  const testFilter = `Swap ${arg}:`;
+  try {
+    execSync(
+      `BOUNCER_LOG_LEVEL=debug pnpm vitest --maxConcurrency=100 --hideSkippedTests run tests/fast_bouncer.test.ts -t "${testFilter}"`,
+      { stdio: 'inherit' },
+    );
+  } catch (err) {
+    console.error(`Swap test ${arg} failed:`, err);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+const testFile = arg;
+if (!existsSync(testFile)) {
   console.error(`Test file ${testFile} not found`);
   process.exit(1);
 }

--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -26,9 +26,9 @@ import {
 } from 'shared/utils';
 import { SwapContext, SwapStatus } from 'shared/utils/swap_context';
 import { getChainflipApi } from 'shared/utils/substrate';
-import { executeEvmVaultSwap } from 'shared/evm_vault_swap';
-import { executeSolVaultSwap } from 'shared/sol_vault_swap';
-import { buildAndSendBtcVaultSwap } from 'shared/btc_vault_swap';
+import { executeEvmVaultSwap } from 'shared/vault_swap/evm_vault_swap';
+import { executeSolVaultSwap } from 'shared/vault_swap/sol_vault_swap';
+import { buildAndSendBtcVaultSwap } from 'shared/vault_swap/btc_vault_swap';
 import { throwError } from 'shared/utils/logger';
 import { swappingSwapDepositAddressReady } from 'generated/events/swapping/swapDepositAddressReady';
 import { swappingSwapRequestCompleted } from 'generated/events/swapping/swapRequestCompleted';

--- a/bouncer/shared/vault_swap/btc_vault_swap.ts
+++ b/bouncer/shared/vault_swap/btc_vault_swap.ts
@@ -1,21 +1,12 @@
 import assert from 'assert';
 import { sendVaultTransaction } from 'shared/send_btc';
-import {
-  Asset,
-  assetDecimals,
-  Assets,
-  cfMutex,
-  chainFromAsset,
-  Chains,
-  decodeDotAddressForContract,
-  fineAmountToAmount,
-  stateChainAssetFromAsset,
-} from 'shared/utils';
+import { Asset, assetDecimals, Assets, cfMutex, fineAmountToAmount } from 'shared/utils';
 import { getChainflipApi } from 'shared/utils/substrate';
 import { fundFlip } from 'shared/fund_flip';
 import { ChainflipIO, WithBrokerAccount } from 'shared/utils/chainflip_io';
 import { swappingAffiliateRegistration } from 'generated/events/swapping/affiliateRegistration';
 import { swappingPrivateBrokerChannelOpened } from 'generated/events/swapping/privateBrokerChannelOpened';
+import { requestSwapParameterEncoding } from './vault_swap';
 
 interface BtcVaultSwapDetails {
   chain: string;
@@ -125,21 +116,19 @@ export async function buildAndSendBtcVaultSwap<A extends WithBrokerAccount>(
   };
 
   cf.trace('Requesting vault swap parameter encoding');
-  const BtcVaultSwapDetails = (await chainflip.rpc(
-    `cf_request_swap_parameter_encoding`,
+  const BtcVaultSwapDetails = await requestSwapParameterEncoding<BtcVaultSwapDetails>(
+    chainflip,
     broker.address,
-    stateChainAssetFromAsset(Assets.Btc),
-    stateChainAssetFromAsset(destinationAsset),
-    chainFromAsset(destinationAsset) === Chains.Assethub
-      ? decodeDotAddressForContract(destinationAddress)
-      : destinationAddress,
+    Assets.Btc,
+    destinationAsset,
+    destinationAddress,
     brokerFee,
     extraParameters,
-    null, // channel_metadata
+    undefined, // channel_metadata
     0, // boost_fee
     affiliateFees,
-    null, // dca_params
-  )) as unknown as BtcVaultSwapDetails;
+    undefined, // dca_params
+  );
 
   assert.strictEqual(BtcVaultSwapDetails.chain, 'Bitcoin');
 
@@ -176,21 +165,19 @@ export async function buildAndSendInvalidBtcVaultSwap<A extends WithBrokerAccoun
     retry_duration: 0,
   };
 
-  const BtcVaultSwapDetails = (await chainflip.rpc(
-    `cf_request_swap_parameter_encoding`,
+  const BtcVaultSwapDetails = await requestSwapParameterEncoding<BtcVaultSwapDetails>(
+    chainflip,
     broker.address,
-    stateChainAssetFromAsset(Assets.Btc),
-    stateChainAssetFromAsset(destinationAsset),
-    chainFromAsset(destinationAsset) === Chains.Assethub
-      ? decodeDotAddressForContract(destinationAddress)
-      : destinationAddress,
+    Assets.Btc,
+    destinationAsset,
+    destinationAddress,
     brokerFee,
     extraParameters,
-    null, // channel_metadata
+    undefined, // channel_metadata
     0, // boost_fee
     affiliateFees,
-    null, // dca_params
-  )) as unknown as BtcVaultSwapDetails;
+    undefined, // dca_params
+  );
 
   assert.strictEqual(BtcVaultSwapDetails.chain, 'Bitcoin');
 

--- a/bouncer/shared/vault_swap/evm_vault_swap.ts
+++ b/bouncer/shared/vault_swap/evm_vault_swap.ts
@@ -7,19 +7,17 @@ import {
   defaultAssetAmounts,
   chainFromAsset,
   assetDecimals,
-  stateChainAssetFromAsset,
   createEvmWalletAndFund,
   newAssetAddress,
-  decodeDotAddressForContract,
-  Chains,
   Asset,
 } from 'shared/utils';
 import { CcmDepositMetadata, DcaParams, FillOrKillParamsX128 } from 'shared/new_swap';
 import { getChainflipApi } from 'shared/utils/substrate';
-import { ChannelRefundParameters } from 'shared/sol_vault_swap';
 import { getErc20abi } from 'shared/contract_interfaces';
 import { ChainflipIO, WithBrokerAccount } from 'shared/utils/chainflip_io';
 import { signAndSendTxEvm } from 'shared/send_evm';
+import { ChannelRefundParameters } from './sol_vault_swap';
+import { requestSwapParameterEncoding } from './vault_swap';
 
 const erc20Assets: Asset[] = ['Flip', 'Usdc', 'Usdt', 'Wbtc', 'ArbUsdc', 'ArbUsdt'];
 
@@ -55,7 +53,6 @@ export async function executeEvmVaultSwap<A extends WithBrokerAccount>(
   optionalRefundAddress?: string,
 ) {
   const srcChain = chainFromAsset(sourceAsset);
-  const destChain = chainFromAsset(destAsset);
   const amountToSwap = amount ?? defaultAssetAmounts(sourceAsset);
   const refundAddress =
     optionalRefundAddress ?? (await newAssetAddress(sourceAsset, randomBytes(32).toString('hex')));
@@ -102,29 +99,19 @@ export async function executeEvmVaultSwap<A extends WithBrokerAccount>(
   };
 
   cf.debug('Requesting vault swap parameter encoding');
-  const vaultSwapDetails = (await chainflip.rpc(
-    `cf_request_swap_parameter_encoding`,
+  const vaultSwapDetails = await requestSwapParameterEncoding<EvmVaultSwapDetails>(
+    chainflip,
     cf.requirements.account.keypair.address,
-    stateChainAssetFromAsset(sourceAsset),
-    stateChainAssetFromAsset(destAsset),
-    destChain === Chains.Assethub ? decodeDotAddressForContract(destAddress) : destAddress,
+    sourceAsset,
+    destAsset,
+    destAddress,
     brokerCommissionBps,
     extraParameters,
-    messageMetadata && {
-      message: messageMetadata.message as `0x${string}`,
-      gas_budget: messageMetadata.gasBudget,
-      ccm_additional_data: messageMetadata.ccmAdditionalData,
-    },
+    messageMetadata,
     boostFeeBps ?? 0,
-    affiliateFees.map((fee) => ({
-      account: fee.accountAddress,
-      bps: fee.commissionBps,
-    })),
-    dcaParams && {
-      number_of_chunks: dcaParams.numberOfChunks,
-      chunk_interval: dcaParams.chunkIntervalBlocks,
-    },
-  )) as unknown as EvmVaultSwapDetails;
+    affiliateFees.map((fee) => ({ account: fee.accountAddress, bps: fee.commissionBps })),
+    dcaParams,
+  );
 
   const tx = {
     to: vaultSwapDetails.to,

--- a/bouncer/shared/vault_swap/sol_vault_swap.ts
+++ b/bouncer/shared/vault_swap/sol_vault_swap.ts
@@ -29,7 +29,7 @@ import { getBalance } from 'shared/get_balance';
 import { TestContext } from 'shared/utils/test_context';
 import { throwError } from 'shared/utils/logger';
 import { ChainflipIO, WithBrokerAccount } from 'shared/utils/chainflip_io';
-import { SwapEndpoint } from '../../contract-interfaces/sol-program-idls/v1.3.0/swap_endpoint';
+import { SwapEndpoint } from '../../../contract-interfaces/sol-program-idls/v1.3.0/swap_endpoint';
 import { requestSwapParameterEncoding } from './vault_swap';
 
 const createdEventAccounts: [PublicKey, boolean][] = [];

--- a/bouncer/shared/vault_swap/sol_vault_swap.ts
+++ b/bouncer/shared/vault_swap/sol_vault_swap.ts
@@ -13,16 +13,12 @@ import {
   getContractAddress,
   amountToFineAmount,
   defaultAssetAmounts,
-  chainFromAsset,
   assetDecimals,
   getSolWhaleKeyPair,
   getSolConnection,
   sleep,
-  stateChainAssetFromAsset,
   decodeSolAddress,
-  decodeDotAddressForContract,
   observeFetch,
-  Chains,
   Asset,
 } from 'shared/utils';
 import { CcmDepositMetadata, DcaParams, FillOrKillParamsX128 } from 'shared/new_swap';
@@ -34,6 +30,7 @@ import { TestContext } from 'shared/utils/test_context';
 import { throwError } from 'shared/utils/logger';
 import { ChainflipIO, WithBrokerAccount } from 'shared/utils/chainflip_io';
 import { SwapEndpoint } from '../../contract-interfaces/sol-program-idls/v1.3.0/swap_endpoint';
+import { requestSwapParameterEncoding } from './vault_swap';
 
 const createdEventAccounts: [PublicKey, boolean][] = [];
 
@@ -133,28 +130,19 @@ export async function executeSolVaultSwap<A extends WithBrokerAccount>(
   };
 
   cf.trace('Requesting vault swap parameter encoding');
-  const vaultSwapDetails = (await chainflip.rpc(
-    `cf_request_swap_parameter_encoding`,
+  const vaultSwapDetails = await requestSwapParameterEncoding<SolVaultSwapDetails>(
+    chainflip,
     cf.requirements.account.keypair.address,
-    stateChainAssetFromAsset(srcAsset),
-    stateChainAssetFromAsset(destAsset),
-    chainFromAsset(destAsset) === Chains.Assethub
-      ? decodeDotAddressForContract(destAddress)
-      : destAddress,
+    srcAsset,
+    destAsset,
+    destAddress,
     brokerCommissionBps,
     extraParameters,
-    messageMetadata && {
-      message: messageMetadata.message,
-      gas_budget: messageMetadata.gasBudget,
-      ccm_additional_data: messageMetadata.ccmAdditionalData,
-    },
+    messageMetadata,
     boostFeeBps ?? 0,
     affiliateFees,
-    dcaParams && {
-      number_of_chunks: dcaParams.numberOfChunks,
-      chunk_interval: dcaParams.chunkIntervalBlocks,
-    },
-  )) as unknown as SolVaultSwapDetails;
+    dcaParams,
+  );
 
   assert.strictEqual(vaultSwapDetails.chain, 'Solana');
   assert.strictEqual(

--- a/bouncer/shared/vault_swap/vault_swap.ts
+++ b/bouncer/shared/vault_swap/vault_swap.ts
@@ -88,10 +88,26 @@ export async function requestSwapParameterEncoding<T>(
     )) as unknown as VaultSwapInputRpc;
 
     // Compare the decoded values with the original input
-    assert.deepStrictEqual(decoded.source_asset, stateChainAssetFromAsset(sourceAsset), 'source_asset mismatch');
-    assert.deepStrictEqual(decoded.destination_asset, stateChainAssetFromAsset(destAsset), 'destination_asset mismatch');
-    assert.strictEqual(decoded.destination_address.toLowerCase(), encodedDestAddress.toLowerCase(), 'destination_address mismatch');
-    assert.strictEqual(decoded.broker_commission, brokerCommissionBps, 'broker_commission mismatch');
+    assert.deepStrictEqual(
+      decoded.source_asset,
+      stateChainAssetFromAsset(sourceAsset),
+      'source_asset mismatch',
+    );
+    assert.deepStrictEqual(
+      decoded.destination_asset,
+      stateChainAssetFromAsset(destAsset),
+      'destination_asset mismatch',
+    );
+    assert.strictEqual(
+      decoded.destination_address.toLowerCase(),
+      encodedDestAddress.toLowerCase(),
+      'destination_address mismatch',
+    );
+    assert.strictEqual(
+      decoded.broker_commission,
+      brokerCommissionBps,
+      'broker_commission mismatch',
+    );
     assert.strictEqual(decoded.boost_fee, boostFeeBps, 'boost_fee mismatch');
 
     if (messageMetadata) {
@@ -114,19 +130,35 @@ export async function requestSwapParameterEncoding<T>(
       assert.strictEqual(decoded.channel_metadata, null, 'channel_metadata should be null');
     }
 
-    assert.strictEqual(decoded.affiliate_fees.length, affiliateFees.length, 'affiliate_fees length mismatch');
+    assert.strictEqual(
+      decoded.affiliate_fees.length,
+      affiliateFees.length,
+      'affiliate_fees length mismatch',
+    );
     for (let i = 0; i < affiliateFees.length; i++) {
       assert.strictEqual(
         decoded.affiliate_fees[i].account.toLowerCase(),
         affiliateFees[i].account.toLowerCase(),
         `affiliate_fees[${i}].account mismatch`,
       );
-      assert.strictEqual(decoded.affiliate_fees[i].bps, affiliateFees[i].bps, `affiliate_fees[${i}].bps mismatch`);
+      assert.strictEqual(
+        decoded.affiliate_fees[i].bps,
+        affiliateFees[i].bps,
+        `affiliate_fees[${i}].bps mismatch`,
+      );
     }
 
     if (dcaParams) {
-      assert.strictEqual(decoded.dca_parameters?.number_of_chunks, dcaParams.numberOfChunks, 'dca_parameters.number_of_chunks mismatch');
-      assert.strictEqual(decoded.dca_parameters?.chunk_interval, dcaParams.chunkIntervalBlocks, 'dca_parameters.chunk_interval mismatch');
+      assert.strictEqual(
+        decoded.dca_parameters?.number_of_chunks,
+        dcaParams.numberOfChunks,
+        'dca_parameters.number_of_chunks mismatch',
+      );
+      assert.strictEqual(
+        decoded.dca_parameters?.chunk_interval,
+        dcaParams.chunkIntervalBlocks,
+        'dca_parameters.chunk_interval mismatch',
+      );
     } else if (chainFromAsset(sourceAsset) !== Chains.Bitcoin) {
       // BTC always encodes dca_parameters even when not provided
       assert.strictEqual(decoded.dca_parameters, null, 'dca_parameters should be null');

--- a/bouncer/shared/vault_swap/vault_swap.ts
+++ b/bouncer/shared/vault_swap/vault_swap.ts
@@ -88,44 +88,48 @@ export async function requestSwapParameterEncoding<T>(
     )) as unknown as VaultSwapInputRpc;
 
     // Compare the decoded values with the original input
-    assert.deepStrictEqual(decoded.source_asset, stateChainAssetFromAsset(sourceAsset));
-    assert.deepStrictEqual(decoded.destination_asset, stateChainAssetFromAsset(destAsset));
-    assert.strictEqual(decoded.destination_address.toLowerCase(), encodedDestAddress.toLowerCase());
-    assert.strictEqual(decoded.broker_commission, brokerCommissionBps);
-    assert.strictEqual(decoded.boost_fee, boostFeeBps);
+    assert.deepStrictEqual(decoded.source_asset, stateChainAssetFromAsset(sourceAsset), 'source_asset mismatch');
+    assert.deepStrictEqual(decoded.destination_asset, stateChainAssetFromAsset(destAsset), 'destination_asset mismatch');
+    assert.strictEqual(decoded.destination_address.toLowerCase(), encodedDestAddress.toLowerCase(), 'destination_address mismatch');
+    assert.strictEqual(decoded.broker_commission, brokerCommissionBps, 'broker_commission mismatch');
+    assert.strictEqual(decoded.boost_fee, boostFeeBps, 'boost_fee mismatch');
 
     if (messageMetadata) {
       assert.strictEqual(
-        decoded.channel_metadata?.message.toLowerCase(),
-        messageMetadata.message.toLowerCase(),
+        decoded.channel_metadata?.message.toLowerCase().replace('0x', ''),
+        messageMetadata.message.toLowerCase().replace('0x', ''),
+        'channel_metadata.message mismatch',
       );
       assert.strictEqual(
         decoded.channel_metadata?.gas_budget.toLowerCase(),
         `0x${BigInt(messageMetadata.gasBudget).toString(16)}`.toLowerCase(),
+        'channel_metadata.gas_budget mismatch',
       );
       assert.strictEqual(
-        decoded.channel_metadata?.ccm_additional_data?.toLowerCase(),
-        messageMetadata.ccmAdditionalData?.toLowerCase() ?? null,
+        decoded.channel_metadata?.ccm_additional_data?.toLowerCase().replace('0x', ''),
+        messageMetadata.ccmAdditionalData?.toLowerCase().replace('0x', '') ?? null,
+        'channel_metadata.ccm_additional_data mismatch',
       );
     } else {
-      assert.strictEqual(decoded.channel_metadata, null);
+      assert.strictEqual(decoded.channel_metadata, null, 'channel_metadata should be null');
     }
 
-    assert.strictEqual(decoded.affiliate_fees.length, affiliateFees.length);
+    assert.strictEqual(decoded.affiliate_fees.length, affiliateFees.length, 'affiliate_fees length mismatch');
     for (let i = 0; i < affiliateFees.length; i++) {
       assert.strictEqual(
         decoded.affiliate_fees[i].account.toLowerCase(),
         affiliateFees[i].account.toLowerCase(),
+        `affiliate_fees[${i}].account mismatch`,
       );
-      assert.strictEqual(decoded.affiliate_fees[i].bps, affiliateFees[i].bps);
+      assert.strictEqual(decoded.affiliate_fees[i].bps, affiliateFees[i].bps, `affiliate_fees[${i}].bps mismatch`);
     }
 
     if (dcaParams) {
-      assert.strictEqual(decoded.dca_parameters?.number_of_chunks, dcaParams.numberOfChunks);
-      assert.strictEqual(decoded.dca_parameters?.chunk_interval, dcaParams.chunkIntervalBlocks);
+      assert.strictEqual(decoded.dca_parameters?.number_of_chunks, dcaParams.numberOfChunks, 'dca_parameters.number_of_chunks mismatch');
+      assert.strictEqual(decoded.dca_parameters?.chunk_interval, dcaParams.chunkIntervalBlocks, 'dca_parameters.chunk_interval mismatch');
     } else if (chainFromAsset(sourceAsset) !== Chains.Bitcoin) {
       // BTC always encodes dca_parameters even when not provided
-      assert.strictEqual(decoded.dca_parameters, null);
+      assert.strictEqual(decoded.dca_parameters, null, 'dca_parameters should be null');
     }
   }
 

--- a/bouncer/shared/vault_swap/vault_swap.ts
+++ b/bouncer/shared/vault_swap/vault_swap.ts
@@ -8,6 +8,7 @@ import {
   Asset,
 } from 'shared/utils';
 import { CcmDepositMetadata, DcaParams } from 'shared/new_swap';
+import { AssetAndChain } from '@chainflip/utils/chainflip';
 
 function toCcmRpcParams(metadata: CcmDepositMetadata) {
   return {
@@ -25,8 +26,8 @@ function toDcaRpcParams(dcaParams: DcaParams) {
 }
 
 type VaultSwapInputRpc = {
-  source_asset: unknown;
-  destination_asset: unknown;
+  source_asset: AssetAndChain;
+  destination_asset: AssetAndChain;
   destination_address: string;
   broker_commission: number;
   boost_fee: number;

--- a/bouncer/shared/vault_swap/vault_swap.ts
+++ b/bouncer/shared/vault_swap/vault_swap.ts
@@ -1,0 +1,132 @@
+import assert from 'assert';
+import { ApiPromise } from '@polkadot/api';
+import {
+  stateChainAssetFromAsset,
+  chainFromAsset,
+  decodeDotAddressForContract,
+  Chains,
+  Asset,
+} from 'shared/utils';
+import { CcmDepositMetadata, DcaParams } from 'shared/new_swap';
+
+function toCcmRpcParams(metadata: CcmDepositMetadata) {
+  return {
+    message: metadata.message,
+    gas_budget: `0x${BigInt(metadata.gasBudget).toString(16)}`,
+    ccm_additional_data: metadata.ccmAdditionalData,
+  };
+}
+
+function toDcaRpcParams(dcaParams: DcaParams) {
+  return {
+    number_of_chunks: dcaParams.numberOfChunks,
+    chunk_interval: dcaParams.chunkIntervalBlocks,
+  };
+}
+
+type VaultSwapInputRpc = {
+  source_asset: unknown;
+  destination_asset: unknown;
+  destination_address: string;
+  broker_commission: number;
+  boost_fee: number;
+  channel_metadata: {
+    message: string;
+    gas_budget: string;
+    ccm_additional_data: string | null;
+  } | null;
+  affiliate_fees: { account: string; bps: number }[];
+  dca_parameters: { number_of_chunks: number; chunk_interval: number } | null;
+};
+
+const evmChains: ReadonlySet<string> = new Set([Chains.Ethereum, Chains.Arbitrum]);
+
+/**
+ * Requests the encoded vault swap parameters using the `cf_request_swap_parameter_encoding` RPC.
+ * For non-EVM source chains, the encoded result is immediately decoded via the `cf_decode_vault_swap_parameter` RPC as a sanity check.
+ */
+export async function requestSwapParameterEncoding<T>(
+  chainflip: ApiPromise,
+  brokerAddress: string,
+  sourceAsset: Asset,
+  destAsset: Asset,
+  destAddress: string,
+  brokerCommissionBps: number,
+  extraParameters: unknown,
+  messageMetadata: CcmDepositMetadata | undefined,
+  boostFeeBps: number,
+  affiliateFees: { account: string; bps: number }[],
+  dcaParams: DcaParams | undefined,
+): Promise<T> {
+  const encodedDestAddress =
+    chainFromAsset(destAsset) === Chains.Assethub
+      ? decodeDotAddressForContract(destAddress)
+      : destAddress;
+
+  // Encode the payload
+  const encoded = (await chainflip.rpc(
+    'cf_request_swap_parameter_encoding',
+    brokerAddress,
+    stateChainAssetFromAsset(sourceAsset),
+    stateChainAssetFromAsset(destAsset),
+    encodedDestAddress,
+    brokerCommissionBps,
+    extraParameters,
+    messageMetadata ? toCcmRpcParams(messageMetadata) : null,
+    boostFeeBps,
+    affiliateFees,
+    dcaParams ? toDcaRpcParams(dcaParams) : null,
+  )) as unknown as T;
+
+  // Sanity check the encoding by decoding it (EVM decoding is not supported)
+  if (!evmChains.has(chainFromAsset(sourceAsset))) {
+    const decoded = (await chainflip.rpc(
+      'cf_decode_vault_swap_parameter',
+      brokerAddress,
+      encoded,
+    )) as unknown as VaultSwapInputRpc;
+
+    // Compare the decoded values with the original input
+    assert.deepStrictEqual(decoded.source_asset, stateChainAssetFromAsset(sourceAsset));
+    assert.deepStrictEqual(decoded.destination_asset, stateChainAssetFromAsset(destAsset));
+    assert.strictEqual(decoded.destination_address.toLowerCase(), encodedDestAddress.toLowerCase());
+    assert.strictEqual(decoded.broker_commission, brokerCommissionBps);
+    assert.strictEqual(decoded.boost_fee, boostFeeBps);
+
+    if (messageMetadata) {
+      assert.strictEqual(
+        decoded.channel_metadata?.message.toLowerCase(),
+        messageMetadata.message.toLowerCase(),
+      );
+      assert.strictEqual(
+        decoded.channel_metadata?.gas_budget.toLowerCase(),
+        `0x${BigInt(messageMetadata.gasBudget).toString(16)}`.toLowerCase(),
+      );
+      assert.strictEqual(
+        decoded.channel_metadata?.ccm_additional_data?.toLowerCase(),
+        messageMetadata.ccmAdditionalData?.toLowerCase() ?? null,
+      );
+    } else {
+      assert.strictEqual(decoded.channel_metadata, null);
+    }
+
+    assert.strictEqual(decoded.affiliate_fees.length, affiliateFees.length);
+    for (let i = 0; i < affiliateFees.length; i++) {
+      assert.strictEqual(
+        decoded.affiliate_fees[i].account.toLowerCase(),
+        affiliateFees[i].account.toLowerCase(),
+      );
+      assert.strictEqual(decoded.affiliate_fees[i].bps, affiliateFees[i].bps);
+    }
+
+    if (dcaParams) {
+      assert.strictEqual(decoded.dca_parameters?.number_of_chunks, dcaParams.numberOfChunks);
+      assert.strictEqual(decoded.dca_parameters?.chunk_interval, dcaParams.chunkIntervalBlocks);
+    } else if (chainFromAsset(sourceAsset) !== Chains.Bitcoin) {
+      // BTC always encodes dca_parameters even when not provided
+      assert.strictEqual(decoded.dca_parameters, null);
+    }
+  }
+
+  return encoded;
+}

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -26,8 +26,8 @@ import { TestContext } from 'shared/utils/test_context';
 import { getIsoTime, globalLogger } from 'shared/utils/logger';
 import { getBalance } from 'shared/get_balance';
 import { send } from 'shared/send';
-import { buildAndSendBtcVaultSwap } from 'shared/btc_vault_swap';
-import { executeEvmVaultSwap } from 'shared/evm_vault_swap';
+import { buildAndSendBtcVaultSwap } from 'shared/vault_swap/btc_vault_swap';
+import { executeEvmVaultSwap } from 'shared/vault_swap/evm_vault_swap';
 import { newCcmMetadata } from 'shared/swapping';
 import {
   ChainflipIO,

--- a/bouncer/tests/broker_level_screening/sol.ts
+++ b/bouncer/tests/broker_level_screening/sol.ts
@@ -14,7 +14,7 @@ import { FillOrKillParamsX128 } from 'shared/new_swap';
 import { getBalance } from 'shared/get_balance';
 import { send } from 'shared/send';
 import { newCcmMetadata } from 'shared/swapping';
-import { executeSolVaultSwap } from 'shared/sol_vault_swap';
+import { executeSolVaultSwap } from 'shared/vault_swap/sol_vault_swap';
 import { ChainflipIO, fullAccountFromUri } from 'shared/utils/chainflip_io';
 import { solanaIngressEgressTransactionRejectedByBroker } from 'generated/events/solanaIngressEgress/transactionRejectedByBroker';
 import { solanaIngressEgressDepositFinalised } from 'generated/events/solanaIngressEgress/depositFinalised';

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -1,7 +1,7 @@
 import { describe } from 'vitest';
 import { testBoostingSwap } from 'tests/boost';
 import { testVaultSwap } from 'tests/vault_swap_tests';
-import { checkSolEventAccountsClosure } from 'shared/sol_vault_swap';
+import { checkSolEventAccountsClosure } from 'shared/vault_swap/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from 'shared/utils';
 import { testAllSwaps } from 'tests/all_swaps';
 import { testEvmDeposits } from 'tests/evm_deposits';

--- a/bouncer/tests/vault_swap_tests.ts
+++ b/bouncer/tests/vault_swap_tests.ts
@@ -1,7 +1,10 @@
 import assert from 'assert';
 import { Assets, defaultAssetAmounts, newAssetAddress, sleep, Asset } from 'shared/utils';
 import { getEarnedBrokerFees } from 'tests/broker_fee_collection';
-import { buildAndSendInvalidBtcVaultSwap, registerAffiliate } from 'shared/btc_vault_swap';
+import {
+  buildAndSendInvalidBtcVaultSwap,
+  registerAffiliate,
+} from 'shared/vault_swap/btc_vault_swap';
 import { AccountRole, setupAccount } from 'shared/setup_account';
 import { executeVaultSwap, prepareVaultSwapSource, performVaultSwap } from 'shared/perform_swap';
 import { prepareSwap } from 'shared/swapping';

--- a/foreign-chains/solana/sol-prim/Cargo.toml
+++ b/foreign-chains/solana/sol-prim/Cargo.toml
@@ -71,3 +71,4 @@ std = [
 	"cf-primitives/std",
 ]
 runtime-integration-tests = []
+test = []

--- a/foreign-chains/solana/sol-prim/src/consts.rs
+++ b/foreign-chains/solana/sol-prim/src/consts.rs
@@ -81,3 +81,4 @@ pub const X_SWAP_FROM_ACC_IDX: u8 = 2u8;
 pub const X_SWAP_NATIVE_EVENT_DATA_ACC_IDX: u8 = 3u8;
 pub const X_SWAP_TOKEN_FROM_TOKEN_ACC_IDX: u8 = 3u8;
 pub const X_SWAP_TOKEN_EVENT_DATA_ACC_IDX: u8 = 4u8;
+pub const X_SWAP_TOKEN_MINT_ACC_IDX: u8 = 8u8;

--- a/foreign-chains/solana/sol-prim/src/signer.rs
+++ b/foreign-chains/solana/sol-prim/src/signer.rs
@@ -97,9 +97,9 @@ pub mod presigner {
 	}
 }
 
-#[cfg(feature = "runtime-integration-tests")]
+#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 pub struct TestSigners<S>(pub Vec<S>);
-#[cfg(feature = "runtime-integration-tests")]
+#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 impl<S: Signer> TestSigners<S> {
 	pub fn pubkeys(&self) -> Vec<Pubkey> {
 		self.0.iter().map(|keypair| keypair.pubkey()).collect()
@@ -130,7 +130,7 @@ impl<S: Signer> TestSigners<S> {
 	}
 }
 
-#[cfg(feature = "runtime-integration-tests")]
+#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 impl<S> From<Vec<S>> for TestSigners<S> {
 	fn from(s: Vec<S>) -> Self {
 		Self(s)

--- a/foreign-chains/solana/sol-prim/src/transaction.rs
+++ b/foreign-chains/solana/sol-prim/src/transaction.rs
@@ -32,7 +32,7 @@ use serde::{
 use sp_std::fmt;
 use v0::VersionedMessageV0;
 
-#[cfg(feature = "runtime-integration-tests")]
+#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 use crate::signer::{Signer, TestSigners};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -333,7 +333,7 @@ impl VersionedTransaction {
 		}
 	}
 
-	#[cfg(feature = "runtime-integration-tests")]
+	#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 	pub fn test_only_sign<S: Signer>(&mut self, signers: TestSigners<S>, recent_blockhash: Hash) {
 		let positions = self.get_signing_keypair_positions(signers.pubkeys());
 
@@ -353,7 +353,7 @@ impl VersionedTransaction {
 		}
 	}
 
-	#[cfg(feature = "runtime-integration-tests")]
+	#[cfg(any(feature = "test", feature = "runtime-integration-tests"))]
 	fn get_signing_keypair_positions(&self, pubkeys: Vec<Pubkey>) -> Vec<usize> {
 		let account_keys = self.message.static_account_keys();
 		let required_sigs = self.message.header().num_required_signatures as usize;

--- a/state-chain/chains/Cargo.toml
+++ b/state-chain/chains/Cargo.toml
@@ -87,6 +87,7 @@ cf-test-utilities = { workspace = true }
 serde_json = { workspace = true, default-features = true }
 rand = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
+sol-prim = { workspace = true, features = ["test"] }
 
 [features]
 default = ["std"]

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -637,9 +637,16 @@ pub fn decode_sol_instruction_data(
 			)
 			.map_err(|_| "Failed to deserialize SolInstruction")?;
 
-			let token_mint_pubkey: SolAddress = instruction
+			let from_token_account: SolAddress = instruction
 				.accounts
 				.get(sol_tx_core::consts::X_SWAP_TOKEN_FROM_TOKEN_ACC_IDX as usize)
+				.ok_or("Invalid accounts in SolInstruction")?
+				.pubkey
+				.into();
+
+			let token_mint_pubkey: SolAddress = instruction
+				.accounts
+				.get(sol_tx_core::consts::X_SWAP_TOKEN_MINT_ACC_IDX as usize)
 				.ok_or("Invalid accounts in SolInstruction")?
 				.pubkey
 				.into();
@@ -655,7 +662,7 @@ pub fn decode_sol_instruction_data(
 			Ok((
 				amount,
 				src_asset,
-				Some(token_mint_pubkey),
+				Some(from_token_account),
 				dst_chain,
 				dst_address,
 				dst_token,
@@ -739,7 +746,8 @@ mod test {
 			instruction_builder::SolanaInstructionBuilder,
 			sol_tx_core::{
 				address_derivation::{
-					derive_swap_endpoint_native_vault_account, derive_vault_swap_account,
+					derive_associated_token_account, derive_swap_endpoint_native_vault_account,
+					derive_vault_swap_account,
 				},
 				sol_test_values,
 			},
@@ -948,7 +956,11 @@ mod test {
 		let destination_asset = Asset::Sol;
 		let destination_address = EncodedAddress::Sol([0xF0; 32]);
 		let from = SolPubkey([0xF1; 32]);
-		let from_token_account = SolPubkey::from(sol_test_values::USDC_TOKEN_MINT_PUB_KEY);
+		let from_token_account: SolPubkey =
+			derive_associated_token_account(from.into(), sol_test_values::USDC_TOKEN_MINT_PUB_KEY)
+				.unwrap()
+				.address
+				.into();
 		let seed: &[u8] = &[0xF2; 32];
 		let event_data_account =
 			derive_vault_swap_account(sol_test_values::SWAP_ENDPOINT_PROGRAM, from.into(), seed)

--- a/state-chain/chains/src/sol.rs
+++ b/state-chain/chains/src/sol.rs
@@ -577,7 +577,7 @@ pub fn decode_sol_instruction_data(
 	let (
 		amount,
 		src_asset,
-		src_token_from_account,
+		from_token_account,
 		dst_chain,
 		dst_address,
 		dst_token,
@@ -715,7 +715,7 @@ pub fn decode_sol_instruction_data(
 			.ok_or("Invalid accounts in SolInstruction")?
 			.pubkey
 			.into(),
-		from_token_account: src_token_from_account,
+		from_token_account,
 		dst_address: EncodedAddress::from_chain_bytes(chain, dst_address)?,
 		dst_token: AnyChainAsset::try_from(dst_token).map_err(|_| "Invalid dst_token")?,
 		refund_parameters: refund_params.map_address(Into::into),


### PR DESCRIPTION
# Pull Request

Closes: PRO-2235

## Summary

- Moved all of the vault swap files into a folder. 
- Refactored the use of the `cf_request_swap_parameter_encoding` rpc so it was common.
- Used the `cf_decode_vault_swap_parameter` to always check the encoded params.
- Fixed the solana vault swap decoding RPC. Would always fail with "unsupported solana token".