### PR TITLE
chore: add `*_MAX_SUBMIT_HEADERS_IN_BHW_VOTER` constants to control BHW voter behaviour.

### DIFF
--- a/engine/src/witness/arb_elections.rs
+++ b/engine/src/witness/arb_elections.rs
@@ -54,6 +54,7 @@ use state_chain_runtime::{
 	chainflip::witnessing::arbitrum_elections::{
 		ArbitrumBlockHeightWitnesserES, ArbitrumChain, ArbitrumElectoralSystemRunner,
 		ArbitrumFeeTracking, ArbitrumLiveness, ARBITRUM_MAINNET_SAFETY_BUFFER,
+		ARBITRUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 	},
 	ArbitrumInstance,
 };
@@ -242,6 +243,7 @@ impl VoterApi<ArbitrumBlockHeightWitnesserES>
 			self,
 			properties,
 			ARBITRUM_MAINNET_SAFETY_BUFFER,
+			ARBITRUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 			"ARB BHW",
 		)
 		.await

--- a/engine/src/witness/btc.rs
+++ b/engine/src/witness/btc.rs
@@ -48,7 +48,7 @@ use sp_runtime::AccountId32;
 use state_chain_runtime::{
 	chainflip::witnessing::bitcoin_elections::{
 		BitcoinBlockHeightWitnesserES, BitcoinChain, BitcoinElectoralSystemRunner, BitcoinLiveness,
-		BITCOIN_MAINNET_SAFETY_BUFFER,
+		BITCOIN_MAINNET_SAFETY_BUFFER, BITCOIN_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 	},
 	BitcoinInstance, Runtime,
 };
@@ -155,6 +155,7 @@ impl VoterApi<BitcoinBlockHeightWitnesserES> for BitcoinBlockHeightWitnesserVote
 			&self.client,
 			properties,
 			BITCOIN_MAINNET_SAFETY_BUFFER,
+			BITCOIN_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 			"BTC BHW",
 		)
 		.await

--- a/engine/src/witness/common/block_height_witnesser.rs
+++ b/engine/src/witness/common/block_height_witnesser.rs
@@ -13,6 +13,7 @@ pub async fn witness_headers<ES, Client, Chain>(
 	client: &Client,
 	properties: <ES as ElectoralSystemTypes>::ElectionProperties,
 	safety_buffer: u32,
+	max_submit_headers: u32,
 	tag: &'static str,
 ) -> anyhow::Result<Option<NonemptyContinuousHeaders<Chain>>>
 where
@@ -44,13 +45,13 @@ where
 
 	// Compute the highest block height we want to fetch a header for,
 	// since for performance reasons we're bounding the number of headers
-	// submitted in one vote. We're submitting at most SAFETY_BUFFER headers.
+	// submitted in one vote. We're submitting at most `max_submit_headers` headers.
 	let highest_submitted_height = std::cmp::min(
 		best_block_header.block_height,
-		witness_from_index.saturating_forward(safety_buffer as usize + 1),
+		witness_from_index.saturating_forward(max_submit_headers as usize + 1),
 	);
 
-	// request headers for at most SAFETY_BUFFER heights, in parallel
+	// request headers for at most `max_submit_headers` heights, in parallel
 	let requests = (witness_from_index..highest_submitted_height)
 		.map(|index| async move { client.block_header_by_height(index).await })
 		.collect::<Vec<_>>();

--- a/engine/src/witness/eth_elections.rs
+++ b/engine/src/witness/eth_elections.rs
@@ -78,6 +78,7 @@ use state_chain_runtime::{
 		EthereumBlockHeightWitnesserES, EthereumChain, EthereumElectoralSystemRunner,
 		EthereumFeeTracking, EthereumLiveness, ScUtilsCall,
 		StateChainGatewayEvent as ScGatewayEvent, ETHEREUM_MAINNET_SAFETY_BUFFER,
+		ETHEREUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 	},
 	EthereumInstance,
 };
@@ -235,6 +236,7 @@ impl VoterApi<EthereumBlockHeightWitnesserES> for EvmVoter<EthereumChain, EvmSin
 			self,
 			properties,
 			ETHEREUM_MAINNET_SAFETY_BUFFER,
+			ETHEREUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 			"ETH BHW",
 		)
 		.await

--- a/engine/src/witness/tron_elections.rs
+++ b/engine/src/witness/tron_elections.rs
@@ -72,7 +72,7 @@ use state_chain_runtime::{
 		pallet_hooks::{EvmKeyManagerEvent, EvmVaultContractEvent},
 		tron_elections::{
 			TronBlockHeightWitnesserES, TronChain, TronElectoralSystemRunner, TronLiveness,
-			TRON_MAINNET_SAFETY_BUFFER,
+			TRON_MAINNET_SAFETY_BUFFER, TRON_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 		},
 	},
 	Runtime, TronInstance,
@@ -182,6 +182,7 @@ impl VoterApi<TronBlockHeightWitnesserES> for TronVoter {
 			self,
 			properties,
 			TRON_MAINNET_SAFETY_BUFFER,
+			TRON_MAX_SUBMIT_HEADERS_IN_BHW_VOTER,
 			"TRON BHW",
 		)
 		.await

--- a/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
@@ -75,6 +75,7 @@ impl ChainTypes for ArbitrumChain {
 }
 
 pub const ARBITRUM_MAINNET_SAFETY_BUFFER: u32 = 8;
+pub const ARBITRUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER: u32 = 8;
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, RuntimeDebug, TypeInfo)]
 pub enum ArbitrumElectoralEvents {

--- a/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
@@ -456,6 +456,7 @@ impl
 }
 
 pub const BITCOIN_MAINNET_SAFETY_BUFFER: u32 = 8;
+pub const BITCOIN_MAX_SUBMIT_HEADERS_IN_BHW_VOTER: u32 = 8;
 
 pub fn initial_state() -> InitialStateOf<Runtime, BitcoinInstance> {
 	InitialState {

--- a/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
@@ -75,6 +75,7 @@ impl ChainTypes for EthereumChain {
 }
 
 pub const ETHEREUM_MAINNET_SAFETY_BUFFER: u32 = 8;
+pub const ETHEREUM_MAX_SUBMIT_HEADERS_IN_BHW_VOTER: u32 = 8;
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, RuntimeDebug, TypeInfo)]
 pub enum EthereumElectoralEvents {

--- a/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
@@ -86,6 +86,7 @@ impl ChainTypes for TronChain {
 
 pub const TRON_MAINNET_SAFETY_MARGIN: u32 = 19;
 pub const TRON_MAINNET_SAFETY_BUFFER: u32 = 25;
+pub const TRON_MAX_SUBMIT_HEADERS_IN_BHW_VOTER: u32 = 16;
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, DecodeWithMemTracking, RuntimeDebug, TypeInfo)]
 pub enum TronElectoralEvents {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2796

## Summary

Previously, the max amount of headers has been controlled by the `*_MAINNET_SAFETY_BUFFER` constants which are ok to be used for this purpose (they would usually be within the same range of sensible values) - but it still makes sense to have a semantically better named separate constant for this purpose.

This PR adds a `${CHAIN}_MAX_SUBMIT_HEADERS_IN_BHW_VOTER` constant for each chain and updates the generic BHW voter implementation to use it. 

## API Changes

### Witnessing

All the new constants are set to the same value as the respective `MAINNET_SAFETY_BUFFER` constant, so there won't be an observable change in behaviour for existing chains.

For Tron I've set the new value to 16 which results in max. 48s worth of Tron blocks per SC block. This is the same catching-up speed that we have for Arbitrum.

### RPCS

None

### Extrinsics & Events

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
