### PR TITLE
feat: add extra fields to SystemLiquidationExcessAmount

### DIFF
--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -1897,7 +1897,11 @@ export const palletCfLendingPoolsSupplyAddedActionType = z.discriminatedUnion('_
     loanId: numberOrHex,
     swapRequestId: numberOrHex,
   }),
-  z.object({ __kind: z.literal('SystemLiquidationUnusedAmount') }),
+  z.object({
+    __kind: z.literal('SystemLiquidationUnusedAmount'),
+    loanId: numberOrHex,
+    swapRequestId: numberOrHex,
+  }),
 ]);
 
 export const palletCfLendingPoolsSupplyRemovedActionType = simpleEnum([

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -475,7 +475,10 @@ impl<T: Config> LoanAccount<T> {
 				self.supply_from_liquidation(
 					from_asset,
 					swap_progress.remaining_input_amount,
-					SupplyAddedActionType::SystemLiquidationUnusedAmount,
+					SupplyAddedActionType::SystemLiquidationUnusedAmount {
+						loan_id,
+						swap_request_id,
+					},
 				);
 			} else {
 				log_or_panic!("Failed to abort swap request: {swap_request_id}");

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -3073,7 +3073,10 @@ fn adding_collateral_during_liquidation() {
 					lender_id: BORROWER,
 					asset: COLLATERAL_ASSET,
 					amount,
-					action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount,
+					action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount {
+						loan_id: LOAN_ID,
+						swap_request_id: LIQUIDATION_SWAP_1,
+					},
 				}) if amount == INIT_COLLATERAL - SWAPPED_COLLATERAL_1,
 				RuntimeEvent::LendingPools(Event::<Test>::LendingFundsRemoved {
 					lender_id: BORROWER,
@@ -3516,7 +3519,10 @@ mod voluntary_liquidation {
 						lender_id: BORROWER,
 						asset: COLLATERAL_ASSET,
 						amount,
-						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount,
+						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount {
+							loan_id: LOAN_ID,
+							swap_request_id: LIQUIDATION_SWAP,
+						},
 					}) if amount == INIT_COLLATERAL - SWAPPED_COLLATERAL,
 					RuntimeEvent::LendingPools(Event::<Test>::LoanSettled {
 						loan_id: LOAN_ID,
@@ -3720,7 +3726,10 @@ mod voluntary_liquidation {
 						lender_id: BORROWER,
 						asset: COLLATERAL_ASSET,
 						amount,
-						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount,
+						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount {
+							loan_id: LOAN_ID,
+							swap_request_id: LIQUIDATION_SWAP_1,
+						},
 					}) if amount == INIT_COLLATERAL - SWAPPED_COLLATERAL_1,
 					RuntimeEvent::LendingPools(Event::<Test>::LendingFundsRemoved {
 						lender_id: BORROWER,
@@ -3822,7 +3831,10 @@ mod voluntary_liquidation {
 						lender_id: BORROWER,
 						asset: COLLATERAL_ASSET,
 						amount,
-						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount,
+						action_type: SupplyAddedActionType::SystemLiquidationUnusedAmount {
+							loan_id: LOAN_ID,
+							swap_request_id: LIQUIDATION_SWAP_2,
+						},
 					}) if amount == INIT_COLLATERAL - SWAPPED_COLLATERAL_1 - SWAPPED_COLLATERAL_2,
 					RuntimeEvent::LendingPools(Event::<Test>::LendingFundsRemoved {
 						lender_id: BORROWER,

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -216,7 +216,7 @@ pub enum SupplyAddedActionType {
 	/// than was required.
 	SystemLiquidationExcessAmount { loan_id: LoanId, swap_request_id: SwapRequestId },
 	/// Triggered by the protocol when liquidation did not swap all of input amount.
-	SystemLiquidationUnusedAmount,
+	SystemLiquidationUnusedAmount { loan_id: LoanId, swap_request_id: SwapRequestId },
 }
 
 /// Indicates how the action of supplying funds was triggered.


### PR DESCRIPTION
# Pull Request

## Summary

As requested, adding `swap_request_id` and `loan_id` to `SystemLiquidationUnusedAmount` to match `SystemLiquidationExcessAmount`. fyi @GabrielBuragev

### Extrinsics & Events

- `LendingFundsAdded` has changed (contains `SystemLiquidationExcessAmount`)


