### PR TITLE
feat: bouncer ccm tests fixes

### DIFF
--- a/bouncer/shared/perform_swap.ts
+++ b/bouncer/shared/perform_swap.ts
@@ -35,6 +35,19 @@ import { swappingSwapRequestCompleted } from 'generated/events/swapping/swapRequ
 import { swappingSwapEgressScheduled } from 'generated/events/swapping/swapEgressScheduled';
 import { ChainflipIO, WithBrokerAccount } from 'shared/utils/chainflip_io';
 import { swappingSwapEgressIgnored } from 'generated/events/swapping/swapEgressIgnored';
+import z from 'zod';
+import { ethereumIngressEgressCcmBroadcastRequested } from 'generated/events/ethereumIngressEgress/ccmBroadcastRequested';
+import { ethereumIngressEgressCcmEgressInvalid } from 'generated/events/ethereumIngressEgress/ccmEgressInvalid';
+import { ethereumIngressEgressCcmBroadcastFailed } from 'generated/events/ethereumIngressEgress/ccmBroadcastFailed';
+import { ethereumBroadcasterBroadcastSuccess } from 'generated/events/ethereumBroadcaster/broadcastSuccess';
+import { arbitrumIngressEgressCcmBroadcastRequested } from 'generated/events/arbitrumIngressEgress/ccmBroadcastRequested';
+import { arbitrumIngressEgressCcmEgressInvalid } from 'generated/events/arbitrumIngressEgress/ccmEgressInvalid';
+import { arbitrumIngressEgressCcmBroadcastFailed } from 'generated/events/arbitrumIngressEgress/ccmBroadcastFailed';
+import { arbitrumBroadcasterBroadcastSuccess } from 'generated/events/arbitrumBroadcaster/broadcastSuccess';
+import { solanaIngressEgressCcmBroadcastRequested } from 'generated/events/solanaIngressEgress/ccmBroadcastRequested';
+import { solanaIngressEgressCcmEgressInvalid } from 'generated/events/solanaIngressEgress/ccmEgressInvalid';
+import { solanaIngressEgressCcmBroadcastFailed } from 'generated/events/solanaIngressEgress/ccmBroadcastFailed';
+import { solanaBroadcasterBroadcastSuccess } from 'generated/events/solanaBroadcaster/broadcastSuccess';
 
 export type SwapParams = {
   sourceAsset: Asset;
@@ -121,7 +134,7 @@ async function waitForEgressScheduled<A = []>(
   cf: ChainflipIO<A>,
   swapRequestId: bigint,
   swapContext?: SwapContext,
-): Promise<void> {
+): Promise<z.infer<typeof swappingSwapEgressScheduled>['egressId']> {
   const resultEvent = await cf.stepUntilOneEventOf({
     egressScheduled: {
       name: 'Swapping.SwapEgressScheduled',
@@ -136,9 +149,162 @@ async function waitForEgressScheduled<A = []>(
   if (resultEvent.key === 'egressIgnored') {
     const reason = decodeDispatchError(resultEvent.data.reason, await getChainflipApi());
     throwError(cf.logger, new Error(`Swap Egress was ignored reason: ${reason}`));
-  } else {
-    swapContext?.updateStatus(cf.logger, SwapStatus.EgressScheduled);
-    cf.debug(`Egress ID: ${resultEvent.data.egressId}, Egress amount: ${resultEvent.data.amount}.`);
+  }
+
+  swapContext?.updateStatus(cf.logger, SwapStatus.EgressScheduled);
+  cf.debug(`Egress ID: ${resultEvent.data.egressId}, Egress amount: ${resultEvent.data.amount}.`);
+  return resultEvent.data.egressId;
+}
+
+async function waitForCcmExecution<A = []>(
+  cf: ChainflipIO<A>,
+  destAsset: Asset,
+  egressId: z.infer<typeof swappingSwapEgressScheduled>['egressId'],
+) {
+  const destChain = chainFromAsset(destAsset);
+  let broadcastId: number;
+
+  switch (destChain) {
+    case 'Ethereum': {
+      const ccmEgressResult = await cf.stepUntilOneEventOf({
+        ccmBroadcastRequested: {
+          name: 'EthereumIngressEgress.CcmBroadcastRequested',
+          schema: ethereumIngressEgressCcmBroadcastRequested.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+        ccmEgressInvalid: {
+          name: 'EthereumIngressEgress.CcmEgressInvalid',
+          schema: ethereumIngressEgressCcmEgressInvalid.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+      });
+
+      if (ccmEgressResult.key === 'ccmEgressInvalid') {
+        throw new Error(
+          `CCM egress invalid for egress ${JSON.stringify(egressId)}: ${JSON.stringify(ccmEgressResult.data.error)}`,
+        );
+      }
+
+      broadcastId = ccmEgressResult.data.broadcastId;
+
+      const broadcastResult = await cf.stepUntilOneEventOf({
+        broadcastSuccess: {
+          name: 'EthereumBroadcaster.BroadcastSuccess',
+          schema: ethereumBroadcasterBroadcastSuccess.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+        ccmBroadcastFailed: {
+          name: 'EthereumIngressEgress.CcmBroadcastFailed',
+          schema: ethereumIngressEgressCcmBroadcastFailed.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+      });
+
+      if (broadcastResult.key === 'ccmBroadcastFailed') {
+        throw new Error(`CCM broadcast failed for ${destAsset} broadcast ${broadcastId}`);
+      }
+      break;
+    }
+    case 'Arbitrum': {
+      const ccmEgressResult = await cf.stepUntilOneEventOf({
+        ccmBroadcastRequested: {
+          name: 'ArbitrumIngressEgress.CcmBroadcastRequested',
+          schema: arbitrumIngressEgressCcmBroadcastRequested.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+        ccmEgressInvalid: {
+          name: 'ArbitrumIngressEgress.CcmEgressInvalid',
+          schema: arbitrumIngressEgressCcmEgressInvalid.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+      });
+
+      if (ccmEgressResult.key === 'ccmEgressInvalid') {
+        throw new Error(
+          `CCM egress invalid for egress ${JSON.stringify(egressId)}: ${JSON.stringify(ccmEgressResult.data.error)}`,
+        );
+      }
+
+      broadcastId = ccmEgressResult.data.broadcastId;
+
+      const broadcastResult = await cf.stepUntilOneEventOf({
+        broadcastSuccess: {
+          name: 'ArbitrumBroadcaster.BroadcastSuccess',
+          schema: arbitrumBroadcasterBroadcastSuccess.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+        ccmBroadcastFailed: {
+          name: 'ArbitrumIngressEgress.CcmBroadcastFailed',
+          schema: arbitrumIngressEgressCcmBroadcastFailed.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+      });
+
+      if (broadcastResult.key === 'ccmBroadcastFailed') {
+        throw new Error(`CCM broadcast failed for ${destAsset} broadcast ${broadcastId}`);
+      }
+      break;
+    }
+    case 'Solana': {
+      const ccmEgressResult = await cf.stepUntilOneEventOf({
+        ccmBroadcastRequested: {
+          name: 'SolanaIngressEgress.CcmBroadcastRequested',
+          schema: solanaIngressEgressCcmBroadcastRequested.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+        ccmEgressInvalid: {
+          name: 'SolanaIngressEgress.CcmEgressInvalid',
+          schema: solanaIngressEgressCcmEgressInvalid.refine(
+            (event) =>
+              event.egressId[0] === egressId[0] && `${event.egressId[1]}` === `${egressId[1]}`,
+          ),
+        },
+      });
+
+      if (ccmEgressResult.key === 'ccmEgressInvalid') {
+        throw new Error(
+          `CCM egress invalid for egress ${JSON.stringify(egressId)}: ${JSON.stringify(ccmEgressResult.data.error)}`,
+        );
+      }
+
+      broadcastId = ccmEgressResult.data.broadcastId;
+
+      const broadcastResult = await cf.stepUntilOneEventOf({
+        broadcastSuccess: {
+          name: 'SolanaBroadcaster.BroadcastSuccess',
+          schema: solanaBroadcasterBroadcastSuccess.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+        ccmBroadcastFailed: {
+          name: 'SolanaIngressEgress.CcmBroadcastFailed',
+          schema: solanaIngressEgressCcmBroadcastFailed.refine(
+            (event) => event.broadcastId === broadcastId,
+          ),
+        },
+      });
+
+      if (broadcastResult.key === 'ccmBroadcastFailed') {
+        throw new Error(`CCM broadcast failed for ${destAsset} broadcast ${broadcastId}`);
+      }
+      break;
+    }
+    default:
+      throw new Error(`Unsupported CCM destination chain: ${destChain}`);
   }
 }
 
@@ -189,7 +355,10 @@ export async function doPerformSwap<A = []>(
     `Swap Request Completed. Waiting for egress scheduled event, balance increase and CCM emitted (if CCM swap).`,
   );
 
-  await waitForEgressScheduled(cf, swapRequestId, swapContext);
+  const egressId = await waitForEgressScheduled(cf, swapRequestId, swapContext);
+  if (messageMetadata) {
+    await waitForCcmExecution(cf, destAsset, egressId);
+  }
 
   try {
     const [newBalance] = await Promise.all([
@@ -469,7 +638,10 @@ export async function performVaultSwap<A extends WithBrokerAccount>(
       `Swap Request Completed. Waiting for egress scheduled event, balance increase and CCM emitted if CCM swap.`,
     );
 
-    await waitForEgressScheduled(cf, swapRequestId, swapContext);
+    const egressId = await waitForEgressScheduled(cf, swapRequestId, swapContext);
+    if (messageMetadata) {
+      await waitForCcmExecution(cf, destAsset, egressId);
+    }
 
     const [newBalance] = await Promise.all([
       observeBalanceIncrease(cf.logger, destAsset, destAddress, oldBalance),

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -25,7 +25,7 @@ const MAX_CCM_ADDITIONAL_DATA_LENGTH = 3000;
 // In Arbitrum's localnet large messages (~ >4k) end up with large gas estimations
 // of >70M gas, surpassing our hardcoded gas limit (25M) and Arbitrum's block gas
 // gas limit (32M). We cap it to a lower value than Ethereum to work around that.
-const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 10;
+const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 8;
 
 // Solana transactions have a length of 1232. Capping it to some reasonable values
 // that when construction the call the Solana length is not exceeded. Technically the
@@ -186,8 +186,9 @@ export async function newCcmMetadata(
   ccmMessage?: string,
   ccmAdditionalDataArray?: string,
 ): Promise<CcmDepositMetadata> {
-  const destChain = chainFromAsset(destAsset);
   const message = ccmMessage ?? newCcmMessage(destAsset);
+  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
+  const destChain = chainFromAsset(destAsset);
 
   let userLogicGasBudget;
   if (destChain === 'Arbitrum' || destChain === 'Ethereum') {
@@ -203,8 +204,6 @@ export async function newCcmMetadata(
   } else {
     throw new Error(`Unsupported chain: ${destChain}`);
   }
-
-  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
 
   return {
     message,

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -25,7 +25,7 @@ const MAX_CCM_ADDITIONAL_DATA_LENGTH = 3000;
 // In Arbitrum's localnet large messages (~ >4k) end up with large gas estimations
 // of >70M gas, surpassing our hardcoded gas limit (25M) and Arbitrum's block gas
 // gas limit (32M). We cap it to a lower value than Ethereum to work around that.
-const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 5;
+const ARB_MAX_CCM_MSG_LENGTH = MAX_CCM_MSG_LENGTH / 10;
 
 // Solana transactions have a length of 1232. Capping it to some reasonable values
 // that when construction the call the Solana length is not exceeded. Technically the
@@ -186,9 +186,8 @@ export async function newCcmMetadata(
   ccmMessage?: string,
   ccmAdditionalDataArray?: string,
 ): Promise<CcmDepositMetadata> {
-  const message = ccmMessage ?? newCcmMessage(destAsset);
-  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
   const destChain = chainFromAsset(destAsset);
+  const message = ccmMessage ?? newCcmMessage(destAsset);
 
   let userLogicGasBudget;
   if (destChain === 'Arbitrum' || destChain === 'Ethereum') {
@@ -204,6 +203,8 @@ export async function newCcmMetadata(
   } else {
     throw new Error(`Unsupported chain: ${destChain}`);
   }
+
+  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
 
   return {
     message,


### PR DESCRIPTION
# Pull Request

Closes: PRO-2549

## Summary

* This PR introduces a fix to the ARB CCM tests flakiness that was breaking turbo-bouncer
* The problem was that in ARB there a hard gas limit applied by the protocol, in CCM swaps data was chosen randomly and sometimes results in gas above the hard limit. The fix was to make ARB_MAX_CCM_MSG_LENGTH smaller.
* Instead of relying on the test timing out while waiting to observe the CCM, this PR adds more robust checking waiting for BroadcastSuccess or CcmBroadcastFailed state chain events failing the test fast  accordingly.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [ ] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
