### PR TITLE
chore: automatically copy ingress-egress's WitnessSafetyMargin to elections' BlockWitnesser settings on every block

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -912,11 +912,16 @@ pub mod pallet {
 	pub type DepositChannelRecycleBlocks<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, ChannelRecycleQueue<T, I>, ValueQuery>;
 
-	// Determines the number of block confirmations is required for a block on
-	// an external chain before CFE can submit any witness extrinsics for it.
+	// Election based witnessing: Determines the number of block confirmations required for a block
+	// to be considered safe and all contained transactions to be forwarded to the ingress egress
+	// pallet.
 	//
-	// This storage item won't be used for any chains using the elections witnessing and
-	// will be removed once all chains are migrated
+	// This value is mirrored to the `safety_margin` setting of all ingress related BlockWitnesser
+	// instances in the respective elections pallet.
+	//
+	// Legacy witnessing (only used for Assethub): Determines the number of block confirmations
+	// required for a block on an external chain before CFE can submit any witness extrinsics for
+	// it.
 	#[pallet::storage]
 	#[pallet::getter(fn witness_safety_margin)]
 	pub type WitnessSafetyMargin<T: Config<I>, I: 'static = ()> =

--- a/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
@@ -323,6 +323,18 @@ impl
 	) -> Result<(), CorruptStorageError> {
 		let current_sc_block_number = crate::System::block_number();
 
+		if let Some(ingress_safety_margin) =
+			pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, ArbitrumInstance>::get()
+		{
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, ArbitrumInstance>::mutate_extant(|settings|  {
+				// We apply the safety margin to *all* BlockWitnessers. On EVM chains we have the same safety margin for
+				// ingresses and egresses since egresses are entangled with other other stuff in the KeyManager BW.
+				settings.1.safety_margin = ingress_safety_margin as u32;
+				settings.2.safety_margin = ingress_safety_margin as u32;
+				settings.3.safety_margin = ingress_safety_margin as u32;
+			});
+		}
+
 		let chain_progress = ArbitrumBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,

--- a/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
@@ -391,6 +391,17 @@ impl
 	) -> Result<(), CorruptStorageError> {
 		let current_sc_block_number = crate::System::block_number();
 
+		if let Some(ingress_safety_margin) =
+			pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, BitcoinInstance>::get()
+		{
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, BitcoinInstance>::mutate_extant(|settings|  {
+				// We apply the safety margin *only* to the ingress BlockWitnessers. The egress witnessing is not critical
+				// and it keeps its own lower safety margin (which has to be updated from the election pallet settings).
+				settings.1.safety_margin = ingress_safety_margin as u32;
+				settings.2.safety_margin = ingress_safety_margin as u32;
+			});
+		}
+
 		let chain_progress = BitcoinBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,

--- a/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
@@ -508,6 +508,20 @@ impl
 	) -> Result<(), CorruptStorageError> {
 		let current_sc_block_number = crate::System::block_number();
 
+		if let Some(ingress_safety_margin) =
+			pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, EthereumInstance>::get()
+		{
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, EthereumInstance>::mutate_extant(|settings|  {
+				// We apply the safety margin to *all* BlockWitnessers. On EVM chains we have the same safety margin for
+				// ingresses and egresses since egresses are entangled with other other stuff in the KeyManager BW.
+				settings.1.safety_margin = ingress_safety_margin as u32;
+				settings.2.safety_margin = ingress_safety_margin as u32;
+				settings.3.safety_margin = ingress_safety_margin as u32;
+				settings.6.safety_margin = ingress_safety_margin as u32;
+				settings.7.safety_margin = ingress_safety_margin as u32;
+			});
+		}
+
 		let chain_progress = EthereumBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,

--- a/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
@@ -295,6 +295,18 @@ impl
 	) -> Result<(), CorruptStorageError> {
 		let current_sc_block_number = crate::System::block_number();
 
+		if let Some(ingress_safety_margin) =
+			pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, TronInstance>::get()
+		{
+			pallet_cf_elections::ElectoralUnsynchronisedSettings::<Runtime, TronInstance>::mutate_extant(|settings|  {
+				// We apply the safety margin to *all* BlockWitnessers. On EVM chains we have the same safety margin for
+				// ingresses and egresses since egresses are entangled with other other stuff in the KeyManager BW.
+				settings.1.safety_margin = ingress_safety_margin as u32;
+				settings.2.safety_margin = ingress_safety_margin as u32;
+				settings.3.safety_margin = ingress_safety_margin as u32;
+			});
+		}
+
 		let chain_progress = TronBlockHeightWitnesserES::on_finalize::<
 			DerivedElectoralAccess<
 				_,

--- a/state-chain/runtime/src/migrations/tron_integration.rs
+++ b/state-chain/runtime/src/migrations/tron_integration.rs
@@ -1,4 +1,4 @@
-use crate::Runtime;
+use crate::{chainflip::witnessing::tron_elections::TRON_MAINNET_SAFETY_MARGIN, Runtime};
 use cf_chains::instances::TronInstance;
 #[cfg(feature = "try-runtime")]
 use codec::Encode;
@@ -78,8 +78,7 @@ impl OnRuntimeUpgrade for TronElectionsInit {
 
 /// Initialize Tron ingress-egress pallet values (deposit channel lifetime).
 /// These are normally set via GenesisConfig but must be set via migration when adding a new chain.
-/// Note: WitnessSafetyMargin is deprecated for chains using elections-based witnessing (see
-/// comment on WitnessSafetyMargin storage item), so we only set the channel lifetime here.
+/// This sets both the channel lifetime and the witness safety margin.
 pub struct TronIngressEgressInit;
 
 impl OnRuntimeUpgrade for TronIngressEgressInit {
@@ -94,12 +93,17 @@ impl OnRuntimeUpgrade for TronIngressEgressInit {
 		};
 
 		log::info!(
-			"🔧 Initializing Tron ingress-egress: deposit_channel_lifetime={}",
+			"🔧 Initializing Tron ingress-egress: deposit_channel_lifetime={}, ingress_safety_margin={}",
 			deposit_channel_lifetime,
+			TRON_MAINNET_SAFETY_MARGIN,
 		);
 
 		pallet_cf_ingress_egress::DepositChannelLifetime::<Runtime, TronInstance>::put(
 			deposit_channel_lifetime,
+		);
+
+		pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, TronInstance>::put(
+			TRON_MAINNET_SAFETY_MARGIN as u64,
 		);
 
 		Weight::zero()
@@ -110,6 +114,13 @@ impl OnRuntimeUpgrade for TronIngressEgressInit {
 		let lifetime =
 			pallet_cf_ingress_egress::DepositChannelLifetime::<Runtime, TronInstance>::get();
 		frame_support::ensure!(lifetime > 0, "Tron deposit channel lifetime must be non-zero");
+
+		let safety_margin =
+			pallet_cf_ingress_egress::WitnessSafetyMargin::<Runtime, TronInstance>::get();
+		frame_support::ensure!(
+			safety_margin == Some(TRON_MAINNET_SAFETY_MARGIN as u64),
+			"Tron safety margin not set correctly during migration"
+		);
 
 		Ok(())
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2842

## Summary

Currently the value for the witness safety margin in our ingress egress pallets (which is reported by the safety_margins rpc) and the actual safety margins used by the election-based witnessing are not connected with each other.

The best way forward is to connect them by using the ingress-egress pallets' safety margin for the elections. This is nicer than vice-versa because it's easier to update the value in the ingress-egress pallet and there's only a single value there. (Compared with the elections which have a separate setting for every BW instance.)

This PR does the following:
 - Properly initializes `ingress_egress_pallet::WitnessSafetyMargin` during the Tron setup migration
 - Adds code to copy the current witness safety margin to all electoral BlockWitnesser settings on every `on_finalize()` call.

NOTE: it sets the safety_margin of every BW *except the Bitcoin EgressWitnessingBW* because for this one we want to keep a safety margin that's independent of the ingress safety margin.

## API Changes

### RPCS

There are no changes to the rpc interface.

### Witnessing

I've checked and the current WitnessSafetyMargin in the ingress-egress pallets for Bitcoin, Arbitrum and Ethereum are the same as the `safety_margin` setting in their respective BWs. This means there will be no sudden change of safety margin after the upgrade.

### Extrinsics & Events

No changes here.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.
