### PR TITLE
chore: remove serde derivations for `types/before_version_*.rs`.

### DIFF
--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
@@ -1,7 +1,7 @@
 use super::*;
 use codec::{DecodeWithMemTracking, MaxEncodedLen};
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct VaultAddresses {
 	pub ethereum: EncodedAddress,
 	pub arbitrum: EncodedAddress,
@@ -41,23 +41,16 @@ impl From<VaultAddresses> for super::VaultAddresses {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone, Default, Debug)]
-#[serde(bound(deserialize = "Balance: Deserialize<'de> + Default"))]
+#[derive(Encode, Decode, TypeInfo, Clone, Default, Debug)]
 pub struct RpcAccountInfoCommonItems<Balance> {
-	#[serde(skip_serializing_if = "Vec::is_empty")]
-	#[serde(serialize_with = "serialize_vanity_name::from_utf8")]
 	pub vanity_name: VanityName,
 	pub flip_balance: Balance,
 	pub asset_balances: AssetMap<Balance>,
 	pub bond: Balance,
 	pub estimated_redeemable_balance: Balance,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub bound_redeem_address: Option<EvmAddress>,
-	#[serde(skip_serializing_if = "BTreeMap::is_empty")]
 	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub current_delegation_status: Option<DelegationInfo<Balance>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
 }
 
@@ -68,8 +61,6 @@ pub struct RpcAccountInfoCommonItems<Balance> {
 	PartialEq,
 	Eq,
 	Hash,
-	Serialize,
-	Deserialize,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -77,25 +68,12 @@ pub struct RpcAccountInfoCommonItems<Balance> {
 	MaxEncodedLen,
 	Default,
 )]
-#[serde(bound(deserialize = "T: Deserialize<'de> + Default"))]
 pub struct AssetMap<T> {
-	#[serde(rename = "Ethereum")]
-	#[serde(default)]
 	pub eth: EthAssetMap<T>,
-	#[serde(rename = "Polkadot")]
-	#[serde(default)]
 	pub dot: cf_primitives::chains::assets::dot::AssetMap<T>,
-	#[serde(rename = "Bitcoin")]
-	#[serde(default)]
 	pub btc: cf_primitives::chains::assets::btc::AssetMap<T>,
-	#[serde(rename = "Arbitrum")]
-	#[serde(default)]
 	pub arb: ArbAssetMap<T>,
-	#[serde(rename = "Solana")]
-	#[serde(default)]
 	pub sol: SolAssetMap<T>,
-	#[serde(rename = "Assethub")]
-	#[serde(default)]
 	pub hub: cf_primitives::chains::assets::hub::AssetMap<T>,
 }
 
@@ -106,8 +84,6 @@ pub struct AssetMap<T> {
 	PartialEq,
 	Eq,
 	Hash,
-	Serialize,
-	Deserialize,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -115,19 +91,10 @@ pub struct AssetMap<T> {
 	MaxEncodedLen,
 	Default,
 )]
-#[serde(bound(deserialize = "T: Deserialize<'de> + Default"))]
 pub struct EthAssetMap<T> {
-	#[serde(rename = "ETH")]
-	#[serde(default)]
 	pub eth: T,
-	#[serde(rename = "FLIP")]
-	#[serde(default)]
 	pub flip: T,
-	#[serde(rename = "USDC")]
-	#[serde(default)]
 	pub usdc: T,
-	#[serde(rename = "USDT")]
-	#[serde(default)]
 	pub usdt: T,
 }
 impl<T: Default> From<EthAssetMap<T>> for cf_primitives::chains::assets::eth::AssetMap<T> {
@@ -149,8 +116,6 @@ impl<T: Default> From<EthAssetMap<T>> for cf_primitives::chains::assets::eth::As
 	PartialEq,
 	Eq,
 	Hash,
-	Serialize,
-	Deserialize,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -158,13 +123,8 @@ impl<T: Default> From<EthAssetMap<T>> for cf_primitives::chains::assets::eth::As
 	MaxEncodedLen,
 	Default,
 )]
-#[serde(bound(deserialize = "T: Deserialize<'de> + Default"))]
 pub struct ArbAssetMap<T> {
-	#[serde(rename = "ETH")]
-	#[serde(default)]
 	pub eth: T,
-	#[serde(rename = "USDC")]
-	#[serde(default)]
 	pub usdc: T,
 }
 impl<T: Default> From<ArbAssetMap<T>> for cf_primitives::chains::assets::arb::AssetMap<T> {
@@ -180,8 +140,6 @@ impl<T: Default> From<ArbAssetMap<T>> for cf_primitives::chains::assets::arb::As
 	PartialEq,
 	Eq,
 	Hash,
-	Serialize,
-	Deserialize,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -189,13 +147,8 @@ impl<T: Default> From<ArbAssetMap<T>> for cf_primitives::chains::assets::arb::As
 	MaxEncodedLen,
 	Default,
 )]
