### PR TITLE
feat: Remove collateral auto-topup

### DIFF
--- a/bouncer/generated/events/arbitrumIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/arbitrumIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const arbitrumIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfArbitrumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/assethubIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/assethubIngressEgress/depositBoosted.ts
@@ -18,7 +18,7 @@ export const assethubIngressEgressDepositBoosted = z.object({
   blockHeight: z.number(),
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfAssethubIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/bitcoinIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/bitcoinIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const bitcoinIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfBitcoinIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -1829,7 +1829,6 @@ export const palletCfLendingPoolsGeneralLendingConfigLendingPoolConfiguration = 
 
 export const palletCfLendingPoolsGeneralLendingConfigLtvThresholds = z.object({
   target: z.number(),
-  topup: z.number().nullish(),
   softLiquidation: z.number(),
   softLiquidationAbort: z.number(),
   hardLiquidation: z.number(),
@@ -1891,7 +1890,6 @@ export const palletCfLendingPoolsBoostBoostPoolId = z.object({
 
 export const palletCfLendingPoolsSupplyAddedActionType = z.discriminatedUnion('__kind', [
   z.object({ __kind: z.literal('Manual') }),
-  z.object({ __kind: z.literal('SystemTopup') }),
   z.object({
     __kind: z.literal('SystemLiquidationExcessAmount'),
     loanId: numberOrHex,

--- a/bouncer/generated/events/ethereumIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/ethereumIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const ethereumIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfEthereumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/lendingPools/collateralTopupAssetUpdated.ts
+++ b/bouncer/generated/events/lendingPools/collateralTopupAssetUpdated.ts
@@ -1,7 +1,0 @@
-import { z } from 'zod';
-import { accountId, cfPrimitivesChainsAssetsAnyAsset } from '../common';
-
-export const lendingPoolsCollateralTopupAssetUpdated = z.object({
-  borrowerId: accountId,
-  collateralTopupAsset: cfPrimitivesChainsAssetsAnyAsset.nullish(),
-});

--- a/bouncer/generated/events/polkadotIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/polkadotIngressEgress/depositBoosted.ts
@@ -18,7 +18,7 @@ export const polkadotIngressEgressDepositBoosted = z.object({
   blockHeight: z.number(),
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfPolkadotIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/solanaIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/solanaIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const solanaIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfSolanaIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/tests/lending.ts
+++ b/bouncer/tests/lending.ts
@@ -117,7 +117,6 @@ async function lendingTestForAsset<A = []>(
       api.tx.lendingPools.requestLoan(
         loanAsset,
         amountToFineAmount(loanAmount.toString(), assetDecimals(loanAsset)),
-        collateralAsset,
         null,
       ),
     expectedEvent: {

--- a/state-chain/cf-integration-tests/src/lending.rs
+++ b/state-chain/cf-integration-tests/src/lending.rs
@@ -106,13 +106,7 @@ fn basic_lending() {
 			));
 
 			// open the loan
-			assert_ok!(LendingPools::new_loan(
-				BORROWER.clone(),
-				LOAN_ASSET,
-				LOAN_AMOUNT,
-				Some(COLLATERAL_ASSET),
-				None
-			));
+			assert_ok!(LendingPools::new_loan(BORROWER.clone(), LOAN_ASSET, LOAN_AMOUNT, None));
 
 			// Check that we got the loan amount
 			assert_eq!(AssetBalances::get_balance(&BORROWER, LOAN_ASSET), LOAN_AMOUNT);

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1700,7 +1700,6 @@ where
 		cf_get_open_deposit_channels(account_id: Option<state_chain_runtime::AccountId>) -> ChainAccounts,
 		cf_affiliate_details(broker: state_chain_runtime::AccountId, affiliate: Option<state_chain_runtime::AccountId>) -> Vec<(state_chain_runtime::AccountId, AffiliateDetails)>,
 		cf_all_open_deposit_channels() -> Vec<OpenedDepositChannels>,
-		cf_lending_config() -> RpcLendingConfig,
 		cf_auction_state() -> RpcAuctionState [map: Into::into],
 	}
 
@@ -1838,6 +1837,20 @@ where
 			} else {
 				api.cf_loan_accounts(hash, borrower_id.clone())
 					.map(|accounts| accounts.into_iter().map(Into::into).collect())
+			}
+		})
+	}
+
+	fn cf_lending_config(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RpcLendingConfig> {
+		self.rpc_backend.with_versioned_runtime_api(at, |api, hash, version| {
+			if version < 17 {
+				#[expect(deprecated)]
+				api.cf_lending_config_before_version_17(hash).map(Into::into)
+			} else {
+				api.cf_lending_config(hash)
 			}
 		})
 	}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__lending_config_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__lending_config_serialization.snap
@@ -5,7 +5,6 @@ expression: config
 {
   "ltv_thresholds": {
     "target": 750000,
-    "topup": 800000,
     "soft_liquidation": 900000,
     "soft_liquidation_abort": 880000,
     "hard_liquidation": 950000,

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__loan_account_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__loan_account_serialization.snap
@@ -4,10 +4,6 @@ expression: loan_account
 ---
 {
   "account": "5C62Ck4UrFPiBtoCmeSrgF7x9yv9mn38446dhCpsi2mLHiFT",
-  "collateral_topup_asset": {
-    "chain": "Bitcoin",
-    "asset": "BTC"
-  },
   "ltv_ratio": "1333333333",
   "collateral": [
     {

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -1344,7 +1344,6 @@ fn loan_account_serialization() {
 
 	let loan_account = RpcLoanAccount::<_, U256> {
 		account: ID_1,
-		collateral_topup_asset: Some(Asset::Btc),
 		ltv_ratio: Some(FixedU64::from_rational(4, 3)),
 		collateral: vec![(AssetAndAmount { asset: Asset::Btc, amount: 3u128.into() })],
 		loans: vec![RpcLoan {
@@ -1392,7 +1391,6 @@ fn lending_config_serialization() {
 		ltv_thresholds: LtvThresholds {
 			low_ltv: Permill::from_percent(50),
 			target: Permill::from_percent(75),
-			topup: Some(Permill::from_percent(80)),
 			soft_liquidation: Permill::from_percent(90),
 			soft_liquidation_abort: Permill::from_percent(88),
 			hard_liquidation: Permill::from_percent(95),

--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -34,12 +34,11 @@ pub mod benchmark_types {
 	use sp_std::collections::btree_map::BTreeMap;
 
 	/// Mimics a realistic pallet call similar to `request_loan`.
-	/// Parameters: asset enum, amount (u128), optional asset, BTreeMap<Asset, Amount>
+	/// Parameters: asset enum, amount (u128), BTreeMap<Asset, Amount>
 	#[derive(TypeInfo, Clone, Encode, Decode, DecodeWithMemTracking, Debug, PartialEq, Eq)]
 	pub struct RealisticCallParams {
 		pub loan_asset: Asset,
 		pub loan_amount: AssetAmount,
-		pub collateral_topup_asset: Option<Asset>,
 		pub extra_collateral: BTreeMap<Asset, AssetAmount>,
 	}
 
@@ -53,7 +52,6 @@ pub mod benchmark_types {
 				RealisticCallParams {
 					loan_asset: Asset::Usdc,
 					loan_amount: 100_000_000_000u128,
-					collateral_topup_asset: Some(Asset::Eth),
 					extra_collateral,
 				}
 			}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1122,7 +1122,8 @@ pub mod pallet {
 		DepositBoosted {
 			deposit_address: Option<TargetChainAccount<T, I>>,
 			asset: TargetChainAsset<T, I>,
-			/// Per-source amounts funded (entries present only if that source contributed).
+			/// Per-source amounts funded, including the boost fee charged by that source
+			/// (entries present only if that source contributed).
 			amounts: BTreeMap<BoostSource, TargetChainAmount<T, I>>,
 			deposit_details: <T::TargetChain as Chain>::DepositDetails,
 			prewitnessed_deposit_id: PrewitnessedDepositId,
@@ -1132,8 +1133,9 @@ pub mod pallet {
 			// a non-gas asset. The ingress fee is taken *after* the boost fee.
 			ingress_fee: TargetChainAmount<T, I>,
 			max_boost_fee_bps: BasisPoints,
-			// Total fee the user paid for their deposit to be boosted.
-			boost_fee: TargetChainAmount<T, I>,
+			/// Per-source boost fees the user paid for their deposit to be boosted
+			/// (entries present only if that source contributed).
+			boost_fee: BTreeMap<BoostSource, TargetChainAmount<T, I>>,
 			action: DepositAction<T, I>,
 			origin_type: DepositOriginType,
 		},
@@ -2667,9 +2669,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				amount.into(),
 				boost_fee,
 			) {
-				Ok(BoostOutcome { total_fee, amounts }) => {
-					let boost_fee_amount = total_fee.unique_saturated_into();
-					let amount_after_boost_fee = amount.saturating_sub(boost_fee_amount);
+				Ok(BoostOutcome { amounts, fees }) => {
+					let total_boost_fee: AssetAmount = fees.values().copied().sum();
+					let amount_after_boost_fee =
+						amount.saturating_sub(total_boost_fee.unique_saturated_into());
 
 					// Note that ingress fee is deducted at the time of boosting rather than the
 					// time the deposit is finalised (which allows us to perform the channel
@@ -2701,7 +2704,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						deposit_details,
 						ingress_fee,
 						max_boost_fee_bps: boost_fee,
-						boost_fee: boost_fee_amount,
+						boost_fee: fees
+							.into_iter()
+							.map(|(source, fee)| (source, fee.unique_saturated_into()))
+							.collect(),
 						action,
 						origin_type: origin.into(),
 					});

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -156,7 +156,7 @@ fn basic_passive_boosting() {
 				deposit_details: Default::default(),
 				ingress_fee: INGRESS_FEE,
 				max_boost_fee_bps: BOOST_FEE_BPS,
-				boost_fee: BOOST_FEE,
+				boost_fee: [(BoostSource::LendingPool, BOOST_FEE)].into(),
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
 				origin_type: DepositOriginType::DepositChannel,
 			}));

--- a/state-chain/pallets/cf-lending-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lending-pools/src/benchmarking.rs
@@ -97,7 +97,6 @@ mod benchmarks {
 			RawOrigin::Signed(borrower.clone()).into(),
 			LOAN_ASSET,
 			amount,
-			Some(COLLATERAL_ASSET),
 			None,
 		));
 		let loan_account = LoanAccounts::<T>::get(borrower).unwrap();
@@ -141,7 +140,6 @@ mod benchmarks {
 				RawOrigin::Signed(borrower.clone()).into(),
 				loan_asset,
 				loan_amount,
-				Some(collateral_asset),
 				None,
 			));
 		}
@@ -428,13 +426,7 @@ mod benchmarks {
 		let price_cache = OraclePriceCache::<T>::default();
 
 		#[extrinsic_call]
-		request_loan(
-			RawOrigin::Signed(borrower),
-			LOAN_ASSET,
-			LOAN_AMOUNT,
-			Some(COLLATERAL_ASSET),
-			None,
-		);
+		request_loan(RawOrigin::Signed(borrower), LOAN_ASSET, LOAN_AMOUNT, None);
 
 		assert!(
 			LoanAccounts::<T>::iter()
@@ -463,13 +455,9 @@ mod benchmarks {
 			COLLATERAL_ASSET,
 			200_000_000,
 		));
-		assert_ok!(Pallet::<T>::request_loan(
-			origin.clone().into(),
-			LOAN_ASSET,
-			LOAN_AMOUNT,
-			Some(COLLATERAL_ASSET),
-			None,
-		));
+		assert_ok!(
+			Pallet::<T>::request_loan(origin.clone().into(), LOAN_ASSET, LOAN_AMOUNT, None,)
+		);
 
 		let total_owed = || {
 			LoanAccounts::<T>::iter()
@@ -516,36 +504,6 @@ mod benchmarks {
 		);
 
 		assert!(total_owed() < owed_before);
-	}
-
-	#[benchmark]
-	fn update_collateral_topup_asset() {
-		setup_lending_pool::<T>(NUMBER_OF_LENDERS);
-		let borrower = setup_lp_account::<T>(COLLATERAL_ASSET, 0);
-		let origin = RawOrigin::Signed(borrower.clone());
-
-		// Supply collateral and create a loan
-		assert_ok!(Pallet::<T>::create_lending_pool(gov_origin::<T>(), COLLATERAL_ASSET));
-		assert_ok!(Pallet::<T>::add_lender_funds(
-			origin.clone().into(),
-			COLLATERAL_ASSET,
-			200_000_000,
-		));
-		assert_ok!(Pallet::<T>::request_loan(
-			origin.clone().into(),
-			LOAN_ASSET,
-			50_000_000,
-			Some(COLLATERAL_ASSET),
-			None,
-		));
-
-		#[extrinsic_call]
-		update_collateral_topup_asset(origin, Some(LOAN_ASSET));
-
-		assert_eq!(
-			get_loan_accounts::<T>(Some(borrower)).first().unwrap().collateral_topup_asset,
-			Some(LOAN_ASSET)
-		);
 	}
 
 	#[benchmark]
@@ -652,26 +610,6 @@ mod benchmarks {
 		// Make sure that some interest was actually collected
 		let total_amount_after = GeneralLendingPools::<T>::get(LOAN_ASSET).unwrap().total_amount;
 		assert!(total_amount_after > total_amount_before);
-	}
-
-	#[benchmark]
-	fn loan_calculate_top_up_amount() {
-		let borrower = setup_lp_account::<T>(COLLATERAL_ASSET, 0);
-		let lender = setup_lp_account::<T>(LOAN_ASSET, 1);
-
-		create_pools_and_loans_for_some_assets::<T>(&borrower, &lender, 100_000_000);
-
-		let price_cache = get_prefilled_price_cache();
-		let loan_account = LoanAccounts::<T>::get(borrower.clone()).unwrap();
-
-		#[block]
-		{
-			assert_ok!(loan_account.calculate_top_up_amount(
-				&borrower,
-				LENDING_DEFAULT_CONFIG.ltv_thresholds.target,
-				&price_cache
-			));
-		}
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -250,14 +250,17 @@ impl<T: Config> BoostApi for Pallet<T> {
 		);
 
 		let mut amounts = BTreeMap::new();
+		let mut fees = BTreeMap::new();
 		if lending_pool_principal > 0 {
 			amounts.insert(BoostSource::LendingPool, lending_pool_principal + lending_pool_fee);
+			fees.insert(BoostSource::LendingPool, lending_pool_fee);
 		}
 		if boost_pool_principal > 0 {
 			amounts.insert(BoostSource::BoostPool, boost_pool_principal + boost_pool_fee);
+			fees.insert(BoostSource::BoostPool, boost_pool_fee);
 		}
 
-		Ok(BoostOutcome { total_fee, amounts })
+		Ok(BoostOutcome { amounts, fees })
 	}
 
 	fn finalise_boost(deposit_id: PrewitnessedDepositId, asset: Asset) -> BoostFinalisationOutcome {

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -95,7 +95,6 @@ pub enum LiquidationCompletionReason {
 #[scale_info(skip_type_params(T))]
 pub struct LoanAccount<T: Config> {
 	pub(super) borrower_id: T::AccountId,
-	pub(super) collateral_topup_asset: Option<Asset>,
 	pub(super) loans: BTreeMap<LoanId, GeneralLoan<T>>,
 	pub(super) liquidation_status: LiquidationStatus,
 	pub(super) voluntary_liquidation_requested: bool,
@@ -104,7 +103,7 @@ pub struct LoanAccount<T: Config> {
 #[derive(Clone, Debug)]
 enum SurplusOrDeficit {
 	Surplus(AssetAmount),
-	Deficit(AssetAmount),
+	Deficit,
 }
 
 #[derive(
@@ -152,7 +151,6 @@ impl<T: Config> LoanAccount<T> {
 	pub fn new(borrower_id: T::AccountId) -> Self {
 		Self {
 			borrower_id,
-			collateral_topup_asset: None,
 			loans: BTreeMap::new(),
 			liquidation_status: LiquidationStatus::NoLiquidation,
 			voluntary_liquidation_requested: false,
@@ -589,52 +587,6 @@ impl<T: Config> LoanAccount<T> {
 		}
 	}
 
-	/// Checks if a top up is required and if so, performs it. Returns
-	/// boolean indicating whether a topup has been performed.
-	#[transactional]
-	pub fn check_and_process_auto_top_up(
-		&mut self,
-		borrower_id: &T::AccountId,
-		ltv: FixedU64,
-		price_cache: &OraclePriceCache<T>,
-		weight_used: &mut Weight,
-	) -> Result<bool, DispatchError> {
-		let config = LendingConfig::<T>::get();
-
-		if config.ltv_thresholds.topup.is_none_or(|threshold| ltv <= threshold.into()) {
-			return Ok(false)
-		}
-
-		// No topup if topup asset is not specified:
-		let Some(collateral_topup_asset) = self.collateral_topup_asset else { return Ok(false) };
-
-		// Ignoring weight of sweep as we expect most borrowers to not have open orders
-		try_sweep::<T>(borrower_id);
-
-		weight_used.saturating_accrue(T::WeightInfo::loan_calculate_top_up_amount());
-		let top_up_amount =
-			self.calculate_top_up_amount(borrower_id, config.ltv_thresholds.target, price_cache)?;
-
-		if top_up_amount > 0 {
-			weight_used.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
-			T::Balance::try_debit_account(borrower_id, collateral_topup_asset, top_up_amount)
-				.inspect_err(|_| {
-					log_or_panic!("Unable to debit after checking balance");
-				})?;
-
-			supply_funds::<T>(
-				borrower_id.clone(),
-				collateral_topup_asset,
-				top_up_amount,
-				SupplyAddedActionType::SystemTopup,
-			)?;
-
-			Ok(true)
-		} else {
-			Ok(false)
-		}
-	}
-
 	fn calculate_collateral_surplus_or_deficit(
 		&self,
 		ltv_threshold_target: Permill,
@@ -650,38 +602,10 @@ impl<T: Config> LoanAccount<T> {
 			.ok_or(Error::<T>::InvalidConfigurationParameters)?;
 
 		if collateral_required_in_usd >= collateral_value_in_usd {
-			Ok(SurplusOrDeficit::Deficit(collateral_required_in_usd - collateral_value_in_usd))
+			Ok(SurplusOrDeficit::Deficit)
 		} else {
 			Ok(SurplusOrDeficit::Surplus(collateral_value_in_usd - collateral_required_in_usd))
 		}
-	}
-
-	pub(super) fn calculate_top_up_amount(
-		&self,
-		borrower_id: &T::AccountId,
-		ltv_threshold_target: Permill,
-		price_cache: &OraclePriceCache<T>,
-	) -> Result<AssetAmount, Error<T>> {
-		let Some(topup_asset) = self.collateral_topup_asset else {
-			return Ok(0);
-		};
-
-		let top_up_required_in_usd = match self
-			.calculate_collateral_surplus_or_deficit(ltv_threshold_target, price_cache)?
-		{
-			SurplusOrDeficit::Surplus(_) => 0,
-			SurplusOrDeficit::Deficit(amount) => amount,
-		};
-
-		// Auto top up is currently only possible from the primary collateral asset
-		let top_up_required_in_collateral_asset =
-			price_cache.amount_from_usd_value(topup_asset, top_up_required_in_usd)?;
-
-		// Don't attempt to charge more than what's available:
-		Ok(core::cmp::min(
-			T::Balance::get_balance(borrower_id, topup_asset),
-			top_up_required_in_collateral_asset,
-		))
 	}
 
 	/// Split collateral proportionally to the usd value of each loan (to give each loan a fair
@@ -1232,19 +1156,6 @@ impl<T: Config> GeneralLoan<T> {
 	}
 }
 
-/// Sweeping but it is a no-op if it fails for whatever reason
-fn try_sweep<T: Config>(account_id: &T::AccountId) {
-	use frame_support::sp_runtime::TransactionOutcome;
-
-	storage::with_transaction_unchecked(|| {
-		if T::PoolApi::sweep(account_id).is_ok() {
-			TransactionOutcome::Commit(())
-		} else {
-			TransactionOutcome::Rollback(())
-		}
-	})
-}
-
 /// Collateral amount linked to a specific loan
 #[derive(Debug)]
 pub(super) struct AssetCollateralForLoan {
@@ -1287,29 +1198,12 @@ pub fn lending_upkeep<T: Config>(current_block: BlockNumberFor<T>) -> Weight {
 					&mut weight_used,
 				);
 
-				let new_ltv = if let Ok(true) = loan_account.check_and_process_auto_top_up(
+				loan_account.update_liquidation_status(
 					borrower_id,
 					ltv,
 					&price_cache,
 					&mut weight_used,
-				) {
-					// A successful topup means we have to re-derive LTV
-					weight_used.saturating_accrue(T::WeightInfo::derive_ltv());
-					loan_account.derive_ltv(&price_cache)
-				} else {
-					Ok(ltv)
-				};
-
-				// `new_ltv` should always be Ok (otherwise we wouldn't be able to derive LTV the
-				// first time), but let's avoid unwrapping as a defensive measure:
-				new_ltv.and_then(|new_ltv| {
-					loan_account.update_liquidation_status(
-						borrower_id,
-						new_ltv,
-						&price_cache,
-						&mut weight_used,
-					)
-				})
+				)
 			});
 
 			// If all loans are repaid manually while in liquidation, liquidation swaps will be
@@ -1422,14 +1316,12 @@ impl<T: Config> LendingApi for Pallet<T> {
 	type AccountId = T::AccountId;
 
 	/// Create a new loan (assigning a new loan id) provided that the account's existing collateral
-	/// plus any `extra_collateral` is sufficient. Will update the primary collateral asset if
-	/// provided.
+	/// is sufficient.
 	#[transactional]
 	fn new_loan(
 		borrower_id: T::AccountId,
 		asset: Asset,
 		amount_to_borrow: AssetAmount,
-		collateral_topup_asset: Option<Asset>,
 		broker: Option<Beneficiary<T::AccountId>>,
 	) -> Result<LoanId, DispatchError> {
 		T::LpRegistrationApi::ensure_has_refund_address_for_asset(&borrower_id, asset)
@@ -1458,11 +1350,7 @@ impl<T: Config> LendingApi for Pallet<T> {
 		let loan_id = loan.id;
 
 		LoanAccounts::<T>::mutate(&borrower_id, |maybe_account| {
-			let account = Self::create_or_update_loan_account(
-				borrower_id.clone(),
-				maybe_account,
-				collateral_topup_asset,
-			)?;
+			let account = maybe_account.get_or_insert(LoanAccount::new(borrower_id.clone()));
 
 			// NOTE: it is important that this event is emitted before `OriginationFeeTaken` event
 			Self::deposit_event(Event::LoanCreated {
@@ -1596,26 +1484,6 @@ impl<T: Config> LendingApi for Pallet<T> {
 		})
 	}
 
-	fn update_collateral_topup_asset(
-		borrower_id: &Self::AccountId,
-		collateral_topup_asset: Option<Asset>,
-	) -> Result<(), DispatchError> {
-		LoanAccounts::<T>::try_mutate(borrower_id, |maybe_account| {
-			let loan_account = maybe_account.as_mut().ok_or(Error::<T>::LoanAccountNotFound)?;
-
-			if loan_account.collateral_topup_asset != collateral_topup_asset {
-				loan_account.collateral_topup_asset = collateral_topup_asset;
-
-				Self::deposit_event(Event::CollateralTopupAssetUpdated {
-					borrower_id: borrower_id.clone(),
-					collateral_topup_asset,
-				});
-			}
-
-			Ok(())
-		})
-	}
-
 	fn set_voluntary_liquidation_flag(borrower_id: Self::AccountId, value: bool) -> DispatchResult {
 		LoanAccounts::<T>::try_mutate(&borrower_id, |maybe_account| {
 			let loan_account = maybe_account.as_mut().ok_or(Error::<T>::LoanAccountNotFound)?;
@@ -1658,7 +1526,7 @@ pub fn remove_lender_funds<T: Config>(
 			.calculate_collateral_surplus_or_deficit(config.ltv_thresholds.target, &price_cache)?
 		{
 			SurplusOrDeficit::Surplus(amount) => amount,
-			SurplusOrDeficit::Deficit(_) => 0,
+			SurplusOrDeficit::Deficit => 0,
 		};
 
 		Some(price_cache.amount_from_usd_value(asset, surplus_usd)?)
@@ -1960,24 +1828,6 @@ impl<T: Config> Pallet<T> {
 		PendingNetworkFees::<T>::mutate(fee_asset, |pending_amount| {
 			pending_amount.saturating_accrue(fee_amount);
 		});
-	}
-
-	fn create_or_update_loan_account(
-		borrower_id: T::AccountId,
-		maybe_account: &mut Option<LoanAccount<T>>,
-		collateral_topup_asset: Option<Asset>,
-	) -> Result<&mut LoanAccount<T>, Error<T>> {
-		let account = maybe_account.get_or_insert(LoanAccount::new(borrower_id.clone()));
-
-		if account.collateral_topup_asset != collateral_topup_asset {
-			account.collateral_topup_asset = collateral_topup_asset;
-			Self::deposit_event(Event::CollateralTopupAssetUpdated {
-				borrower_id,
-				collateral_topup_asset: account.collateral_topup_asset,
-			});
-		}
-
-		Ok(account)
 	}
 
 	/// Mutates the pool for `asset` expecting it to exist. If the pool is missing the

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
@@ -75,8 +75,6 @@ pub struct LtvThresholds {
 	/// Borrowers aren't allowed to borrow more (or withdraw collateral) if their Loan-to-value
 	/// ratio (principal/collateral) would exceed this threshold.
 	pub target: Permill,
-	/// Reaching this threshold will trigger a top-up of the collateral
-	pub topup: Option<Permill>,
 	/// Reaching this threshold will trigger soft liquidation account's loans
 	pub soft_liquidation: Permill,
 	/// If a loan that's being liquidated reaches this threshold, it will be considered
@@ -97,11 +95,6 @@ pub struct LtvThresholds {
 impl LtvThresholds {
 	pub fn validate(&self) -> DispatchResult {
 		ensure!(self.soft_liquidation <= self.hard_liquidation, "Invalid LTV thresholds");
-		ensure!(
-			self.topup
-				.is_none_or(|topup| self.target <= topup && topup <= self.soft_liquidation),
-			"Invalid LTV thresholds"
-		);
 
 		ensure!(
 			self.hard_liquidation_abort < self.hard_liquidation &&

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -96,7 +96,6 @@ impl<Ctx: Clone> LendingTestRunnerExt for cf_test_utilities::TestExternalities<T
 					BORROWER,
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 				),
 				Ok(LOAN_ID)
@@ -213,7 +212,6 @@ fn create_loan_and_supply_collateral(
 	borrower: u64,
 	asset: Asset,
 	amount: AssetAmount,
-	collateral_topup_asset: Option<Asset>,
 	collateral: BTreeMap<Asset, AssetAmount>,
 ) -> Result<LoanId, DispatchError> {
 	for (collateral_asset, collateral_amount) in &collateral {
@@ -226,7 +224,7 @@ fn create_loan_and_supply_collateral(
 			*collateral_amount,
 		)?;
 	}
-	LendingPools::new_loan(borrower, asset, amount, collateral_topup_asset, None)
+	LendingPools::new_loan(borrower, asset, amount, None)
 }
 
 #[test]
@@ -380,7 +378,6 @@ fn basic_general_lending() {
 					BORROWER,
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 				),
 				Ok(LOAN_ID)
@@ -410,14 +407,6 @@ fn basic_general_lending() {
 					..
 				})
 			);
-			assert_no_matching_event!(
-				Test,
-				RuntimeEvent::LendingPools(Event::<Test>::CollateralTopupAssetUpdated {
-					borrower_id: BORROWER,
-					collateral_topup_asset: Some(COLLATERAL_ASSET),
-				}),
-			);
-
 			assert_has_event::<Test>(RuntimeEvent::LendingPools(
 				Event::<Test>::OriginationFeeTaken {
 					loan_id: LOAN_ID,
@@ -448,7 +437,6 @@ fn basic_general_lending() {
 				LoanAccounts::<Test>::get(BORROWER),
 				Some(LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: None,
 					liquidation_status: LiquidationStatus::NoLiquidation,
 					voluntary_liquidation_requested: false,
 					loans: BTreeMap::from([(
@@ -685,7 +673,6 @@ fn broker_interest_credited_to_broker() {
 				BORROWER,
 				LOAN_ASSET,
 				PRINCIPAL,
-				None,
 				Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
 			));
 
@@ -794,7 +781,6 @@ fn broker_fee_collected_after_pool_replenished() {
 				BORROWER,
 				LOAN_ASSET,
 				PRINCIPAL,
-				None,
 				Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
 			));
 
@@ -888,7 +874,7 @@ mod broker_fees {
 			SupplyAddedActionType::Manual,
 		));
 
-		LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None, Some(broker))
+		LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(broker))
 	}
 
 	/// `new_loan` rejects broker fees above [`MAX_BROKER_FEE_BPS`].
@@ -932,101 +918,6 @@ mod broker_fees {
 }
 
 #[test]
-fn collateral_auto_topup() {
-	const COLLATERAL_TOPUP: AssetAmount = INIT_COLLATERAL / 100;
-
-	// The user deposits this much of collateral asset into their balance at a later point
-	const EXTRA_FUNDS: AssetAmount = INIT_COLLATERAL;
-
-	fn get_ltv() -> FixedU64 {
-		let price_cache = OraclePriceCache::<Test>::default();
-		LoanAccounts::<Test>::get(BORROWER).unwrap().derive_ltv(&price_cache).unwrap()
-	}
-
-	new_test_ext()
-		.execute_with(|| {
-			MockPriceFeedApi::set_price_usd_fine(LOAN_ASSET, SWAP_RATE * 1_000_000);
-			MockPriceFeedApi::set_price_usd_fine(COLLATERAL_ASSET, 1_000_000);
-			setup_pool_with_funds(LOAN_ASSET, INIT_POOL_AMOUNT);
-
-			// Enable auto top-up for this test.
-			assert_ok!(Pallet::<Test>::update_pallet_config(
-				RuntimeOrigin::root(),
-				bounded_vec![PalletConfigUpdate::SetLtvThresholds {
-					ltv_thresholds: LtvThresholds {
-						topup: Some(Permill::from_percent(85)),
-						..CONFIG.ltv_thresholds
-					}
-				}],
-			));
-
-			MockBalance::credit_account(
-				&BORROWER,
-				COLLATERAL_ASSET,
-				INIT_COLLATERAL + COLLATERAL_TOPUP,
-			);
-			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-
-			assert_eq!(
-				create_loan_and_supply_collateral(
-					BORROWER,
-					LOAN_ASSET,
-					PRINCIPAL,
-					Some(COLLATERAL_ASSET),
-					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
-				),
-				Ok(LOAN_ID)
-			);
-
-			assert_eq!(get_ltv(), FixedU64::from_rational(750_075, 1_000_000)); // ~75%
-
-			// The price drops 1%, but that shouldn't trigger a top-up
-			// at the next block
-			MockPriceFeedApi::set_price_usd_fine(COLLATERAL_ASSET, 990_000);
-
-			assert_eq!(get_ltv(), FixedU64::from_rational(757_651_515, 1_000_000_000)); // ~76%
-		})
-		.then_execute_at_next_block(|_| {
-			// No change in collateral (no auto top up):
-			assert_eq!(get_collateral(), INIT_COLLATERAL);
-
-			// Drop the price further, this time auto-top up should be triggered
-			MockPriceFeedApi::set_price_usd_fine(COLLATERAL_ASSET, 870_000);
-
-			assert_eq!(get_ltv(), FixedU64::from_rational(862_155_173, 1_000_000_000)); // ~86%
-		})
-		.then_execute_at_next_block(|_| {
-			// The user only had a small amount in their balance, all of it gets used:
-			assert_eq!(get_collateral(), INIT_COLLATERAL + COLLATERAL_TOPUP);
-			assert_eq!(get_ltv(), FixedU64::from_rational(853_618_983, 1_000_000_000)); // ~85%
-			assert_eq!(MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET), 0);
-
-			// After we give the user more funds, auto-top up should bring CR back to target
-			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, EXTRA_FUNDS);
-
-			assert_has_event::<Test>(RuntimeEvent::LendingPools(
-				Event::<Test>::LendingFundsAdded {
-					lender_id: BORROWER,
-					asset: COLLATERAL_ASSET,
-					amount: COLLATERAL_TOPUP,
-					action_type: SupplyAddedActionType::SystemTopup,
-				},
-			));
-		})
-		.then_execute_at_next_block(|_| {
-			let collateral_topup_2 =
-				get_collateral().saturating_sub(INIT_COLLATERAL + COLLATERAL_TOPUP);
-
-			assert_ne!(collateral_topup_2, 0);
-			assert_eq!(get_ltv(), FixedU64::from_rational(80, 100)); // 80%
-			assert_eq!(
-				MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET),
-				EXTRA_FUNDS - collateral_topup_2
-			);
-		});
-}
-
-#[test]
 fn basic_loan_aggregation() {
 	// Should be able to borrow this amount without providing any extra collateral:
 	const EXTRA_PRINCIPAL_1: AssetAmount = PRINCIPAL / 100;
@@ -1061,7 +952,6 @@ fn basic_loan_aggregation() {
 				BORROWER,
 				LOAN_ASSET,
 				PRINCIPAL,
-				Some(COLLATERAL_ASSET),
 				BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 			),
 			Ok(LOAN_ID)
@@ -1116,7 +1006,6 @@ fn basic_loan_aggregation() {
 				LoanAccounts::<Test>::get(BORROWER).unwrap(),
 				LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: Some(COLLATERAL_ASSET),
 					loans: BTreeMap::from([(
 						LOAN_ID,
 						GeneralLoan {
@@ -1204,7 +1093,6 @@ fn basic_loan_aggregation() {
 				LoanAccounts::<Test>::get(BORROWER).unwrap(),
 				LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: Some(COLLATERAL_ASSET),
 					loans: BTreeMap::from([(
 						LOAN_ID,
 						GeneralLoan {
@@ -1445,7 +1333,6 @@ fn basic_liquidation() {
 				LoanAccounts::<Test>::get(BORROWER),
 				Some(LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: None,
 					liquidation_status: LiquidationStatus::NoLiquidation,
 					voluntary_liquidation_requested: false,
 					loans: BTreeMap::from([(
@@ -2035,7 +1922,6 @@ fn liquidation_with_outstanding_principal_and_owed_network_fees() {
 					BORROWER,
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 				),
 				Ok(LOAN_ID)
@@ -2421,7 +2307,6 @@ mod multi_asset_collateral_liquidation {
 						BORROWER,
 						LOAN_ASSET,
 						PRINCIPAL,
-						None,
 						BTreeMap::from([
 							(COLLATERAL_ASSET, INIT_COLLATERAL),
 							(COLLATERAL_ASSET_2, INIT_COLLATERAL_2),
@@ -2431,7 +2316,7 @@ mod multi_asset_collateral_liquidation {
 				);
 
 				assert_eq!(
-					LendingPools::new_loan(BORROWER, LOAN_ASSET_2, PRINCIPAL_2, None, None),
+					LendingPools::new_loan(BORROWER, LOAN_ASSET_2, PRINCIPAL_2, None),
 					Ok(LOAN_ID_2)
 				);
 			})
@@ -2658,7 +2543,6 @@ fn small_interest_amounts_accumulate() {
 					BORROWER,
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 				),
 				Ok(LOAN_ID)
@@ -2977,7 +2861,7 @@ fn borrowing_disallowed_during_liquidation() {
 			);
 
 			assert_noop!(
-				LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None, None),
+				LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 				Error::<Test>::LiquidationInProgress
 			);
 
@@ -2986,60 +2870,6 @@ fn borrowing_disallowed_during_liquidation() {
 				Error::<Test>::LiquidationInProgress
 			);
 		});
-}
-
-#[test]
-fn updating_collateral_topup_asset() {
-	const COLLATERAL_TOPUP_ASSET: Asset = Asset::Btc;
-
-	assert_ne!(COLLATERAL_ASSET, COLLATERAL_TOPUP_ASSET);
-
-	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).execute_with(|| {
-		// Must have LP role:
-		assert_noop!(
-			LendingPools::update_collateral_topup_asset(
-				RuntimeOrigin::signed(NON_LP),
-				Some(COLLATERAL_TOPUP_ASSET)
-			),
-			DispatchError::BadOrigin
-		);
-
-		// Must already have a loan account:
-		assert_noop!(
-			LendingPools::update_collateral_topup_asset(
-				RuntimeOrigin::signed(BORROWER),
-				Some(COLLATERAL_TOPUP_ASSET)
-			),
-			Error::<Test>::LoanAccountNotFound
-		);
-
-		// Should succeed after creating a loan (which creates an account):
-		MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
-		MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-
-		assert_eq!(
-			create_loan_and_supply_collateral(
-				BORROWER,
-				LOAN_ASSET,
-				PRINCIPAL,
-				None,
-				BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
-			),
-			Ok(LOAN_ID)
-		);
-
-		assert_ok!(LendingPools::update_collateral_topup_asset(
-			RuntimeOrigin::signed(BORROWER),
-			Some(COLLATERAL_TOPUP_ASSET)
-		));
-
-		assert_has_event::<Test>(RuntimeEvent::LendingPools(
-			Event::<Test>::CollateralTopupAssetUpdated {
-				borrower_id: BORROWER,
-				collateral_topup_asset: Some(COLLATERAL_TOPUP_ASSET),
-			},
-		));
-	});
 }
 
 #[test]
@@ -3111,7 +2941,6 @@ fn network_fees_under_full_utilisation() {
 					BORROWER,
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 				),
 				Ok(LOAN_ID)
@@ -3449,7 +3278,6 @@ fn adding_collateral_during_liquidation() {
 				get_account(),
 				LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: None,
 					loans: BTreeMap::from([(
 						LOAN_ID,
 						GeneralLoan {
@@ -3536,7 +3364,6 @@ fn full_loan_repayment_followed_by_full_liquidation() {
 				LoanAccounts::<Test>::get(BORROWER).unwrap(),
 				LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: None,
 					loans: Default::default(),
 					liquidation_status: LiquidationStatus::Liquidating {
 						liquidation_swaps: BTreeMap::from([(
@@ -3686,7 +3513,6 @@ fn full_loan_repayment_during_partial_liquidation() {
 				LoanAccounts::<Test>::get(BORROWER).unwrap(),
 				LoanAccount {
 					borrower_id: BORROWER,
-					collateral_topup_asset: None,
 					loans: Default::default(),
 					liquidation_status: LiquidationStatus::Liquidating {
 						liquidation_swaps: BTreeMap::from([(
@@ -3900,7 +3726,6 @@ mod voluntary_liquidation {
 					LoanAccounts::<Test>::get(BORROWER).unwrap(),
 					LoanAccount {
 						borrower_id: BORROWER,
-						collateral_topup_asset: None,
 						// The loan is partially repaid:
 						loans: BTreeMap::from([(
 							LOAN_ID,
@@ -4366,7 +4191,7 @@ mod safe_mode {
 	fn safe_mode_for_creating_loan() {
 		const INIT_COLLATERAL: AssetAmount = 2 * PRINCIPAL * SWAP_RATE;
 
-		let try_to_borrow = || LendingPools::new_loan(LP, LOAN_ASSET, PRINCIPAL, None, None);
+		let try_to_borrow = || LendingPools::new_loan(LP, LOAN_ASSET, PRINCIPAL, None);
 
 		new_test_ext().with_funded_pool(2 * INIT_POOL_AMOUNT).execute_with(|| {
 			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
@@ -4542,7 +4367,6 @@ mod whitelisting {
 				LOAN_ASSET,
 				PRINCIPAL,
 				None,
-				None,
 			));
 
 			assert_noop!(
@@ -4550,7 +4374,6 @@ mod whitelisting {
 					RuntimeOrigin::signed(NON_WHITELISTED_USER),
 					LOAN_ASSET,
 					PRINCIPAL,
-					None,
 					None,
 				),
 				Error::<Test>::AccountNotWhitelisted
@@ -4577,7 +4400,6 @@ fn init_liquidation_swaps_test() {
 
 	let mut loan_account = LoanAccount::<Test> {
 		borrower_id: BORROWER,
-		collateral_topup_asset: Some(Asset::Eth),
 		loans: BTreeMap::from([
 			(
 				LOAN_1,
@@ -4821,7 +4643,6 @@ fn can_repay_but_not_expand_or_create_a_loan_with_stale_price() {
 			BORROWER,
 			LOAN_ASSET,
 			PRINCIPAL,
-			Some(COLLATERAL_ASSET_1),
 			BTreeMap::from([(COLLATERAL_ASSET_1, INIT_COLLATERAL)])
 		));
 
@@ -4843,7 +4664,7 @@ fn can_repay_but_not_expand_or_create_a_loan_with_stale_price() {
 
 		// Or create a new loan
 		assert_noop!(
-			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(COLLATERAL_ASSET_1), None),
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 			Error::<Test>::OraclePriceUnavailable
 		);
 
@@ -4857,7 +4678,7 @@ fn can_repay_but_not_expand_or_create_a_loan_with_stale_price() {
 			SupplyAddedActionType::Manual,
 		));
 		assert_noop!(
-			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(COLLATERAL_ASSET_2), None),
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 			Error::<Test>::OraclePriceUnavailable
 		);
 	});
@@ -4933,7 +4754,6 @@ mod rpcs {
 						BORROWER,
 						LOAN_ASSET,
 						PRINCIPAL,
-						Some(COLLATERAL_ASSET),
 						BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 					),
 					Ok(LOAN_ID)
@@ -4944,7 +4764,6 @@ mod rpcs {
 						BORROWER_2,
 						LOAN_ASSET_2,
 						PRINCIPAL_2,
-						Some(COLLATERAL_ASSET_2),
 						BTreeMap::from([(COLLATERAL_ASSET_2, INIT_COLLATERAL_2)])
 					),
 					Ok(LOAN_ID_2)
@@ -4955,7 +4774,6 @@ mod rpcs {
 					super::rpc::get_loan_accounts::<Test>(Some(BORROWER)),
 					vec![RpcLoanAccount {
 						account: BORROWER,
-						collateral_topup_asset: Some(COLLATERAL_ASSET),
 						ltv_ratio: Some(FixedU64::from_rational(750_075, 1_000_000)),
 						collateral: vec![AssetAndAmount {
 							asset: COLLATERAL_ASSET,
@@ -5040,7 +4858,6 @@ mod rpcs {
 					vec![
 						RpcLoanAccount {
 							account: BORROWER_2,
-							collateral_topup_asset: Some(COLLATERAL_ASSET_2),
 							ltv_ratio: Some(FixedU64::from_rational(1_173_483_514, 1_000_000_000)),
 							// NOTE: all of collateral is in liquidation swaps, but we include
 							// any amount that has not been swapped yet:
@@ -5070,7 +4887,6 @@ mod rpcs {
 						},
 						RpcLoanAccount {
 							account: BORROWER,
-							collateral_topup_asset: Some(COLLATERAL_ASSET),
 							// LTV slightly increased due to interest payment:
 							ltv_ratio: Some(FixedU64::from_rational(750_075_090, 1_000_000_000)),
 							collateral: vec![AssetAndAmount {
@@ -5148,25 +4964,13 @@ fn loan_minimum_is_enforced() {
 
 		// Should not be able to create a loan below the minimum amount
 		assert_noop!(
-			LendingPools::new_loan(
-				BORROWER,
-				LOAN_ASSET,
-				MIN_LOAN_AMOUNT_ASSET - 1,
-				Some(COLLATERAL_ASSET),
-				None,
-			),
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, MIN_LOAN_AMOUNT_ASSET - 1, None,),
 			Error::<Test>::AmountBelowMinimum
 		);
 
 		// A loan equal to or above the minimum amount should be fine
 		assert_eq!(
-			LendingPools::new_loan(
-				BORROWER,
-				LOAN_ASSET,
-				MIN_LOAN_AMOUNT_ASSET,
-				Some(COLLATERAL_ASSET),
-				None,
-			),
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, MIN_LOAN_AMOUNT_ASSET, None,),
 			Ok(LOAN_ID)
 		);
 
@@ -5374,7 +5178,6 @@ fn expand_or_repay_loan_minimum_is_enforced() {
 				BORROWER,
 				LOAN_ASSET,
 				MIN_LOAN_AMOUNT_ASSET,
-				Some(COLLATERAL_ASSET),
 				BTreeMap::from([(COLLATERAL_ASSET, COLLATERAL_AMOUNT)])
 			),
 			Ok(LOAN_ID)
@@ -5454,16 +5257,13 @@ fn must_have_refund_address_for_loan_asset() {
 
 		// Should not be able to create a loan without a refund address set
 		assert_noop!(
-			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(COLLATERAL_ASSET), None),
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 			Error::<Test>::NoRefundAddressSet
 		);
 
 		// Set refund address and try again
 		MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-		assert_eq!(
-			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(COLLATERAL_ASSET), None),
-			Ok(LOAN_ID)
-		);
+		assert_eq!(LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None), Ok(LOAN_ID));
 	});
 }
 
@@ -5476,7 +5276,6 @@ fn can_handle_liquidation_with_zero_collateral() {
 	// want to make sure that it is handled gracefully.
 	let loan_account = LoanAccount::<Test> {
 		borrower_id: BORROWER,
-		collateral_topup_asset: None,
 		loans: BTreeMap::from([(
 			LOAN_ID,
 			GeneralLoan {
@@ -5531,10 +5330,7 @@ fn same_asset_loan() {
 				LOAN_ASSET,
 				INIT_COLLATERAL,
 			));
-			assert_eq!(
-				LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, Some(LOAN_ASSET), None),
-				Ok(LOAN_ID)
-			);
+			assert_eq!(LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None), Ok(LOAN_ID));
 
 			// Supply additional collateral and expand
 			assert_ok!(LendingPools::add_lender_funds(
@@ -5660,7 +5456,7 @@ mod supply_as_collateral {
 				);
 
 				assert_eq!(
-					LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None, None),
+					LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 					Ok(LOAN_ID)
 				);
 
@@ -5816,7 +5612,7 @@ mod supply_as_collateral {
 				);
 
 				assert_eq!(
-					LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None, None),
+					LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None),
 					Ok(LOAN_ID)
 				);
 			})
@@ -5832,7 +5628,6 @@ mod supply_as_collateral {
 						BORROWER_2,
 						COLLATERAL_ASSET,
 						PRINCIPAL_2,
-						None,
 						BTreeMap::from([(COLLATERAL_ASSET_2, INIT_COLLATERAL)])
 					),
 					Ok(LOAN_2_ID)
@@ -5905,7 +5700,6 @@ mod supply_as_collateral {
 					get_account(),
 					LoanAccount {
 						borrower_id: BORROWER,
-						collateral_topup_asset: None,
 						loans: BTreeMap::from([(
 							LOAN_ID,
 							GeneralLoan {
@@ -6001,7 +5795,6 @@ mod supply_as_collateral {
 						BORROWER,
 						LOAN_ASSET,
 						PRINCIPAL,
-						None,
 						BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 					),
 					Ok(LOAN_ID)
@@ -6064,7 +5857,6 @@ mod supply_as_collateral {
 						BORROWER,
 						LOAN_ASSET,
 						PRINCIPAL,
-						None,
 						BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 					),
 					Ok(LOAN_ID)
@@ -6192,13 +5984,7 @@ mod utilisation_cap {
 
 				// A large loan should fail due to hitting utilisation cap:
 				assert_noop!(
-					LendingPools::new_loan(
-						BORROWER_2,
-						COLLATERAL_ASSET,
-						EXCESSIVE_BORROW,
-						None,
-						None
-					),
+					LendingPools::new_loan(BORROWER_2, COLLATERAL_ASSET, EXCESSIVE_BORROW, None),
 					Error::<Test>::UtilisationCapExceeded
 				);
 				assert_eq!(eth_pool_utilisation(), utilisation_before);
@@ -6208,7 +5994,6 @@ mod utilisation_cap {
 					BORROWER_2,
 					COLLATERAL_ASSET,
 					MODEST_BORROW,
-					None,
 					None
 				));
 				let utilisation_after = eth_pool_utilisation();
@@ -6380,7 +6165,6 @@ mod utilisation_cap {
 				BORROWER_A,
 				Asset::Usdt,
 				LOAN_A_USDT,
-				None,
 				None
 			));
 			// Loan B:
@@ -6388,7 +6172,6 @@ mod utilisation_cap {
 				BORROWER_B,
 				Asset::Usdc,
 				LOAN_B_USDC,
-				None,
 				None
 			));
 			// Loan C:
@@ -6396,7 +6179,6 @@ mod utilisation_cap {
 				BORROWER_C,
 				Asset::Btc,
 				LOAN_C_BTC,
-				None,
 				None
 			));
 
@@ -6495,7 +6277,7 @@ mod utilisation_cap {
 				Asset::Usdt,
 				SUPPLY,
 			));
-			assert_ok!(LendingPools::new_loan(USER_B, Asset::Usdc, BORROW_B, None, None));
+			assert_ok!(LendingPools::new_loan(USER_B, Asset::Usdc, BORROW_B, None));
 
 			assert_eq!(
 				GeneralLendingPools::<Test>::get(Asset::Usdc).unwrap().get_utilisation(),
@@ -6505,7 +6287,7 @@ mod utilisation_cap {
 			// Step 4: A borrows 40 BTC. The new collateral-pool cap check rejects this because
 			// USDC's cap drops below USDC's existing 80% utilisation.
 			assert_noop!(
-				LendingPools::new_loan(USER_A, Asset::Btc, BORROW_A, None, None),
+				LendingPools::new_loan(USER_A, Asset::Btc, BORROW_A, None),
 				Error::<Test>::CollateralPoolUtilisationCapExceeded,
 			);
 		});

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/rpc.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/rpc.rs
@@ -67,7 +67,6 @@ pub struct RpcLiquidationStatus {
 #[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct RpcLoanAccount<AccountId, Amount> {
 	pub account: AccountId,
-	pub collateral_topup_asset: Option<Asset>,
 	pub ltv_ratio: Option<FixedU64>,
 	pub collateral: Vec<AssetAndAmount<Amount>>,
 	pub loans: Vec<RpcLoan<AccountId, Amount>>,
@@ -91,7 +90,6 @@ impl<AccountId> From<RpcLoanAccount<AccountId, AssetAmount>> for RpcLoanAccount<
 	fn from(acc: RpcLoanAccount<AccountId, AssetAmount>) -> Self {
 		Self {
 			account: acc.account,
-			collateral_topup_asset: acc.collateral_topup_asset,
 			ltv_ratio: acc.ltv_ratio,
 			collateral: acc.collateral.into_iter().map(Into::into).collect(),
 			loans: acc.loans.into_iter().map(Into::into).collect(),
@@ -127,7 +125,6 @@ fn build_rpc_loan_account<T: Config>(
 
 	RpcLoanAccount {
 		account: borrower_id.clone(),
-		collateral_topup_asset: loan_account.collateral_topup_asset,
 		ltv_ratio: loan_account.derive_ltv(price_cache).ok(),
 		collateral: loan_account
 			.get_total_collateral()

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -210,9 +210,6 @@ pub enum LoanUsage {
 pub enum SupplyAddedActionType {
 	/// Triggered manually by the user. Funds are taken from the user's free balance.
 	Manual,
-	/// Triggered by the protocol due to high LTV. Funds are taken from the user's free
-	/// balance.
-	SystemTopup,
 	/// Triggered by the protocol as a result of liquidation obtaining more of the loan asset
 	/// than was required.
 	SystemLiquidationExcessAmount { loan_id: LoanId, swap_request_id: SwapRequestId },
@@ -271,7 +268,6 @@ const LENDING_DEFAULT_CONFIG: LendingConfiguration = LendingConfiguration {
 	},
 	ltv_thresholds: LtvThresholds {
 		target: Permill::from_percent(80),
-		topup: None,
 		soft_liquidation: Permill::from_percent(90),
 		soft_liquidation_abort: Permill::from_percent(88),
 		hard_liquidation: Permill::from_percent(95),
@@ -473,10 +469,6 @@ pub mod pallet {
 		LoanUpdated {
 			loan_id: LoanId,
 			extra_principal_amount: AssetAmount,
-		},
-		CollateralTopupAssetUpdated {
-			borrower_id: T::AccountId,
-			collateral_topup_asset: Option<Asset>,
 		},
 		OriginationFeeTaken {
 			loan_id: LoanId,
@@ -921,7 +913,6 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			loan_asset: Asset,
 			loan_amount: AssetAmount,
-			collateral_topup_asset: Option<Asset>,
 			broker: Option<Beneficiary<T::AccountId>>,
 		) -> DispatchResult {
 			let borrower_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
@@ -931,23 +922,9 @@ pub mod pallet {
 				Error::<T>::AccountNotWhitelisted
 			);
 
-			Self::new_loan(borrower_id, loan_asset, loan_amount, collateral_topup_asset, broker)?;
+			Self::new_loan(borrower_id, loan_asset, loan_amount, broker)?;
 
 			Ok(())
-		}
-
-		#[pallet::call_index(10)]
-		#[pallet::weight(T::WeightInfo::update_collateral_topup_asset())]
-		pub fn update_collateral_topup_asset(
-			origin: OriginFor<T>,
-			collateral_topup_asset: Option<Asset>,
-		) -> DispatchResult {
-			let borrower_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
-
-			<Self as LendingApi>::update_collateral_topup_asset(
-				&borrower_id,
-				collateral_topup_asset,
-			)
 		}
 
 		#[pallet::call_index(11)]

--- a/state-chain/pallets/cf-lending-pools/src/migrations/lending_config_migration.rs
+++ b/state-chain/pallets/cf-lending-pools/src/migrations/lending_config_migration.rs
@@ -5,9 +5,19 @@ pub struct Migration<T: Config>(PhantomData<T>);
 
 mod old {
 	use super::*;
-	use crate::general_lending::config::{
-		LendingPoolConfiguration, LtvThresholds, NetworkFeeContributions,
-	};
+	use crate::general_lending::config::{LendingPoolConfiguration, NetworkFeeContributions};
+
+	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+	pub struct LtvThresholds {
+		pub target: Permill,
+		// This field is being removed:
+		pub topup: Option<Permill>,
+		pub soft_liquidation: Permill,
+		pub soft_liquidation_abort: Permill,
+		pub hard_liquidation: Permill,
+		pub hard_liquidation_abort: Permill,
+		pub low_ltv: Permill,
+	}
 
 	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 	pub struct LendingConfiguration {
@@ -33,16 +43,24 @@ mod old {
 
 impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 	fn on_runtime_upgrade() -> Weight {
-		// Reads the on-chain `LendingConfig` value as the old (pre-`liquidation_coverage_factor`)
-		// layout and rewrites it with the new field defaulted to 100%, matching
-		// `LENDING_DEFAULT_CONFIG`. If decoding the old layout fails (e.g. on a fresh chain
-		// where no value has been written), we leave the storage empty so subsequent reads
-		// fall back to `LendingConfigDefault`, which already includes the new field.
+		// Reads the on-chain `LendingConfig` value as the old (pre-`liquidation_coverage_factor`,
+		// pre-topup-removal) layout and rewrites it with `liquidation_coverage_factor` defaulted
+		// to 100% (matching `LENDING_DEFAULT_CONFIG`) and the now-removed `LtvThresholds.topup`
+		// dropped. If decoding the old layout fails (e.g. on a fresh chain where no value has
+		// been written), we leave the storage empty so subsequent reads fall back to
+		// `LendingConfigDefault`, which already has the new shape.
 		let translate_result = LendingConfig::<T>::translate::<old::LendingConfiguration, _>(
 			|maybe_old: Option<old::LendingConfiguration>| {
 				maybe_old.map(|old| LendingConfiguration {
 					default_pool_config: old.default_pool_config,
-					ltv_thresholds: old.ltv_thresholds,
+					ltv_thresholds: LtvThresholds {
+						target: old.ltv_thresholds.target,
+						soft_liquidation: old.ltv_thresholds.soft_liquidation,
+						soft_liquidation_abort: old.ltv_thresholds.soft_liquidation_abort,
+						hard_liquidation: old.ltv_thresholds.hard_liquidation,
+						hard_liquidation_abort: old.ltv_thresholds.hard_liquidation_abort,
+						low_ltv: old.ltv_thresholds.low_ltv,
+					},
 					network_fee_contributions: old.network_fee_contributions,
 					fee_swap_interval_blocks: old.fee_swap_interval_blocks,
 					interest_payment_interval_blocks: old.interest_payment_interval_blocks,

--- a/state-chain/pallets/cf-lending-pools/src/migrations/loan_account_migration.rs
+++ b/state-chain/pallets/cf-lending-pools/src/migrations/loan_account_migration.rs
@@ -48,7 +48,7 @@ fn migrate_loan<T: Config>(old_loan: old::GeneralLoan<T>) -> general_lending::Ge
 impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 	fn on_runtime_upgrade() -> Weight {
 		// Migrate user loan accounts: move collateral to supply pools, drop the `collateral`
-		// field, and add `broker: None` to every nested loan.
+		// and `collateral_topup_asset` fields, and add `broker: None` to every nested loan.
 		let old_accounts: Vec<_> = old::LoanAccounts::<T>::drain().collect();
 
 		for (account_id, old_account) in &old_accounts {
@@ -86,8 +86,8 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 				}
 			}
 
-			// Write the new LoanAccount without the collateral field, with `broker: None`
-			// added to each loan.
+			// Write the new LoanAccount: drop the `collateral` and `collateral_topup_asset`
+			// fields, and add `broker: None` to each nested loan.
 			let migrated_loans = old_account
 				.loans
 				.iter()
@@ -98,7 +98,6 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 				account_id,
 				LoanAccount {
 					borrower_id: old_account.borrower_id.clone(),
-					collateral_topup_asset: old_account.collateral_topup_asset,
 					loans: migrated_loans,
 					liquidation_status: old_account.liquidation_status.clone(),
 					voluntary_liquidation_requested: old_account.voluntary_liquidation_requested,
@@ -107,7 +106,8 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 		}
 
 		log::info!(
-			"Migrated {} loan accounts (collateral moved to supply pools, broker field added)",
+			"Migrated {} loan accounts (collateral moved to supply pools, collateral_topup_asset \
+			 dropped, broker field added)",
 			old_accounts.len(),
 		);
 

--- a/state-chain/pallets/cf-lending-pools/src/mocks.rs
+++ b/state-chain/pallets/cf-lending-pools/src/mocks.rs
@@ -57,7 +57,6 @@ pub type AccountId = <Test as frame_system::Config>::AccountId;
 
 pub const LP: AccountId = 123u64;
 pub const OTHER_LP: AccountId = 234u64;
-pub const NON_LP: AccountId = 345u64;
 pub const BOOSTER_1: AccountId = 1;
 pub const BOOSTER_2: AccountId = 2;
 pub const BOOSTER_3: AccountId = 3;

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -132,7 +132,6 @@ fn can_update_all_config_items() {
 
 		const NEW_LTV_THRESHOLDS: LtvThresholds = LtvThresholds {
 			target: Permill::from_percent(61),
-			topup: Some(Permill::from_percent(71)),
 			soft_liquidation: Permill::from_percent(81),
 			soft_liquidation_abort: Permill::from_percent(80),
 			hard_liquidation: Permill::from_percent(91),
@@ -1685,7 +1684,7 @@ fn get_all_loans_returns_boost_and_user_loans() {
 			Asset::Btc,
 			BTC_COLLATERAL,
 		));
-		assert_ok!(LendingPools::new_loan(LP, BOOST_ASSET, PRINCIPAL, None, Some(BROKER)));
+		assert_ok!(LendingPools::new_loan(LP, BOOST_ASSET, PRINCIPAL, Some(BROKER)));
 
 		// Boost: owed_principal = required_amount + pool_fee + 0 network_fee =
 		// BOOST_DEPOSIT_AMOUNT.

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -1148,7 +1148,7 @@ fn boost_pool_details() {
 /// Boosting with both lending and legacy boost pools
 mod hybrid_boosting {
 
-	use cf_traits::lending::BoostFinalisationOutcome;
+	use cf_traits::lending::{BoostFinalisationOutcome, BoostOutcome, BoostSource};
 
 	use super::*;
 
@@ -1223,12 +1223,21 @@ mod hybrid_boosting {
 			frame_system::Pallet::<Test>::reset_events();
 
 			// 3. Boost deposit.
-			assert_ok!(LendingPools::try_boosting(
-				DEPOSIT_ID,
-				BOOST_ASSET,
-				DEPOSIT_AMOUNT,
-				BOOST_FEE_BPS,
-			));
+			assert_eq!(
+				LendingPools::try_boosting(DEPOSIT_ID, BOOST_ASSET, DEPOSIT_AMOUNT, BOOST_FEE_BPS,),
+				Ok(BoostOutcome {
+					amounts: [
+						(BoostSource::LendingPool, LENDING_FUNDS + LENDING_FEE_TOTAL),
+						(BoostSource::BoostPool, LEGACY_POOL_FUNDS + LEGACY_FEE_TOTAL),
+					]
+					.into(),
+					fees: [
+						(BoostSource::LendingPool, LENDING_FEE_TOTAL),
+						(BoostSource::BoostPool, LEGACY_FEE_TOTAL),
+					]
+					.into(),
+				})
+			);
 
 			assert_event_sequence!(
 				Test,

--- a/state-chain/pallets/cf-lending-pools/src/weights.rs
+++ b/state-chain/pallets/cf-lending-pools/src/weights.rs
@@ -60,14 +60,12 @@ pub trait WeightInfo {
 	fn request_loan() -> Weight;
 	fn expand_loan() -> Weight;
 	fn make_repayment() -> Weight;
-	fn update_collateral_topup_asset() -> Weight;
 	fn usd_value_of() -> Weight;
 	fn initiate_network_fee_swap() -> Weight;
 	fn derive_ltv() -> Weight;
 	fn loan_charge_interest() -> Weight;
 	fn loan_charge_low_ltv_penalty() -> Weight;
 	fn collect_pending_interest() -> Weight;
-	fn loan_calculate_top_up_amount() -> Weight;
 	fn start_liquidation_swaps() -> Weight;
 	fn abort_liquidation_swaps() -> Weight;
 	fn change_voluntary_liquidation() -> Weight;
@@ -317,19 +315,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
-	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LendingPools::LoanAccounts` (r:1 w:1)
-	/// Proof: `LendingPools::LoanAccounts` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn update_collateral_topup_asset() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `839`
-		//  Estimated: `4304`
-		// Minimum execution time: 28_046_000 picoseconds.
-		Weight::from_parts(28_448_000, 4304)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
 	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
 	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn usd_value_of() -> Weight {
@@ -398,16 +383,6 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 		Weight::from_parts(246_302_000, 43824)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
-	}
-	/// Storage: `AssetBalances::FreeBalances` (r:1 w:0)
-	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn loan_calculate_top_up_amount() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `278`
-		//  Estimated: `3743`
-		// Minimum execution time: 16_764_000 picoseconds.
-		Weight::from_parts(17_181_000, 3743)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	/// Storage: `LendingPools::LendingConfig` (r:1 w:0)
 	/// Proof: `LendingPools::LendingConfig` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -711,19 +686,6 @@ impl WeightInfo for () {
 			.saturating_add(ParityDbWeight::get().reads(7_u64))
 			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
-	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
-	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LendingPools::LoanAccounts` (r:1 w:1)
-	/// Proof: `LendingPools::LoanAccounts` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn update_collateral_topup_asset() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `839`
-		//  Estimated: `4304`
-		// Minimum execution time: 28_046_000 picoseconds.
-		Weight::from_parts(28_448_000, 4304)
-			.saturating_add(ParityDbWeight::get().reads(2_u64))
-			.saturating_add(ParityDbWeight::get().writes(1_u64))
-	}
 	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
 	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn usd_value_of() -> Weight {
@@ -792,16 +754,6 @@ impl WeightInfo for () {
 		Weight::from_parts(246_302_000, 43824)
 			.saturating_add(ParityDbWeight::get().reads(2_u64))
 			.saturating_add(ParityDbWeight::get().writes(2_u64))
-	}
-	/// Storage: `AssetBalances::FreeBalances` (r:1 w:0)
-	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn loan_calculate_top_up_amount() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `278`
-		//  Estimated: `3743`
-		// Minimum execution time: 16_764_000 picoseconds.
-		Weight::from_parts(17_181_000, 3743)
-			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 	/// Storage: `LendingPools::LendingConfig` (r:1 w:0)
 	/// Proof: `LendingPools::LendingConfig` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -332,6 +332,8 @@ decl_runtime_apis!(
 		fn cf_lending_pool_supply_balances(
 			asset: Option<Asset>,
 		) -> Vec<LendingPoolAndSupplyPositions<AccountId32, AssetAmount>>;
+		#[changed_in(17)]
+		fn cf_lending_config() -> before_version_17::RpcLendingConfig;
 		fn cf_lending_config() -> RpcLendingConfig;
 		fn cf_evm_calldata(
 			caller: EvmAddress,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -1,7 +1,7 @@
 use super::*;
 use cf_traits::lending::LoanId;
 use frame_support::sp_runtime::Percent;
-use pallet_cf_lending_pools::LendingPoolConfiguration;
+use pallet_cf_lending_pools::{LendingPoolConfiguration, NetworkFeeContributions};
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct BoostConfiguration {
@@ -44,7 +44,6 @@ impl<AccountId: Clone> From<RpcLoanAccount<AccountId, AssetAmount>>
 		let account = acc.account;
 		Self {
 			account: account.clone(),
-			collateral_topup_asset: acc.collateral_topup_asset,
 			ltv_ratio: acc.ltv_ratio,
 			collateral: acc.collateral.into_iter().map(Into::into).collect(),
 			loans: acc
@@ -87,6 +86,71 @@ impl<Amount> From<RpcLendingPool<Amount>> for pallet_cf_lending_pools::RpcLendin
 			utilisation_cap: Permill::one(),
 			current_interest_rate: value.current_interest_rate,
 			config: value.config,
+		}
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug)]
+pub struct LtvThresholds {
+	pub target: Permill,
+	pub topup: Option<Permill>,
+	pub soft_liquidation: Permill,
+	pub soft_liquidation_abort: Permill,
+	pub hard_liquidation: Permill,
+	pub hard_liquidation_abort: Permill,
+	pub low_ltv: Permill,
+}
+
+impl From<LtvThresholds> for pallet_cf_lending_pools::LtvThresholds {
+	fn from(value: LtvThresholds) -> Self {
+		Self {
+			target: value.target,
+			soft_liquidation: value.soft_liquidation,
+			soft_liquidation_abort: value.soft_liquidation_abort,
+			hard_liquidation: value.hard_liquidation,
+			hard_liquidation_abort: value.hard_liquidation_abort,
+			low_ltv: value.low_ltv,
+		}
+	}
+}
+
+#[derive(Encode, Decode, TypeInfo, Clone, Debug)]
+pub struct RpcLendingConfig {
+	pub ltv_thresholds: LtvThresholds,
+	pub network_fee_contributions: NetworkFeeContributions,
+	pub fee_swap_interval_blocks: u32,
+	pub interest_payment_interval_blocks: u32,
+	pub fee_swap_threshold_usd: U256,
+	pub interest_collection_threshold_usd: U256,
+	pub soft_liquidation_swap_chunk_size_usd: U256,
+	pub hard_liquidation_swap_chunk_size_usd: U256,
+	pub soft_liquidation_max_oracle_slippage: BasisPoints,
+	pub hard_liquidation_max_oracle_slippage: BasisPoints,
+	pub fee_swap_max_oracle_slippage: BasisPoints,
+	pub minimum_loan_amount_usd: U256,
+	pub minimum_supply_amount_usd: U256,
+	pub minimum_update_loan_amount_usd: U256,
+	pub minimum_update_supply_amount_usd: U256,
+}
+
+impl From<RpcLendingConfig> for super::RpcLendingConfig {
+	fn from(value: RpcLendingConfig) -> Self {
+		Self {
+			ltv_thresholds: value.ltv_thresholds.into(),
+			network_fee_contributions: value.network_fee_contributions,
+			fee_swap_interval_blocks: value.fee_swap_interval_blocks,
+			interest_payment_interval_blocks: value.interest_payment_interval_blocks,
+			fee_swap_threshold_usd: value.fee_swap_threshold_usd,
+			interest_collection_threshold_usd: value.interest_collection_threshold_usd,
+			soft_liquidation_swap_chunk_size_usd: value.soft_liquidation_swap_chunk_size_usd,
+			hard_liquidation_swap_chunk_size_usd: value.hard_liquidation_swap_chunk_size_usd,
+			soft_liquidation_max_oracle_slippage: value.soft_liquidation_max_oracle_slippage,
+			hard_liquidation_max_oracle_slippage: value.hard_liquidation_max_oracle_slippage,
+			fee_swap_max_oracle_slippage: value.fee_swap_max_oracle_slippage,
+			minimum_loan_amount_usd: value.minimum_loan_amount_usd,
+			minimum_supply_amount_usd: value.minimum_supply_amount_usd,
+			minimum_update_loan_amount_usd: value.minimum_update_loan_amount_usd,
+			minimum_update_supply_amount_usd: value.minimum_update_supply_amount_usd,
 		}
 	}
 }

--- a/state-chain/traits/src/lending.rs
+++ b/state-chain/traits/src/lending.rs
@@ -105,7 +105,6 @@ pub trait LendingApi {
 		borrower: Self::AccountId,
 		asset: Asset,
 		amount_to_borrow: AssetAmount,
-		collateral_topup_asset: Option<Asset>,
 		broker: Option<Beneficiary<Self::AccountId>>,
 	) -> Result<LoanId, DispatchError>;
 
@@ -113,11 +112,6 @@ pub trait LendingApi {
 		borrower_id: &Self::AccountId,
 		loan_id: LoanId,
 		amount: RepaymentAmount,
-	) -> DispatchResult;
-
-	fn update_collateral_topup_asset(
-		borrower_id: &Self::AccountId,
-		collateral_topup_asset: Option<Asset>,
 	) -> DispatchResult;
 
 	/// Can be used to indicate user's intent to trigger (value=true) or stop (value=false)

--- a/state-chain/traits/src/lending.rs
+++ b/state-chain/traits/src/lending.rs
@@ -49,9 +49,11 @@ pub enum BoostSource {
 
 #[derive(Debug, PartialEq)]
 pub struct BoostOutcome {
-	pub total_fee: AssetAmount,
-	/// Per-source principal amounts funded (entries present only if that source contributed).
+	/// Per-source amounts funded, including the boost fee charged by that source
+	/// (entries present only if that source contributed).
 	pub amounts: BTreeMap<BoostSource, AssetAmount>,
+	/// Per-source boost fees charged (entries present only if that source contributed).
+	pub fees: BTreeMap<BoostSource, AssetAmount>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]

--- a/state-chain/traits/src/mocks/lending_pools.rs
+++ b/state-chain/traits/src/mocks/lending_pools.rs
@@ -124,8 +124,8 @@ impl BoostApi for MockBoostApi {
 		Self::set_available_amount(available_amount - required_amount);
 
 		Ok(BoostOutcome {
-			total_fee,
 			amounts: [(BoostSource::LendingPool, deposit_amount)].into_iter().collect(),
+			fees: [(BoostSource::LendingPool, total_fee)].into_iter().collect(),
 		})
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2836

## Summary

Removes support for collateral auto-topup.

## Migrations:

- lending config storage: removes the `topup` field
- loan accounts storage: removes `collateral_topup_asset` field from every account

(migrations have been tested against a mainnet snapshot)

## RPCs:

- `cf_lending_config` (topup threshold removed)
- `loan_accounts` (accounts no longer have `collateral_topup_asset`)

## Extrinsics:

- `request_loan`: `collateral_topup_asset` field removed
- `update_collateral_topup_asset`: removed


## Events:

- `CollateralTopupAssetUpdated`: removed
- `LendingFundsAdded`: `SupplyAddedActionType` no longer has `SystemTopup` variant

---

FYI @GabrielBuragev 

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
  * [x] Migrations: if you wrote one, did you test it using try-runtime?
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
