### PR TITLE
feat: Flip 2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,7 @@ dependencies = [
  "jsonrpsee",
  "log",
  "pallet-cf-elections",
+ "pallet-cf-swapping",
  "pallet-staking",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",

--- a/bouncer/generated/chaintypes/chainflip-node/events.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/events.d.ts
@@ -405,6 +405,11 @@ export interface ChainEvents extends GenericChainEvents {
       'BondUpdated',
       { accountId: AccountId32; newBond: bigint }
     >;
+    FlipDistributed: GenericPalletEvent<
+      'Flip',
+      'FlipDistributed',
+      { amounts: Array<[AccountId32, bigint]> }
+    >;
 
     /**
      * Generic pallet event
@@ -2707,6 +2712,24 @@ export interface ChainEvents extends GenericChainEvents {
         shortId: CfPrimitivesAffiliateShortId;
         affiliateAccountId: AccountId32;
       }
+    >;
+
+    /**
+     * FLIP was successfully scheduled for egress to the State Chain Gateway.
+     **/
+    SentFlipToGateway: GenericPalletEvent<
+      'Swapping',
+      'SentFlipToGateway',
+      { amount: bigint; egressId: [CfPrimitivesChainsForeignChain, bigint] }
+    >;
+
+    /**
+     * FLIP egress to the State Chain Gateway was skipped.
+     **/
+    FlipTransferToGatewaySkipped: GenericPalletEvent<
+      'Swapping',
+      'FlipTransferToGatewaySkipped',
+      { reason: DispatchError }
     >;
 
     /**

--- a/bouncer/generated/chaintypes/chainflip-node/json-rpc.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/json-rpc.d.ts
@@ -164,6 +164,7 @@ export type ChainJsonRpcApis = Pick<
   | 'cf_pools_environment'
   | 'cf_request_swap_parameter_encoding'
   | 'cf_required_asset_ratio_for_range_order'
+  | 'cf_reward_distribution_estimate'
   | 'cf_safe_mode_statuses'
   | 'cf_scheduled_swaps'
   | 'cf_solana_electoral_data'

--- a/bouncer/generated/chaintypes/chainflip-node/query.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/query.d.ts
@@ -902,6 +902,20 @@ export interface ChainStorage extends GenericChainStorage {
     feeScalingRate: GenericStorageQuery<() => PalletCfFlipOnChargeTransactionFeeScalingRateConfig>;
 
     /**
+     *
+     * @param {Callback<bigint> =} callback
+     **/
+    flipToDistribute: GenericStorageQuery<() => bigint>;
+
+    /**
+     * The epoch from which flip 2.1 activates.
+     * Defaults to u32::MAX (effectively disabled) until set via governance.
+     *
+     * @param {Callback<number> =} callback
+     **/
+    feeRewardsActivationEpoch: GenericStorageQuery<() => number>;
+
+    /**
      * Generic pallet storage query
      **/
     [storage: string]: GenericStorageQuery;
@@ -3053,7 +3067,7 @@ export interface ChainStorage extends GenericChainStorage {
     flipToBeSentToGateway: GenericStorageQuery<() => bigint>;
 
     /**
-     * Interval at which we buy FLIP in order to burn it.
+     * Interval at which we buy FLIP from swap fees in order to distribute as rewards.
      *
      * @param {Callback<number> =} callback
      **/
@@ -3479,6 +3493,19 @@ export interface ChainStorage extends GenericChainStorage {
     >;
 
     /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[H256, [bigint, CfPrimitivesChainsAssetsEthAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[H256, [bigint, CfPrimitivesChainsAssetsEthAsset]]>
+    >;
+
+    /**
      *
      * @param {number} arg
      * @param {Callback<Array<PalletCfIngressEgressPendingPrewitnessedDepositEntry>> =} callback
@@ -3778,6 +3805,19 @@ export interface ChainStorage extends GenericChainStorage {
     >;
 
     /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[CfPrimitivesTxId, [number, CfPrimitivesChainsAssetsDotAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[CfPrimitivesTxId, [number, CfPrimitivesChainsAssetsDotAsset]]>
+    >;
+
+    /**
      *
      * @param {number} arg
      * @param {Callback<Array<PalletCfIngressEgressPendingPrewitnessedDepositEntry002>> =} callback
@@ -4069,6 +4109,19 @@ export interface ChainStorage extends GenericChainStorage {
     boostedVaultTransactions: GenericStorageQuery<
       (arg: H256) => PalletCfIngressEgressBoostStatusU64,
       H256
+    >;
+
+    /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[H256, [bigint, CfPrimitivesChainsAssetsBtcAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[H256, [bigint, CfPrimitivesChainsAssetsBtcAsset]]>
     >;
 
     /**
@@ -4664,6 +4717,19 @@ export interface ChainStorage extends GenericChainStorage {
     boostedVaultTransactions: GenericStorageQuery<
       (arg: H256) => PalletCfIngressEgressBoostStatus,
       H256
+    >;
+
+    /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[H256, [bigint, CfPrimitivesChainsAssetsArbAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[H256, [bigint, CfPrimitivesChainsAssetsArbAsset]]>
     >;
 
     /**
@@ -5309,6 +5375,19 @@ export interface ChainStorage extends GenericChainStorage {
     boostedVaultTransactions: GenericStorageQuery<
       (arg: [SolPrimAddress, bigint]) => PalletCfIngressEgressBoostStatusU64,
       [SolPrimAddress, bigint]
+    >;
+
+    /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[[SolPrimAddress, bigint], [bigint, CfPrimitivesChainsAssetsSolAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[[SolPrimAddress, bigint], [bigint, CfPrimitivesChainsAssetsSolAsset]]>
     >;
 
     /**
@@ -6190,6 +6269,19 @@ export interface ChainStorage extends GenericChainStorage {
     boostedVaultTransactions: GenericStorageQuery<
       (arg: CfPrimitivesTxId) => PalletCfIngressEgressBoostStatus,
       CfPrimitivesTxId
+    >;
+
+    /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[CfPrimitivesTxId, [number, CfPrimitivesChainsAssetsHubAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[CfPrimitivesTxId, [number, CfPrimitivesChainsAssetsHubAsset]]>
     >;
 
     /**
@@ -7826,6 +7918,19 @@ export interface ChainStorage extends GenericChainStorage {
     >;
 
     /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[H256, [bigint, CfPrimitivesChainsAssetsTronAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[H256, [bigint, CfPrimitivesChainsAssetsTronAsset]]>
+    >;
+
+    /**
      *
      * @param {number} arg
      * @param {Callback<Array<PalletCfIngressEgressPendingPrewitnessedDepositEntry007>> =} callback
@@ -8545,6 +8650,19 @@ export interface ChainStorage extends GenericChainStorage {
     boostedVaultTransactions: GenericStorageQuery<
       (arg: H256) => PalletCfIngressEgressBoostStatus,
       H256
+    >;
+
+    /**
+     * Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
+     * full witnessing. Additionally stores the boosted asset required to finalise the boost.
+     *
+     * Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+     * that a lost boosted deposit is correctly accounted for.
+     *
+     * @param {Callback<Array<[H256, [bigint, CfPrimitivesChainsAssetsBscAsset]]>> =} callback
+     **/
+    boostedVaultTransactionTimeout: GenericStorageQuery<
+      () => Array<[H256, [bigint, CfPrimitivesChainsAssetsBscAsset]]>
     >;
 
     /**

--- a/bouncer/generated/chaintypes/chainflip-node/runtime.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/runtime.d.ts
@@ -118,6 +118,7 @@ import type {
   PalletCfElectionsElectoralSystemsOraclePricePricePriceAsset,
   StateChainRuntimeRuntimeApisCustomApiTypesRpcAccountInfoCommonItems,
   StateChainRuntimeRuntimeApisCustomApiTypesRuntimeApiAccountInfoWrapper,
+  StateChainRuntimeRuntimeApisCustomApiTypesRewardDistributionEstimate,
   PalletCfLendingPoolsBoostConfiguration,
   StateChainRuntimeRuntimeApisCustomApiTypesEncodedNonNativeCallGeneric,
   PalletCfEnvironmentSubmitRuntimeCallTransactionMetadata,
@@ -1874,6 +1875,14 @@ export interface RuntimeApis extends GenericRuntimeApis {
       (
         account?: AccountId32Like | undefined,
       ) => Promise<Array<PalletCfValidatorDelegationDelegationSnapshot>>
+    >;
+
+    /**
+     *
+     * @callname: CustomRuntimeApi_cf_reward_distribution_estimate
+     **/
+    cfRewardDistributionEstimate: GenericRuntimeApiMethod<
+      () => Promise<StateChainRuntimeRuntimeApisCustomApiTypesRewardDistributionEstimate>
     >;
 
     /**

--- a/bouncer/generated/chaintypes/chainflip-node/types.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/types.d.ts
@@ -858,7 +858,8 @@ export type PalletCfFlipCallLike =
 
 export type PalletCfFlipPalletConfigUpdate =
   | { type: 'SetSlashingRate'; value: Permill }
-  | { type: 'SetFeeScalingRate'; value: PalletCfFlipOnChargeTransactionFeeScalingRateConfig };
+  | { type: 'SetFeeScalingRate'; value: PalletCfFlipOnChargeTransactionFeeScalingRateConfig }
+  | { type: 'SetFeeRewardsActivationEpoch'; value: number };
 
 export type PalletCfFlipOnChargeTransactionFeeScalingRateConfig =
   | { type: 'DelayedExponential'; value: { threshold: number; exponent: number } }
@@ -12740,7 +12741,8 @@ export type PalletCfFlipEvent =
   | { name: 'AccountReaped'; data: { who: AccountId32; dustBurned: bigint } }
   | { name: 'PalletConfigUpdated'; data: { update: PalletCfFlipPalletConfigUpdate } }
   | { name: 'FlipMinted'; data: { to: AccountId32; amount: bigint } }
-  | { name: 'BondUpdated'; data: { accountId: AccountId32; newBond: bigint } };
+  | { name: 'BondUpdated'; data: { accountId: AccountId32; newBond: bigint } }
+  | { name: 'FlipDistributed'; data: { amounts: Array<[AccountId32, bigint]> } };
 
 export type PalletCfFlipImbalancesImbalanceSource =
   | { type: 'External' }
@@ -14260,7 +14262,18 @@ export type PalletCfSwappingEvent =
         shortId: CfPrimitivesAffiliateShortId;
         affiliateAccountId: AccountId32;
       };
-    };
+    }
+  /**
+   * FLIP was successfully scheduled for egress to the State Chain Gateway.
+   **/
+  | {
+      name: 'SentFlipToGateway';
+      data: { amount: bigint; egressId: [CfPrimitivesChainsForeignChain, bigint] };
+    }
+  /**
+   * FLIP egress to the State Chain Gateway was skipped.
+   **/
+  | { name: 'FlipTransferToGatewaySkipped'; data: { reason: DispatchError } };
 
 export type CfChainsSwapOrigin =
   | {
@@ -22187,6 +22200,28 @@ export type StateChainRuntimeRuntimeApisCustomApiTypesRuntimeApiAccountInfo =
     }
   | { type: 'Validator'; value: StateChainRuntimeRuntimeApisCustomApiTypesValidatorInfo }
   | { type: 'Operator'; value: StateChainRuntimeRuntimeApisCustomApiTypesOperatorInfo };
+
+export type StateChainRuntimeRuntimeApisCustomApiTypesRewardDistributionEstimate = {
+  epochIndex: number;
+  currentBlock: number;
+  currentEpochStartedAt: number;
+  epochDuration: number;
+  bond: bigint;
+  authorityCount: number;
+  totalRewards: bigint;
+  perAuthorityShare: bigint;
+  rewardPool: Array<StateChainRuntimeRuntimeApisCustomApiTypesAccountReward>;
+};
+
+export type StateChainRuntimeRuntimeApisCustomApiTypesAccountReward = {
+  account: AccountId32;
+  bid: bigint;
+  bond: bigint;
+  reward: bigint;
+  role: CfPrimitivesAccountRole;
+  managedBy?: AccountId32 | undefined;
+  delegatedTo?: AccountId32 | undefined;
+};
 
 export type StateChainRuntimeRuntimeApisCustomApiTypesNonceOrAccount =
   | { type: 'Nonce'; value: number }

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -379,6 +379,7 @@ export const palletCfFlipPalletConfigUpdate = z.discriminatedUnion('__kind', [
     __kind: z.literal('SetFeeScalingRate'),
     value: palletCfFlipOnChargeTransactionFeeScalingRateConfig,
   }),
+  z.object({ __kind: z.literal('SetFeeRewardsActivationEpoch'), value: z.number() }),
 ]);
 
 export const cfPrimitivesChainsForeignChain = simpleEnum([

--- a/bouncer/generated/events/flip/flipDistributed.ts
+++ b/bouncer/generated/events/flip/flipDistributed.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import { accountId, numberOrHex } from '../common';
 import { defineEvent } from '@chainflip/processor/event';
 
-export const flipFlipDistributed = z.object({ amount: z.array(z.tuple([accountId, numberOrHex])) });
+export const flipFlipDistributed = z.object({
+  amounts: z.array(z.tuple([accountId, numberOrHex])),
+});
 
 export const flipFlipDistributedEvent = defineEvent('Flip.FlipDistributed', flipFlipDistributed);

--- a/bouncer/generated/events/flip/flipDistributed.ts
+++ b/bouncer/generated/events/flip/flipDistributed.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod';
 import { accountId, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const flipFlipDistributed = z.object({ amount: z.array(z.tuple([accountId, numberOrHex])) });
+
+export const flipFlipDistributedEvent = defineEvent('Flip.FlipDistributed', flipFlipDistributed);

--- a/bouncer/generated/events/flip/flipDistributed.ts
+++ b/bouncer/generated/events/flip/flipDistributed.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import { accountId, numberOrHex } from '../common';
+
+export const flipFlipDistributed = z.object({ amount: z.array(z.tuple([accountId, numberOrHex])) });

--- a/bouncer/generated/events/swapping/flipTransferToGatewaySkipped.ts
+++ b/bouncer/generated/events/swapping/flipTransferToGatewaySkipped.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+import { spRuntimeDispatchError } from '../common';
+
+export const swappingFlipTransferToGatewaySkipped = z.object({ reason: spRuntimeDispatchError });

--- a/bouncer/generated/events/swapping/flipTransferToGatewaySkipped.ts
+++ b/bouncer/generated/events/swapping/flipTransferToGatewaySkipped.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 import { spRuntimeDispatchError } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingFlipTransferToGatewaySkipped = z.object({ reason: spRuntimeDispatchError });
+
+export const swappingFlipTransferToGatewaySkippedEvent = defineEvent(
+  'Swapping.FlipTransferToGatewaySkipped',
+  swappingFlipTransferToGatewaySkipped,
+);

--- a/bouncer/generated/events/swapping/sentFlipToGateway.ts
+++ b/bouncer/generated/events/swapping/sentFlipToGateway.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
 
 export const swappingSentFlipToGateway = z.object({
   amount: numberOrHex,
   egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
 });
+
+export const swappingSentFlipToGatewayEvent = defineEvent(
+  'Swapping.SentFlipToGateway',
+  swappingSentFlipToGateway,
+);

--- a/bouncer/generated/events/swapping/sentFlipToGateway.ts
+++ b/bouncer/generated/events/swapping/sentFlipToGateway.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+import { cfPrimitivesChainsForeignChain, numberOrHex } from '../common';
+
+export const swappingSentFlipToGateway = z.object({
+  amount: numberOrHex,
+  egressId: z.tuple([cfPrimitivesChainsForeignChain, numberOrHex]),
+});

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { sleep } from 'shared/utils';
+import { testSwap } from 'shared/swapping';
 import { getChainflipApi } from 'shared/utils/substrate';
 import { newChainflipIO } from 'shared/utils/chainflip_io';
 import { TestContext } from 'shared/utils/test_context';
@@ -7,6 +8,8 @@ import { flipPalletConfigUpdatedEvent } from 'generated/events/flip/palletConfig
 import { flipFlipDistributedEvent } from 'generated/events/flip/flipDistributed';
 import { emissionsSupplyUpdateBroadcastRequestedEvent } from 'generated/events/emissions/supplyUpdateBroadcastRequested';
 import { validatorNewEpochEvent } from 'generated/events/validator/newEpoch';
+
+const SWAP_FEE_VOLUME_COUNT = 5;
 
 async function getCurrentEpoch(): Promise<number> {
   await using chainflip = await getChainflipApi();
@@ -80,14 +83,23 @@ export async function testFlipRewardActivation(testContext: TestContext) {
 
   const issuanceAtActivation = await getTotalIssuance();
 
+  // Generate some real swap fee volume during the activation epoch, so that the reserve has a
+  // non-zero balance to distribute at the next rotation.
+  logger.info(`Generating swap fee volume post-activation: ${SWAP_FEE_VOLUME_COUNT}x Eth->Btc`);
+  await cf.all(
+    Array.from(
+      { length: SWAP_FEE_VOLUME_COUNT },
+      () => (subcf) => testSwap(subcf, 'Eth', 'Btc', undefined, undefined, testContext.swapContext),
+    ),
+  );
+
   // Post-activation there's no more block emission minting and no more periodic fee burning, so
-  // total issuance is now fixed.
-  await sleep(12_000);
-  const issuanceAfterActivation = await getTotalIssuance();
+  // total issuance stays fixed even though real fee-generating swap volume just went through.
+  const issuanceAfterSwaps = await getTotalIssuance();
   assert.strictEqual(
-    issuanceAfterActivation,
+    issuanceAfterSwaps,
     issuanceAtActivation,
-    `Expected FLIP total issuance to stay fixed after activation, but went from ${issuanceAtActivation} to ${issuanceAfterActivation}`,
+    `Expected FLIP total issuance to stay fixed after activation, but went from ${issuanceAtActivation} to ${issuanceAfterSwaps}`,
   );
 
   logger.info('Forcing a second rotation to trigger the first FLIP reward distribution');
@@ -95,8 +107,14 @@ export async function testFlipRewardActivation(testContext: TestContext) {
   const epochAfterActivation = await cf.stepUntilEvent(validatorNewEpochEvent);
   assert.strictEqual(epochAfterActivation, activationEpoch + 1);
 
-  // The epoch following activation distributes accrued fee rewards to authorities.
-  await cf.expectEvent(flipFlipDistributedEvent);
+  // The epoch following activation distributes accrued fee rewards to authorities. With real
+  // swap volume behind it, a non-zero amount should actually have been distributed.
+  const distributed = await cf.expectEvent(flipFlipDistributedEvent);
+  const totalDistributed = distributed.amount.reduce((sum, [, amount]) => sum + amount, 0n);
+  assert.ok(
+    totalDistributed > 0n,
+    `Expected a non-zero FLIP reward distribution after generating swap fee volume, got ${totalDistributed}`,
+  );
 
   // Distribution moves FLIP out of the on-chain reserve to authorities without minting or
   // burning, so total issuance is still unaffected.

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -110,7 +110,7 @@ export async function testFlipRewardActivation(testContext: TestContext) {
   // The epoch following activation distributes accrued fee rewards to authorities. With real
   // swap volume behind it, a non-zero amount should actually have been distributed.
   const distributed = await cf.expectEvent(flipFlipDistributedEvent);
-  const totalDistributed = distributed.amount.reduce((sum, [, amount]) => sum + amount, 0n);
+  const totalDistributed = distributed.amounts.reduce((sum, [, amount]) => sum + amount, 0n);
   assert.ok(
     totalDistributed > 0n,
     `Expected a non-zero FLIP reward distribution after generating swap fee volume, got ${totalDistributed}`,

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -1,0 +1,111 @@
+import assert from 'assert';
+import { sleep } from 'shared/utils';
+import { getChainflipApi } from 'shared/utils/substrate';
+import { newChainflipIO } from 'shared/utils/chainflip_io';
+import { TestContext } from 'shared/utils/test_context';
+import { flipPalletConfigUpdatedEvent } from 'generated/events/flip/palletConfigUpdated';
+import { flipFlipDistributedEvent } from 'generated/events/flip/flipDistributed';
+import { emissionsSupplyUpdateBroadcastRequestedEvent } from 'generated/events/emissions/supplyUpdateBroadcastRequested';
+import { validatorNewEpochEvent } from 'generated/events/validator/newEpoch';
+
+async function getCurrentEpoch(): Promise<number> {
+  await using chainflip = await getChainflipApi();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((await chainflip.query.validator.currentEpoch()) as any).toNumber();
+}
+
+async function getFeeRewardsActivationEpoch(): Promise<number> {
+  await using chainflip = await getChainflipApi();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((await chainflip.query.flip.feeRewardsActivationEpoch()) as any).toNumber();
+}
+
+async function getTotalIssuance(): Promise<bigint> {
+  await using chainflip = await getChainflipApi();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((await chainflip.query.flip.totalIssuance()) as any).toBigInt();
+}
+
+// Tests the activation flow of the FLIP 2.1 reward system: governance sets an activation epoch
+// ahead of the current one, nothing changes until that epoch is reached, and once it is, fee
+// rewards are distributed to authorities instead of burned, fixing the total FLIP supply (aside
+// from the one-off forced supply sync that fires in the activation epoch itself).
+export async function testFlipRewardActivation(testContext: TestContext) {
+  const logger = testContext.logger;
+  const cf = await newChainflipIO(logger, {});
+
+  const activationEpoch = (await getCurrentEpoch()) + 1;
+  logger.info(`Setting FLIP reward activation epoch to ${activationEpoch} via governance`);
+
+  await cf.submitGovernance({
+    extrinsic: (api) =>
+      api.tx.flip.updatePalletConfig([{ SetFeeRewardsActivationEpoch: activationEpoch }]),
+    expectedEvent: flipPalletConfigUpdatedEvent.refine(
+      (event) =>
+        event.update.__kind === 'SetFeeRewardsActivationEpoch' &&
+        event.update.value === activationEpoch,
+    ),
+  });
+
+  const storedActivationEpoch = await getFeeRewardsActivationEpoch();
+  assert.strictEqual(
+    storedActivationEpoch,
+    activationEpoch,
+    'FeeRewardsActivationEpoch storage was not updated by the governance call',
+  );
+
+  // Pre-activation, per-block authority emissions are still minted, so total issuance keeps
+  // growing.
+  const issuanceBeforeActivation = await getTotalIssuance();
+  await sleep(12_000);
+  const issuanceStillPreActivation = await getTotalIssuance();
+  assert.ok(
+    issuanceStillPreActivation > issuanceBeforeActivation,
+    `Expected FLIP total issuance to increase before activation (block emissions), but went from ${issuanceBeforeActivation} to ${issuanceStillPreActivation}`,
+  );
+
+  logger.info('Forcing a rotation to reach the activation epoch');
+  await cf.submitGovernance({ extrinsic: (api) => api.tx.validator.forceRotation() });
+  const epochAtActivation = await cf.stepUntilEvent(validatorNewEpochEvent);
+  assert.strictEqual(
+    epochAtActivation,
+    activationEpoch,
+    `Expected the forced rotation to land exactly on the activation epoch ${activationEpoch}, got ${epochAtActivation}`,
+  );
+
+  // Reaching the activation epoch triggers a one-off forced supply sync in place of the
+  // (now disabled) periodic burn-and-broadcast cycle.
+  await cf.expectEvent(emissionsSupplyUpdateBroadcastRequestedEvent);
+  logger.info(`Reached FLIP reward activation epoch ${epochAtActivation}`);
+
+  const issuanceAtActivation = await getTotalIssuance();
+
+  // Post-activation there's no more block emission minting and no more periodic fee burning, so
+  // total issuance is now fixed.
+  await sleep(12_000);
+  const issuanceAfterActivation = await getTotalIssuance();
+  assert.strictEqual(
+    issuanceAfterActivation,
+    issuanceAtActivation,
+    `Expected FLIP total issuance to stay fixed after activation, but went from ${issuanceAtActivation} to ${issuanceAfterActivation}`,
+  );
+
+  logger.info('Forcing a second rotation to trigger the first FLIP reward distribution');
+  await cf.submitGovernance({ extrinsic: (api) => api.tx.validator.forceRotation() });
+  const epochAfterActivation = await cf.stepUntilEvent(validatorNewEpochEvent);
+  assert.strictEqual(epochAfterActivation, activationEpoch + 1);
+
+  // The epoch following activation distributes accrued fee rewards to authorities.
+  await cf.expectEvent(flipFlipDistributedEvent);
+
+  // Distribution moves FLIP out of the on-chain reserve to authorities without minting or
+  // burning, so total issuance is still unaffected.
+  const issuanceAfterDistribution = await getTotalIssuance();
+  assert.strictEqual(
+    issuanceAfterDistribution,
+    issuanceAtActivation,
+    `Expected FLIP total issuance to remain fixed through reward distribution, but went from ${issuanceAtActivation} to ${issuanceAfterDistribution}`,
+  );
+
+  logger.info('FLIP reward system activated successfully with fixed total issuance');
+}

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -107,8 +107,9 @@ export async function testFlipRewardActivation(testContext: TestContext) {
   const epochAfterActivation = await cf.stepUntilEvent(validatorNewEpochEvent);
   assert.strictEqual(epochAfterActivation, activationEpoch + 1);
 
-  // The epoch following activation distributes accrued fee rewards to authorities. With real
-  // swap volume behind it, a non-zero amount should actually have been distributed.
+  // The fee rewards accrued during the activation epoch are distributed at its end, in the same
+  // block as the transition to the next epoch. With real swap volume behind it, a non-zero
+  // amount should actually have been distributed.
   const distributed = await cf.expectEvent(flipFlipDistributedEvent);
   const totalDistributed = distributed.amounts.reduce((sum, [, amount]) => sum + amount, 0n);
   assert.ok(

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -42,7 +42,9 @@ export async function testFlipRewardActivation(testContext: TestContext) {
 
   await cf.submitGovernance({
     extrinsic: (api) =>
-      api.tx.flip.updatePalletConfig([{ SetFeeRewardsActivationEpoch: activationEpoch }]),
+      api.tx.flip.updatePalletConfig([
+        { type: 'SetFeeRewardsActivationEpoch', value: activationEpoch },
+      ]),
     expectedEvent: flipPalletConfigUpdatedEvent.refine(
       (event) =>
         event.update.__kind === 'SetFeeRewardsActivationEpoch' &&

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -82,6 +82,11 @@ export async function testFlipRewardActivation(testContext: TestContext) {
 
   const issuanceAtActivation = await getTotalIssuance();
 
+  // The block(s) right after a rotation completes are still congested with rotation-related
+  // extrinsics, so give the chain a couple of blocks to settle before submitting a burst of
+  // concurrent swaps (otherwise the deposit address requests can fail with ExhaustsResources).
+  await sleep(12_000);
+
   // Generate some real swap fee volume during the activation epoch, so that the reserve has a
   // non-zero balance to distribute at the next rotation.
   logger.info(`Generating swap fee volume post-activation: ${SWAP_FEE_VOLUME_COUNT}x Eth->Btc`);

--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -13,20 +13,17 @@ const SWAP_FEE_VOLUME_COUNT = 5;
 
 async function getCurrentEpoch(): Promise<number> {
   await using chainflip = await getChainflipApi();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return ((await chainflip.query.validator.currentEpoch()) as any).toNumber();
+  return chainflip.query.validator.currentEpoch();
 }
 
 async function getFeeRewardsActivationEpoch(): Promise<number> {
   await using chainflip = await getChainflipApi();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return ((await chainflip.query.flip.feeRewardsActivationEpoch()) as any).toNumber();
+  return chainflip.query.flip.feeRewardsActivationEpoch();
 }
 
 async function getTotalIssuance(): Promise<bigint> {
   await using chainflip = await getChainflipApi();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return ((await chainflip.query.flip.totalIssuance()) as any).toBigInt();
+  return chainflip.query.flip.totalIssuance();
 }
 
 // Tests the activation flow of the FLIP 2.1 reward system: governance sets an activation epoch

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -3,6 +3,7 @@ import { testBtcUtxoConsolidation } from 'tests/btc_utxo_consolidation';
 import { testRotatesThroughBtcSwap } from 'tests/rotates_through_btc_swap';
 import { testRotationBarrier } from 'tests/rotation_barrier';
 import { testSolanaVaultSettingsGovernance } from 'tests/solana_vault_settings_governance';
+import { testFlipRewardActivation } from 'tests/flip_reward_activation';
 import { serialTest } from 'shared/utils/vitest';
 import { testMinimumDeposit } from 'tests/minimum_deposit';
 import { testSwapAfterDisconnection } from 'tests/swap_after_temp_disconnecting_chains';
@@ -15,6 +16,7 @@ describe('SerialTests2', () => {
   serialTest('RotationBarrier', testRotationBarrier, 320);
   serialTest('MinimumDeposit', testMinimumDeposit, 150);
   serialTest('SolanaVaultSettingsGovernance', testSolanaVaultSettingsGovernance, 120);
+  serialTest('FlipRewardActivation', testFlipRewardActivation, 600);
 
   if (process.env.LOCALNET) {
     serialTest('SwapAfterDisconnection', testSwapAfterDisconnection, 250);

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -16,7 +16,7 @@ describe('SerialTests2', () => {
   serialTest('RotationBarrier', testRotationBarrier, 320);
   serialTest('MinimumDeposit', testMinimumDeposit, 150);
   serialTest('SolanaVaultSettingsGovernance', testSolanaVaultSettingsGovernance, 120);
-  serialTest('FlipRewardActivation', testFlipRewardActivation, 600);
+  serialTest('FlipRewardActivation', testFlipRewardActivation, 900);
 
   if (process.env.LOCALNET) {
     serialTest('SwapAfterDisconnection', testSwapAfterDisconnection, 250);

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -35,7 +35,7 @@ use state_chain_runtime::{
 	System, Validator,
 };
 
-fn setup_delegation(
+pub(crate) fn setup_delegation(
 	testnet: &mut Network,
 	validator: AccountId,
 	operator: AccountId,

--- a/state-chain/cf-integration-tests/src/lib.rs
+++ b/state-chain/cf-integration-tests/src/lib.rs
@@ -33,6 +33,7 @@ mod grandpa_delegation;
 mod historical_compatibility;
 mod lending;
 mod new_epoch;
+mod rewards;
 mod solana;
 mod swapping;
 mod trading_strategy;

--- a/state-chain/cf-integration-tests/src/rewards.rs
+++ b/state-chain/cf-integration-tests/src/rewards.rs
@@ -163,9 +163,16 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 					RuntimeEvent::Swapping(pallet_cf_swapping::Event::SentFlipToGateway {
 						amount,
 						..
-					}) if *amount == OFFCHAIN_FEE
+					}) if *amount + pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get() == OFFCHAIN_FEE
 				)),
 				"Expected the off-chain portion to be sent to the gateway",
+			);
+			// The gateway egress fee withheld from this distribution is credited back as a
+			// pending off-chain debit, so it's clawed back from the next distribution.
+			assert_eq!(
+				pallet_cf_flip::FlipToDistribute::<Runtime>::get(),
+				-(pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get() as i128),
+				"Expected FlipToDistribute to offset the residual gateway balance",
 			);
 
 			// Authorities' balances increased by at least the reward (block rewards accrue on
@@ -179,7 +186,11 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 			}
 
 			// The remainder stays pending for the next distribution.
-			assert_eq!(Flip::pending_rewards(), REMAINDER as i128);
+			assert_eq!(
+				Flip::pending_rewards(),
+				(REMAINDER as i128) -
+					(pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get() as i128)
+			);
 		});
 }
 

--- a/state-chain/cf-integration-tests/src/rewards.rs
+++ b/state-chain/cf-integration-tests/src/rewards.rs
@@ -186,10 +186,7 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 			}
 
 			// The remainder stays pending for the next distribution.
-			assert_eq!(
-				Flip::pending_rewards(),
-				REMAINDER - pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get()
-			);
+			assert_eq!(Flip::pending_rewards(), REMAINDER);
 		});
 }
 

--- a/state-chain/cf-integration-tests/src/rewards.rs
+++ b/state-chain/cf-integration-tests/src/rewards.rs
@@ -1,0 +1,347 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for FLIP 2.1 fee-reward distribution at epoch transitions.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+	delegation::setup_delegation, genesis::GENESIS_BALANCE, network, AccountId, AuthorityCount,
+	VAULT_ROTATION_BLOCKS,
+};
+use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
+use cf_traits::{AccountInfo, EpochInfo, FeePayment, FundAccount, FundingSource};
+use frame_support::assert_ok;
+use pallet_cf_flip::PalletConfigUpdate;
+use pallet_cf_validator::{DelegationAmount, DelegationSnapshots, HistoricalBonds};
+use state_chain_runtime::{Flip, Funding, Runtime, RuntimeEvent, RuntimeOrigin, System, Validator};
+
+/// Steps through the rotation one block at a time and returns the events of the block in which
+/// the epoch index was incremented, ie. the block in which `on_new_epoch` runs.
+fn move_through_epoch_transition(testnet: &mut network::Network) -> Vec<RuntimeEvent> {
+	let epoch = Validator::epoch_index();
+	testnet.move_to_the_end_of_epoch();
+	for _ in 0..=VAULT_ROTATION_BLOCKS + 1 {
+		testnet.move_forward_blocks(1);
+		if Validator::epoch_index() == epoch + 1 {
+			return System::events().into_iter().map(|record| record.event).collect();
+		}
+	}
+	panic!("Epoch did not rotate");
+}
+
+#[test]
+fn fee_rewards_are_burned_before_activation_and_distributed_after() {
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
+	const MAX_AUTHORITIES: AuthorityCount = 3;
+
+	const ONCHAIN_FEE: FlipBalance = 100 * FLIPPERINOS_PER_FLIP;
+	// Chosen so that the total is not a multiple of MAX_AUTHORITIES: the remainder should stay in
+	// the reserve rather than being distributed.
+	const OFFCHAIN_FEE: FlipBalance = 200 * FLIPPERINOS_PER_FLIP + 1;
+	const PER_AUTHORITY_REWARD: FlipBalance =
+		(ONCHAIN_FEE + OFFCHAIN_FEE) / MAX_AUTHORITIES as u128;
+	const REMAINDER: FlipBalance = (ONCHAIN_FEE + OFFCHAIN_FEE) % MAX_AUTHORITIES as u128;
+
+	super::genesis::with_test_defaults()
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
+		.max_authorities(MAX_AUTHORITIES)
+		.build()
+		.execute_with(|| {
+			let (mut testnet, _, _) = network::fund_authorities_and_join_auction(MAX_AUTHORITIES);
+			testnet.move_to_the_next_epoch();
+
+			// An unbonded account from which fees can be taken.
+			let fee_payer = AccountId::from([0xfe; 32]);
+			Funding::fund_account(
+				fee_payer.clone(),
+				1_000 * FLIPPERINOS_PER_FLIP,
+				FundingSource::EthTransaction {
+					tx_hash: Default::default(),
+					funder: Default::default(),
+				},
+			);
+
+			// Pre-activation, fees are burned and nothing accrues to the distribution reserve.
+			let issuance_before = pallet_cf_flip::TotalIssuance::<Runtime>::get();
+			assert_ok!(<Flip as FeePayment>::try_take_fee(&fee_payer, ONCHAIN_FEE));
+			assert_eq!(
+				pallet_cf_flip::TotalIssuance::<Runtime>::get(),
+				issuance_before - ONCHAIN_FEE
+			);
+			assert_eq!(Flip::pending_rewards(), 0);
+
+			// Activate FLIP 2.1 from the next epoch.
+			let activation_epoch = Validator::epoch_index() + 1;
+			assert_ok!(Flip::update_pallet_config(
+				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
+				vec![PalletConfigUpdate::SetFeeRewardsActivationEpoch(activation_epoch)]
+					.try_into()
+					.unwrap(),
+			));
+
+			// The transition into the activation epoch forces a final supply sync and does not
+			// distribute anything.
+			let events = move_through_epoch_transition(&mut testnet);
+			assert_eq!(Validator::epoch_index(), activation_epoch);
+			assert!(
+				events.iter().any(|event| matches!(
+					event,
+					RuntimeEvent::Emissions(
+						pallet_cf_emissions::Event::SupplyUpdateBroadcastRequested(..)
+					)
+				)),
+				"Expected a forced supply update at the activation epoch transition",
+			);
+			assert!(!events.iter().any(|event| matches!(
+				event,
+				RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed { .. })
+			)));
+
+			// Post-activation, on-chain fees accrue to the distribution reserve instead of being
+			// burned...
+			let issuance_before = pallet_cf_flip::TotalIssuance::<Runtime>::get();
+			assert_ok!(<Flip as FeePayment>::try_take_fee(&fee_payer, ONCHAIN_FEE));
+			assert_eq!(pallet_cf_flip::TotalIssuance::<Runtime>::get(), issuance_before);
+			assert_eq!(Flip::pending_rewards(), ONCHAIN_FEE as i128);
+
+			// ...and off-chain fees (eg. FLIP bought with swap network fees) accumulate for the
+			// same distribution.
+			<Flip as FeePayment>::add_to_offchain_flip_to_be_distributed(OFFCHAIN_FEE as i128);
+			assert_eq!(Flip::pending_rewards(), (ONCHAIN_FEE + OFFCHAIN_FEE) as i128);
+
+			let authorities: BTreeSet<AccountId> =
+				Validator::current_authorities().into_iter().collect();
+			assert_eq!(authorities.len(), MAX_AUTHORITIES as usize);
+			let pre_rotation_balances: BTreeMap<AccountId, FlipBalance> = authorities
+				.iter()
+				.map(|account_id| (account_id.clone(), Flip::balance(account_id)))
+				.collect();
+
+			// At the next epoch transition, the accrued fees are distributed evenly among the
+			// authorities of the epoch that just ended.
+			let events = move_through_epoch_transition(&mut testnet);
+
+			assert!(
+				events.contains(&RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed {
+					amount: authorities
+						.iter()
+						.map(|account_id| (account_id.clone(), PER_AUTHORITY_REWARD))
+						.collect(),
+				})),
+				"Expected an even distribution to all authorities, got: {:#?}",
+				events
+					.iter()
+					.filter(|event| matches!(event, RuntimeEvent::Flip(..)))
+					.collect::<Vec<_>>(),
+			);
+			assert!(
+				!events.iter().any(|event| matches!(
+					event,
+					RuntimeEvent::Flip(pallet_cf_flip::Event::RemainingImbalance { .. })
+				)),
+				"Rewards were not fully settled",
+			);
+			// The off-chain portion that was bridged in is egressed to the gateway to back the
+			// newly credited on-chain balances.
+			assert!(
+				events.iter().any(|event| matches!(
+					event,
+					RuntimeEvent::Swapping(pallet_cf_swapping::Event::SentFlipToGateway {
+						amount,
+						..
+					}) if *amount == OFFCHAIN_FEE
+				)),
+				"Expected the off-chain portion to be sent to the gateway",
+			);
+
+			// Authorities' balances increased by at least the reward (block rewards accrue on
+			// top).
+			for (account_id, pre_rotation_balance) in &pre_rotation_balances {
+				assert!(
+					Flip::balance(account_id) >= pre_rotation_balance + PER_AUTHORITY_REWARD,
+					"Reward was not credited to authority {:?}",
+					account_id,
+				);
+			}
+
+			// The remainder stays pending for the next distribution.
+			assert_eq!(Flip::pending_rewards(), REMAINDER as i128);
+		});
+}
+
+/// Fees accrued during epoch N are distributed at the transition to epoch N+1. The distribution
+/// must be based on epoch N's delegation snapshot and bond: a delegator who backed the whole of
+/// epoch N gets a share even if they undelegated in the meantime, a delegator who only joined
+/// during epoch N (first active in epoch N+1) does not get paid out of fees they never backed,
+/// and the validator/delegator split is computed against epoch N's bond even if the auction
+/// outcome changes the bond at the transition.
+#[test]
+fn fee_rewards_are_split_according_to_the_snapshot_and_bond_of_the_epoch_in_which_they_accrued() {
+	const EPOCH_DURATION_BLOCKS: u32 = 100;
+	const MAX_AUTHORITIES: AuthorityCount = 3;
+	const ONCHAIN_FEE: FlipBalance = 100 * FLIPPERINOS_PER_FLIP;
+
+	let managed_validator = AccountId::from([0xcf; 32]);
+	super::genesis::with_test_defaults()
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
+		.max_authorities(MAX_AUTHORITIES)
+		.with_additional_accounts(&[(
+			managed_validator.clone(),
+			cf_primitives::AccountRole::Validator,
+			GENESIS_BALANCE / 5,
+		)])
+		.build()
+		.execute_with(|| {
+			let (mut testnet, _, _) = network::fund_authorities_and_join_auction(MAX_AUTHORITIES);
+			testnet.move_to_the_next_epoch();
+
+			let operator = AccountId::from([0xe1; 32]);
+			let departing_delegator = AccountId::from([0xa0; 32]);
+			let joining_delegator = AccountId::from([0xa1; 32]);
+
+			setup_delegation(
+				&mut testnet,
+				managed_validator.clone(),
+				operator.clone(),
+				2000, // 20%
+				[(departing_delegator.clone(), 2 * GENESIS_BALANCE)].into(),
+			);
+
+			// Activate FLIP 2.1 as of the current epoch and accrue some fees.
+			let fee_epoch = Validator::epoch_index();
+			assert_ok!(Flip::update_pallet_config(
+				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
+				vec![PalletConfigUpdate::SetFeeRewardsActivationEpoch(fee_epoch)]
+					.try_into()
+					.unwrap(),
+			));
+			let fee_payer = AccountId::from([0xfe; 32]);
+			Funding::fund_account(
+				fee_payer.clone(),
+				1_000 * FLIPPERINOS_PER_FLIP,
+				FundingSource::EthTransaction {
+					tx_hash: Default::default(),
+					funder: Default::default(),
+				},
+			);
+			assert_ok!(<Flip as FeePayment>::try_take_fee(&fee_payer, ONCHAIN_FEE));
+
+			let fee_epoch_authorities = Validator::current_authorities();
+
+			// Mid-epoch, the delegation structure changes: the original delegator leaves and a
+			// new one joins. This only takes effect in the next epoch's snapshot.
+			assert_ok!(Validator::undelegate(
+				RuntimeOrigin::signed(departing_delegator.clone()),
+				DelegationAmount::Max,
+			));
+			Funding::fund_account(
+				joining_delegator.clone(),
+				2 * GENESIS_BALANCE,
+				FundingSource::EthTransaction {
+					tx_hash: Default::default(),
+					funder: Default::default(),
+				},
+			);
+			assert_ok!(Validator::delegate(
+				RuntimeOrigin::signed(joining_delegator.clone()),
+				operator.clone(),
+				DelegationAmount::Max,
+			));
+
+			// Also raise the solo authorities' bids so that the next auction resolves to a
+			// different bond.
+			for authority in &fee_epoch_authorities {
+				if *authority != managed_validator {
+					Funding::fund_account(
+						authority.clone(),
+						GENESIS_BALANCE,
+						FundingSource::EthTransaction {
+							tx_hash: Default::default(),
+							funder: Default::default(),
+						},
+					);
+				}
+			}
+
+			let events = move_through_epoch_transition(&mut testnet);
+
+			// Sanity check the scenario: the two epochs' snapshots contain different delegators,
+			// and the auction resolved to a different bond.
+			for (epoch, delegator) in
+				[(fee_epoch, &departing_delegator), (fee_epoch + 1, &joining_delegator)]
+			{
+				assert_eq!(
+					DelegationSnapshots::<Runtime>::get(epoch, &operator)
+						.expect("snapshot should exist")
+						.delegators
+						.keys()
+						.collect::<Vec<_>>(),
+					vec![delegator],
+					"Unexpected delegation snapshot for epoch {}",
+					epoch,
+				);
+			}
+			let fee_epoch_bond = HistoricalBonds::<Runtime>::get(fee_epoch);
+			assert_ne!(
+				fee_epoch_bond,
+				HistoricalBonds::<Runtime>::get(fee_epoch + 1),
+				"The bond should change at the transition for this test to be conclusive",
+			);
+
+			let distributed: std::collections::BTreeMap<AccountId, FlipBalance> = events
+				.iter()
+				.find_map(|event| match event {
+					RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed { amount }) =>
+						Some(amount.iter().cloned().collect()),
+					_ => None,
+				})
+				.expect("rewards should be distributed at the epoch transition");
+
+			assert!(
+				distributed.get(&departing_delegator).copied().unwrap_or_default() > 0,
+				"The delegator who backed the fee epoch should receive a share, got: {:#?}",
+				distributed,
+			);
+			assert!(
+				!distributed.contains_key(&joining_delegator),
+				"The delegator who joined mid-epoch must not be paid out of fees accrued \
+				before their delegation was active, got: {:#?}",
+				distributed,
+			);
+
+			// The exact payout must be the fee epoch's snapshot distributed against the fee
+			// epoch's bond.
+			let per_authority_reward = ONCHAIN_FEE / MAX_AUTHORITIES as u128;
+			let mut expected = BTreeMap::new();
+			for authority in &fee_epoch_authorities {
+				if *authority == managed_validator {
+					for (account, amount) in
+						DelegationSnapshots::<Runtime>::get(fee_epoch, &operator)
+							.expect("snapshot should exist")
+							.distribute(per_authority_reward, fee_epoch_bond)
+					{
+						if amount > 0 {
+							*expected.entry(account.clone()).or_default() += amount;
+						}
+					}
+				} else {
+					expected.insert(authority.clone(), per_authority_reward);
+				}
+			}
+			assert_eq!(distributed, expected);
+		});
+}

--- a/state-chain/cf-integration-tests/src/rewards.rs
+++ b/state-chain/cf-integration-tests/src/rewards.rs
@@ -137,7 +137,7 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 
 			assert!(
 				events.contains(&RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed {
-					amount: authorities
+					amounts: authorities
 						.iter()
 						.map(|account_id| (account_id.clone(), PER_AUTHORITY_REWARD))
 						.collect(),
@@ -316,8 +316,8 @@ fn fee_rewards_are_split_according_to_the_snapshot_and_bond_of_the_epoch_in_whic
 			let distributed: std::collections::BTreeMap<AccountId, FlipBalance> = events
 				.iter()
 				.find_map(|event| match event {
-					RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed { amount }) =>
-						Some(amount.iter().cloned().collect()),
+					RuntimeEvent::Flip(pallet_cf_flip::Event::FlipDistributed { amounts }) =>
+						Some(amounts.iter().cloned().collect()),
 					_ => None,
 				})
 				.expect("rewards should be distributed at the epoch transition");

--- a/state-chain/cf-integration-tests/src/rewards.rs
+++ b/state-chain/cf-integration-tests/src/rewards.rs
@@ -116,12 +116,12 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 			let issuance_before = pallet_cf_flip::TotalIssuance::<Runtime>::get();
 			assert_ok!(<Flip as FeePayment>::try_take_fee(&fee_payer, ONCHAIN_FEE));
 			assert_eq!(pallet_cf_flip::TotalIssuance::<Runtime>::get(), issuance_before);
-			assert_eq!(Flip::pending_rewards(), ONCHAIN_FEE as i128);
+			assert_eq!(Flip::pending_rewards(), ONCHAIN_FEE);
 
 			// ...and off-chain fees (eg. FLIP bought with swap network fees) accumulate for the
 			// same distribution.
 			<Flip as FeePayment>::add_to_offchain_flip_to_be_distributed(OFFCHAIN_FEE as i128);
-			assert_eq!(Flip::pending_rewards(), (ONCHAIN_FEE + OFFCHAIN_FEE) as i128);
+			assert_eq!(Flip::pending_rewards(), (ONCHAIN_FEE + OFFCHAIN_FEE));
 
 			let authorities: BTreeSet<AccountId> =
 				Validator::current_authorities().into_iter().collect();
@@ -188,8 +188,7 @@ fn fee_rewards_are_burned_before_activation_and_distributed_after() {
 			// The remainder stays pending for the next distribution.
 			assert_eq!(
 				Flip::pending_rewards(),
-				(REMAINDER as i128) -
-					(pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get() as i128)
+				REMAINDER - pallet_cf_swapping::FlipToBeSentToGateway::<Runtime>::get()
 			);
 		});
 }

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -101,9 +101,9 @@ use state_chain_runtime::{
 			DispatchErrorWithMessage, EncodedNonNativeCall, EncodedNonNativeCallGeneric,
 			EncodingType, EvmCallDetails, FailingWitnessValidators, FeeTypes, IngressEvents,
 			LendingPosition, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, NetworkFees,
-			NonceOrAccount, OpenedDepositChannels, OperatorInfo, RpcAccountInfoCommonItems,
-			RpcLendingConfig, RpcLendingPool, RuntimeApiAccountInfo, RuntimeApiPenalty,
-			ShouldSweep, SimulateSwapAdditionalOrder, SimulatedSwapInformation,
+			NonceOrAccount, OpenedDepositChannels, OperatorInfo, RewardDistributionEstimate,
+			RpcAccountInfoCommonItems, RpcLendingConfig, RpcLendingPool, RuntimeApiAccountInfo,
+			RuntimeApiPenalty, ShouldSweep, SimulateSwapAdditionalOrder, SimulatedSwapInformation,
 			TradingStrategyInfo, TradingStrategyLimits, TransactionScreeningEvents, ValidatorInfo,
 			VaultAddresses, VaultSwapDetails,
 		},
@@ -1425,6 +1425,11 @@ pub trait CustomApi {
 		operator: Option<state_chain_runtime::AccountId>,
 		at: Option<state_chain_runtime::Hash>,
 	) -> RpcResult<Vec<DelegationSnapshot<state_chain_runtime::AccountId, NumberOrHex>>>;
+	#[method(name = "reward_distribution_estimate")]
+	fn cf_reward_distribution_estimate(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RewardDistributionEstimate<NumberOrHex>>;
 	#[method(name = "encode_non_native_call")]
 	fn cf_encode_non_native_call(
 		&self,
@@ -3393,6 +3398,31 @@ where
 					.into_iter()
 					.map(|delegation| delegation.try_map_bids(TryInto::try_into))
 					.try_collect()
+					.map_err(|s| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InvalidParams.code(),
+							format!("Failed to convert call parameters: {s}."),
+							None::<()>,
+						))
+					})
+			}
+		})
+	}
+
+	fn cf_reward_distribution_estimate(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RewardDistributionEstimate<NumberOrHex>> {
+		self.rpc_backend.with_versioned_runtime_api(at, |api, hash, version| {
+			if version < 20 {
+				Err(CfApiError::ErrorObject(call_error(
+					"Reward distribution estimates are not supported at this runtime api version",
+					CfErrorCode::RuntimeApiError,
+				)))
+			} else {
+				api.cf_reward_distribution_estimate(hash)
+					.map_err(CfApiError::from)?
+					.try_map_amounts(TryInto::try_into)
 					.map_err(|s| {
 						CfApiError::ErrorObject(ErrorObject::owned(
 							ErrorCode::InvalidParams.code(),

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__reward_distribution_estimate.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__reward_distribution_estimate.snap
@@ -1,0 +1,43 @@
+---
+source: state-chain/custom-rpc/src/tests.rs
+expression: "serde_json::to_string_pretty(&value).unwrap()"
+---
+{
+  "epoch_index": 123,
+  "current_block": 1000500,
+  "current_epoch_started_at": 1000000,
+  "epoch_duration": 3600,
+  "bond": "0x4c4b40",
+  "authority_count": 3,
+  "total_rewards": "0xdbba0",
+  "per_authority_share": "0x493e0",
+  "reward_pool": [
+    {
+      "account": "5CT5jwBEAhveEjgiSCQbkaKcKcUyF3VJ8qNXM9rXsuQyn3Kd",
+      "bid": "0x0",
+      "bond": "0x0",
+      "reward": "0x493e0",
+      "role": "Operator",
+      "managed_by": null,
+      "delegated_to": null
+    },
+    {
+      "account": "5CqTdCcXCC7kv1Nwq2sCeJUNVqxbBPXjMAUXrbhRJtrUiyPP",
+      "bid": "0x4c4b40",
+      "bond": "0x4c4b40",
+      "reward": "0x3d090",
+      "role": "Validator",
+      "managed_by": "5CT5jwBEAhveEjgiSCQbkaKcKcUyF3VJ8qNXM9rXsuQyn3Kd",
+      "delegated_to": "5CT5jwBEAhveEjgiSCQbkaKcKcUyF3VJ8qNXM9rXsuQyn3Kd"
+    },
+    {
+      "account": "5DDqWU3pDgJsbH5BDsKoY2d8g5SD7jaAZVaYN3YJjtHygLwZ",
+      "bid": "0xf4240",
+      "bond": "0xf4240",
+      "reward": "0xc350",
+      "role": "Unregistered",
+      "managed_by": null,
+      "delegated_to": "5CT5jwBEAhveEjgiSCQbkaKcKcUyF3VJ8qNXM9rXsuQyn3Kd"
+    }
+  ]
+}

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -65,7 +65,7 @@ use cf_primitives::{
 
 use state_chain_runtime::{
 	runtime_apis::types::{
-		BrokerRejectionEventFor, ChannelActionType, EvmCallDetails, LendingPosition,
+		AccountReward, BrokerRejectionEventFor, ChannelActionType, EvmCallDetails, LendingPosition,
 		NetworkFeeDetails, OpenedDepositChannels,
 	},
 	Runtime,
@@ -1537,6 +1537,51 @@ fn operator_info() {
 			delegators: BTreeMap::from([(AccountId32::new([0x44; 32]), 1_500_000u128.into())]),
 			delegation_fee_bps: 2_000,
 		}),
+	};
+
+	insta::assert_snapshot!(serde_json::to_string_pretty(&value).unwrap());
+}
+
+#[test]
+fn reward_distribution_estimate() {
+	let value = RewardDistributionEstimate::<NumberOrHex> {
+		epoch_index: 123,
+		current_block: 1_000_500,
+		current_epoch_started_at: 1_000_000,
+		epoch_duration: 3_600,
+		bond: 5_000_000u128.into(),
+		authority_count: 3,
+		total_rewards: 900_000u128.into(),
+		per_authority_share: 300_000u128.into(),
+		reward_pool: vec![
+			AccountReward {
+				account: AccountId32::new([0x11; 32]),
+				bid: 0u128.into(),
+				bond: 0u128.into(),
+				reward: 300_000u128.into(),
+				role: AccountRole::Operator,
+				managed_by: None,
+				delegated_to: None,
+			},
+			AccountReward {
+				account: AccountId32::new([0x22; 32]),
+				bid: 5_000_000u128.into(),
+				bond: 5_000_000u128.into(),
+				reward: 250_000u128.into(),
+				role: AccountRole::Validator,
+				managed_by: Some(AccountId32::new([0x11; 32])),
+				delegated_to: Some(AccountId32::new([0x11; 32])),
+			},
+			AccountReward {
+				account: AccountId32::new([0x33; 32]),
+				bid: 1_000_000u128.into(),
+				bond: 1_000_000u128.into(),
+				reward: 50_000u128.into(),
+				role: AccountRole::Unregistered,
+				managed_by: None,
+				delegated_to: Some(AccountId32::new([0x11; 32])),
+			},
+		],
 	};
 
 	insta::assert_snapshot!(serde_json::to_string_pretty(&value).unwrap());

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -32,6 +32,7 @@ cf-rpc-apis = { workspace = true }
 cf-utilities = { workspace = true, default-features = true }
 sol-prim = { workspace = true, default-features = true }
 pallet-cf-elections = { workspace = true, default-features = true } # Todo: Either we have to add this, or move what we need to the cf-utilities crate
+pallet-cf-swapping = { workspace = true, default-features = true }
 
 # Added by Chainflip
 hex = { workspace = true, default-features = true }

--- a/state-chain/node/src/chain_spec.rs
+++ b/state-chain/node/src/chain_spec.rs
@@ -35,6 +35,7 @@ use cf_primitives::{
 };
 use common::SHARED_DATA_REFERENCE_LIFETIME;
 use pallet_cf_elections::generic_tools::{ArrayContainer, ArrayToVector};
+use pallet_cf_swapping::FeeRateAndMinimum;
 pub use sc_service::{ChainType, Properties};
 use sc_telemetry::serde_json::json;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -1183,7 +1184,13 @@ fn testnet_genesis(
 		// We can't use ..Default::default() here because chain tracking panics on default (by
 		// design). And the way ..Default::default() syntax works is that it generates the default
 		// value for the whole struct, not just the fields that are missing.
-		swapping: Default::default(),
+		swapping: state_chain_runtime::SwappingConfig {
+			flip_buy_interval: 3,
+			network_fee: FeeRateAndMinimum {
+				rate: Permill::from_rational(1u32, 1000u32),
+				minimum: 100_000u128,
+			},
+		},
 		bitcoin_vault: Default::default(),
 		polkadot_vault: Default::default(),
 		system: Default::default(),

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -21,7 +21,7 @@
 use cf_chains::{eth::api::StateChainGatewayAddressProvider, UpdateFlipSupply};
 use cf_primitives::{AssetAmount, EgressId};
 use cf_traits::{
-	impl_pallet_safe_mode, Broadcaster, EgressApi, FlipBurnOrMoveInfo, Issuance,
+	impl_pallet_safe_mode, Broadcaster, EgressApi, EpochInfo, FlipBurnOrMoveInfo, Issuance,
 	RewardsDistribution, ScheduledEgressDetails,
 };
 use codec::MaxEncodedLen;
@@ -34,7 +34,6 @@ pub mod migrations;
 mod mock;
 mod tests;
 
-use cf_traits::EpochInfo;
 use frame_support::{
 	sp_runtime::{
 		traits::{AtLeast32BitUnsigned, UniqueSaturatedInto, Zero},
@@ -355,7 +354,11 @@ impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>>
 				epoch_index,
 				reward_amount,
 				&author,
-				T::Issuance::mint,
+				|account, amount| {
+					if !amount.is_zero() {
+						T::Issuance::mint(account, amount);
+					}
+				},
 			);
 		}
 	}

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -239,7 +239,7 @@ impl<T: Config> Pallet<T> {
 	/// Burns the network fee and broadcasts an updated total supply to the gateway.
 	/// No-ops if safe mode has disabled emissions sync.
 	pub fn burn_and_broadcast_supply_update(current_block: BlockNumberFor<T>, force: bool) {
-		if T::SafeMode::get().emissions_sync_enabled {
+		if force || T::SafeMode::get().emissions_sync_enabled {
 			Self::burn_flip_network_fee(force);
 			Self::broadcast_update_total_supply(T::Issuance::total_issuance(), current_block);
 			Self::deposit_event(Event::SupplyUpdateBroadcastRequested(current_block));

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -19,9 +19,9 @@
 #![doc = include_str!("../../cf-doc-head.md")]
 
 use cf_chains::{eth::api::StateChainGatewayAddressProvider, UpdateFlipSupply};
-use cf_primitives::{AssetAmount, EgressId};
+use cf_primitives::{AssetAmount, EgressId, ACCUMULATE_REWARDS_EPOCH_START};
 use cf_traits::{
-	impl_pallet_safe_mode, Broadcaster, EgressApi, FlipBurnOrMoveInfo, Issuance,
+	impl_pallet_safe_mode, Broadcaster, EgressApi, EpochInfo, FlipBurnOrMoveInfo, Issuance,
 	RewardsDistribution, ScheduledEgressDetails,
 };
 use codec::MaxEncodedLen;
@@ -176,19 +176,11 @@ pub mod pallet {
 			if current_block % T::CompoundingInterval::get() == Zero::zero() {
 				Self::update_block_emissions();
 			}
-			if Self::should_update_supply_at(current_block) {
-				if T::SafeMode::get().emissions_sync_enabled {
-					Self::burn_flip_network_fee();
-					Self::broadcast_update_total_supply(
-						T::Issuance::total_issuance(),
-						current_block,
-					);
-					Self::deposit_event(Event::SupplyUpdateBroadcastRequested(current_block));
-					LastSupplyUpdateBlock::<T>::set(current_block);
-					return T::WeightInfo::rewards_minted()
-				} else {
-					log::info!("Runtime Safe Mode is CODE RED: Flip total issuance update broadcast are paused for now.");
-				}
+			if Self::should_update_supply_at(current_block) &&
+				T::EpochInfo::epoch_index() < ACCUMULATE_REWARDS_EPOCH_START
+			{
+				Self::burn_and_broadcast_supply_update(current_block);
+				return T::WeightInfo::rewards_minted()
 			}
 			T::WeightInfo::rewards_not_minted()
 		}
@@ -245,6 +237,19 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+	/// Burns the network fee and broadcasts an updated total supply to the gateway.
+	/// No-ops if safe mode has disabled emissions sync.
+	pub fn burn_and_broadcast_supply_update(current_block: BlockNumberFor<T>) {
+		if T::SafeMode::get().emissions_sync_enabled {
+			Self::burn_flip_network_fee();
+			Self::broadcast_update_total_supply(T::Issuance::total_issuance(), current_block);
+			Self::deposit_event(Event::SupplyUpdateBroadcastRequested(current_block));
+			LastSupplyUpdateBlock::<T>::set(current_block);
+		} else {
+			log::info!("Runtime Safe Mode is CODE RED: Flip total issuance update broadcast are paused for now.");
+		}
+	}
+
 	/// Determines if we should broadcast supply update at block number `block_number`.
 	fn should_update_supply_at(block_number: BlockNumberFor<T>) -> bool {
 		let supply_update_interval = SupplyUpdateInterval::<T>::get();
@@ -343,7 +348,9 @@ where
 impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>> for Pallet<T> {
 	fn note_author(author: T::AccountId) {
 		let reward_amount = CurrentAuthorityEmissionPerBlock::<T>::get();
-		if reward_amount != Zero::zero() {
+		if reward_amount != Zero::zero() &&
+			T::EpochInfo::epoch_index() < ACCUMULATE_REWARDS_EPOCH_START
+		{
 			T::RewardsDistribution::distribute(reward_amount, &author, T::Issuance::mint);
 		}
 	}

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -19,7 +19,7 @@
 #![doc = include_str!("../../cf-doc-head.md")]
 
 use cf_chains::{eth::api::StateChainGatewayAddressProvider, UpdateFlipSupply};
-use cf_primitives::{AssetAmount, EgressId, ACCUMULATE_REWARDS_EPOCH_START};
+use cf_primitives::{AssetAmount, EgressId};
 use cf_traits::{
 	impl_pallet_safe_mode, Broadcaster, EgressApi, EpochInfo, FlipBurnOrMoveInfo, Issuance,
 	RewardsDistribution, ScheduledEgressDetails,
@@ -177,7 +177,7 @@ pub mod pallet {
 				Self::update_block_emissions();
 			}
 			if Self::should_update_supply_at(current_block) &&
-				T::EpochInfo::epoch_index() < ACCUMULATE_REWARDS_EPOCH_START
+				T::EpochInfo::epoch_index() < T::Issuance::fee_rewards_activation_epoch()
 			{
 				Self::burn_and_broadcast_supply_update(current_block);
 				return T::WeightInfo::rewards_minted()
@@ -349,7 +349,7 @@ impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>>
 	fn note_author(author: T::AccountId) {
 		let reward_amount = CurrentAuthorityEmissionPerBlock::<T>::get();
 		if reward_amount != Zero::zero() &&
-			T::EpochInfo::epoch_index() < ACCUMULATE_REWARDS_EPOCH_START
+			T::EpochInfo::epoch_index() < T::Issuance::fee_rewards_activation_epoch()
 		{
 			T::RewardsDistribution::distribute(reward_amount, &author, T::Issuance::mint);
 		}

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -21,7 +21,7 @@
 use cf_chains::{eth::api::StateChainGatewayAddressProvider, UpdateFlipSupply};
 use cf_primitives::{AssetAmount, EgressId};
 use cf_traits::{
-	impl_pallet_safe_mode, Broadcaster, EgressApi, EpochInfo, FlipBurnOrMoveInfo, Issuance,
+	impl_pallet_safe_mode, Broadcaster, EgressApi, FlipBurnOrMoveInfo, Issuance,
 	RewardsDistribution, ScheduledEgressDetails,
 };
 use codec::MaxEncodedLen;
@@ -176,8 +176,7 @@ pub mod pallet {
 			if current_block % T::CompoundingInterval::get() == Zero::zero() {
 				Self::update_block_emissions();
 			}
-			if Self::should_update_supply_at(current_block) &&
-				T::EpochInfo::epoch_index() < T::Issuance::fee_rewards_activation_epoch()
+			if Self::should_update_supply_at(current_block) && !T::Issuance::is_flip_2_1_activated()
 			{
 				Self::burn_and_broadcast_supply_update(current_block);
 				return T::WeightInfo::rewards_minted()
@@ -348,9 +347,7 @@ where
 impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>> for Pallet<T> {
 	fn note_author(author: T::AccountId) {
 		let reward_amount = CurrentAuthorityEmissionPerBlock::<T>::get();
-		if reward_amount != Zero::zero() &&
-			T::EpochInfo::epoch_index() < T::Issuance::fee_rewards_activation_epoch()
-		{
+		if reward_amount != Zero::zero() && !T::Issuance::is_flip_2_1_activated() {
 			T::RewardsDistribution::distribute(reward_amount, &author, T::Issuance::mint);
 		}
 	}

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -344,7 +344,7 @@ impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>>
 	fn note_author(author: T::AccountId) {
 		let reward_amount = CurrentAuthorityEmissionPerBlock::<T>::get();
 		if reward_amount != Zero::zero() {
-			T::RewardsDistribution::distribute(reward_amount, &author);
+			T::RewardsDistribution::distribute(reward_amount, &author, T::Issuance::mint);
 		}
 	}
 }

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -34,6 +34,7 @@ pub mod migrations;
 mod mock;
 mod tests;
 
+use cf_traits::EpochInfo;
 use frame_support::{
 	sp_runtime::{
 		traits::{AtLeast32BitUnsigned, UniqueSaturatedInto, Zero},
@@ -347,8 +348,15 @@ where
 impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>> for Pallet<T> {
 	fn note_author(author: T::AccountId) {
 		let reward_amount = CurrentAuthorityEmissionPerBlock::<T>::get();
+
+		let epoch_index = T::EpochInfo::epoch_index();
 		if reward_amount != Zero::zero() && !T::Issuance::is_flip_2_1_activated() {
-			T::RewardsDistribution::distribute(reward_amount, &author, T::Issuance::mint);
+			T::RewardsDistribution::distribute(
+				epoch_index,
+				reward_amount,
+				&author,
+				T::Issuance::mint,
+			);
 		}
 	}
 }

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -178,7 +178,7 @@ pub mod pallet {
 			}
 			if Self::should_update_supply_at(current_block) && !T::Issuance::is_flip_2_1_activated()
 			{
-				Self::burn_and_broadcast_supply_update(current_block);
+				Self::burn_and_broadcast_supply_update(current_block, false);
 				return T::WeightInfo::rewards_minted()
 			}
 			T::WeightInfo::rewards_not_minted()
@@ -238,9 +238,9 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	/// Burns the network fee and broadcasts an updated total supply to the gateway.
 	/// No-ops if safe mode has disabled emissions sync.
-	pub fn burn_and_broadcast_supply_update(current_block: BlockNumberFor<T>) {
+	pub fn burn_and_broadcast_supply_update(current_block: BlockNumberFor<T>, force: bool) {
 		if T::SafeMode::get().emissions_sync_enabled {
-			Self::burn_flip_network_fee();
+			Self::burn_flip_network_fee(force);
 			Self::broadcast_update_total_supply(T::Issuance::total_issuance(), current_block);
 			Self::deposit_event(Event::SupplyUpdateBroadcastRequested(current_block));
 			LastSupplyUpdateBlock::<T>::set(current_block);
@@ -269,7 +269,7 @@ impl<T: Config> Pallet<T> {
 		));
 	}
 
-	fn burn_flip_network_fee() {
+	fn burn_flip_network_fee(force: bool) {
 		match with_storage_layer(|| {
 			let flip_to_be_sent_to_gateway = T::FlipToBurnOrMove::take_flip_to_be_sent_to_gateway();
 			let flip_to_burn = T::FlipToBurnOrMove::take_flip_to_burn();
@@ -285,7 +285,7 @@ impl<T: Config> Pallet<T> {
 			.map_err(Into::into)
 			.and_then(
 				|result @ ScheduledEgressDetails { egress_amount, fee_withheld, .. }| {
-					if egress_amount < BURN_FEE_MULTIPLE * fee_withheld {
+					if !force && egress_amount < BURN_FEE_MULTIPLE * fee_withheld {
 						Err(Error::<T>::FlipBalanceBelowBurnThreshold.into())
 					} else {
 						Ok((result, flip_to_be_sent_to_gateway))

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -163,6 +163,14 @@ impl RewardsDistribution for FlipDistribution {
 	) {
 		pallet_cf_flip::FlipIssuance::<Test>::mint(beneficiary, reward_amount);
 	}
+
+	fn distribute_all(
+		_epoch_index: cf_primitives::EpochIndex,
+		_total_amount: Self::Balance,
+		_settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
+		unimplemented!("not used by the emissions pallet");
+	}
 }
 
 impl pallet_cf_emissions::Config for Test {

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -74,6 +74,7 @@ impl pallet_cf_flip::Config for Test {
 	type Balance = FlipBalance;
 	type BlocksPerDay = BlocksPerDay;
 	type WeightInfo = ();
+	type RewardsDistribution = FlipDistribution;
 	type WaivedFees = WaivedFeesMock<Self>;
 	type CallIndexer = ();
 	type RuntimeHoldReason = ();

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -156,6 +156,7 @@ impl RewardsDistribution for FlipDistribution {
 	type AccountId = AccountId;
 
 	fn distribute(
+		_epoch_index: cf_primitives::EpochIndex,
 		reward_amount: Self::Balance,
 		beneficiary: &Self::AccountId,
 		_settle: impl FnMut(&Self::AccountId, Self::Balance),

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -154,7 +154,11 @@ impl RewardsDistribution for FlipDistribution {
 	type Balance = FlipBalance;
 	type AccountId = AccountId;
 
-	fn distribute(reward_amount: Self::Balance, beneficiary: &Self::AccountId) {
+	fn distribute(
+		reward_amount: Self::Balance,
+		beneficiary: &Self::AccountId,
+		_settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
 		pallet_cf_flip::FlipIssuance::<Test>::mint(beneficiary, reward_amount);
 	}
 }

--- a/state-chain/pallets/cf-emissions/src/tests.rs
+++ b/state-chain/pallets/cf-emissions/src/tests.rs
@@ -211,7 +211,7 @@ fn dont_burn_flip_below_threshold() {
 		assert_eq!(total_issuance, TOTAL_ISSUANCE);
 		// Set the fee to be too high.
 		MockEgressHandler::<Ethereum>::set_fee(FLIP_TO_BURN / BURN_FEE_MULTIPLE);
-		Pallet::<Test>::burn_flip_network_fee();
+		Pallet::<Test>::burn_flip_network_fee(false);
 		assert_has_event::<Test>(
 			Event::FlipBurnSkipped {
 				reason: crate::Error::<Test>::FlipBalanceBelowBurnThreshold.into(),
@@ -234,7 +234,7 @@ fn dont_burn_flip_below_threshold() {
 		// Set a lower fee.
 		const LOW_FEE: u128 = FLIP_TO_BURN / BURN_FEE_MULTIPLE / 2;
 		MockEgressHandler::<Ethereum>::set_fee(LOW_FEE);
-		Pallet::<Test>::burn_flip_network_fee();
+		Pallet::<Test>::burn_flip_network_fee(false);
 		assert_has_matching_event!(
 			Test,
 			RuntimeEvent::Emissions(Event::NetworkFeeBurned {
@@ -276,7 +276,7 @@ fn burn_also_moves_flip_to_gateway() {
 		// the burning
 		MockFlipBurnOrMoveInfo::set_flip_to_be_sent_to_gateway(1_000);
 
-		Pallet::<Test>::burn_flip_network_fee();
+		Pallet::<Test>::burn_flip_network_fee(false);
 		assert_has_matching_event!(
 			Test,
 			RuntimeEvent::Emissions(Event::NetworkFeeBurned {

--- a/state-chain/pallets/cf-environment/src/mock.rs
+++ b/state-chain/pallets/cf-environment/src/mock.rs
@@ -390,7 +390,7 @@ cf_test_utilities::impl_test_helpers! {
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarks_mock {
-	use cf_traits::WaivedFees;
+	use cf_traits::{mocks::rewards_distribution::MockRewardsDistribution, WaivedFees};
 	use sp_core::ConstU64;
 
 	use super::*;
@@ -447,6 +447,7 @@ pub mod benchmarks_mock {
 		type BlocksPerDay = ConstU64<14400>;
 		type WeightInfo = ();
 		type WaivedFees = MockWaivedFees;
+		type RewardsDistribution = MockRewardsDistribution<Self>;
 		type RuntimeHoldReason = ();
 		type CallIndexer = ();
 	}

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -572,7 +572,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Self::deposit_event(Event::FlipDistributed { amount: flip_minted_list });
-		return flip_to_distribute.into();
+		flip_to_distribute.into()
 	}
 }
 

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -109,7 +109,7 @@ pub mod pallet {
 	/// A 4-byte identifier for different reserves.
 	pub type ReserveId = [u8; 4];
 
-	pub const ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID: ReserveId = *b"FEES";
+	pub(crate) const ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID: ReserveId = *b"FEES";
 
 	#[pallet::config]
 	#[pallet::disable_frame_system_supertrait_check]
@@ -607,6 +607,15 @@ impl<T: Config> Pallet<T> {
 			amount: flip_distributed_map.into_iter().collect(),
 		});
 		offchain_flip_bridged
+	}
+
+	/// Fee rewards pending distribution to authorities: the balance of the on-chain distribution
+	/// reserve plus any off-chain accumulated fees (which may be negative).
+	pub fn pending_rewards() -> i128 {
+		Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID)
+			.try_into()
+			.unwrap_or(i128::MAX)
+			.saturating_add(FlipToDistribute::<T>::get())
 	}
 
 	/// Whether FLIP 2.1 is active: fee rewards are accumulated for distribution to authorities

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -33,7 +33,8 @@ use scale_info::TypeInfo;
 pub use weights::WeightInfo;
 
 use cf_traits::{
-	AccountInfo, Bonding, DeregistrationCheck, FeePayment, FundingInfo, Issuance, Slashing,
+	AccountInfo, Bonding, DeregistrationCheck, FeePayment, FundingInfo, Issuance,
+	RewardsDistribution, Slashing,
 };
 use imbalances::{Deficit, ImbalanceSource, Surplus};
 
@@ -46,7 +47,7 @@ use frame_support::{
 	ensure,
 	pallet_prelude::*,
 	sp_runtime::{
-		traits::{AtLeast32BitUnsigned, Zero},
+		traits::{AtLeast32BitUnsigned, Hash as HashT, Zero},
 		DispatchError, Permill, RuntimeDebug,
 	},
 	traits::{Get, Imbalance, OnKilledAccount, SignedImbalance},
@@ -121,6 +122,12 @@ pub mod pallet {
 
 		type CallIndexer: CallIndexer<<Self as frame_system::Config>::RuntimeCall>;
 
+		/// An implementation of `RewardsDistribution` defining how to distribute rewards.
+		type RewardsDistribution: RewardsDistribution<
+			Balance = Self::Balance,
+			AccountId = Self::AccountId,
+		>;
+
 		/// Required in order to inject a HoldReason for impls in [substrate_impls]
 		type RuntimeHoldReason: Encode + TypeInfo + 'static;
 	}
@@ -167,6 +174,9 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type FeeScalingRate<T: Config> = StorageValue<_, FeeScalingRateConfig, ValueQuery>;
 
+	#[pallet::storage]
+	pub type FlipToDistribute<T: Config> = StorageValue<_, i128, ValueQuery>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -193,6 +203,9 @@ pub mod pallet {
 		BondUpdated {
 			account_id: T::AccountId,
 			new_bond: T::Balance,
+		},
+		FlipDistributed {
+			amount: Vec<(T::AccountId, T::Balance)>,
 		},
 	}
 
@@ -515,6 +528,51 @@ impl<T: Config> Pallet<T> {
 				amount: slash_amount,
 			})
 		}
+	}
+
+	pub fn trigger_flip_reward_distribution(authorities: Vec<T::AccountId>) -> T::Balance {
+		let flip_to_distribute = FlipToDistribute::<T>::take();
+		if flip_to_distribute <= Zero::zero() {
+			FlipToDistribute::<T>::put(flip_to_distribute);
+			return Zero::zero()
+		}
+		let flip_to_distribute: u128 =
+			flip_to_distribute.try_into().expect("checked for negative number above");
+
+		let count = authorities.len();
+		let count_u128 = count as u128;
+		let (per_authority_reward, remainder) =
+			(flip_to_distribute / count_u128, flip_to_distribute % count_u128);
+
+		let winner_authority = if remainder > 0 {
+			let parent_hash = frame_system::Pallet::<T>::parent_hash();
+			let seed =
+				<T as frame_system::Config>::Hashing::hash_of(&(parent_hash, b"flip_distribution"));
+			let random_num = u64::from_le_bytes(seed.as_ref()[..8].try_into().unwrap_or([0u8; 8]));
+			let winner_idx = (random_num % count as u64) as usize;
+			Some(&authorities[winner_idx])
+		} else {
+			None
+		};
+
+		let mut flip_minted_list = vec![];
+		for authority in &authorities {
+			T::RewardsDistribution::distribute(
+				if winner_authority.is_some_and(|wa| authority == wa) {
+					(per_authority_reward + remainder).into()
+				} else {
+					per_authority_reward.into()
+				},
+				authority,
+				|account, amount| {
+					Pallet::<T>::settle(account, Pallet::<T>::bridge_in(amount).into());
+					flip_minted_list.push((account.clone(), amount));
+				},
+			);
+		}
+
+		Self::deposit_event(Event::FlipDistributed { amount: flip_minted_list });
+		return flip_to_distribute.into();
 	}
 }
 

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -30,10 +30,12 @@ pub mod substrate_impls;
 
 pub mod weights;
 use scale_info::TypeInfo;
+use sp_runtime::traits::Saturating;
 pub use weights::WeightInfo;
 
+use cf_primitives::ACCUMULATE_REWARDS_EPOCH_START;
 use cf_traits::{
-	AccountInfo, Bonding, DeregistrationCheck, FeePayment, FundingInfo, Issuance,
+	AccountInfo, Bonding, DeregistrationCheck, EpochInfo, FeePayment, FundingInfo, Issuance,
 	RewardsDistribution, Slashing,
 };
 use imbalances::{Deficit, ImbalanceSource, Surplus};
@@ -101,11 +103,17 @@ pub mod pallet {
 	/// A 4-byte identifier for different reserves.
 	pub type ReserveId = [u8; 4];
 
+	/// Reserve ID derived from blake2_256("OnchainFees")[..4].
+	pub const ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID: ReserveId = [0xc3, 0xee, 0x10, 0x5a];
+
 	#[pallet::config]
 	#[pallet::disable_frame_system_supertrait_check]
 	pub trait Config: Chainflip<Amount = Self::Balance> {
 		/// The balance of an account.
-		type Balance: frame_support::traits::tokens::Balance + From<u128> + From<u64>;
+		type Balance: frame_support::traits::tokens::Balance
+			+ From<u128>
+			+ From<u64>
+			+ TryInto<i128>;
 
 		/// Blocks per day.
 		#[pallet::constant]
@@ -522,7 +530,15 @@ impl<T: Config> Pallet<T> {
 
 	fn slash(account_id: &T::AccountId, slash_amount: T::Balance) {
 		if !slash_amount.is_zero() && Account::<T>::get(account_id).can_be_slashed(slash_amount) {
-			Pallet::<T>::settle(account_id, Pallet::<T>::burn(slash_amount).into());
+			Pallet::<T>::settle(
+				account_id,
+				if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+					Pallet::<T>::add_to_onchain_flip_to_be_distributed(slash_amount)
+				} else {
+					Pallet::<T>::burn(slash_amount)
+				}
+				.into(),
+			);
 			Self::deposit_event(Event::<T>::SlashingPerformed {
 				who: account_id.clone(),
 				amount: slash_amount,
@@ -531,20 +547,30 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn trigger_flip_reward_distribution(authorities: Vec<T::AccountId>) -> T::Balance {
-		let flip_to_distribute = FlipToDistribute::<T>::take();
-		if flip_to_distribute <= Zero::zero() {
-			FlipToDistribute::<T>::put(flip_to_distribute);
-			return Zero::zero()
-		}
-		let flip_to_distribute: u128 =
-			flip_to_distribute.try_into().expect("checked for negative number above");
+		let onchain_flip_to_distribute = Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID);
 
 		let count = authorities.len();
 		let count_u128 = count as u128;
-		let (per_authority_reward, remainder) =
-			(flip_to_distribute / count_u128, flip_to_distribute % count_u128);
 
-		let winner_authority = if remainder > 0 {
+		let (onchain_per_authority_reward, onchain_remainder) = (
+			onchain_flip_to_distribute / count_u128.into(),
+			onchain_flip_to_distribute % count_u128.into(),
+		);
+
+		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
+		let offchain_flip_to_distribute: u128 = if offchain_flip_to_distribute <= Zero::zero() {
+			FlipToDistribute::<T>::put(offchain_flip_to_distribute);
+			Zero::zero()
+		} else {
+			offchain_flip_to_distribute
+				.try_into()
+				.expect("checked for negative number above")
+		};
+
+		let (offchain_per_authority_reward, offchain_remainder) =
+			(offchain_flip_to_distribute / count_u128, offchain_flip_to_distribute % count_u128);
+
+		let winner_authority = if offchain_remainder > 0 || onchain_remainder > 0u128.into() {
 			let parent_hash = frame_system::Pallet::<T>::parent_hash();
 			let seed =
 				<T as frame_system::Config>::Hashing::hash_of(&(parent_hash, b"flip_distribution"));
@@ -555,24 +581,52 @@ impl<T: Config> Pallet<T> {
 			None
 		};
 
-		let mut flip_minted_list = vec![];
+		let mut flip_distributed_map = sp_std::collections::btree_map::BTreeMap::new();
 		for authority in &authorities {
 			T::RewardsDistribution::distribute(
 				if winner_authority.is_some_and(|wa| authority == wa) {
-					(per_authority_reward + remainder).into()
+					(offchain_per_authority_reward + offchain_remainder).into()
 				} else {
-					per_authority_reward.into()
+					offchain_per_authority_reward.into()
 				},
 				authority,
 				|account, amount| {
 					Pallet::<T>::settle(account, Pallet::<T>::bridge_in(amount).into());
-					flip_minted_list.push((account.clone(), amount));
+					flip_distributed_map
+						.entry(account.clone())
+						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
+						.or_insert(amount);
+				},
+			);
+
+			T::RewardsDistribution::distribute(
+				if winner_authority.is_some_and(|wa| authority == wa) {
+					onchain_per_authority_reward + onchain_remainder
+				} else {
+					onchain_per_authority_reward
+				},
+				authority,
+				|account, amount| {
+					Pallet::<T>::settle(
+						account,
+						Pallet::<T>::withdraw_reserves(
+							ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+							amount,
+						)
+						.into(),
+					);
+					flip_distributed_map
+						.entry(account.clone())
+						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
+						.or_insert(amount);
 				},
 			);
 		}
 
-		Self::deposit_event(Event::FlipDistributed { amount: flip_minted_list });
-		flip_to_distribute.into()
+		Self::deposit_event(Event::FlipDistributed {
+			amount: flip_distributed_map.into_iter().collect(),
+		});
+		offchain_flip_to_distribute.into()
 	}
 }
 
@@ -592,6 +646,7 @@ impl<T: Config> FundingInfo for Pallet<T> {
 impl<T: Config> FeePayment for Pallet<T> {
 	type Amount = T::Balance;
 	type AccountId = T::AccountId;
+	type Deficit = Deficit<T>;
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(account_id: &Self::AccountId, amount: Self::Amount) {
@@ -603,16 +658,29 @@ impl<T: Config> FeePayment for Pallet<T> {
 		Pallet::<T>::settle(account_id, Pallet::<T>::mint(amount).into());
 	}
 
-	fn try_burn_fee(
+	fn try_take_fee(
 		account_id: &Self::AccountId,
 		amount: Self::Amount,
 	) -> frame_support::dispatch::DispatchResult {
 		if let Some(surplus) = Pallet::<T>::try_debit_from_liquid_funds(account_id, amount) {
-			let _ = surplus.offset(Pallet::<T>::burn(amount));
+			let _ =
+				surplus.offset(if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+					Pallet::<T>::add_to_onchain_flip_to_be_distributed(amount)
+				} else {
+					Pallet::<T>::burn(amount)
+				});
 			Ok(())
 		} else {
 			Err(Error::<T>::InsufficientLiquidity.into())
 		}
+	}
+
+	fn add_to_offchain_flip_to_be_distributed(amount: i128) {
+		FlipToDistribute::<T>::mutate(|flip| flip.saturating_accrue(amount));
+	}
+
+	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Deficit<T> {
+		Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
 	}
 }
 
@@ -753,7 +821,15 @@ pub struct BurnFlipAccount<T: Config>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for BurnFlipAccount<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
 		let dust = Pallet::<T>::total_balance_of(account_id);
-		Pallet::<T>::settle(account_id, Pallet::<T>::burn(dust).into());
+		Pallet::<T>::settle(
+			account_id,
+			if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+				Pallet::<T>::add_to_onchain_flip_to_be_distributed(dust)
+			} else {
+				Pallet::<T>::burn(dust)
+			}
+			.into(),
+		);
 		Account::<T>::remove(account_id);
 		Pallet::<T>::deposit_event(Event::AccountReaped {
 			who: account_id.clone(),

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -558,64 +558,34 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn trigger_flip_reward_distribution(authorities: Vec<T::AccountId>) -> T::Balance {
-		let onchain_flip_to_distribute = Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID);
+		let count_u128 = authorities.len() as u128;
 
-		let count = authorities.len();
-		let count_u128 = count as u128;
-
-		let (onchain_per_authority_reward, onchain_remainder) = (
-			onchain_flip_to_distribute / count_u128.into(),
-			onchain_flip_to_distribute % count_u128.into(),
-		);
-
+		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
+		// that everything is distributed from a single source.
 		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
-		let offchain_flip_to_distribute: u128 = if offchain_flip_to_distribute <= Zero::zero() {
+		let offchain_flip_bridged: T::Balance = if offchain_flip_to_distribute > Zero::zero() {
+			let as_u128: u128 = offchain_flip_to_distribute
+				.try_into()
+				.expect("checked for positive number above");
+			let amount: T::Balance = as_u128.into();
+			let _ = Pallet::<T>::bridge_in(amount).offset(Pallet::<T>::deposit_reserves(
+				ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+				amount,
+			));
+			amount
+		} else {
 			FlipToDistribute::<T>::put(offchain_flip_to_distribute);
 			Zero::zero()
-		} else {
-			offchain_flip_to_distribute
-				.try_into()
-				.expect("checked for negative number above")
 		};
 
-		let (offchain_per_authority_reward, offchain_remainder) =
-			(offchain_flip_to_distribute / count_u128, offchain_flip_to_distribute % count_u128);
-
-		let winner_authority = if offchain_remainder > 0 || onchain_remainder > 0u128.into() {
-			let parent_hash = frame_system::Pallet::<T>::parent_hash();
-			let seed =
-				<T as frame_system::Config>::Hashing::hash_of(&(parent_hash, b"flip_distribution"));
-			let random_num = u64::from_le_bytes(seed.as_ref()[..8].try_into().unwrap_or([0u8; 8]));
-			let winner_idx = (random_num % count as u64) as usize;
-			Some(&authorities[winner_idx])
-		} else {
-			None
-		};
+		// Distribute evenly from the combined reserve. Any remainder stays for the next epoch.
+		let per_authority_reward =
+			Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) / count_u128.into();
 
 		let mut flip_distributed_map = sp_std::collections::btree_map::BTreeMap::new();
 		for authority in &authorities {
 			T::RewardsDistribution::distribute(
-				if winner_authority.is_some_and(|wa| authority == wa) {
-					(offchain_per_authority_reward + offchain_remainder).into()
-				} else {
-					offchain_per_authority_reward.into()
-				},
-				authority,
-				|account, amount| {
-					Pallet::<T>::settle(account, Pallet::<T>::bridge_in(amount).into());
-					flip_distributed_map
-						.entry(account.clone())
-						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
-						.or_insert(amount);
-				},
-			);
-
-			T::RewardsDistribution::distribute(
-				if winner_authority.is_some_and(|wa| authority == wa) {
-					onchain_per_authority_reward + onchain_remainder
-				} else {
-					onchain_per_authority_reward
-				},
+				per_authority_reward,
 				authority,
 				|account, amount| {
 					Pallet::<T>::settle(
@@ -637,7 +607,7 @@ impl<T: Config> Pallet<T> {
 		Self::deposit_event(Event::FlipDistributed {
 			amount: flip_distributed_map.into_iter().collect(),
 		});
-		offchain_flip_to_distribute.into()
+		offchain_flip_bridged
 	}
 }
 

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -113,6 +113,7 @@ pub mod pallet {
 		/// The balance of an account.
 		type Balance: frame_support::traits::tokens::Balance
 			+ From<u128>
+			+ Into<u128>
 			+ From<u64>
 			+ TryInto<i128>;
 
@@ -603,12 +604,12 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Fee rewards pending distribution to authorities: the balance of the on-chain distribution
-	/// reserve plus any off-chain accumulated fees (which may be negative).
-	pub fn pending_rewards() -> i128 {
-		Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID)
+	/// reserve plus any off-chain accumulated fees.
+	pub fn pending_rewards() -> u128 {
+		FlipToDistribute::<T>::get()
 			.try_into()
-			.unwrap_or(i128::MAX)
-			.saturating_add(FlipToDistribute::<T>::get())
+			.unwrap_or(0u128)
+			.saturating_add(Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID).into())
 	}
 
 	/// Whether FLIP 2.1 is active: fee rewards are accumulated for distribution to authorities

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -105,8 +105,7 @@ pub mod pallet {
 	/// A 4-byte identifier for different reserves.
 	pub type ReserveId = [u8; 4];
 
-	/// Reserve ID derived from blake2_256("OnchainFees")[..4].
-	pub const ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID: ReserveId = [0xc3, 0xee, 0x10, 0x5a];
+	pub const ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID: ReserveId = *b"FEES";
 
 	#[pallet::config]
 	#[pallet::disable_frame_system_supertrait_check]

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -33,7 +33,7 @@ use scale_info::TypeInfo;
 use sp_runtime::traits::Saturating;
 pub use weights::WeightInfo;
 
-use cf_primitives::ACCUMULATE_REWARDS_EPOCH_START;
+use cf_primitives::EpochIndex;
 use cf_traits::{
 	AccountInfo, Bonding, DeregistrationCheck, EpochInfo, FeePayment, FundingInfo, Issuance,
 	RewardsDistribution, Slashing,
@@ -49,7 +49,7 @@ use frame_support::{
 	ensure,
 	pallet_prelude::*,
 	sp_runtime::{
-		traits::{AtLeast32BitUnsigned, Hash as HashT, Zero},
+		traits::{AtLeast32BitUnsigned, Zero},
 		DispatchError, Permill, RuntimeDebug,
 	},
 	traits::{Get, Imbalance, OnKilledAccount, SignedImbalance},
@@ -76,6 +76,8 @@ pub enum PalletConfigUpdate {
 	SetSlashingRate(Permill),
 	// Set fee scaling rate for any calls that are scaled.
 	SetFeeScalingRate(FeeScalingRateConfig),
+	// Set the epoch from which flip 2.1 activates.
+	SetFeeRewardsActivationEpoch(EpochIndex),
 }
 
 #[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
@@ -185,6 +187,12 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type FlipToDistribute<T: Config> = StorageValue<_, i128, ValueQuery>;
 
+	/// The epoch from which flip 2.1 activates.
+	/// Defaults to u32::MAX (effectively disabled) until set via governance.
+	#[pallet::storage]
+	pub type FeeRewardsActivationEpoch<T: Config> =
+		StorageValue<_, EpochIndex, ValueQuery, ConstU32<{ u32::MAX }>>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -266,6 +274,9 @@ pub mod pallet {
 					// i.e. there are 9 decimal places.
 					PalletConfigUpdate::SetFeeScalingRate(fee_scaling_rate) => {
 						FeeScalingRate::<T>::set(fee_scaling_rate);
+					},
+					PalletConfigUpdate::SetFeeRewardsActivationEpoch(epoch) => {
+						FeeRewardsActivationEpoch::<T>::set(epoch);
 					},
 				};
 				Self::deposit_event(Event::PalletConfigUpdated { update });
@@ -532,7 +543,7 @@ impl<T: Config> Pallet<T> {
 		if !slash_amount.is_zero() && Account::<T>::get(account_id).can_be_slashed(slash_amount) {
 			Pallet::<T>::settle(
 				account_id,
-				if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
 					Pallet::<T>::add_to_onchain_flip_to_be_distributed(slash_amount)
 				} else {
 					Pallet::<T>::burn(slash_amount)
@@ -663,12 +674,13 @@ impl<T: Config> FeePayment for Pallet<T> {
 		amount: Self::Amount,
 	) -> frame_support::dispatch::DispatchResult {
 		if let Some(surplus) = Pallet::<T>::try_debit_from_liquid_funds(account_id, amount) {
-			let _ =
-				surplus.offset(if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+			let _ = surplus.offset(
+				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
 					Pallet::<T>::add_to_onchain_flip_to_be_distributed(amount)
 				} else {
 					Pallet::<T>::burn(amount)
-				});
+				},
+			);
 			Ok(())
 		} else {
 			Err(Error::<T>::InsufficientLiquidity.into())
@@ -681,6 +693,10 @@ impl<T: Config> FeePayment for Pallet<T> {
 
 	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Deficit<T> {
 		Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
+	}
+
+	fn fee_rewards_activation_epoch() -> EpochIndex {
+		FeeRewardsActivationEpoch::<T>::get()
 	}
 }
 
@@ -727,6 +743,10 @@ impl<T: Config> Issuance for Pallet<T> {
 	fn burn_offchain(amount: Self::Balance) {
 		let _remainder = Pallet::<T>::burn(amount).offset(Pallet::<T>::bridge_in(amount));
 	}
+
+	fn fee_rewards_activation_epoch() -> EpochIndex {
+		FeeRewardsActivationEpoch::<T>::get()
+	}
 }
 
 pub struct FlipIssuance<T>(PhantomData<T>);
@@ -745,6 +765,10 @@ impl<T: Config> Issuance for FlipIssuance<T> {
 
 	fn burn_offchain(amount: Self::Balance) {
 		<Pallet<T> as Issuance>::burn_offchain(amount);
+	}
+
+	fn fee_rewards_activation_epoch() -> EpochIndex {
+		<Pallet<T> as Issuance>::fee_rewards_activation_epoch()
 	}
 }
 
@@ -823,7 +847,7 @@ impl<T: Config> OnKilledAccount<T::AccountId> for BurnFlipAccount<T> {
 		let dust = Pallet::<T>::total_balance_of(account_id);
 		Pallet::<T>::settle(
 			account_id,
-			if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+			if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
 				Pallet::<T>::add_to_onchain_flip_to_be_distributed(dust)
 			} else {
 				Pallet::<T>::burn(dust)

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -469,6 +469,16 @@ impl<T: Config> Pallet<T> {
 		Deficit::from_burn(amount)
 	}
 
+	/// Burns `amount`, unless fee reward distribution has been activated, in which case `amount`
+	/// is deposited into the reserve to be distributed to authorities as fee rewards instead.
+	fn burn_or_deposit_to_reserve(amount: T::Balance) -> Deficit<T> {
+		if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
+			Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
+		} else {
+			Pallet::<T>::burn(amount)
+		}
+	}
+
 	/// Increases total issuance and returns a corresponding imbalance that must be reconciled.
 	fn mint(amount: T::Balance) -> Surplus<T> {
 		Surplus::from_mint(amount)
@@ -542,15 +552,7 @@ impl<T: Config> Pallet<T> {
 		if !slash_amount.is_zero() && Account::<T>::get(account_id).can_be_slashed(slash_amount) {
 			Pallet::<T>::settle(
 				account_id,
-				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-					Pallet::<T>::deposit_reserves(
-						ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-						slash_amount,
-					)
-				} else {
-					Pallet::<T>::burn(slash_amount)
-				}
-				.into(),
+				Pallet::<T>::burn_or_deposit_to_reserve(slash_amount).into(),
 			);
 			Self::deposit_event(Event::<T>::SlashingPerformed {
 				who: account_id.clone(),
@@ -645,13 +647,7 @@ impl<T: Config> FeePayment for Pallet<T> {
 		amount: Self::Amount,
 	) -> frame_support::dispatch::DispatchResult {
 		if let Some(surplus) = Pallet::<T>::try_debit_from_liquid_funds(account_id, amount) {
-			let _ = surplus.offset(
-				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-					Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
-				} else {
-					Pallet::<T>::burn(amount)
-				},
-			);
+			let _ = surplus.offset(Pallet::<T>::burn_or_deposit_to_reserve(amount));
 			Ok(())
 		} else {
 			Err(Error::<T>::InsufficientLiquidity.into())
@@ -817,15 +813,7 @@ pub struct BurnFlipAccount<T: Config>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for BurnFlipAccount<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
 		let dust = Pallet::<T>::total_balance_of(account_id);
-		Pallet::<T>::settle(
-			account_id,
-			if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-				Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, dust)
-			} else {
-				Pallet::<T>::burn(dust)
-			}
-			.into(),
-		);
+		Pallet::<T>::settle(account_id, Pallet::<T>::burn_or_deposit_to_reserve(dust).into());
 		Account::<T>::remove(account_id);
 		Pallet::<T>::deposit_event(Event::AccountReaped {
 			who: account_id.clone(),

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -561,13 +561,6 @@ impl<T: Config> Pallet<T> {
 			.offset(Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
 	}
 
-	fn credit_reward_from_reserve(account_id: &T::AccountId, amount: T::Balance) {
-		Pallet::<T>::settle(
-			account_id,
-			Pallet::<T>::withdraw_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount).into(),
-		);
-	}
-
 	pub fn trigger_flip_reward_distribution(authorities: BTreeSet<T::AccountId>) -> T::Balance {
 		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
 		// that everything is distributed from a single source.
@@ -594,7 +587,14 @@ impl<T: Config> Pallet<T> {
 				per_authority_reward,
 				authority,
 				|account, amount| {
-					Pallet::<T>::credit_reward_from_reserve(account, amount);
+					Pallet::<T>::settle(
+						account,
+						Pallet::<T>::withdraw_reserves(
+							ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+							amount,
+						)
+						.into(),
+					);
 					flip_distributed_map
 						.entry(account.clone())
 						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -543,7 +543,10 @@ impl<T: Config> Pallet<T> {
 			Pallet::<T>::settle(
 				account_id,
 				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-					Pallet::<T>::add_to_onchain_flip_to_be_distributed(slash_amount)
+					Pallet::<T>::deposit_reserves(
+						ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+						slash_amount,
+					)
 				} else {
 					Pallet::<T>::burn(slash_amount)
 				}
@@ -626,7 +629,6 @@ impl<T: Config> FundingInfo for Pallet<T> {
 impl<T: Config> FeePayment for Pallet<T> {
 	type Amount = T::Balance;
 	type AccountId = T::AccountId;
-	type Deficit = Deficit<T>;
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(account_id: &Self::AccountId, amount: Self::Amount) {
@@ -645,7 +647,7 @@ impl<T: Config> FeePayment for Pallet<T> {
 		if let Some(surplus) = Pallet::<T>::try_debit_from_liquid_funds(account_id, amount) {
 			let _ = surplus.offset(
 				if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-					Pallet::<T>::add_to_onchain_flip_to_be_distributed(amount)
+					Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
 				} else {
 					Pallet::<T>::burn(amount)
 				},
@@ -660,8 +662,11 @@ impl<T: Config> FeePayment for Pallet<T> {
 		FlipToDistribute::<T>::mutate(|flip| flip.saturating_accrue(amount));
 	}
 
-	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Deficit<T> {
-		Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
+	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(amount: Self::Amount) {
+		let _ = Self::bridge_in(amount).offset(Pallet::<T>::deposit_reserves(
+			ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+			amount,
+		));
 	}
 
 	fn fee_rewards_activation_epoch() -> EpochIndex {
@@ -817,7 +822,7 @@ impl<T: Config> OnKilledAccount<T::AccountId> for BurnFlipAccount<T> {
 		Pallet::<T>::settle(
 			account_id,
 			if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-				Pallet::<T>::add_to_onchain_flip_to_be_distributed(dust)
+				Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, dust)
 			} else {
 				Pallet::<T>::burn(dust)
 			}

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -56,7 +56,11 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use on_charge_transaction::CallIndexFor;
-use sp_std::{marker::PhantomData, prelude::*};
+use sp_std::{
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	marker::PhantomData,
+	prelude::*,
+};
 
 pub use pallet::*;
 
@@ -469,16 +473,6 @@ impl<T: Config> Pallet<T> {
 		Deficit::from_burn(amount)
 	}
 
-	/// Burns `amount`, unless fee reward distribution has been activated, in which case `amount`
-	/// is deposited into the reserve to be distributed to authorities as fee rewards instead.
-	fn burn_or_deposit_to_reserve(amount: T::Balance) -> Deficit<T> {
-		if T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get() {
-			Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
-		} else {
-			Pallet::<T>::burn(amount)
-		}
-	}
-
 	/// Increases total issuance and returns a corresponding imbalance that must be reconciled.
 	fn mint(amount: T::Balance) -> Surplus<T> {
 		Surplus::from_mint(amount)
@@ -561,9 +555,20 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	pub fn trigger_flip_reward_distribution(authorities: Vec<T::AccountId>) -> T::Balance {
-		let count_u128 = authorities.len() as u128;
+	/// Bridge in funds from off-chain and deposit them into the fee distribution reserve.
+	fn bridge_in_to_distribution_reserve(amount: T::Balance) {
+		let _ = Self::bridge_in(amount)
+			.offset(Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
+	}
 
+	fn credit_reward_from_reserve(account_id: &T::AccountId, amount: T::Balance) {
+		Pallet::<T>::settle(
+			account_id,
+			Pallet::<T>::withdraw_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount).into(),
+		);
+	}
+
+	pub fn trigger_flip_reward_distribution(authorities: BTreeSet<T::AccountId>) -> T::Balance {
 		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
 		// that everything is distributed from a single source.
 		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
@@ -572,10 +577,7 @@ impl<T: Config> Pallet<T> {
 				.try_into()
 				.expect("checked for positive number above");
 			let amount: T::Balance = as_u128.into();
-			let _ = Pallet::<T>::bridge_in(amount).offset(Pallet::<T>::deposit_reserves(
-				ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-				amount,
-			));
+			Pallet::<T>::bridge_in_to_distribution_reserve(amount);
 			amount
 		} else {
 			FlipToDistribute::<T>::put(offchain_flip_to_distribute);
@@ -583,23 +585,16 @@ impl<T: Config> Pallet<T> {
 		};
 
 		// Distribute evenly from the combined reserve. Any remainder stays for the next epoch.
-		let per_authority_reward =
-			Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) / count_u128.into();
+		let per_authority_reward = Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) /
+			(authorities.len() as u128).into();
 
-		let mut flip_distributed_map = sp_std::collections::btree_map::BTreeMap::new();
+		let mut flip_distributed_map = BTreeMap::new();
 		for authority in &authorities {
 			T::RewardsDistribution::distribute(
 				per_authority_reward,
 				authority,
 				|account, amount| {
-					Pallet::<T>::settle(
-						account,
-						Pallet::<T>::withdraw_reserves(
-							ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-							amount,
-						)
-						.into(),
-					);
+					Pallet::<T>::credit_reward_from_reserve(account, amount);
 					flip_distributed_map
 						.entry(account.clone())
 						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
@@ -612,6 +607,22 @@ impl<T: Config> Pallet<T> {
 			amount: flip_distributed_map.into_iter().collect(),
 		});
 		offchain_flip_bridged
+	}
+
+	/// Whether FLIP 2.1 is active: fee rewards are accumulated for distribution to authorities
+	/// rather than burned.
+	pub fn is_flip_2_1_activated() -> bool {
+		T::EpochInfo::epoch_index() >= FeeRewardsActivationEpoch::<T>::get()
+	}
+
+	/// Burns `amount`, unless FLIP 2.1 is active, in which case `amount` is deposited into the
+	/// reserve to be distributed to authorities as fee rewards instead.
+	fn burn_or_deposit_to_reserve(amount: T::Balance) -> Deficit<T> {
+		if Self::is_flip_2_1_activated() {
+			Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
+		} else {
+			Self::burn(amount)
+		}
 	}
 }
 
@@ -658,13 +669,16 @@ impl<T: Config> FeePayment for Pallet<T> {
 		FlipToDistribute::<T>::mutate(|flip| flip.saturating_accrue(amount));
 	}
 
-	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(amount: Self::Amount) {
-		let _ = Self::bridge_in(amount)
-			.offset(Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
+	fn burn_or_reserve_offchain(amount: Self::Amount) {
+		if Pallet::<T>::is_flip_2_1_activated() {
+			Pallet::<T>::bridge_in_to_distribution_reserve(amount);
+		} else {
+			<Pallet<T> as Issuance>::burn_offchain(amount);
+		}
 	}
 
-	fn fee_rewards_activation_epoch() -> EpochIndex {
-		FeeRewardsActivationEpoch::<T>::get()
+	fn is_flip_2_1_activated() -> bool {
+		Pallet::<T>::is_flip_2_1_activated()
 	}
 }
 
@@ -712,8 +726,8 @@ impl<T: Config> Issuance for Pallet<T> {
 		let _remainder = Pallet::<T>::burn(amount).offset(Pallet::<T>::bridge_in(amount));
 	}
 
-	fn fee_rewards_activation_epoch() -> EpochIndex {
-		FeeRewardsActivationEpoch::<T>::get()
+	fn is_flip_2_1_activated() -> bool {
+		Pallet::<T>::is_flip_2_1_activated()
 	}
 }
 
@@ -735,8 +749,8 @@ impl<T: Config> Issuance for FlipIssuance<T> {
 		<Pallet<T> as Issuance>::burn_offchain(amount);
 	}
 
-	fn fee_rewards_activation_epoch() -> EpochIndex {
-		<Pallet<T> as Issuance>::fee_rewards_activation_epoch()
+	fn is_flip_2_1_activated() -> bool {
+		<Pallet<T> as Issuance>::is_flip_2_1_activated()
 	}
 }
 

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -224,7 +224,7 @@ pub mod pallet {
 			new_bond: T::Balance,
 		},
 		FlipDistributed {
-			amount: Vec<(T::AccountId, T::Balance)>,
+			amounts: Vec<(T::AccountId, T::Balance)>,
 		},
 	}
 
@@ -561,7 +561,10 @@ impl<T: Config> Pallet<T> {
 			.offset(Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
 	}
 
-	pub fn trigger_flip_reward_distribution(authorities: BTreeSet<T::AccountId>) -> T::Balance {
+	pub fn trigger_flip_reward_distribution(
+		epoch_index: EpochIndex,
+		authorities: BTreeSet<T::AccountId>,
+	) -> T::Balance {
 		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
 		// that everything is distributed from a single source.
 		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
@@ -584,6 +587,7 @@ impl<T: Config> Pallet<T> {
 		let mut flip_distributed_map = BTreeMap::new();
 		for authority in &authorities {
 			T::RewardsDistribution::distribute(
+				epoch_index,
 				per_authority_reward,
 				authority,
 				|account, amount| {
@@ -604,7 +608,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Self::deposit_event(Event::FlipDistributed {
-			amount: flip_distributed_map.into_iter().collect(),
+			amounts: flip_distributed_map.into_iter().collect(),
 		});
 		offchain_flip_bridged
 	}

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -663,10 +663,8 @@ impl<T: Config> FeePayment for Pallet<T> {
 	}
 
 	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(amount: Self::Amount) {
-		let _ = Self::bridge_in(amount).offset(Pallet::<T>::deposit_reserves(
-			ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-			amount,
-		));
+		let _ = Self::bridge_in(amount)
+			.offset(Pallet::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
 	}
 
 	fn fee_rewards_activation_epoch() -> EpochIndex {

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -56,11 +56,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use on_charge_transaction::CallIndexFor;
-use sp_std::{
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-	marker::PhantomData,
-	prelude::*,
-};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
 
 pub use pallet::*;
 
@@ -561,10 +557,7 @@ impl<T: Config> Pallet<T> {
 			.offset(Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
 	}
 
-	pub fn trigger_flip_reward_distribution(
-		epoch_index: EpochIndex,
-		authorities: BTreeSet<T::AccountId>,
-	) -> T::Balance {
+	pub fn trigger_flip_reward_distribution(epoch_index: EpochIndex) -> T::Balance {
 		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
 		// that everything is distributed from a single source.
 		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
@@ -580,32 +573,28 @@ impl<T: Config> Pallet<T> {
 			Zero::zero()
 		};
 
-		// Distribute evenly from the combined reserve. Any remainder stays for the next epoch.
-		let per_authority_reward = Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) /
-			(authorities.len() as u128).into();
-
 		let mut flip_distributed_map = BTreeMap::new();
-		for authority in &authorities {
-			T::RewardsDistribution::distribute(
-				epoch_index,
-				per_authority_reward,
-				authority,
-				|account, amount| {
-					Pallet::<T>::settle(
-						account,
-						Pallet::<T>::withdraw_reserves(
-							ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-							amount,
-						)
+		T::RewardsDistribution::distribute_all(
+			epoch_index,
+			Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID),
+			|account, amount| {
+				// Skip zero-value settlements: `distribute_all` calls this for every reward-pool
+				// participant, including ones with nothing due; avoid the wasted withdrawal/event
+				// noise here rather than baking that policy into the shared distribution logic.
+				if amount.is_zero() {
+					return;
+				}
+				Pallet::<T>::settle(
+					account,
+					Pallet::<T>::withdraw_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
 						.into(),
-					);
-					flip_distributed_map
-						.entry(account.clone())
-						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
-						.or_insert(amount);
-				},
-			);
-		}
+				);
+				flip_distributed_map
+					.entry(account.clone())
+					.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
+					.or_insert(amount);
+			},
+		);
 
 		Self::deposit_event(Event::FlipDistributed {
 			amounts: flip_distributed_map.into_iter().collect(),

--- a/state-chain/pallets/cf-flip/src/mock.rs
+++ b/state-chain/pallets/cf-flip/src/mock.rs
@@ -18,7 +18,11 @@
 
 use crate::{self as pallet_cf_flip, BurnFlipAccount};
 use cf_primitives::FlipBalance;
-use cf_traits::{impl_mock_chainflip, mocks::waived_fees::WaivedFeesMock, Funding};
+use cf_traits::{
+	impl_mock_chainflip,
+	mocks::{rewards_distribution::MockRewardsDistribution, waived_fees::WaivedFeesMock},
+	Funding,
+};
 use frame_support::{
 	derive_impl, parameter_types,
 	traits::{ConstU128, ConstU8, HandleLifetime},
@@ -62,6 +66,7 @@ impl pallet_cf_flip::Config for Test {
 	type BlocksPerDay = BlocksPerDay;
 	type WeightInfo = ();
 	type WaivedFees = WaivedFeesMock<Self>;
+	type RewardsDistribution = MockRewardsDistribution<Self>;
 	type RuntimeHoldReason = ();
 	type CallIndexer = ();
 }

--- a/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
+++ b/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
@@ -20,7 +20,7 @@
 //! 'good' behaviour and (b) to ensure that only funded actors can submit extrinsics to the network.
 
 use crate::{imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip};
-use cf_primitives::{FlipBalance, ACCUMULATE_REWARDS_EPOCH_START, FLIPPERINOS_PER_FLIP};
+use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
 use cf_traits::{AccountInfo, EpochInfo, FeePayment, WaivedFees};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
@@ -142,12 +142,13 @@ impl<T: TxConfig + FlipConfig + Config> OnChargeTransaction<T> for FlipTransacti
 			};
 
 			// If there is a difference this will be reconciled when the result goes out of scope.
-			let _imbalance =
-				surplus.offset(if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+			let _imbalance = surplus.offset(
+				if T::EpochInfo::epoch_index() >= crate::FeeRewardsActivationEpoch::<T>::get() {
 					Flip::<T>::add_to_onchain_flip_to_be_distributed(fee)
 				} else {
 					Flip::<T>::burn(fee)
-				});
+				},
+			);
 		}
 		Ok(())
 	}

--- a/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
+++ b/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
@@ -19,12 +19,9 @@
 //! The Chainflip network is permissioned and as such the main reasons for fees are (a) to encourage
 //! 'good' behaviour and (b) to ensure that only funded actors can submit extrinsics to the network.
 
-use crate::{
-	imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip,
-	ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-};
+use crate::{imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip};
 use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
-use cf_traits::{AccountInfo, EpochInfo, WaivedFees};
+use cf_traits::{AccountInfo, WaivedFees};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::InvalidTransaction,
@@ -145,13 +142,7 @@ impl<T: TxConfig + FlipConfig + Config> OnChargeTransaction<T> for FlipTransacti
 			};
 
 			// If there is a difference this will be reconciled when the result goes out of scope.
-			let _imbalance = surplus.offset(
-				if T::EpochInfo::epoch_index() >= crate::FeeRewardsActivationEpoch::<T>::get() {
-					Flip::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, fee)
-				} else {
-					Flip::<T>::burn(fee)
-				},
-			);
+			let _imbalance = surplus.offset(Flip::<T>::burn_or_deposit_to_reserve(fee));
 		}
 		Ok(())
 	}

--- a/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
+++ b/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
@@ -19,7 +19,10 @@
 //! The Chainflip network is permissioned and as such the main reasons for fees are (a) to encourage
 //! 'good' behaviour and (b) to ensure that only funded actors can submit extrinsics to the network.
 
-use crate::{imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip};
+use crate::{
+	imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip,
+	ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+};
 use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
 use cf_traits::{AccountInfo, EpochInfo, FeePayment, WaivedFees};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
@@ -144,7 +147,7 @@ impl<T: TxConfig + FlipConfig + Config> OnChargeTransaction<T> for FlipTransacti
 			// If there is a difference this will be reconciled when the result goes out of scope.
 			let _imbalance = surplus.offset(
 				if T::EpochInfo::epoch_index() >= crate::FeeRewardsActivationEpoch::<T>::get() {
-					Flip::<T>::add_to_onchain_flip_to_be_distributed(fee)
+					Flip::<T>::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, fee)
 				} else {
 					Flip::<T>::burn(fee)
 				},

--- a/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
+++ b/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
@@ -24,7 +24,7 @@ use crate::{
 	ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
 };
 use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
-use cf_traits::{AccountInfo, EpochInfo, FeePayment, WaivedFees};
+use cf_traits::{AccountInfo, EpochInfo, WaivedFees};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::InvalidTransaction,

--- a/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
+++ b/state-chain/pallets/cf-flip/src/on_charge_transaction.rs
@@ -20,8 +20,8 @@
 //! 'good' behaviour and (b) to ensure that only funded actors can submit extrinsics to the network.
 
 use crate::{imbalances::Surplus, Config as FlipConfig, OpaqueCallIndex, Pallet as Flip};
-use cf_primitives::{FlipBalance, FLIPPERINOS_PER_FLIP};
-use cf_traits::{AccountInfo, WaivedFees};
+use cf_primitives::{FlipBalance, ACCUMULATE_REWARDS_EPOCH_START, FLIPPERINOS_PER_FLIP};
+use cf_traits::{AccountInfo, EpochInfo, FeePayment, WaivedFees};
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{
 	pallet_prelude::InvalidTransaction,
@@ -121,8 +121,8 @@ impl<T: TxConfig + FlipConfig + Config> OnChargeTransaction<T> for FlipTransacti
 	) -> Result<(), frame_support::unsigned::TransactionValidityError> {
 		if let Some((surplus, call_index)) = escrow {
 			// It's possible the account was deleted during extrinsic execution. If this is the
-			// case, we shouldn't refund anything, we can just burn all fees in escrow.
-			let to_burn = if frame_system::Pallet::<T>::account_exists(who) {
+			// case, we shouldn't refund anything, we can just take all the fees in escrow.
+			let fee = if frame_system::Pallet::<T>::account_exists(who) {
 				if let Some(call_index) = call_index {
 					corrected_fee.saturating_mul(
 						crate::CallCounter::<T>::mutate(
@@ -142,7 +142,12 @@ impl<T: TxConfig + FlipConfig + Config> OnChargeTransaction<T> for FlipTransacti
 			};
 
 			// If there is a difference this will be reconciled when the result goes out of scope.
-			let _imbalance = surplus.offset(Flip::<T>::burn(to_burn));
+			let _imbalance =
+				surplus.offset(if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+					Flip::<T>::add_to_onchain_flip_to_be_distributed(fee)
+				} else {
+					Flip::<T>::burn(fee)
+				});
 		}
 		Ok(())
 	}

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -838,7 +838,23 @@ mod test_flip_reward_distribution {
 				let expected_per_authority = total_reserve / COUNT;
 				let expected_remainder = total_reserve % COUNT;
 
+				let total_funds = || {
+					Flip::total_balance_of(&ALICE) as i128 +
+						Flip::total_balance_of(&BOB) as i128 +
+						Flip::total_balance_of(&CHARLIE) as i128 +
+						Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) as i128 +
+						FlipToDistribute::<Test>::get()
+				};
+
+				let total_funds_before = total_funds();
+
 				let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+				// Distribution only moves funds between the reserve, validator balances, and the
+				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.
+				if total_funds() != total_funds_before {
+					return TestResult::failed()
+				}
 
 				// Return value equals what was subtracted from FlipToDistribute
 				if bridged != expected_bridged {

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -736,10 +736,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
@@ -765,10 +763,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(1i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(201u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// All authorities get the same truncated share — no winner receives the remainder
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
@@ -791,10 +787,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// Only onchain: 100 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -817,10 +811,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// 100 offchain each, 0 onchain
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -850,10 +842,8 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				0,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(0, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(0);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 0);
 
@@ -871,10 +861,8 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), AMOUNT);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
@@ -922,10 +910,8 @@ mod test_flip_reward_distribution {
 
 				let total_funds_before = total_funds();
 
-				let bridged = Flip::trigger_flip_reward_distribution(
-					1,
-					BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-				);
+				MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+				let bridged = Flip::trigger_flip_reward_distribution(1);
 
 				// Distribution only moves funds between the reserve, validator balances, and the
 				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -723,14 +723,18 @@ mod transfer {
 #[cfg(test)]
 mod test_flip_reward_distribution {
 	use super::*;
-	use crate::{FlipToDistribute, ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID};
-	use cf_traits::mocks::rewards_distribution::MockRewardsDistribution;
+	use crate::{
+		FeeRewardsActivationEpoch, FlipToDistribute, ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
+	};
+	use cf_traits::{mocks::rewards_distribution::MockRewardsDistribution, FeePayment};
 
 	#[test]
 	fn distributes_offchain_and_onchain_rewards_evenly() {
 		new_test_ext().execute_with(|| {
+			FeeRewardsActivationEpoch::<Test>::set(0);
+
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
-			Flip::bridge_in_to_distribution_reserve(300u128);
+			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -752,10 +756,12 @@ mod test_flip_reward_distribution {
 	#[test]
 	fn remainder_stays_in_reserve_not_awarded_to_winner() {
 		new_test_ext().execute_with(|| {
+			FeeRewardsActivationEpoch::<Test>::set(0);
+
 			// 1 offchain bridged in + 201 onchain = 202 total; 202 / 3 = 67 each, 1 stays in
 			// reserve
 			Flip::add_to_offchain_flip_to_be_distributed(1i128);
-			Flip::bridge_in_to_distribution_reserve(201u128);
+			<Flip as FeePayment>::burn_or_reserve_offchain(201u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -775,9 +781,11 @@ mod test_flip_reward_distribution {
 	#[test]
 	fn negative_offchain_balance_is_not_distributed() {
 		new_test_ext().execute_with(|| {
+			FeeRewardsActivationEpoch::<Test>::set(0);
+
 			// Negative FlipToDistribute should be left intact; only onchain rewards are distributed
 			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
-			Flip::bridge_in_to_distribution_reserve(300u128);
+			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -798,6 +806,8 @@ mod test_flip_reward_distribution {
 	#[test]
 	fn zero_onchain_reserve_only_distributes_offchain() {
 		new_test_ext().execute_with(|| {
+			FeeRewardsActivationEpoch::<Test>::set(0);
+
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
@@ -815,6 +825,52 @@ mod test_flip_reward_distribution {
 		});
 	}
 
+	#[test]
+	fn reward_accrual_gated_by_activation_epoch() {
+		new_test_ext().execute_with(|| {
+			const AMOUNT: u128 = 300;
+
+			// Pre-activation (default FeeRewardsActivationEpoch is u32::MAX): fees are burned
+			// rather than reserved for distribution.
+			assert!(!Flip::is_flip_2_1_activated());
+
+			let issuance_before = TotalIssuance::<Test>::get();
+			let offchain_before = OffchainFunds::<Test>::get();
+			<Flip as FeePayment>::burn_or_reserve_offchain(AMOUNT);
+
+			assert_eq!(TotalIssuance::<Test>::get(), issuance_before - AMOUNT);
+			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
+
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			assert_eq!(bridged, 0);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 0);
+
+			// Advance to the configured activation epoch.
+			MockEpochInfo::set_epoch(1);
+			FeeRewardsActivationEpoch::<Test>::set(1);
+			assert!(Flip::is_flip_2_1_activated());
+
+			// Post-activation: fees are reserved for distribution instead of burned.
+			let issuance_before = TotalIssuance::<Test>::get();
+			let offchain_before = OffchainFunds::<Test>::get();
+			<Flip as FeePayment>::burn_or_reserve_offchain(AMOUNT);
+
+			assert_eq!(TotalIssuance::<Test>::get(), issuance_before);
+			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), AMOUNT);
+
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			assert_eq!(bridged, 0);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&CHARLIE), 100);
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
+		});
+	}
+
 	// Verify distribution invariants on arbitrary inputs.
 	//
 	// Uses i64/u64 inputs (cast to i128/u128) to avoid u128 overflow when summing
@@ -828,13 +884,15 @@ mod test_flip_reward_distribution {
 			.execute_with(|| -> TestResult {
 				const COUNT: u128 = 3; // ALICE, BOB, CHARLIE
 
+				FeeRewardsActivationEpoch::<Test>::set(0);
+
 				// Top up OffchainFunds to cover both the onchain_reserve bridge-in below and the
 				// flip_to_distribute bridge-in inside trigger_flip_reward_distribution
 				let top_up = u64::MAX as u128 + i64::MAX as u128;
 				let _ = Flip::mint(top_up).offset(Flip::bridge_out(top_up));
 
 				Flip::add_to_offchain_flip_to_be_distributed(flip_to_distribute);
-				Flip::bridge_in_to_distribution_reserve(onchain_reserve);
+				<Flip as FeePayment>::burn_or_reserve_offchain(onchain_reserve);
 
 				let expected_bridged: u128 =
 					if flip_to_distribute > 0 { flip_to_distribute as u128 } else { 0 };

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -810,4 +810,62 @@ mod test_flip_reward_distribution {
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
 		});
 	}
+
+	// Verify distribution invariants on arbitrary inputs.
+	//
+	// Uses i64/u64 inputs (cast to i128/u128) to avoid u128 overflow when summing
+	// onchain_reserve + bridged (max sum ~2.7e19 << u128::MAX).
+	// OffchainFunds is topped up with i64::MAX before the call so bridge_in is never capped.
+	#[quickcheck]
+	fn reward_distribution_invariants(flip_to_distribute: i64, onchain_reserve: u64) -> TestResult {
+		let flip_to_distribute = flip_to_distribute as i128;
+		let onchain_reserve = onchain_reserve as u128;
+
+		new_test_ext()
+			.execute_with(|| -> TestResult {
+				const COUNT: u128 = 3; // ALICE, BOB, CHARLIE
+
+				// Top up OffchainFunds so any positive flip_to_distribute can be bridged in without
+				// being capped (initial OffchainFunds=850; i64::MAX ≈ 9.2e18 covers i64 range).
+				let _ = Flip::mint(i64::MAX as u128).offset(Flip::bridge_out(i64::MAX as u128));
+
+				FlipToDistribute::<Test>::put(flip_to_distribute);
+				Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, onchain_reserve);
+
+				let expected_bridged: u128 =
+					if flip_to_distribute > 0 { flip_to_distribute as u128 } else { 0 };
+				let total_reserve = onchain_reserve + expected_bridged;
+				let expected_per_authority = total_reserve / COUNT;
+				let expected_remainder = total_reserve % COUNT;
+
+				let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+				// Return value equals what was subtracted from FlipToDistribute
+				if bridged != expected_bridged {
+					return TestResult::failed()
+				}
+				// Every authority receives the same truncated share
+				for authority in [ALICE, BOB, CHARLIE] {
+					if MockRewardsDistribution::<Test>::get_assigned_rewards(&authority) !=
+						expected_per_authority
+					{
+						return TestResult::failed()
+					}
+				}
+				// Remainder stays in the reserve for the next epoch
+				if Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) != expected_remainder
+				{
+					return TestResult::failed()
+				}
+				// FlipToDistribute is zeroed when positive, preserved otherwise
+				let expected_flip_storage =
+					if flip_to_distribute > 0 { 0 } else { flip_to_distribute };
+				if FlipToDistribute::<Test>::get() != expected_flip_storage {
+					return TestResult::failed()
+				}
+
+				TestResult::passed()
+			})
+			.into_context()
+	}
 }

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -719,3 +719,95 @@ mod transfer {
 		});
 	}
 }
+
+#[cfg(test)]
+mod test_flip_reward_distribution {
+	use super::*;
+	use crate::{FlipToDistribute, ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID};
+	use cf_traits::mocks::rewards_distribution::MockRewardsDistribution;
+
+	#[test]
+	fn distributes_offchain_and_onchain_rewards_evenly() {
+		new_test_ext().execute_with(|| {
+			FlipToDistribute::<Test>::put(300i128);
+			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
+
+			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 200);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&CHARLIE), 200);
+
+			// FlipToDistribute is drained after distribution
+			assert_eq!(FlipToDistribute::<Test>::get(), 0);
+			// Return value equals what was subtracted from FlipToDistribute (300 - 0 = 300)
+			assert_eq!(bridged, 300u128);
+			// Reserve is fully distributed with no remainder
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
+		});
+	}
+
+	#[test]
+	fn remainder_stays_in_reserve_not_awarded_to_winner() {
+		new_test_ext().execute_with(|| {
+			// 1 offchain bridged in + 201 onchain = 202 total; 202 / 3 = 67 each, 1 stays in
+			// reserve
+			FlipToDistribute::<Test>::put(1i128);
+			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 201u128);
+
+			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+			// All authorities get the same truncated share — no winner receives the remainder
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 67);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&CHARLIE), 67);
+
+			// Return value equals what was subtracted from FlipToDistribute (1 - 0 = 1)
+			assert_eq!(bridged, 1u128);
+			// The 1 FLIP remainder stays in the reserve for the next epoch
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 1);
+		});
+	}
+
+	#[test]
+	fn negative_offchain_balance_is_not_distributed() {
+		new_test_ext().execute_with(|| {
+			// Negative FlipToDistribute should be left intact; only onchain rewards are distributed
+			FlipToDistribute::<Test>::put(-100i128);
+			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
+
+			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+			// Only onchain: 100 each
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&CHARLIE), 100);
+
+			// Negative value is preserved; return value equals what was bridged in which is nothing
+			assert_eq!(FlipToDistribute::<Test>::get(), -100);
+			assert_eq!(bridged, 0u128);
+			// Reserve is fully distributed with no remainder
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
+		});
+	}
+
+	#[test]
+	fn zero_onchain_reserve_only_distributes_offchain() {
+		new_test_ext().execute_with(|| {
+			FlipToDistribute::<Test>::put(300i128);
+			// Reserve not set → defaults to 0
+
+			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+
+			// 100 offchain each, 0 onchain
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
+			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&CHARLIE), 100);
+			// Return value equals what was subtracted from FlipToDistribute (300 - 0 = 300)
+			assert_eq!(bridged, 300u128);
+			// Reserve is fully distributed with no remainder
+			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
+		});
+	}
+}

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -732,7 +732,8 @@ mod test_flip_reward_distribution {
 			FlipToDistribute::<Test>::put(300i128);
 			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
 
 			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
@@ -756,7 +757,8 @@ mod test_flip_reward_distribution {
 			FlipToDistribute::<Test>::put(1i128);
 			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 201u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
 
 			// All authorities get the same truncated share — no winner receives the remainder
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
@@ -777,7 +779,8 @@ mod test_flip_reward_distribution {
 			FlipToDistribute::<Test>::put(-100i128);
 			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
 
 			// Only onchain: 100 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -798,7 +801,8 @@ mod test_flip_reward_distribution {
 			FlipToDistribute::<Test>::put(300i128);
 			// Reserve not set → defaults to 0
 
-			let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+			let bridged =
+				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
 
 			// 100 offchain each, 0 onchain
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -848,7 +852,9 @@ mod test_flip_reward_distribution {
 
 				let total_funds_before = total_funds();
 
-				let bridged = Flip::trigger_flip_reward_distribution(vec![ALICE, BOB, CHARLIE]);
+				let bridged = Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([
+					ALICE, BOB, CHARLIE,
+				]));
 
 				// Distribution only moves funds between the reserve, validator balances, and the
 				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -729,8 +729,8 @@ mod test_flip_reward_distribution {
 	#[test]
 	fn distributes_offchain_and_onchain_rewards_evenly() {
 		new_test_ext().execute_with(|| {
-			FlipToDistribute::<Test>::put(300i128);
-			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
+			Flip::add_to_offchain_flip_to_be_distributed(300i128);
+			Flip::bridge_in_to_distribution_reserve(300u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -754,8 +754,8 @@ mod test_flip_reward_distribution {
 		new_test_ext().execute_with(|| {
 			// 1 offchain bridged in + 201 onchain = 202 total; 202 / 3 = 67 each, 1 stays in
 			// reserve
-			FlipToDistribute::<Test>::put(1i128);
-			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 201u128);
+			Flip::add_to_offchain_flip_to_be_distributed(1i128);
+			Flip::bridge_in_to_distribution_reserve(201u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -776,8 +776,8 @@ mod test_flip_reward_distribution {
 	fn negative_offchain_balance_is_not_distributed() {
 		new_test_ext().execute_with(|| {
 			// Negative FlipToDistribute should be left intact; only onchain rewards are distributed
-			FlipToDistribute::<Test>::put(-100i128);
-			Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, 300u128);
+			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
+			Flip::bridge_in_to_distribution_reserve(300u128);
 
 			let bridged =
 				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
@@ -798,7 +798,7 @@ mod test_flip_reward_distribution {
 	#[test]
 	fn zero_onchain_reserve_only_distributes_offchain() {
 		new_test_ext().execute_with(|| {
-			FlipToDistribute::<Test>::put(300i128);
+			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
 			let bridged =
@@ -819,7 +819,6 @@ mod test_flip_reward_distribution {
 	//
 	// Uses i64/u64 inputs (cast to i128/u128) to avoid u128 overflow when summing
 	// onchain_reserve + bridged (max sum ~2.7e19 << u128::MAX).
-	// OffchainFunds is topped up with i64::MAX before the call so bridge_in is never capped.
 	#[quickcheck]
 	fn reward_distribution_invariants(flip_to_distribute: i64, onchain_reserve: u64) -> TestResult {
 		let flip_to_distribute = flip_to_distribute as i128;
@@ -829,12 +828,13 @@ mod test_flip_reward_distribution {
 			.execute_with(|| -> TestResult {
 				const COUNT: u128 = 3; // ALICE, BOB, CHARLIE
 
-				// Top up OffchainFunds so any positive flip_to_distribute can be bridged in without
-				// being capped (initial OffchainFunds=850; i64::MAX ≈ 9.2e18 covers i64 range).
-				let _ = Flip::mint(i64::MAX as u128).offset(Flip::bridge_out(i64::MAX as u128));
+				// Top up OffchainFunds to cover both the onchain_reserve bridge-in below and the
+				// flip_to_distribute bridge-in inside trigger_flip_reward_distribution
+				let top_up = u64::MAX as u128 + i64::MAX as u128;
+				let _ = Flip::mint(top_up).offset(Flip::bridge_out(top_up));
 
-				FlipToDistribute::<Test>::put(flip_to_distribute);
-				Reserve::<Test>::insert(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, onchain_reserve);
+				Flip::add_to_offchain_flip_to_be_distributed(flip_to_distribute);
+				Flip::bridge_in_to_distribution_reserve(onchain_reserve);
 
 				let expected_bridged: u128 =
 					if flip_to_distribute > 0 { flip_to_distribute as u128 } else { 0 };

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -736,8 +736,10 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				1,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 
 			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
@@ -763,8 +765,10 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(1i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(201u128);
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				1,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 
 			// All authorities get the same truncated share — no winner receives the remainder
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
@@ -787,8 +791,10 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				1,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 
 			// Only onchain: 100 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -811,8 +817,10 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				1,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 
 			// 100 offchain each, 0 onchain
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -842,8 +850,10 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				0,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 0);
 
@@ -861,8 +871,10 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), AMOUNT);
 
-			let bridged =
-				Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([ALICE, BOB, CHARLIE]));
+			let bridged = Flip::trigger_flip_reward_distribution(
+				1,
+				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+			);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
@@ -910,9 +922,10 @@ mod test_flip_reward_distribution {
 
 				let total_funds_before = total_funds();
 
-				let bridged = Flip::trigger_flip_reward_distribution(BTreeSet::from_iter([
-					ALICE, BOB, CHARLIE,
-				]));
+				let bridged = Flip::trigger_flip_reward_distribution(
+					1,
+					BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
+				);
 
 				// Distribution only moves funds between the reserve, validator balances, and the
 				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -36,9 +36,8 @@ mod tests;
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
 use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
 use cf_traits::{
-	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, EpochInfo,
-	FeePayment, FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck,
-	SpawnAccount,
+	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
+	FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck, SpawnAccount,
 };
 use cf_utilities::derive_common_traits;
 use codec::{Decode, DecodeWithMemTracking, Encode};
@@ -924,15 +923,7 @@ pub mod pallet {
 						amount < MinimumFunding::<T>::get().into()
 					{
 						// Insufficient funds to create an account.
-						if T::EpochInfo::epoch_index() >=
-							<T::Flip as FeePayment>::fee_rewards_activation_epoch()
-						{
-							T::Flip::bridge_in_and_add_to_onchain_flip_to_be_distributed(
-								amount.into(),
-							);
-						} else {
-							T::Flip::burn_offchain(amount.into());
-						}
+						T::Flip::burn_or_reserve_offchain(amount.into());
 						Self::deposit_event(Event::FailedFundingAttempt {
 							account_id: caller_account_id,
 							withdrawal_address: caller,

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -34,10 +34,13 @@ pub use weights::WeightInfo;
 mod tests;
 
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
-use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
+use cf_primitives::{
+	chains::assets::eth::Asset as EthAsset, AssetAmount, ACCUMULATE_REWARDS_EPOCH_START,
+};
 use cf_traits::{
-	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
-	FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck, SpawnAccount,
+	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, EpochInfo,
+	FeePayment, FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck,
+	SpawnAccount,
 };
 use cf_utilities::derive_common_traits;
 use codec::{Decode, DecodeWithMemTracking, Encode};
@@ -259,9 +262,9 @@ impl<T: Config> Redemption<T> {
 		self.redeem_amount.saturating_add(self.redemption_fee)
 	}
 
-	pub fn burn_fee(&self) -> Result<(), Error<T>> {
+	pub fn take_fee(&self) -> Result<(), Error<T>> {
 		ensure!(
-			T::Flip::try_burn_fee(&self.account_id, self.redemption_fee).is_ok(),
+			T::Flip::try_take_fee(&self.account_id, self.redemption_fee).is_ok(),
 			Error::<T>::InsufficientBalance
 		);
 		Ok(())
@@ -692,7 +695,7 @@ pub mod pallet {
 				redemption.total_debit_amount(),
 			)?;
 
-			redemption.burn_fee()?;
+			redemption.take_fee()?;
 			redemption.update_restricted_balances(None)?;
 
 			// Update the account balance.
@@ -879,7 +882,7 @@ pub mod pallet {
 
 			let redemption =
 				Redemption::<T>::for_rebalance(&source_account_id, amount, redemption_address)?;
-			redemption.burn_fee()?;
+			redemption.take_fee()?;
 			redemption.update_restricted_balances(Some(&recipient_account_id))?;
 
 			T::Flip::try_transfer(
@@ -923,7 +926,11 @@ pub mod pallet {
 						amount < MinimumFunding::<T>::get().into()
 					{
 						// Insufficient funds to create an account.
-						T::Flip::burn_offchain(amount.into());
+						if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+							T::Flip::add_to_onchain_flip_to_be_distributed(amount.into());
+						} else {
+							T::Flip::burn_offchain(amount.into());
+						}
 						Self::deposit_event(Event::FailedFundingAttempt {
 							account_id: caller_account_id,
 							withdrawal_address: caller,

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -927,7 +927,7 @@ pub mod pallet {
 						if T::EpochInfo::epoch_index() >=
 							<T::Flip as FeePayment>::fee_rewards_activation_epoch()
 						{
-							T::Flip::add_to_onchain_flip_to_be_distributed(amount.into());
+							T::Flip::bridge_in_and_add_to_onchain_flip_to_be_distributed(amount.into());
 						} else {
 							T::Flip::burn_offchain(amount.into());
 						}

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -927,7 +927,9 @@ pub mod pallet {
 						if T::EpochInfo::epoch_index() >=
 							<T::Flip as FeePayment>::fee_rewards_activation_epoch()
 						{
-							T::Flip::bridge_in_and_add_to_onchain_flip_to_be_distributed(amount.into());
+							T::Flip::bridge_in_and_add_to_onchain_flip_to_be_distributed(
+								amount.into(),
+							);
 						} else {
 							T::Flip::burn_offchain(amount.into());
 						}

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -34,9 +34,7 @@ pub use weights::WeightInfo;
 mod tests;
 
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
-use cf_primitives::{
-	chains::assets::eth::Asset as EthAsset, AssetAmount, ACCUMULATE_REWARDS_EPOCH_START,
-};
+use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, EpochInfo,
 	FeePayment, FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck,
@@ -926,7 +924,9 @@ pub mod pallet {
 						amount < MinimumFunding::<T>::get().into()
 					{
 						// Insufficient funds to create an account.
-						if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+						if T::EpochInfo::epoch_index() >=
+							<T::Flip as FeePayment>::fee_rewards_activation_epoch()
+						{
 							T::Flip::add_to_onchain_flip_to_be_distributed(amount.into());
 						} else {
 							T::Flip::burn_offchain(amount.into());

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -20,7 +20,12 @@ use cf_chains::{evm::EvmCrypto, ApiCall, Chain, ChainCrypto, Ethereum};
 use cf_primitives::FlipBalance;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
-	mocks::{broadcaster::MockBroadcaster, time_source, waived_fees::WaivedFeesMock},
+	mocks::{
+		broadcaster::MockBroadcaster,
+		rewards_distribution::MockRewardsDistribution,
+		time_source,
+		waived_fees::WaivedFeesMock,
+	},
 	AccountRoleRegistry, RedemptionCheck,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
@@ -65,6 +70,7 @@ impl pallet_cf_flip::Config for Test {
 	type BlocksPerDay = BlocksPerDay;
 	type WeightInfo = ();
 	type WaivedFees = WaivedFeesMock<Self>;
+	type RewardsDistribution = MockRewardsDistribution<Self>;
 	type CallIndexer = ();
 	type RuntimeHoldReason = ();
 }

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -21,9 +21,7 @@ use cf_primitives::FlipBalance;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
-		broadcaster::MockBroadcaster,
-		rewards_distribution::MockRewardsDistribution,
-		time_source,
+		broadcaster::MockBroadcaster, rewards_distribution::MockRewardsDistribution, time_source,
 		waived_fees::WaivedFeesMock,
 	},
 	AccountRoleRegistry, RedemptionCheck,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -426,7 +426,7 @@ pub enum BroadcastAction<ChainAccount> {
 )]
 #[expand_name_with(<T::TargetChain as PalletInstanceAlias>::TYPE_INFO_SUFFIX)]
 pub enum PalletConfigUpdate<T: Config<I>, I: 'static> {
-	/// Set the fixed fee that is burned when opening a channel, denominated in Flipperinos.
+	/// Set the fixed fee that is taken when opening a channel, denominated in Flipperinos.
 	ChannelOpeningFee {
 		fee: T::Amount,
 	},
@@ -3517,7 +3517,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		let channel_opening_fee = ChannelOpeningFee::<T, I>::get();
 		if channel_opening_fee > T::Amount::zero() {
-			T::FeePayment::try_burn_fee(requester, channel_opening_fee)?;
+			T::FeePayment::try_take_fee(requester, channel_opening_fee)?;
 		}
 		Self::deposit_event(Event::<T, I>::ChannelOpeningFeePaid { fee: channel_opening_fee });
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -701,7 +701,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type FlipToBeSentToGateway<T: Config> = StorageValue<_, AssetAmount, ValueQuery>;
 
-	/// Interval at which we buy FLIP in order from swap fee in USDC.
+	/// Interval at which we buy FLIP from swap fees in order to distribute as rewards.
 	#[pallet::storage]
 	pub type FlipBuyInterval<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -30,8 +30,8 @@ use cf_chains::{
 };
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
-	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, EpochIndex, ForeignChain,
-	SwapId, SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP,
+	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, ForeignChain, SwapId,
+	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP,
 	FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK, STABLE_ASSET,
 	SWAP_DELAY_BLOCKS,
 };
@@ -3129,13 +3129,14 @@ pub mod pallet {
 			}
 		}
 
-		pub fn add_to_flip_to_be_sent_to_gateway(amount: AssetAmount) {
+		pub fn maybe_trigger_flip_to_gateway_egress(
+			state_chain_gateway_address: EthereumAddress,
+			amount: AssetAmount,
+		) {
+			// Add flip that was just distributed to validators, to be sent to the gateway
 			FlipToBeSentToGateway::<T>::mutate(|total| {
 				total.saturating_accrue(amount);
 			});
-		}
-
-		pub fn maybe_trigger_flip_to_gateway_egress(state_chain_gateway_address: EthereumAddress) {
 			match with_storage_layer(|| {
 				T::EgressHandler::schedule_egress(
 					cf_chains::assets::any::Asset::Flip,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -31,16 +31,16 @@ use cf_chains::{
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
 	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, ForeignChain, SwapId,
-	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP,
-	FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK, STABLE_ASSET,
-	SWAP_DELAY_BLOCKS,
+	SwapLeg, SwapRequestId, ACCUMULATE_REWARDS_EPOCH_START, BASIS_POINTS_PER_MILLION,
+	FLIPPERINOS_PER_FLIP, FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK,
+	STABLE_ASSET, SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AffiliateRegistry, AssetConverter, BalanceApi, Bonding,
-	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck,
-	EpochTransitionHandler, ExpiryBehaviour, FundingInfo, FundingSource, GetMinimumFunding,
-	IngressEgressFeeApi, PriceFeedApi, PriceLimitsAndExpiry, SwapOutputAction,
+	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck, EpochInfo,
+	EpochTransitionHandler, ExpiryBehaviour, FeePayment, FundingInfo, FundingSource,
+	GetMinimumFunding, IngressEgressFeeApi, PriceFeedApi, PriceLimitsAndExpiry, SwapOutputAction,
 	SwapParameterValidation, SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
 	SwappingApi, WithdrawalAddressRestriction,
 };
@@ -522,7 +522,7 @@ pub enum PalletConfigUpdate<T: Config> {
 	MaximumSwapAmount { asset: Asset, amount: Option<AssetAmount> },
 	/// Set the delay in blocks before retrying a previously failed swap.
 	SwapRetryDelay { delay: BlockNumberFor<T> },
-	/// Set the interval at which we buy FLIP in order to burn it.
+	/// Set the interval at which we buy FLIP using the swap fee that was taken in USDC.
 	FlipBuyInterval { interval: BlockNumberFor<T> },
 	/// Set the max allowed value for the number of blocks to keep retrying a swap before it is
 	/// refunded
@@ -618,8 +618,7 @@ pub mod pallet {
 		/// The Weight information.
 		type WeightInfo: WeightInfo;
 
-		#[cfg(feature = "runtime-benchmarks")]
-		type FeePayment: cf_traits::FeePayment<
+		type FeePayment: FeePayment<
 			Amount = <Self as Chainflip>::Amount,
 			AccountId = <Self as frame_system::Config>::AccountId,
 		>;
@@ -702,7 +701,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type FlipToBeSentToGateway<T: Config> = StorageValue<_, AssetAmount, ValueQuery>;
 
-	/// Interval at which we buy FLIP in order to burn it.
+	/// Interval at which we buy FLIP in order from swap fee in USDC.
 	#[pallet::storage]
 	pub type FlipBuyInterval<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
@@ -1108,18 +1107,23 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub flip_buy_interval: BlockNumberFor<T>,
+		pub network_fee: FeeRateAndMinimum,
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			FlipBuyInterval::<T>::set(self.flip_buy_interval);
+			NetworkFee::<T>::set(self.network_fee.clone());
 		}
 	}
 
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self { flip_buy_interval: BlockNumberFor::<T>::zero() }
+			Self {
+				flip_buy_interval: BlockNumberFor::<T>::zero(),
+				network_fee: FeeRateAndMinimum::default(),
+			}
 		}
 	}
 
@@ -2632,14 +2636,21 @@ pub mod pallet {
 										if output_amount < *flip_to_subtract_from_swap_output {
 											// In the rare event that this occurs we will track the
 											// deficit and offset it against the next burn
-											FlipToBurn::<T>::mutate(|total| {
-												total.saturating_reduce(
-													flip_to_subtract_from_swap_output
-														.saturating_sub(output_amount)
-														.try_into()
-														.unwrap_or(i128::MAX),
+											let deficit = flip_to_subtract_from_swap_output
+												.saturating_sub(output_amount);
+											if T::EpochInfo::epoch_index() >=
+												ACCUMULATE_REWARDS_EPOCH_START
+											{
+												T::FeePayment::add_to_offchain_flip_to_be_distributed(
+													-(deficit.try_into().unwrap_or(i128::MAX)),
 												);
-											});
+											} else {
+												FlipToBurn::<T>::mutate(|total| {
+													total.saturating_reduce(
+														deficit.try_into().unwrap_or(i128::MAX),
+													);
+												});
+											}
 											FlipToBeSentToGateway::<T>::mutate(|total| {
 												total.saturating_accrue(
 													*flip_to_subtract_from_swap_output,
@@ -2670,9 +2681,17 @@ pub mod pallet {
 					},
 				SwapRequestState::NetworkFee => {
 					if swap.output_asset() == Asset::Flip {
-						FlipToBurn::<T>::mutate(|total| {
-							total.saturating_accrue(output_amount.try_into().unwrap_or(i128::MAX));
-						});
+						if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+							T::FeePayment::add_to_offchain_flip_to_be_distributed(
+								output_amount.try_into().unwrap_or(i128::MAX),
+							);
+						} else {
+							FlipToBurn::<T>::mutate(|total| {
+								total.saturating_accrue(
+									output_amount.try_into().unwrap_or(i128::MAX),
+								);
+							});
+						}
 					} else {
 						log_or_panic!(
 							"NetworkFee burning should not be in asset: {:?}",

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -3149,7 +3149,7 @@ pub mod pallet {
 		pub fn maybe_trigger_flip_to_gateway_egress(
 			state_chain_gateway_address: EthereumAddress,
 			amount: AssetAmount,
-		) {
+		) -> AssetAmount {
 			// Add flip that was just distributed to validators, to be sent to the gateway
 			FlipToBeSentToGateway::<T>::mutate(|total| {
 				total.saturating_accrue(amount);
@@ -3173,13 +3173,16 @@ pub mod pallet {
 				)
 			}) {
 				Ok(ScheduledEgressDetails { egress_id, egress_amount, fee_withheld, .. }) => {
+					FlipToBeSentToGateway::<T>::put(fee_withheld);
 					Self::deposit_event(Event::SentFlipToGateway {
-						amount: (egress_amount.saturating_add(fee_withheld)),
+						amount: egress_amount,
 						egress_id,
 					});
+					fee_withheld
 				},
 				Err(e) => {
 					Self::deposit_event(Event::FlipTransferToGatewaySkipped { reason: e });
+					0
 				},
 			}
 		}

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -30,17 +30,19 @@ use cf_chains::{
 };
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
-	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, ForeignChain, SwapId,
-	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP, ONE_AS_BASIS_POINTS,
-	SECONDS_PER_BLOCK, STABLE_ASSET, SWAP_DELAY_BLOCKS,
+	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, EpochIndex, ForeignChain,
+	SwapId, SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP,
+	FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK, STABLE_ASSET,
+	SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AffiliateRegistry, AssetConverter, BalanceApi, Bonding,
-	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck, ExpiryBehaviour,
-	FundingInfo, FundingSource, GetMinimumFunding, IngressEgressFeeApi, PriceFeedApi,
-	PriceLimitsAndExpiry, SwapOutputAction, SwapParameterValidation, SwapRequestHandler,
-	SwapRequestType, SwapRequestTypeEncoded, SwapType, SwappingApi, WithdrawalAddressRestriction,
+	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck,
+	EpochTransitionHandler, ExpiryBehaviour, FundingInfo, FundingSource, GetMinimumFunding,
+	IngressEgressFeeApi, PriceFeedApi, PriceLimitsAndExpiry, SwapOutputAction,
+	SwapParameterValidation, SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
+	SwappingApi, WithdrawalAddressRestriction,
 };
 use cf_utilities::migrations::{
 	basics::{HasGenericVariant, IsHistoricalType},
@@ -52,7 +54,7 @@ use frame_support::{
 		traits::{ConstU16, Get, Saturating},
 		DispatchError, Permill, TransactionOutcome,
 	},
-	storage::with_transaction_unchecked,
+	storage::{with_storage_layer, with_transaction_unchecked},
 	traits::HandleLifetime,
 	transactional, CloneNoBound, Hashable,
 };
@@ -999,6 +1001,15 @@ pub mod pallet {
 			broker_id: T::AccountId,
 			short_id: AffiliateShortId,
 			affiliate_account_id: T::AccountId,
+		},
+		/// FLIP was successfully scheduled for egress to the State Chain Gateway.
+		SentFlipToGateway {
+			amount: AssetAmount,
+			egress_id: EgressId,
+		},
+		/// FLIP egress to the State Chain Gateway was skipped.
+		FlipTransferToGatewaySkipped {
+			reason: DispatchError,
 		},
 	}
 	#[pallet::error]
@@ -3114,6 +3125,43 @@ pub mod pallet {
 						Some(input_lpp.saturating_add(output_lpp)),
 					(Some(lpp), None) | (None, Some(lpp)) => Some(lpp),
 					(None, None) => None,
+				},
+			}
+		}
+
+		pub fn add_to_flip_to_be_sent_to_gateway(amount: AssetAmount) {
+			FlipToBeSentToGateway::<T>::mutate(|total| {
+				total.saturating_accrue(amount);
+			});
+		}
+
+		pub fn maybe_trigger_flip_to_gateway_egress(state_chain_gateway_address: EthereumAddress) {
+			match with_storage_layer(|| {
+				T::EgressHandler::schedule_egress(
+					cf_chains::assets::any::Asset::Flip,
+					FlipToBeSentToGateway::<T>::take(),
+					ForeignChainAddress::Eth(state_chain_gateway_address),
+					None,
+				)
+				.map_err(Into::into)
+				.and_then(
+					|result @ ScheduledEgressDetails { egress_amount, fee_withheld, .. }| {
+						if egress_amount < FLIP_TO_GATEWAY_MULTIPLE * fee_withheld {
+							Err(DispatchError::Other("flip to gateway multiple below threshold"))
+						} else {
+							Ok(result)
+						}
+					},
+				)
+			}) {
+				Ok(ScheduledEgressDetails { egress_id, egress_amount, fee_withheld, .. }) => {
+					Self::deposit_event(Event::SentFlipToGateway {
+						amount: (egress_amount.saturating_add(fee_withheld)),
+						egress_id,
+					});
+				},
+				Err(e) => {
+					Self::deposit_event(Event::FlipTransferToGatewaySkipped { reason: e });
 				},
 			}
 		}

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -31,9 +31,9 @@ use cf_chains::{
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
 	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, ForeignChain, SwapId,
-	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION,
-	FLIPPERINOS_PER_FLIP, FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK,
-	STABLE_ASSET, SWAP_DELAY_BLOCKS,
+	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION, FLIPPERINOS_PER_FLIP,
+	FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK, STABLE_ASSET,
+	SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
@@ -2681,7 +2681,9 @@ pub mod pallet {
 					},
 				SwapRequestState::NetworkFee => {
 					if swap.output_asset() == Asset::Flip {
-						if T::EpochInfo::epoch_index() >= T::FeePayment::fee_rewards_activation_epoch() {
+						if T::EpochInfo::epoch_index() >=
+							T::FeePayment::fee_rewards_activation_epoch()
+						{
 							T::FeePayment::add_to_offchain_flip_to_be_distributed(
 								output_amount.try_into().unwrap_or(i128::MAX),
 							);

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -31,7 +31,7 @@ use cf_chains::{
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
 	Beneficiaries, Beneficiary, BlockNumber, ChannelId, DcaParameters, ForeignChain, SwapId,
-	SwapLeg, SwapRequestId, ACCUMULATE_REWARDS_EPOCH_START, BASIS_POINTS_PER_MILLION,
+	SwapLeg, SwapRequestId, BASIS_POINTS_PER_MILLION,
 	FLIPPERINOS_PER_FLIP, FLIP_TO_GATEWAY_MULTIPLE, ONE_AS_BASIS_POINTS, SECONDS_PER_BLOCK,
 	STABLE_ASSET, SWAP_DELAY_BLOCKS,
 };
@@ -2639,7 +2639,7 @@ pub mod pallet {
 											let deficit = flip_to_subtract_from_swap_output
 												.saturating_sub(output_amount);
 											if T::EpochInfo::epoch_index() >=
-												ACCUMULATE_REWARDS_EPOCH_START
+												T::FeePayment::fee_rewards_activation_epoch()
 											{
 												T::FeePayment::add_to_offchain_flip_to_be_distributed(
 													-(deficit.try_into().unwrap_or(i128::MAX)),
@@ -2681,7 +2681,7 @@ pub mod pallet {
 					},
 				SwapRequestState::NetworkFee => {
 					if swap.output_asset() == Asset::Flip {
-						if T::EpochInfo::epoch_index() >= ACCUMULATE_REWARDS_EPOCH_START {
+						if T::EpochInfo::epoch_index() >= T::FeePayment::fee_rewards_activation_epoch() {
 							T::FeePayment::add_to_offchain_flip_to_be_distributed(
 								output_amount.try_into().unwrap_or(i128::MAX),
 							);

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -38,11 +38,10 @@ use cf_primitives::{
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AffiliateRegistry, AssetConverter, BalanceApi, Bonding,
-	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck, EpochInfo,
-	EpochTransitionHandler, ExpiryBehaviour, FeePayment, FundingInfo, FundingSource,
-	GetMinimumFunding, IngressEgressFeeApi, PriceFeedApi, PriceLimitsAndExpiry, SwapOutputAction,
-	SwapParameterValidation, SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
-	SwappingApi, WithdrawalAddressRestriction,
+	ChainflipNetworkInfo, ChannelIdAllocator, DepositApi, DeregistrationCheck, ExpiryBehaviour,
+	FeePayment, FundingInfo, FundingSource, GetMinimumFunding, IngressEgressFeeApi, PriceFeedApi,
+	PriceLimitsAndExpiry, SwapOutputAction, SwapParameterValidation, SwapRequestHandler,
+	SwapRequestType, SwapRequestTypeEncoded, SwapType, SwappingApi, WithdrawalAddressRestriction,
 };
 use cf_utilities::migrations::{
 	basics::{HasGenericVariant, IsHistoricalType},

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2636,19 +2636,17 @@ pub mod pallet {
 										if output_amount < *flip_to_subtract_from_swap_output {
 											// In the rare event that this occurs we will track the
 											// deficit and offset it against the next burn
-											let deficit = flip_to_subtract_from_swap_output
-												.saturating_sub(output_amount);
-											if T::EpochInfo::epoch_index() >=
-												T::FeePayment::fee_rewards_activation_epoch()
-											{
+											let deficit: i128 = flip_to_subtract_from_swap_output
+												.saturating_sub(output_amount)
+												.try_into()
+												.unwrap_or(i128::MAX);
+											if T::FeePayment::is_flip_2_1_activated() {
 												T::FeePayment::add_to_offchain_flip_to_be_distributed(
-													-(deficit.try_into().unwrap_or(i128::MAX)),
+													-deficit,
 												);
 											} else {
 												FlipToBurn::<T>::mutate(|total| {
-													total.saturating_reduce(
-														deficit.try_into().unwrap_or(i128::MAX),
-													);
+													total.saturating_reduce(deficit);
 												});
 											}
 											FlipToBeSentToGateway::<T>::mutate(|total| {
@@ -2681,9 +2679,7 @@ pub mod pallet {
 					},
 				SwapRequestState::NetworkFee => {
 					if swap.output_asset() == Asset::Flip {
-						if T::EpochInfo::epoch_index() >=
-							T::FeePayment::fee_rewards_activation_epoch()
-						{
+						if T::FeePayment::is_flip_2_1_activated() {
 							T::FeePayment::add_to_offchain_flip_to_be_distributed(
 								output_amount.try_into().unwrap_or(i128::MAX),
 							);

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -226,7 +226,6 @@ impl pallet_cf_swapping::Config for Test {
 	type SwappingApi = MockSwappingApi;
 	type SafeMode = MockRuntimeSafeMode;
 	type WeightInfo = MockWeightInfo;
-	#[cfg(feature = "runtime-benchmarks")]
 	type FeePayment = MockFeePayment<Self>;
 	type LendingSystemApi = MockLendingSystemApi;
 	type IngressEgressFeeHandler = MockIngressEgressFeeHandler<AnyChain>;

--- a/state-chain/pallets/cf-tokenholder-governance/src/lib.rs
+++ b/state-chain/pallets/cf-tokenholder-governance/src/lib.rs
@@ -199,7 +199,7 @@ pub mod pallet {
 					Error::<T>::IncompatibleGovkey
 				);
 			}
-			T::FeePayment::try_burn_fee(&proposer, T::ProposalFee::get())?;
+			T::FeePayment::try_take_fee(&proposer, T::ProposalFee::get())?;
 			Proposals::<T>::insert(
 				<frame_system::Pallet<T>>::block_number() + T::VotingPeriod::get(),
 				proposal.clone(),

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{AuctionOutcome, Config, DelegationSnapshots, Pallet, ValidatorToOperator};
 use cf_primitives::EpochIndex;
-use cf_traits::{EpochInfo, Issuance, RewardsDistribution, Slashing};
+use cf_traits::{EpochInfo, RewardsDistribution, Slashing};
 use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;
 use frame_support::{

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -340,18 +340,21 @@ impl<Account: Ord + Clone, Bid> DelegationSnapshot<Account, Bid> {
 	}
 }
 
-pub struct DelegatedRewardsDistribution<T, I>(PhantomData<(T, I)>);
+pub struct DelegatedRewardsDistribution<T>(PhantomData<T>);
 
-impl<T, I> RewardsDistribution for DelegatedRewardsDistribution<T, I>
+impl<T> RewardsDistribution for DelegatedRewardsDistribution<T>
 where
 	T: Config,
-	I: Issuance<AccountId = T::AccountId, Balance = T::Amount>,
 {
-	type Balance = I::Balance;
-	type AccountId = I::AccountId;
+	type Balance = T::Amount;
+	type AccountId = T::AccountId;
 
-	fn distribute(reward_amount: Self::Balance, beneficiary: &Self::AccountId) {
-		distribute::<T>(beneficiary, reward_amount, I::mint);
+	fn distribute(
+		reward_amount: Self::Balance,
+		beneficiary: &Self::AccountId,
+		settle: impl FnMut(&T::AccountId, T::Amount),
+	) {
+		distribute::<T>(beneficiary, reward_amount, settle);
 	}
 }
 
@@ -385,7 +388,7 @@ where
 pub fn distribute<T: Config>(
 	validator: &T::AccountId,
 	total: T::Amount,
-	settle: impl Fn(&T::AccountId, T::Amount),
+	mut settle: impl FnMut(&T::AccountId, T::Amount),
 ) {
 	use frame_support::sp_runtime::traits::Zero;
 	if total.is_zero() {

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -550,8 +550,10 @@ mod tests {
 			let delegators: BTreeMap<ValidatorId, u128> = delegator_amounts.iter().enumerate()
 				.map(|(i, amount)| (i as u64 + 1000, *amount * FLIPPERINOS_PER_FLIP))
 				.collect();
-			// Every validator in the snapshot is an authority this epoch - the invariant
-			// `distribute_all` relies on to derive authority counts from the snapshot alone.
+			// This proptest covers the all-in case: the authority set is exactly this operator's
+			// snapshot validators, so distribute_all routes the whole total through its pool.
+			// (All-out snapshots from losing operators, which distribute_all skips, are covered
+			// by `distribute_all_matches_looped_distribute`.)
 			let beneficiaries: Vec<ValidatorId> = validators.keys().cloned().collect();
 			// Constructed as an exact multiple of beneficiaries.len() so the internal division
 			// in `distribute_all` recovers `per_beneficiary_amount` exactly (no remainder).

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -350,11 +350,12 @@ where
 	type AccountId = T::AccountId;
 
 	fn distribute(
+		epoch_index: EpochIndex,
 		reward_amount: Self::Balance,
 		beneficiary: &Self::AccountId,
 		settle: impl FnMut(&T::AccountId, T::Amount),
 	) {
-		distribute::<T>(beneficiary, reward_amount, settle);
+		distribute::<T>(epoch_index, beneficiary, reward_amount, settle);
 	}
 }
 
@@ -371,7 +372,12 @@ where
 	type Balance = FlipSlasher::Balance;
 
 	fn slash_balance(account_id: &Self::AccountId, slash_amount: Self::Balance) {
-		distribute::<T>(account_id, slash_amount, FlipSlasher::slash_balance);
+		distribute::<T>(
+			Pallet::<T>::epoch_index(),
+			account_id,
+			slash_amount,
+			FlipSlasher::slash_balance,
+		);
 	}
 
 	fn calculate_slash_amount(
@@ -382,10 +388,11 @@ where
 	}
 }
 
-/// Distribute a settlement to a given validator for the current Epoch.
+/// Distribute a settlement to a given validator for `epoch_index`.
 /// The total amount is shared among all delegators and validators associated with the operator
-/// controlling this validator.
+/// controlling this validator for that epoch.
 pub fn distribute<T: Config>(
+	epoch_index: EpochIndex,
 	validator: &T::AccountId,
 	total: T::Amount,
 	mut settle: impl FnMut(&T::AccountId, T::Amount),
@@ -394,7 +401,6 @@ pub fn distribute<T: Config>(
 	if total.is_zero() {
 		return;
 	}
-	let epoch_index = Pallet::<T>::epoch_index();
 
 	if let Some(operator) = ValidatorToOperator::<T>::get(epoch_index, validator) {
 		if let Some(snapshot) = DelegationSnapshots::<T>::get(epoch_index, &operator) {

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -13,19 +13,26 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::{AuctionOutcome, Config, DelegationSnapshots, Pallet, ValidatorToOperator};
+use crate::{
+	AuctionOutcome, Config, DelegationSnapshots, HistoricalAuthorities, HistoricalBonds, Pallet,
+	ValidatorToOperator,
+};
 use cf_primitives::EpochIndex;
 use cf_traits::{EpochInfo, RewardsDistribution, Slashing};
 use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;
 use frame_support::{
-	sp_runtime::{traits::AtLeast32BitUnsigned, Perquintill},
+	sp_runtime::{traits::AtLeast32BitUnsigned, Perquintill, Saturating},
 	traits::IsType,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
+use sp_std::{
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	marker::PhantomData,
+	prelude::*,
+};
 
 pub const DEFAULT_MIN_OPERATOR_FEE: u32 = 1_500;
 pub const MAX_OPERATOR_FEE: u32 = 10_000;
@@ -357,6 +364,55 @@ where
 	) {
 		distribute::<T>(epoch_index, beneficiary, reward_amount, settle);
 	}
+
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		mut settle: impl FnMut(&T::AccountId, T::Amount),
+	) {
+		let mut authorities_to_reward: BTreeSet<T::AccountId> =
+			HistoricalAuthorities::<T>::get(epoch_index)
+				.into_iter()
+				.map(Into::into)
+				.collect();
+		if authorities_to_reward.is_empty() {
+			return;
+		}
+		let per_authority_amount = total_amount / (authorities_to_reward.len() as u32).into();
+		let bond = HistoricalBonds::<T>::get(epoch_index);
+
+		// Snapshots are registered for *all* operators at auction resolution, including those
+		// whose pooled stake didn't clear the bond: their last remaining validator is never
+		// demoted to delegator, so `snapshot.validators` can contain a non-authority. Only
+		// authority validators earn a share of the rewards. `remove` doubles as the membership
+		// check, draining `authorities` so that only independent (operator-less) authorities
+		// remain for the loop below.
+		for (operator, snapshot) in DelegationSnapshots::<T>::iter_prefix(epoch_index) {
+			let authority_count =
+				snapshot.validators.keys().filter(|v| authorities_to_reward.remove(*v)).count()
+					as u32;
+			if authority_count == 0 {
+				continue;
+			}
+			if (authority_count as usize) < snapshot.validators.len() {
+				// The auction fixed point guarantees a snapshot's validators are all-in or
+				// all-out of the authority set; a mixed snapshot means that invariant broke.
+				cf_runtime_utilities::log_or_panic!(
+					"Delegation snapshot of operator {:?} for epoch {} contains non-authority validators.",
+					operator,
+					epoch_index
+				);
+			}
+			let total = per_authority_amount.saturating_mul(authority_count.into());
+			snapshot
+				.distribute(total, bond)
+				.for_each(|(account, amount)| settle(account, amount));
+		}
+
+		for authority in &authorities_to_reward {
+			settle(authority, per_authority_amount);
+		}
+	}
 }
 
 pub struct DelegationSlasher<T, S>(PhantomData<(T, S)>);
@@ -404,11 +460,9 @@ pub fn distribute<T: Config>(
 
 	if let Some(operator) = ValidatorToOperator::<T>::get(epoch_index, validator) {
 		if let Some(snapshot) = DelegationSnapshots::<T>::get(epoch_index, &operator) {
-			snapshot.distribute(total, Pallet::<T>::bond()).for_each(|(account, amount)| {
-				if amount > Zero::zero() {
-					settle(account, amount);
-				}
-			});
+			snapshot
+				.distribute(total, HistoricalBonds::<T>::get(epoch_index))
+				.for_each(|(account, amount)| settle(account, amount));
 		} else {
 			settle(validator, total);
 			cf_runtime_utilities::log_or_panic!(
@@ -469,6 +523,67 @@ mod tests {
 					sum, total_to_distribute,
 					"Sum of distributions ({}) does not equal total ({})",
 					sum, total_to_distribute
+				);
+
+				Ok(())
+			});
+		}
+	}
+
+	proptest! {
+		#[test]
+		fn distribute_all_sums_to_total(
+			validator_amounts in prop::collection::vec(1u128..1_000_000u128, 1..10),
+			delegator_amounts in prop::collection::vec(1u128..1_000_000u128, 0..50),
+			per_beneficiary_amount in 1u128..10_000u128,
+			delegation_fee_bps in 2_000u32..10_000u32,
+			bond in 100_000u128..10_000_000u128,
+		) {
+			const EPOCH: EpochIndex = 1;
+			let operator_account = 1u64;
+			let per_beneficiary_amount = per_beneficiary_amount * FLIPPERINOS_PER_FLIP;
+			let bond = bond * FLIPPERINOS_PER_FLIP;
+
+			let validators: BTreeMap<ValidatorId, u128> = validator_amounts.iter().enumerate()
+				.map(|(i, amount)| (i as u64 + 100, *amount * FLIPPERINOS_PER_FLIP))
+				.collect();
+			let delegators: BTreeMap<ValidatorId, u128> = delegator_amounts.iter().enumerate()
+				.map(|(i, amount)| (i as u64 + 1000, *amount * FLIPPERINOS_PER_FLIP))
+				.collect();
+			// Every validator in the snapshot is an authority this epoch - the invariant
+			// `distribute_all` relies on to derive authority counts from the snapshot alone.
+			let beneficiaries: Vec<ValidatorId> = validators.keys().cloned().collect();
+			// Constructed as an exact multiple of beneficiaries.len() so the internal division
+			// in `distribute_all` recovers `per_beneficiary_amount` exactly (no remainder).
+			let total_amount = per_beneficiary_amount * beneficiaries.len() as u128;
+
+			new_test_ext().execute_with(|| {
+				crate::HistoricalBonds::<Test>::insert(EPOCH, bond);
+				crate::HistoricalAuthorities::<Test>::insert(EPOCH, &beneficiaries);
+
+				DelegationSnapshot::<ValidatorId, u128> {
+					operator: operator_account,
+					validators,
+					delegators,
+					delegation_fee_bps,
+				}.register_for_epoch::<Test>(EPOCH);
+
+				let mut settled: BTreeMap<ValidatorId, u128> = BTreeMap::new();
+				DelegatedRewardsDistribution::<Test>::distribute_all(
+					EPOCH,
+					total_amount,
+					|account, amount| {
+						settled.entry(*account).and_modify(|a| *a += amount).or_insert(amount);
+					},
+				);
+
+				// Property: the sum of all settled amounts equals total_amount, exactly like
+				// beneficiaries.len() separate `distribute` calls would sum to.
+				let sum: u128 = settled.values().sum();
+				prop_assert_eq!(
+					sum, total_amount,
+					"Sum of settled amounts ({}) does not equal expected total ({})",
+					sum, total_amount
 				);
 
 				Ok(())

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1662,7 +1662,8 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Among other things, updates the authority, historical and backup sets.
 	///
-	/// Also triggers [T::EpochTransitionHandler::on_new_epoch] which may call into other pallets.
+	/// Also triggers [T::EpochTransitionHandler::on_epoch_ending] and
+	/// [T::EpochTransitionHandler::on_new_epoch] which may call into other pallets.
 	///
 	/// Note this function is not benchmarked - it is only ever triggered via the session pallet,
 	/// which at the time of writing uses `T::BlockWeights::get().max_block` ie. it implicitly fills
@@ -1673,11 +1674,12 @@ impl<T: Config> Pallet<T> {
 	) {
 		log::debug!(target: "cf-validator", "Starting new epoch");
 
+		let old_epoch = CurrentEpoch::<T>::get();
+		T::EpochTransitionHandler::on_epoch_ending(old_epoch);
+
 		// Update epoch numbers.
-		let (old_epoch, new_epoch) = CurrentEpoch::<T>::mutate(|epoch| {
-			*epoch = epoch.saturating_add(One::one());
-			(*epoch - 1, *epoch)
-		});
+		let new_epoch = old_epoch.saturating_add(One::one());
+		CurrentEpoch::<T>::put(new_epoch);
 
 		// Set the expiry block number for the old epoch.
 		EpochExpiries::<T>::insert(

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -315,6 +315,8 @@ pub mod pallet {
 
 	/// A map between an epoch and the set of authorities (participating in this epoch).
 	#[pallet::storage]
+	#[pallet::getter(fn historical_authorities)]
+
 	pub type HistoricalAuthorities<T: Config> =
 		StorageMap<_, Twox64Concat, EpochIndex, Vec<ValidatorIdOf<T>>, ValueQuery>;
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -315,8 +315,6 @@ pub mod pallet {
 
 	/// A map between an epoch and the set of authorities (participating in this epoch).
 	#[pallet::storage]
-	#[pallet::getter(fn historical_authorities)]
-
 	pub type HistoricalAuthorities<T: Config> =
 		StorageMap<_, Twox64Concat, EpochIndex, Vec<ValidatorIdOf<T>>, ValueQuery>;
 

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -25,8 +25,8 @@ use cf_traits::{
 	mocks::{
 		cfe_interface_mock::MockCfeInterface, key_rotator::MockKeyRotatorA,
 		minimum_funding::MockMinimumFundingProvider, qualify_node::QualifyAll,
-		reputation_resetter::MockReputationResetter,
-		rewards_distribution::MockRewardsDistribution, waived_fees::WaivedFeesMock,
+		reputation_resetter::MockReputationResetter, rewards_distribution::MockRewardsDistribution,
+		waived_fees::WaivedFeesMock,
 	},
 	AccountRoleRegistry, RotationBroadcastsPending,
 };

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -25,7 +25,8 @@ use cf_traits::{
 	mocks::{
 		cfe_interface_mock::MockCfeInterface, key_rotator::MockKeyRotatorA,
 		minimum_funding::MockMinimumFundingProvider, qualify_node::QualifyAll,
-		reputation_resetter::MockReputationResetter, waived_fees::WaivedFeesMock,
+		reputation_resetter::MockReputationResetter,
+		rewards_distribution::MockRewardsDistribution, waived_fees::WaivedFeesMock,
 	},
 	AccountRoleRegistry, RotationBroadcastsPending,
 };
@@ -80,6 +81,7 @@ impl pallet_cf_flip::Config for Test {
 	type BlocksPerDay = sp_core::ConstU64<14400>;
 	type WeightInfo = ();
 	type WaivedFees = WaivedFeesMock<Self>;
+	type RewardsDistribution = MockRewardsDistribution<Self>;
 	// Required to satisfy trait bounds on InspectHold implementation, required by
 	// pallet_session::Config::Currency.
 	type RuntimeHoldReason = pallet_session::HoldReason;

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -119,7 +119,45 @@ pub const EXPECTED_BOND: Amount = WINNING_BIDS[WINNING_BIDS.len() - 1].amount;
 
 pub struct TestEpochTransitionHandler;
 
-impl EpochTransitionHandler for TestEpochTransitionHandler {}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EpochTransitionHook {
+	EpochEnding,
+	NewEpoch,
+}
+
+thread_local! {
+	pub static EPOCH_TRANSITION_HOOK_CALLS: RefCell<Vec<(EpochTransitionHook, EpochIndex, EpochIndex)>> =
+		RefCell::new(Default::default());
+}
+
+impl TestEpochTransitionHandler {
+	/// Drains the recorded `(hook, passed_epoch, CurrentEpoch at call time)` tuples.
+	pub fn take_hook_calls() -> Vec<(EpochTransitionHook, EpochIndex, EpochIndex)> {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| calls.take())
+	}
+}
+
+impl EpochTransitionHandler for TestEpochTransitionHandler {
+	fn on_epoch_ending(ending: EpochIndex) {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| {
+			calls.borrow_mut().push((
+				EpochTransitionHook::EpochEnding,
+				ending,
+				CurrentEpoch::<Test>::get(),
+			))
+		});
+	}
+
+	fn on_new_epoch(new: EpochIndex) {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| {
+			calls.borrow_mut().push((
+				EpochTransitionHook::NewEpoch,
+				new,
+				CurrentEpoch::<Test>::get(),
+			))
+		});
+	}
+}
 
 thread_local! {
 	pub static MISSED_SLOTS: RefCell<(u64, u64)> = RefCell::new(Default::default());

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3380,25 +3380,10 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 				frame_support::storage::unhashed::get(b"test_minted").unwrap_or_default()
 			}
 
-			fn add_minted(account: u64, amount: u128) {
+			fn add_minted(account: &u64, amount: u128) {
 				let mut minted = Self::get_minted();
-				*minted.entry(account).or_insert(0) += amount;
+				*minted.entry(*account).or_insert(0) += amount;
 				frame_support::storage::unhashed::put(b"test_minted", &minted);
-			}
-		}
-
-		struct MockIssuance;
-		impl cf_traits::Issuance for MockIssuance {
-			type AccountId = u64;
-			type Balance = u128;
-
-			fn mint(account: &Self::AccountId, amount: Self::Balance) {
-				TestMintTracker::add_minted(*account, amount);
-			}
-
-			fn burn_offchain(_amount: Self::Balance) {}
-			fn total_issuance() -> Self::Balance {
-				0
 			}
 		}
 
@@ -3423,7 +3408,11 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		.register_for_epoch::<Test>(EPOCH);
 
 		// Distribute rewards to the validator.
-		DelegatedRewardsDistribution::<Test, MockIssuance>::distribute(REWARD_AMOUNT, &VALIDATOR);
+		DelegatedRewardsDistribution::<Test>::distribute(
+			REWARD_AMOUNT,
+			&VALIDATOR,
+			TestMintTracker::add_minted,
+		);
 
 		// Check minted amounts
 		let minted = TestMintTracker::get_minted();

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3409,6 +3409,7 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 
 		// Distribute rewards to the validator.
 		DelegatedRewardsDistribution::<Test>::distribute(
+			EPOCH,
 			REWARD_AMOUNT,
 			&VALIDATOR,
 			TestMintTracker::add_minted,

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -682,6 +682,26 @@ fn test_reputation_is_reset_on_expired_epoch() {
 		assert!(MockReputationResetter::<Test>::reputation_was_reset());
 	});
 }
+#[test]
+fn epoch_transition_hooks_straddle_the_epoch_increment() {
+	new_test_ext().execute_with(|| {
+		let old_epoch = ValidatorPallet::current_epoch();
+		let _ = TestEpochTransitionHandler::take_hook_calls();
+
+		ValidatorPallet::transition_to_next_epoch(vec![1, 2], 100);
+
+		// `on_epoch_ending` must observe the ending epoch as current (reward distribution
+		// relies on this), `on_new_epoch` the new one.
+		assert_eq!(
+			TestEpochTransitionHandler::take_hook_calls(),
+			vec![
+				(EpochTransitionHook::EpochEnding, old_epoch, old_epoch),
+				(EpochTransitionHook::NewEpoch, old_epoch + 1, old_epoch + 1),
+			]
+		);
+	});
+}
+
 #[cfg(test)]
 mod bond_expiry {
 	use super::*;

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3395,7 +3395,7 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		const REWARD_AMOUNT: u128 = 100_000u128;
 
 		crate::CurrentEpoch::<Test>::put(EPOCH);
-		crate::Bond::<Test>::put(BOND);
+		crate::HistoricalBonds::<Test>::insert(EPOCH, BOND);
 
 		DelegationSnapshot::<u64, u128> {
 			operator: OPERATOR,
@@ -3434,6 +3434,102 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		// Verify total
 		let total_minted: u128 = minted.values().sum();
 		assert_eq!(total_minted, REWARD_AMOUNT);
+	});
+}
+
+#[test]
+fn distribute_all_matches_looped_distribute() {
+	use crate::delegation::DelegatedRewardsDistribution;
+	use cf_traits::RewardsDistribution;
+
+	new_test_ext().execute_with(|| {
+		const VALIDATOR_A: u64 = 100;
+		const VALIDATOR_B: u64 = 101;
+		const OPERATOR: u64 = 200;
+		const DELEGATOR1: u64 = 300;
+		const DELEGATOR2: u64 = 400;
+		const SOLO_VALIDATOR: u64 = 500;
+		const LOSING_OPERATOR: u64 = 600;
+		const LOSING_VALIDATOR: u64 = 601;
+		const LOSING_DELEGATOR: u64 = 602;
+
+		const EPOCH: u32 = 10;
+		const BOND: u128 = 1_000_000u128;
+		const PER_BENEFICIARY_AMOUNT: u128 = 100_000u128;
+
+		crate::CurrentEpoch::<Test>::put(EPOCH);
+		crate::HistoricalBonds::<Test>::insert(EPOCH, BOND);
+		crate::HistoricalAuthorities::<Test>::insert(
+			EPOCH,
+			vec![VALIDATOR_A, VALIDATOR_B, SOLO_VALIDATOR],
+		);
+
+		DelegationSnapshot::<u64, u128> {
+			operator: OPERATOR,
+			validators: [(VALIDATOR_A, 200_000u128), (VALIDATOR_B, 300_000u128)]
+				.into_iter()
+				.collect(),
+			delegators: [(DELEGATOR1, 500_000u128), (DELEGATOR2, 1_500_000u128)]
+				.into_iter()
+				.collect(),
+			delegation_fee_bps: 2000, // 20% fee
+		}
+		.register_for_epoch::<Test>(EPOCH);
+
+		// An operator whose pooled stake didn't clear the bond: its snapshot is registered for
+		// the epoch, but its sole validator is not an authority and must not earn anything.
+		DelegationSnapshot::<u64, u128> {
+			operator: LOSING_OPERATOR,
+			validators: [(LOSING_VALIDATOR, 100_000u128)].into_iter().collect(),
+			delegators: [(LOSING_DELEGATOR, 400_000u128)].into_iter().collect(),
+			delegation_fee_bps: 2000,
+		}
+		.register_for_epoch::<Test>(EPOCH);
+
+		let beneficiaries = [VALIDATOR_A, VALIDATOR_B, SOLO_VALIDATOR];
+
+		// Ground truth: loop `distribute` once per authority with an even share, accumulating
+		// into a single map.
+		let mut looped = BTreeMap::new();
+		for beneficiary in &beneficiaries {
+			DelegatedRewardsDistribution::<Test>::distribute(
+				EPOCH,
+				PER_BENEFICIARY_AMOUNT,
+				beneficiary,
+				|account, amount| {
+					looped
+						.entry(*account)
+						.and_modify(|a: &mut u128| *a += amount)
+						.or_insert(amount);
+				},
+			);
+		}
+
+		let mut batched = BTreeMap::new();
+		DelegatedRewardsDistribution::<Test>::distribute_all(
+			EPOCH,
+			PER_BENEFICIARY_AMOUNT * beneficiaries.len() as u128,
+			|account, amount| {
+				batched
+					.entry(*account)
+					.and_modify(|a: &mut u128| *a += amount)
+					.or_insert(amount);
+			},
+		);
+
+		assert_eq!(batched, looped);
+
+		// The solo authority (no operator) is settled with its full share directly.
+		assert_eq!(batched.get(&SOLO_VALIDATOR), Some(&PER_BENEFICIARY_AMOUNT));
+
+		// The losing operator's snapshot earns nothing.
+		assert_eq!(batched.get(&LOSING_OPERATOR), None);
+		assert_eq!(batched.get(&LOSING_VALIDATOR), None);
+		assert_eq!(batched.get(&LOSING_DELEGATOR), None);
+
+		// Total settled equals beneficiaries.len() * per_beneficiary_amount.
+		let total: u128 = batched.values().sum();
+		assert_eq!(total, PER_BENEFICIARY_AMOUNT * beneficiaries.len() as u128);
 	});
 }
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -271,10 +271,6 @@ pub struct TxId {
 /// The very first epoch number
 pub const GENESIS_EPOCH: u32 = 1;
 
-/// From this epoch onward, functionality that accumulates rewards for off-chain distribution is
-/// enabled. Used to gate behaviour that should only activate after a protocol upgrade.
-pub const ACCUMULATE_REWARDS_EPOCH_START: EpochIndex = 6; // todo: set a reasonable value before releasing
-
 /// Number of blocks in the future a swap is scheduled for.
 pub const SWAP_DELAY_BLOCKS: u32 = 2;
 

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -117,6 +117,10 @@ pub type EgressId = (ForeignChain, EgressCounter);
 
 pub type AssetAmount = u128;
 
+/// In order to trigger the sending of vault FLIP to the SC Gateway, the egress amount must be at
+/// least this many times greater than the egress fee.
+pub const FLIP_TO_GATEWAY_MULTIPLE: AssetAmount = 100;
+
 pub type BasisPoints = u16;
 
 pub type BroadcastId = u32;

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -271,6 +271,10 @@ pub struct TxId {
 /// The very first epoch number
 pub const GENESIS_EPOCH: u32 = 1;
 
+/// From this epoch onward, functionality that accumulates rewards for off-chain distribution is
+/// enabled. Used to gate behaviour that should only activate after a protocol upgrade.
+pub const ACCUMULATE_REWARDS_EPOCH_START: EpochIndex = 6; // todo: set a reasonable value before releasing
+
 /// Number of blocks in the future a swap is scheduled for.
 pub const SWAP_DELAY_BLOCKS: u32 = 2;
 

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -29,6 +29,9 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 		let flip_distributed =
 			Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
 
-		Swapping::maybe_trigger_flip_to_gateway_egress(Environment::state_chain_gateway_address());
+		Swapping::maybe_trigger_flip_to_gateway_egress(
+			Environment::state_chain_gateway_address(),
+			flip_distributed,
+		);
 	}
 }

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -16,7 +16,7 @@
 
 use crate::{AssetBalances, Emissions, Environment, Flip, Swapping, Witnesser};
 use cf_primitives::EpochIndex;
-use cf_traits::EpochTransitionHandler;
+use cf_traits::{EpochTransitionHandler, FeePayment};
 
 pub struct ChainflipEpochTransitions;
 
@@ -39,9 +39,12 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 					.into_iter()
 					.collect(),
 			);
-			Swapping::maybe_trigger_flip_to_gateway_egress(
+			let egress_fee_consumed = Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,
+			);
+			Flip::add_to_offchain_flip_to_be_distributed(
+				i128::try_from(egress_fee_consumed).unwrap_or(i128::MAX).saturating_neg(),
 			);
 		}
 	}

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -35,6 +35,7 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 			);
 		} else if new > activation_epoch {
 			let flip_distributed = Flip::trigger_flip_reward_distribution(
+				new - 1,
 				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1)
 					.into_iter()
 					.collect(),

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -27,11 +27,12 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_new_epoch(new: EpochIndex) {
 		AssetBalances::trigger_reconciliation();
 
-		if new == ACCUMULATE_REWARDS_EPOCH_START {
+		let activation_epoch = pallet_cf_flip::FeeRewardsActivationEpoch::<crate::Runtime>::get();
+		if new == activation_epoch {
 			Emissions::burn_and_broadcast_supply_update(
 				frame_system::Pallet::<crate::Runtime>::block_number(),
 			);
-		} else if new > ACCUMULATE_REWARDS_EPOCH_START {
+		} else if new > activation_epoch {
 			let flip_distributed =
 				Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
 			Swapping::maybe_trigger_flip_to_gateway_egress(

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -34,12 +34,7 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 				true,
 			);
 		} else if new > activation_epoch {
-			let flip_distributed = Flip::trigger_flip_reward_distribution(
-				new - 1,
-				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1)
-					.into_iter()
-					.collect(),
-			);
+			let flip_distributed = Flip::trigger_flip_reward_distribution(new - 1);
 			let egress_fee_consumed = Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{AssetBalances, Witnesser};
+use crate::{AssetBalances, Environment, Flip, Swapping, Validator, Witnesser};
 use cf_primitives::EpochIndex;
 use cf_traits::EpochTransitionHandler;
 
@@ -24,7 +24,11 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_expired_epoch(expired: EpochIndex) {
 		<Witnesser as EpochTransitionHandler>::on_expired_epoch(expired);
 	}
-	fn on_new_epoch(_new: EpochIndex) {
+	fn on_new_epoch(new: EpochIndex) {
 		AssetBalances::trigger_reconciliation();
+		let flip_distributed =
+			Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
+
+		Swapping::maybe_trigger_flip_to_gateway_egress(Environment::state_chain_gateway_address());
 	}
 }

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -34,7 +34,9 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 			);
 		} else if new > activation_epoch {
 			let flip_distributed = Flip::trigger_flip_reward_distribution(
-				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1),
+				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1)
+					.into_iter()
+					.collect(),
 			);
 			Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -31,6 +31,7 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 		if new == activation_epoch {
 			Emissions::burn_and_broadcast_supply_update(
 				frame_system::Pallet::<crate::Runtime>::block_number(),
+				true,
 			);
 		} else if new > activation_epoch {
 			let flip_distributed = Flip::trigger_flip_reward_distribution(

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{AssetBalances, Environment, Flip, Swapping, Validator, Witnesser};
-use cf_primitives::EpochIndex;
+use crate::{AssetBalances, Emissions, Environment, Flip, Swapping, Validator, Witnesser};
+use cf_primitives::{EpochIndex, ACCUMULATE_REWARDS_EPOCH_START};
 use cf_traits::EpochTransitionHandler;
 
 pub struct ChainflipEpochTransitions;
@@ -26,12 +26,18 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 	}
 	fn on_new_epoch(new: EpochIndex) {
 		AssetBalances::trigger_reconciliation();
-		let flip_distributed =
-			Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
 
-		Swapping::maybe_trigger_flip_to_gateway_egress(
-			Environment::state_chain_gateway_address(),
-			flip_distributed,
-		);
+		if new == ACCUMULATE_REWARDS_EPOCH_START {
+			Emissions::burn_and_broadcast_supply_update(
+				frame_system::Pallet::<crate::Runtime>::block_number(),
+			);
+		} else if new > ACCUMULATE_REWARDS_EPOCH_START {
+			let flip_distributed =
+				Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
+			Swapping::maybe_trigger_flip_to_gateway_egress(
+				Environment::state_chain_gateway_address(),
+				flip_distributed,
+			);
+		}
 	}
 }

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -24,23 +24,28 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_expired_epoch(expired: EpochIndex) {
 		<Witnesser as EpochTransitionHandler>::on_expired_epoch(expired);
 	}
-	fn on_new_epoch(new: EpochIndex) {
-		AssetBalances::trigger_reconciliation();
-
-		let activation_epoch = pallet_cf_flip::FeeRewardsActivationEpoch::<crate::Runtime>::get();
-		if new == activation_epoch {
-			Emissions::burn_and_broadcast_supply_update(
-				frame_system::Pallet::<crate::Runtime>::block_number(),
-				true,
-			);
-		} else if new > activation_epoch {
-			let flip_distributed = Flip::trigger_flip_reward_distribution(new - 1);
+	fn on_epoch_ending(ending: EpochIndex) {
+		if Flip::is_flip_2_1_activated() {
+			let flip_distributed = Flip::trigger_flip_reward_distribution(ending);
 			let egress_fee_consumed = Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,
 			);
 			Flip::add_to_offchain_flip_to_be_distributed(
 				i128::try_from(egress_fee_consumed).unwrap_or(i128::MAX).saturating_neg(),
+			);
+		}
+	}
+
+	fn on_new_epoch(new: EpochIndex) {
+		AssetBalances::trigger_reconciliation();
+
+		// One-off supply sync on activation: settles the outstanding burn so that fee
+		// accumulation starts from a clean slate.
+		if new == pallet_cf_flip::FeeRewardsActivationEpoch::<crate::Runtime>::get() {
+			Emissions::burn_and_broadcast_supply_update(
+				frame_system::Pallet::<crate::Runtime>::block_number(),
+				true,
 			);
 		}
 	}

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{AssetBalances, Emissions, Environment, Flip, Swapping, Validator, Witnesser};
-use cf_primitives::{EpochIndex, ACCUMULATE_REWARDS_EPOCH_START};
+use crate::{AssetBalances, Emissions, Environment, Flip, Swapping, Witnesser};
+use cf_primitives::EpochIndex;
 use cf_traits::EpochTransitionHandler;
 
 pub struct ChainflipEpochTransitions;
@@ -33,8 +33,9 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 				frame_system::Pallet::<crate::Runtime>::block_number(),
 			);
 		} else if new > activation_epoch {
-			let flip_distributed =
-				Flip::trigger_flip_reward_distribution(Validator::historical_authorities(new - 1));
+			let flip_distributed = Flip::trigger_flip_reward_distribution(
+				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1),
+			);
 			Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -243,7 +243,6 @@ impl pallet_cf_swapping::Config for Runtime {
 	type AddressConverter = ChainAddressConverter;
 	type SafeMode = RuntimeSafeMode;
 	type WeightInfo = pallet_cf_swapping::weights::PalletWeight<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
 	type FeePayment = Flip;
 	type IngressEgressFeeHandler = chainflip::IngressEgressFeeHandler;
 	type BalanceApi = AssetBalances;

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -81,7 +81,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use frame_system::Call as SystemCall;
-use pallet_cf_flip::{Bonder, FlipIssuance, FlipSlasher};
+use pallet_cf_flip::{Bonder, FlipSlasher};
 use pallet_cf_reputation::{ExclusionList, HeartbeatQualification, ReputationPointsQualification};
 pub use pallet_cf_validator::SetSizeParameters;
 use pallet_cf_validator::{DelegatedRewardsDistribution, DelegationSlasher};

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -750,6 +750,7 @@ impl pallet_cf_flip::Config for Runtime {
 	type BlocksPerDay = ConstU32<DAYS>;
 	type WeightInfo = pallet_cf_flip::weights::PalletWeight<Runtime>;
 	type WaivedFees = chainflip::WaivedFees;
+	type RewardsDistribution = DelegatedRewardsDistribution<Runtime>;
 	type CallIndexer = chainflip::LpOrderCallIndexer;
 	// Required to satisfy trait bounds on InspectHold implementation, required by
 	// pallet_session::Config::Currency.
@@ -809,7 +810,7 @@ impl pallet_cf_emissions::Config for Runtime {
 	type ApiCall = eth::api::EthereumApi<EvmEnvironment>;
 	type Broadcaster = EthereumBroadcaster;
 	type Issuance = pallet_cf_flip::FlipIssuance<Runtime>;
-	type RewardsDistribution = DelegatedRewardsDistribution<Runtime, FlipIssuance<Runtime>>;
+	type RewardsDistribution = DelegatedRewardsDistribution<Runtime>;
 	type CompoundingInterval = ConstU32<COMPOUNDING_INTERVAL>;
 	type EthEnvironment = EvmEnvironment;
 	type FlipToBurnOrMove = Swapping;

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -79,7 +79,7 @@ use sp_api::decl_runtime_apis;
 // `#[renamed($OLD_NAME, $VERSION)]` attribute which will handle renaming
 // of apis automatically.
 decl_runtime_apis!(
-	#[api_version(19)]
+	#[api_version(20)]
 	pub trait CustomRuntimeApi {
 		/// Returns true if the current phase is the auction phase.
 		fn cf_is_auction_phase() -> bool;
@@ -434,6 +434,9 @@ decl_runtime_apis!(
 		fn cf_active_delegations(
 			account: Option<AccountId32>,
 		) -> Vec<DelegationSnapshot<AccountId32, FlipBalance>>;
+		#[changed_in(20)]
+		fn cf_reward_distribution_estimate();
+		fn cf_reward_distribution_estimate() -> RewardDistributionEstimate<FlipBalance>;
 		#[changed_in(8)]
 		fn cf_ingress_delay();
 		fn cf_ingress_delay(chain: ForeignChain) -> u32;

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -28,7 +28,10 @@ use cf_chains::{
 	Arbitrum, Bitcoin, Chain, ChainCrypto, Ethereum, ForeignChainAddress, TransactionInId, Tron,
 };
 pub use cf_chains::{dot::PolkadotAccountId, sol::SolAddress, ChainEnvironment};
-use cf_primitives::{chains::Bsc, Asset, BroadcastId, EpochIndex, FlipBalance, ForeignChain};
+use cf_primitives::{
+	chains::Bsc, AccountRole, Asset, BlockNumber, BroadcastId, EpochIndex, FlipBalance,
+	ForeignChain,
+};
 pub use cf_primitives::{AssetAmount, BasisPoints};
 use cf_utilities::migrations::{
 	basics::{
@@ -331,6 +334,81 @@ impl<A> OperatorInfo<A> {
 				.map(|(k, v)| Ok((k, f(v)?)))
 				.collect::<Result<_, E>>()?,
 			active_delegation: self.active_delegation.map(|d| d.try_map_bids(&f)).transpose()?,
+		})
+	}
+}
+
+/// A single account's cumulative cut of the FLIP 2.1 fee-reward pool for the in-progress epoch.
+#[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Clone, Debug, Serialize, Deserialize)]
+pub struct AccountReward<Amount> {
+	pub account: AccountId32,
+	/// The delegated bid (principal). Zero for operators.
+	pub bid: Amount,
+	/// Amount locked as bond. Equal to `bid` for delegators; zero for operators.
+	pub bond: Amount,
+	/// Pure earnings so far this epoch.
+	pub reward: Amount,
+	pub role: AccountRole,
+	/// The operator managing this node, if this account is a validator claimed by an operator.
+	pub managed_by: Option<AccountId32>,
+	/// The operator this account delegates to, if any (can be a regular delegator or a
+	/// delegating validator).
+	pub delegated_to: Option<AccountId32>,
+}
+
+impl<A> AccountReward<A> {
+	pub fn try_map_amounts<B, E>(
+		self,
+		f: impl Fn(A) -> Result<B, E>,
+	) -> Result<AccountReward<B>, E> {
+		Ok(AccountReward {
+			account: self.account,
+			bid: f(self.bid)?,
+			bond: f(self.bond)?,
+			reward: f(self.reward)?,
+			role: self.role,
+			managed_by: self.managed_by,
+			delegated_to: self.delegated_to,
+		})
+	}
+}
+
+/// A structured, per-epoch projection of FLIP 2.1 reward distribution: the current on-chain
+/// reward state and every operator/validator/delegator's cumulative cut so far this epoch.
+/// `reward_pool` is empty (and `total_rewards`/`per_authority_share` are zero) if FLIP 2.1's
+/// fee-reward distribution has not yet been activated for the current epoch.
+#[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Clone, Debug, Serialize, Deserialize)]
+pub struct RewardDistributionEstimate<Amount> {
+	pub epoch_index: EpochIndex,
+	pub current_block: BlockNumber,
+	pub current_epoch_started_at: BlockNumber,
+	pub epoch_duration: BlockNumber,
+	pub bond: Amount,
+	pub authority_count: u32,
+	pub total_rewards: Amount,
+	pub per_authority_share: Amount,
+	pub reward_pool: Vec<AccountReward<Amount>>,
+}
+
+impl<A> RewardDistributionEstimate<A> {
+	pub fn try_map_amounts<B, E>(
+		self,
+		f: impl Fn(A) -> Result<B, E>,
+	) -> Result<RewardDistributionEstimate<B>, E> {
+		Ok(RewardDistributionEstimate {
+			epoch_index: self.epoch_index,
+			current_block: self.current_block,
+			current_epoch_started_at: self.current_epoch_started_at,
+			epoch_duration: self.epoch_duration,
+			bond: f(self.bond)?,
+			authority_count: self.authority_count,
+			total_rewards: f(self.total_rewards)?,
+			per_authority_share: f(self.per_authority_share)?,
+			reward_pool: self
+				.reward_pool
+				.into_iter()
+				.map(|r| r.try_map_amounts(&f))
+				.collect::<Result<_, E>>()?,
 		})
 	}
 }

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -914,7 +914,7 @@ impl_runtime_apis! {
 
 			let (total_rewards, per_authority_share, reward_pool) =
 				if is_active && authority_count > 0 {
-					let total_rewards = Flip::pending_rewards() as FlipBalance;
+					let total_rewards = Flip::pending_rewards();
 					let per_authority_share = total_rewards / authority_count as FlipBalance;
 
 					let role_of = |account: &AccountId| {

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -51,7 +51,7 @@ use cf_primitives::{
 };
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, ChainflipWithTargetChain, EpochKey,
-	GetBlockHeight, KeyProvider, RewardsDistribution, SwapLimits, SwapParameterValidation,
+	GetBlockHeight, KeyProvider, SwapLimits, SwapParameterValidation,
 };
 use codec::{Decode, Encode};
 use core::ops::Range;
@@ -77,13 +77,10 @@ use pallet_cf_pools::{
 };
 use pallet_cf_reputation::HeartbeatQualification;
 use pallet_cf_swapping::{AffiliateDetails, BrokerPrivateBtcChannels, SwapLegInfo};
-use pallet_cf_validator::{
-	AssociationToOperator, DelegatedRewardsDistribution, DelegationAcceptance,
-};
+use pallet_cf_validator::{AssociationToOperator, DelegationAcceptance};
 use scale_info::prelude::string::String;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
-use sp_runtime::traits::Zero;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	vec::Vec,
@@ -924,77 +921,45 @@ impl_runtime_apis! {
 						pallet_cf_account_roles::AccountRoles::<Runtime>::get(account)
 							.unwrap_or_default()
 					};
-					let managed_by = |account: &AccountId| {
-						pallet_cf_validator::ValidatorToOperator::<Runtime>::get(epoch_index, account)
-					};
 
-					// `distribute` looks up each authority's managing operator (if any) and
-					// settles its cut across that operator's validators/delegators, or pays the
-					// authority directly if it's independent - mirroring
-					// `Flip::trigger_flip_reward_distribution`'s per-authority settlement, without
-					// mutating any storage.
-					let mut operators_with_authorities: BTreeSet<AccountId> = BTreeSet::new();
-					let mut rewards: BTreeMap<AccountId, FlipBalance> = BTreeMap::new();
-					let mut reward_pool = Vec::new();
+					let mut reward_pool: Vec<AccountReward<FlipBalance>> = Vec::new();
 
-					for validator in &authorities {
-						match managed_by(validator) {
-							Some(operator) => {
-								operators_with_authorities.insert(operator);
-							},
-							None => {
-								reward_pool.push(AccountReward {
-									account: validator.clone(),
-									bid: Flip::balance(validator),
-									bond: Flip::bond(validator),
-									reward: per_authority_share,
-									role: AccountRole::Validator,
-									managed_by: None,
-									delegated_to: None,
-								});
-							},
+					// Mirrors `DelegatedRewardsDistribution::distribute_all`: snapshot validators
+					// are drained out of `authority_set` as we go, leaving only independent
+					// authorities, which get their full share directly after the loop below.
+					let mut authorities_to_reward: BTreeSet<&AccountId> = authorities.iter().collect();
+
+					for (operator, snapshot) in
+						pallet_cf_validator::DelegationSnapshots::<Runtime>::iter_prefix(epoch_index)
+					{
+						// Snapshots of operators whose pooled stake didn't clear the bond are
+						// still registered but hold a non-authority validator - they earn nothing.
+						let num_authority_nodes = snapshot
+							.validators
+							.keys()
+							.filter(|v| authorities_to_reward.remove(*v))
+							.count() as u32;
+						if num_authority_nodes == 0 {
+							continue;
 						}
 
-						<DelegatedRewardsDistribution<Runtime> as RewardsDistribution>::distribute(
-							epoch_index,
-							per_authority_share,
-							validator,
-							|account, amount| {
-								rewards
-									.entry(account.clone())
-									.and_modify(|r: &mut FlipBalance| *r = r.saturating_add(amount))
-									.or_insert(amount);
-							},
-						);
-					}
-
-					let reward_of =
-						|account: &AccountId| rewards.get(account).copied().unwrap_or_default();
-
-					for operator in operators_with_authorities {
+						let total = per_authority_share.saturating_mul(num_authority_nodes as FlipBalance);
+						let rewards: BTreeMap<AccountId, FlipBalance> = snapshot
+							.distribute(total, bond)
+							.map(|(account, amount)| (account.clone(), amount))
+							.collect();
+						let reward_of =
+							|account: &AccountId| rewards.get(account).copied().unwrap_or_default();
 
 						reward_pool.push(AccountReward {
 							account: operator.clone(),
-							bid: Zero::zero(),
-							bond: Flip::bond(&operator),
+							bid: 0,
+							bond: 0,
 							reward: reward_of(&operator),
 							role: AccountRole::Operator,
 							managed_by: None,
 							delegated_to: None,
 						});
-
-						let Some(snapshot) = pallet_cf_validator::DelegationSnapshots::<Runtime>::get(
-							epoch_index,
-							&operator,
-						) else {
-							log::warn!(
-									"Operator {:?} has authority slot(s) in epoch {} but no delegation snapshot found.",
-									operator,
-									epoch_index
-								);
-							continue;
-						};
-
 
 						for (account, bid) in &snapshot.validators {
 							reward_pool.push(AccountReward {
@@ -1009,16 +974,32 @@ impl_runtime_apis! {
 						}
 
 						for (account, bid) in &snapshot.delegators {
+							let role = role_of(account);
 							reward_pool.push(AccountReward {
 								account: account.clone(),
 								bid: *bid,
 								bond: Flip::bond(account),
 								reward: reward_of(account),
-								role: role_of(account),
-								managed_by: managed_by(account),
+								role,
+								// `Validator`-role accounts can't hold a `DelegationChoice`
+								// (`delegate` rejects Validator/Operator callers), so a Validator
+								// here can only be demoted from this same operator's own set.
+								managed_by: (role == AccountRole::Validator).then(|| operator.clone()),
 								delegated_to: Some(operator.clone()),
 							});
 						}
+					}
+
+					for authority in authorities_to_reward {
+						reward_pool.push(AccountReward {
+							account: authority.clone(),
+							bid: Flip::balance(authority),
+							bond: Flip::bond(authority),
+							reward: per_authority_share,
+							role: AccountRole::Validator,
+							managed_by: None,
+							delegated_to: None,
+						});
 					}
 
 					(total_rewards, per_authority_share, reward_pool)

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -51,7 +51,7 @@ use cf_primitives::{
 };
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, ChainflipWithTargetChain, EpochKey,
-	GetBlockHeight, KeyProvider, SwapLimits, SwapParameterValidation,
+	GetBlockHeight, KeyProvider, RewardsDistribution, SwapLimits, SwapParameterValidation,
 };
 use codec::{Decode, Encode};
 use core::ops::Range;
@@ -77,10 +77,13 @@ use pallet_cf_pools::{
 };
 use pallet_cf_reputation::HeartbeatQualification;
 use pallet_cf_swapping::{AffiliateDetails, BrokerPrivateBtcChannels, SwapLegInfo};
-use pallet_cf_validator::{AssociationToOperator, DelegationAcceptance};
+use pallet_cf_validator::{
+	AssociationToOperator, DelegatedRewardsDistribution, DelegationAcceptance,
+};
 use scale_info::prelude::string::String;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
+use sp_runtime::traits::Zero;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	vec::Vec,
@@ -894,6 +897,145 @@ impl_runtime_apis! {
 					Validator::current_epoch(),
 					account_id,
 				),
+			}
+		}
+
+		/// Projects each operator/validator/delegator's cumulative FLIP 2.1 fee-reward cut for the
+		/// in-progress epoch, as if the currently accumulated reserve were distributed right now.
+		/// Returns an empty reward pool (and zeroed pool amounts) if FLIP 2.1's fee-reward
+		/// distribution has not yet been activated for the current epoch.
+		fn cf_reward_distribution_estimate() -> RewardDistributionEstimate<FlipBalance> {
+			let epoch_index = Validator::current_epoch();
+			let current_block = System::block_number();
+			let current_epoch_started_at = Validator::current_epoch_started_at();
+			let epoch_duration = Validator::epoch_duration();
+			let bond = Validator::bond();
+			let authorities = pallet_cf_validator::CurrentAuthorities::<Runtime>::get();
+			let authority_count = authorities.len() as u32;
+
+			let is_active = epoch_index >= pallet_cf_flip::FeeRewardsActivationEpoch::<Runtime>::get();
+
+			let (total_rewards, per_authority_share, reward_pool) =
+				if is_active && authority_count > 0 {
+					let total_rewards = Flip::pending_rewards() as FlipBalance;
+					let per_authority_share = total_rewards / authority_count as FlipBalance;
+
+					let role_of = |account: &AccountId| {
+						pallet_cf_account_roles::AccountRoles::<Runtime>::get(account)
+							.unwrap_or_default()
+					};
+					let managed_by = |account: &AccountId| {
+						pallet_cf_validator::ValidatorToOperator::<Runtime>::get(epoch_index, account)
+					};
+
+					// `distribute` looks up each authority's managing operator (if any) and
+					// settles its cut across that operator's validators/delegators, or pays the
+					// authority directly if it's independent - mirroring
+					// `Flip::trigger_flip_reward_distribution`'s per-authority settlement, without
+					// mutating any storage.
+					let mut operators_with_authorities: BTreeSet<AccountId> = BTreeSet::new();
+					let mut rewards: BTreeMap<AccountId, FlipBalance> = BTreeMap::new();
+					let mut reward_pool = Vec::new();
+
+					for validator in &authorities {
+						match managed_by(validator) {
+							Some(operator) => {
+								operators_with_authorities.insert(operator);
+							},
+							None => {
+								reward_pool.push(AccountReward {
+									account: validator.clone(),
+									bid: Flip::balance(validator),
+									bond: Flip::bond(validator),
+									reward: per_authority_share,
+									role: AccountRole::Validator,
+									managed_by: None,
+									delegated_to: None,
+								});
+							},
+						}
+
+						<DelegatedRewardsDistribution<Runtime> as RewardsDistribution>::distribute(
+							epoch_index,
+							per_authority_share,
+							validator,
+							|account, amount| {
+								rewards
+									.entry(account.clone())
+									.and_modify(|r: &mut FlipBalance| *r = r.saturating_add(amount))
+									.or_insert(amount);
+							},
+						);
+					}
+
+					let reward_of =
+						|account: &AccountId| rewards.get(account).copied().unwrap_or_default();
+
+					for operator in operators_with_authorities {
+
+						reward_pool.push(AccountReward {
+							account: operator.clone(),
+							bid: Zero::zero(),
+							bond: Flip::bond(&operator),
+							reward: reward_of(&operator),
+							role: AccountRole::Operator,
+							managed_by: None,
+							delegated_to: None,
+						});
+
+						let Some(snapshot) = pallet_cf_validator::DelegationSnapshots::<Runtime>::get(
+							epoch_index,
+							&operator,
+						) else {
+							log::warn!(
+									"Operator {:?} has authority slot(s) in epoch {} but no delegation snapshot found.",
+									operator,
+									epoch_index
+								);
+							continue;
+						};
+
+
+						for (account, bid) in &snapshot.validators {
+							reward_pool.push(AccountReward {
+								account: account.clone(),
+								bid: *bid,
+								bond: Flip::bond(account),
+								reward: reward_of(account),
+								role: AccountRole::Validator,
+								managed_by: Some(operator.clone()),
+								delegated_to: None,
+							});
+						}
+
+						for (account, bid) in &snapshot.delegators {
+							reward_pool.push(AccountReward {
+								account: account.clone(),
+								bid: *bid,
+								bond: Flip::bond(account),
+								reward: reward_of(account),
+								role: role_of(account),
+								managed_by: managed_by(account),
+								delegated_to: Some(operator.clone()),
+							});
+						}
+					}
+
+					(total_rewards, per_authority_share, reward_pool)
+				} else {
+					(0, 0, Vec::new())
+				};
+
+			RewardDistributionEstimate {
+				epoch_index,
+				current_block,
+				current_epoch_started_at,
+				epoch_duration,
+				bond,
+				authority_count,
+				total_rewards,
+				per_authority_share,
+				reward_pool,
 			}
 		}
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -395,6 +395,16 @@ pub trait RewardsDistribution {
 		beneficiary: &Self::AccountId,
 		settle: impl FnMut(&Self::AccountId, Self::Balance),
 	);
+
+	/// Splits `total_amount` evenly across `epoch_index`'s complete set of reward recipients
+	/// (e.g. that epoch's full authority set), as determined by the implementation.
+	/// To settle a partial
+	/// set, call [Self::distribute] per beneficiary instead.
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		settle: impl FnMut(&Self::AccountId, Self::Balance),
+	);
 }
 
 /// A representation of the current network state for this heartbeat interval.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -284,6 +284,10 @@ pub enum StartKeyActivationResult {
 pub trait EpochTransitionHandler {
 	/// When an epoch has been expired.
 	fn on_expired_epoch(_expired: EpochIndex) {}
+	/// When an epoch is ending. Called in the same block as [Self::on_new_epoch], but *before*
+	/// the epoch index is incremented, so `EpochInfo::epoch_index()` still returns the ending
+	/// epoch.
+	fn on_epoch_ending(_ending: EpochIndex) {}
 	/// When a new epoch has started.
 	fn on_new_epoch(_new: EpochIndex) {}
 }

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -378,8 +378,9 @@ pub trait Issuance {
 	/// Use with care.
 	fn burn_offchain(amount: Self::Balance);
 
-	/// The epoch from which fee rewards are accumulated on-chain rather than burned.
-	fn fee_rewards_activation_epoch() -> EpochIndex;
+	/// Whether FLIP 2.1 is active: fee rewards are accumulated for distribution to authorities
+	/// rather than burned.
+	fn is_flip_2_1_activated() -> bool;
 }
 
 /// Distribute rewards somehow.
@@ -763,11 +764,14 @@ pub trait FeePayment {
 	/// Accumulate FLIP to be distributed off-chain (e.g. via the StateChainGateway).
 	fn add_to_offchain_flip_to_be_distributed(amount: i128);
 
-	/// Accumulate FLIP to be distributed on-chain, returning a deficit imbalance.
-	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(amount: Self::Amount);
+	/// Burns `amount` of off-chain funds (eg. in the StateChainGateway contract), unless FLIP 2.1
+	/// is active, in which case the funds are bridged in and reserved for distribution to
+	/// authorities instead.
+	fn burn_or_reserve_offchain(amount: Self::Amount);
 
-	/// The epoch from which fee rewards are accumulated on-chain rather than burned.
-	fn fee_rewards_activation_epoch() -> EpochIndex;
+	/// Whether FLIP 2.1 is active: fee rewards are accumulated for distribution to authorities
+	/// rather than burned.
+	fn is_flip_2_1_activated() -> bool;
 }
 
 /// Provides information about on-chain funds.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -385,7 +385,11 @@ pub trait RewardsDistribution {
 	type AccountId;
 
 	/// Distribute some rewards.
-	fn distribute(amount: Self::Balance, beneficiary: &Self::AccountId);
+	fn distribute(
+		amount: Self::Balance,
+		beneficiary: &Self::AccountId,
+		settle: impl FnMut(&Self::AccountId, Self::Balance),
+	);
 }
 
 /// A representation of the current network state for this heartbeat interval.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -377,6 +377,9 @@ pub trait Issuance {
 	///
 	/// Use with care.
 	fn burn_offchain(amount: Self::Balance);
+
+	/// The epoch from which fee rewards are accumulated on-chain rather than burned.
+	fn fee_rewards_activation_epoch() -> EpochIndex;
 }
 
 /// Distribute rewards somehow.
@@ -763,6 +766,9 @@ pub trait FeePayment {
 
 	/// Accumulate FLIP to be distributed on-chain, returning a deficit imbalance.
 	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Self::Deficit;
+
+	/// The epoch from which fee rewards are accumulated on-chain rather than burned.
+	fn fee_rewards_activation_epoch() -> EpochIndex;
 }
 
 /// Provides information about on-chain funds.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -751,7 +751,6 @@ pub trait MissedAuthorshipSlots {
 pub trait FeePayment {
 	type Amount;
 	type AccountId;
-	type Deficit;
 	/// Helper function to mint FLIP to an account.
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(_account_id: &Self::AccountId, _amount: Self::Amount) {
@@ -765,7 +764,7 @@ pub trait FeePayment {
 	fn add_to_offchain_flip_to_be_distributed(amount: i128);
 
 	/// Accumulate FLIP to be distributed on-chain, returning a deficit imbalance.
-	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Self::Deficit;
+	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(amount: Self::Amount);
 
 	/// The epoch from which fee rewards are accumulated on-chain rather than burned.
 	fn fee_rewards_activation_epoch() -> EpochIndex;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -388,8 +388,9 @@ pub trait RewardsDistribution {
 	type Balance;
 	type AccountId;
 
-	/// Distribute some rewards.
+	/// Distribute some rewards accrued during `epoch_index`.
 	fn distribute(
+		epoch_index: EpochIndex,
 		amount: Self::Balance,
 		beneficiary: &Self::AccountId,
 		settle: impl FnMut(&Self::AccountId, Self::Balance),

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -748,6 +748,7 @@ pub trait MissedAuthorshipSlots {
 pub trait FeePayment {
 	type Amount;
 	type AccountId;
+	type Deficit;
 	/// Helper function to mint FLIP to an account.
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(_account_id: &Self::AccountId, _amount: Self::Amount) {
@@ -755,7 +756,13 @@ pub trait FeePayment {
 	}
 
 	/// Burns an amount of tokens, if the account has enough. Otherwise fails.
-	fn try_burn_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult;
+	fn try_take_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult;
+
+	/// Accumulate FLIP to be distributed off-chain (e.g. via the StateChainGateway).
+	fn add_to_offchain_flip_to_be_distributed(amount: i128);
+
+	/// Accumulate FLIP to be distributed on-chain, returning a deficit imbalance.
+	fn add_to_onchain_flip_to_be_distributed(amount: Self::Amount) -> Self::Deficit;
 }
 
 /// Provides information about on-chain funds.

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -28,12 +28,17 @@ pub const ERROR_INSUFFICIENT_LIQUIDITY: DispatchError =
 impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayment<T> {
 	type AccountId = T::AccountId;
 	type Amount = T::Amount;
+	type Deficit = ();
 
-	fn try_burn_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult {
+	fn try_take_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult {
 		MockFundingInfo::<T>::try_debit_funds(account_id, amount)
 			.map(|_| ())
 			.ok_or(ERROR_INSUFFICIENT_LIQUIDITY)
 	}
+
+	fn add_to_offchain_flip_to_be_distributed(_amount: i128) {}
+
+	fn add_to_onchain_flip_to_be_distributed(_amount: Self::Amount) -> Self::Deficit {}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(account_id: &Self::AccountId, amount: Self::Amount) {

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -16,6 +16,7 @@
 
 use frame_support::sp_runtime::{DispatchError, DispatchResult};
 
+use cf_primitives::EpochIndex;
 use crate::{Chainflip, FeePayment};
 
 use super::funding_info::MockFundingInfo;
@@ -39,6 +40,10 @@ impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayme
 	fn add_to_offchain_flip_to_be_distributed(_amount: i128) {}
 
 	fn add_to_onchain_flip_to_be_distributed(_amount: Self::Amount) -> Self::Deficit {}
+
+	fn fee_rewards_activation_epoch() -> EpochIndex {
+		EpochIndex::MAX
+	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(account_id: &Self::AccountId, amount: Self::Amount) {

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -29,7 +29,6 @@ pub const ERROR_INSUFFICIENT_LIQUIDITY: DispatchError =
 impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayment<T> {
 	type AccountId = T::AccountId;
 	type Amount = T::Amount;
-	type Deficit = ();
 
 	fn try_take_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult {
 		MockFundingInfo::<T>::try_debit_funds(account_id, amount)
@@ -39,7 +38,7 @@ impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayme
 
 	fn add_to_offchain_flip_to_be_distributed(_amount: i128) {}
 
-	fn add_to_onchain_flip_to_be_distributed(_amount: Self::Amount) -> Self::Deficit {}
+	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(_amount: Self::Amount) {}
 
 	fn fee_rewards_activation_epoch() -> EpochIndex {
 		EpochIndex::MAX

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -16,8 +16,8 @@
 
 use frame_support::sp_runtime::{DispatchError, DispatchResult};
 
-use cf_primitives::EpochIndex;
 use crate::{Chainflip, FeePayment};
+use cf_primitives::EpochIndex;
 
 use super::funding_info::MockFundingInfo;
 

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -17,7 +17,6 @@
 use frame_support::sp_runtime::{DispatchError, DispatchResult};
 
 use crate::{Chainflip, FeePayment};
-use cf_primitives::EpochIndex;
 
 use super::funding_info::MockFundingInfo;
 
@@ -38,10 +37,10 @@ impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayme
 
 	fn add_to_offchain_flip_to_be_distributed(_amount: i128) {}
 
-	fn bridge_in_and_add_to_onchain_flip_to_be_distributed(_amount: Self::Amount) {}
+	fn burn_or_reserve_offchain(_amount: Self::Amount) {}
 
-	fn fee_rewards_activation_epoch() -> EpochIndex {
-		EpochIndex::MAX
+	fn is_flip_2_1_activated() -> bool {
+		false
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/state-chain/traits/src/mocks/rewards_distribution.rs
+++ b/state-chain/traits/src/mocks/rewards_distribution.rs
@@ -27,7 +27,11 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 	type Balance = T::Amount;
 	type AccountId = T::AccountId;
 
-	fn distribute(amount: Self::Balance, beneficiary: &Self::AccountId) {
+	fn distribute(
+		amount: Self::Balance,
+		beneficiary: &Self::AccountId,
+		_settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
 		<Self as MockPalletStorage>::mutate_storage(
 			b"REWARDS",
 			beneficiary,

--- a/state-chain/traits/src/mocks/rewards_distribution.rs
+++ b/state-chain/traits/src/mocks/rewards_distribution.rs
@@ -44,6 +44,23 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 		);
 		settle(beneficiary, amount);
 	}
+
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		mut settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
+		let beneficiaries: sp_std::vec::Vec<Self::AccountId> =
+			<Self as MockPalletStorage>::get_storage(b"BENEFICIARIES", epoch_index)
+				.unwrap_or_default();
+		if beneficiaries.is_empty() {
+			return;
+		}
+		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
+		for beneficiary in &beneficiaries {
+			Self::distribute(epoch_index, per_beneficiary_amount, beneficiary, &mut settle);
+		}
+	}
 }
 
 impl<T: Chainflip> MockRewardsDistribution<T> {
@@ -51,5 +68,12 @@ impl<T: Chainflip> MockRewardsDistribution<T> {
 		beneficiary: &<Self as RewardsDistribution>::AccountId,
 	) -> <Self as RewardsDistribution>::Balance {
 		<Self as MockPalletStorage>::get_storage(b"REWARDS", beneficiary).unwrap_or_default()
+	}
+
+	pub fn set_beneficiaries(
+		epoch_index: EpochIndex,
+		beneficiaries: sp_std::vec::Vec<<Self as RewardsDistribution>::AccountId>,
+	) {
+		<Self as MockPalletStorage>::put_storage(b"BENEFICIARIES", epoch_index, beneficiaries);
 	}
 }

--- a/state-chain/traits/src/mocks/rewards_distribution.rs
+++ b/state-chain/traits/src/mocks/rewards_distribution.rs
@@ -16,6 +16,7 @@
 
 use super::{MockPallet, MockPalletStorage};
 use crate::{Chainflip, RewardsDistribution};
+use cf_primitives::EpochIndex;
 
 pub struct MockRewardsDistribution<T>(core::marker::PhantomData<T>);
 
@@ -28,6 +29,7 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 	type AccountId = T::AccountId;
 
 	fn distribute(
+		_epoch_index: EpochIndex,
 		amount: Self::Balance,
 		beneficiary: &Self::AccountId,
 		mut settle: impl FnMut(&Self::AccountId, Self::Balance),

--- a/state-chain/traits/src/mocks/rewards_distribution.rs
+++ b/state-chain/traits/src/mocks/rewards_distribution.rs
@@ -30,7 +30,7 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 	fn distribute(
 		amount: Self::Balance,
 		beneficiary: &Self::AccountId,
-		_settle: impl FnMut(&Self::AccountId, Self::Balance),
+		mut settle: impl FnMut(&Self::AccountId, Self::Balance),
 	) {
 		<Self as MockPalletStorage>::mutate_storage(
 			b"REWARDS",
@@ -40,6 +40,7 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 				*balance = Some(current_balance + amount);
 			},
 		);
+		settle(beneficiary, amount);
 	}
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2862, PRO-2863

## Summary

This feature changes the tokenomics from emissions and "buy and burn" model to fixed supply and "buy and distribute" model. The can be scheduled to be activated at any future epoch by governance (`Update_pallet_config` extrinsic).

- The onchain flip revenue (flip tx fees, slashing stc) is stored in in onchain reserve (`Reserve` storage item with `ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID` as reserve id)
- The offchain flip revenue (swap fees) is stored in `FlipToDistribute` storage item.
- The rewards for the whole epoch are distributed at the end of the epoch together to all validators and delegators.
- The offchain flip revenue is bridged in at the time of reward distribution and the subsequent transfer of these bridged flip from the vault to the State Chain gateway is attempted, and is scheduled for later if it cant be carried out immediately (due to the amount not big enough relative to how much eth tx fees it would cause).
- unit tests, integration tests and bouncer test was added to assert soundness of funds distribution and expected behaviour.


### RPCS

`cf_reward_distribution_estimate` rpc is added for product to be able to get a real time estimate of rewards accumulated for validators and delegators from the start of the epoch up until that moment.

### Extrinsics & Events

- A new `FlipDistributed` event was created which will be emitted at epoch boundary which will contain info about rewards that were distributed to validators and delegators.
- the `update_pallet_config` extrinsic in the flip pallet was modified to allow setting of the Flip 2.1 activation epoch.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [x] Proptests for important invariants.
    * [x] Integration tests for runtime-wide behaviours.
    * [x] Bouncer test
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
