### PR TITLE
fix: move `RealisticCallParams` type to its own file and update compilation guard.

### DIFF
--- a/state-chain/pallets/cf-environment/src/benchmarking.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking.rs
@@ -24,41 +24,6 @@ use cf_traits::VaultKeyWitnessedHandler;
 use frame_benchmarking::v2::*;
 use frame_support::{assert_ok, traits::UnfilteredDispatchable};
 
-/// Representative benchmark types modeled after real pallet call parameters.
-/// Based on `request_loan` from cf-lending-pools which has typical complexity.
-#[allow(dead_code)]
-pub mod benchmark_types {
-	use cf_primitives::{Asset, AssetAmount};
-	use codec::{Decode, DecodeWithMemTracking, Encode};
-	use scale_info::TypeInfo;
-	use sp_std::collections::btree_map::BTreeMap;
-
-	/// Mimics a realistic pallet call similar to `request_loan`.
-	/// Parameters: asset enum, amount (u128), BTreeMap<Asset, Amount>
-	#[derive(TypeInfo, Clone, Encode, Decode, DecodeWithMemTracking, Debug, PartialEq, Eq)]
-	pub struct RealisticCallParams {
-		pub loan_asset: Asset,
-		pub loan_amount: AssetAmount,
-		pub extra_collateral: BTreeMap<Asset, AssetAmount>,
-	}
-
-	impl Default for RealisticCallParams {
-		fn default() -> Self {
-			{
-				let mut extra_collateral = BTreeMap::new();
-				extra_collateral.insert(Asset::Eth, 1_000_000_000_000_000_000u128);
-				extra_collateral.insert(Asset::Usdc, 50_000_000_000u128);
-
-				RealisticCallParams {
-					loan_asset: Asset::Usdc,
-					loan_amount: 100_000_000_000u128,
-					extra_collateral,
-				}
-			}
-		}
-	}
-}
-
 #[benchmarks(
 	where
 	T: pallet_cf_flip::Config,
@@ -414,7 +379,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn eip712_encode_realistic_call() {
-		use crate::benchmarking::benchmark_types::RealisticCallParams;
+		use crate::benchmarking_types::RealisticCallParams;
 		use ethereum_eip712::{eip712::EIP712Domain, encode_eip712_using_type_info};
 
 		// Use the benchmark_realistic_call call which embeds RealisticCallParams in RuntimeCall
@@ -440,7 +405,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn eip712_encode_realistic_call_fast() {
-		use crate::benchmarking::benchmark_types::RealisticCallParams;
+		use crate::benchmarking_types::RealisticCallParams;
 		use ethereum_eip712::{eip712::EIP712Domain, encode_eip712_using_type_info_fast};
 
 		// Use the benchmark_realistic_call call which embeds RealisticCallParams in RuntimeCall
@@ -480,7 +445,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn eip712_step2_encode_decode() {
-		use crate::benchmarking::benchmark_types::RealisticCallParams;
+		use crate::benchmarking_types::RealisticCallParams;
 		use ethereum_eip712::benchmark_helpers::{
 			step1_registry_and_type_registration, step2_encode_decode,
 		};
@@ -510,7 +475,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn eip712_step3_recursive_type_construction() {
-		use crate::benchmarking::benchmark_types::RealisticCallParams;
+		use crate::benchmarking_types::RealisticCallParams;
 		use ethereum_eip712::benchmark_helpers::{
 			step1_registry_and_type_registration, step2_encode_decode,
 			step3_recursive_type_construction,
@@ -543,7 +508,7 @@ mod benchmarks {
 
 	#[benchmark]
 	fn eip712_step4_minimized_conversion() {
-		use crate::benchmarking::benchmark_types::RealisticCallParams;
+		use crate::benchmarking_types::RealisticCallParams;
 		use ethereum_eip712::benchmark_helpers::{
 			step1_registry_and_type_registration, step2_encode_decode,
 			step3_recursive_type_construction, step4_minimized_scale_value_conversion,

--- a/state-chain/pallets/cf-environment/src/benchmarking_types.rs
+++ b/state-chain/pallets/cf-environment/src/benchmarking_types.rs
@@ -1,0 +1,35 @@
+// The `RealisticCallParams` type is used in a runtime call and has to be available when building
+// with `doc` configuration.
+#![cfg(any(feature = "runtime-benchmarks", doc))]
+#![allow(dead_code)]
+
+use cf_primitives::{Asset, AssetAmount};
+use codec::{Decode, DecodeWithMemTracking, Encode};
+use scale_info::TypeInfo;
+use sp_std::collections::btree_map::BTreeMap;
+
+/// Representative benchmark type modeled after real pallet call parameters.
+/// Based on `request_loan` from cf-lending-pools which has typical complexity.
+/// Parameters: asset enum, amount (u128), BTreeMap<Asset, Amount>
+#[derive(TypeInfo, Clone, Encode, Decode, DecodeWithMemTracking, Debug, PartialEq, Eq)]
+pub struct RealisticCallParams {
+	pub loan_asset: Asset,
+	pub loan_amount: AssetAmount,
+	pub extra_collateral: BTreeMap<Asset, AssetAmount>,
+}
+
+impl Default for RealisticCallParams {
+	fn default() -> Self {
+		{
+			let mut extra_collateral = BTreeMap::new();
+			extra_collateral.insert(Asset::Eth, 1_000_000_000_000_000_000u128);
+			extra_collateral.insert(Asset::Usdc, 50_000_000_000u128);
+
+			RealisticCallParams {
+				loan_asset: Asset::Usdc,
+				loan_amount: 100_000_000_000u128,
+				extra_collateral,
+			}
+		}
+	}
+}

--- a/state-chain/pallets/cf-environment/src/lib.rs
+++ b/state-chain/pallets/cf-environment/src/lib.rs
@@ -65,6 +65,7 @@ pub use pallet::*;
 use sp_std::{boxed::Box, vec, vec::Vec};
 
 mod benchmarking;
+mod benchmarking_types;
 mod mock;
 mod tests;
 
@@ -782,7 +783,7 @@ pub mod pallet {
 		pub fn benchmark_realistic_call(
 			_origin: OriginFor<T>,
 			#[cfg(feature = "runtime-benchmarks")]
-			_params: crate::benchmarking::benchmark_types::RealisticCallParams,
+			_params: crate::benchmarking_types::RealisticCallParams,
 		) -> DispatchResult {
 			Ok(())
 		}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2882

## Summary

Currently `cargo test` fails because the `RealisticCallParams` type is available only with feature `runtime-benchmarks`, but it's also being included in auto-generated docs code where its inclusion is not feature-guarded.

This PR moves it into its own file and guards by "either `runtime-benchmarks` OR `doc`".

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.

