### PR TITLE
feat: changed LPP behaviour with stale prices

### DIFF
--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2091,54 +2091,74 @@ pub mod pallet {
 			if let Some(stable_amount_after_fees) = swap.stable_amount {
 				// Calculate the slippage from oracle prices for both legs of the swap.
 				let to_stable_delta = if swap.input_asset() == STABLE_ASSET {
-					Some(SignedHundredthBasisPoints(0))
+					Ok(Some(SignedHundredthBasisPoints(0)))
 				} else {
 					Self::get_delta_from_oracle_price(
 						swap.swap.input_amount,
 						stable_amount_after_fees + swap.fees_amount(),
 						swap.input_asset(),
 						STABLE_ASSET,
-					)?
+					)
 				};
 				let from_stable_delta = if swap.output_asset() == STABLE_ASSET {
-					Some(SignedHundredthBasisPoints(0))
+					Ok(Some(SignedHundredthBasisPoints(0)))
 				} else {
 					Self::get_delta_from_oracle_price(
 						stable_amount_after_fees,
 						final_output,
 						STABLE_ASSET,
 						swap.output_asset(),
-					)?
+					)
 				};
 
 				// Sum the deltas or just use a single leg delta if the other leg doesn't have
 				// an oracle price.
 				let total_delta = match (to_stable_delta, from_stable_delta) {
-					(Some(to_stable), Some(from_stable)) =>
-						Some(to_stable.saturating_add(&from_stable)),
+					(Ok(Some(to_stable)), Ok(Some(from_stable))) =>
+						Ok(Some(to_stable.saturating_add(&from_stable))),
 					// Use the one sided slippage as long as that side is not USDC.
-					(Some(delta), None) if swap.input_asset() != STABLE_ASSET => Some(delta),
-					(None, Some(delta)) if swap.output_asset() != STABLE_ASSET => Some(delta),
-					_ => None,
+					(Ok(Some(delta)), Ok(None)) if swap.input_asset() != STABLE_ASSET =>
+						Ok(Some(delta)),
+					(Ok(None), Ok(Some(delta))) if swap.output_asset() != STABLE_ASSET =>
+						Ok(Some(delta)),
+					(Err(e), _) | (_, Err(e)) => Err(e),
+					_ => Ok(None),
 				};
 
