### PR TITLE
chore: bump version & changelog for 2.1.11

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -60,6 +60,17 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0020: Wasmtime memory leak, we don't have any control over the wasmtime version.
 # - RUSTSEC-2026-0021: Wasmtime panic, we don't have any control over the wasmtime version.
 # - RUSTSEC-2026-0049: Transitive dependency and "an attacker would need to compromise a trusted issuing authority to trigger this bug". It's a dependency of `rustls`.
+# - RUSTSEC-2026-0085: Wasmtime panic when lifting `flags` component value. Dependency of substrate.
+# - RUSTSEC-2026-0086: Wasmtime host data leakage with 64-bit tables and Winch. Dependency of substrate.
+# - RUSTSEC-2026-0087: Wasmtime segfault with `f64x2.splat` on Cranelift x86-64. Dependency of substrate.
+# - RUSTSEC-2026-0088: Wasmtime data leakage between pooling allocator instances. Dependency of substrate.
+# - RUSTSEC-2026-0089: Wasmtime host panic when Winch executes `table.fill`. Dependency of substrate.
+# - RUSTSEC-2026-0091: Wasmtime OOB write or crash when transcoding component model strings. Dependency of substrate.
+# - RUSTSEC-2026-0092: Wasmtime panic when transcoding misaligned component model UTF-16 strings. Dependency of substrate.
+# - RUSTSEC-2026-0093: Wasmtime heap OOB read in component model UTF-16 to latin1+utf16 transcoding. Dependency of substrate.
+# - RUSTSEC-2026-0094: Wasmtime improperly masked return value from `table.grow` with Winch. Dependency of substrate.
+# - RUSTSEC-2026-0095: Wasmtime with Winch may allow sandbox-escaping memory access. Dependency of substrate.
+# - RUSTSEC-2026-0096: Wasmtime miscompiled guest heap access enables sandbox escape on aarch64 Cranelift. Dependency of substrate.
 #
 cf-audit = '''
 audit -D unmaintained -D unsound
@@ -87,6 +98,17 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0020
 	--ignore RUSTSEC-2026-0021
 	--ignore RUSTSEC-2026-0049
+	--ignore RUSTSEC-2026-0085
+	--ignore RUSTSEC-2026-0086
+	--ignore RUSTSEC-2026-0087
+	--ignore RUSTSEC-2026-0088
+	--ignore RUSTSEC-2026-0089
+	--ignore RUSTSEC-2026-0091
+	--ignore RUSTSEC-2026-0092
+	--ignore RUSTSEC-2026-0093
+	--ignore RUSTSEC-2026-0094
+	--ignore RUSTSEC-2026-0095
+	--ignore RUSTSEC-2026-0096
 '''
 
 [build]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -71,6 +71,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0094: Wasmtime improperly masked return value from `table.grow` with Winch. Dependency of substrate.
 # - RUSTSEC-2026-0095: Wasmtime with Winch may allow sandbox-escaping memory access. Dependency of substrate.
 # - RUSTSEC-2026-0096: Wasmtime miscompiled guest heap access enables sandbox escape on aarch64 Cranelift. Dependency of substrate.
+# - RUSTSEC-2026-0097: Rng issue in the rand 0.8.5 crate. Transitive dependency. Unlikely and low impact.
 #
 cf-audit = '''
 audit -D unmaintained -D unsound
@@ -109,6 +110,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0094
 	--ignore RUSTSEC-2026-0095
 	--ignore RUSTSEC-2026-0096
+	--ignore RUSTSEC-2026-0097
 '''
 
 [build]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [2.1.11] - 2026-04-13
+
+- Apply unsigned validation checks during pre-dispatch.
+
 ## [2.1.10] - 2026-03-23
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6073,7 +6073,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring 0.17.14",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6116,7 +6116,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -11298,7 +11298,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger 0.11.9",
  "log",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -11342,7 +11342,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
@@ -11408,9 +11408,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -11418,9 +11418,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
  "rand_core 0.10.0",
@@ -17227,7 +17227,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
@@ -19205,7 +19205,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.3",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "cf-amm-math",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "engine-p2p"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "engine-sc-client"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15673,7 +15673,7 @@ dependencies = [
 
 [[package]]
 name = "state-chain-runtime"
-version = "2.1.10"
+version = "2.1.11"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "2.1.10"
+version = "2.1.11"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v2_1_10"
+name = "chainflip_engine_v2_1_11"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "2.1.10"
+version = "2.1.11"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v2_1_10.so",
+		"target/release/libchainflip_engine_v2_1_11.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v2_1_10.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v2_1_11.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("2.1.10")]
+	#[engine_proc_macros::link_engine_library_version("2.1.11")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -27,7 +27,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "2.0.13";
-pub const NEW_VERSION: &str = "2.1.10";
+pub const NEW_VERSION: &str = "2.1.11";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lib]

--- a/engine/p2p/Cargo.toml
+++ b/engine/p2p/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 name = "engine-p2p"
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lib]

--- a/engine/sc-client/Cargo.toml
+++ b/engine/sc-client/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 name = "engine-sc-client"
-version = "2.1.10"
+version = "2.1.11"
 license = "Apache-2.0"
 
 [lints]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "2.1.10"
+version = "2.1.11"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -19,7 +19,9 @@
 #![doc = include_str!("../../cf-doc-head.md")]
 #![allow(clippy::allow_attributes)]
 
