### PR TITLE
fix: cf_account_info includes collateral in supply-only accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes included in each Chainflip release will be documented in this file.
 
+## [2.2.2] - 2026-05-20
+
+### Fixes
+
+- cf_account_info includes collateral in supply-only accounts
+
 ## [2.2.1] - 2026-05-20
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "cf-engine-dylib"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "chainflip-engine",
  "engine-proc-macros",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-api"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-broker-api"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "cf-chains",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-cli"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-engine"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-lp-api"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "cf-amm-math",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "chainflip-node"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "cf-chains",
  "cf-primitives",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "engine-p2p"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "engine-proc-macros"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "engine-upgrade-utils",
  "proc-macro2",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "engine-runner"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "engine-sc-client"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15598,7 +15598,7 @@ dependencies = [
 
 [[package]]
 name = "state-chain-runtime"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bitvec",
  "cf-amm",

--- a/api/bin/chainflip-broker-api/Cargo.toml
+++ b/api/bin/chainflip-broker-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-broker-api"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 build = "build.rs"
 name = "chainflip-cli"
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lints]

--- a/api/bin/chainflip-lp-api/Cargo.toml
+++ b/api/bin/chainflip-lp-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 name = "chainflip-lp-api"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/api/lib/Cargo.toml
+++ b/api/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainflip-api"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/engine-dylib/Cargo.toml
+++ b/engine-dylib/Cargo.toml
@@ -3,12 +3,12 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "cf-engine-dylib"
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]
-name = "chainflip_engine_v2_2_1"
+name = "chainflip_engine_v2_2_2"
 path = "src/lib.rs"
 
 [dependencies]

--- a/engine-proc-macros/Cargo.toml
+++ b/engine-proc-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 name = "engine-proc-macros"
 # The version here is the version that will be used for the generated code, and therefore will be the
 # suffix of the generated engine entrypoint. TODO: Fix this.
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lib]

