### PR TITLE
feat: Lending further improvements

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -853,7 +853,6 @@ impl<T: Config> LoanAccount<T> {
 		}
 
 		if self.voluntary_liquidation_requested {
-			log_or_panic!("Voluntary liquidation flag is set on loan creation");
 			// If the user requests any additional loans, we assume they no longer want to
 			// be in voluntary liquidation mode (if for whatever reason it was active)
 			self.voluntary_liquidation_requested = false;

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1594,6 +1594,12 @@ pub fn remove_lender_funds<T: Config>(
 /// Returns `Permill::one()` if the pool does not exist or is empty. Allows stale oracle
 /// prices (since we still want the cap to hold during price outages), and propagates
 /// an error only when a price is completely unavailable.
+///
+/// Boost loans (in `BoostLoans`) are deliberately excluded from this sum: they are not
+/// secured by collateral and therefore reserve no liquidation capacity. We assume boost
+/// principal will always be repaid because boost loans are funded against prewitnessed
+/// deposits. They still consume `available_amount` via `fund_loan` and so push real pool
+/// utilisation up against this cap, but they do not lower the cap themselves.
 pub fn compute_utilisation_cap<T: Config>(
 	asset: Asset,
 	coverage_factor: Percent,

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1545,8 +1545,10 @@ pub fn remove_lender_funds<T: Config>(
 		};
 
 		if let Some(amount) = amount {
+			// Note that stale prices are acceptable for minimum-amount checks.
 			ensure!(
-				price_cache.usd_value_of(asset, amount)? >= config.minimum_update_supply_amount_usd,
+				price_cache.usd_value_of_allow_stale(asset, amount)? >=
+					config.minimum_update_supply_amount_usd,
 				Error::<T>::InsufficientLtvHeadroom
 			);
 		}

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -4753,30 +4753,33 @@ fn init_liquidation_swaps_test() {
 
 #[test]
 fn can_add_but_not_remove_supply_with_stale_price_if_has_loans() {
-	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).with_default_loan().execute_with(|| {
-		// BORROWER now has a loan in LOAN_ASSET with COLLATERAL_ASSET as collateral (the
-		// supply position doubles as collateral in this lending model).
-		MockPriceFeedApi::set_stale(COLLATERAL_ASSET, true);
+	new_test_ext()
+		.with_funded_pool(INIT_POOL_AMOUNT)
+		.with_default_loan()
+		.execute_with(|| {
+			// BORROWER now has a loan in LOAN_ASSET with COLLATERAL_ASSET as collateral (the
+			// supply position doubles as collateral in this lending model).
+			MockPriceFeedApi::set_stale(COLLATERAL_ASSET, true);
 
-		// Should still be able to add supply with stale price
-		MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
-		assert_ok!(LendingPools::add_lender_funds(
-			RuntimeOrigin::signed(BORROWER),
-			COLLATERAL_ASSET,
-			INIT_COLLATERAL,
-		));
-
-		// But should not be able to remove supply with stale price: computing the LTV
-		// headroom requires fresh oracle prices.
-		assert_noop!(
-			LendingPools::remove_lender_funds(
+			// Should still be able to add supply with stale price
+			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
+			assert_ok!(LendingPools::add_lender_funds(
 				RuntimeOrigin::signed(BORROWER),
 				COLLATERAL_ASSET,
-				Some(INIT_COLLATERAL / 2),
-			),
-			Error::<Test>::OraclePriceUnavailable
-		);
-	});
+				INIT_COLLATERAL,
+			));
+
+			// But should not be able to remove supply with stale price: computing the LTV
+			// headroom requires fresh oracle prices.
+			assert_noop!(
+				LendingPools::remove_lender_funds(
+					RuntimeOrigin::signed(BORROWER),
+					COLLATERAL_ASSET,
+					Some(INIT_COLLATERAL / 2),
+				),
+				Error::<Test>::OraclePriceUnavailable
+			);
+		});
 }
 
 /// Makes sure that stale oracle prices don't affect lenders' ability

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -4752,40 +4752,26 @@ fn init_liquidation_swaps_test() {
 }
 
 #[test]
-fn can_add_but_not_remove_supply_with_stale_price() {
-	const SUPPLY_ASSET: Asset = Asset::Eth;
-
-	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).execute_with(|| {
-		MockPriceFeedApi::set_price_usd_fine(SUPPLY_ASSET, 1);
-		MockPriceFeedApi::set_stale(SUPPLY_ASSET, false);
-
-		MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-		MockBalance::credit_account(&BORROWER, SUPPLY_ASSET, INIT_COLLATERAL * 2);
-
-		assert_ok!(LendingPools::new_lending_pool(SUPPLY_ASSET));
-
-		// Add supply while price is fresh
-		assert_ok!(LendingPools::add_lender_funds(
-			RuntimeOrigin::signed(BORROWER),
-			SUPPLY_ASSET,
-			INIT_COLLATERAL,
-		));
-
-		// Make the price stale
-		MockPriceFeedApi::set_stale(SUPPLY_ASSET, true);
+fn can_add_but_not_remove_supply_with_stale_price_if_has_loans() {
+	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).with_default_loan().execute_with(|| {
+		// BORROWER now has a loan in LOAN_ASSET with COLLATERAL_ASSET as collateral (the
+		// supply position doubles as collateral in this lending model).
+		MockPriceFeedApi::set_stale(COLLATERAL_ASSET, true);
 
 		// Should still be able to add supply with stale price
+		MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
 		assert_ok!(LendingPools::add_lender_funds(
 			RuntimeOrigin::signed(BORROWER),
-			SUPPLY_ASSET,
+			COLLATERAL_ASSET,
 			INIT_COLLATERAL,
 		));
 
-		// But should not be able to remove supply with stale price
+		// But should not be able to remove supply with stale price: computing the LTV
+		// headroom requires fresh oracle prices.
 		assert_noop!(
 			LendingPools::remove_lender_funds(
 				RuntimeOrigin::signed(BORROWER),
-				SUPPLY_ASSET,
+				COLLATERAL_ASSET,
 				Some(INIT_COLLATERAL / 2),
 			),
 			Error::<Test>::OraclePriceUnavailable
@@ -4824,6 +4810,41 @@ fn can_remove_supply_with_stale_price_if_no_loans() {
 			RuntimeOrigin::signed(BORROWER),
 			SUPPLY_ASSET,
 			None,
+		));
+	});
+}
+
+/// Same as above but with a partial-amount withdrawal: stale prices should
+/// not block a no-loans lender from removing a specific amount either.
+#[test]
+fn can_partially_remove_supply_with_stale_price_if_no_loans() {
+	const SUPPLY_ASSET: Asset = Asset::Eth;
+
+	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).execute_with(|| {
+		MockPriceFeedApi::set_price_usd_fine(SUPPLY_ASSET, 1);
+		MockPriceFeedApi::set_stale(SUPPLY_ASSET, false);
+
+		MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
+		MockBalance::credit_account(&BORROWER, SUPPLY_ASSET, INIT_COLLATERAL * 2);
+
+		assert_ok!(LendingPools::new_lending_pool(SUPPLY_ASSET));
+
+		// Add supply while price is fresh
+		assert_ok!(LendingPools::add_lender_funds(
+			RuntimeOrigin::signed(BORROWER),
+			SUPPLY_ASSET,
+			INIT_COLLATERAL,
+		));
+
+		// Make the price stale
+		MockPriceFeedApi::set_stale(SUPPLY_ASSET, true);
+
+		// Should be able to partially remove supply with stale price if the user has
+		// no loans (no LTV check is needed).
+		assert_ok!(LendingPools::remove_lender_funds(
+			RuntimeOrigin::signed(BORROWER),
+			SUPPLY_ASSET,
+			Some(INIT_COLLATERAL / 2),
 		));
 	});
 }

--- a/state-chain/pallets/cf-lending-pools/src/utils.rs
+++ b/state-chain/pallets/cf-lending-pools/src/utils.rs
@@ -45,14 +45,17 @@ where
 		.collect();
 
 	// Due to always rounding down we may have a small amount left over, give it a random key
-	let remaining_to_distribute = total_to_distribute.saturating_sub(total_distributed);
-	let lucky_index = {
-		// Convert to u64 by ignoring high bits
-		let seed = u128::from(total_to_distribute) as u64;
-		nanorand::WyRand::new_seed(seed).generate_range(0..distribution.len())
-	};
-	if let Some((_lp_id, amount)) = distribution.iter_mut().nth(lucky_index) {
-		amount.saturating_accrue(remaining_to_distribute);
+	if !distribution.is_empty() {
+		let remaining_to_distribute = total_to_distribute.saturating_sub(total_distributed);
+
+		let lucky_index = {
+			// Convert to u64 by ignoring high bits
+			let seed = u128::from(total_to_distribute) as u64;
+			nanorand::WyRand::new_seed(seed).generate_range(0..distribution.len())
+		};
+		if let Some((_lp_id, amount)) = distribution.iter_mut().nth(lucky_index) {
+			amount.saturating_accrue(remaining_to_distribute);
+		}
 	}
 
 	distribution


### PR DESCRIPTION
# Pull Request

## Summary

Minor fixes/improvments:

- Lenders can withdraw their funds even if prices are stale as long as they don't have loans (non-stale prices are required for accounts with loans for LTV check). Added test.
- Removed dubious log_or_panic (in debug builds it is possible to make it panic by submitting two extrinsics at the same time); removing it is still correct: the fallback is reasonable.
- Futureproofed `distribute_proportionally` so it doesn't rely on undocumented gen_range behaviour when the range is empty
- Updated some comments

## Checklist

* The PR is complete:
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
