### PR TITLE
fix: emit operator removed event when validaotr deregisters

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -884,11 +884,7 @@ pub mod pallet {
 				T::CfePeerRegistration::peer_deregistered(validator_id.clone(), peer_id);
 			}
 
-			if let Some(operator) = OperatorChoice::<T>::take(&account_id) {
-				ManagedValidators::<T>::mutate(&operator, |validators| {
-					validators.remove(&account_id);
-				});
-			}
+			Self::do_remove_from_operator(account_id.clone());
 
 			ClaimedValidators::<T>::remove(&account_id);
 
@@ -998,12 +994,7 @@ pub mod pallet {
 			let operator =
 				OperatorChoice::<T>::get(&validator).ok_or(Error::<T>::ValidatorDoesNotExist)?;
 			ensure!(account_id == operator || account_id == validator, Error::<T>::NotAuthorized);
-			OperatorChoice::<T>::remove(&validator);
-			ManagedValidators::<T>::mutate(&operator, |validators| {
-				validators.remove(&validator);
-			});
-
-			Self::deposit_event(Event::ValidatorRemovedFromOperator { validator, operator });
+			Self::do_remove_from_operator(validator);
 
 			Ok(())
 		}
@@ -1492,6 +1483,18 @@ impl<T: Config> pallet_session::ShouldEndSession<BlockNumberFor<T>> for Pallet<T
 }
 
 impl<T: Config> Pallet<T> {
+	/// Removes a validator from an operator's managed pool, cleaning up both storage items and
+	/// emitting the `ValidatorRemovedFromOperator` event. This is the single source of truth for
+	/// this operation, called from both `remove_validator` and `deregister_as_validator`.
+	fn do_remove_from_operator(validator: T::AccountId) {
+		if let Some(operator) = OperatorChoice::<T>::take(&validator) {
+			ManagedValidators::<T>::mutate(&operator, |validators| {
+				validators.remove(&validator);
+			});
+			Self::deposit_event(Event::ValidatorRemovedFromOperator { validator, operator });
+		}
+	}
+
 	/// Makes the transition to the next epoch.
 	///
 	/// Among other things, updates the authority, historical and backup sets.

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1387,6 +1387,39 @@ fn validator_registration_operator_binding_and_deregistration() {
 }
 
 #[test]
+fn deregister_as_validator_emits_validator_removed_from_operator_event() {
+	new_test_ext().execute_with(|| {
+		const OPERATOR: u64 = 1001;
+		const VALIDATOR: u64 = 2001;
+
+		assert_ok!(ValidatorPallet::register_as_operator(
+			OriginTrait::signed(OPERATOR),
+			OPERATOR_SETTINGS,
+			vanity()
+		));
+
+		assert_ok!(ValidatorPallet::register_as_validator(RuntimeOrigin::signed(VALIDATOR)));
+
+		assert_ok!(ValidatorPallet::claim_validator(OriginTrait::signed(OPERATOR), VALIDATOR));
+		assert_ok!(ValidatorPallet::accept_operator(OriginTrait::signed(VALIDATOR), OPERATOR));
+
+		assert_eq!(OperatorChoice::<Test>::get(VALIDATOR), Some(OPERATOR));
+		assert!(ManagedValidators::<Test>::get(OPERATOR).contains(&VALIDATOR));
+
+		assert_ok!(ValidatorPallet::deregister_as_validator(RuntimeOrigin::signed(VALIDATOR)));
+
+		// Storage should be cleaned up.
+		assert_eq!(OperatorChoice::<Test>::get(VALIDATOR), None);
+		assert!(!ManagedValidators::<Test>::get(OPERATOR).contains(&VALIDATOR));
+
+		// ValidatorRemovedFromOperator must be emitted, same as remove_validator does.
+		cf_test_utilities::assert_has_event::<Test>(RuntimeEvent::ValidatorPallet(
+			Event::ValidatorRemovedFromOperator { validator: VALIDATOR, operator: OPERATOR },
+		));
+	});
+}
+
+#[test]
 fn test_start_and_stop_bidding() {
 	new_test_ext().execute_with(|| {
 		MockEpochInfo::add_authorities(ALICE);


### PR DESCRIPTION
# Pull Request

Closes: PRO-2810

## Summary

*Please include a succinct description of the purpose and content of the PR. What problem does it solve, and how? Link issues, discussions, other PRs, and anything else that will help the reviewer.*

## API Changes

*Document the impact on any external APIs, whether breaking or non-breaking.*

### RPCS

*Any changes to the RPC interfaces, or internal behaviour?*

### Extrinsics & Events

*Any changes to extrinsic or event encodings?*

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [ ] Scope is clear and fully implemented.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [ ] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
