### PR TITLE
fix: use full swap logic for get scheduled swaps rpc

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -330,6 +330,18 @@ impl<T: Config> Swap<T> {
 	) -> Self {
 		Self { swap_id, swap_request_id, from, to, input_amount, refund_params, execute_at }
 	}
+
+	pub fn without_refund_params(self) -> Self {
+		Self {
+			swap_id: self.swap_id,
+			swap_request_id: self.swap_request_id,
+			from: self.from,
+			to: self.to,
+			input_amount: self.input_amount,
+			refund_params: None,
+			execute_at: self.execute_at,
+		}
+	}
 }
 
 #[derive(Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq)]
@@ -1779,18 +1791,24 @@ pub mod pallet {
 				return vec![];
 			}
 
-			let mut swaps: Vec<_> = ScheduledSwaps::<T>::get()
+			let swaps: Vec<_> = ScheduledSwaps::<T>::get()
 				.values()
 				.filter(|swap| swap.from == base_asset || swap.to == base_asset)
 				.cloned()
-				.map(SwapState::new)
+				// Remove refund parameters for swap simulation to avoid price violations.
+				.map(|swap| swap.without_refund_params())
 				.collect();
 
-			// Can ignore the result here because we use pool price fallback below
-			let _res = Self::swap_into_stable_taking_fees(&mut swaps);
+			// Run the full execution logic
+			let BatchExecutionOutcomes { successful_swaps, failed_swaps } =
+				Self::execute_batch(swaps);
 
-			swaps
+			// Map the swaps to SwapLegInfo
+			successful_swaps
 				.into_iter()
+				// Turn the failed swaps into fresh swap states. Pool price fallback will be used
+				// for these swaps.
+				.chain(failed_swaps.into_iter().map(|(swap, _)| SwapState::new(swap)))
 				.filter_map(|state| {
 					let swap_request = SwapRequests::<T>::get(state.swap_request_id())
 						.expect("Swap request should exist");

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1363,24 +1363,10 @@ fn test_get_scheduled_swap_legs_fallback() {
 			Price::from_usd_fine_amount(PRICE),
 		);
 
+		// The order changed due to failed swaps being put after successful ones, but thats fine.
 		assert_eq!(
 			Swapping::get_scheduled_swap_legs(Asset::Eth),
 			vec![
-				(
-					SwapLegInfo {
-						swap_id: SwapId(1),
-						swap_request_id: SwapRequestId(1),
-						base_asset: Asset::Eth,
-						quote_asset: Asset::Usdc,
-						side: Side::Buy,
-						amount: INIT_AMOUNT * PRICE,
-						source_asset: Some(Asset::Flip),
-						source_amount: Some(INIT_AMOUNT),
-						remaining_chunks: 0,
-						chunk_interval: SWAP_DELAY_BLOCKS,
-					},
-					BLOCK
-				),
 				(
 					SwapLegInfo {
 						swap_id: SwapId(2),
@@ -1391,6 +1377,21 @@ fn test_get_scheduled_swap_legs_fallback() {
 						amount: INIT_AMOUNT,
 						source_asset: None,
 						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(1),
+						swap_request_id: SwapRequestId(1),
+						base_asset: Asset::Eth,
+						quote_asset: Asset::Usdc,
+						side: Side::Buy,
+						amount: INIT_AMOUNT * PRICE,
+						source_asset: Some(Asset::Flip),
+						source_amount: Some(INIT_AMOUNT),
 						remaining_chunks: 0,
 						chunk_interval: SWAP_DELAY_BLOCKS,
 					},


### PR DESCRIPTION
# Pull Request

## Summary

Fix for a bug in the `cf_scheduled_swaps` rpc. If a single swap would fail due to low liquidity, it would stop the execution loop and return error, leaving any other swaps not-executed. The non-executed swaps would use the pool price fallback.

- Fixed the `get_scheduled_swap_legs` partial execution bug
- Using full swap execution logic instead of just the `swap_into_stable_taking_fees` function. So now it will do the failed swap split off logic just like the real execution.
- Removed the refund params so that the price protection logic will be ignored. We fallback to pool price anyway, so might as well get the best swap estimation we can.

Note:
- The `get_scheduled_swap_legs` is refactored a lot in #6476. That PR has all of the above changes, but it will not get merged for a while, so I put up this fix in the meantime.
- The pool price fallback does not take the network and broker fees into account. This is existing behaviour and is out of scope for this PR.