### PR TITLE
[codex] fix stale bitcoin broadcast signing payloads

### DIFF
--- a/state-chain/chains/src/btc.rs
+++ b/state-chain/chains/src/btc.rs
@@ -828,6 +828,25 @@ fn extend_with_inputs_outputs(bytes: &mut Vec<u8>, inputs: &[Utxo], outputs: &[B
 }
 
 impl BitcoinTransaction {
+	fn old_utxo_input_indices_for(agg_key: &AggKey, inputs: &[Utxo]) -> VecDeque<u32> {
+		(0..)
+			.zip(inputs)
+			.filter_map(|(i, Utxo { deposit_address, .. })| {
+				if deposit_address.pubkey_x == agg_key.current {
+					None
+				} else if agg_key
+					.previous
+					.is_some_and(|previous| deposit_address.pubkey_x == previous)
+				{
+					Some(i)
+				} else {
+					log_or_panic!("Utxo is not spendable by the current or previous key");
+					None
+				}
+			})
+			.collect()
+	}
+
 	pub fn create_new_unsigned(
 		agg_key: &AggKey,
 		inputs: Vec<Utxo>,
@@ -836,25 +855,7 @@ impl BitcoinTransaction {
 		const SEGWIT_MARKER: u8 = 0u8;
 		const SEGWIT_FLAG: u8 = 1u8;
 
-		let old_utxo_input_indices = (0..)
-			.zip(&inputs)
-			.filter_map(|(i, Utxo { deposit_address, .. })| {
-				if deposit_address.pubkey_x == agg_key.current {
-					None
-				} else {
-					agg_key.previous.and_then(|previous| {
-						if deposit_address.pubkey_x == previous {
-							Some(i)
-						} else {
-							cf_runtime_utilities::log_or_panic!(
-								"Utxo is not spendable by the current or previous key"
-							);
-							None
-						}
-					})
-				}
-			})
-			.collect::<VecDeque<_>>();
+		let old_utxo_input_indices = Self::old_utxo_input_indices_for(agg_key, &inputs);
 
 		let mut transaction_bytes = Vec::default();
 		transaction_bytes.extend(VERSION);
@@ -880,6 +881,46 @@ impl BitcoinTransaction {
 			signatures.len() == self.inputs.len() &&
 				!signatures.iter().any(|signature| signature == &[0u8; 64])
 		})
+	}
+
+	fn selected_signing_key<'a>(
+		signer: &'a AggKey,
+		previous_or_current: PreviousOrCurrent,
+	) -> Option<&'a [u8; 32]> {
+		match previous_or_current {
+			PreviousOrCurrent::Previous => signer.previous.as_ref(),
+			PreviousOrCurrent::Current => Some(&signer.current),
+		}
+	}
+
+	pub fn signatures_use_expected_input_keys(&self) -> bool {
+		if !self.is_signed() {
+			return false
+		}
+		let Some((signer, signatures)) = self.signer_and_signatures.as_ref() else {
+			return false
+		};
+		if signatures.len() != self.inputs.len() {
+			return false
+		}
+		self.get_signing_payloads()
+			.iter()
+			.zip(&self.inputs)
+			.all(|((previous_or_current, _), input)| {
+				Self::selected_signing_key(signer, *previous_or_current)
+					.is_some_and(|key| *key == input.deposit_address.pubkey_x)
+			})
+	}
+
+	pub fn refresh_signing_key_selection(&mut self, agg_key: &AggKey) -> bool {
+		let old_utxo_input_indices = Self::old_utxo_input_indices_for(agg_key, &self.inputs);
+		if old_utxo_input_indices == self.old_utxo_input_indices {
+			false
+		} else {
+			self.old_utxo_input_indices = old_utxo_input_indices;
+			self.signer_and_signatures = None;
+			true
+		}
 	}
 
 	pub fn txid(&self) -> Hash {
@@ -1458,9 +1499,11 @@ mod test {
 		}
 	}
 
