### PR TITLE
feat: deduplicate scheduled set/close orders for the same order

### DIFF
--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -115,7 +115,7 @@ enum LimitOrderUpdateDetails<BlockNumber: sp_std::fmt::Debug> {
 }
 
 impl<T: Config> LimitOrderUpdate<T> {
-	fn targets_same_order(&self, other: &Self) -> bool {
+	fn can_override_order(&self, other: &Self) -> bool {
 		self.lp == other.lp &&
 			self.base_asset == other.base_asset &&
 			self.quote_asset == other.quote_asset &&
@@ -207,7 +207,7 @@ impl<T: Config> LimitOrderUpdate<T> {
 			let order_id = self.id;
 			ScheduledLimitOrderUpdates::<T>::try_mutate(dispatch_at, |orders| {
 				if let Some(scheduled_order) =
-					orders.iter_mut().find(|order| self.targets_same_order(order))
+					orders.iter_mut().find(|order| self.can_override_order(order))
 				{
 					*scheduled_order = self;
 				} else {

--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -115,6 +115,19 @@ enum LimitOrderUpdateDetails<BlockNumber: sp_std::fmt::Debug> {
 }
 
 impl<T: Config> LimitOrderUpdate<T> {
+	fn targets_same_order(&self, other: &Self) -> bool {
+		self.lp == other.lp &&
+			self.base_asset == other.base_asset &&
+			self.quote_asset == other.quote_asset &&
+			self.side == other.side &&
+			self.id == other.id &&
+			matches!(
+				(&self.details, &other.details),
+				(LimitOrderUpdateDetails::Set { .. }, LimitOrderUpdateDetails::Set { .. }) |
+					(LimitOrderUpdateDetails::Close, LimitOrderUpdateDetails::Close)
+			)
+	}
+
 	pub fn dispatch(self) -> (Weight, DispatchResult) {
 		let (weight, result) = match self.details {
 			LimitOrderUpdateDetails::Set { option_tick, sell_amount, close_order_at } => {
@@ -190,18 +203,29 @@ impl<T: Config> LimitOrderUpdate<T> {
 		/// The maximum number of scheduled updates per (lp, block number).
 		const MAX_SCHEDULED_UPDATES: u32 = 12;
 		ScheduledLimitOrderUpdateCount::<T>::try_mutate((self.lp.clone(), dispatch_at), |count| {
-			if *count >= MAX_SCHEDULED_UPDATES {
-				Err(Error::<T>::SheduledUpdateLimitReached)
-			} else {
-				*count += 1;
+			let lp = self.lp.clone();
+			let order_id = self.id;
+			ScheduledLimitOrderUpdates::<T>::try_mutate(dispatch_at, |orders| {
+				if let Some(scheduled_order) =
+					orders.iter_mut().find(|order| self.targets_same_order(order))
+				{
+					*scheduled_order = self;
+				} else {
+					ensure!(*count < MAX_SCHEDULED_UPDATES, Error::<T>::SheduledUpdateLimitReached);
+					*count += 1;
+					orders.push(self);
+				}
+
 				Pallet::<T>::deposit_event(Event::<T>::LimitOrderSetOrUpdateScheduled {
-					lp: self.lp.clone(),
-					order_id: self.id,
+					lp,
+					order_id,
 					dispatch_at,
 				});
-				ScheduledLimitOrderUpdates::<T>::append(dispatch_at, self);
+
 				Ok(())
-			}
+			})?;
+
+			Ok(())
 		})?;
 		Ok(())
 	}

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -453,6 +453,138 @@ fn can_execute_scheduled_limit_order_updates() {
 }
 
 #[test]
+fn scheduled_set_replaces_existing_set_for_same_order() {
+	const DISPATCH_AT: u64 = 2;
+	const ORDER_ID: OrderId = 0;
+	const FIRST_AMOUNT: AssetAmount = 55;
+	const SECOND_AMOUNT: AssetAmount = 77;
+
+	new_test_ext()
+		.execute_with(|| {
+			assert_ok!(LiquidityPools::new_pool(
+				RuntimeOrigin::root(),
+				Asset::Flip,
+				STABLE_ASSET,
+				400_000u32,
+				Price::at_tick_zero(),
+			));
+
+			MockBalance::credit_account(&ALICE, STABLE_ASSET, FIRST_AMOUNT + SECOND_AMOUNT);
+
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				ORDER_ID,
+				Some(100),
+				FIRST_AMOUNT,
+				Some(DISPATCH_AT),
+				None,
+			));
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				ORDER_ID,
+				Some(101),
+				SECOND_AMOUNT,
+				Some(DISPATCH_AT),
+				None,
+			));
+
+			assert_eq!(ScheduledLimitOrderUpdateCount::<Test>::get((ALICE, DISPATCH_AT)), 1);
+
+			let scheduled_updates = ScheduledLimitOrderUpdates::<Test>::get(DISPATCH_AT);
+			assert_eq!(scheduled_updates.len(), 1);
+			assert_eq!(
+				scheduled_updates[0].details,
+				LimitOrderUpdateDetails::Set {
+					option_tick: Some(101),
+					sell_amount: SECOND_AMOUNT,
+					close_order_at: None,
+				}
+			);
+		})
+		.then_process_blocks_until_block(DISPATCH_AT)
+		.then_execute_with(|_| {
+			let order =
+				LiquidityPools::pool_orders_for_account(Asset::Flip, STABLE_ASSET, &ALICE, false)
+					.unwrap()
+					.limit_orders
+					.bids
+					.into_iter()
+					.next()
+					.unwrap();
+
+			assert_eq!(order.tick, 101);
+			assert_eq!(order.sell_amount, SECOND_AMOUNT.into());
+		});
+}
+
+#[test]
+fn scheduled_close_replaces_existing_close_for_same_order() {
+	const CURRENT_BLOCK: u64 = 10;
+	const CLOSE_ORDER_AT: u64 = CURRENT_BLOCK + 1;
+	const ORDER_ID: OrderId = 0;
+	const AMOUNT: AssetAmount = 55;
+
+	new_test_ext()
+		.then_execute_at_block(CURRENT_BLOCK as u32, |_| {
+			assert_ok!(LiquidityPools::new_pool(
+				RuntimeOrigin::root(),
+				Asset::Flip,
+				STABLE_ASSET,
+				400_000u32,
+				Price::at_tick_zero(),
+			));
+
+			MockBalance::credit_account(&ALICE, STABLE_ASSET, AMOUNT * 2);
+
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				ORDER_ID,
+				Some(100),
+				AMOUNT,
+				None,
+				Some(CLOSE_ORDER_AT),
+			));
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				ORDER_ID,
+				Some(101),
+				AMOUNT,
+				None,
+				Some(CLOSE_ORDER_AT),
+			));
+
+			assert_eq!(ScheduledLimitOrderUpdateCount::<Test>::get((ALICE, CLOSE_ORDER_AT)), 1);
+
+			let scheduled_updates = ScheduledLimitOrderUpdates::<Test>::get(CLOSE_ORDER_AT);
+			assert_eq!(scheduled_updates.len(), 1);
+			assert_eq!(scheduled_updates[0].details, LimitOrderUpdateDetails::Close);
+		})
+		.then_process_blocks_until_block(CLOSE_ORDER_AT)
+		.then_execute_with(|_| {
+			assert_eq!(
+				LiquidityPools::pool_orders_for_account(Asset::Flip, STABLE_ASSET, &ALICE, false)
+					.unwrap()
+					.limit_orders
+					.bids
+					.len(),
+				0
+			);
+		});
+}
+
+#[test]
 fn test_dispatch_at_validation() {
 	const CURRENT_BLOCK: u64 = 10;
 	new_test_ext().then_execute_at_block(10u32, |_| {

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -585,6 +585,88 @@ fn scheduled_close_replaces_existing_close_for_same_order() {
 }
 
 #[test]
+fn scheduled_set_does_not_override_different_order() {
+	const DISPATCH_AT: u64 = 2;
+	const FIRST_ORDER_ID: OrderId = 0;
+	const SECOND_ORDER_ID: OrderId = 1;
+	const FIRST_AMOUNT: AssetAmount = 55;
+	const SECOND_AMOUNT: AssetAmount = 77;
+
+	new_test_ext()
+		.execute_with(|| {
+			assert_ok!(LiquidityPools::new_pool(
+				RuntimeOrigin::root(),
+				Asset::Flip,
+				STABLE_ASSET,
+				400_000u32,
+				Price::at_tick_zero(),
+			));
+
+			MockBalance::credit_account(&ALICE, STABLE_ASSET, FIRST_AMOUNT + SECOND_AMOUNT);
+
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				FIRST_ORDER_ID,
+				Some(100),
+				FIRST_AMOUNT,
+				Some(DISPATCH_AT),
+				None,
+			));
+			assert_ok!(LiquidityPools::set_limit_order(
+				RuntimeOrigin::signed(ALICE),
+				Asset::Flip,
+				STABLE_ASSET,
+				Side::Buy,
+				SECOND_ORDER_ID,
+				Some(101),
+				SECOND_AMOUNT,
+				Some(DISPATCH_AT),
+				None,
+			));
+
+			assert_eq!(ScheduledLimitOrderUpdateCount::<Test>::get((ALICE, DISPATCH_AT)), 2);
+
+			let scheduled_updates = ScheduledLimitOrderUpdates::<Test>::get(DISPATCH_AT);
+			assert_eq!(scheduled_updates.len(), 2);
+			assert_eq!(scheduled_updates[0].id, FIRST_ORDER_ID);
+			assert_eq!(
+				scheduled_updates[0].details,
+				LimitOrderUpdateDetails::Set {
+					option_tick: Some(100),
+					sell_amount: FIRST_AMOUNT,
+					close_order_at: None,
+				}
+			);
+			assert_eq!(scheduled_updates[1].id, SECOND_ORDER_ID);
+			assert_eq!(
+				scheduled_updates[1].details,
+				LimitOrderUpdateDetails::Set {
+					option_tick: Some(101),
+					sell_amount: SECOND_AMOUNT,
+					close_order_at: None,
+				}
+			);
+		})
+		.then_process_blocks_until_block(DISPATCH_AT)
+		.then_execute_with(|_| {
+			let bids =
+				LiquidityPools::pool_orders_for_account(Asset::Flip, STABLE_ASSET, &ALICE, false)
+					.unwrap()
+					.limit_orders
+					.bids;
+
+			assert_eq!(bids.len(), 2);
+			let by_tick: std::collections::BTreeMap<_, _> =
+				bids.into_iter().map(|o| (o.tick, o.sell_amount)).collect();
+			assert_eq!(by_tick.get(&100), Some(&FIRST_AMOUNT.into()));
+			assert_eq!(by_tick.get(&101), Some(&SECOND_AMOUNT.into()));
+		});
+}
+
+#[test]
 fn test_dispatch_at_validation() {
 	const CURRENT_BLOCK: u64 = 10;
 	new_test_ext().then_execute_at_block(10u32, |_| {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2814

## Summary

Deduplicate scheduled `Set`/`Close` orders targeting the same exact order (same lp, pool, side and id). 

---

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.