### PR TITLE
chore: fix tron Vault swap encoding string addresses

### DIFF
--- a/bouncer/shared/vault_swap/tron_vault_swap.ts
+++ b/bouncer/shared/vault_swap/tron_vault_swap.ts
@@ -70,7 +70,7 @@ export async function executeTronVaultSwap<A extends WithBrokerAccount>(
   } else {
     // TRC20 vault swap: transfer tokens to vaultSwapDetails.to
     const tokenContractAddress = getEncodedTronAddress(
-      getContractAddress(chainFromAsset(sourceAsset), sourceAsset),
+      '0x' + getContractAddress(chainFromAsset(sourceAsset), sourceAsset),
     );
     if (tokenContractAddress !== vaultSwapDetails.source_token_address)
       throw new Error(

--- a/bouncer/shared/vault_swap/tron_vault_swap.ts
+++ b/bouncer/shared/vault_swap/tron_vault_swap.ts
@@ -70,7 +70,7 @@ export async function executeTronVaultSwap<A extends WithBrokerAccount>(
   } else {
     // TRC20 vault swap: transfer tokens to vaultSwapDetails.to
     const tokenContractAddress = getEncodedTronAddress(
-      '0x' + getContractAddress(chainFromAsset(sourceAsset), sourceAsset),
+      '0x' + getContractAddress(chainFromAsset(sourceAsset), sourceAsset).slice(2),
     );
     if (tokenContractAddress !== vaultSwapDetails.source_token_address)
       throw new Error(

--- a/bouncer/shared/vault_swap/tron_vault_swap.ts
+++ b/bouncer/shared/vault_swap/tron_vault_swap.ts
@@ -63,7 +63,7 @@ export async function executeTronVaultSwap<A extends WithBrokerAccount>(
     }
     // Create a native TRX transfer transaction
     transaction = await tronWeb.transactionBuilder.sendTrx(
-      getEncodedTronAddress(vaultSwapDetails.to),
+      vaultSwapDetails.to,
       Number(vaultSwapDetails.value),
       getEncodedTronAddress(pubkey),
     );
@@ -72,7 +72,7 @@ export async function executeTronVaultSwap<A extends WithBrokerAccount>(
     const tokenContractAddress = getEncodedTronAddress(
       getContractAddress(chainFromAsset(sourceAsset), sourceAsset),
     );
-    if (tokenContractAddress.slice(2) !== vaultSwapDetails.source_token_address?.slice(2))
+    if (tokenContractAddress !== vaultSwapDetails.source_token_address)
       throw new Error(
         `Source token address mismatch. Expected ${tokenContractAddress}, got ${vaultSwapDetails.source_token_address}`,
       );
@@ -82,7 +82,7 @@ export async function executeTronVaultSwap<A extends WithBrokerAccount>(
       'transfer(address,uint256)',
       { feeLimit: 100_000_000 },
       [
-        { type: 'address', value: getEncodedTronAddress(vaultSwapDetails.to) },
+        { type: 'address', value: vaultSwapDetails.to },
         { type: 'uint256', value: amountToFineAmount(amountToSwap, assetDecimals(sourceAsset)) },
       ],
       getEncodedTronAddress(pubkey),

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -172,8 +172,7 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 			VaultSwapDetails::Solana { instruction } => VaultSwapDetails::Solana { instruction },
 			VaultSwapDetails::Ethereum { details } => VaultSwapDetails::Ethereum { details },
 			VaultSwapDetails::Arbitrum { details } => VaultSwapDetails::Arbitrum { details },
-			VaultSwapDetails::Tron { details, note } =>
-				VaultSwapDetails::Tron { details, note },
+			VaultSwapDetails::Tron { details, note } => VaultSwapDetails::Tron { details, note },
 		}
 	}
 }

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -122,29 +122,21 @@ pub enum VaultSwapDetails<BtcAddress> {
 	},
 }
 
-#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Serialize, Deserialize)]
-pub struct TronCallDetails {
-	#[serde(with = "sp_core::bytes")]
-	pub calldata: Vec<u8>,
-	pub value: sp_core::U256,
-	pub to: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub source_token_address: Option<String>,
-}
+pub type TronCallDetails = EvmCallDetails<String>;
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Serialize, Deserialize)]
-pub struct EvmCallDetails {
+pub struct EvmCallDetails<Address = sp_core::H160> {
 	/// The encoded calldata payload including function selector.
 	#[serde(with = "sp_core::bytes")]
 	pub calldata: Vec<u8>,
 	/// The ETH/ArbETH amount. Always 0 for ERC-20 tokens.
 	pub value: sp_core::U256,
-	/// The vault address for either Ethereum or Arbitrum.
-	pub to: sp_core::H160,
+	/// The vault address.
+	pub to: Address,
 	/// The address of the source token that requires user approval for the swap to succeed, if
 	/// any.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub source_token_address: Option<sp_core::H160>,
+	pub source_token_address: Option<Address>,
 }
 
 impl<BtcAddress> VaultSwapDetails<BtcAddress> {

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -24,6 +24,7 @@ use cf_chains::{
 	evm::Address as EvmAddress,
 	instances::{ArbitrumInstance, BitcoinInstance, EthereumInstance, TronInstance},
 	sol::SolInstructionRpc,
+	tron::TronAddress,
 	Arbitrum, Bitcoin, Chain, ChainCrypto, Ethereum, ForeignChainAddress, Tron,
 };
 pub use cf_chains::{dot::PolkadotAccountId, sol::SolAddress, ChainEnvironment};
@@ -115,10 +116,20 @@ pub enum VaultSwapDetails<BtcAddress> {
 	},
 	Tron {
 		#[serde(flatten)]
-		details: EvmCallDetails,
+		details: TronCallDetails,
 		#[serde(with = "sp_core::bytes")]
 		note: Vec<u8>,
 	},
+}
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Serialize, Deserialize)]
+pub struct TronCallDetails {
+	#[serde(with = "sp_core::bytes")]
+	pub calldata: Vec<u8>,
+	pub value: sp_core::U256,
+	pub to: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub source_token_address: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, Serialize, Deserialize)]
@@ -145,8 +156,18 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 		VaultSwapDetails::Arbitrum { details }
 	}
 
