### PR TITLE
refactor: liquidation cap checks

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lending-pools/src/benchmarking.rs
@@ -438,6 +438,82 @@ mod benchmarks {
 		);
 	}
 
+	/// Measures the cost of `request_loan` as a function of `n`, the number of
+	/// pre-existing borrower accounts in `LoanAccounts`.
+	///
+	/// Setup: three collateral pools and one loan pool seeded by a lender, `n`
+	/// pre-existing borrowers each with collateral and a small loan, then a target
+	/// borrower with supply in every collateral pool requesting a loan against the
+	/// loan-asset pool.
+	#[benchmark]
+	fn request_loan_with_borrowers(n: Linear<1, 50>) {
+		const LOAN: Asset = Asset::Btc;
+		const COLLATERALS: [Asset; 3] = [Asset::Eth, Asset::Usdc, Asset::Usdt];
+
+		const PER_BORROWER_COLLATERAL: AssetAmount = 10_000_000;
+		const PER_BORROWER_LOAN: AssetAmount = 1_000_000;
+		const TARGET_COLLATERAL: AssetAmount = 200_000_000;
+		const TARGET_LOAN: AssetAmount = 50_000_000;
+		const LENDER_SUPPLY: AssetAmount = 1_000_000_000_000;
+
+		disable_whitelist::<T>();
+
+		set_asset_price_in_usd::<T>(LOAN, 100_000_000_000);
+		assert_ok!(Pallet::<T>::create_lending_pool(gov_origin::<T>(), LOAN));
+		for asset in COLLATERALS {
+			set_asset_price_in_usd::<T>(asset, 100_000_000_000);
+			assert_ok!(Pallet::<T>::create_lending_pool(gov_origin::<T>(), asset));
+		}
+
+		// Deep liquidity so only the cap check (not LTV or available balance) bites.
+		let lender = setup_lp_account::<T>(LOAN, 100_000);
+		for asset in core::iter::once(LOAN).chain(COLLATERALS) {
+			T::Balance::credit_account(&lender, asset, LENDER_SUPPLY);
+			assert_ok!(Pallet::<T>::add_lender_funds(
+				RawOrigin::Signed(lender.clone()).into(),
+				asset,
+				LENDER_SUPPLY,
+			));
+		}
+
+		// `n` pre-existing borrowers, each contributing one record to `LoanAccounts`
+		// with non-zero α-weights on two collateral pools and a debt in a third.
+		for i in 0..n {
+			let b = setup_lp_account::<T>(COLLATERALS[0], 1_000 + i);
+			for asset in [COLLATERALS[0], COLLATERALS[1]] {
+				T::Balance::credit_account(&b, asset, PER_BORROWER_COLLATERAL);
+				assert_ok!(Pallet::<T>::add_lender_funds(
+					RawOrigin::Signed(b.clone()).into(),
+					asset,
+					PER_BORROWER_COLLATERAL,
+				));
+			}
+			assert_ok!(Pallet::<T>::request_loan(
+				RawOrigin::Signed(b).into(),
+				COLLATERALS[2],
+				PER_BORROWER_LOAN,
+				None,
+			));
+		}
+
+		// Target borrower holds supply in all three collateral pools — maximises the
+		// number of pools the post-borrow cap check has to visit.
+		let target = setup_lp_account::<T>(COLLATERALS[0], 0);
+		for asset in COLLATERALS {
+			T::Balance::credit_account(&target, asset, TARGET_COLLATERAL);
+			assert_ok!(Pallet::<T>::add_lender_funds(
+				RawOrigin::Signed(target.clone()).into(),
+				asset,
+				TARGET_COLLATERAL,
+			));
+		}
+
+		#[extrinsic_call]
+		request_loan(RawOrigin::Signed(target.clone()), LOAN, TARGET_LOAN, None);
+
+		assert!(LoanAccounts::<T>::contains_key(&target));
+	}
+
 	#[benchmark]
 	fn expand_loan() {
 		setup_lending_pool::<T>(NUMBER_OF_LENDERS);

--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -2,8 +2,9 @@ use cf_traits::lending::BoostFinalisationOutcome;
 
 use crate::{
 	core_lending_pool::{CoreLendingPool, CoreLoanId},
-	general_lending::{create_new_loan, fund_loan, OraclePriceCache},
+	general_lending::{check_pool_caps_after_borrow, create_new_loan, fund_loan, OraclePriceCache},
 };
+use sp_std::collections::btree_set::BTreeSet;
 
 use super::*;
 
@@ -204,15 +205,17 @@ impl<T: Config> BoostApi for Pallet<T> {
 				principal_amount: lending_pool_principal,
 			});
 