-				if let Some(total_delta) = total_delta {
-					// Oracle price protection, aka Live price protection (LPP)
-					if let Some(params) = swap.refund_params() {
-						if let Some(max_slippage) = params.price_limits.max_oracle_price_slippage {
-							// The swapper expresses the limit as a worst acceptable *sell*
-							// price, so slippage needs to be measured in the negative
-							// direction (lower sell price is worse).
-							if total_delta <
-								SignedBasisPoints::negative_slippage(max_slippage).into()
-							{
-								return Err(SwapFailureReason::OraclePriceSlippageExceeded);
-							}
+				if let Some(refund_params) = swap.refund_params() {
+					// Oracle price protection, aka Live price protection (LPP).
+					let delta = match total_delta {
+						Ok(Some(total_delta)) => total_delta,
+						// Surface a stale oracle as a violation only if the user has set a max
+						// slippage.
+						Err(e)
+							if refund_params.price_limits.max_oracle_price_slippage.is_some() =>
+							return Err(e),
+						// Return nothing if the price is stale or the oracle price is unavailable
+						// for both legs.
+						Err(_) | Ok(None) => return Ok(None),
+					};
+
+					// Enforce the user's limit, falling back to the default LPP.
+					let max_slippage =
+						refund_params.price_limits.max_oracle_price_slippage.or_else(|| {
+							Self::get_default_oracle_price_protection(
+								swap.input_asset(),
+								swap.output_asset(),
+							)
+						});
+					if let Some(max_slippage) = max_slippage {
+						// The swapper expresses the limit as a worst acceptable *sell* price, so
+						// slippage needs to be measured in the negative direction (lower sell
+						// price is worse).
+						if delta < SignedBasisPoints::negative_slippage(max_slippage).into() {
+							return Err(SwapFailureReason::OraclePriceSlippageExceeded);
 						}
 					}
-
-					return Ok(Some(total_delta.pessimistic_rounded_into()));
 				}
+
+				// Report the gross delta even when no protection was enforced.
+				return Ok(total_delta.ok().flatten().map(|d| d.pessimistic_rounded_into()));
 			}
 
 			Ok(None)
@@ -3044,11 +3064,11 @@ pub mod pallet {
 
 		/// Returns the default price protection to apply to a one or two-leg swap.
 		///
-		/// Returns `None` if no oracle price is available for any leg of the swap (no
+		/// Returns `None` if no oracle price is available for both legs of the swap (no
 		/// meaningful protection can be applied). For two-leg swaps where only one leg
 		/// has an oracle, the other leg contributes zero to the total limit so that
 		/// the oracle-priced leg is still protected.
-		fn get_default_oracle_price_protection(
+		pub(super) fn get_default_oracle_price_protection(
 			input_asset: Asset,
 			output_asset: Asset,
 		) -> Option<BasisPoints> {
@@ -3133,22 +3153,6 @@ pub mod pallet {
 				dca_params
 			});
 
-			// Enforce the default oracle price protection for regular swaps
-			let processed_price_limits_and_expiry = match request_type {
-				SwapRequestType::Regular { .. } | SwapRequestType::RegularNoNetworkFee { .. } => {
-					price_limits_and_expiry.map(|limits| PriceLimitsAndExpiry {
-						// Only apply default oracle protection if no slippage is already set
-						max_oracle_price_slippage: if limits.max_oracle_price_slippage.is_none() {
-							Self::get_default_oracle_price_protection(input_asset, output_asset)
-						} else {
-							limits.max_oracle_price_slippage
-						},
-						..limits
-					})
-				},
-				SwapRequestType::NetworkFee | SwapRequestType::IngressEgressFee => None,
-			};
-
 			Self::deposit_event(Event::<T>::SwapRequested {
 				swap_request_id: request_id,
 				input_asset,
@@ -3157,7 +3161,7 @@ pub mod pallet {
 				request_type: request_type.clone().into_encoded::<T::AddressConverter>(),
 				origin: origin.clone(),
 				broker_fees: broker_fees.clone(),
-				price_limits_and_expiry: processed_price_limits_and_expiry.clone(),
+				price_limits_and_expiry: price_limits_and_expiry.clone(),
 				dca_parameters: dca_params.clone(),
 			});
 
@@ -3236,7 +3240,7 @@ pub mod pallet {
 						input_asset,
 						output_asset,
 						chunk_input_amount,
-						processed_price_limits_and_expiry.as_ref(),
+						price_limits_and_expiry.as_ref(),
 						SwapType::Swap,
 						request_id,
 						SWAP_DELAY_BLOCKS.into(),
@@ -3257,7 +3261,7 @@ pub mod pallet {
 									input_asset,
 									output_asset,
 									chunk_input_amount,
-									processed_price_limits_and_expiry.as_ref(),
+									price_limits_and_expiry.as_ref(),
 									SwapType::Swap,
 									request_id,
 									SWAP_DELAY_BLOCKS.saturating_add(chunk_interval).into(),
@@ -3275,7 +3279,7 @@ pub mod pallet {
 							output_asset,
 							state: SwapRequestState::UserSwap {
 								output_action: output_action.clone(),
-								price_limits_and_expiry: processed_price_limits_and_expiry,
+								price_limits_and_expiry,
 								dca_state,
 								fees,
 							},

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -1097,107 +1097,101 @@ mod oracle_swaps {
 				);
 			});
 		}
+
+		#[test]
+		fn stale_oracle_price_only_fails_when_slippage_limit_set() {
+			new_test_ext().execute_with(|| {
+				set_prices();
+				DefaultOraclePriceSlippageProtection::<Test>::set(
+					AssetPair::new(Asset::Btc, STABLE_ASSET).unwrap(),
+					10,
+				);
+				DefaultOraclePriceSlippageProtection::<Test>::set(
+					AssetPair::new(Asset::Eth, STABLE_ASSET).unwrap(),
+					10,
+				);
+				MockPriceFeedApi::set_stale(Asset::Btc, true);
+
+				// With no slippage limit configured, the stale-price error is silently
+				// dropped. No default LPP is enforced.
+				assert_eq!(
+					Pallet::<Test>::check_swap_price_violation(&test_swap_state(None)),
+					Ok(None),
+				);
+
+				// With a slippage limit configured, the stale-price error is surfaced.
+				assert_err!(
+					Pallet::<Test>::check_swap_price_violation(&test_swap_state(Some(100))),
+					SwapFailureReason::OraclePriceStale,
+				);
+
+				// Check that a stale price will not fail a simulated swap (no refund params)
+				assert_eq!(
+					Pallet::<Test>::check_swap_price_violation(&SwapState {
+						swap: Swap::new(
+							0.into(),
+							0.into(),
+							Asset::Btc,
+							Asset::Eth,
+							INPUT_AMOUNT,
+							None,
+							Default::default(),
+						),
+
+						network_fee_taken: Some(NETWORK_FEE),
+						broker_fee_taken: Some(BROKER_FEE),
+						stable_amount: Some(STABLE_AMOUNT),
+						final_output: Some(OUTPUT_AMOUNT),
+						oracle_delta: None,
+						oracle_delta_ex_fees: None,
+					}),
+					Ok(None),
+				);
+
+				// Confirm that the default LPP is enforced when not stale.
+				MockPriceFeedApi::set_stale(Asset::Btc, false);
+				assert_err!(
+					Pallet::<Test>::check_swap_price_violation(&test_swap_state(None)),
+					SwapFailureReason::OraclePriceSlippageExceeded,
+				);
+			});
+		}
 	}
 
 	#[test]
 	fn will_use_default_oracle_price_protection() {
+		const SWAP_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
 		const INPUT_ASSET: Asset = Asset::Eth;
 		const OUTPUT_ASSET: Asset = Asset::Btc;
 		const INPUT_PROTECTION_BPS: BasisPoints = 100;
 		const OUTPUT_PROTECTION_BPS: BasisPoints = 200;
-		// We want a non-zero network fee and broker fee to ensure they don't affect the
-		// price protection calculation.
-		const NETWORK_FEE_BPS: BasisPoints = 50;
-		const BROKER1_FEE_BPS: BasisPoints = 15;
-
-		const EXPECTED_PRICE_PROTECTION_BPS: BasisPoints =
-			INPUT_PROTECTION_BPS + OUTPUT_PROTECTION_BPS;
-
-		new_test_ext().execute_with(|| {
-			// Set the price, default oracle protections and network fee.
-			MockPriceFeedApi::set_price_usd(INPUT_ASSET, 10_000_000);
-			MockPriceFeedApi::set_price_usd(OUTPUT_ASSET, 40_000_000);
-			DefaultOraclePriceSlippageProtection::<Test>::set(
-				AssetPair::new(INPUT_ASSET, STABLE_ASSET).unwrap(),
-				INPUT_PROTECTION_BPS,
-			);
-			DefaultOraclePriceSlippageProtection::<Test>::set(
-				AssetPair::new(OUTPUT_ASSET, STABLE_ASSET).unwrap(),
-				OUTPUT_PROTECTION_BPS,
-			);
-			InternalSwapNetworkFee::<Test>::set(FeeRateAndMinimum {
-				rate: Permill::from_parts(NETWORK_FEE_BPS as u32 * 100),
-				minimum: 0,
-			});
-
-			// Init a swap request that has no oracle price protection set. Triggering the
-			// default to be calculated and used.
-			let _ = Swapping::init_swap_request(
-				INPUT_ASSET,
-				INPUT_AMOUNT,
-				OUTPUT_ASSET,
-				SwapRequestType::Regular {
-					output_action: SwapOutputAction::CreditOnChain { account_id: 1 },
-				},
-				vec![Beneficiary { account: BROKER, bps: BROKER1_FEE_BPS }].try_into().unwrap(),
-				Some(PriceLimitsAndExpiry {
-					expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
-						retry_duration: SWAP_DELAY_BLOCKS,
-						refund_address: AccountOrAddress::InternalAccount(1),
-						refund_ccm_metadata: None,
-					},
-					min_price: Price::zero(),
-					// No max oracle slippage is set
-					max_oracle_price_slippage: None,
-				}),
-				None,
-				SwapOrigin::OnChainAccount(0),
-			);
-
-			// Check the event for the adjusted price protection
-			assert_has_matching_event!(
-			Test,
-			RuntimeEvent::Swapping(Event::SwapRequested {
-				price_limits_and_expiry,
-				..
-			}) if *price_limits_and_expiry == Some(PriceLimitsAndExpiry {
-				expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
-					retry_duration: SWAP_DELAY_BLOCKS,
-					refund_address: AccountOrAddress::InternalAccount(1),
-					refund_ccm_metadata: None,
-				},
-				min_price: Price::zero(),
-				// Just the max oracle slippage has been changed
-				max_oracle_price_slippage: Some(EXPECTED_PRICE_PROTECTION_BPS),
-			}));
-		});
-	}
-
-	/// A single-sided oracle swap is where one of the assets supports oracle price but the other
-	/// does not. In this case, we should still be able to use oracle price protection for the
-	/// supported asset.
-	#[test]
-	fn single_sided_oracle_swap() {
-		const SWAP_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64; // TODO JAMIE: can we factor this out? .then_process_blocks(
-
-		const INPUT_ASSET: Asset = Asset::Eth;
-		const OUTPUT_ASSET: Asset = Asset::Flip;
-		const INPUT_PROTECTION_BPS: BasisPoints = 100;
 
 		new_test_ext()
 			.execute_with(|| {
-				// Set the price and default oracle protection for just one asset
-				MockPriceFeedApi::set_price_usd_fine(INPUT_ASSET, 10_000_000);
+				// Prices consistent with the default swap rate so the oracle delta is ~0
+				// when the rate is unchanged.
+				const OUTPUT_PRICE: u128 = 100_000_000;
+				const STABLE_PRICE: u128 = OUTPUT_PRICE * DEFAULT_SWAP_RATE;
+				const INPUT_PRICE: u128 = STABLE_PRICE * DEFAULT_SWAP_RATE;
+				MockPriceFeedApi::set_price_usd_fine(INPUT_ASSET, INPUT_PRICE);
+				MockPriceFeedApi::set_price_usd_fine(STABLE_ASSET, STABLE_PRICE);
+				MockPriceFeedApi::set_price_usd_fine(OUTPUT_ASSET, OUTPUT_PRICE);
+
 				DefaultOraclePriceSlippageProtection::<Test>::set(
 					AssetPair::new(INPUT_ASSET, STABLE_ASSET).unwrap(),
 					INPUT_PROTECTION_BPS,
 				);
-				// USDC needs to also have a price set for the oracle price protection to work.
-				MockPriceFeedApi::set_price_usd_fine(STABLE_ASSET, 10_000_000 * DEFAULT_SWAP_RATE);
+				DefaultOraclePriceSlippageProtection::<Test>::set(
+					AssetPair::new(OUTPUT_ASSET, STABLE_ASSET).unwrap(),
+					OUTPUT_PROTECTION_BPS,
+				);
 
-				// Init a swap request that has no oracle price protection set. Triggering the
-				// default to be calculated and used.
-				let _ = Swapping::init_swap_request(
+				// Drop the swap rate well below the combined default tolerance so the
+				// LPP check has something to reject.
+				SwapRate::set(0.1);
+
+				// Swap with no user-supplied oracle slippage — the per-chunk default applies.
+				Swapping::init_swap_request(
 					INPUT_ASSET,
 					INPUT_AMOUNT,
 					OUTPUT_ASSET,
@@ -1212,32 +1206,12 @@ mod oracle_swaps {
 							refund_ccm_metadata: None,
 						},
 						min_price: Price::zero(),
-						// No max oracle slippage is set
+						// No user-supplied slippage, so the default protection should be used
 						max_oracle_price_slippage: None,
 					}),
 					None,
 					SwapOrigin::OnChainAccount(0),
 				);
-
-				// Check the event for the adjusted price protection
-				assert_has_matching_event!(
-				Test,
-				RuntimeEvent::Swapping(Event::SwapRequested {
-					price_limits_and_expiry,
-					..
-				}) if *price_limits_and_expiry == Some(PriceLimitsAndExpiry {
-					expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
-						retry_duration: 0,
-						refund_address: AccountOrAddress::InternalAccount(1),
-						refund_ccm_metadata: None,
-					},
-					min_price: Price::zero(),
-					// Just the max oracle slippage has been changed
-					max_oracle_price_slippage: Some(INPUT_PROTECTION_BPS),
-				}));
-
-				// Set the swap rate so the swap will fail
-				SwapRate::set(0.1);
 			})
 			.then_process_blocks_until_block(SWAP_BLOCK)
 			.then_execute_with(|_| {
@@ -1249,5 +1223,130 @@ mod oracle_swaps {
 					})
 				);
 			});