+	const TEST_PUBKEY_X: [u8; 32] =
+		hex_literal::hex!("78C79A2B436DA5575A03CDE40197775C656FFF9F0F59FC1466E09C20A81A9CDB");
+
 	fn create_test_unsigned_transaction(sign_with: PreviousOrCurrent) -> BitcoinTransaction {
-		let pubkey_x =
-			hex_literal::hex!("78C79A2B436DA5575A03CDE40197775C656FFF9F0F59FC1466E09C20A81A9CDB");
+		let pubkey_x = TEST_PUBKEY_X;
 		let script_pubkey = ScriptPubkey::try_from_address(
 			"bc1pgtj0f3u2rk8ex6khlskz7q50nwc48r8unfgfhxzsx9zhcdnczhqq60lzjt",
 			&BitcoinNetwork::Mainnet,
@@ -1483,6 +1526,26 @@ mod test {
 		};
 		let output = BitcoinOutput { amount: 100000000, script_pubkey };
 		BitcoinTransaction::create_new_unsigned(&agg_key, vec![input], vec![output])
+	}
+
+	#[test]
+	fn detects_and_refreshes_stale_bitcoin_signing_key_selection() {
+		let mut tx = create_test_unsigned_transaction(PreviousOrCurrent::Current);
+		let rotated_agg_key = AggKey { previous: Some(TEST_PUBKEY_X), current: [0xcf; 32] };
+
+		tx.add_signer_and_signatures(rotated_agg_key, vec![[1u8; 64]]);
+		assert!(!tx.signatures_use_expected_input_keys());
+
+		assert!(tx.refresh_signing_key_selection(&rotated_agg_key));
+		assert_eq!(
+			tx.get_signing_payloads()
+				.first()
+				.map(|(previous_or_current, _)| *previous_or_current),
+			Some(PreviousOrCurrent::Previous)
+		);
+
+		tx.add_signer_and_signatures(rotated_agg_key, vec![[1u8; 64]]);
+		assert!(tx.signatures_use_expected_input_keys());
 	}
 
 	#[test]

--- a/state-chain/chains/src/btc/api.rs
+++ b/state-chain/chains/src/btc/api.rs
@@ -61,6 +61,26 @@ pub enum UtxoSelectionType {
 	Some { output_amount: BtcAmount, number_of_outputs: u64 },
 }
 
+impl<E> BitcoinApi<E> {
+	pub fn signatures_use_expected_input_keys(&self) -> bool {
+		match self {
+			BitcoinApi::BatchTransfer(call) =>
+				call.bitcoin_transaction.signatures_use_expected_input_keys(),
+			BitcoinApi::NoChangeTransfer(call) => call.signatures_use_expected_input_keys(),
+			BitcoinApi::_Phantom(..) => unreachable!(),
+		}
+	}
+
+	pub fn refresh_signing_key_selection(&mut self, agg_key: &AggKey) -> bool {
+		match self {
+			BitcoinApi::BatchTransfer(call) =>
+				call.bitcoin_transaction.refresh_signing_key_selection(agg_key),
+			BitcoinApi::NoChangeTransfer(call) => call.refresh_signing_key_selection(agg_key),
+			BitcoinApi::_Phantom(..) => unreachable!(),
+		}
+	}
+}
+
 impl<E> ConsolidateCall<Bitcoin> for BitcoinApi<E>
 where
 	E: ChainEnvironment<UtxoSelectionType, SelectedUtxosAndChangeAmount>

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -378,17 +378,73 @@ impl TransactionBuilder<Bitcoin, BitcoinApi<BtcEnvironment>> for BtcTransactionB
 	}
 
 	fn requires_signature_refresh(
-		_call: &BitcoinApi<BtcEnvironment>,
-		_payload: &<<Bitcoin as Chain>::ChainCrypto as ChainCrypto>::Payload,
-		_maybe_current_onchain_key: Option<<BitcoinCrypto as ChainCrypto>::AggKey>,
+		call: &BitcoinApi<BtcEnvironment>,
+		payload: &<<Bitcoin as Chain>::ChainCrypto as ChainCrypto>::Payload,
+		maybe_current_onchain_key: Option<<BitcoinCrypto as ChainCrypto>::AggKey>,
 	) -> RequiresSignatureRefresh<BitcoinCrypto, BitcoinApi<BtcEnvironment>> {
-		// The payload for a Bitcoin transaction will never change and so it doesn't need to be
-		// checked here. We also don't need to check for the signature here because even if we are
-		// in the next epoch and the key has changed, the old signature for the btc tx is still
-		// valid since its based on those old input UTXOs. In fact, we never have to resign btc
-		// txs and the btc tx is always valid as long as the input UTXOs are valid. Therefore, we
-		// don't have to check anything here and just rebroadcast.
-		RequiresSignatureRefresh::False
+		if &call.threshold_signature_payload() != payload {
+			return RequiresSignatureRefresh::True(None)
+		}
+
+		if call.signatures_use_expected_input_keys() {
+			return RequiresSignatureRefresh::False
+		}
+
+		maybe_current_onchain_key.map_or(RequiresSignatureRefresh::True(None), |agg_key| {
+			let mut modified_call = call.clone();
+			if modified_call.refresh_signing_key_selection(&agg_key) {
+				RequiresSignatureRefresh::True(Some(modified_call))
+			} else {
+				RequiresSignatureRefresh::True(None)
+			}
+		})
+	}
+}
+
+#[cfg(test)]
+mod bitcoin_transaction_builder_tests {
+	use super::*;
+	use cf_chains::btc::{
+		deposit_address::DepositAddress, AggKey, BitcoinOutput, BitcoinTransaction, ScriptPubkey,
+		Utxo, UtxoId,
+	};
+
+	#[test]
+	fn btc_retry_refreshes_stale_key_selection_after_rotation() {
+		let deposit_key = [0x12; 32];
+		let old_agg_key = AggKey { previous: None, current: deposit_key };
+		let rotated_agg_key = AggKey { previous: Some(deposit_key), current: [0x34; 32] };
+
+		let mut tx = BitcoinTransaction::create_new_unsigned(
+			&old_agg_key,
+			vec![Utxo {
+				amount: 100_000,
+				id: UtxoId { tx_id: Default::default(), vout: 0 },
+				deposit_address: DepositAddress::new(deposit_key, 1),
+			}],
+			vec![BitcoinOutput {
+				amount: 90_000,
+				script_pubkey: ScriptPubkey::Taproot([0x56; 32]),
+			}],
+		);
+		tx.add_signer_and_signatures(rotated_agg_key, vec![[1u8; 64]]);
+
+		let call = BitcoinApi::<BtcEnvironment>::NoChangeTransfer(tx);
+		let original_payload = call.threshold_signature_payload();
+
+		match BtcTransactionBuilder::requires_signature_refresh(
+			&call,
+			&original_payload,
+			Some(rotated_agg_key),
+		) {
+			RequiresSignatureRefresh::True(Some(modified_call)) => {
+				let modified_payload = modified_call.threshold_signature_payload();
+				assert!(modified_payload.first().is_some_and(|(previous_or_current, _)| {
+					*previous_or_current == cf_chains::btc::PreviousOrCurrent::Previous
+				}));
+			},
+			_ => panic!("stale Bitcoin signing key selection should be refreshed"),
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Detect Bitcoin broadcasts whose signed payload selects `Current`/`Previous` keys that do not match the deposit UTXO keys being spent.
- Recompute Bitcoin signing key selection against the current on-chain aggregate key before retrying, so broadcasts can be re-signed instead of repeatedly rebroadcasting an invalid transaction.
- Add focused unit coverage for the key-rotation case that can otherwise produce a Schnorr signature for the wrong Taproot script key.

## Root cause

Bitcoin retry handling assumed signed BTC transactions never need signature refresh. That is true for stable inputs, but it misses a key-rotation edge case where a transaction can be constructed with one aggregate-key view and signed after rotation with another. In that case the signature can be valid for the threshold signer payload while still not matching the deposit address key embedded in the Bitcoin input script.

## Validation

- `cargo test -p cf-chains detects_and_refreshes_stale_bitcoin_signing_key_selection`
- `cargo test -p state-chain-runtime btc_retry_refreshes_stale_key_selection_after_rotation`
- `cargo test -p cf-chains btc::test::test_payloads`
- `cargo test -p cf-chains btc::test::test_finalize`
- `git diff --check`