-			fund_loan::<T>(
-				&mut loan,
-				lending_pool_principal,
-				pool_fee,
-				network_fee,
+			fund_loan::<T>(&mut loan, lending_pool_principal, pool_fee, network_fee)?;
+
+			BoostLoans::<T>::insert(loan_id, loan);
+
+			// Boost loans are not collateralised, so only the loan-asset pool is affected.
+			check_pool_caps_after_borrow::<T>(
+				asset,
+				BTreeSet::new(),
 				&OraclePriceCache::<T>::default(),
 			)?;
 
-			BoostLoans::<T>::insert(loan_id, loan);
 			Some(loan_id)
 		} else {
 			None

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -904,12 +904,7 @@ impl<T: Config> LoanAccount<T> {
 
 		let origination_fee_pool = origination_fee_total.saturating_sub(origination_fee_network);
 
-		fund_loan::<T>(
-			&mut loan,
-			extra_principal,
-			origination_fee_pool,
-			origination_fee_network,
-		)?;
+		fund_loan::<T>(&mut loan, extra_principal, origination_fee_pool, origination_fee_network)?;
 
 		self.loans.insert(loan.id, loan);
 
@@ -1714,25 +1709,29 @@ pub fn remove_lender_funds<T: Config>(
 	Ok(())
 }
 
-/// Across all loan accounts, sums the amount of `asset` that the pool would need to
-/// release to liquidate `coverage_factor * total_loans_usd` of each account's debt at
-/// current oracle prices. Each account contributes in proportion to its share of
-/// `asset` in its collateral, capped by the account's total collateral USD value
-/// (we can never extract more than is held).
+/// For each `(asset, coverage_factor)` pair, sums across all loan accounts the amount of
+/// `asset` the pool would need to release to liquidate `coverage_factor * total_loans_usd`
+/// of each account's debt at current oracle prices. Each account contributes in proportion
+/// to its share of `asset` in its collateral, capped by the account's total collateral USD
+/// value (we can never extract more than is held).
+///
+/// Iterates `LoanAccounts` exactly once regardless of `asset_coverage.len()`, so callers
+/// that need to evaluate several pools in the same context should batch their queries.
 ///
 /// Allows stale oracle prices; errors only when a price is completely unavailable.
-fn required_liquidation_amount<T: Config>(
-	asset: Asset,
-	coverage_factor: Percent,
+fn required_liquidation_amounts<T: Config>(
+	asset_coverage: &[(Asset, Percent)],
 	price_cache: &OraclePriceCache<T>,
-) -> Result<AssetAmount, DispatchError> {
-	LoanAccounts::<T>::iter().try_fold(0 as AssetAmount, |acc, (_borrower_id, loan_account)| {
+) -> Result<BTreeMap<Asset, AssetAmount>, DispatchError> {
+	let mut totals: BTreeMap<Asset, AssetAmount> =
+		asset_coverage.iter().map(|(asset, _)| (*asset, 0)).collect();
+
+	LoanAccounts::<T>::iter().try_for_each(|(_borrower_id, loan_account)| -> DispatchResult {
 		let collateral = loan_account.get_total_collateral();
-		let collateral_in_asset = collateral.get(&asset).copied().unwrap_or_default();
 
 		let total_collateral_usd = price_cache.total_usd_value_of_allow_stale(&collateral)?;
 		if total_collateral_usd == 0 {
-			return Ok(acc);
+			return Ok(());
 		}
 
 		let total_loans_usd =
@@ -1742,29 +1741,37 @@ fn required_liquidation_amount<T: Config>(
 					.map(|usd| sum.saturating_add(usd))
 			})?;
 
-		// Undercollateralised accounts can be liquidated for at most their collateral value.
-		let target_liquidation_usd =
-			core::cmp::min(coverage_factor * total_loans_usd, total_collateral_usd);
+		for (asset, coverage_factor) in asset_coverage {
+			let collateral_in_asset = collateral.get(asset).copied().unwrap_or_default();
 
-		let required_in_asset = multiply_by_rational_with_rounding(
-			collateral_in_asset,
-			target_liquidation_usd,
-			total_collateral_usd,
-			Rounding::Up,
-		)
-		.unwrap_or(u128::MAX);
+			// Undercollateralised accounts can be liquidated for at most their collateral value.
+			let target_liquidation_usd =
+				core::cmp::min(*coverage_factor * total_loans_usd, total_collateral_usd);
 
-		Ok::<_, DispatchError>(acc.saturating_add(required_in_asset))
-	})
+			let required_in_asset = multiply_by_rational_with_rounding(
+				collateral_in_asset,
+				target_liquidation_usd,
+				total_collateral_usd,
+				Rounding::Up,
+			)
+			.unwrap_or(u128::MAX);
+
+			let entry = totals.entry(*asset).or_default();
+			*entry = entry.saturating_add(required_in_asset);
+		}
+
+		Ok(())
+	})?;
+
+	Ok(totals)
 }
 
 /// Maximum utilisation ratio allowed for `asset`'s lending pool while still leaving
 /// enough liquidity to liquidate `coverage_factor` of all outstanding loans at current
-/// oracle prices. The cap is `1 - required_liquidation_amount / pool.total_amount`,
-/// saturating at zero. Returns `Permill::one()` if the pool does not exist or is empty.
+/// oracle prices. Returns `Permill::one()` if the pool does not exist or is empty.
 ///
 /// Used by the RPC for the human-readable view of the cap. Enforcement compares the
-/// underlying amount directly — see [`required_liquidation_amount`].
+/// underlying amount directly — see [`required_liquidation_amounts`].
 pub fn compute_utilisation_cap<T: Config>(
 	asset: Asset,
 	coverage_factor: Percent,
@@ -1778,28 +1785,19 @@ pub fn compute_utilisation_cap<T: Config>(
 		return Ok(Permill::one());
 	}
 
-	let required = required_liquidation_amount::<T>(asset, coverage_factor, price_cache)?;
+	let required = required_liquidation_amounts::<T>(&[(asset, coverage_factor)], price_cache)?
+		.get(&asset)
+		.copied()
+		.unwrap_or_default();
 	Ok(Permill::one().saturating_sub(Permill::from_rational(required, pool.total_amount)))
-}
-
-/// True iff `asset`'s pool can still liquidate `coverage_factor` of outstanding loans at
-/// current oracle prices.
-fn pool_can_cover_required_liquidation<T: Config>(
-	asset: Asset,
-	coverage_factor: Percent,
-	price_cache: &OraclePriceCache<T>,
-) -> Result<bool, DispatchError> {
-	let required = required_liquidation_amount::<T>(asset, coverage_factor, price_cache)?;
-	let pool = GeneralLendingPools::<T>::get(asset).ok_or(Error::<T>::PoolDoesNotExist)?;
-	Ok(required <= pool.available_for_borrowing())
 }
 
 /// Checks the utilisation cap on every pool affected by a just-committed borrow:
 ///
-/// - `loan_asset`: the pool that funded the borrow (its `available_for_borrowing` just
-///   dropped). Always present.
-/// - `collateral_assets`: pools where the borrower's α-weight moved. Empty for boost
-///   loans (not collateralised).
+/// - `loan_asset`: the pool that funded the borrow (its `available_for_borrowing` just dropped).
+///   Always present.
+/// - `collateral_assets`: pools where the borrower's α-weight moved. Empty for boost loans (not
+///   collateralised).
 ///
 /// Must be called *after* the loan account has been written to storage; the surrounding
 /// `#[transactional]` rolls back on failure.
@@ -1810,20 +1808,29 @@ pub fn check_pool_caps_after_borrow<T: Config>(
 ) -> DispatchResult {
 	let coverage_factor = LendingConfig::<T>::get().liquidation_coverage_factor;
 
-	ensure!(
-		pool_can_cover_required_liquidation::<T>(loan_asset, coverage_factor, price_cache)?,
-		Error::<T>::UtilisationCapExceeded
-	);
+	// Build the asset slice, deduplicating loan_asset if also a collateral asset.
+	let mut asset_coverage: Vec<(Asset, Percent)> = Vec::with_capacity(collateral_assets.len() + 1);
+	asset_coverage.push((loan_asset, coverage_factor));
+	for asset in &collateral_assets {
+		if *asset != loan_asset {
+			asset_coverage.push((*asset, coverage_factor));
+		}
+	}
+
+	let required = required_liquidation_amounts::<T>(&asset_coverage, price_cache)?;
+
+	let pool_can_cover = |asset: Asset| -> Result<bool, DispatchError> {
+		let pool = GeneralLendingPools::<T>::get(asset).ok_or(Error::<T>::PoolDoesNotExist)?;
+		Ok(required.get(&asset).copied().unwrap_or_default() <= pool.available_for_borrowing())
+	};
+
+	ensure!(pool_can_cover(loan_asset)?, Error::<T>::UtilisationCapExceeded);
 
 	for asset in collateral_assets {
-		// Skip if it's also the loan asset — already checked above.
 		if asset == loan_asset {
 			continue;
 		}
-		ensure!(
-			pool_can_cover_required_liquidation::<T>(asset, coverage_factor, price_cache)?,
-			Error::<T>::CollateralPoolUtilisationCapExceeded
-		);
+		ensure!(pool_can_cover(asset)?, Error::<T>::CollateralPoolUtilisationCapExceeded);
 	}
 
 	Ok(())

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1717,25 +1717,57 @@ pub fn remove_lender_funds<T: Config>(
 	Ok(())
 }
 
-/// Computes the maximum utilisation ratio allowed for `asset`'s lending pool such that
-/// enough of the pool's asset is still available to fully liquidate `coverage_factor`
-/// of all outstanding loans at current oracle prices.
+/// Across all loan accounts, sums the amount of `asset` that the pool would need to
+/// release to liquidate `coverage_factor * total_loans_usd` of each account's debt at
+/// current oracle prices. Each account contributes in proportion to its share of
+/// `asset` in its collateral, capped by the account's total collateral USD value
+/// (we can never extract more than is held).
 ///
-/// For each loan account, the share of its collateral (by USD value) held in `asset` is
-/// multiplied by `coverage_factor * total_loans_usd` (capped by total collateral USD
-/// value for undercollateralised accounts). The sum across accounts is the amount of
-/// `asset` that may need to be released from the pool during liquidation; the cap is
-/// `1 - required / pool.total_amount`, saturating at zero.
+/// Allows stale oracle prices; errors only when a price is completely unavailable.
+fn required_liquidation_amount<T: Config>(
+	asset: Asset,
+	coverage_factor: Percent,
+	price_cache: &OraclePriceCache<T>,
+) -> Result<AssetAmount, DispatchError> {
+	LoanAccounts::<T>::iter().try_fold(0 as AssetAmount, |acc, (_borrower_id, loan_account)| {
+		let collateral = loan_account.get_total_collateral();
+		let collateral_in_asset = collateral.get(&asset).copied().unwrap_or_default();
+
+		let total_collateral_usd = price_cache.total_usd_value_of_allow_stale(&collateral)?;
+		if total_collateral_usd == 0 {
+			return Ok(acc);
+		}
+
+		let total_loans_usd =
+			loan_account.loans.values().try_fold(0 as AssetAmount, |sum, loan| {
+				price_cache
+					.usd_value_of_allow_stale(loan.asset, loan.owed_principal)
+					.map(|usd| sum.saturating_add(usd))
+			})?;
+
+		// Undercollateralised accounts can be liquidated for at most their collateral value.
+		let target_liquidation_usd =
+			core::cmp::min(coverage_factor * total_loans_usd, total_collateral_usd);
+
+		let required_in_asset = multiply_by_rational_with_rounding(
+			collateral_in_asset,
+			target_liquidation_usd,
+			total_collateral_usd,
+			Rounding::Up,
+		)
+		.unwrap_or(u128::MAX);
+
+		Ok::<_, DispatchError>(acc.saturating_add(required_in_asset))
+	})
+}
+
+/// Maximum utilisation ratio allowed for `asset`'s lending pool while still leaving
+/// enough liquidity to liquidate `coverage_factor` of all outstanding loans at current
+/// oracle prices. The cap is `1 - required_liquidation_amount / pool.total_amount`,
+/// saturating at zero. Returns `Permill::one()` if the pool does not exist or is empty.
 ///
-/// Returns `Permill::one()` if the pool does not exist or is empty. Allows stale oracle
-/// prices (since we still want the cap to hold during price outages), and propagates
-/// an error only when a price is completely unavailable.
-///
-/// Boost loans (in `BoostLoans`) are deliberately excluded from this sum: they are not
-/// secured by collateral and therefore reserve no liquidation capacity. We assume boost
-/// principal will always be repaid because boost loans are funded against prewitnessed
-/// deposits. They still consume `available_amount` via `fund_loan` and so push real pool
-/// utilisation up against this cap, but they do not lower the cap themselves.
+/// Used by the RPC for the human-readable view of the cap. Enforcement compares the
+/// underlying amount directly — see [`required_liquidation_amount`].
 pub fn compute_utilisation_cap<T: Config>(
 	asset: Asset,
 	coverage_factor: Percent,
@@ -1749,47 +1781,8 @@ pub fn compute_utilisation_cap<T: Config>(
 		return Ok(Permill::one());
 	}
 
-	// For each loan account, compute the amount of `asset` needed to cover `coverage_factor`
-	// of its loans. When the account holds multiple collateral assets, we attribute the
-	// required amount in proportion to each asset's USD share of the collateral.
-	let total_required_amount_across_accounts = LoanAccounts::<T>::iter().try_fold(
-		0 as AssetAmount,
-		|acc, (_borrower_id, loan_account)| {
-			let collateral = loan_account.get_total_collateral();
-			let collateral_in_asset = collateral.get(&asset).copied().unwrap_or_default();
-
-			let total_collateral_usd = price_cache.total_usd_value_of_allow_stale(&collateral)?;
-			if total_collateral_usd == 0 {
-				return Ok(acc);
-			}
-
-			let total_loans_usd =
-				loan_account.loans.values().try_fold(0 as AssetAmount, |sum, loan| {
-					price_cache
-						.usd_value_of_allow_stale(loan.asset, loan.owed_principal)
-						.map(|usd| sum.saturating_add(usd))
-				})?;
-
-			// For undercollateralised accounts we can extract at most the full collateral value.
-			let target_liquidation_usd =
-				core::cmp::min(coverage_factor * total_loans_usd, total_collateral_usd);
-
-			let required_in_asset = multiply_by_rational_with_rounding(
-				collateral_in_asset,
-				target_liquidation_usd,
-				total_collateral_usd,
-				Rounding::Up,
-			)
-			.unwrap_or(u128::MAX);
-
-			Ok::<_, DispatchError>(acc.saturating_add(required_in_asset))
-		},
-	)?;
-
-	let required_fraction =
-		Permill::from_rational(total_required_amount_across_accounts, pool.total_amount);
-
-	Ok(Permill::one().saturating_sub(required_fraction))
+	let required = required_liquidation_amount::<T>(asset, coverage_factor, price_cache)?;
+	Ok(Permill::one().saturating_sub(Permill::from_rational(required, pool.total_amount)))
 }
 
 /// Checks that, for every pool in which `borrower_id` holds collateral, the pool's current

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1412,7 +1412,7 @@ pub fn fund_loan<T: Config>(
 	origination_fee_network: AssetAmount,
 	price_cache: &OraclePriceCache<T>,
 ) -> Result<(), DispatchError> {
-	let utilisation_cap = compute_utilisation_cap::<T>(
+	let required_liquidation = required_liquidation_amount::<T>(
 		loan.asset,
 		LendingConfig::<T>::get().liquidation_coverage_factor,
 		price_cache,
@@ -1423,7 +1423,10 @@ pub fn fund_loan<T: Config>(
 
 		pool.provide_funds_for_loan(principal).map_err(Error::<T>::from)?;
 
-		ensure!(pool.get_utilisation() <= utilisation_cap, Error::<T>::UtilisationCapExceeded);
+		ensure!(
+			required_liquidation <= pool.available_for_borrowing(),
+			Error::<T>::UtilisationCapExceeded
+		);
 
 		pool.record_pool_fee(origination_fee_pool);
 
@@ -1785,10 +1788,10 @@ pub fn compute_utilisation_cap<T: Config>(
 	Ok(Permill::one().saturating_sub(Permill::from_rational(required, pool.total_amount)))
 }
 
-/// Checks that, for every pool in which `borrower_id` holds collateral, the pool's current
-/// utilisation does not exceed the (post-borrow) liquidation-coverage cap. Intended to be
-/// called after the loan account has been committed to storage so that
-/// [`compute_utilisation_cap`] sees the new principal directly.
+/// Checks that, for every pool in which `borrower_id` holds collateral, the pool can still
+/// cover the configured liquidation fraction of outstanding loans. Must be called after the
+/// loan account is written to storage so that [`required_liquidation_amount`] sees the new
+/// principal directly.
 fn check_collateral_pool_caps<T: Config>(
 	borrower_id: &T::AccountId,
 	price_cache: &OraclePriceCache<T>,
@@ -1800,13 +1803,15 @@ fn check_collateral_pool_caps<T: Config>(
 	let coverage_factor = LendingConfig::<T>::get().liquidation_coverage_factor;
 
 	for collateral_asset in loan_account.get_total_collateral().into_keys() {
-		let cap = compute_utilisation_cap::<T>(collateral_asset, coverage_factor, price_cache)?;
+		let required =
+			required_liquidation_amount::<T>(collateral_asset, coverage_factor, price_cache)?;
+		let pool = GeneralLendingPools::<T>::get(collateral_asset)
+			.ok_or(Error::<T>::PoolDoesNotExist)?;
 
-		let pool_utilisation = GeneralLendingPools::<T>::get(collateral_asset)
-			.ok_or(Error::<T>::PoolDoesNotExist)?
-			.get_utilisation();
-
-		ensure!(pool_utilisation <= cap, Error::<T>::CollateralPoolUtilisationCapExceeded);
+		ensure!(
+			required <= pool.available_for_borrowing(),
+			Error::<T>::CollateralPoolUtilisationCapExceeded
+		);
 	}
 
 	Ok(())

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -12,6 +12,8 @@ use frame_support::{
 	DefaultNoBound,
 };
 
+use sp_std::collections::btree_set::BTreeSet;
+
 use crate::core_lending_pool::ScaledAmountHP;
 
 use super::*;
@@ -907,7 +909,6 @@ impl<T: Config> LoanAccount<T> {
 			extra_principal,
 			origination_fee_pool,
 			origination_fee_network,
-			price_cache,
 		)?;
 
 		self.loans.insert(loan.id, loan);
@@ -1402,6 +1403,9 @@ pub(super) fn initiate_network_fee_swap<T: Config>(asset: Asset, fee_amount: Ass
 /// origination_fee_pool + origination_fee_network`. The pool fee stays in the pool (increasing
 /// lenders' share), while the network fee is immediately credited to the network.
 ///
+/// Does *not* enforce the utilisation cap — callers must check it once the loan account
+/// has been committed to storage (see [`check_pool_caps_after_borrow`]).
+///
 /// Emits [`Event::OriginationFeeTaken`].
 ///
 /// Fails if the pool for `loan.asset` does not exist or has insufficient available funds.
@@ -1410,23 +1414,11 @@ pub fn fund_loan<T: Config>(
 	principal: AssetAmount,
 	origination_fee_pool: AssetAmount,
 	origination_fee_network: AssetAmount,
-	price_cache: &OraclePriceCache<T>,
 ) -> Result<(), DispatchError> {
-	let required_liquidation = required_liquidation_amount::<T>(
-		loan.asset,
-		LendingConfig::<T>::get().liquidation_coverage_factor,
-		price_cache,
-	)?;
-
 	GeneralLendingPools::<T>::try_mutate(loan.asset, |pool| {
 		let pool = pool.as_mut().ok_or(Error::<T>::PoolDoesNotExist)?;
 
 		pool.provide_funds_for_loan(principal).map_err(Error::<T>::from)?;
-
-		ensure!(
-			required_liquidation <= pool.available_for_borrowing(),
-			Error::<T>::UtilisationCapExceeded
-		);
 
 		pool.record_pool_fee(origination_fee_pool);
 
@@ -1489,28 +1481,26 @@ impl<T: Config> LendingApi for Pallet<T> {
 		let loan = create_new_loan::<T>(asset, broker);
 		let loan_id = loan.id;
 
-		LoanAccounts::<T>::mutate(&borrower_id, |maybe_account| {
-			let account = maybe_account.get_or_insert(LoanAccount::new(borrower_id.clone()));
+		let collateral_assets = LoanAccounts::<T>::mutate(
+			&borrower_id,
+			|maybe_account| -> Result<BTreeSet<Asset>, DispatchError> {
+				let account = maybe_account.get_or_insert(LoanAccount::new(borrower_id.clone()));
 
-			// NOTE: it is important that this event is emitted before `OriginationFeeTaken` event
-			Self::deposit_event(Event::LoanCreated {
-				loan_id,
-				loan_type: LoanType::User(borrower_id.clone()),
-				asset,
-				principal_amount: amount_to_borrow,
-			});
+				// NOTE: this event must be emitted before `OriginationFeeTaken`.
+				Self::deposit_event(Event::LoanCreated {
+					loan_id,
+					loan_type: LoanType::User(borrower_id.clone()),
+					asset,
+					principal_amount: amount_to_borrow,
+				});
 
-			account.expand_loan_inner(loan, amount_to_borrow, &price_cache)?;
+				account.expand_loan_inner(loan, amount_to_borrow, &price_cache)?;
 
-			Ok::<_, DispatchError>(())
-		})?;
+				Ok(account.get_total_collateral().into_keys().collect())
+			},
+		)?;
 
-		// Borrowing more raises this account's total_loans_usd, which lowers the utilisation
-		// cap of every pool whose asset the account holds as collateral. Reject the loan if
-		// any of those caps would drop below the pool's current utilisation. We check this
-		// after the loan account is committed so `compute_utilisation_cap` sees the new
-		// principal directly; the surrounding `#[transactional]` rolls back on failure.
-		check_collateral_pool_caps::<T>(&borrower_id, &price_cache)?;
+		check_pool_caps_after_borrow::<T>(asset, collateral_assets, &price_cache)?;
 
 		Ok(loan_id)
 	}
@@ -1526,32 +1516,36 @@ impl<T: Config> LendingApi for Pallet<T> {
 	) -> Result<(), DispatchError> {
 		let price_cache = OraclePriceCache::<T>::default();
 
-		LoanAccounts::<T>::mutate(&borrower_id, |maybe_account| {
-			let loan_account = maybe_account.as_mut().ok_or(Error::<T>::LoanNotFound)?;
+		let (loan_asset, collateral_assets) = LoanAccounts::<T>::mutate(
+			&borrower_id,
+			|maybe_account| -> Result<(Asset, BTreeSet<Asset>), DispatchError> {
+				let loan_account = maybe_account.as_mut().ok_or(Error::<T>::LoanNotFound)?;
 
-			let loan = loan_account.loans.remove(&loan_id).ok_or(Error::<T>::LoanNotFound)?;
+				let loan = loan_account.loans.remove(&loan_id).ok_or(Error::<T>::LoanNotFound)?;
+				let loan_asset = loan.asset;
 
-			Self::deposit_event(Event::LoanUpdated {
-				loan_id,
-				extra_principal_amount: extra_amount_to_borrow,
-			});
+				Self::deposit_event(Event::LoanUpdated {
+					loan_id,
+					extra_principal_amount: extra_amount_to_borrow,
+				});
 
-			let config = LendingConfig::<T>::get();
-			ensure!(
-				extra_amount_to_borrow >=
-					price_cache.amount_from_usd_value(
-						loan.asset,
-						config.minimum_update_loan_amount_usd
-					)?,
-				Error::<T>::AmountBelowMinimum
-			);
+				let config = LendingConfig::<T>::get();
+				ensure!(
+					extra_amount_to_borrow >=
+						price_cache.amount_from_usd_value(
+							loan_asset,
+							config.minimum_update_loan_amount_usd
+						)?,
+					Error::<T>::AmountBelowMinimum
+				);
 
-			loan_account.expand_loan_inner(loan, extra_amount_to_borrow, &price_cache)?;
+				loan_account.expand_loan_inner(loan, extra_amount_to_borrow, &price_cache)?;
 
-			Ok::<_, DispatchError>(())
-		})?;
+				Ok((loan_asset, loan_account.get_total_collateral().into_keys().collect()))
+			},
+		)?;
 
-		check_collateral_pool_caps::<T>(&borrower_id, &price_cache)?;
+		check_pool_caps_after_borrow::<T>(loan_asset, collateral_assets, &price_cache)?;
 
 		Ok(())
 	}
@@ -1788,28 +1782,46 @@ pub fn compute_utilisation_cap<T: Config>(
 	Ok(Permill::one().saturating_sub(Permill::from_rational(required, pool.total_amount)))
 }
 
-/// Checks that, for every pool in which `borrower_id` holds collateral, the pool can still
-/// cover the configured liquidation fraction of outstanding loans. Must be called after the
-/// loan account is written to storage so that [`required_liquidation_amount`] sees the new
-/// principal directly.
-fn check_collateral_pool_caps<T: Config>(
-	borrower_id: &T::AccountId,
+/// True iff `asset`'s pool can still liquidate `coverage_factor` of outstanding loans at
+/// current oracle prices.
+fn pool_can_cover_required_liquidation<T: Config>(
+	asset: Asset,
+	coverage_factor: Percent,
+	price_cache: &OraclePriceCache<T>,
+) -> Result<bool, DispatchError> {
+	let required = required_liquidation_amount::<T>(asset, coverage_factor, price_cache)?;
+	let pool = GeneralLendingPools::<T>::get(asset).ok_or(Error::<T>::PoolDoesNotExist)?;
+	Ok(required <= pool.available_for_borrowing())
+}
+
+/// Checks the utilisation cap on every pool affected by a just-committed borrow:
+///
+/// - `loan_asset`: the pool that funded the borrow (its `available_for_borrowing` just
+///   dropped). Always present.
+/// - `collateral_assets`: pools where the borrower's α-weight moved. Empty for boost
+///   loans (not collateralised).
+///
+/// Must be called *after* the loan account has been written to storage; the surrounding
+/// `#[transactional]` rolls back on failure.
+pub fn check_pool_caps_after_borrow<T: Config>(
+	loan_asset: Asset,
+	collateral_assets: BTreeSet<Asset>,
 	price_cache: &OraclePriceCache<T>,
 ) -> DispatchResult {
-	let Some(loan_account) = LoanAccounts::<T>::get(borrower_id) else {
-		return Ok(());
-	};
-
 	let coverage_factor = LendingConfig::<T>::get().liquidation_coverage_factor;
 
-	for collateral_asset in loan_account.get_total_collateral().into_keys() {
-		let required =
-			required_liquidation_amount::<T>(collateral_asset, coverage_factor, price_cache)?;
-		let pool = GeneralLendingPools::<T>::get(collateral_asset)
-			.ok_or(Error::<T>::PoolDoesNotExist)?;
+	ensure!(
+		pool_can_cover_required_liquidation::<T>(loan_asset, coverage_factor, price_cache)?,
+		Error::<T>::UtilisationCapExceeded
+	);
 
+	for asset in collateral_assets {
+		// Skip if it's also the loan asset — already checked above.
+		if asset == loan_asset {
+			continue;
+		}
 		ensure!(
-			required <= pool.available_for_borrowing(),
+			pool_can_cover_required_liquidation::<T>(asset, coverage_factor, price_cache)?,
 			Error::<T>::CollateralPoolUtilisationCapExceeded
 		);
 	}

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_pool.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_pool.rs
@@ -139,9 +139,14 @@ where
 		Ok(())
 	}
 
+	/// Pool balance that can actually be drawn for a new borrow: the available balance
+	/// minus what's earmarked for the network.
+	pub fn available_for_borrowing(&self) -> AssetAmount {
+		self.available_amount.saturating_sub(self.owed_to_network)
+	}
+
 	pub fn get_utilisation(&self) -> Permill {
-		let available_for_borrowing = self.available_amount.saturating_sub(self.owed_to_network);
-		let in_use = self.total_amount.saturating_sub(available_for_borrowing);
+		let in_use = self.total_amount.saturating_sub(self.available_for_borrowing());
 
 		// Note: `from_rational` does not panic on invalid inputs and instead returns 100%.
 		Permill::from_rational(in_use, self.total_amount)

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -6945,8 +6945,8 @@ mod utilisation_cap {
 				Permill::from_percent(80),
 			);
 
-			// Step 4: A borrows 40 BTC. The new collateral-pool cap check rejects this because
-			// USDC's cap drops below USDC's existing 80% utilisation.
+			// Step 4: A borrows 40 BTC. USDC (one of A's collateral pools) cannot cover the
+			// configured liquidation fraction once A's $40 of new debt is included.
 			assert_noop!(
 				LendingPools::new_loan(USER_A, Asset::Btc, BORROW_A, None),
 				Error::<Test>::CollateralPoolUtilisationCapExceeded,

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -588,10 +588,11 @@ pub mod pallet {
 		BoostedFundsRemaining,
 		/// Can't removed funds due to LTV check
 		InsufficientLtvHeadroom,
-		/// The new loan would push pool utilisation above the utilisation cap.
+		/// The new loan would leave the loan-asset pool unable to liquidate the configured
+		/// fraction of outstanding loans.
 		UtilisationCapExceeded,
-		/// The new loan would lower the utilisation cap of one of the borrower's
-		/// collateral pools below that pool's current utilisation.
+		/// The new loan would leave one of the borrower's collateral pools unable to
+		/// liquidate the configured fraction of outstanding loans.
 		CollateralPoolUtilisationCapExceeded,
 		/// The broker fee specified on the loan request exceeds the maximum allowed.
 		BrokerFeeTooHigh,


### PR DESCRIPTION
# Pull Request

I started pulling on this thread after reviewing the utilisation caps and this is the resulting refactor. 

- I noticed that we checked the caps twice under slightly different conditions: once, mid-mutation, inside `fund_loan` for the loan asset, then again after the loan for the collateral assets 
	=> I felt it made sense to only do this check once, *outside* of the mutation closure, on the final loan state. This way we don't need to think about intermediate states, and `fund_loan` fewer responsibilities. 
- We were taking two absolute quantities (total pool exposure and total coverage amount) and then converted both to Permill values to compare
	=> We can just compare amounts, the Permill conversion is redundant.
- We were iterating over `LoanAccounts` once per asset
	=> I changed the function signature to take a single loan asset and list of collateral assets, and only iterate once. 

I feel like this makes the code a bit easier to reason about. The only small wart is that we need to expose the cap via rpc, so we have a new dedicated helper for that. 

Also, for the common case where there are 2 pools to check (1 loan asset + 1 collateral asset), it's almost twice as efficient (1.8x improvement measured based on the included benchmark).

