### PR TITLE
feat: drop vote tasks for closed elections

### DIFF
--- a/engine/src/elections.rs
+++ b/engine/src/elections.rs
@@ -34,7 +34,7 @@ use pallet_cf_elections::{
 };
 use rand::Rng;
 use std::{
-	collections::{BTreeMap, HashMap},
+	collections::{BTreeMap, BTreeSet, HashMap},
 	sync::Arc,
 };
 use tokio::sync::mpsc;
@@ -243,6 +243,21 @@ where
 								}
 							}
 						}
+
+						let open_election_identifiers =
+							electoral_data.current_elections.keys().copied().collect::<BTreeSet<_>>();
+						for election_identifier in vote_tasks.remove_where(|election_identifier| {
+								!open_election_identifiers.contains(election_identifier)
+							}) {
+							self.log(
+								Level::DEBUG,
+								&format!(
+									"Voting task for election: '{:?}' aborted as election is no longer open.",
+									election_identifier
+								),
+							);
+						}
+
 						for (election_identifier, election_data) in electoral_data.current_elections {
 							if election_data.is_vote_desired {
 								if !vote_tasks.contains_key(&election_identifier) {

--- a/utilities/src/with_std/future_map.rs
+++ b/utilities/src/with_std/future_map.rs
@@ -16,6 +16,7 @@
 
 use futures::{Future, Stream};
 use std::{collections::BTreeSet, iter::IntoIterator};
+use tracing::debug;
 
 #[pin_project::pin_project]
 struct Wrapper<Key, Fut> {
@@ -86,7 +87,8 @@ impl<Key: Ord + Copy, Fut: Future + Unpin> FutureMap<Key, Fut> {
 
 		for future in futures {
 			if predicate(&future.key) {
-				assert!(self.keys.remove(&future.key));
+				let was_present = self.keys.remove(&future.key);
+				debug_assert!(was_present);
 				removed_keys.push(future.key);
 			} else {
 				self.futures.push(future);

--- a/utilities/src/with_std/future_map.rs
+++ b/utilities/src/with_std/future_map.rs
@@ -155,8 +155,7 @@ mod tests {
 		map.insert(2, ready(200));
 		map.insert(3, ready(300));
 
-		let mut removed_keys = map.remove_where(|key| *key % 2 == 0);
-		removed_keys.sort();
+		let removed_keys = map.remove_where(|key| *key % 2 == 0);
 
 		assert_eq!(removed_keys, vec![2]);
 		assert!(map.contains_key(&1));

--- a/utilities/src/with_std/future_map.rs
+++ b/utilities/src/with_std/future_map.rs
@@ -77,6 +77,25 @@ impl<Key: Ord + Copy, Fut: Future + Unpin> FutureMap<Key, Fut> {
 		self.keys.contains(key)
 	}
 
+	pub fn remove_where<Predicate>(&mut self, mut predicate: Predicate) -> Vec<Key>
+	where
+		Predicate: FnMut(&Key) -> bool,
+	{
+		let mut removed_keys = Vec::new();
+		let futures = std::mem::take(&mut self.futures).into_iter();
+
+		for future in futures {
+			if predicate(&future.key) {
+				assert!(self.keys.remove(&future.key));
+				removed_keys.push(future.key);
+			} else {
+				self.futures.push(future);
+			}
+		}
+
+		removed_keys
+	}
+
 	pub fn len(&self) -> usize {
 		self.keys.len()
 	}
@@ -126,5 +145,36 @@ mod tests {
 		assert!(removed_future.is_some());
 		assert_eq!(removed_future.unwrap().now_or_never(), Some(FUT_OUTPUT));
 		assert!(map.is_empty());
+	}
+
+	#[test]
+	fn test_remove_where_removes_matching_keys() {
+		let mut map: FutureMap<i32, _> = Default::default();
+
+		map.insert(1, ready(100));
+		map.insert(2, ready(200));
+		map.insert(3, ready(300));
+
+		let mut removed_keys = map.remove_where(|key| *key % 2 == 0);
+		removed_keys.sort();
+
+		assert_eq!(removed_keys, vec![2]);
+		assert!(map.contains_key(&1));
+		assert!(!map.contains_key(&2));
+		assert!(map.contains_key(&3));
+	}
+
+	#[test]
+	fn test_remove_where_no_matches() {
+		let mut map: FutureMap<i32, _> = Default::default();
+
+		map.insert(1, ready(100));
+		map.insert(2, ready(200));
+
+		let removed_keys = map.remove_where(|_| false);
+
+		assert!(removed_keys.is_empty());
+		assert!(map.contains_key(&1));
+		assert!(map.contains_key(&2));
 	}
 }

--- a/utilities/src/with_std/future_map.rs
+++ b/utilities/src/with_std/future_map.rs
@@ -16,7 +16,6 @@
 
 use futures::{Future, Stream};
 use std::{collections::BTreeSet, iter::IntoIterator};
-use tracing::debug;
 
 #[pin_project::pin_project]
 struct Wrapper<Key, Fut> {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2780

## Summary

The voter implementation uses the `RetrierClient` which retries any voting task up to 3 times on failure. However, retrying vote tasks is unnecessary and potentially harmful — slow RPC calls can cause timeouts, but since new elections are processed every block, a failed vote for an already-resolved election is wasted work.

This PR removes vote tasks from the `FutureMap` when their corresponding election no longer appears in the current elections set. When a task is removed from the `FutureMap`, its future — which holds the `oneshot::Receiver` returned by `request_with_limit` is dropped. This causes the `oneshot::Sender` on the retrier side to detect that the receiver is closed (`response_sender.is_closed()`) which makes the retrier discard the request instead of scheduling another retry attempt.

Note, this doesn't completely abort the task, in-flight task will still running, this will only prevent the task to be retried in case it fails/times out.


* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.