-#[serde(bound(deserialize = "T: Deserialize<'de> + Default"))]
 pub struct SolAssetMap<T> {
-	#[serde(rename = "SOL")]
-	#[serde(default)]
 	pub sol: T,
-	#[serde(rename = "USDC")]
-	#[serde(default)]
 	pub usdc: T,
 }
 impl<T: Default> From<SolAssetMap<T>> for cf_primitives::chains::assets::sol::AssetMap<T> {
@@ -258,7 +211,7 @@ impl From<LiquidityProviderInfo> for super::LiquidityProviderInfo {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct TradingStrategyLimits {
 	pub minimum_deployment_amount: AssetMap<Option<AssetAmount>>,
 	pub minimum_added_funds_amount: AssetMap<Option<AssetAmount>>,
@@ -273,7 +226,7 @@ impl From<TradingStrategyLimits> for super::TradingStrategyLimits {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct NetworkFeeDetails {
 	pub standard_rate_and_minimum: FeeRateAndMinimum,
 	pub rates: AssetMap<Permill>,
@@ -288,7 +241,7 @@ impl From<NetworkFeeDetails> for super::NetworkFeeDetails {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct NetworkFees {
 	pub regular_network_fee: NetworkFeeDetails,
 	pub internal_swap_network_fee: NetworkFeeDetails,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -169,8 +169,6 @@ impl From<RpcLendingConfig> for super::RpcLendingConfig {
 	PartialEq,
 	Eq,
 	Hash,
-	Serialize,
-	Deserialize,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -178,25 +176,12 @@ impl From<RpcLendingConfig> for super::RpcLendingConfig {
 	MaxEncodedLen,
 	Default,
 )]
-#[serde(bound(deserialize = "T: Deserialize<'de> + Default"))]
 pub struct AssetMap<T> {
-	#[serde(rename = "Ethereum")]
-	#[serde(default)]
 	pub eth: cf_primitives::chains::assets::eth::AssetMap<T>,
-	#[serde(rename = "Polkadot")]
-	#[serde(default)]
 	pub dot: cf_primitives::chains::assets::dot::AssetMap<T>,
-	#[serde(rename = "Bitcoin")]
-	#[serde(default)]
 	pub btc: cf_primitives::chains::assets::btc::AssetMap<T>,
-	#[serde(rename = "Arbitrum")]
-	#[serde(default)]
 	pub arb: cf_primitives::chains::assets::arb::AssetMap<T>,
-	#[serde(rename = "Solana")]
-	#[serde(default)]
 	pub sol: cf_primitives::chains::assets::sol::AssetMap<T>,
-	#[serde(rename = "Assethub")]
-	#[serde(default)]
 	pub hub: cf_primitives::chains::assets::hub::AssetMap<T>,
 }
 
@@ -214,7 +199,7 @@ impl<T: Default> From<AssetMap<T>> for cf_primitives::chains::assets::any::Asset
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct NetworkFeeDetails {
 	pub standard_rate_and_minimum: FeeRateAndMinimum,
 	pub rates: AssetMap<Permill>,
@@ -229,7 +214,7 @@ impl From<NetworkFeeDetails> for super::NetworkFeeDetails {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct NetworkFees {
 	pub regular_network_fee: NetworkFeeDetails,
 	pub internal_swap_network_fee: NetworkFeeDetails,
@@ -244,7 +229,7 @@ impl From<NetworkFees> for super::NetworkFees {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct TradingStrategyLimits {
 	pub minimum_deployment_amount: AssetMap<Option<AssetAmount>>,
 	pub minimum_added_funds_amount: AssetMap<Option<AssetAmount>>,
@@ -282,23 +267,16 @@ impl From<LiquidityProviderInfo> for super::LiquidityProviderInfo {
 	}
 }
 
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone, Default, Debug)]
-#[serde(bound(deserialize = "Balance: Deserialize<'de> + Default"))]
+#[derive(Encode, Decode, TypeInfo, Clone, Default, Debug)]
 pub struct RpcAccountInfoCommonItems<Balance> {
-	#[serde(skip_serializing_if = "Vec::is_empty")]
-	#[serde(serialize_with = "serialize_vanity_name::from_utf8")]
 	pub vanity_name: VanityName,
 	pub flip_balance: Balance,
 	pub asset_balances: AssetMap<Balance>,
 	pub bond: Balance,
 	pub estimated_redeemable_balance: Balance,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub bound_redeem_address: Option<EvmAddress>,
-	#[serde(skip_serializing_if = "BTreeMap::is_empty")]
 	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub current_delegation_status: Option<DelegationInfo<Balance>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
 }
 
@@ -321,7 +299,7 @@ impl<B: Default> From<RpcAccountInfoCommonItems<B>> for super::RpcAccountInfoCom
 
 // VaultAddresses as returned by api_version 16 runtimes: has usdt fields added in v16
 // but lacks the tron field added in v17.
-#[derive(Encode, Decode, TypeInfo, Serialize, Deserialize, Clone)]
+#[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct VaultAddresses {
 	pub ethereum: EncodedAddress,
 	pub arbitrum: EncodedAddress,


### PR DESCRIPTION
# Pull Request

Part of PRO-2868

## Summary

This removes serde derivations from `types/before_version_16.rs` and `types/before_version_17.rs` (the others don't have them). The reason is that we don't use the serde implementations at all for historical types. These types only exist to provide backwards compatibility at the runtime api interface.

## Effects on runtime size

Removing these serde impls results in the runtime (build with `cf-build-release`) to be 3.5KB smaller. Which is a bit surprising, I would have assumed that these (unused) impls could have been optimized away by the compiler.
```
mxu@Maxims-Macbook chainflip-backend-21 % ls -la target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
-rw-r--r--  1 mxu  staff  4744434 May 13 11:45 target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
mxu@Maxims-Macbook chainflip-backend-21 % ls -la target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm 
-rw-r--r--  1 mxu  staff  4750980 May 13 11:59 target/release/wbuild/state-chain-runtime/state_chain_runtime.compact.compressed.wasm
```

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
   * [x] Anything non-obvious is documented in the `Summary` section above.
