### PR TITLE
feat: update DepositBoosted to include boost fee breakdown by source

### DIFF
--- a/bouncer/generated/events/arbitrumIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/arbitrumIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const arbitrumIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfArbitrumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/assethubIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/assethubIngressEgress/depositBoosted.ts
@@ -18,7 +18,7 @@ export const assethubIngressEgressDepositBoosted = z.object({
   blockHeight: z.number(),
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfAssethubIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/bitcoinIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/bitcoinIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const bitcoinIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfBitcoinIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/ethereumIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/ethereumIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const ethereumIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfEthereumIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/polkadotIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/polkadotIngressEgress/depositBoosted.ts
@@ -18,7 +18,7 @@ export const polkadotIngressEgressDepositBoosted = z.object({
   blockHeight: z.number(),
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfPolkadotIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/bouncer/generated/events/solanaIngressEgress/depositBoosted.ts
+++ b/bouncer/generated/events/solanaIngressEgress/depositBoosted.ts
@@ -19,7 +19,7 @@ export const solanaIngressEgressDepositBoosted = z.object({
   blockHeight: numberOrHex,
   ingressFee: numberOrHex,
   maxBoostFeeBps: z.number(),
-  boostFee: numberOrHex,
+  boostFee: z.array(z.tuple([cfTraitsLendingBoostSource, numberOrHex])),
   action: palletCfSolanaIngressEgressDepositAction,
   originType: cfChainsDepositOriginType,
 });

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1122,7 +1122,8 @@ pub mod pallet {
 		DepositBoosted {
 			deposit_address: Option<TargetChainAccount<T, I>>,
 			asset: TargetChainAsset<T, I>,
-			/// Per-source amounts funded (entries present only if that source contributed).
+			/// Per-source amounts funded, including the boost fee charged by that source
+			/// (entries present only if that source contributed).
 			amounts: BTreeMap<BoostSource, TargetChainAmount<T, I>>,
 			deposit_details: <T::TargetChain as Chain>::DepositDetails,
 			prewitnessed_deposit_id: PrewitnessedDepositId,
@@ -1132,8 +1133,9 @@ pub mod pallet {
 			// a non-gas asset. The ingress fee is taken *after* the boost fee.
 			ingress_fee: TargetChainAmount<T, I>,
 			max_boost_fee_bps: BasisPoints,
-			// Total fee the user paid for their deposit to be boosted.
-			boost_fee: TargetChainAmount<T, I>,
+			/// Per-source boost fees the user paid for their deposit to be boosted
+			/// (entries present only if that source contributed).
+			boost_fee: BTreeMap<BoostSource, TargetChainAmount<T, I>>,
 			action: DepositAction<T, I>,
 			origin_type: DepositOriginType,
 		},
@@ -2667,9 +2669,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				amount.into(),
 				boost_fee,
 			) {
-				Ok(BoostOutcome { total_fee, amounts }) => {
-					let boost_fee_amount = total_fee.unique_saturated_into();
-					let amount_after_boost_fee = amount.saturating_sub(boost_fee_amount);
+				Ok(BoostOutcome { amounts, fees }) => {
+					let total_boost_fee: AssetAmount = fees.values().copied().sum();
+					let amount_after_boost_fee =
+						amount.saturating_sub(total_boost_fee.unique_saturated_into());
 
 					// Note that ingress fee is deducted at the time of boosting rather than the
 					// time the deposit is finalised (which allows us to perform the channel
@@ -2701,7 +2704,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						deposit_details,
 						ingress_fee,
 						max_boost_fee_bps: boost_fee,
-						boost_fee: boost_fee_amount,
+						boost_fee: fees
+							.into_iter()
+							.map(|(source, fee)| (source, fee.unique_saturated_into()))
+							.collect(),
 						action,
 						origin_type: origin.into(),
 					});

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -156,7 +156,7 @@ fn basic_passive_boosting() {
 				deposit_details: Default::default(),
 				ingress_fee: INGRESS_FEE,
 				max_boost_fee_bps: BOOST_FEE_BPS,
-				boost_fee: BOOST_FEE,
+				boost_fee: [(BoostSource::LendingPool, BOOST_FEE)].into(),
 				action: DepositAction::LiquidityProvision { lp_account: LP_ACCOUNT },
 				origin_type: DepositOriginType::DepositChannel,
 			}));

--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -250,14 +250,17 @@ impl<T: Config> BoostApi for Pallet<T> {
 		);
 
 		let mut amounts = BTreeMap::new();
+		let mut fees = BTreeMap::new();
 		if lending_pool_principal > 0 {
 			amounts.insert(BoostSource::LendingPool, lending_pool_principal + lending_pool_fee);
+			fees.insert(BoostSource::LendingPool, lending_pool_fee);
 		}
 		if boost_pool_principal > 0 {
 			amounts.insert(BoostSource::BoostPool, boost_pool_principal + boost_pool_fee);
+			fees.insert(BoostSource::BoostPool, boost_pool_fee);
 		}
 
-		Ok(BoostOutcome { total_fee, amounts })
+		Ok(BoostOutcome { amounts, fees })
 	}
 
 	fn finalise_boost(deposit_id: PrewitnessedDepositId, asset: Asset) -> BoostFinalisationOutcome {

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -1148,7 +1148,7 @@ fn boost_pool_details() {
 /// Boosting with both lending and legacy boost pools
 mod hybrid_boosting {
 
-	use cf_traits::lending::BoostFinalisationOutcome;
+	use cf_traits::lending::{BoostFinalisationOutcome, BoostOutcome, BoostSource};
 
 	use super::*;
 
@@ -1223,12 +1223,21 @@ mod hybrid_boosting {
 			frame_system::Pallet::<Test>::reset_events();
 
 			// 3. Boost deposit.
-			assert_ok!(LendingPools::try_boosting(
-				DEPOSIT_ID,
-				BOOST_ASSET,
-				DEPOSIT_AMOUNT,
-				BOOST_FEE_BPS,
-			));
+			assert_eq!(
+				LendingPools::try_boosting(DEPOSIT_ID, BOOST_ASSET, DEPOSIT_AMOUNT, BOOST_FEE_BPS,),
+				Ok(BoostOutcome {
+					amounts: [
+						(BoostSource::LendingPool, LENDING_FUNDS + LENDING_FEE_TOTAL),
+						(BoostSource::BoostPool, LEGACY_POOL_FUNDS + LEGACY_FEE_TOTAL),
+					]
+					.into(),
+					fees: [
+						(BoostSource::LendingPool, LENDING_FEE_TOTAL),
+						(BoostSource::BoostPool, LEGACY_FEE_TOTAL),
+					]
+					.into(),
+				})
+			);
 
 			assert_event_sequence!(
 				Test,

--- a/state-chain/traits/src/lending.rs
+++ b/state-chain/traits/src/lending.rs
@@ -49,9 +49,11 @@ pub enum BoostSource {
 
 #[derive(Debug, PartialEq)]
 pub struct BoostOutcome {
-	pub total_fee: AssetAmount,
-	/// Per-source principal amounts funded (entries present only if that source contributed).
+	/// Per-source amounts funded, including the boost fee charged by that source
+	/// (entries present only if that source contributed).
 	pub amounts: BTreeMap<BoostSource, AssetAmount>,
+	/// Per-source boost fees charged (entries present only if that source contributed).
+	pub fees: BTreeMap<BoostSource, AssetAmount>,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]

--- a/state-chain/traits/src/mocks/lending_pools.rs
+++ b/state-chain/traits/src/mocks/lending_pools.rs
@@ -124,8 +124,8 @@ impl BoostApi for MockBoostApi {
 		Self::set_available_amount(available_amount - required_amount);
 
 		Ok(BoostOutcome {
-			total_fee,
 			amounts: [(BoostSource::LendingPool, deposit_amount)].into_iter().collect(),
+			fees: [(BoostSource::LendingPool, total_fee)].into_iter().collect(),
 		})
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2845

## Summary

As requested, `boostFee` from `DepositBoosted` now works the same way as `amounts`: it exposes the boost fee breakdown by source (legacy pool vs lending pool). FYI @GabrielBuragev 

### Extrinsics & Events

- DepositBoosted: `boostFee` is now a tuple (containing up to two elements, one for each pool)

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
