### PR TITLE
fix: remove implicit sqrt price conversions

### DIFF
--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -349,14 +349,6 @@ impl SqrtPrice {
 	}
 }
 
-impl TryFrom<U512> for SqrtPrice {
-	type Error = ();
-
-	fn try_from(value: U512) -> Result<Self, Self::Error> {
-		U256::try_from(value).map(SqrtPrice).map_err(|_| ())
-	}
-}
-
 /// Computes the floor and ceil of `a * b / c` in `U512` space. Returns `None` if `c` is zero.
 fn mul_div_floor_ceil<C: Into<U512>>(a: U256, b: U256, c: C) -> Option<(U512, U512)> {
 	let c: U512 = c.into();

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -42,11 +42,9 @@ pub type Amount = U256;
 	Debug,
 	TypeInfo,
 	Encode,
-	Decode,
 	DecodeWithMemTracking,
 	MaxEncodedLen,
 	Serialize,
-	Deserialize,
 	PartialEq,
 	Eq,
 	PartialOrd,
@@ -55,6 +53,20 @@ pub type Amount = U256;
 	Default,
 )]
 pub struct SqrtPrice(U256);
+
+impl Decode for SqrtPrice {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let raw = U256::decode(input)?;
+		Self::try_from_raw(raw).map_err(|_| codec::Error::from("SqrtPrice out of bounds"))
+	}
+}
+
+impl<'de> serde::de::Deserialize<'de> for SqrtPrice {
+	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		let raw = U256::deserialize(deserializer)?;
+		Self::try_from_raw(raw).map_err(|_| serde::de::Error::custom("SqrtPrice out of bounds"))
+	}
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConversionError {

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -74,17 +74,20 @@ pub enum ConversionError {
 	OutsideValidRange,
 }
 
+/// The raw (unbounded) sqrt price corresponding to a price, before range validation.
+fn raw_sqrt_price_from_price(price: Price) -> Result<U256, ConversionError> {
+	U256::try_from(
+		(U512::from(price.0) << Price::FRACTIONAL_BITS).integer_sqrt() >>
+			(Price::FRACTIONAL_BITS - SqrtPrice::FRACTIONAL_BITS),
+	)
+	.map_err(|_| ConversionError::Overflow)
+}
+
 impl TryFrom<Price> for SqrtPrice {
 	type Error = ConversionError;
 
 	fn try_from(price: Price) -> Result<Self, Self::Error> {
-		let sqrt_price = U256::try_from(
-			(U512::from(price.0) << Price::FRACTIONAL_BITS).integer_sqrt() >>
-				(Price::FRACTIONAL_BITS - SqrtPrice::FRACTIONAL_BITS),
-		)
-		.map_err(|_| ConversionError::Overflow)?;
-
-		SqrtPrice::try_from_raw(sqrt_price)
+		raw_sqrt_price_from_price(price).and_then(SqrtPrice::try_from_raw)
 	}
 }
 
@@ -436,6 +439,14 @@ impl Price {
 
 	pub fn as_raw(self) -> U256 {
 		self.0
+	}
+
+	/// Converts to a valid `SqrtPrice`, clamping into `[MIN_SQRT_PRICE, MAX_SQRT_PRICE]` when the
+	/// price lies outside the representable tick range.
+	pub fn to_sqrt_price_clamped(self) -> SqrtPrice {
+		raw_sqrt_price_from_price(self)
+			.map(SqrtPrice::clamp_from_raw)
+			.unwrap_or(MAX_SQRT_PRICE)
 	}
 
 	pub fn one() -> Self {

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -56,12 +56,26 @@ pub type Amount = U256;
 )]
 pub struct SqrtPrice(U256);
 
-impl From<Price> for SqrtPrice {
-	fn from(price: Price) -> Self {
-		((U512::from(price.0) << Price::FRACTIONAL_BITS).integer_sqrt() >>
-			(Price::FRACTIONAL_BITS - SqrtPrice::FRACTIONAL_BITS))
-			.try_into()
-			.unwrap_or(SqrtPrice::from_raw(U256::MAX))
+pub enum ConversionError {
+	Overflow,
+	OutsideValidRange,
+}
+
+impl TryFrom<Price> for SqrtPrice {
+	type Error = ConversionError;
+
+	fn try_from(price: Price) -> Result<Self, Self::Error> {
+		let sqrt_price = U256::try_from(
+			(U512::from(price.0) << Price::FRACTIONAL_BITS).integer_sqrt() >>
+				(Price::FRACTIONAL_BITS - SqrtPrice::FRACTIONAL_BITS),
+		)
+		.map(SqrtPrice)
+		.map_err(|_| ConversionError::Overflow)?;
+
+		sqrt_price
+			.is_valid()
+			.then_some(sqrt_price)
+			.ok_or(ConversionError::OutsideValidRange)
 	}
 }
 
@@ -82,19 +96,29 @@ impl SqrtPrice {
 		if base.is_zero() {
 			MAX_SQRT_PRICE
 		} else {
-			let unbounded_sqrt_price = SqrtPrice::try_from(
+			let unbounded_sqrt_price = U256::try_from(
 				((U512::from(quote) << 256) / U512::from(base)).integer_sqrt() >>
 					(128 - Self::FRACTIONAL_BITS),
 			)
-			.unwrap();
+			.expect(
+				"
+				base is nonzero in this branch, so ((quote << 256) / base) <= (U256::MAX << 256) < 2^512;
+				therefore its integer square root is < 2^256, and after shifting down by
+				(128 - Self::FRACTIONAL_BITS) the result is still < 2^256, so this conversion cannot fail
+				",
+			);
 
-			if unbounded_sqrt_price < MIN_SQRT_PRICE {
-				MIN_SQRT_PRICE
-			} else if unbounded_sqrt_price > MAX_SQRT_PRICE {
-				MAX_SQRT_PRICE
-			} else {
-				unbounded_sqrt_price
-			}
+			SqrtPrice::clamp_from_raw(unbounded_sqrt_price)
+		}
+	}
+
+	pub fn clamp_from_raw(value: U256) -> Self {
+		if value < MIN_SQRT_PRICE.0 {
+			MIN_SQRT_PRICE
+		} else if value > MAX_SQRT_PRICE.0 {
+			MAX_SQRT_PRICE
+		} else {
+			SqrtPrice(value)
 		}
 	}
 
@@ -490,12 +514,11 @@ impl Price {
 	///
 	/// This function never panics.
 	pub fn into_tick(self) -> Option<Tick> {
-		let sqrt_price = SqrtPrice::from(self);
-		if sqrt_price.is_valid() {
-			Some(sqrt_price.to_tick())
-		} else {
-			None
-		}
+		self.try_into_sqrt_price().map(SqrtPrice::to_tick)
+	}
+
+	pub fn try_into_sqrt_price(self) -> Option<SqrtPrice> {
+		SqrtPrice::try_from(self).ok()
 	}
 
 	pub fn at_tick_zero() -> Self {
@@ -785,11 +808,16 @@ mod test {
 
 	#[test]
 	fn test_price_from_sqrt_price() {
+		let max_price = Price::from(MAX_SQRT_PRICE);
+		let clearly_out_of_range_price = Price::from_raw(U256::MAX);
+
 		assert_eq!(
 			Price::from(SqrtPrice::from_raw(U256::from(1) << 96)),
 			Price::from_raw(U256::from(1) << Price::FRACTIONAL_BITS)
 		);
-		assert!(Price::from(MIN_SQRT_PRICE) < Price::from(MAX_SQRT_PRICE));
+		assert!(Price::from(MIN_SQRT_PRICE) < max_price);
+		assert!(max_price.try_into_sqrt_price().is_some_and(|sqrt_price| sqrt_price.is_valid()));
+		assert!(clearly_out_of_range_price.try_into_sqrt_price().is_none());
 	}
 
 	#[test]

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -56,6 +56,7 @@ pub type Amount = U256;
 )]
 pub struct SqrtPrice(U256);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConversionError {
 	Overflow,
 	OutsideValidRange,
@@ -69,20 +70,16 @@ impl TryFrom<Price> for SqrtPrice {
 			(U512::from(price.0) << Price::FRACTIONAL_BITS).integer_sqrt() >>
 				(Price::FRACTIONAL_BITS - SqrtPrice::FRACTIONAL_BITS),
 		)
-		.map(SqrtPrice)
 		.map_err(|_| ConversionError::Overflow)?;
 
-		sqrt_price
-			.is_valid()
-			.then_some(sqrt_price)
-			.ok_or(ConversionError::OutsideValidRange)
+		SqrtPrice::try_from_raw(sqrt_price)
 	}
 }
 
 impl SqrtPrice {
 	pub const FRACTIONAL_BITS: u32 = 96;
 
-	pub fn is_valid(&self) -> bool {
+	fn is_valid(&self) -> bool {
 		(MIN_SQRT_PRICE..=MAX_SQRT_PRICE).contains(self)
 	}
 
@@ -112,6 +109,15 @@ impl SqrtPrice {
 		}
 	}
 
+	pub fn try_from_raw(value: U256) -> Result<Self, ConversionError> {
+		let sqrt_price = SqrtPrice(value);
+
+		sqrt_price
+			.is_valid()
+			.then_some(sqrt_price)
+			.ok_or(ConversionError::OutsideValidRange)
+	}
+
 	pub fn clamp_from_raw(value: U256) -> Self {
 		if value < MIN_SQRT_PRICE.0 {
 			MIN_SQRT_PRICE
@@ -120,10 +126,6 @@ impl SqrtPrice {
 		} else {
 			SqrtPrice(value)
 		}
-	}
-
-	pub fn from_raw(value: U256) -> Self {
-		SqrtPrice(value)
 	}
 
 	pub fn as_raw(&self) -> U256 {
@@ -812,7 +814,7 @@ mod test {
 		let clearly_out_of_range_price = Price::from_raw(U256::MAX);
 
 		assert_eq!(
-			Price::from(SqrtPrice::from_raw(U256::from(1) << 96)),
+			Price::from(SqrtPrice::try_from_raw(U256::from(1) << 96).unwrap()),
 			Price::from_raw(U256::from(1) << Price::FRACTIONAL_BITS)
 		);
 		assert!(Price::from(MIN_SQRT_PRICE) < max_price);

--- a/state-chain/amm/src/common.rs
+++ b/state-chain/amm/src/common.rs
@@ -544,10 +544,11 @@ mod test {
 			let mut rng: rand::rngs::StdRng = rand::rngs::StdRng::from_seed([0; 32]);
 
 			for _i in 0..10000000 {
-				let sqrt_price = SqrtPrice::from_raw(rng_u256_inclusive_bound(
+				let sqrt_price = SqrtPrice::try_from_raw(rng_u256_inclusive_bound(
 					&mut rng,
 					(MIN_SQRT_PRICE.as_raw() + 1)..=(MAX_SQRT_PRICE.as_raw() - 1),
-				));
+				))
+				.unwrap();
 				assert!(SD::sqrt_price_op_more_than(
 					SD::increase_sqrt_price(sqrt_price, 1),
 					sqrt_price

--- a/state-chain/amm/src/lib.rs
+++ b/state-chain/amm/src/lib.rs
@@ -131,11 +131,14 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 						);
 
 						(0..(count - 1)).scan(current_sqrt_price, move |sqrt_price, _| {
-							*sqrt_price = SqrtPrice::from_raw(mul_div_floor_checked(
+							*sqrt_price = SqrtPrice::try_from_raw(mul_div_floor_checked(
 								sqrt_price.as_raw(),
 								U256::one() << 128,
 								root,
-							).expect("root !=0 because current_sqrt_price & worst_sqrt_price are always > 0"));
+							).expect("root !=0 because current_sqrt_price & worst_sqrt_price are always > 0"))
+							.expect(
+								"interpolated sqrt prices stay within the existing valid range",
+							);
 							Some(*sqrt_price)
 						})
 					})
@@ -152,13 +155,16 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 						);
 
 						(0..(count - 1)).scan(current_sqrt_price, move |sqrt_price, _| {
-							*sqrt_price = SqrtPrice::from_raw(
+							*sqrt_price = SqrtPrice::try_from_raw(
 								mul_div_floor_checked(
 									sqrt_price.as_raw(),
 									root,
 									U256::one() << 128,
 								)
 								.unwrap(),
+							)
+							.expect(
+								"interpolated sqrt prices stay within the existing valid range",
 							);
 							Some(*sqrt_price)
 						})
@@ -177,14 +183,12 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 		sqrt_price: SqrtPrice,
 		delta: Tick,
 	) -> Option<SqrtPrice> {
-		if sqrt_price.is_valid() {
-			Some(match order {
-				Side::Buy => QuoteToBase::increase_sqrt_price(sqrt_price, delta),
-				Side::Sell => BaseToQuote::increase_sqrt_price(sqrt_price, delta),
-			})
-		} else {
-			None
-		}
+		let sqrt_price = SqrtPrice::try_from_raw(sqrt_price.as_raw()).ok()?;
+
+		Some(match order {
+			Side::Buy => QuoteToBase::increase_sqrt_price(sqrt_price, delta),
+			Side::Sell => BaseToQuote::increase_sqrt_price(sqrt_price, delta),
+		})
 	}
 
 	fn inner_current_sqrt_price<

--- a/state-chain/amm/src/lib.rs
+++ b/state-chain/amm/src/lib.rs
@@ -198,7 +198,7 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 	) -> Option<SqrtPrice> {
 		let limit_orders_sqrt_price = self.limit_orders.current_sqrt_price::<SD>();
 		let range_orders_sqrt_price =
-			self.range_orders.current_sqrt_price::<SD>().and_then(|sqrt_price| {
+			self.range_orders.current_sqrt_price::<SD>().map(|sqrt_price| {
 				sqrt_price_adjusted_by_pool_fee::<SD>(
 					sqrt_price,
 					self.range_orders.fee_hundredth_pips,
@@ -263,7 +263,7 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			// (We do this instead of adjusting the range order's price to avoid
 			// having to both adjust and "inverse adjust" the price, which due to
 			// rounding errors could lead to an infinite loop):
-			let limit_orders_sqrt_price = limit_orders_sqrt_price.and_then(|price| {
+			let limit_orders_sqrt_price = limit_orders_sqrt_price.map(|price| {
 				sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
 					price,
 					self.range_orders.fee_hundredth_pips,
@@ -562,21 +562,19 @@ fn grow_by_pool_fee(input: U256, fee_hundredth_pips: u32) -> U256 {
 	.unwrap_or(U256::MAX)
 }
 
-/// Adjusts a valid range-order sqrt price by the pool fee in the swap direction.
-///
-/// The result is clamped to `[MIN_SQRT_PRICE, MAX_SQRT_PRICE]`.
+/// Adjusts a range-order sqrt price by the pool fee in the swap direction, clamping the result into
+/// `[MIN_SQRT_PRICE, MAX_SQRT_PRICE]`.
 fn sqrt_price_adjusted_by_pool_fee<SD: common::SwapDirection>(
 	sqrt_price: SqrtPrice,
 	fee_hundredth_pips: u32,
-) -> Option<SqrtPrice> {
+) -> SqrtPrice {
 	let price = Price::from(sqrt_price);
 
-	let adjusted_price = Price::from_raw(match SD::INPUT_SIDE.sell_order() {
+	Price::from_raw(match SD::INPUT_SIDE.sell_order() {
 		Side::Buy => grow_by_pool_fee(price.as_raw(), fee_hundredth_pips),
 		Side::Sell => reduce_by_pool_fee(price.as_raw(), fee_hundredth_pips),
-	});
-
-	adjusted_price.try_into_sqrt_price()
+	})
+	.to_sqrt_price_clamped()
 }
 
 pub fn input_amount_from_fee(fee: U256, fee_hundredth_pips: u32) -> Option<U256> {

--- a/state-chain/amm/src/lib.rs
+++ b/state-chain/amm/src/lib.rs
@@ -20,9 +20,7 @@ mod tests;
 
 use core::convert::Infallible;
 
-use cf_amm_math::{
-	mul_div_floor_checked, Amount, Price, SqrtPrice, Tick, MAX_SQRT_PRICE, MIN_SQRT_PRICE,
-};
+use cf_amm_math::{mul_div_floor_checked, Amount, Price, SqrtPrice, Tick};
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use common::{
 	nth_root_of_integer_as_fixed_point, BaseToQuote, Pairs, PoolPairsMap, QuoteToBase,
@@ -64,11 +62,15 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 		fee_hundredth_pips: u32,
 		initial_range_order_price: Price,
 	) -> Result<Self, NewError> {
+		let initial_range_order_sqrt_price = initial_range_order_price
+			.try_into_sqrt_price()
+			.ok_or(NewError::RangeOrders(range_orders::NewError::InvalidInitialPrice))?;
+
 		Ok(Self {
 			limit_orders: limit_orders::PoolState::new(),
 			range_orders: range_orders::PoolState::new(
 				fee_hundredth_pips,
-				initial_range_order_price.into(),
+				initial_range_order_sqrt_price,
 			)
 			.map_err(NewError::RangeOrders)?,
 		})
@@ -192,7 +194,7 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 	) -> Option<SqrtPrice> {
 		let limit_orders_sqrt_price = self.limit_orders.current_sqrt_price::<SD>();
 		let range_orders_sqrt_price =
-			self.range_orders.current_sqrt_price::<SD>().map(|sqrt_price| {
+			self.range_orders.current_sqrt_price::<SD>().and_then(|sqrt_price| {
 				sqrt_price_adjusted_by_pool_fee::<SD>(
 					sqrt_price,
 					self.range_orders.fee_hundredth_pips,
@@ -257,7 +259,7 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			// (We do this instead of adjusting the range order's price to avoid
 			// having to both adjust and "inverse adjust" the price, which due to
 			// rounding errors could lead to an infinite loop):
-			let limit_orders_sqrt_price = limit_orders_sqrt_price.map(|price| {
+			let limit_orders_sqrt_price = limit_orders_sqrt_price.and_then(|price| {
 				sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
 					price,
 					self.range_orders.fee_hundredth_pips,
@@ -562,7 +564,7 @@ fn grow_by_pool_fee(input: U256, fee_hundredth_pips: u32) -> U256 {
 fn sqrt_price_adjusted_by_pool_fee<SD: common::SwapDirection>(
 	sqrt_price: SqrtPrice,
 	fee_hundredth_pips: u32,
-) -> SqrtPrice {
+) -> Option<SqrtPrice> {
 	let price = Price::from(sqrt_price);
 
 	let adjusted_price = Price::from_raw(match SD::INPUT_SIDE.sell_order() {
@@ -570,8 +572,7 @@ fn sqrt_price_adjusted_by_pool_fee<SD: common::SwapDirection>(
 		Side::Sell => reduce_by_pool_fee(price.as_raw(), fee_hundredth_pips),
 	});
 
-	let adjusted_sqrt_price: SqrtPrice = adjusted_price.into();
-	adjusted_sqrt_price.clamp(MIN_SQRT_PRICE, MAX_SQRT_PRICE)
+	adjusted_price.try_into_sqrt_price()
 }
 
 pub fn input_amount_from_fee(fee: U256, fee_hundredth_pips: u32) -> Option<U256> {

--- a/state-chain/amm/src/limit_orders.rs
+++ b/state-chain/amm/src/limit_orders.rs
@@ -543,14 +543,15 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			.and_then(|()| SD::best_priced_fixed_pool(&mut self.fixed_pools[!SD::INPUT_SIDE]))
 			.map(|entry| (*entry.key(), entry))
 			.filter(|(sqrt_price, _)| {
-				super::sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
+				// Compare in the clamped `SqrtPrice` domain, consistently with
+				// `super::PoolState::inner_swap`.
+				let sqrt_price_adjusted = super::sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
 					*sqrt_price,
 					range_orders_pool_fee_hundredth_pips,
-				)
-				.is_some_and(|sqrt_price_adjusted| {
-					sqrt_price_limit.is_none_or(|sqrt_price_limit| {
-						!SD::sqrt_price_op_more_than(sqrt_price_adjusted, sqrt_price_limit)
-					})
+				);
+
+				sqrt_price_limit.is_none_or(|sqrt_price_limit| {
+					!SD::sqrt_price_op_more_than(sqrt_price_adjusted, sqrt_price_limit)
 				})
 			}) {
 			let fixed_pool = fixed_pool_entry.get_mut();

--- a/state-chain/amm/src/limit_orders.rs
+++ b/state-chain/amm/src/limit_orders.rs
@@ -543,13 +543,14 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 			.and_then(|()| SD::best_priced_fixed_pool(&mut self.fixed_pools[!SD::INPUT_SIDE]))
 			.map(|entry| (*entry.key(), entry))
 			.filter(|(sqrt_price, _)| {
-				let sqrt_price_adjusted = super::sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
+				super::sqrt_price_adjusted_by_pool_fee::<SD::Inverse>(
 					*sqrt_price,
 					range_orders_pool_fee_hundredth_pips,
-				);
-
-				sqrt_price_limit.is_none_or(|sqrt_price_limit| {
-					!SD::sqrt_price_op_more_than(sqrt_price_adjusted, sqrt_price_limit)
+				)
+				.is_some_and(|sqrt_price_adjusted| {
+					sqrt_price_limit.is_none_or(|sqrt_price_limit| {
+						!SD::sqrt_price_op_more_than(sqrt_price_adjusted, sqrt_price_limit)
+					})
 				})
 			}) {
 			let fixed_pool = fixed_pool_entry.get_mut();

--- a/state-chain/amm/src/limit_orders/tests.rs
+++ b/state-chain/amm/src/limit_orders/tests.rs
@@ -611,7 +611,7 @@ fn swap() {
 				SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
 			)
 			.unwrap()
-				.to_tick(),
+			.to_tick(),
 			100.into()
 		));
 		assert_eq!(pool_state.swap::<BaseToQuote>(150.into(), None, 0), (200.into(), 24.into()));
@@ -630,7 +630,7 @@ fn swap() {
 				SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
 			)
 			.unwrap()
-				.to_tick(),
+			.to_tick(),
 			100.into()
 		));
 		assert_eq!(pool_state.swap::<QuoteToBase>(550.into(), None, 0), (200.into(), 50.into()));

--- a/state-chain/amm/src/limit_orders/tests.rs
+++ b/state-chain/amm/src/limit_orders/tests.rs
@@ -556,9 +556,10 @@ fn swap() {
 			assert_ok!(pool_state.collect_and_mint::<BaseToQuote>(
 				&LiquidityProvider::from([0; 32]),
 				offset +
-					SqrtPrice::from_raw(
+					SqrtPrice::try_from_raw(
 						SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
 					)
+					.unwrap()
 					.to_tick(),
 				100000000.into()
 			));
@@ -582,9 +583,10 @@ fn swap() {
 			assert_ok!(pool_state.collect_and_mint::<QuoteToBase>(
 				&LiquidityProvider::from([0; 32]),
 				offset +
-					SqrtPrice::from_raw(
+					SqrtPrice::try_from_raw(
 						SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
 					)
+					.unwrap()
 					.to_tick(),
 				100000000.into()
 			));
@@ -605,7 +607,10 @@ fn swap() {
 		));
 		assert_ok!(pool_state.collect_and_mint::<BaseToQuote>(
 			&LiquidityProvider::from([0; 32]),
-			SqrtPrice::from_raw(SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt())
+			SqrtPrice::try_from_raw(
+				SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
+			)
+			.unwrap()
 				.to_tick(),
 			100.into()
 		));
@@ -621,7 +626,10 @@ fn swap() {
 		));
 		assert_ok!(pool_state.collect_and_mint::<QuoteToBase>(
 			&LiquidityProvider::from([0; 32]),
-			SqrtPrice::from_raw(SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt())
+			SqrtPrice::try_from_raw(
+				SqrtPrice::from_tick(tick).as_raw() * U256::from(4).integer_sqrt()
+			)
+			.unwrap()
 				.to_tick(),
 			100.into()
 		));

--- a/state-chain/amm/src/limit_orders/tests.rs
+++ b/state-chain/amm/src/limit_orders/tests.rs
@@ -637,6 +637,25 @@ fn swap() {
 	}
 }
 
+// Regression test: a limit order placed at the extreme boundary tick must still be matched by a
+// swap with no price limit.
+#[test]
+fn boundary_tick_limit_order_consumed_without_price_limit() {
+	for tick in [MIN_TICK, MAX_TICK] {
+		let mut pool_state = PoolState::new();
+		assert_ok!(pool_state.collect_and_mint::<BaseToQuote>(
+			&LiquidityProvider::from([0; 32]),
+			tick,
+			1000.into()
+		));
+		assert_eq!(
+			pool_state.swap::<BaseToQuote>(Amount::MAX, None, 0).0,
+			1000.into(),
+			"limit order at tick {tick} should be fully consumed by an unbounded swap"
+		);
+	}
+}
+
 #[cfg(feature = "slow-tests")]
 #[test]
 fn maximum_liquidity_swap() {

--- a/state-chain/amm/src/range_orders.rs
+++ b/state-chain/amm/src/range_orders.rs
@@ -319,13 +319,14 @@ impl SwapDirection for BaseToQuote {
 			Then L / (L + R * A) <= 1
 			Then R * L / (L + R * A) <= u256::MAX
 		*/
-		Some(SqrtPrice::from_raw(mul_div_ceil_checked(
+		Some(SqrtPrice::try_from_raw(mul_div_ceil_checked(
 			liquidity,
 			sqrt_price_current.as_raw(),
 			// Addition will not overflow as function is not called if amount >=
 			// amount_required_to_reach_target
 			U512::from(liquidity) + U256::full_mul(amount, sqrt_price_current.as_raw()),
 		)?))
+		.expect("next sqrt price from input stays within the valid range before reaching target")
 	}
 
 	fn liquidity_delta_on_crossing_tick(tick_liquidity: &TickDelta) -> i128 {
@@ -378,7 +379,7 @@ impl SwapDirection for QuoteToBase {
 	) -> Option<SqrtPrice> {
 		// Will not overflow as function is not called if amount >= amount_required_to_reach_target,
 		// therefore bounding the function output to approximately <= MAX_SQRT_PRICE
-		Some(SqrtPrice::from_raw(
+		Some(SqrtPrice::try_from_raw(
 			sqrt_price_current.as_raw() +
 				mul_div_floor_checked(
 					amount,
@@ -386,6 +387,7 @@ impl SwapDirection for QuoteToBase {
 					liquidity,
 				)?,
 		))
+		.expect("next sqrt price from input stays within the valid range before reaching target")
 	}
 
 	fn liquidity_delta_on_crossing_tick(tick_liquidity: &TickDelta) -> i128 {
@@ -500,9 +502,8 @@ impl<LiquidityProvider: Clone + Ord> PoolState<LiquidityProvider> {
 		Self::validate_fees(fee_hundredth_pips)
 			.then_some(())
 			.ok_or(NewError::InvalidFeeAmount)?;
-		if !initial_sqrt_price.is_valid() {
-			return Err(NewError::InvalidInitialPrice);
-		}
+		let initial_sqrt_price = SqrtPrice::try_from_raw(initial_sqrt_price.as_raw())
+			.map_err(|_| NewError::InvalidInitialPrice)?;
 
 		let initial_tick = initial_sqrt_price.to_tick();
 		Ok(Self {

--- a/state-chain/amm/src/range_orders.rs
+++ b/state-chain/amm/src/range_orders.rs
@@ -319,14 +319,18 @@ impl SwapDirection for BaseToQuote {
 			Then L / (L + R * A) <= 1
 			Then R * L / (L + R * A) <= u256::MAX
 		*/
-		Some(SqrtPrice::try_from_raw(mul_div_ceil_checked(
-			liquidity,
-			sqrt_price_current.as_raw(),
-			// Addition will not overflow as function is not called if amount >=
-			// amount_required_to_reach_target
-			U512::from(liquidity) + U256::full_mul(amount, sqrt_price_current.as_raw()),
-		)?))
-		.expect("next sqrt price from input stays within the valid range before reaching target")
+		Some(
+			SqrtPrice::try_from_raw(mul_div_ceil_checked(
+				liquidity,
+				sqrt_price_current.as_raw(),
+				// Addition will not overflow as function is not called if amount >=
+				// amount_required_to_reach_target
+				U512::from(liquidity) + U256::full_mul(amount, sqrt_price_current.as_raw()),
+			)?)
+			.expect(
+				"next sqrt price from input stays within the valid range before reaching target",
+			),
+		)
 	}
 
 	fn liquidity_delta_on_crossing_tick(tick_liquidity: &TickDelta) -> i128 {
@@ -379,15 +383,19 @@ impl SwapDirection for QuoteToBase {
 	) -> Option<SqrtPrice> {
 		// Will not overflow as function is not called if amount >= amount_required_to_reach_target,
 		// therefore bounding the function output to approximately <= MAX_SQRT_PRICE
-		Some(SqrtPrice::try_from_raw(
-			sqrt_price_current.as_raw() +
-				mul_div_floor_checked(
-					amount,
-					U256::one() << SqrtPrice::FRACTIONAL_BITS,
-					liquidity,
-				)?,
-		))
-		.expect("next sqrt price from input stays within the valid range before reaching target")
+		Some(
+			SqrtPrice::try_from_raw(
+				sqrt_price_current.as_raw() +
+					mul_div_floor_checked(
+						amount,
+						U256::one() << SqrtPrice::FRACTIONAL_BITS,
+						liquidity,
+					)?,
+			)
+			.expect(
+				"next sqrt price from input stays within the valid range before reaching target",
+			),
+		)
 	}
 
 	fn liquidity_delta_on_crossing_tick(tick_liquidity: &TickDelta) -> i128 {

--- a/state-chain/amm/src/range_orders/tests.rs
+++ b/state-chain/amm/src/range_orders/tests.rs
@@ -148,7 +148,7 @@ fn test_amounts_to_liquidity() {
 
 					let pool_state = PoolState::new(
 						0,
-						SqrtPrice::from_raw(rng_u256_inclusive_bound(
+						SqrtPrice::try_from_raw(rng_u256_inclusive_bound(
 							&mut rng,
 							if tick > MIN_TICK {
 								SqrtPrice::from_tick(tick - 1).as_raw()..=
@@ -157,7 +157,8 @@ fn test_amounts_to_liquidity() {
 								SqrtPrice::from_tick(tick).as_raw()..=
 									SqrtPrice::from_tick(tick + 1).as_raw()
 							},
-						)),
+						))
+						.unwrap(),
 					)
 					.unwrap();
 

--- a/state-chain/amm/src/tests.rs
+++ b/state-chain/amm/src/tests.rs
@@ -276,9 +276,9 @@ fn check_price_adjustment_by_pool_fee() {
 
 		// Output is computed by adjusting the price instead:
 		let output = {
-			let sqrt_price = SqrtPrice::from(price);
+			let sqrt_price = price.try_into_sqrt_price().unwrap();
 			let adjusted_sqrt_price =
-				sqrt_price_adjusted_by_pool_fee::<SD>(sqrt_price, fee_hundredth_pips);
+				sqrt_price_adjusted_by_pool_fee::<SD>(sqrt_price, fee_hundredth_pips).unwrap();
 			let adjusted_price = Price::from(adjusted_sqrt_price);
 
 			SD::output_amount_floor(input, adjusted_price)
@@ -294,29 +294,11 @@ fn check_price_adjustment_by_pool_fee() {
 	}
 }
 
-// Boundary check: `sqrt_price_adjusted_by_pool_fee` must never produce an invalid
-// SqrtPrice across the full range of allowed pool fees, for both swap directions
-// at every valid tick — including the edges of [MIN_TICK, MAX_TICK] where the
-// raw fee adjustment would overflow into an invalid SqrtPrice.
 #[test]
-fn sqrt_price_adjusted_by_pool_fee_never_returns_invalid_sqrt_price() {
-	use cf_amm_math::MIN_TICK;
-
-	for &fee in &[0u32, 1, 100, 500, 50_000, 500_000] {
-		for &tick in &[MIN_TICK, MIN_TICK + 1, -1, 0, 1, MAX_TICK - 1, MAX_TICK] {
-			let sqrt_price = SqrtPrice::from_tick(tick);
-			for adjusted in [
-				sqrt_price_adjusted_by_pool_fee::<BaseToQuote>(sqrt_price, fee),
-				sqrt_price_adjusted_by_pool_fee::<QuoteToBase>(sqrt_price, fee),
-			] {
-				assert!(
-					adjusted.is_valid(),
-					"fee {} tick {}: adjusted SqrtPrice {:?} is invalid",
-					fee,
-					tick,
-					adjusted
-				);
-			}
-		}
+fn fee_adjustment_rejects_out_of_range_buy_prices() {
+	for (tick, fee) in [(887271, 100), (887267, 500), (MAX_TICK, 1), (MAX_TICK, 500_000)] {
+		let sqrt_price = Price::from_tick(tick).unwrap().try_into_sqrt_price().unwrap();
+		assert_eq!(sqrt_price_adjusted_by_pool_fee::<QuoteToBase>(sqrt_price, fee), None);
+		assert!(sqrt_price_adjusted_by_pool_fee::<BaseToQuote>(sqrt_price, fee).is_some());
 	}
 }

--- a/state-chain/amm/src/tests.rs
+++ b/state-chain/amm/src/tests.rs
@@ -277,9 +277,8 @@ fn check_price_adjustment_by_pool_fee() {
 		// Output is computed by adjusting the price instead:
 		let output = {
 			let sqrt_price = price.try_into_sqrt_price().unwrap();
-			let adjusted_sqrt_price =
-				sqrt_price_adjusted_by_pool_fee::<SD>(sqrt_price, fee_hundredth_pips).unwrap();
-			let adjusted_price = Price::from(adjusted_sqrt_price);
+			let adjusted_price =
+				Price::from(sqrt_price_adjusted_by_pool_fee::<SD>(sqrt_price, fee_hundredth_pips));
 
 			SD::output_amount_floor(input, adjusted_price)
 		};
@@ -294,11 +293,20 @@ fn check_price_adjustment_by_pool_fee() {
 	}
 }
 
+// Near `MAX_TICK` the buy-side fee adjustment pushes the price past the representable tick range.
+// It must be clamped to `MAX_SQRT_PRICE` (rather than rejected) so a swap can still execute against
+// the order at the extreme price. The sell-side adjustment stays in range.
 #[test]
-fn fee_adjustment_rejects_out_of_range_buy_prices() {
+fn fee_adjustment_clamps_out_of_range_buy_prices() {
 	for (tick, fee) in [(887271, 100), (887267, 500), (MAX_TICK, 1), (MAX_TICK, 500_000)] {
 		let sqrt_price = Price::from_tick(tick).unwrap().try_into_sqrt_price().unwrap();
-		assert_eq!(sqrt_price_adjusted_by_pool_fee::<QuoteToBase>(sqrt_price, fee), None);
-		assert!(sqrt_price_adjusted_by_pool_fee::<BaseToQuote>(sqrt_price, fee).is_some());
+
+		assert_eq!(
+			sqrt_price_adjusted_by_pool_fee::<QuoteToBase>(sqrt_price, fee),
+			MAX_SQRT_PRICE,
+			"tick {tick} fee {fee}: buy-side adjusted price should clamp to MAX_SQRT_PRICE"
+		);
+
+		assert!(sqrt_price_adjusted_by_pool_fee::<BaseToQuote>(sqrt_price, fee) < MAX_SQRT_PRICE);
 	}
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__ask_bid_map_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__ask_bid_map_serialization.snap
@@ -5,21 +5,21 @@ expression: val
 {
   "asks": {
     "limit_orders": {
-      "price": "0x1000276a3",
+      "price": "0x1000458e3",
       "depth": "0x9fbf1"
     },
     "range_orders": {
-      "price": "0x1000276a3",
+      "price": "0x100060aea",
       "depth": "0xbadf8"
     }
   },
   "bids": {
     "limit_orders": {
-      "price": "0x1000276a3",
+      "price": "0x10007bcf1",
       "depth": "0xd5fff"
     },
     "range_orders": {
-      "price": "0x1000276a3",
+      "price": "0x100096ef8",
       "depth": "0xf1206"
     }
   }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__ask_bid_map_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__ask_bid_map_serialization.snap
@@ -5,21 +5,21 @@ expression: val
 {
   "asks": {
     "limit_orders": {
-      "price": "0x1e240",
+      "price": "0x1000276a3",
       "depth": "0x9fbf1"
     },
     "range_orders": {
-      "price": "0x39447",
+      "price": "0x1000276a3",
       "depth": "0xbadf8"
     }
   },
   "bids": {
     "limit_orders": {
-      "price": "0x5464e",
+      "price": "0x1000276a3",
       "depth": "0xd5fff"
     },
     "range_orders": {
-      "price": "0x6f855",
+      "price": "0x1000276a3",
       "depth": "0xf1206"
     }
   }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_order_book_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_order_book_serialization.snap
@@ -6,13 +6,13 @@ expression: val
   "bids": [
     {
       "amount": "0xbc614e",
-      "sqrt_price": "0x5397fb1"
+      "sqrt_price": "0x1000276a3"
     }
   ],
   "asks": [
     {
       "amount": "0x165ec15",
-      "sqrt_price": "0x5e30a78"
+      "sqrt_price": "0x1000276a3"
     }
   ]
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_order_book_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_order_book_serialization.snap
@@ -6,13 +6,13 @@ expression: val
   "bids": [
     {
       "amount": "0xbc614e",
-      "sqrt_price": "0x1000276a3"
+      "sqrt_price": "0x1053bf654"
     }
   ],
   "asks": [
     {
       "amount": "0x165ec15",
-      "sqrt_price": "0x1000276a3"
+      "sqrt_price": "0x105e5811b"
     }
   ]
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v1_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v1_serialization.snap
@@ -4,6 +4,6 @@ expression: val
 ---
 {
   "price": "0xbc614e",
-  "sqrt_price": "0x1000276a3",
+  "sqrt_price": "0x1053bf654",
   "tick": -100
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v1_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v1_serialization.snap
@@ -4,6 +4,6 @@ expression: val
 ---
 {
   "price": "0xbc614e",
-  "sqrt_price": "0x5397fb1",
+  "sqrt_price": "0x1000276a3",
   "tick": -100
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v2_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v2_serialization.snap
@@ -11,7 +11,7 @@ expression: val
     "chain": "Ethereum",
     "asset": "USDC"
   },
-  "sell": "0x12d687",
-  "buy": "0x12d687",
-  "range_order": "0x12d687"
+  "sell": "0x1000276a3",
+  "buy": "0x1000276a3",
+  "range_order": "0x1000276a3"
 }

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v2_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__pool_price_v2_serialization.snap
@@ -11,7 +11,7 @@ expression: val
     "chain": "Ethereum",
     "asset": "USDC"
   },
-  "sell": "0x1000276a3",
-  "buy": "0x1000276a3",
-  "range_order": "0x1000276a3"
+  "sell": "0x100154d2a",
+  "buy": "0x100264171",
+  "range_order": "0x1003735b8"
 }

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -25,6 +25,7 @@ use cf_amm::{
 	common::LimitOrder,
 	math::{Price, SqrtPrice},
 };
+use cf_amm_math::{MAX_SQRT_PRICE, MIN_SQRT_PRICE};
 use cf_rpc_apis::{
 	broker::{SwapDepositAddress, WithdrawFeesDetail},
 	lp::{
@@ -146,12 +147,9 @@ fn ccm_unchecked() -> CcmChannelMetadataUnchecked {
 	}
 }
 
+#[track_caller]
 pub fn price_from_u128(value: u128) -> Price {
 	Price::from_raw(value.into())
-}
-
-pub fn sqrt_price_from_u128(value: u128) -> SqrtPrice {
-	SqrtPrice::try_from_raw(value.into()).unwrap()
 }
 
 #[test]
@@ -600,7 +598,7 @@ fn auction_state_serialization() {
 fn pool_price_v1_serialization() {
 	let val = PoolPriceV1 {
 		price: price_from_u128(12345678u128),
-		sqrt_price: sqrt_price_from_u128(87654321u128),
+		sqrt_price: MIN_SQRT_PRICE,
 		tick: -100i32,
 	};
 
@@ -613,9 +611,9 @@ fn pool_price_v2_serialization() {
 		base_asset: any::Asset::Eth,
 		quote_asset: any::Asset::Usdc,
 		price: pallet_cf_pools::PoolPriceV2 {
-			sell: Some(sqrt_price_from_u128(1234567u128)),
-			buy: Some(sqrt_price_from_u128(1234567u128)),
-			range_order: sqrt_price_from_u128(1234567u128),
+			sell: Some(MIN_SQRT_PRICE),
+			buy: Some(MIN_SQRT_PRICE),
+			range_order: MIN_SQRT_PRICE,
 		},
 	};
 
@@ -642,14 +640,8 @@ fn pool_pairs_map_serialization() {
 #[test]
 fn pool_order_book_serialization() {
 	let val = PoolOrderbook {
-		bids: vec![PoolOrder {
-			amount: 12345678u128.into(),
-			sqrt_price: sqrt_price_from_u128(87654321u128),
-		}],
-		asks: vec![PoolOrder {
-			amount: 23456789u128.into(),
-			sqrt_price: sqrt_price_from_u128(98765432u128),
-		}],
+		bids: vec![PoolOrder { amount: 12345678u128.into(), sqrt_price: MIN_SQRT_PRICE }],
+		asks: vec![PoolOrder { amount: 23456789u128.into(), sqrt_price: MIN_SQRT_PRICE }],
 	};
 
 	insta::assert_json_snapshot!(val);
@@ -677,21 +669,21 @@ fn ask_bid_map_serialization() {
 	let val = AskBidMap::<UnidirectionalPoolDepth> {
 		asks: UnidirectionalPoolDepth {
 			limit_orders: UnidirectionalSubPoolDepth {
-				price: Some(sqrt_price_from_u128(123456)),
+				price: Some(MIN_SQRT_PRICE),
 				depth: 654321.into(),
 			},
 			range_orders: UnidirectionalSubPoolDepth {
-				price: Some(sqrt_price_from_u128(234567)),
+				price: Some(MIN_SQRT_PRICE),
 				depth: 765432.into(),
 			},
 		},
 		bids: UnidirectionalPoolDepth {
 			limit_orders: UnidirectionalSubPoolDepth {
-				price: Some(sqrt_price_from_u128(345678)),
+				price: Some(MIN_SQRT_PRICE),
 				depth: 876543.into(),
 			},
 			range_orders: UnidirectionalSubPoolDepth {
-				price: Some(sqrt_price_from_u128(456789)),
+				price: Some(MIN_SQRT_PRICE),
 				depth: 987654.into(),
 			},
 		},

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -21,11 +21,8 @@ pub mod account_info;
 pub mod before_v7;
 pub mod eip712;
 
-use cf_amm::{
-	common::LimitOrder,
-	math::{Price, SqrtPrice},
-};
-use cf_amm_math::{MAX_SQRT_PRICE, MIN_SQRT_PRICE};
+use cf_amm::{common::LimitOrder, math::Price};
+use cf_amm_math::MIN_SQRT_PRICE;
 use cf_rpc_apis::{
 	broker::{SwapDepositAddress, WithdrawFeesDetail},
 	lp::{

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -22,7 +22,7 @@ pub mod before_v7;
 pub mod eip712;
 
 use cf_amm::{common::LimitOrder, math::Price};
-use cf_amm_math::MIN_SQRT_PRICE;
+use cf_amm_math::{SqrtPrice, MIN_SQRT_PRICE};
 use cf_rpc_apis::{
 	broker::{SwapDepositAddress, WithdrawFeesDetail},
 	lp::{
@@ -147,6 +147,13 @@ fn ccm_unchecked() -> CcmChannelMetadataUnchecked {
 #[track_caller]
 pub fn price_from_u128(value: u128) -> Price {
 	Price::from_raw(value.into())
+}
+
+/// Builds a distinct but valid `SqrtPrice` by offsetting from `MIN_SQRT_PRICE`, since arbitrary
+/// small raw values are no longer guaranteed to fall within the valid range.
+#[track_caller]
+pub fn sqrt_price_from_offset(offset: u64) -> SqrtPrice {
+	SqrtPrice::try_from_raw(MIN_SQRT_PRICE.as_raw() + sp_core::U256::from(offset)).unwrap()
 }
 
 #[test]
@@ -595,7 +602,7 @@ fn auction_state_serialization() {
 fn pool_price_v1_serialization() {
 	let val = PoolPriceV1 {
 		price: price_from_u128(12345678u128),
-		sqrt_price: MIN_SQRT_PRICE,
+		sqrt_price: sqrt_price_from_offset(87654321),
 		tick: -100i32,
 	};
 
@@ -608,9 +615,9 @@ fn pool_price_v2_serialization() {
 		base_asset: any::Asset::Eth,
 		quote_asset: any::Asset::Usdc,
 		price: pallet_cf_pools::PoolPriceV2 {
-			sell: Some(MIN_SQRT_PRICE),
-			buy: Some(MIN_SQRT_PRICE),
-			range_order: MIN_SQRT_PRICE,
+			sell: Some(sqrt_price_from_offset(1234567)),
+			buy: Some(sqrt_price_from_offset(2345678)),
+			range_order: sqrt_price_from_offset(3456789),
 		},
 	};
 
@@ -637,8 +644,14 @@ fn pool_pairs_map_serialization() {
 #[test]
 fn pool_order_book_serialization() {
 	let val = PoolOrderbook {
-		bids: vec![PoolOrder { amount: 12345678u128.into(), sqrt_price: MIN_SQRT_PRICE }],
-		asks: vec![PoolOrder { amount: 23456789u128.into(), sqrt_price: MIN_SQRT_PRICE }],
+		bids: vec![PoolOrder {
+			amount: 12345678u128.into(),
+			sqrt_price: sqrt_price_from_offset(87654321),
+		}],
+		asks: vec![PoolOrder {
+			amount: 23456789u128.into(),
+			sqrt_price: sqrt_price_from_offset(98765432),
+		}],
 	};
 
 	insta::assert_json_snapshot!(val);
@@ -666,21 +679,21 @@ fn ask_bid_map_serialization() {
 	let val = AskBidMap::<UnidirectionalPoolDepth> {
 		asks: UnidirectionalPoolDepth {
 			limit_orders: UnidirectionalSubPoolDepth {
-				price: Some(MIN_SQRT_PRICE),
+				price: Some(sqrt_price_from_offset(123456)),
 				depth: 654321.into(),
 			},
 			range_orders: UnidirectionalSubPoolDepth {
-				price: Some(MIN_SQRT_PRICE),
+				price: Some(sqrt_price_from_offset(234567)),
 				depth: 765432.into(),
 			},
 		},
 		bids: UnidirectionalPoolDepth {
 			limit_orders: UnidirectionalSubPoolDepth {
-				price: Some(MIN_SQRT_PRICE),
+				price: Some(sqrt_price_from_offset(345678)),
 				depth: 876543.into(),
 			},
 			range_orders: UnidirectionalSubPoolDepth {
-				price: Some(MIN_SQRT_PRICE),
+				price: Some(sqrt_price_from_offset(456789)),
 				depth: 987654.into(),
 			},
 		},

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -151,7 +151,7 @@ pub fn price_from_u128(value: u128) -> Price {
 }
 
 pub fn sqrt_price_from_u128(value: u128) -> SqrtPrice {
-	SqrtPrice::from_raw(value.into())
+	SqrtPrice::try_from_raw(value.into()).unwrap()
 }
 
 #[test]

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -187,12 +187,7 @@ fn swap_single_leg_returns_error_instead_of_panicking() {
 		}));
 
 		assert!(result.is_ok(), "swap_single_leg should not panic in the danger band");
-		assert_noop!(result.unwrap(), Error::<Test>::InsufficientLiquidity);
-
-		assert!(
-			LiquidityPools::pool_price(ASSET, STABLE_ASSET).unwrap().buy.is_some(),
-			"failed swap should roll back and leave the pool queryable"
-		);
+		assert!(result.unwrap().is_ok(), "swap should execute even within the danger band");
 	});
 }
 

--- a/state-chain/pallets/cf-pools/src/tests.rs
+++ b/state-chain/pallets/cf-pools/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::{self as pallet_cf_pools, mock::*, *};
 use cf_amm::{
-	common::{AskBidMap, LimitOrder, Side},
+	common::{AskBidMap, AssetPair, LimitOrder, Side},
 	math::Tick,
 };
 use cf_primitives::{chains::assets::any::Asset, AssetAmount};
@@ -137,6 +137,62 @@ fn test_mint_range_order_with_asset_amounts() {
 			Some(POSITION),
 			RangeOrderSize::Liquidity { liquidity: 0 }
 		));
+	});
+}
+
+#[test]
+fn swap_single_leg_returns_error_instead_of_panicking() {
+	use cf_amm::{math::MAX_TICK, range_orders::Size};
+	use core::convert::Infallible;
+
+	const ASSET: Asset = Asset::Eth;
+	const POOL_FEE: u32 = 500;
+	const ORDER_ID: OrderId = 0;
+	const DANGER_RANGE: core::ops::Range<Tick> = (MAX_TICK - 2)..MAX_TICK;
+
+	new_test_ext().execute_with(|| {
+		let asset_pair = AssetPair::new(ASSET, STABLE_ASSET).unwrap();
+
+		assert_ok!(LiquidityPools::new_pool(
+			RuntimeOrigin::root(),
+			ASSET,
+			STABLE_ASSET,
+			POOL_FEE,
+			Price::at_tick_zero(),
+		));
+
+		Pools::<Test>::mutate(asset_pair, |pool| {
+			let pool = pool.as_mut().expect("pool should exist");
+			pool.pool_state
+				.collect_and_mint_range_order(
+					&(ALICE, ORDER_ID),
+					DANGER_RANGE.clone(),
+					Size::Liquidity { liquidity: 1_000 },
+					Result::<_, Infallible>::Ok,
+				)
+				.expect("danger-band range order should mint");
+			pool.range_orders_cache
+				.entry(ALICE)
+				.or_default()
+				.insert(ORDER_ID, DANGER_RANGE.clone());
+		});
+
+		assert!(
+			LiquidityPools::pool_price(ASSET, STABLE_ASSET).unwrap().buy.is_some(),
+			"pre-swap buy price should still be available"
+		);
+
+		let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+			LiquidityPools::swap_single_leg(STABLE_ASSET, ASSET, 1)
+		}));
+
+		assert!(result.is_ok(), "swap_single_leg should not panic in the danger band");
+		assert_noop!(result.unwrap(), Error::<Test>::InsufficientLiquidity);
+
+		assert!(
+			LiquidityPools::pool_price(ASSET, STABLE_ASSET).unwrap().buy.is_some(),
+			"failed swap should roll back and leave the pool queryable"
+		);
 	});
 }
 


### PR DESCRIPTION
# Pull Request

This is a slightly more complete fix for PRO-2855 (see: #6574). 

Instead of clamping the SqrtPrice ony at the comparison, this makes constructing an out-of-bounds SqrtPrice invalid at the type level: 
- remove implicit `from` conversions
- make `from_raw` private

This means it's now explicitly that caller's responsiblity to ensure any validity constraints are enforced / checked. 

I considered extending this approach the `Price` type but it's slightly more complicated in that case since the Price is used in many non-AMM contexts where we don't necessarily mean "AMM-internal bounded price". We might want to consider introducing something like this, but not in this PR. 