-	pub fn tron(details: EvmCallDetails, note: Vec<u8>) -> Self {
-		VaultSwapDetails::Tron { details, note }
+	pub fn tron(evm_details: EvmCallDetails, note: Vec<u8>) -> Self {
+		VaultSwapDetails::Tron {
+			details: TronCallDetails {
+				calldata: evm_details.calldata,
+				value: evm_details.value,
+				to: TronAddress::from_evm_address(evm_details.to).to_base58check(),
+				source_token_address: evm_details
+					.source_token_address
+					.map(|a| TronAddress::from_evm_address(a).to_base58check()),
+			},
+			note,
+		}
 	}
 
 	pub fn map_btc_address<F, T>(self, f: F) -> VaultSwapDetails<T>
@@ -159,7 +180,8 @@ impl<BtcAddress> VaultSwapDetails<BtcAddress> {
 			VaultSwapDetails::Solana { instruction } => VaultSwapDetails::Solana { instruction },
 			VaultSwapDetails::Ethereum { details } => VaultSwapDetails::Ethereum { details },
 			VaultSwapDetails::Arbitrum { details } => VaultSwapDetails::Arbitrum { details },
-			VaultSwapDetails::Tron { details, note } => VaultSwapDetails::Tron { details, note },
+			VaultSwapDetails::Tron { details, note } =>
+				VaultSwapDetails::Tron { details, note },
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

## Summary

We always want to return string Tron addresses on the rpcs. For Vault swaps the `EvmCallDetails` returned when encoding swaps has the "to" and "source_token_address" which were reused from EVM, declared as 20-bytes. Updated to return a String for Tron instead.

I considered using `TronAddress` instead of `String` but the serialize/deserialize are already implemented for the hex addresses, which are the ones used in the engines (21-byte addresses). It seems unnecessary to add more wrappers or types for just this, that's why it's implemented with a `String`.
