### PR TITLE
chore: fix cargo audit

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -77,6 +77,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0099: rustl-webpki issue, transitive and unrelated to us. Requires issuance of invalid certificates.
 # - RUSTSEC-2026-0104: rustls-webpki CRL parsing panic. Transitive via rustls (reqwest and libp2p). Per the advisory, "applications that do not use CRLs are not affected"; no CRL-related rustls-webpki APIs are reachable from this repo or any of the intermediate crates (reqwest, hyper-rustls, tokio-rustls, futures-rustls, libp2p-{tls,quic,websocket}, substrate, ethers-rs).
 # - RUSTSEC-2026-0105: core2 unmaintained/yanked. Transitive dependency of `cid` used by substrate's `sc-network`.
+# - RUSTSEC-2026-0114: Wasmtime panic when allocating a table exceeding the host address space. Dependency of substrate.
 #
 cf-audit = '''
 audit -D unmaintained -D unsound
@@ -121,6 +122,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0099
 	--ignore RUSTSEC-2026-0104
 	--ignore RUSTSEC-2026-0105
+	--ignore RUSTSEC-2026-0114
 '''
 
 [build]


### PR DESCRIPTION
# Pull Request

## Summary

RUSTSEC-2026-0114 is a (medium severity) wasmtime vulnerability that doesn't seem to apply to us (and it is a transitive depencency of substrate). Ignoring it is consitent with other wasmtime vulnerabilities.