### PR TITLE
fix: Correct accounting in some rare edge cases

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1301,6 +1301,50 @@ fn compute_per_asset_liquidation_estimates(
 		.collect()
 }
 
+/// Run a single upkeep tick for one borrower. Wrapped in `#[transactional]` so any
+/// error rolls back the full set of storage writes for this account (interest
+/// collection touches pool and `PendingNetworkFees` storage outside of
+/// `LoanAccounts`, which `try_mutate_exists` does not roll back on its own).
+#[transactional]
+fn upkeep_for_borrower<T: Config>(
+	borrower_id: &T::AccountId,
+	price_cache: &OraclePriceCache<T>,
+	config: &LendingConfiguration,
+	weight_used: &mut Weight,
+) -> DispatchResult {
+	LoanAccounts::<T>::try_mutate_exists(borrower_id, |maybe_account| {
+		let loan_account =
+			maybe_account.as_mut().expect("The caller guarantees that the key exists");
+
+		loan_account.derive_and_charge_interest(weight_used);
+
+		// Some of these may fail due to oracle prices being unavailable, but that's
+		// OK and doesn't need any specific error handling (they will simply be re-tried
+		// at a later point).
+		weight_used.saturating_accrue(T::WeightInfo::derive_ltv());
+		let ltv = loan_account.derive_ltv(price_cache)?;
+
+		loan_account.check_low_ltv_penalty_and_collect_interest(
+			ltv,
+			price_cache,
+			config,
+			weight_used,
+		);
+
+		loan_account.update_liquidation_status(borrower_id, ltv, price_cache, weight_used)?;
+
+		// If all loans are repaid manually while in liquidation, liquidation swaps will be
+		// aborted above and we need to delete the account:
+		if loan_account.loans.is_empty() &&
+			loan_account.liquidation_status == LiquidationStatus::NoLiquidation
+		{
+			*maybe_account = None;
+		}
+
+		Ok::<_, DispatchError>(())
+	})
+}
+
 /// Check collateralisation ratio (triggering/aborting liquidations if necessary) and
 /// periodically swap collected fees into each pool's desired asset.
 pub fn lending_upkeep<T: Config>(current_block: BlockNumberFor<T>) -> Weight {
@@ -1317,42 +1361,7 @@ pub fn lending_upkeep<T: Config>(current_block: BlockNumberFor<T>) -> Weight {
 	{
 		// Not being able to process a loan account is acceptable (expected when oracle
 		// prices are down).
-		let _ = LoanAccounts::<T>::try_mutate_exists(borrower_id, |maybe_account| {
-			let loan_account = maybe_account.as_mut().expect("Using keys read just above");
-
-			loan_account.derive_and_charge_interest(&mut weight_used);
-
-			// Some of these may fail due to oracle prices being unavailable, but that's
-			// OK and doesn't need any specific error handling (they will simply be re-tried
-			// at a later point).
-			weight_used.saturating_accrue(T::WeightInfo::derive_ltv());
-			let result: DispatchResult =
-				loan_account.derive_ltv(&price_cache).map_err(Into::into).and_then(|ltv| {
-					loan_account.check_low_ltv_penalty_and_collect_interest(
-						ltv,
-						&price_cache,
-						&config,
-						&mut weight_used,
-					);
-
-					loan_account.update_liquidation_status(
-						borrower_id,
-						ltv,
-						&price_cache,
-						&mut weight_used,
-					)
-				});
-
-			// If all loans are repaid manually while in liquidation, liquidation swaps will be
-			// aborted above and we need to delete the account:
-			if loan_account.loans.is_empty() &&
-				loan_account.liquidation_status == LiquidationStatus::NoLiquidation
-			{
-				*maybe_account = None;
-			}
-
-			result
-		});
+		let _ = upkeep_for_borrower::<T>(borrower_id, &price_cache, &config, &mut weight_used);
 	}
 
 	// Swap fees in every asset every fee_swap_interval_blocks, but only if they exceed

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1313,8 +1313,10 @@ fn upkeep_for_borrower<T: Config>(
 	weight_used: &mut Weight,
 ) -> DispatchResult {
 	LoanAccounts::<T>::try_mutate_exists(borrower_id, |maybe_account| {
-		let loan_account =
-			maybe_account.as_mut().expect("The caller guarantees that the key exists");
+		let Some(loan_account) = maybe_account.as_mut() else {
+			log_or_panic!("Loan account missing for borrower {borrower_id:?} during upkeep");
+			return Ok(());
+		};
 
 		loan_account.derive_and_charge_interest(weight_used);
 
@@ -1360,7 +1362,7 @@ pub fn lending_upkeep<T: Config>(current_block: BlockNumberFor<T>) -> Weight {
 		.iter()
 	{
 		// Not being able to process a loan account is acceptable (expected when oracle
-		// prices are down).
+		// prices are down or when liquidations are disabled).
 		let _ = upkeep_for_borrower::<T>(borrower_id, &price_cache, &config, &mut weight_used);
 	}
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_pool.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_pool.rs
@@ -188,10 +188,16 @@ where
 	}
 
 	/// Inform the pool that it won't be receiving `amount` as a result of account liquidation
-	/// not being able to recover the debt in full. This effectively socialises the loss by
-	/// reducing the pool's total amount.
+	/// not being able to recover the debt in full. The loss is split between the network and
+	/// the lenders: any outstanding network IOU is forgiven first (up to `amount`), and the
+	/// remainder is socialised across lenders by reducing `total_amount`. Forgiving the
+	/// network IOU first is necessary because `total_amount` was never grown by the network
+	/// portion of the loan's fees, so absorbing the full write-off into `total_amount` can
+	/// saturate it below `available_amount` and violate the pool's invariant.
 	pub fn write_off_unrecoverable_debt(&mut self, amount: AssetAmount) {
-		self.total_amount.saturating_reduce(amount);
+		let network_portion = core::cmp::min(amount, self.owed_to_network);
+		self.owed_to_network.saturating_reduce(network_portion);
+		self.total_amount.saturating_reduce(amount.saturating_sub(network_portion));
 	}
 
 	/// Receives repayment funds in the pool's asset (after they has been swapped)
@@ -407,5 +413,46 @@ mod tests {
 				(LENDER_3, Perquintill::from_rational(1u64, 6)),
 			],
 		);
+	}
+
+	#[test]
+	fn write_off_forgives_network_iou_before_charging_lenders() {
+		// Lender deposits 1000, pool lends out everything, then accrues 50 pool fees
+		// and 20 network fees (which cannot be collected because available_amount is 0).
+		// A subsequent full default of 1070 must reduce both owed_to_network and the pool's
+		// total amount.
+		let mut chp_pool = LendingPool::<AccountId>::new();
+		chp_pool.add_funds(&LENDER_1, 1000);
+		assert_ok!(chp_pool.provide_funds_for_loan(1000));
+
+		chp_pool.record_pool_fee(50);
+		let collected = chp_pool.record_and_collect_network_fee(20);
+		assert_eq!(collected, 0);
+		assert_eq!(chp_pool.total_amount, 1050);
+		assert_eq!(chp_pool.available_amount, 0);
+		assert_eq!(chp_pool.owed_to_network, 20);
+
+		chp_pool.write_off_unrecoverable_debt(1070);
+
+		assert_eq!(chp_pool.total_amount, 0);
+		assert_eq!(chp_pool.available_amount, 0);
+		assert_eq!(chp_pool.owed_to_network, 0);
+	}
+
+	#[test]
+	fn write_off_smaller_than_network_iou_leaves_total_amount_untouched() {
+		// When the write-off is smaller than the pool's outstanding network IOU, the IOU
+		// absorbs the full write-off and lenders' `total_amount` is unaffected.
+		let mut chp_pool = LendingPool::<AccountId>::new();
+		chp_pool.add_funds(&LENDER_1, 1000);
+		assert_ok!(chp_pool.provide_funds_for_loan(1000));
+		chp_pool.record_and_collect_network_fee(50);
+		assert_eq!(chp_pool.owed_to_network, 50);
+		assert_eq!(chp_pool.total_amount, 1000);
+
+		chp_pool.write_off_unrecoverable_debt(10);
+
+		assert_eq!(chp_pool.owed_to_network, 40);
+		assert_eq!(chp_pool.total_amount, 1000);
 	}
 }

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -4717,6 +4717,88 @@ mod safe_mode {
 				);
 			});
 	}