+	}
+
+	#[test]
+	fn oracle_price_protection_user_specified() {
+		const SWAP_BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+		const INPUT_ASSET: Asset = Asset::Eth;
+		const OUTPUT_ASSET: Asset = Asset::Btc;
+		const PROTECTION_BPS: BasisPoints = 100;
+		// Set the default protection to a high value so it would not trigger if it is used
+		const DEFAULT_PROTECTION_BPS: BasisPoints = 10000;
+
+		new_test_ext()
+			.execute_with(|| {
+				// Prices consistent with the default swap rate so the oracle delta is ~0
+				// when the rate is unchanged.
+				const OUTPUT_PRICE: u128 = 100_000_000;
+				const STABLE_PRICE: u128 = OUTPUT_PRICE * DEFAULT_SWAP_RATE;
+				const INPUT_PRICE: u128 = STABLE_PRICE * DEFAULT_SWAP_RATE;
+				MockPriceFeedApi::set_price_usd_fine(INPUT_ASSET, INPUT_PRICE);
+				MockPriceFeedApi::set_price_usd_fine(STABLE_ASSET, STABLE_PRICE);
+				MockPriceFeedApi::set_price_usd_fine(OUTPUT_ASSET, OUTPUT_PRICE);
+
+				DefaultOraclePriceSlippageProtection::<Test>::set(
+					AssetPair::new(INPUT_ASSET, STABLE_ASSET).unwrap(),
+					DEFAULT_PROTECTION_BPS,
+				);
+				DefaultOraclePriceSlippageProtection::<Test>::set(
+					AssetPair::new(OUTPUT_ASSET, STABLE_ASSET).unwrap(),
+					DEFAULT_PROTECTION_BPS,
+				);
+
+				// Drop the swap rate so the user-specified protection will trigger.
+				SwapRate::set(0.9);
+
+				// Swap with no user-supplied oracle slippage — the per-chunk default applies.
+				Swapping::init_swap_request(
+					INPUT_ASSET,
+					INPUT_AMOUNT,
+					OUTPUT_ASSET,
+					SwapRequestType::Regular {
+						output_action: SwapOutputAction::CreditOnChain { account_id: 1 },
+					},
+					vec![].try_into().unwrap(),
+					Some(PriceLimitsAndExpiry {
+						expiry_behaviour: ExpiryBehaviour::RefundIfExpires {
+							retry_duration: 0,
+							refund_address: AccountOrAddress::InternalAccount(1),
+							refund_ccm_metadata: None,
+						},
+						min_price: Price::zero(),
+						// We set a user-specified slippage that is different from the default
+						max_oracle_price_slippage: Some(PROTECTION_BPS),
+					}),
+					None,
+					SwapOrigin::OnChainAccount(0),
+				);
+			})
+			.then_process_blocks_until_block(SWAP_BLOCK)
+			.then_execute_with(|_| {
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::Swapping(Event::SwapAborted {
+						reason: SwapFailureReason::OraclePriceSlippageExceeded,
+						..
+					})
+				);
+			});
+	}
+
+	#[test]
+	fn default_oracle_price_protection_values() {
+		const ASSET_A: Asset = Asset::Eth;
+		const ASSET_B: Asset = Asset::Btc;
+		const PROTECTION_A_BPS: BasisPoints = 100;
+		const PROTECTION_B_BPS: BasisPoints = 200;
+		const UNCONFIGURED_ASSET: Asset = Asset::Flip;
+
+		new_test_ext().execute_with(|| {
+			MockPriceFeedApi::set_price_usd(ASSET_A, 10_000_000);
+			MockPriceFeedApi::set_price_usd(ASSET_B, 40_000_000);
+			MockPriceFeedApi::set_price_usd(UNCONFIGURED_ASSET, 1);
+
+			DefaultOraclePriceSlippageProtection::<Test>::set(
+				AssetPair::new(ASSET_A, STABLE_ASSET).unwrap(),
+				PROTECTION_A_BPS,
+			);
+			DefaultOraclePriceSlippageProtection::<Test>::set(
+				AssetPair::new(ASSET_B, STABLE_ASSET).unwrap(),
+				PROTECTION_B_BPS,
+			);
+
+			// Two-leg swap: both legs contribute, slippage is summed.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(ASSET_A, ASSET_B),
+				Some(PROTECTION_A_BPS + PROTECTION_B_BPS),
+			);
+			// Direction doesn't matter — the sum is symmetric.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(ASSET_B, ASSET_A),
+				Some(PROTECTION_A_BPS + PROTECTION_B_BPS),
+			);
+
+			// Single-leg swap (stable in): only the non-stable leg contributes.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(STABLE_ASSET, ASSET_B),
+				Some(PROTECTION_B_BPS),
+			);
+			// Single-leg swap (stable out): same on the other side.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(ASSET_A, STABLE_ASSET),
+				Some(PROTECTION_A_BPS),
+			);
+
+			// Stable to stable, not a real swap, but make sure it doesn't cause any issues.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(STABLE_ASSET, STABLE_ASSET),
+				None,
+			);
+
+			// An unconfigured leg falls back to FALLBACK_DEFAULT_LPP_LIMIT_BPS rather than 0.
+			assert_eq!(
+				Pallet::<Test>::get_default_oracle_price_protection(ASSET_A, UNCONFIGURED_ASSET),
+				Some(PROTECTION_A_BPS + FALLBACK_DEFAULT_LPP_LIMIT_BPS),
+			);
+		});
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2857

## Summary

Changed the LPP behaviour:
- The default LPP is now calculated each chunk instead of being calculated at swap request time and stored in place of the user set LPP. So the default LPP can no longer be seen from events.
- A default LPP will no longer be enforced if a price is stale.
- A stale price will no longer fail a simulated swap. Therefore `swap_rate_v3` (quoting) will now pass with a stale price.
- unchanged: A stale price will still fail a swap if the user has explicitly set the oracle protection (normal oracle swap).

---

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
