### PR TITLE
fix: Clamp price

### DIFF
--- a/state-chain/amm/src/lib.rs
+++ b/state-chain/amm/src/lib.rs
@@ -20,7 +20,10 @@ mod tests;
 
 use core::convert::Infallible;
 
-use cf_amm_math::{mul_div_floor, mul_div_floor_checked, Amount, Price, SqrtPrice, Tick};
+use cf_amm_math::{
+	mul_div_floor, mul_div_floor_checked, Amount, Price, SqrtPrice, Tick, MAX_SQRT_PRICE,
+	MIN_SQRT_PRICE,
+};
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use common::{
 	nth_root_of_integer_as_fixed_point, BaseToQuote, Pairs, PoolPairsMap, QuoteToBase,
@@ -551,6 +554,9 @@ fn grow_by_pool_fee(input: U256, fee_hundredth_pips: u32) -> U256 {
 	.unwrap_or(U256::MAX)
 }
 
+/// Adjusts a valid range-order sqrt price by the pool fee in the swap direction.
+///
+/// The result is clamped to `[MIN_SQRT_PRICE, MAX_SQRT_PRICE]`.
 fn sqrt_price_adjusted_by_pool_fee<SD: common::SwapDirection>(
 	sqrt_price: SqrtPrice,
 	fee_hundredth_pips: u32,
@@ -562,7 +568,8 @@ fn sqrt_price_adjusted_by_pool_fee<SD: common::SwapDirection>(
 		Side::Sell => reduce_by_pool_fee(price.as_raw(), fee_hundredth_pips),
 	});
 
-	adjusted_price.into()
+	let adjusted_sqrt_price: SqrtPrice = adjusted_price.into();
+	adjusted_sqrt_price.clamp(MIN_SQRT_PRICE, MAX_SQRT_PRICE)
 }
 
 pub fn input_amount_from_fee(fee: U256, fee_hundredth_pips: u32) -> Option<U256> {

--- a/state-chain/amm/src/tests.rs
+++ b/state-chain/amm/src/tests.rs
@@ -21,7 +21,7 @@ use core::convert::Infallible;
 use sp_core::crypto::AccountId32;
 
 use crate::range_orders::Liquidity;
-use cf_amm_math::{Price, MAX_SQRT_PRICE, MIN_SQRT_PRICE};
+use cf_amm_math::{Price, MAX_SQRT_PRICE, MAX_TICK, MIN_SQRT_PRICE};
 
 use super::*;
 
@@ -291,5 +291,32 @@ fn check_price_adjustment_by_pool_fee() {
 	for (tick, fee) in [(100, 500), (20_000, 500), (-20_000, 50_000), (-100, 0), (0, 0)] {
 		test_case::<BaseToQuote>(tick, fee);
 		test_case::<QuoteToBase>(tick, fee);
+	}
+}
+
+// Boundary check: `sqrt_price_adjusted_by_pool_fee` must never produce an invalid
+// SqrtPrice across the full range of allowed pool fees, for both swap directions
+// at every valid tick — including the edges of [MIN_TICK, MAX_TICK] where the
+// raw fee adjustment would overflow into an invalid SqrtPrice.
+#[test]
+fn sqrt_price_adjusted_by_pool_fee_never_returns_invalid_sqrt_price() {
+	use cf_amm_math::MIN_TICK;
+
+	for &fee in &[0u32, 1, 100, 500, 50_000, 500_000] {
+		for &tick in &[MIN_TICK, MIN_TICK + 1, -1, 0, 1, MAX_TICK - 1, MAX_TICK] {
+			let sqrt_price = SqrtPrice::from_tick(tick);
+			for adjusted in [
+				sqrt_price_adjusted_by_pool_fee::<BaseToQuote>(sqrt_price, fee),
+				sqrt_price_adjusted_by_pool_fee::<QuoteToBase>(sqrt_price, fee),
+			] {
+				assert!(
+					adjusted.is_valid(),
+					"fee {} tick {}: adjusted SqrtPrice {:?} is invalid",
+					fee,
+					tick,
+					adjusted
+				);
+			}
+		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2855

## Summary

I chose to clamp price when adjusting it by fee as it is the simplest approach and at extreme values we are not concerned about accuracy.