+
+	// Regression test for PRO-2860.
+	//
+	// When `update_liquidation_status` returns `Err(LiquidationsDisabled)` from inside
+	// `lending_upkeep`'s `try_mutate_exists` closure, the prior
+	// `check_low_ltv_penalty_and_collect_interest` call writes to external storage
+	// (lending pool totals, `PendingNetworkFees`). Those writes must roll back together
+	// with the borrower-side mutations (which `try_mutate_exists` discards on `Err`),
+	// otherwise the pool/network books reflect interest the borrower no longer owes.
+	#[test]
+	fn upkeep_does_not_commit_fees_when_liquidations_are_disabled() {
+		new_test_ext()
+			.with_funded_pool(INIT_POOL_AMOUNT)
+			.with_default_loan()
+			.then_execute_with(|_| {
+				// Snapshot pool / fee / loan state right after loan creation — once the
+				// origination fee has been taken. With the fix, this is exactly what we
+				// expect to see after upkeep runs while liquidations are disabled.
+				let pool_before = GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap();
+				let pending_network_fees_before = PendingNetworkFees::<Test>::get(LOAN_ASSET);
+				let loan_account_before = LoanAccounts::<Test>::get(BORROWER).unwrap();
+
+				// Trigger the bug's preconditions:
+				//  - liquidations disabled via safe mode,
+				//  - collection threshold low enough that any accrued interest gets collected,
+				//  - oracle price moved so that LTV exceeds the hard liquidation threshold (forces
+				//    `update_liquidation_status` down the `LiquidationsDisabled` path).
+				MockRuntimeSafeMode::set_safe_mode(PalletSafeMode {
+					liquidations_enabled: false,
+					..PalletSafeMode::code_green()
+				});
+				assert_ok!(Pallet::<Test>::update_pallet_config(
+					RuntimeOrigin::root(),
+					bounded_vec![PalletConfigUpdate::SetInterestCollectionThresholdUsd(1)],
+				));
+				MockPriceFeedApi::set_price_usd_fine(LOAN_ASSET, SWAP_RATE * 20);
+
+				System::reset_events();
+
+				(pool_before, pending_network_fees_before, loan_account_before)
+			})
+			// Process up to the first interest payment block so that upkeep runs
+			// `derive_and_charge_interest` followed by
+			// `check_low_ltv_penalty_and_collect_interest` followed by
+			// `update_liquidation_status` (which errors).
+			.then_process_blocks_until_block(
+				INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
+			)
+			.then_execute_with(|(pool_before, fees_before, loan_account_before)| {
+				// Sanity: liquidation must not have started.
+				assert_eq!(
+					LoanAccounts::<Test>::get(BORROWER).unwrap().liquidation_status,
+					LiquidationStatus::NoLiquidation
+				);
+				assert_no_matching_event!(
+					Test,
+					RuntimeEvent::LendingPools(Event::<Test>::LiquidationInitiated { .. })
+				);
+
+				// The invariant: because the per-account closure returned `Err`, the
+				// upkeep tick for this borrower must be a no-op across all storage.
+				assert_eq!(
+					GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
+					pool_before,
+					"pool accounting moved despite the loan-account mutations being rolled back",
+				);
+				assert_eq!(
+					PendingNetworkFees::<Test>::get(LOAN_ASSET),
+					fees_before,
+					"network fees were collected without a matching borrower receivable",
+				);
+				assert_eq!(
+					LoanAccounts::<Test>::get(BORROWER).unwrap(),
+					loan_account_before,
+					"loan account changed but upkeep was supposed to be a no-op",
+				);
+				assert_no_matching_event!(
+					Test,
+					RuntimeEvent::LendingPools(Event::<Test>::InterestTaken { .. })
+				);
+			});
+	}
 }
 
 mod liquidation_math_tests {

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -1913,9 +1913,10 @@ fn liquidation_with_outstanding_principal() {
 #[test]
 fn liquidation_with_outstanding_principal_and_owed_network_fees() {
 	// Same as in `liquidation_with_outstanding_principal`, we test a scenario where a loan is
-	// liquidated and the recovered principal isn't enough to cover the total loan amount. However,
-	// in this test utilisation is 100% and we want to check that the pool owing some fees to the
-	// network does not break anything when writing off debt.
+	// liquidated and the recovered principal isn't enough to cover the total loan amount. Here
+	// utilisation is 100% so the pool has an outstanding network IOU at the time of write-off;
+	// the IOU should be forgiven up to the written-off amount rather than left for future
+	// lender liquidity to cover.
 
 	const PRINCIPAL: AssetAmount = INIT_POOL_AMOUNT;
 	const INIT_COLLATERAL: AssetAmount = (4 * PRINCIPAL / 3) * SWAP_RATE; // 75% LTV
@@ -2004,18 +2005,20 @@ fn liquidation_with_outstanding_principal_and_owed_network_fees() {
 			assert_eq!(MockBalance::get_balance(&BORROWER, LOAN_ASSET), PRINCIPAL);
 			assert_eq!(MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET), 0);
 
-			// The pool has lost outstanding principal (but has accrued origination and liquidation fees):
+			// The pool has lost outstanding principal (but has accrued origination and liquidation fees).
+			// The defaulted loan's outstanding network fees are forgiven against the network's IOU
+			// rather than charged to lenders, so `total_amount` only absorbs the portion of the
+			// write-off that exceeds the network IOU.
 			let new_total_amount = INIT_POOL_AMOUNT + origination_fee_pool + liquidation_fee_pool -
-expected_outstanding_principal;
+				(expected_outstanding_principal - origination_fee_network);
 
 			assert_eq!(
 				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
 				LendingPool {
 					total_amount: new_total_amount,
-					// Network hasn't collected the fees, but the funds for that are available:
-					available_amount: new_total_amount + origination_fee_network,
+					available_amount: new_total_amount,
 					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: origination_fee_network,
+					owed_to_network: 0,
 				}
 			);
 

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -1547,8 +1547,6 @@ mod hybrid_boosting {
 
 			const LENDING_FEE_TOTAL: AssetAmount = TOTAL_FEE / 2; // 50_000
 
-			const LENDING_NETWORK_FEE: AssetAmount = LENDING_FEE_TOTAL * NETWORK_FEE_PERCENT / 100; // 10_000
-
 			// Total funds taken from the boost pool:
 			const LEGACY_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT - LENDING_FUNDS; // 99_950_000
 
@@ -1597,12 +1595,8 @@ mod hybrid_boosting {
 			// Lending pool lost all its funds:
 			assert_eq!(get_supply_position(BOOST_ASSET, BOOSTER_1), Some(0));
 
-			// The pool additionally owes some funds to the network (a side effect from
-			// optimistically crediting network at the time of boosting):
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().owed_to_network,
-				LENDING_NETWORK_FEE
-			);
+			// Network loses the uncollected fees:
+			assert_eq!(GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().owed_to_network, 0);
 
 			// Boost pool booster lost the funds it provided for boosting (no network fee
 			// had been taken):


### PR DESCRIPTION
# Pull Request

Closes: PRO-2859, PRO-2860

## Summary

1. `lending_upkeep` is now transactional per borrower (split the inner code into a separate function `lending_upkeep_for_borrower`). This addresses accounting inconsistency when fees are collected while liquidations are disabled due to safe mode.
2. A slight behaviour change in `write_off_unrecoverable_debt`: in case of bad debt a portion of it may now be absorbed by the pending network fees (likely a very small amount). This addresses accounting inconsistency in an extremely unlikely edge case where all loans are completely lost at 100% utilisation. A more long term solution is to implement PRO-2850 which would let us remove `owed_to_network` completely.


---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.