--- a/engine-runner-bin/Cargo.toml
+++ b/engine-runner-bin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "engine-runner"
 description = "The central runner for the chainflip engine, it requires two shared library versions to run."
 # NB: When updating this version, you must update the debian assets appropriately too.
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
@@ -22,10 +22,10 @@ assets = [
 	# to specify this. We do this in the `chainflip-engine.service` files, so the user does not need to set it
 	# manually.
 	[
-		"target/release/libchainflip_engine_v2_2_1.so",
+		"target/release/libchainflip_engine_v2_2_2.so",
 		# This is the path where the engine dylib is searched for on linux.
 		# As set in the build.rs file.
-		"usr/lib/chainflip-engine/libchainflip_engine_v2_2_1.so",
+		"usr/lib/chainflip-engine/libchainflip_engine_v2_2_2.so",
 		"755",
 	],
 	# The old version gets put into target/release/deps by the package github actions workflow.

--- a/engine-runner-bin/src/main.rs
+++ b/engine-runner-bin/src/main.rs
@@ -29,7 +29,7 @@ mod old {
 }
 
 mod new {
-	#[engine_proc_macros::link_engine_library_version("2.2.1")]
+	#[engine_proc_macros::link_engine_library_version("2.2.2")]
 	extern "C" {
 		fn cfe_entrypoint(
 			c_args: engine_upgrade_utils::CStrArray,

--- a/engine-upgrade-utils/src/lib.rs
+++ b/engine-upgrade-utils/src/lib.rs
@@ -27,7 +27,7 @@ pub mod build_helpers;
 // relevant crates.
 // Should also check that the compatibility function below `args_compatible_with_old` is correct.
 pub const OLD_VERSION: &str = "2.1.18";
-pub const NEW_VERSION: &str = "2.2.1";
+pub const NEW_VERSION: &str = "2.2.2";
 
 pub const ENGINE_LIB_PREFIX: &str = "chainflip_engine_v";
 pub const ENGINE_ENTRYPOINT_PREFIX: &str = "cfe_entrypoint_v";

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Chainflip team <https://github.com/chainflip-io>"]
 build = "build.rs"
 edition = "2021"
 name = "chainflip-engine"
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lib]

--- a/engine/p2p/Cargo.toml
+++ b/engine/p2p/Cargo.toml
@@ -3,7 +3,7 @@
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 name = "engine-p2p"
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lib]

--- a/engine/sc-client/Cargo.toml
+++ b/engine/sc-client/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Chainflip team <https://github.com/chainflip-io>"]
 edition = "2021"
 name = "engine-sc-client"
-version = "2.2.1"
+version = "2.2.2"
 license = "Apache-2.0"
 
 [lints]

--- a/state-chain/node/Cargo.toml
+++ b/state-chain/node/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "chainflip-node"
 publish = false
 repository = "https://github.com/chainflip-io/chainflip-backend"
-version = "2.2.1"
+version = "2.2.2"
 
 [[bin]]
 name = "chainflip-node"

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -183,33 +183,26 @@ impl<T: Config> LoanAccount<T> {
 		}
 	}
 
-	pub fn get_collateral_in_supply_pools(&self) -> BTreeMap<Asset, AssetAmount> {
-		GeneralLendingPools::<T>::iter()
-			.filter_map(|(asset, pool)| {
-				pool.get_supply_position_for_account(&self.borrower_id)
-					.ok()
-					.map(|amount| (asset, amount))
-			})
-			.collect()
-	}
-
 	/// Returns the account's collateral including any amounts that are in liquidation swaps.
 	pub fn get_total_collateral(&self) -> BTreeMap<Asset, AssetAmount> {
+		let mut collateral = get_collateral_in_supply_pools::<T>(&self.borrower_id);
+		self.add_collateral_in_liquidation_swaps(&mut collateral);
+		collateral
+	}
+
+	/// Adds collateral that is currently locked in liquidation swaps to `collateral`.
+	fn add_collateral_in_liquidation_swaps(&self, collateral: &mut BTreeMap<Asset, AssetAmount>) {
 		// Note that in order to keep things simple we don't guarantee that all of the
-		// all collateral is being liquidated (e.g. it is possible for the user to top
+		// collateral is being liquidated (e.g. it is possible for the user to top
 		// up collateral during liquidation in which case we currently don't update the
 		// liquidation swaps), but we *do* include collateral that is not in liquidation
 		// when determining account's collateralisation ratio.
-
-		let mut total_collateral = self.get_collateral_in_supply_pools();
-
-		// Add any collateral in liquidation swaps:
 		if let LiquidationStatus::Liquidating { liquidation_swaps, .. } = &self.liquidation_status {
 			for (swap_request_id, LiquidationSwap { from_asset, .. }) in liquidation_swaps {
 				if let Some(swap_progress) =
 					T::SwapRequestHandler::inspect_swap_request(*swap_request_id)
 				{
-					total_collateral
+					collateral
 						.entry(*from_asset)
 						.or_default()
 						.saturating_accrue(swap_progress.remaining_input_amount);
@@ -218,8 +211,6 @@ impl<T: Config> LoanAccount<T> {
 				}
 			}
 		}
-
-		total_collateral
 	}
 
 	/// Supply funds after liquidation (either from unused input amount or from
@@ -635,14 +626,14 @@ impl<T: Config> LoanAccount<T> {
 		};
 
 		// Gather available collateral positions per asset, paired with their USD value.
-		let positions_with_usd: Vec<(Asset, AssetAmount, AssetAmount)> = self
-			.get_collateral_in_supply_pools()
-			.into_iter()
-			.filter(|(_, amount)| *amount > 0)
-			.map(|(asset, amount)| {
-				price_cache.usd_value_of(asset, amount).map(|usd| (asset, amount, usd))
-			})
-			.collect::<Result<Vec<_>, Error<T>>>()?;
+		let positions_with_usd: Vec<(Asset, AssetAmount, AssetAmount)> =
+			get_collateral_in_supply_pools::<T>(&self.borrower_id)
+				.into_iter()
+				.filter(|(_, amount)| *amount > 0)
+				.map(|(asset, amount)| {
+					price_cache.usd_value_of(asset, amount).map(|usd| (asset, amount, usd))
+				})
+				.collect::<Result<Vec<_>, Error<T>>>()?;
 
 		let total_owed_usd = self.total_owed_usd_value(price_cache)?;
 
@@ -1961,8 +1952,9 @@ impl<T: Config> cf_traits::lending::LendingSystemApi for Pallet<T> {
 						},
 					);
 
-					let no_collateral_left =
-						is_zero_collateral(&loan_account.get_collateral_in_supply_pools());
+					let no_collateral_left = is_zero_collateral(
+						&get_collateral_in_supply_pools::<T>(&loan_account.borrower_id),
+					);
 
 					// If this swap is the last liquidation swap for the loan, we should
 					// "settle" it if it has been fully repaid:
@@ -2030,4 +2022,39 @@ impl<T: Config> Pallet<T> {
 
 pub fn is_zero_collateral(collateral: &BTreeMap<Asset, AssetAmount>) -> bool {
 	collateral.values().all(|amount| *amount == 0)
+}
+
+/// Returns the account's supply positions across all lending pools. Supply positions are
+/// treated as collateral, so they are reported for any account that has supplied funds,
+/// regardless of whether it has taken out a loan.
+pub fn get_collateral_in_supply_pools<T: Config>(
+	account_id: &T::AccountId,
+) -> BTreeMap<Asset, AssetAmount> {
+	GeneralLendingPools::<T>::iter()
+		.filter_map(|(asset, pool)| {
+			pool.get_supply_position_for_account(account_id)
+				.ok()
+				.map(|amount| (asset, amount))
+		})
+		.collect()
+}
+
+/// Returns the account's total collateral: its supply positions across all lending pools,
+/// plus any amounts currently locked in liquidation swaps. The latter only applies to
+/// accounts that have an active loan account.
+///
+/// Prefer the `LoanAccount::get_total_collateral` method when a `LoanAccount` is already in
+/// scope (especially inside `LoanAccounts` mutation closures, where the `LoanAccounts::get`
+/// below would return a stale liquidation status).
+pub fn get_total_collateral_for_account<T: Config>(
+	account_id: &T::AccountId,
+) -> BTreeMap<Asset, AssetAmount> {
+	let mut collateral = get_collateral_in_supply_pools::<T>(account_id);
+
+	// Liquidation swaps only exist for accounts that have a loan account:
+	if let Some(loan_account) = LoanAccounts::<T>::get(account_id) {
+		loan_account.add_collateral_in_liquidation_swaps(&mut collateral);
+	}
+
+	collateral
 }

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -229,6 +229,22 @@ fn create_loan_and_supply_collateral(
 }
 
 #[test]
+fn collateral_reported_for_supply_only_account() {
+	// `cf_account_info` reports collateral via `get_total_collateral_for_account`. An account
+	// that has supplied funds but never borrowed has no loan account, yet its supply positions
+	// must still be reported as collateral.
+	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).execute_with(|| {
+		// LENDER supplied funds via `with_funded_pool` but never took out a loan:
+		assert!(LoanAccounts::<Test>::get(LENDER).is_none());
+
+		assert_eq!(
+			get_total_collateral_for_account::<Test>(&LENDER),
+			BTreeMap::from([(LOAN_ASSET, INIT_POOL_AMOUNT)]),
+		);
+	});
+}
+
+#[test]
 fn lender_basic_adding_and_removing_funds() {
 	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT).execute_with(|| {
 		// Test that it is possible to withdraw funds if you are the sole contributor
@@ -1315,7 +1331,7 @@ fn basic_liquidation() {
 			// Only the collateral required to repay the loan (plus the slippage buffer) is
 			// removed from the supply pool — the rest stays available to other lenders.
 			assert_eq!(
-				loan_account.get_collateral_in_supply_pools(),
+				get_collateral_in_supply_pools::<Test>(&loan_account.borrower_id),
 				BTreeMap::from([(COLLATERAL_ASSET, pool_remainder_after_init)])
 			);
 
@@ -2491,7 +2507,7 @@ mod multi_asset_collateral_liquidation {
 				// buffer, drawn from each collateral asset proportionally to its share of the
 				// available USD value. The remainder stays in the supply pools.
 				assert_eq!(
-					get_loan_account().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([
 						(COLLATERAL_ASSET, collateral_leftover_at_init),
 						(COLLATERAL_ASSET_2, collateral_2_leftover_at_init),
@@ -2540,7 +2556,7 @@ mod multi_asset_collateral_liquidation {
 					(PRINCIPAL + ORIGINATION_FEE + liquidation_fee_1 + liquidation_fee_2);
 
 				assert_eq!(
-					get_loan_account().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([
 						(LOAN_ASSET, excess_loan_asset_amount),
 						(COLLATERAL_ASSET, collateral_leftover_at_init),
@@ -2594,7 +2610,7 @@ mod multi_asset_collateral_liquidation {
 				);
 
 				assert_eq!(
-					get_loan_account().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([
 						(LOAN_ASSET, excess_loan_asset_amount),
 						(COLLATERAL_ASSET, REMAINING_INPUT_SWAP_2 + collateral_leftover_at_init),
@@ -2656,7 +2672,9 @@ mod multi_asset_collateral_liquidation {
 			.then_execute_at_next_block(|_| {
 				// All collateral has been pulled into liquidation swaps (take_all path):
 				let acc = get_loan_account();
-				assert!(general_lending::is_zero_collateral(&acc.get_collateral_in_supply_pools()));
+				assert!(general_lending::is_zero_collateral(
+					&get_collateral_in_supply_pools::<Test>(&acc.borrower_id)
+				));
 				match &acc.liquidation_status {
 					LiquidationStatus::Liquidating { liquidation_swaps, .. } => {
 						assert_eq!(liquidation_swaps.len(), 2);
@@ -2899,7 +2917,7 @@ fn small_interest_amounts_accumulate() {
 		.then_execute_with(|_| {
 			let account = LoanAccounts::<Test>::get(BORROWER).unwrap();
 			assert_eq!(
-				account.get_collateral_in_supply_pools(),
+				get_collateral_in_supply_pools::<Test>(&account.borrower_id),
 				BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
 			);
 
@@ -3516,7 +3534,7 @@ fn adding_collateral_during_liquidation() {
 			// We don't bother restarting liquidation swaps to incorporate the extra supply,
 			// instead the supply is simply added to the pool:
 			assert_eq!(
-				get_account().get_collateral_in_supply_pools(),
+				get_collateral_in_supply_pools::<Test>(&BORROWER),
 				BTreeMap::from([(COLLATERAL_ASSET, EXTRA_COLLATERAL)])
 			);
 
@@ -3614,7 +3632,7 @@ fn adding_collateral_during_liquidation() {
 
 			// The unused remainder stays in the supply pool:
 			assert_eq!(
-				get_account().get_collateral_in_supply_pools(),
+				get_collateral_in_supply_pools::<Test>(&BORROWER),
 				BTreeMap::from([(COLLATERAL_ASSET, pool_remainder_after_init)])
 			);
 
@@ -3665,7 +3683,7 @@ fn adding_collateral_during_liquidation() {
 
 			// Collateral returned to supply pools after liquidation abort:
 			assert_eq!(
-				get_account().get_collateral_in_supply_pools(),
+				get_collateral_in_supply_pools::<Test>(&BORROWER),
 				BTreeMap::from([(
 					COLLATERAL_ASSET,
 					INIT_COLLATERAL + EXTRA_COLLATERAL + EXTRA_COLLATERAL_2 + EXTRA_COLLATERAL_3 -
@@ -4128,7 +4146,7 @@ mod voluntary_liquidation {
 				);
 				// Part of collateral was returned to supply pool:
 				assert_eq!(
-					LoanAccounts::<Test>::get(BORROWER).unwrap().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL - SWAPPED_COLLATERAL)])
 				);
 
@@ -4263,7 +4281,7 @@ mod voluntary_liquidation {
 				let pool_leftover_after_soft_init =
 					INIT_COLLATERAL - SWAPPED_COLLATERAL_1 - liquidation_input_2;
 				assert_eq!(
-					get_account().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([(COLLATERAL_ASSET, pool_leftover_after_soft_init)])
 				);
 
@@ -4357,7 +4375,7 @@ mod voluntary_liquidation {
 					SWAPPED_COLLATERAL_2 -
 					liquidation_input_3;
 				assert_eq!(
-					get_account().get_collateral_in_supply_pools(),
+					get_collateral_in_supply_pools::<Test>(&BORROWER),
 					BTreeMap::from([(COLLATERAL_ASSET, pool_leftover_after_voluntary_reinit)])
 				);
 

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -25,6 +25,7 @@ mod utils;
 use cf_chains::SwapOrigin;
 use general_lending::LoanAccount;
 pub use general_lending::{
+	get_collateral_in_supply_pools, get_total_collateral_for_account,
 	rpc::{
 		get_all_loans, get_lending_pools, get_loan_accounts, LendingPoolAndSupplyPositions,
 		LendingSupplyPosition, RpcLendingPool, RpcLiquidationStatus, RpcLiquidationSwap, RpcLoan,

--- a/state-chain/runtime/Cargo.toml
+++ b/state-chain/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "state-chain-runtime"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Chainflip Team <https://github.com/chainflip-io>"]
 edition = "2021"
 homepage = "https://chainflip.io"

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_std::borrow::Cow::Borrowed("chainflip-node"),
 	impl_name: sp_std::borrow::Cow::Borrowed("chainflip-node"),
 	authoring_version: 1,
-	spec_version: 2_02_01,
+	spec_version: 2_02_02,
 	impl_version: 1,
 	apis: crate::runtime_apis::impl_api::RUNTIME_API_VERSIONS,
 	transaction_version: 13,

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -773,15 +773,17 @@ impl_runtime_apis! {
 
 			});
 
-			let lending_collateral_balances = pallet_cf_lending_pools::LoanAccounts::<Runtime>::get(&account_id).map(|loan_account| {
+			let lending_collateral_balances = {
 				let mut asset_map = AssetMap::<AssetAmount>::default();
 
-				for (asset, amount) in loan_account.get_total_collateral() {
+				for (asset, amount) in
+					pallet_cf_lending_pools::get_total_collateral_for_account::<Runtime>(&account_id)
+				{
 					asset_map[asset].saturating_accrue(amount);
 				}
 
 				asset_map
-			}).unwrap_or_default();
+			};
 
 
 			free_balances
@@ -1242,11 +1244,11 @@ impl_runtime_apis! {
 							})
 					})
 					.collect(),
-				collateral_balances: pallet_cf_lending_pools::LoanAccounts::<Runtime>::get(&account_id)
-					.map(|loan_account| {
-						loan_account.get_total_collateral().iter().map(|(asset, amount)| (*asset, *amount)).collect()
-					})
-					.unwrap_or_default(),
+				collateral_balances: pallet_cf_lending_pools::get_total_collateral_for_account::<
+					Runtime,
+				>(&account_id)
+				.into_iter()
+				.collect(),
 			}
 		}
 


### PR DESCRIPTION
# Pull Request

## Summary

Added a free function `get_total_collateral_for_account` similar to `get_total_collateral` but does not require a loan account to exist. It is now used in `cf_account_info` which now correctly includes supplied funds as collateral in accounts that don't have loans. (I kept `get_total_collateral` as it is still useful in cases where we have already loaded the account).