-use crate::submit_runtime_call::{batch_all, weight_and_dispatch_class, SignatureData};
+use crate::submit_runtime_call::{
+	batch_all, weight_and_dispatch_class, ChainflipExtrinsic, SignatureData,
+};
 pub use crate::submit_runtime_call::{
 	build_domain_data, is_valid_signature, BatchedCalls, EthEncodingType, SolEncodingType,
 	TransactionMetadata, DOMAIN_OFFCHAIN_PREFIX, MAX_BATCHED_CALLS,
@@ -105,7 +107,7 @@ pub enum SafeModeUpdate<T: Config> {
 
 #[frame_support::pallet]
 pub mod pallet {
-	use crate::submit_runtime_call::{validate_metadata, ChainflipExtrinsic};
+	use crate::submit_runtime_call::ChainflipExtrinsic;
 
 	use super::*;
 	use cf_chains::{btc::Utxo, sol::api::DurableNonceAndAccount, Arbitrum};
@@ -761,67 +763,15 @@ pub mod pallet {
 		type Call = Call<T>;
 
 		fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
-			use frame_support::sp_runtime::traits::TxBaseImplication;
-
-			if let Call::non_native_signed_call {
-				chainflip_extrinsic: ChainflipExtrinsic { call: inner_call, transaction_metadata },
-				signature_data,
-			} = call
-			{
-				let Ok(signer_account) = signature_data.signer_account::<T::AccountId>() else {
-					return Err(InvalidTransaction::BadSigner.into());
-				};
-				ensure!(
-					frame_system::Account::<T>::contains_key(&signer_account),
-					InvalidTransaction::BadSigner
-				);
-				T::GetTransactionPayments::get().0.validate(
-					OriginTrait::signed(signer_account.clone()),
-					inner_call,
-					&inner_call.get_dispatch_info(),
-					inner_call.encoded_size(),
-					(),
-					&TxBaseImplication(()),
-					source,
-				)?;
-				let valid_tx = validate_metadata::<T>(transaction_metadata, &signer_account)?;
-
-				let runtime_version = <T as frame_system::Config>::Version::get();
-
-				match is_valid_signature(
-					(*inner_call).clone(),
-					&ChainflipNetworkName::<T>::get(),
-					transaction_metadata,
-					signature_data,
-					runtime_version.spec_version,
-				) {
-					Ok(is_valid) => ensure!(is_valid, InvalidTransaction::BadProof),
-					Err(_) => return Err(InvalidTransaction::Custom(0).into()),
-				}
-				Ok(valid_tx)
-			} else {
-				Err(InvalidTransaction::Call.into())
-			}
+			let (_, valid_tx) = Self::validate_unsigned_call(source, call)?;
+			Ok(valid_tx)
 		}
 
 		fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
-			if let Call::non_native_signed_call {
-				chainflip_extrinsic: ChainflipExtrinsic { transaction_metadata, .. },
-				signature_data,
-				..
-			} = call
-			{
-				let Ok(signer_account) = signature_data.signer_account() else {
-					return Err(InvalidTransaction::BadSigner.into());
-				};
-
-				// Signature validity already checked in `validate_unsigned`
-				let _ = validate_metadata::<T>(transaction_metadata, &signer_account)?;
-				frame_system::Pallet::<T>::inc_account_nonce(&signer_account);
-				Ok(())
-			} else {
-				Err(InvalidTransaction::Call.into())
-			}
+			let (signer_account, _valid_tx) =
+				Self::validate_unsigned_call(TransactionSource::InBlock, call)?;
+			frame_system::Pallet::<T>::inc_account_nonce(&signer_account);
+			Ok(())
 		}
 	}
 
@@ -1119,6 +1069,54 @@ impl<T: Config> Pallet<T> {
 			*id += 1;
 			current_id
 		})
+	}
+
+	fn validate_unsigned_call(
+		source: TransactionSource,
+		call: &Call<T>,
+	) -> Result<(T::AccountId, ValidTransaction), TransactionValidityError> {
+		use frame_support::sp_runtime::traits::{TransactionExtension, TxBaseImplication};
+
+		if let Call::non_native_signed_call {
+			chainflip_extrinsic: ChainflipExtrinsic { call: inner_call, transaction_metadata },
+			signature_data,
+		} = call
+		{
+			let Ok(signer_account) = signature_data.signer_account::<T::AccountId>() else {
+				return Err(InvalidTransaction::BadSigner.into());
+			};
+			ensure!(
+				frame_system::Account::<T>::contains_key(&signer_account),
+				InvalidTransaction::BadSigner
+			);
+			T::GetTransactionPayments::get().0.validate(
+				OriginTrait::signed(signer_account.clone()),
+				inner_call,
+				&inner_call.get_dispatch_info(),
+				inner_call.encoded_size(),
+				(),
+				&TxBaseImplication(()),
+				source,
+			)?;
+			let valid_tx =
+				submit_runtime_call::validate_metadata::<T>(transaction_metadata, &signer_account)?;
+
+			let runtime_version = <T as frame_system::Config>::Version::get();
+
+			match is_valid_signature(
+				(*inner_call).clone(),
+				&ChainflipNetworkName::<T>::get(),
+				transaction_metadata,
+				signature_data,
+				runtime_version.spec_version,
+			) {
+				Ok(is_valid) => ensure!(is_valid, InvalidTransaction::BadProof),
+				Err(_) => return Err(InvalidTransaction::Custom(0).into()),
+			}
+			Ok((signer_account, valid_tx))
+		} else {
+			Err(InvalidTransaction::Call.into())
+		}
 	}
 }
 

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "2.1.10"
+version = "2.1.11"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_std::borrow::Cow::Borrowed("chainflip-node"),
 	impl_name: sp_std::borrow::Cow::Borrowed("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 2_01_10,
+	spec_version: 2_01_11,
 	impl_version: 1,
 	apis: crate::runtime_apis::impl_api::RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
Ensures we apply unsigned validation on pre-dispatch.