### PR TITLE
chore: add separate retry policy to retry the next block 

### DIFF
--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -1441,6 +1441,15 @@ impl RetryPolicy for DefaultRetryPolicy {
 		Some(10u32)
 	}
 }
+pub struct RetryNextBlockPolicy;
+impl RetryPolicy for RetryNextBlockPolicy {
+	type BlockNumber = u32;
+	type AttemptCount = u32;
+
+	fn next_attempt_delay(_retry_attempts: Self::AttemptCount) -> Option<Self::BlockNumber> {
+		Some(1u32)
+	}
+}
 
 pub enum RequiresSignatureRefresh<C: ChainCrypto, Api: ApiCall<C>> {
 	True(Option<Api>),

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -1446,8 +1446,12 @@ impl RetryPolicy for RetryNextBlockPolicy {
 	type BlockNumber = u32;
 	type AttemptCount = u32;
 
-	fn next_attempt_delay(_retry_attempts: Self::AttemptCount) -> Option<Self::BlockNumber> {
-		Some(1u32)
+	fn next_attempt_delay(retry_attempts: Self::AttemptCount) -> Option<Self::BlockNumber> {
+		if retry_attempts > 10 {
+			Some(10)
+		} else {
+			Some(1)
+		}
 	}
 }
 

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -132,7 +132,7 @@ mod benchmarks {
 		insert_transaction_broadcast_attempt::<T, I>(Some(caller.clone().into()), broadcast_id);
 		frame_system::Pallet::<T>::set_block_number(10u32.into());
 		let retry_block = frame_system::Pallet::<T>::block_number().saturating_add(
-			T::RetryPolicy::next_attempt_delay(Pallet::<T, I>::attempt_count(broadcast_id) + 1)
+			T::DelayRetryPolicy::next_attempt_delay(Pallet::<T, I>::attempt_count(broadcast_id) + 1)
 				.unwrap_or(One::one()),
 		);
 

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -132,7 +132,7 @@ mod benchmarks {
 		insert_transaction_broadcast_attempt::<T, I>(Some(caller.clone().into()), broadcast_id);
 		frame_system::Pallet::<T>::set_block_number(10u32.into());
 		let retry_block = frame_system::Pallet::<T>::block_number().saturating_add(
-			T::DelayRetryPolicy::next_attempt_delay(
+			T::BroadcastFailureRetryPolicy::next_attempt_delay(
 				Pallet::<T, I>::attempt_count(broadcast_id) + 1,
 			)
 			.unwrap_or(One::one()),

--- a/state-chain/pallets/cf-broadcast/src/benchmarking.rs
+++ b/state-chain/pallets/cf-broadcast/src/benchmarking.rs
@@ -132,8 +132,10 @@ mod benchmarks {
 		insert_transaction_broadcast_attempt::<T, I>(Some(caller.clone().into()), broadcast_id);
 		frame_system::Pallet::<T>::set_block_number(10u32.into());
 		let retry_block = frame_system::Pallet::<T>::block_number().saturating_add(
-			T::DelayRetryPolicy::next_attempt_delay(Pallet::<T, I>::attempt_count(broadcast_id) + 1)
-				.unwrap_or(One::one()),
+			T::DelayRetryPolicy::next_attempt_delay(
+				Pallet::<T, I>::attempt_count(broadcast_id) + 1,
+			)
+			.unwrap_or(One::one()),
 		);
 
 		#[extrinsic_call]

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -238,8 +238,15 @@ pub mod pallet {
 		/// by this number of blocks every time it runs out.
 		type SafeModeChainBlockMargin: Get<ChainBlockNumberFor<Self, I>>;
 
-		/// The policy on which decide when we slow down the retry of a broadcast.
-		type RetryPolicy: RetryPolicy<
+		/// The policy which defines when to retry with a delay a broadcast
+		/// (i.e. no authorities available/waiting for the broadcast barrier).
+		type DelayRetryPolicy: RetryPolicy<
+			BlockNumber = BlockNumberFor<Self>,
+			AttemptCount = AttemptCount,
+		>;
+
+		/// The policy which defines when to retry a broadcast failure.
+		type BroadcastFailureRetryPolicy: RetryPolicy<
 			BlockNumber = BlockNumberFor<Self>,
 			AttemptCount = AttemptCount,
 		>;
@@ -518,10 +525,7 @@ pub mod pallet {
 						nominee,
 					))
 				}
-				// Timeouts::<T, I>::append((
-				// 	current_chain_block.saturating_add(T::SafeModeChainBlockMargin::get()),
-				// 	expiries,
-				// ));
+
 				DelayedBroadcastRetryQueue::<T, I>::mutate(
 					block_number.saturating_add(T::SafeModeBlockMargin::get()),
 					|current| current.append(&mut delayed_retries),
@@ -603,7 +607,7 @@ pub mod pallet {
 						if BroadcastBarriers::<T, I>::get().first().is_some_and(
 							|broadcast_barrier_id| broadcast_id > *broadcast_barrier_id,
 						) {
-							Self::schedule_for_retry(broadcast_id);
+							Self::schedule_for_retry::<T::DelayRetryPolicy>(broadcast_id);
 						} else {
 							Self::start_broadcast_attempt(broadcast_data);
 						}
@@ -1039,15 +1043,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				broadcast_id
 			);
 			// Schedule for retry later, when more broadcasters become available.
-			Self::schedule_for_retry(broadcast_id);
+			Self::schedule_for_retry::<T::DelayRetryPolicy>(broadcast_id);
 		}
 	}
 
-	fn schedule_for_retry(broadcast_id: BroadcastId) {
+	fn schedule_for_retry<
+		P: RetryPolicy<BlockNumber = BlockNumberFor<T>, AttemptCount = AttemptCount>,
+	>(
+		broadcast_id: BroadcastId,
+	) {
 		// If no delay, retry in the next block.
 		let retry_block = frame_system::Pallet::<T>::block_number().saturating_add(
-			T::RetryPolicy::next_attempt_delay(Self::attempt_count(broadcast_id))
-				.unwrap_or(One::one()),
+			P::next_attempt_delay(Self::attempt_count(broadcast_id)).unwrap_or(One::one()),
 		);
 
 		DelayedBroadcastRetryQueue::<T, I>::append(retry_block, broadcast_id);
@@ -1087,7 +1094,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			if attempt_count >= T::EpochInfo::current_authority_count() as usize {
 				Self::abort_broadcast(broadcast_id);
 			} else {
-				Self::schedule_for_retry(broadcast_id);
+				Self::schedule_for_retry::<T::BroadcastFailureRetryPolicy>(broadcast_id);
 			}
 		} else {
 			// Do nothing since this failure has already been reported.

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -74,18 +74,29 @@ impl OnBroadcastReady<MockEthereum> for MockBroadcastReadyProvider {
 	type ApiCall = MockApiCall<MockEthereumChainCrypto>;
 }
 
-pub struct MockRetryPolicy;
+pub struct MockDelayRetryPolicy;
+pub struct MockBroadcastFailureRetryPolicy;
 
 parameter_types! {
-	pub static BroadcastDelay: Option<BlockNumberFor<Test>> = None;
+	pub static DelayRetryDelay: Option<BlockNumberFor<Test>> = None;
+	pub static BroadcastFailureRetryDelay: Option<BlockNumberFor<Test>> = None;
 }
 
-impl RetryPolicy for MockRetryPolicy {
+impl RetryPolicy for MockDelayRetryPolicy {
 	type BlockNumber = u64;
 	type AttemptCount = u32;
 
 	fn next_attempt_delay(_retry_attempts: Self::AttemptCount) -> Option<Self::BlockNumber> {
-		BroadcastDelay::get()
+		DelayRetryDelay::get()
+	}
+}
+
+impl RetryPolicy for MockBroadcastFailureRetryPolicy {
+	type BlockNumber = u64;
+	type AttemptCount = u32;
+
+	fn next_attempt_delay(_retry_attempts: Self::AttemptCount) -> Option<Self::BlockNumber> {
+		BroadcastFailureRetryDelay::get()
 	}
 }
 
@@ -112,8 +123,8 @@ impl pallet_cf_broadcast::Config<Instance1> for Test {
 	type SafeModeChainBlockMargin = ConstU64<SAFEMODE_CHAINBLOCK_MARGIN>;
 	type ChainTracking = BlockHeightProvider<MockEthereum>;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<MockEthereumChainCrypto>;
-	type DelayRetryPolicy = MockRetryPolicy;
-	type BroadcastFailureRetryPolicy = MockRetryPolicy;
+	type DelayRetryPolicy = MockDelayRetryPolicy;
+	type BroadcastFailureRetryPolicy = MockBroadcastFailureRetryPolicy;
 	type LiabilityTracker = MockLiabilityTracker;
 	type CfeBroadcastRequest = MockCfeInterface;
 	type BroadcastOutcomeHandler = MockBroadcastOutcomeHandler<MockEthereum>;
@@ -129,6 +140,8 @@ cf_test_utilities::impl_test_helpers! {
 		..Default::default()
 	},
 	|| {
+		DelayRetryDelay::set(None);
+		BroadcastFailureRetryDelay::set(None);
 		MockEpochInfo::next_epoch((0..151).collect());
 		MockNominator::use_current_authorities_as_nominees::<MockEpochInfo>();
 		for id in &MockEpochInfo::current_authorities() {

--- a/state-chain/pallets/cf-broadcast/src/mock.rs
+++ b/state-chain/pallets/cf-broadcast/src/mock.rs
@@ -112,7 +112,8 @@ impl pallet_cf_broadcast::Config<Instance1> for Test {
 	type SafeModeChainBlockMargin = ConstU64<SAFEMODE_CHAINBLOCK_MARGIN>;
 	type ChainTracking = BlockHeightProvider<MockEthereum>;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<MockEthereumChainCrypto>;
-	type RetryPolicy = MockRetryPolicy;
+	type DelayRetryPolicy = MockRetryPolicy;
+	type BroadcastFailureRetryPolicy = MockRetryPolicy;
 	type LiabilityTracker = MockLiabilityTracker;
 	type CfeBroadcastRequest = MockCfeInterface;
 	type BroadcastOutcomeHandler = MockBroadcastOutcomeHandler<MockEthereum>;

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -1059,7 +1059,7 @@ fn broadcast_retry_delay_works() {
 		.execute_with(|| {
 			let broadcast_id = start_mock_broadcast(SIG1);
 
-			BroadcastDelay::set(None);
+			BroadcastFailureRetryDelay::set(None);
 			// With no delay, retries are added to the normal queue, and is retried in the next
 			// block.
 			let next_block = System::block_number() + 1;
@@ -1074,7 +1074,7 @@ fn broadcast_retry_delay_works() {
 		})
 		.then_process_next_block()
 		.then_execute_with(|broadcast_id| {
-			BroadcastDelay::set(Some(delay));
+			BroadcastFailureRetryDelay::set(Some(delay));
 			// Set delay - retries will be added to the Delayed queue.
 			assert_ok!(Broadcaster::transaction_failed(RuntimeOrigin::signed(1u64), broadcast_id));
 			target = System::block_number() + delay;
@@ -1108,6 +1108,57 @@ fn broadcast_retry_delay_works() {
 }
 
 #[test]
+fn retry_policy_depends_on_retry_reason() {
+	let delay_retry_delay = 10;
+	let failure_retry_delay = 3;
+
+	new_test_ext().execute_with(|| {
+		DelayRetryDelay::set(Some(delay_retry_delay));
+		BroadcastFailureRetryDelay::set(Some(failure_retry_delay));
+
+		let retry_after_delay = System::block_number() + delay_retry_delay;
+		let retry_after_failure = System::block_number() + failure_retry_delay;
+
+		let failed_broadcast_id =
+			initiate_and_sign_broadcast(&mock_api_call(), SIG1, TxType::Normal);
+		let failed_broadcaster = AwaitingBroadcast::<Test, Instance1>::get(failed_broadcast_id)
+			.unwrap()
+			.nominee
+			.unwrap();
+
+		BroadcastBarriers::<Test, Instance1>::put(BTreeSet::from([failed_broadcast_id]));
+		let delayed_broadcast_id =
+			initiate_and_sign_broadcast(&mock_api_call(), SIG2, TxType::Normal);
+
+		assert!(DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_delay)
+			.contains(&delayed_broadcast_id));
+		assert!(!DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_failure)
+			.contains(&delayed_broadcast_id));
+
+		BroadcastBarriers::<Test, Instance1>::put(BTreeSet::<BroadcastId>::new());
+		assert!(BroadcastBarriers::<Test, Instance1>::get().is_empty());
+		MockNominator::set_nominees(Some(Default::default()));
+		let no_nominee_broadcast_id =
+			initiate_and_sign_broadcast(&mock_api_call(), SIG3, TxType::Normal);
+		assert!(BroadcastBarriers::<Test, Instance1>::get().is_empty());
+		assert!(DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_delay)
+			.contains(&no_nominee_broadcast_id));
+		assert!(!DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_failure)
+			.contains(&no_nominee_broadcast_id));
+
+		assert_ok!(Broadcaster::transaction_failed(
+			RuntimeOrigin::signed(failed_broadcaster),
+			failed_broadcast_id
+		));
+
+		assert!(DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_failure)
+			.contains(&failed_broadcast_id));
+		assert!(!DelayedBroadcastRetryQueue::<Test, Instance1>::get(retry_after_delay)
+			.contains(&failed_broadcast_id));
+	});
+}
+
+#[test]
 fn broadcast_timeout_delay_works() {
 	let mut target = 0;
 	let mut external_target = 0;
@@ -1116,7 +1167,7 @@ fn broadcast_timeout_delay_works() {
 		.execute_with(|| {
 			let broadcast_id = start_mock_broadcast(SIG1);
 
-			BroadcastDelay::set(Some(delay));
+			BroadcastFailureRetryDelay::set(Some(delay));
 			target = System::block_number() + BROADCAST_EXPIRY_BLOCKS;
 			external_target =
 				BlockHeightProvider::<MockEthereum>::get_block_height() + BROADCAST_EXPIRY_BLOCKS;
@@ -1147,7 +1198,7 @@ fn aborted_broadcasts_will_not_retry() {
 	new_test_ext()
 		.execute_with(|| {
 			let broadcast_id = start_mock_broadcast(SIG1);
-			BroadcastDelay::set(Some(delay));
+			BroadcastFailureRetryDelay::set(Some(delay));
 			target = System::block_number() + delay;
 			assert_ok!(Broadcaster::transaction_failed(RuntimeOrigin::signed(0u64), broadcast_id));
 			assert!(
@@ -1180,7 +1231,7 @@ fn succeeded_broadcasts_will_not_retry() {
 	new_test_ext()
 		.execute_with(|| {
 			let broadcast_id = start_mock_broadcast(SIG1);
-			BroadcastDelay::set(Some(delay));
+			BroadcastFailureRetryDelay::set(Some(delay));
 			target = System::block_number() + delay;
 			assert_ok!(Broadcaster::transaction_failed(RuntimeOrigin::signed(0u64), broadcast_id));
 			assert!(
@@ -1225,7 +1276,7 @@ fn broadcast_retries_will_not_be_overwritten_during_safe_mode() {
 	new_test_ext()
 		.then_execute_at_block(1_000u64, |_| {
 			let broadcast_id = start_mock_broadcast(SIG1);
-			BroadcastDelay::set(Some(1));
+			BroadcastFailureRetryDelay::set(Some(1));
 			assert_ok!(Broadcaster::transaction_failed(RuntimeOrigin::signed(0u64), broadcast_id));
 
 			// On safe mode next block, storage will be re-added to this target block.

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -27,7 +27,7 @@ use cf_chains::{
 	hub,
 	instances::ChainInstanceAlias,
 	sol::SolanaCrypto,
-	Arbitrum, Assethub, Bitcoin, DefaultRetryPolicy, Polkadot, Solana, Tron,
+	Arbitrum, Assethub, Bitcoin, DefaultRetryPolicy, Polkadot, RetryNextBlockPolicy, Solana, Tron,
 };
 pub use cf_primitives::{
 	chains::assets::any, AccountRole, Asset, AssetAmount, BlockNumber, FlipBalance, OrderId,
@@ -856,7 +856,8 @@ impl pallet_cf_broadcast::Config<Instance1> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_ETHEREUM>;
 	type ChainTracking = EthereumChainTracking;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<EvmCrypto>;
@@ -880,7 +881,8 @@ impl pallet_cf_broadcast::Config<Instance2> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU32<BLOCKS_PER_MINUTE_POLKADOT>;
 	type ChainTracking = PolkadotChainTracking;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<PolkadotCrypto>;
@@ -904,7 +906,8 @@ impl pallet_cf_broadcast::Config<Instance3> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU64<1>; // 10 minutes
 	type ChainTracking = BitcoinChainTracking;
-	type RetryPolicy = BitcoinRetryPolicy;
+	type DelayRetryPolicy = BitcoinRetryPolicy;
+	type BroadcastFailureRetryPolicy = BitcoinRetryPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<BitcoinCrypto>;
@@ -928,7 +931,8 @@ impl pallet_cf_broadcast::Config<Instance4> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_ARBITRUM>;
 	type ChainTracking = ArbitrumChainTracking;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<EvmCrypto>;
@@ -952,7 +956,8 @@ impl pallet_cf_broadcast::Config<Instance5> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU64<BLOCKS_PER_MINUTE_SOLANA>;
 	type ChainTracking = SolanaChainTrackingProvider;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = SolanaEgressWitnessingTrigger;
@@ -976,7 +981,8 @@ impl pallet_cf_broadcast::Config<Instance6> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU32<BLOCKS_PER_MINUTE_POLKADOT>;
 	type ChainTracking = AssethubChainTracking;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<PolkadotCrypto>;
@@ -1000,7 +1006,8 @@ impl pallet_cf_broadcast::Config<Instance7> for Runtime {
 	type SafeModeBlockMargin = ConstU32<10>;
 	type SafeModeChainBlockMargin = ConstU64<10>;
 	type ChainTracking = TronChainTracking;
-	type RetryPolicy = DefaultRetryPolicy;
+	type DelayRetryPolicy = DefaultRetryPolicy;
+	type BroadcastFailureRetryPolicy = RetryNextBlockPolicy;
 	type LiabilityTracker = AssetBalances;
 	type CfeBroadcastRequest = CfeInterface;
 	type ElectionEgressWitnesser = DummyEgressSuccessWitnesser<EvmCrypto>;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2867

## Summary

Add a separate `RetryPolicy` to be used in case of broadcast failure.
Keep the old policy, which delays for 10 blocks, for the other scenarios:
- no available authority
- waiting for broadcast barrier 

---

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.