### PR TITLE
feat: non-usdc swapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9575,6 +9575,7 @@ dependencies = [
  "pallet-cf-account-roles",
  "pallet-cf-environment",
  "parity-scale-codec",
+ "proptest",
  "scale-info",
  "serde",
  "sp-arithmetic 28.0.0",
@@ -9582,6 +9583,8 @@ dependencies = [
  "sp-io 43.0.0",
  "sp-runtime 44.0.0",
  "sp-std 14.0.0 (git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-1)",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]

--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -655,7 +655,7 @@ fn failed_swaps_are_rolled_back() {
 			RuntimeEvent::Swapping(
 				pallet_cf_swapping::Event::BatchSwapFailed {
 					asset: Asset::Flip,
-					direction: cf_primitives::SwapLeg::FromStable,
+					direction: cf_primitives::LegacySwapLegDirection::FromStable,
 					..
 				},
 			) => ()
@@ -1135,7 +1135,10 @@ mod swap_simulation {
 			// Small rounding error
 			let expected_intermediate_amount =
 				AMOUNT - expected_network_fee - simulated_swap.ingress_fee.amount - 1;
-			assert_eq!(simulated_swap.intermediary, Some(expected_intermediate_amount));
+			assert_eq!(
+				simulated_swap.intermediates,
+				vec![AssetAndAmount::new(Asset::Usdc, expected_intermediate_amount)]
+			);
 
 			let expected_broker_fee = broker_fee_rate * (expected_intermediate_amount);
 			assert_eq!(simulated_swap.broker_fee.amount, expected_broker_fee);
@@ -1200,11 +1203,20 @@ mod swap_simulation {
 				let epsilon = a / 10_000;
 				a.abs_diff(b) <= epsilon
 			};
-			assert!(match (simulated_non_dca_swap.intermediary, simulated_dca_swap.intermediary) {
-				(Some(a), Some(b)) => check(a, b),
-				_ => false,
-			});
-			assert!(check(simulated_non_dca_swap.output, simulated_dca_swap.output),);
+			assert_eq!(simulated_non_dca_swap.intermediates.len(), 1);
+			assert_eq!(simulated_dca_swap.intermediates.len(), 1);
+			let non_dca_intermediate = simulated_non_dca_swap
+				.intermediates
+				.first()
+				.expect("Should have usdc as the intermediate");
+			let dca_intermediate = simulated_dca_swap
+				.intermediates
+				.first()
+				.expect("Should have usdc as the intermediate");
+			assert_eq!(non_dca_intermediate.asset, Asset::Usdc);
+			assert_eq!(dca_intermediate.asset, Asset::Usdc);
+			assert!(check(non_dca_intermediate.amount, dca_intermediate.amount));
+			assert!(check(simulated_non_dca_swap.output, simulated_dca_swap.output));
 		});
 	}
 
@@ -1264,8 +1276,8 @@ mod swap_simulation {
 				simulated_normal_swap.broker_fee.amount < simulated_internal_swap.broker_fee.amount
 			);
 			assert!(
-				simulated_normal_swap.intermediary.unwrap() <
-					simulated_internal_swap.intermediary.unwrap()
+				simulated_normal_swap.intermediates.first().unwrap().amount <
+					simulated_internal_swap.intermediates.first().unwrap().amount
 			);
 			assert!(simulated_normal_swap.output < simulated_internal_swap.output);
 		});
@@ -1313,7 +1325,8 @@ mod swap_simulation {
 			// swapping pallet applies to the oracle price.
 			assert!(simulated_swap.network_fee.amount >= MINIMUM_NETWORK_FEE_INPUT_ASSET);
 			assert!(
-				simulated_swap.intermediary.unwrap() < AMOUNT - MINIMUM_NETWORK_FEE_INPUT_ASSET
+				simulated_swap.intermediates.first().unwrap().amount <
+					AMOUNT - MINIMUM_NETWORK_FEE_INPUT_ASSET
 			);
 		});
 	}

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -589,7 +589,11 @@ pub struct RpcSwapOutputV2 {
 impl From<SimulatedSwapInformation> for RpcSwapOutputV2 {
 	fn from(simulated_swap_info: SimulatedSwapInformation) -> Self {
 		RpcSwapOutputV2 {
-			intermediary: simulated_swap_info.intermediary.map(Into::into),
+			// TODO JAMIE: Currently this only supports a single intermediary.
+			intermediary: simulated_swap_info
+				.intermediates
+				.first()
+				.map(|intermediate| intermediate.amount.into()),
 			output: simulated_swap_info.output.into(),
 			network_fee: simulated_swap_info.network_fee.into(),
 			ingress_fee: simulated_swap_info.ingress_fee.into(),

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -2292,7 +2292,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 									Asset::Flip,
 									flip_amount_to_credit,
 									false, // No network fee
-									false, // Not internal
 								);
 							let input_amount =
 								core::cmp::min(input_amount, amount_after_fees.into());

--- a/state-chain/pallets/cf-swapping/Cargo.toml
+++ b/state-chain/pallets/cf-swapping/Cargo.toml
@@ -38,6 +38,8 @@ sp-arithmetic = { workspace = true }
 sp-std = { workspace = true }
 sp-runtime = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [dev-dependencies]
 cf-test-utilities = { workspace = true, default-features = true }
@@ -48,6 +50,7 @@ sp-core = { workspace = true, default-features = true }
 itertools = { workspace = true }
 cf-traits = { workspace = true, features = ["mocks"] }
 cf-amm-math = { workspace = true, features = ["test"] }
+proptest = { workspace = true }
 
 [features]
 default = ["std"]
@@ -70,6 +73,7 @@ std = [
 	"cf-runtime-utilities/std",
 	"itertools/use_std",
 	"pallet-cf-environment/std",
+	"strum/std",
 ]
 runtime-benchmarks = [
 	"cf-chains/runtime-benchmarks",

--- a/state-chain/pallets/cf-swapping/src/execution.rs
+++ b/state-chain/pallets/cf-swapping/src/execution.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::{
-	swap_state::{AfterBrokerFee4, AfterFirstLeg2, AfterNetworkFee1, AfterSecondLeg3, SwapState},
+	swap_state::{AfterBrokerFee4, AfterNetworkFee1, AfterSwapLegs3, SwapLegs2, SwapState},
 	utilities::split_off_highest_impact_swap,
 };
 use cf_chains::{AccountOrAddress, CcmDepositMetadataChecked};
@@ -25,7 +25,7 @@ use cf_primitives::{
 };
 use cf_traits::{
 	lending::LendingSystemApi, AssetConverter, EgressApi, ExpiryBehaviour, FundAccount,
-	FundingSource, PoolPriceProvider, ScheduledEgressDetails, SwapExecutionProgress,
+	FundingSource, PoolPriceProvider, PriceFeedApi, ScheduledEgressDetails, SwapExecutionProgress,
 	SwapRequestType,
 };
 use frame_support::{storage::with_transaction_unchecked, transactional};
@@ -35,143 +35,130 @@ use sp_runtime::{
 };
 use sp_std::{cmp::max, collections::btree_set::BTreeSet};
 
+use strum::IntoEnumIterator;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct SwapLeg {
+	pub from: Asset,
+	pub to: Asset,
+}
+
+pub enum SwapLegOutcome<T: Config> {
+	Complete(SwapState<T, AfterSwapLegs3>),
+	Continuing(SwapState<T, SwapLegs2>),
+}
+
+/// We split the grouping logic into 4 execution phases.
+/// 1) Non-usdc native swaps (e.g. Wbtc<->Btc)
+/// 2) Swaps to USDC
+/// 3) Swaps from USDC
+/// 4) Any remaining native swaps
+///
+/// This prioritizes grouping of USDC swaps while ensuring that all assets are swapped within
+/// 4 legs.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, strum_macros::EnumIter)]
+pub enum GroupExecutionPhase {
+	InitialNativePools,
+	ToUSDC,
+	FromUSDC,
+	FinalNativePools,
+}
+
+pub(crate) struct BatchSwapFailed<T: Config> {
+	swaps: Vec<SwapState<T, SwapLegs2>>,
+	amount: AssetAmount,
+}
+
 impl<T: Config> Pallet<T> {
-	pub fn get_scheduled_swap_legs(base_asset: Asset) -> Vec<(SwapLegInfo, BlockNumberFor<T>)> {
+	/// Returns all scheduled swap legs for the given base/quote pair, along with the block number
+	/// they are scheduled to execute at.
+	/// If safe mode is enabled, nothing will be returned since all swaps will be rescheduled.
+	pub fn get_scheduled_swap_legs(
+		base_asset: Asset,
+		quote_asset: Asset,
+	) -> Vec<(SwapLegInfo, BlockNumberFor<T>)> {
 		if !T::SafeMode::get().swaps_enabled {
 			return vec![];
 		}
 
-		// Get all of the swaps that are scheduled to swap from or to the given asset.
-		let swaps: BTreeMap<_, _> = ScheduledSwaps::<T>::get()
-			.into_iter()
-			.filter_map(|(swap_id, swap)| {
-				if swap.from == base_asset || swap.to == base_asset {
-					// We ignore price protection for the simulation
-					Some((swap_id, swap.clone().without_price_protection()))
-				} else {
-					None
-				}
-			})
-			.collect();
-
-		// Run the normal swap execution logic on these swaps to get the amounts and
-		// intermediate swap outcomes.
-		let BatchExecutionOutcomes { successful_swaps, failed_swaps } =
-			Self::execute_batch(swaps.clone());
-
-		// For all failed swaps, we can use price pool fallback to estimate the amounts
-		let failed_swaps: Vec<SwapState<T, AfterFirstLeg2>> = if !failed_swaps.is_empty() {
-			let swaps = failed_swaps.into_iter().map(|(swap, _)| SwapState::new(swap)).collect();
-
-			// Manually execute the fist step of the swap logic to get the input amount
-			// after fees
-			Self::take_network_fees(swaps)
-				.into_iter()
-				.filter_map(|state| {
-					let intermediate_amount = if state.input_asset() == STABLE_ASSET ||
-						state.output_asset() == STABLE_ASSET
-					{
-						// Single leg swap, so no intermediate amount.
-						None
-					} else {
-						// Pool price fallback. If pool does not exist, the swap will be
-						// filtered out.
-						let sell_price =
-							T::PoolPriceApi::pool_price(state.input_asset(), STABLE_ASSET)
-								.ok()
-								.map(|price| price.sell)?;
-
-						Some(
-							sell_price
-								.output_amount_ceil(state.stage.input_amount_after_fees)
-								.saturated_into(),
-						)
-					};
-
-					Some(
-						state.with_intermediate(
-							intermediate_amount
-								.map(|amount| AssetAndAmount { asset: STABLE_ASSET, amount }),
-						),
-					)
-				})
-				.collect()
-		} else {
-			// No failed swaps
-			vec![]
-		};
-
-		successful_swaps
-			.into_iter()
-			.map(|swap_result| {
-				// We only need the swaps at the stage after the first leg is complete. So we
-				// strip away the unused part of the state for the fully executed swaps.
-				let swap_id = swap_result.swap_id;
-				swap_result.into_stage_2(swaps.get(&swap_id).unwrap().clone())
-			})
-			.chain(failed_swaps)
-			.filter_map(|state| {
-				let swap_request = SwapRequests::<T>::get(state.swap_request_id())
+		ScheduledSwaps::<T>::get()
+			.into_values()
+			.flat_map(|swap| {
+				let swap_request = SwapRequests::<T>::get(swap.swap_request_id)
 					.expect("Swap request should exist");
-				let (remaining_chunks, chunk_interval) = match swap_request.state {
+
+				// Determine the network fee for this swap and deduct it from the input amount.
+				let network_fee = Self::get_network_fee_for_swap(
+					swap.from,
+					swap.to,
+					NetworkFeeType::from_swap_request_state(&swap_request.state),
+				);
+				let fee = max(network_fee.rate * swap.input_amount, network_fee.minimum);
+				let input_amount_after_fees =
+					swap.input_amount.saturating_sub(core::cmp::min(fee, swap.input_amount));
+
+				// Get the DCA details from the swap request
+				let (remaining_chunks, chunk_interval) = match &swap_request.state {
 					SwapRequestState::UserSwap { dca_state, .. } =>
 						(dca_state.remaining_chunks, dca_state.chunk_interval),
 					_ => (0, SWAP_DELAY_BLOCKS),
 				};
 
-				if state.input_asset() != STABLE_ASSET && state.input_asset() == base_asset {
-					Some((
-						SwapLegInfo {
-							swap_id: state.swap_id(),
-							swap_request_id: state.swap_request_id(),
-							base_asset,
-							// All swaps from `base_asset` have to go through the stable asset:
-							quote_asset: STABLE_ASSET,
-							side: Side::Sell,
-							amount: state.stage.input_amount_after_fees,
-							source_asset: None,
-							source_amount: None,
-							remaining_chunks,
-							chunk_interval,
-						},
-						state.execute_at(),
-					))
-				} else if state.output_asset() != STABLE_ASSET && state.output_asset() == base_asset
-				{
-					// In case the swap is "simulated", the amount is just an estimate,
-					// so we additionally include `source_asset` and `source_amount`:
-					let (source_asset, source_amount) = if state.input_asset() != STABLE_ASSET {
-						(Some(state.input_asset()), Some(state.stage.input_amount_after_fees))
-					} else {
-						(None, None)
-					};
+				// Check the swap route for any legs we care about
+				Self::get_swap_route(swap.from, swap.to)
+					.into_iter()
+					.filter_map(|leg| {
+						// Filter for just the base/quote pair that we are interested in
+						if (leg.from == base_asset && leg.to == quote_asset) ||
+							(leg.from == quote_asset && leg.to == base_asset)
+						{
+							return None;
+						}
 
-					Some((
-						SwapLegInfo {
-							swap_id: state.swap_id(),
-							swap_request_id: state.swap_request_id(),
-							base_asset,
-							// All swaps to `base_asset` have to go through the stable asset:
-							quote_asset: STABLE_ASSET,
-							side: Side::Buy,
-							// If the intermediate is None, then it means the swap input was
-							// already in the stable asset.
-							amount: state
-								.stage
-								.intermediate
-								.as_ref()
-								.map(|intermediate| intermediate.amount)
-								.unwrap_or(state.input_amount_before_fees()),
-							source_asset,
-							source_amount,
-							remaining_chunks,
-							chunk_interval,
-						},
-						state.execute_at(),
-					))
-				} else {
-					None
-				}
+						// Get the input amount for this leg
+						let (leg_input_amount, source_asset, source_amount) =
+							if leg.from == swap.from {
+								// Must be the first leg, so no need to estimate
+								(input_amount_after_fees, None, None)
+							} else {
+								// For all other legs, estimate using oracle price with pool price
+								// fallback
+								let conversion_price =
+									T::PriceFeedApi::get_relative_price(swap.from, leg.from)
+										.map(|oracle| oracle.price)
+										.or_else(|| {
+											T::PoolPriceApi::pool_price(swap.from, leg.from)
+												.ok()
+												.map(|p| p.sell)
+										})?;
+								let amount = conversion_price
+									.output_amount_ceil(input_amount_after_fees)
+									.unique_saturated_into();
+								(amount, Some(swap.from), Some(swap.input_amount))
+							};
+
+						let side = if leg.from == base_asset { Side::Sell } else { Side::Buy };
+
+						Some((
+							SwapLegInfo {
+								swap_id: swap.swap_id,
+								swap_request_id: swap.swap_request_id,
+								base_asset,
+								quote_asset,
+								side,
+								amount: leg_input_amount,
+								source_asset,
+								source_amount,
+								remaining_chunks,
+								chunk_interval,
+							},
+							swap.execute_at,
+						))
+					})
+					.collect::<Vec<_>>()
 			})
 			.collect()
 	}
@@ -196,7 +183,7 @@ impl<T: Config> Pallet<T> {
 									Pallet::<T>::get_network_fee_rate_for_swap(
 										state.input_asset(),
 										state.output_asset(),
-										false, // is_internal_swap
+										NetworkFeeType::NoMinimum,
 									),
 								)),
 							SwapRequestState::NetworkFee => None,
@@ -228,7 +215,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn take_broker_fees(
-		swaps: Vec<SwapState<T, AfterSecondLeg3>>,
+		swaps: Vec<SwapState<T, AfterSwapLegs3>>,
 	) -> Vec<SwapState<T, AfterBrokerFee4>> {
 		// Take the broker fee from the output amount
 		swaps
@@ -310,6 +297,8 @@ impl<T: Config> Pallet<T> {
 
 	/// Enforce price protections (minimum price and oracle price) and return the price delta from
 	/// oracle (excluding fees) if available.
+	/// A stale price on any leg of the swap will only cause a failure if the swap has refund
+	/// params.
 	pub(crate) fn check_swap_price_violation(
 		swap: &SwapState<T, AfterBrokerFee4>,
 	) -> Result<Option<SignedBasisPoints>, SwapFailureReason> {
@@ -325,39 +314,36 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		// Calculate the slippage from oracle prices for both legs of the swap (without being
-		// affected by fees).
-		let (first_leg_delta, second_leg_delta) = if let Some(intermediate) =
-			&swap.stage.intermediate
-		{
-			(
-				Self::get_delta_from_oracle_price(
-					AssetAndAmount::new(swap.input_asset(), swap.stage.input_amount_after_fees),
-					*intermediate,
-				)?,
-				Self::get_delta_from_oracle_price(
-					*intermediate,
-					AssetAndAmount::new(swap.output_asset(), swap.stage.output_amount_before_fees),
-				)?,
-			)
-		} else {
-			// No intermediate asset, so must be a single leg swap.
-			(
-				Self::get_delta_from_oracle_price(
-					AssetAndAmount::new(swap.input_asset(), swap.stage.input_amount_after_fees),
-					AssetAndAmount::new(swap.output_asset(), swap.stage.output_amount_before_fees),
-				)?,
-				None,
-			)
-		};
+		// Calculate the slippage from oracle prices for each leg of the swap (without being
+		// affected by fees), then sum the deltas. Legs without an oracle price contribute
+		// nothing rather. This way we can partially enforce oracle price protection.
+		let route_amd_amounts = sp_std::iter::once(AssetAndAmount::new(
+			swap.input_asset(),
+			swap.stage.input_amount_after_fees,
+		))
+		.chain(swap.stage.intermediates.iter().copied())
+		.chain(sp_std::iter::once(AssetAndAmount::new(
+			swap.output_asset(),
+			swap.stage.output_amount_before_fees,
+		)))
+		.collect::<Vec<_>>();
 
-		// Sum the deltas or just use a single leg delta if the other leg doesn't have
-		// an oracle price.
-		let total_delta = match (first_leg_delta, second_leg_delta) {
-			(Some(first_leg), Some(second_leg)) => Some(first_leg.saturating_add(&second_leg)),
-			(Some(delta), None) | (None, Some(delta)) => Some(delta),
-			_ => None,
-		};
+		let mut total_delta: Option<SignedHundredthBasisPoints> = None;
+		for leg in route_amd_amounts.windows(2) {
+			let leg_delta = match Self::get_delta_from_oracle_price(leg[0], leg[1]) {
+				// A stale oracle price only fails the check when the swap has refund params. This
+				// way the swap simulation can still run with stale prices.
+				Err(SwapFailureReason::OraclePriceStale) if swap.refund_params().is_none() =>
+					return Ok(None),
+				other => other?,
+			};
+			if let Some(leg_delta) = leg_delta {
+				total_delta = Some(match total_delta {
+					Some(acc) => acc.saturating_add(&leg_delta),
+					None => leg_delta,
+				});
+			}
+		}
 
 		if let Some(total_delta) = total_delta {
 			// Oracle price protection, aka Live price protection (LPP)
@@ -386,10 +372,8 @@ impl<T: Config> Pallet<T> {
 		let swap_states: Vec<_> = swaps.values().cloned().map(SwapState::new).collect();
 		// Take the network fee
 		let swap_states = Self::take_network_fees(swap_states);
-		// Run the first leg of the swaps
-		let swap_states = Self::do_group_and_swap(swap_states)?;
-		// Run the second leg of the swaps
-		let swap_states = Self::do_group_and_swap(swap_states)?;
+		// Run the actual swaps
+		let swap_states = Self::execute_all_swap_legs(swap_states)?;
 		// Take the broker fees
 		let swap_states = Self::take_broker_fees(swap_states);
 
@@ -507,9 +491,9 @@ impl<T: Config> Pallet<T> {
 					Self::deposit_event(Event::<T>::BatchSwapFailed {
 						asset: if from_asset == STABLE_ASSET { to_asset } else { from_asset },
 						direction: if from_asset == STABLE_ASSET {
-							SwapLeg::FromStable
+							LegacySwapLegDirection::FromStable
 						} else {
-							SwapLeg::ToStable
+							LegacySwapLegDirection::ToStable
 						},
 						amount,
 					});
@@ -585,7 +569,9 @@ impl<T: Config> Pallet<T> {
 					..
 				}) = price_limits_and_expiry.as_ref().map(|p| &p.expiry_behaviour)
 				else {
-					log_or_panic!("Trying to refund swap request {swap_request_id}, but missing refund parameters");
+					log_or_panic!(
+						"Trying to refund swap request {swap_request_id}, but missing refund parameters"
+					);
 					return;
 				};
 
@@ -737,7 +723,7 @@ impl<T: Config> Pallet<T> {
 			network_fee: AssetAndAmount::new(swap.input_asset, swap.network_fee_taken),
 			broker_fee: AssetAndAmount::new(swap.output_asset, swap.broker_fee_taken),
 			output: AssetAndAmount::new(swap.output_asset, swap.output_amount_after_fees),
-			intermediate: swap.intermediate,
+			intermediates: swap.intermediates,
 			oracle_delta: swap.oracle_delta,
 			oracle_delta_ex_fees: swap.oracle_delta_ex_fees,
 		});
@@ -843,7 +829,9 @@ impl<T: Config> Pallet<T> {
 										});
 									}
 								} else {
-									log_or_panic!("Encountered transfer to gateway swap for asset that isn't Flip: {swap_request_id:?}");
+									log_or_panic!(
+										"Encountered transfer to gateway swap for asset that isn't Flip: {swap_request_id:?}"
+									);
 								},
 						}
 
@@ -910,49 +898,177 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	// Groups the swaps that are swapping from->to the same assets and does a large single swap
-	// for each group. Then splits the output among the individual swaps. Processed and
-	// unprocessed swaps are returned.
-	pub(crate) fn do_group_and_swap<CurrentState: GroupSwapState<T> + Debug>(
-		swaps: Vec<CurrentState>,
-	) -> Result<Vec<CurrentState::OutputState>, BatchExecutionError<T>> {
-		let mut outcome_swaps = Vec::new();
-		let mut swap_groups = BTreeMap::<SwapGroupPair, Vec<CurrentState>>::new();
+	fn advance_swap_with_leg_output(
+		swap_state: SwapState<T, SwapLegs2>,
+		swap_leg_output: AssetAndAmount,
+	) -> SwapLegOutcome<T> {
+		if swap_leg_output.asset == swap_state.output_asset() {
+			// This was the final leg, so the swap is complete
+			SwapLegOutcome::Complete(swap_state.finished_swap_legs(swap_leg_output))
+		} else {
+			// This was an intermediate leg, so the swap is continuing
+			SwapLegOutcome::Continuing(swap_state.advance_swap_leg(swap_leg_output))
+		}
+	}
 
-		// First split the swaps into groups for this leg
-		for swap in swaps {
-			if let Some(swap_group_pair) = swap.swap_group() {
-				swap_groups.entry(swap_group_pair).or_default().push(swap);
+	/// Determines the route a swap will take. Returning a vector of all the swap legs.
+	pub(crate) fn get_swap_route(input_asset: Asset, output_asset: Asset) -> Vec<SwapLeg> {
+		let mut route = Vec::new();
+		let mut current_asset = input_asset;
+
+		for _ in GroupExecutionPhase::iter() {
+			if let Some(next_leg) = Self::get_next_swap_leg(current_asset, output_asset) {
+				current_asset = next_leg.to;
+				route.push(next_leg);
 			} else {
-				// If the swap doesn't need to be swapped because its already in the correct
-				// asset, then we can just update the swap state and leave it be.
-				outcome_swaps.push(swap.advance_no_swap());
+				break;
 			}
 		}
 
-		for (swap_group_pair, swaps) in swap_groups {
-			outcome_swaps.extend(
-				Self::execute_group_of_swaps(swaps, swap_group_pair.clone()).map_err(
-					|(failed_swaps, amount)| BatchExecutionError::SwapLegFailed {
-						from_asset: swap_group_pair.from,
-						to_asset: swap_group_pair.to,
-						amount,
-						failed_swap_group: failed_swaps
-							.into_iter()
-							.map(|swap| swap.failed_swap())
-							.collect::<Vec<FailedSwapState<T>>>(),
-					},
-				)?,
-			);
-		}
-		Ok(outcome_swaps)
+		route
 	}
 
-	/// Bundle the given swaps and do a single swap of a given direction
-	pub(crate) fn execute_group_of_swaps<CurrentState: GroupSwapState<T> + Debug>(
-		swaps: Vec<CurrentState>,
-		swap_group_pair: SwapGroupPair,
-	) -> Result<Vec<CurrentState::OutputState>, (Vec<CurrentState>, AssetAmount)> {
+	// Routing logic. Determines the next swap leg needed to get from the input asset to the output
+	// asset,
+	pub fn get_next_swap_leg(input_asset: Asset, output_asset: Asset) -> Option<SwapLeg> {
+		match (input_asset, output_asset) {
+			// No swap needed if the assets are the same
+			(input, output) if input == output => None,
+			// Use the non-usdc native swap pools first
+			(Asset::Btc, Asset::Wbtc) | (Asset::Wbtc, Asset::Btc) if ENABLE_WBTC_BTC_ROUTE =>
+				Some(SwapLeg { from: input_asset, to: output_asset }),
+			// If either asset is the stable asset, we can swap directly between them
+			(Asset::Usdc, _) | (_, Asset::Usdc) =>
+				Some(SwapLeg { from: input_asset, to: output_asset }),
+			// If none of the above conditions are met, then we must swap through the stable asset
+			// as an intermediate.
+			_ => Some(SwapLeg { from: input_asset, to: Asset::Usdc }),
+		}
+	}
+
+	// Grouping logic. Returns true if the swap leg should be executed in
+	// this iteration or false if it should be delayed to a later iteration.
+	pub fn should_group_leg_execute(
+		from_asset: Asset,
+		to_asset: Asset,
+		phase: GroupExecutionPhase,
+	) -> bool {
+		match (phase, from_asset, to_asset) {
+			// First we swap the Wbtc/Btc native swaps
+			(GroupExecutionPhase::InitialNativePools, from, to)
+				if (to == Asset::Wbtc && from == Asset::Btc) ||
+					(to == Asset::Btc && from == Asset::Wbtc) =>
+				true,
+			// Next we swap to USDC
+			(GroupExecutionPhase::ToUSDC, _, Asset::Usdc) => true,
+			// Then we swap from USDC
+			(GroupExecutionPhase::FromUSDC, Asset::Usdc, _) => true,
+			// Finally we swap any remaining Wbtc/Btc native swaps
+			(GroupExecutionPhase::FinalNativePools, from, to)
+				if (to == Asset::Wbtc && from == Asset::Btc) ||
+					(to == Asset::Btc && from == Asset::Wbtc) =>
+				true,
+			// Delay the swaps until a later leg
+			_ => false,
+		}
+	}
+
+	/// Runs all 4 possible swap legs of all swaps with grouping logic
+	pub(crate) fn execute_all_swap_legs(
+		swaps: Vec<SwapState<T, AfterNetworkFee1>>,
+	) -> Result<Vec<SwapState<T, AfterSwapLegs3>>, BatchExecutionError<T>> {
+		let mut completed_swaps = Vec::new();
+		let mut continuing_swaps = Vec::new();
+
+		// Skip execution for swaps that are already in the final asset and prepare the rest for
+		// execution
+		for swap_state in swaps {
+			if swap_state.input_asset() == swap_state.output_asset() {
+				completed_swaps.push(swap_state.proceed_without_execution());
+			} else {
+				continuing_swaps.push(swap_state.prepare_for_execution());
+			}
+		}
+
+		// Run all 4 phases of swap leg execution
+		for phase in GroupExecutionPhase::iter() {
+			let mut leg_outcomes = Vec::new();
+			let mut all_swap_leg_groups = BTreeMap::<SwapLeg, Vec<SwapState<T, SwapLegs2>>>::new();
+
+			// First split the swaps into groups based on what the next swap leg for each swap is
+			for swap_state in continuing_swaps.drain(..) {
+				if let Some(swap_group_pair) =
+					Self::get_next_swap_leg(swap_state.swap_asset(), swap_state.output_asset())
+				{
+					all_swap_leg_groups.entry(swap_group_pair).or_default().push(swap_state);
+				} else {
+					// If the swap doesn't need to be swapped because it is already in the
+					// final asset, just advance with no swap output.
+					leg_outcomes.push(SwapLegOutcome::Continuing(swap_state));
+				}
+			}
+
+			// Use the grouping logic to determine which swap legs should be executed in this
+			let groups_to_execute: BTreeMap<SwapLeg, Vec<SwapState<T, SwapLegs2>>> =
+				all_swap_leg_groups
+					.into_iter()
+					.filter_map(|(swap_leg, swaps)| {
+						if !Self::should_group_leg_execute(swap_leg.from, swap_leg.to, phase) {
+							// If we're not executing this group yet, just advance the swaps with no
+							// output
+							swaps.into_iter().for_each(|swap_state| {
+								leg_outcomes.push(SwapLegOutcome::Continuing(swap_state));
+							});
+							None
+						} else {
+							Some((swap_leg, swaps))
+						}
+					})
+					.collect();
+
+			// Execute just the groups that we determined should be executed in this leg
+			for (swap_leg, swaps) in groups_to_execute {
+				leg_outcomes.extend(
+					Self::execute_group_of_swaps(swaps, swap_leg.clone()).map_err(
+						|BatchSwapFailed { swaps: failed_swaps, amount }| {
+							BatchExecutionError::SwapLegFailed {
+								from_asset: swap_leg.from,
+								to_asset: swap_leg.to,
+								amount,
+								failed_swap_group: failed_swaps
+									.into_iter()
+									.map(|swap| swap.failed_swap())
+									.collect(),
+							}
+						},
+					)?,
+				);
+			}
+
+			// We have now processed all swaps, split off the completed ones and continue to the
+			// next leg
+			debug_assert!(
+				continuing_swaps.is_empty(),
+				"All continuing swaps should have been processed into leg_outcomes"
+			);
+			leg_outcomes.into_iter().for_each(|outcome| match outcome {
+				SwapLegOutcome::Complete(swap_state) => completed_swaps.push(swap_state),
+				SwapLegOutcome::Continuing(swap_state) => continuing_swaps.push(swap_state),
+			});
+		}
+
+		debug_assert!(
+			continuing_swaps.is_empty(),
+			"All swaps should have been completed after 4 legs of swapping"
+		);
+		Ok(completed_swaps)
+	}
+
+	/// Bundle the given swaps and do a single swap of a given swap group pair.
+	pub(crate) fn execute_group_of_swaps(
+		swaps: Vec<SwapState<T, SwapLegs2>>,
+		swap_group_pair: SwapLeg,
+	) -> Result<Vec<SwapLegOutcome<T>>, BatchSwapFailed<T>> {
 		debug_assert!(
 			!swaps.is_empty(),
 			"The implementation of grouped_swaps ensures that the swap groups are non-empty."
@@ -971,10 +1087,9 @@ impl<T: Config> Pallet<T> {
 				.into_iter()
 				.enumerate()
 				.map(|(index, swap)| {
-					if index == number_of_swaps - 1 {
+					let swap_output = if index == number_of_swaps - 1 {
 						// Give the dust to the last swap to ensure all output is assigned
-						let swap_output = bundle_output.saturating_sub(total_assigned_output);
-						swap.advance_with_swap_result(swap_output)
+						bundle_output.saturating_sub(total_assigned_output)
 					} else {
 						let swap_output = if bundle_input > 0 {
 							multiply_by_rational_with_rounding(
@@ -991,12 +1106,16 @@ impl<T: Config> Pallet<T> {
 						};
 
 						total_assigned_output.saturating_accrue(swap_output);
-						swap.advance_with_swap_result(swap_output)
-					}
+						swap_output
+					};
+					Self::advance_swap_with_leg_output(
+						swap,
+						AssetAndAmount::new(swap_group_pair.to, swap_output),
+					)
 				})
 				.collect())
 		} else {
-			Err((swaps, bundle_input))
+			Err(BatchSwapFailed { swaps, amount: bundle_input })
 		}
 	}
 
@@ -1202,36 +1321,50 @@ impl<T: Config> Pallet<T> {
 
 	/// Returns the configured default oracle price slippage protection for a single pool leg.
 	/// Returns `None` if the asset has no oracle price feed or no valid pool pair.
-	pub fn default_oracle_lpp_for_asset(asset: Asset) -> Option<BasisPoints> {
-		T::PriceFeedApi::get_price(asset)?;
-		Some(DefaultOraclePriceSlippageProtection::<T>::get(AssetPair::new(asset, STABLE_ASSET)?))
+	pub fn default_oracle_lpp_for_asset(leg: SwapLeg) -> Option<BasisPoints> {
+		match (leg.from, leg.to) {
+			(Asset::Btc, Asset::Wbtc) | (Asset::Wbtc, Asset::Btc) if ENABLE_WBTC_BTC_ROUTE =>
+				Some(DefaultOraclePriceSlippageProtection::<T>::get(AssetPair::new(
+					Asset::Wbtc,
+					Asset::Btc,
+				)?)),
+			(Asset::Usdc, asset) | (asset, Asset::Usdc) => {
+				if T::PriceFeedApi::get_price(asset).is_none() {
+					return None;
+				}
+				Some(DefaultOraclePriceSlippageProtection::<T>::get(AssetPair::new(
+					asset,
+					Asset::Usdc,
+				)?))
+			},
+			_ => None,
+		}
 	}
 
-	/// Returns the default price protection to apply to a one or two-leg swap.
+	/// Returns the default price protection to apply to a swap request.
 	///
 	/// Returns `None` if no oracle price is available for any leg of the swap (no
-	/// meaningful protection can be applied). For two-leg swaps where only one leg
-	/// has an oracle, the other leg contributes zero to the total limit so that
-	/// the oracle-priced leg is still protected.
+	/// meaningful protection can be applied). For multi-leg swaps where only some legs
+	/// have an oracle, the other legs contribute zero to the total limit so that
+	/// the oracle-priced legs are still protected.
 	fn get_default_oracle_price_protection(
 		input_asset: Asset,
 		output_asset: Asset,
 	) -> Option<BasisPoints> {
-		match (input_asset, output_asset) {
-			// Swaps to/from the stable asset use a single pool, so only one
-			// leg's slippage applies.
-			(STABLE_ASSET, asset) | (asset, STABLE_ASSET) =>
-				Self::default_oracle_lpp_for_asset(asset),
-			// Non-stable swaps go through two pools. At least one leg must have
-			// oracle data for the default to be meaningful.
-			(input_asset, output_asset) => match (
-				Self::default_oracle_lpp_for_asset(input_asset),
-				Self::default_oracle_lpp_for_asset(output_asset),
-			) {
-				(Some(input_lpp), Some(output_lpp)) => Some(input_lpp.saturating_add(output_lpp)),
-				(Some(lpp), None) | (None, Some(lpp)) => Some(lpp),
-				(None, None) => None,
-			},
+		// TODO JAMIE: needs to be updated with changes to behaviour from PR #6586
+		let total_lpp =
+			Self::get_swap_route(input_asset, output_asset)
+				.into_iter()
+				.fold(0u16, |acc, leg| {
+					Self::default_oracle_lpp_for_asset(leg)
+						.map(|lpp| acc.saturating_add(lpp))
+						.unwrap_or(acc)
+				});
+
+		if total_lpp > 0 {
+			Some(total_lpp)
+		} else {
+			None
 		}
 	}
 
@@ -1240,22 +1373,36 @@ impl<T: Config> Pallet<T> {
 	fn get_network_fee(
 		input_asset: Asset,
 		output_asset: Asset,
-		is_internal_swap: bool,
+		fee_type: NetworkFeeType,
 	) -> FeeRateAndMinimum {
-		let (input_asset_fee, output_asset_fee, usdc_minimum) = if is_internal_swap {
-			let default_fee = InternalSwapNetworkFee::<T>::get();
-			(
-				InternalSwapNetworkFeeForAsset::<T>::get(input_asset).unwrap_or(default_fee.rate),
-				InternalSwapNetworkFeeForAsset::<T>::get(output_asset).unwrap_or(default_fee.rate),
-				default_fee.minimum,
-			)
-		} else {
-			let default_fee = NetworkFee::<T>::get();
-			(
-				NetworkFeeForAsset::<T>::get(input_asset).unwrap_or(default_fee.rate),
-				NetworkFeeForAsset::<T>::get(output_asset).unwrap_or(default_fee.rate),
-				default_fee.minimum,
-			)
+		let (input_asset_fee, output_asset_fee, usdc_minimum) = match fee_type {
+			NetworkFeeType::Internal => {
+				let default_fee = InternalSwapNetworkFee::<T>::get();
+				(
+					InternalSwapNetworkFeeForAsset::<T>::get(input_asset)
+						.unwrap_or(default_fee.rate),
+					InternalSwapNetworkFeeForAsset::<T>::get(output_asset)
+						.unwrap_or(default_fee.rate),
+					default_fee.minimum,
+				)
+			},
+			NetworkFeeType::Standard => {
+				let default_fee = NetworkFee::<T>::get();
+				(
+					NetworkFeeForAsset::<T>::get(input_asset).unwrap_or(default_fee.rate),
+					NetworkFeeForAsset::<T>::get(output_asset).unwrap_or(default_fee.rate),
+					default_fee.minimum,
+				)
+			},
+			NetworkFeeType::NoMinimum => {
+				let default_fee = NetworkFee::<T>::get();
+				(
+					NetworkFeeForAsset::<T>::get(input_asset).unwrap_or(default_fee.rate),
+					NetworkFeeForAsset::<T>::get(output_asset).unwrap_or(default_fee.rate),
+					0_u128,
+				)
+			},
+			NetworkFeeType::None => (Permill::zero(), Permill::zero(), 0_u128),
 		};
 
 		FeeRateAndMinimum { rate: input_asset_fee.max(output_asset_fee), minimum: usdc_minimum }
@@ -1264,30 +1411,28 @@ impl<T: Config> Pallet<T> {
 	fn get_network_fee_rate_for_swap(
 		input_asset: Asset,
 		output_asset: Asset,
-		is_internal_swap: bool,
+		fee_type: NetworkFeeType,
 	) -> Permill {
-		Self::get_network_fee(input_asset, output_asset, is_internal_swap).rate
+		Self::get_network_fee(input_asset, output_asset, fee_type).rate
 	}
 
 	/// Gets the network fee rate and minimum in the input asset terms.
 	pub fn get_network_fee_for_swap(
 		input_asset: Asset,
 		output_asset: Asset,
-		is_internal_swap: bool,
-		with_minimum: bool,
+		fee_type: NetworkFeeType,
 	) -> FeeRateAndMinimum {
 		// Find the correct fee values in USDC
 		let FeeRateAndMinimum { rate, minimum: usdc_minimum } =
-			Self::get_network_fee(input_asset, output_asset, is_internal_swap);
+			Self::get_network_fee(input_asset, output_asset, fee_type);
 
 		// Convert the minimum amount to the input asset
-		let minimum = if with_minimum {
+		let minimum = if fee_type.has_minimum() {
 			Pallet::<T>::calculate_input_for_desired_output_or_default_to_zero(
 				input_asset,
 				Asset::Usdc,
 				usdc_minimum,
 				false, // no network fee
-				false, // not internal
 			)
 		} else {
 			0
@@ -1459,22 +1604,6 @@ impl<T: Config> SwapRequestHandler for Pallet<T> {
 				let mut dca_state = DcaState::new(net_amount, dca_params.clone());
 				let chunk_input_amount = dca_state.calculate_next_chunk().unwrap_or_default();
 
-				// Choose correct network fee for the swap
-				let network_fee_rate_and_minimum =
-					if matches!(request_type, SwapRequestType::Regular { output_action: _ }) {
-						Pallet::<T>::get_network_fee_for_swap(
-							input_asset,
-							output_asset,
-							// TODO: see if we want to treat lending swaps as internal for
-							// the purposes of determining network fee?
-							matches!(output_action, SwapOutputAction::CreditOnChain { .. }),
-							true, // with minimum
-						)
-					} else {
-						// No network fee for RegularNoNetworkFee
-						FeeRateAndMinimum { rate: Permill::zero(), minimum: 0 }
-					};
-
 				let swap_id = Self::schedule_swap(
 					input_asset,
 					output_asset,
@@ -1521,7 +1650,11 @@ impl<T: Config> SwapRequestHandler for Pallet<T> {
 							price_limits_and_expiry: processed_price_limits_and_expiry,
 							dca_state,
 							network_fee_tracker: NetworkFeeTracker::new(
-								network_fee_rate_and_minimum,
+								Pallet::<T>::get_network_fee_for_swap(
+									input_asset,
+									output_asset,
+									NetworkFeeType::from_swap_request_type(&request_type),
+								),
 							),
 							broker_fees_tracker: BrokerFeesTracker::new(broker_fees),
 						},
@@ -1587,13 +1720,13 @@ impl<T: Config> SwapRequestHandler for Pallet<T> {
 	}
 }
 
+// TODO JAMIE: move to impls file?
 impl<T: Config> AssetConverter for Pallet<T> {
 	fn calculate_input_for_desired_output_or_default_to_zero(
 		input_asset: Asset,
 		output_asset: Asset,
 		desired_output_amount: AssetAmount,
 		with_network_fee: bool,
-		is_internal_swap: bool,
 	) -> AssetAmount {
 		// Approximate one sided slippage adjustments for oracle prices
 		const ORACLE_SLIPPAGE: BasisPoints = 40;
@@ -1603,13 +1736,13 @@ impl<T: Config> AssetConverter for Pallet<T> {
 			return 0;
 		}
 
-		let network_fee = if with_network_fee {
-			// Ignoring the minimum network fee because this function is only used for fees and
-			// gas (no minimum).
-			Pallet::<T>::get_network_fee_rate_for_swap(input_asset, output_asset, is_internal_swap)
-		} else {
-			Permill::zero()
-		};
+		// Ignoring the minimum network fee because this function is only used for fees and
+		// gas (no minimum).
+		let network_fee = Pallet::<T>::get_network_fee_rate_for_swap(
+			input_asset,
+			output_asset,
+			if with_network_fee { NetworkFeeType::NoMinimum } else { NetworkFeeType::None },
+		);
 
 		let required_input = if input_asset == output_asset {
 			desired_output_amount
@@ -1620,7 +1753,7 @@ impl<T: Config> AssetConverter for Pallet<T> {
 				if asset == Asset::Flip || asset == Asset::Dot {
 					let asset_price =
 						Self::estimate_usdc_price_using_simulated_swap_or_fallback(asset, side); // USDC / Asset
-					let usdc_price = T::PriceFeedApi::get_price(STABLE_ASSET) // USD / USDC
+					let usdc_price = T::PriceFeedApi::get_price(Asset::Usdc) // USD / USDC
 						// Ignore staleness because it will always be less stale
 						// than hard-coded prices.
 						.map(|price_data| price_data.price)
@@ -1631,7 +1764,7 @@ impl<T: Config> AssetConverter for Pallet<T> {
 					T::PriceFeedApi::get_price(asset)
 						.map(|price_data| {
 							// Apply a hard coded slippage in the correct direction
-							let slippage_bps = if asset == STABLE_ASSET {
+							let slippage_bps = if asset == Asset::Usdc {
 								0
 							} else if asset.is_usd_stablecoin() {
 								ORACLE_SLIPPAGE_STABLE

--- a/state-chain/pallets/cf-swapping/src/execution/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/execution/tests.rs
@@ -1,0 +1,62 @@
+
+use super::*;
+use crate::{
+	execution::{GroupExecutionPhase, SwapLeg},
+	mock::Test,
+};
+use proptest::prelude::*;
+use strum::IntoEnumIterator;
+
+fn any_asset() -> impl Strategy<Value = Asset> {
+	proptest::sample::select(Asset::iter().collect::<Vec<_>>())
+}
+
+/// Sanity check to ensure that we don't try to execute on pools that don't exist. This will
+/// need to be updated as we add pools.
+fn pool_exists_for_swap_leg(leg: SwapLeg) -> bool {
+	match (leg.from, leg.to) {
+		(Asset::Btc, Asset::Wbtc) | (Asset::Wbtc, Asset::Btc) if ENABLE_WBTC_BTC_ROUTE => true,
+		(Asset::Usdc, _) | (_, Asset::Usdc) => true,
+		_ => false,
+	}
+}
+
+proptest! {
+	#[test]
+	/// Test that for any given input and output asset, the routing and grouping logic will complete
+	/// the swap within the 4 execution phases using only available pools. This does not test the
+	/// actual swap execution logic, just the routing and grouping logic.
+	/// It also checks that the route returned by get_swap_route matches the legs that were actually
+	/// executed.
+	fn all_swap_routes_complete(
+		starting_asset in any_asset(),
+		final_asset in any_asset(),
+	) {
+		let mut input = starting_asset;
+		let mut executed_legs = Vec::new();
+		for phase in GroupExecutionPhase::iter() {
+			if let Some(leg) = Pallet::<Test>::get_next_swap_leg(input, final_asset) {
+				prop_assert!(
+					pool_exists_for_swap_leg(leg.clone()),
+					"Routing logic produced a swap leg for an invalid pool: {:?} -> {:?}",
+					leg.from,
+					leg.to,
+				);
+				if Pallet::<Test>::should_group_leg_execute(leg.from, leg.to, phase) {
+					input = leg.to;
+					executed_legs.push(leg);
+				}
+			}
+		}
+		prop_assert_eq!(
+			input, final_asset,
+			"Swap from {:?} to {:?} did not reach the final asset",
+			starting_asset,
+			final_asset,
+		);
+
+		// get_swap_route should agree with the legs produced by phase execution.
+		let route = Pallet::<Test>::get_swap_route(starting_asset, final_asset);
+		prop_assert_eq!(route, executed_legs);
+	}
+}

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -27,16 +27,18 @@ use cf_chains::{
 };
 use cf_primitives::{
 	basis_points::SignedBasisPoints, AffiliateShortId, Affiliates, Asset, AssetAmount, BasisPoints,
-	Beneficiaries, Beneficiary, BlockNumber, ChannelId, ForeignChain, SwapId, SwapLeg,
-	SwapRequestId, FLIPPERINOS_PER_FLIP, SECONDS_PER_BLOCK, SWAP_DELAY_BLOCKS,
+	Beneficiaries, Beneficiary, BlockNumber, ChannelId, ForeignChain, LegacySwapLegDirection,
+	SwapId, SwapRequestId, FLIPPERINOS_PER_FLIP, SECONDS_PER_BLOCK, SWAP_DELAY_BLOCKS,
 };
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AffiliateRegistry, BalanceApi, Bonding, ChainflipNetworkInfo,
 	ChannelIdAllocator, DepositApi, DeregistrationCheck, FundingInfo, GetMinimumFunding,
 	IngressEgressFeeApi, PriceFeedApi, PriceLimitsAndExpiry, SwapOutputAction,
-	SwapParameterValidation, SwapRequestHandler, SwapRequestTypeEncoded, SwapType, SwappingApi,
+	SwapParameterValidation, SwapRequestHandler, SwapRequestType, SwapRequestTypeEncoded, SwapType,
+	SwappingApi,
 };
+pub use execution::SwapLeg;
 use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::{
@@ -75,7 +77,6 @@ pub mod migrations;
 pub mod weights;
 pub use dca_state::DcaState;
 pub use fees::{BrokerFeesTracker, FeeRateAndMinimum, NetworkFeeTracker};
-pub(crate) use swap_state::{GroupSwapState, SwapGroupPair};
 pub use weights::WeightInfo;
 
 use crate::swap_state::SuccessfulSwap;
@@ -85,6 +86,8 @@ pub(crate) type AssetAndAmount = cf_primitives::AssetAndAmount<AssetAmount>;
 
 pub const STORAGE_VERSION_U16: u16 = 18;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
+
+pub const ENABLE_WBTC_BTC_ROUTE: bool = true;
 
 pub(crate) const DEFAULT_SWAP_RETRY_DELAY_BLOCKS: u32 = 5;
 const DEFAULT_MAX_SWAP_RETRY_DURATION_BLOCKS: u32 = 3600 / SECONDS_PER_BLOCK as u32; // 1 hour
@@ -180,11 +183,6 @@ impl<T: Config> Swap<T> {
 	) -> Self {
 		Self { swap_id, swap_request_id, from, to, input_amount, refund_params, execute_at }
 	}
-
-	/// Remove the refund params from the swap. Used for simulating swaps without price protection.
-	fn without_price_protection(self) -> Self {
-		Self { refund_params: None, ..self }
-	}
 }
 
 #[derive(Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq)]
@@ -262,6 +260,55 @@ pub(crate) enum SwapRequestState<T: Config> {
 	BrokerFee {
 		account_id: T::AccountId,
 	},
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum NetworkFeeType {
+	/// Used for standard swaps
+	Standard,
+	/// Used for standard swaps that are going to be credited on-chain
+	// TODO: see if we want to treat lending swaps as internal for
+	// the purposes of determining network fee?
+	Internal,
+	/// Used for Ingress and Egress and broker fee swaps
+	NoMinimum,
+	/// Used for NetworkFee swaps
+	None,
+}
+
+impl NetworkFeeType {
+	fn from_swap_request_type<AccountId>(
+		swap_request_type: &SwapRequestType<AccountId>,
+	) -> NetworkFeeType {
+		match swap_request_type {
+			SwapRequestType::Regular { output_action } |
+			SwapRequestType::RegularNoNetworkFee { output_action } => match output_action {
+				SwapOutputAction::CreditOnChain { .. } => NetworkFeeType::Internal,
+				_ => NetworkFeeType::Standard,
+			},
+			SwapRequestType::BrokerFee { .. } | SwapRequestType::IngressEgressFee =>
+				NetworkFeeType::NoMinimum,
+			SwapRequestType::NetworkFee => NetworkFeeType::None,
+		}
+	}
+
+	fn from_swap_request_state<T: Config>(
+		swap_request_state: &SwapRequestState<T>,
+	) -> NetworkFeeType {
+		match swap_request_state {
+			SwapRequestState::UserSwap { output_action, .. } => match output_action {
+				SwapOutputAction::CreditOnChain { .. } => NetworkFeeType::Internal,
+				_ => NetworkFeeType::Standard,
+			},
+			SwapRequestState::BrokerFee { .. } | SwapRequestState::IngressEgressFee =>
+				NetworkFeeType::NoMinimum,
+			SwapRequestState::NetworkFee => NetworkFeeType::None,
+		}
+	}
+
+	fn has_minimum(&self) -> bool {
+		!matches!(self, NetworkFeeType::NoMinimum | NetworkFeeType::None)
+	}
 }
 
 #[derive(DebugNoBound, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo)]
@@ -639,7 +686,7 @@ pub mod pallet {
 			output: AssetAndAmount,
 			network_fee: AssetAndAmount,
 			broker_fee: AssetAndAmount,
-			intermediate: Option<AssetAndAmount>,
+			intermediates: Vec<AssetAndAmount>,
 			// Total difference between final swap output price and oracle price (including fees).
 			// Negative means worse price than oracle.
 			oracle_delta: Option<SignedBasisPoints>,
@@ -677,7 +724,8 @@ pub mod pallet {
 		/// liquidity in the Pool. Also this could happen if the result overflowed u128::MAX
 		BatchSwapFailed {
 			asset: Asset,
-			direction: SwapLeg,
+			// TODO JAMIE: breaking change: need to use SwapLeg here instead of direction.
+			direction: LegacySwapLegDirection,
 			amount: AssetAmount,
 		},
 		SwapAmountConfiscated {

--- a/state-chain/pallets/cf-swapping/src/migrations/fee_fields_in_swap_requests.rs
+++ b/state-chain/pallets/cf-swapping/src/migrations/fee_fields_in_swap_requests.rs
@@ -175,8 +175,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 								NetworkFeeTracker::new(Pallet::<T>::get_network_fee_for_swap(
 									old.input_asset,
 									old.output_asset,
-									false, // not internal
-									false, // with minimum
+									NetworkFeeType::Standard,
 								))
 							}),
 							// Starting a new tracker for broker fees is safe.

--- a/state-chain/pallets/cf-swapping/src/swap_state.rs
+++ b/state-chain/pallets/cf-swapping/src/swap_state.rs
@@ -14,12 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_primitives::{
-	basis_points::SignedBasisPoints, Asset, AssetAmount, SwapId, SwapRequestId, STABLE_ASSET,
-};
+use cf_primitives::{basis_points::SignedBasisPoints, Asset, AssetAmount, SwapId, SwapRequestId};
 use frame_support::pallet_prelude::*;
-use frame_system::pallet_prelude::BlockNumberFor;
-use sp_std::fmt::Debug;
+use sp_std::{fmt::Debug, vec::Vec};
+
+use crate::execution::SwapLeg;
 
 use super::{
 	AssetAndAmount, BrokerFeesTracker, Config, FeeTaken, NetworkFeeTracker, Pallet, Swap,
@@ -36,7 +35,7 @@ pub struct SuccessfulSwap {
 	pub input_amount_after_fees: AssetAmount,
 	/// Always in terms of input asset
 	pub network_fee_taken: AssetAmount,
-	pub intermediate: Option<AssetAndAmount>,
+	pub intermediates: Vec<AssetAndAmount>,
 	pub output_amount_after_fees: AssetAmount,
 	/// Always in terms of output asset
 	pub broker_fee_taken: AssetAmount,
@@ -45,16 +44,22 @@ pub struct SuccessfulSwap {
 }
 
 impl SuccessfulSwap {
-	/// Downgrades a completed swap state to a Stage2. Used in the 'get_scheduled_swaps' RPC's
-	pub(crate) fn into_stage_2<T: Config>(self, swap: Swap<T>) -> SwapState<T, AfterFirstLeg2> {
-		SwapState {
-			swap,
-			stage: AfterFirstLeg2 {
-				input_amount_after_fees: self.input_amount_after_fees,
-				network_fee_taken: self.network_fee_taken,
-				intermediate: self.intermediate,
-			},
+	// Returns a list of the swap legs and the output amount for each leg.
+	pub fn get_swap_route(&self) -> Vec<(SwapLeg, AssetAmount)> {
+		let mut route = Vec::new();
+		let mut current_asset = self.input_asset;
+		for intermediate in &self.intermediates {
+			route.push((
+				SwapLeg { from: current_asset, to: intermediate.asset },
+				intermediate.amount,
+			));
+			current_asset = intermediate.asset;
 		}
+		route.push((
+			SwapLeg { from: current_asset, to: self.output_asset },
+			self.output_amount_after_fees,
+		));
+		route
 	}
 }
 
@@ -77,19 +82,21 @@ pub struct AfterNetworkFee1 {
 }
 
 #[derive(Debug)]
-/// The stage after the first leg of the swap is done (to the intermediate asset)
-pub struct AfterFirstLeg2 {
+/// The stage used to progress through all legs of the swap. May be advanced multiple times until it
+/// becomes AfterSwapLegs3.
+pub struct SwapLegs2 {
 	pub input_amount_after_fees: AssetAmount,
 	pub network_fee_taken: AssetAmount,
-	pub intermediate: Option<AssetAndAmount>,
+	pub current_asset_and_amount: AssetAndAmount,
+	pub intermediates: Vec<AssetAndAmount>,
 }
 
 #[derive(Debug)]
-/// The stage after the second leg of the swap is done (to the output asset)
-pub struct AfterSecondLeg3 {
+/// The stage after all legs of the swap are done
+pub struct AfterSwapLegs3 {
 	pub input_amount_after_fees: AssetAmount,
 	pub network_fee_taken: AssetAmount,
-	pub intermediate: Option<AssetAndAmount>,
+	pub intermediates: Vec<AssetAndAmount>,
 	pub output_amount_before_fees: AssetAmount,
 }
 
@@ -98,7 +105,7 @@ pub struct AfterSecondLeg3 {
 pub struct AfterBrokerFee4 {
 	pub input_amount_after_fees: AssetAmount,
 	pub network_fee_taken: AssetAmount,
-	pub intermediate: Option<AssetAndAmount>,
+	pub intermediates: Vec<AssetAndAmount>,
 	pub output_amount_before_fees: AssetAmount,
 	pub output_amount_after_fees: AssetAmount,
 	pub broker_fee_taken: AssetAmount,
@@ -109,7 +116,7 @@ pub struct AfterBrokerFee4 {
 pub struct AfterPriceProtection5 {
 	pub input_amount_after_fees: AssetAmount,
 	pub network_fee_taken: AssetAmount,
-	pub intermediate: Option<AssetAndAmount>,
+	pub intermediates: Vec<AssetAndAmount>,
 	pub output_amount_before_fees: AssetAmount,
 	pub output_amount_after_fees: AssetAmount,
 	pub broker_fee_taken: AssetAmount,
@@ -121,125 +128,6 @@ pub struct AfterPriceProtection5 {
 /// failed swaps.
 pub struct StageFailed {
 	pub swap_amount: AssetAmount,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub(crate) struct SwapGroupPair {
-	pub from: Asset,
-	pub to: Asset,
-}
-
-/// The 2 stages that are handed to the group swap logic (to & from intermediate) implement this
-/// trait to allow them to be grouped and executed.
-pub(crate) trait GroupSwapState<T: Config> {
-	type OutputState;
-
-	/// The input amount that is being swapped for the next leg.
-	fn swap_amount(&self) -> AssetAmount;
-	/// Returns the "to" and "from" assets as a swap pair to allow grouping of swaps. Returns None
-	/// if the asset does not need to be swapped for this leg (e.g. if the input or output asset is
-	/// already the intermediate asset).
-	fn swap_group(&self) -> Option<SwapGroupPair>;
-	/// Updates the swap state with the output amount of a swap for this single leg.
-	fn advance_with_swap_result(self, amount: AssetAmount) -> Self::OutputState;
-	/// Used when the asset does not need to be swapped for this leg, just passes through the input
-	/// amount as the output amount.
-	fn advance_no_swap(self) -> Self::OutputState;
-	/// Strip away the swap state details and just return the swap with some failure information
-	fn failed_swap(self) -> SwapState<T, StageFailed>;
-}
-
-impl<T: Config> GroupSwapState<T> for SwapState<T, AfterNetworkFee1> {
-	type OutputState = SwapState<T, AfterFirstLeg2>;
-
-	fn swap_amount(&self) -> AssetAmount {
-		self.stage.input_amount_after_fees
-	}
-
-	fn swap_group(&self) -> Option<SwapGroupPair> {
-		if self.swap.from == STABLE_ASSET {
-			None
-		} else {
-			Some(SwapGroupPair { from: self.swap.from, to: STABLE_ASSET })
-		}
-	}
-
-	fn advance_with_swap_result(self, output: AssetAmount) -> Self::OutputState {
-		SwapState {
-			stage: AfterFirstLeg2 {
-				input_amount_after_fees: self.stage.input_amount_after_fees,
-				network_fee_taken: self.stage.network_fee_taken,
-				intermediate: Some(AssetAndAmount::new(
-					self.swap_group().map(|pair| pair.to).unwrap_or(self.swap.from),
-					output,
-				)),
-			},
-			swap: self.swap,
-		}
-	}
-
-	fn advance_no_swap(self) -> Self::OutputState {
-		SwapState {
-			stage: AfterFirstLeg2 {
-				input_amount_after_fees: self.stage.input_amount_after_fees,
-				network_fee_taken: self.stage.network_fee_taken,
-				intermediate: None,
-			},
-			swap: self.swap,
-		}
-	}
-
-	fn failed_swap(self) -> SwapState<T, StageFailed> {
-		SwapState { stage: StageFailed { swap_amount: self.swap_amount() }, swap: self.swap }
-	}
-}
-
-impl<T: Config> GroupSwapState<T> for SwapState<T, AfterFirstLeg2> {
-	type OutputState = SwapState<T, AfterSecondLeg3>;
-
-	fn swap_amount(&self) -> AssetAmount {
-		self.stage
-			.intermediate
-			.as_ref()
-			.map(|AssetAndAmount { asset: _, amount }| *amount)
-			.unwrap_or(self.stage.input_amount_after_fees)
-	}
-
-	fn swap_group(&self) -> Option<SwapGroupPair> {
-		if self.swap.to == STABLE_ASSET {
-			None
-		} else {
-			Some(SwapGroupPair { from: STABLE_ASSET, to: self.swap.to })
-		}
-	}
-
-	fn advance_with_swap_result(self, output: AssetAmount) -> Self::OutputState {
-		SwapState {
-			swap: self.swap,
-			stage: AfterSecondLeg3 {
-				input_amount_after_fees: self.stage.input_amount_after_fees,
-				network_fee_taken: self.stage.network_fee_taken,
-				intermediate: self.stage.intermediate,
-				output_amount_before_fees: output,
-			},
-		}
-	}
-
-	fn advance_no_swap(self) -> Self::OutputState {
-		SwapState {
-			stage: AfterSecondLeg3 {
-				input_amount_after_fees: self.stage.input_amount_after_fees,
-				network_fee_taken: self.stage.network_fee_taken,
-				output_amount_before_fees: self.swap_amount(),
-				intermediate: self.stage.intermediate,
-			},
-			swap: self.swap,
-		}
-	}
-
-	fn failed_swap(self) -> SwapState<T, StageFailed> {
-		SwapState { stage: StageFailed { swap_amount: self.swap_amount() }, swap: self.swap }
-	}
 }
 
 impl<T: Config, Stage: Debug> SwapState<T, Stage> {
@@ -263,10 +151,6 @@ impl<T: Config, Stage: Debug> SwapState<T, Stage> {
 		self.swap.input_amount
 	}
 
-	pub(crate) fn execute_at(&self) -> BlockNumberFor<T> {
-		self.swap.execute_at
-	}
-
 	pub(crate) fn refund_params(&self) -> Option<&SwapRefundParameters> {
 		self.swap.refund_params.as_ref()
 	}
@@ -283,20 +167,78 @@ impl<T: Config, Stage: Debug> SwapState<T, Stage> {
 }
 
 impl<T: Config> SwapState<T, AfterNetworkFee1> {
-	/// Transition to Stage2 with a given intermediate amount. Used when the intermediate is
-	/// computed via a pool price estimate rather than an actual swap.
-	pub(crate) fn with_intermediate(
-		self,
-		intermediate: Option<AssetAndAmount>,
-	) -> SwapState<T, AfterFirstLeg2> {
+	pub(crate) fn prepare_for_execution(self) -> SwapState<T, SwapLegs2> {
 		SwapState {
-			swap: self.swap,
-			stage: AfterFirstLeg2 {
+			stage: SwapLegs2 {
 				input_amount_after_fees: self.stage.input_amount_after_fees,
 				network_fee_taken: self.stage.network_fee_taken,
-				intermediate,
+				current_asset_and_amount: AssetAndAmount::new(
+					self.swap.from,
+					self.stage.input_amount_after_fees,
+				),
+				intermediates: Vec::new(),
+			},
+			swap: self.swap,
+		}
+	}
+
+	// If the input asset is the same as the output asset, we can skip all execution.
+	pub(crate) fn proceed_without_execution(self) -> SwapState<T, AfterSwapLegs3> {
+		SwapState {
+			stage: AfterSwapLegs3 {
+				input_amount_after_fees: self.stage.input_amount_after_fees,
+				network_fee_taken: self.stage.network_fee_taken,
+				intermediates: Vec::new(),
+				output_amount_before_fees: self.stage.input_amount_after_fees,
+			},
+			swap: self.swap,
+		}
+	}
+}
+
+impl<T: Config> SwapState<T, SwapLegs2> {
+	pub fn swap_amount(&self) -> AssetAmount {
+		self.stage.current_asset_and_amount.amount
+	}
+
+	pub fn swap_asset(&self) -> Asset {
+		self.stage.current_asset_and_amount.asset
+	}
+
+	pub(crate) fn advance_swap_leg(self, swap_output: AssetAndAmount) -> SwapState<T, SwapLegs2> {
+		SwapState {
+			swap: self.swap,
+			stage: SwapLegs2 {
+				input_amount_after_fees: self.stage.input_amount_after_fees,
+				network_fee_taken: self.stage.network_fee_taken,
+				current_asset_and_amount: swap_output,
+				intermediates: self
+					.stage
+					.intermediates
+					.into_iter()
+					.chain(Some(swap_output))
+					.collect(),
 			},
 		}
+	}
+
+	pub(crate) fn finished_swap_legs(
+		self,
+		swap_output: AssetAndAmount,
+	) -> SwapState<T, AfterSwapLegs3> {
+		SwapState {
+			swap: self.swap,
+			stage: AfterSwapLegs3 {
+				input_amount_after_fees: self.stage.input_amount_after_fees,
+				network_fee_taken: self.stage.network_fee_taken,
+				intermediates: self.stage.intermediates,
+				output_amount_before_fees: swap_output.amount,
+			},
+		}
+	}
+
+	pub(crate) fn failed_swap(self) -> SwapState<T, StageFailed> {
+		SwapState { stage: StageFailed { swap_amount: self.swap_amount() }, swap: self.swap }
 	}
 }
 
@@ -332,7 +274,7 @@ impl<T: Config> SwapState<T, ()> {
 	}
 }
 
-impl<T: Config> SwapState<T, AfterSecondLeg3> {
+impl<T: Config> SwapState<T, AfterSwapLegs3> {
 	pub(crate) fn take_broker_fees(
 		self,
 		fee_tracker: &mut BrokerFeesTracker<T::AccountId>,
@@ -344,7 +286,7 @@ impl<T: Config> SwapState<T, AfterSecondLeg3> {
 			stage: AfterBrokerFee4 {
 				input_amount_after_fees: self.stage.input_amount_after_fees,
 				network_fee_taken: self.stage.network_fee_taken,
-				intermediate: self.stage.intermediate,
+				intermediates: self.stage.intermediates,
 				output_amount_before_fees: self.stage.output_amount_before_fees,
 				output_amount_after_fees: remaining_amount,
 				broker_fee_taken: fee,
@@ -358,7 +300,7 @@ impl<T: Config> SwapState<T, AfterSecondLeg3> {
 			stage: AfterBrokerFee4 {
 				input_amount_after_fees: self.stage.input_amount_after_fees,
 				network_fee_taken: self.stage.network_fee_taken,
-				intermediate: self.stage.intermediate,
+				intermediates: self.stage.intermediates,
 				output_amount_before_fees: self.stage.output_amount_before_fees,
 				output_amount_after_fees: self.stage.output_amount_before_fees,
 				broker_fee_taken: 0,
@@ -379,7 +321,7 @@ impl<T: Config> SwapState<T, AfterBrokerFee4> {
 				stage: AfterPriceProtection5 {
 					input_amount_after_fees: self.stage.input_amount_after_fees,
 					network_fee_taken: self.stage.network_fee_taken,
-					intermediate: self.stage.intermediate,
+					intermediates: self.stage.intermediates,
 					output_amount_before_fees: self.stage.output_amount_before_fees,
 					output_amount_after_fees: self.stage.output_amount_after_fees,
 					broker_fee_taken: self.stage.broker_fee_taken,
@@ -415,7 +357,7 @@ impl<T: Config> SwapState<T, AfterPriceProtection5> {
 			output_asset: self.output_asset(),
 			input_amount_after_fees: self.stage.input_amount_after_fees,
 			network_fee_taken: self.stage.network_fee_taken,
-			intermediate: self.stage.intermediate,
+			intermediates: self.stage.intermediates,
 			output_amount_after_fees: self.stage.output_amount_after_fees,
 			broker_fee_taken: self.stage.broker_fee_taken,
 			oracle_delta_ex_fees: self.stage.oracle_delta_ex_fees,

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1226,15 +1226,18 @@ fn test_get_scheduled_swap_legs() {
 			]);
 		});
 
-		SwapRate::set(2f64);
-		// The amount of USDC in the middle of swap (5):
+		// Oracle price of 2 USD/Eth is used to estimate the intermediate USDC amount for swap 5
+		// (Eth -> Flip), where the Usdc -> Flip leg's input amount is the Eth amount converted
+		// to Usdc.
+		MockPriceFeedApi::set_price_usd_fine(Asset::Eth, 2);
+		MockPriceFeedApi::set_price_usd_fine(Asset::Usdc, 1);
 		const INTERMEDIATE_AMOUNT: AssetAmount = 2000;
 
 		// The test is more useful when these aren't equal:
 		assert_ne!(INIT_AMOUNT, INTERMEDIATE_AMOUNT);
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(Asset::Flip),
+			Swapping::get_scheduled_swap_legs(Asset::Flip, Asset::Usdc),
 			vec![
 				(
 					SwapLegInfo {
@@ -1266,23 +1269,6 @@ fn test_get_scheduled_swap_legs() {
 					},
 					BLOCK
 				),
-				// The order of swap 5 and 4 changed due to the swap grouping. But that doesn't
-				// matter.
-				(
-					SwapLegInfo {
-						swap_id: SwapId(5),
-						swap_request_id: SwapRequestId(5),
-						base_asset: Asset::Flip,
-						quote_asset: Asset::Usdc,
-						side: Side::Buy,
-						amount: INTERMEDIATE_AMOUNT,
-						source_asset: Some(Asset::Eth),
-						source_amount: Some(INIT_AMOUNT),
-						remaining_chunks: 0,
-						chunk_interval: SWAP_DELAY_BLOCKS,
-					},
-					BLOCK
-				),
 				(
 					SwapLegInfo {
 						swap_id: SwapId(4),
@@ -1293,6 +1279,21 @@ fn test_get_scheduled_swap_legs() {
 						amount: INIT_AMOUNT,
 						source_asset: None,
 						source_amount: None,
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(5),
+						swap_request_id: SwapRequestId(5),
+						base_asset: Asset::Flip,
+						quote_asset: Asset::Usdc,
+						side: Side::Buy,
+						amount: INTERMEDIATE_AMOUNT,
+						source_asset: Some(Asset::Eth),
+						source_amount: Some(INIT_AMOUNT),
 						remaining_chunks: 0,
 						chunk_interval: SWAP_DELAY_BLOCKS,
 					},
@@ -1317,12 +1318,12 @@ fn test_get_scheduled_swap_legs_returns_empty_when_swaps_disabled() {
 		});
 
 		// Sanity check: swaps are returned when safe mode is green
-		assert!(!Swapping::get_scheduled_swap_legs(Asset::Flip).is_empty());
+		assert!(!Swapping::get_scheduled_swap_legs(Asset::Flip, Asset::Usdc).is_empty());
 
 		// Disable swaps via safe mode
 		<MockRuntimeSafeMode as SetSafeMode<MockRuntimeSafeMode>>::set_code_red();
 
-		assert!(Swapping::get_scheduled_swap_legs(Asset::Flip).is_empty());
+		assert!(Swapping::get_scheduled_swap_legs(Asset::Flip, Asset::Usdc).is_empty());
 	});
 }
 
@@ -1340,40 +1341,17 @@ fn test_get_scheduled_swap_legs_fallback() {
 			]);
 		});
 
-		// Setting the swap rate to something different from the price so that if the fallback is
-		// not used, it will give a different result, avoiding a false positive.
-		SwapRate::set(PRICE.checked_add(1).unwrap() as f64);
-
-		// The swap simulation must fail for it to use the fallback price estimation
-		MockSwappingApi::set_swaps_should_fail(true);
-
-		// Only setting pool price for FLIP to make sure that the test would fail
-		// if the code tried to use the price of some other asset.
+		// Only set the pool price (and no oracle price) for FLIP to make sure the pool-price
+		// fallback is used when no oracle is available.
 		MockPoolPriceApi::set_pool_price(
 			Asset::Flip,
 			STABLE_ASSET,
 			Price::from_usd_fine_amount(PRICE),
 		);
 
-		// The ordering changed due to swap grouping, but that doesn't matter.
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(Asset::Eth),
+			Swapping::get_scheduled_swap_legs(Asset::Eth, Asset::Usdc),
 			vec![
-				(
-					SwapLegInfo {
-						swap_id: SwapId(2),
-						swap_request_id: SwapRequestId(2),
-						base_asset: Asset::Eth,
-						quote_asset: Asset::Usdc,
-						side: Side::Sell,
-						amount: INIT_AMOUNT,
-						source_asset: None,
-						source_amount: None,
-						remaining_chunks: 0,
-						chunk_interval: SWAP_DELAY_BLOCKS,
-					},
-					BLOCK
-				),
 				(
 					SwapLegInfo {
 						swap_id: SwapId(1),
@@ -1384,6 +1362,21 @@ fn test_get_scheduled_swap_legs_fallback() {
 						amount: INIT_AMOUNT * PRICE,
 						source_asset: Some(Asset::Flip),
 						source_amount: Some(INIT_AMOUNT),
+						remaining_chunks: 0,
+						chunk_interval: SWAP_DELAY_BLOCKS,
+					},
+					BLOCK
+				),
+				(
+					SwapLegInfo {
+						swap_id: SwapId(2),
+						swap_request_id: SwapRequestId(2),
+						base_asset: Asset::Eth,
+						quote_asset: Asset::Usdc,
+						side: Side::Sell,
+						amount: INIT_AMOUNT,
+						source_asset: None,
+						source_amount: None,
 						remaining_chunks: 0,
 						chunk_interval: SWAP_DELAY_BLOCKS,
 					},
@@ -1401,7 +1394,10 @@ fn test_get_scheduled_swap_legs_for_dca() {
 		const NUMBER_OF_CHUNKS: u32 = 3;
 		const CHUNK_INTERVAL: u32 = 10;
 		const BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
-		SwapRate::set(1_f64);
+
+		// Oracle price of 1 USD for both assets so the intermediate USDC amount equals the input.
+		MockPriceFeedApi::set_price_usd_fine(Asset::Flip, 1);
+		MockPriceFeedApi::set_price_usd_fine(Asset::Usdc, 1);
 
 		let dca_params =
 			DcaParameters { number_of_chunks: NUMBER_OF_CHUNKS, chunk_interval: CHUNK_INTERVAL };
@@ -1414,7 +1410,7 @@ fn test_get_scheduled_swap_legs_for_dca() {
 		});
 
 		assert_eq!(
-			Swapping::get_scheduled_swap_legs(Asset::Eth),
+			Swapping::get_scheduled_swap_legs(Asset::Eth, Asset::Usdc),
 			vec![(
 				SwapLegInfo {
 					swap_id: SwapId(1),
@@ -1432,6 +1428,41 @@ fn test_get_scheduled_swap_legs_for_dca() {
 				BLOCK
 			)]
 		);
+	});
+}
+
+#[test]
+fn test_get_scheduled_swap_legs_applies_network_fee() {
+	new_test_ext().execute_with(|| {
+		const INIT_AMOUNT: AssetAmount = 1_000_000;
+		const BLOCK: u64 = INIT_BLOCK + SWAP_DELAY_BLOCKS as u64;
+		// 1% network fee.
+		const NETWORK_FEE_RATE: Permill = Permill::from_parts(10_000);
+		NetworkFee::<Test>::set(FeeRateAndMinimum { rate: NETWORK_FEE_RATE, minimum: 0 });
+
+		// Oracle price of 1 USD/Flip and 1 USD/Usdc, so the buy-leg's input amount in Usdc terms
+		// equals the swap's input amount (after fees).
+		MockPriceFeedApi::set_price_usd_fine(Asset::Flip, 1);
+		MockPriceFeedApi::set_price_usd_fine(Asset::Usdc, 1);
+
+		ScheduledSwaps::<Test>::mutate(|swaps| {
+			swaps.extend(vec![
+				// Sell direction with respect to base_asset = Flip.
+				(1.into(), create_test_swap(1, Asset::Flip, Asset::Eth, INIT_AMOUNT, None, BLOCK)),
+				// Buy direction with respect to base_asset = Flip.
+				(2.into(), create_test_swap(2, Asset::Usdc, Asset::Flip, INIT_AMOUNT, None, BLOCK)),
+			]);
+		});
+
+		// The network fee is taken from the swap's input amount in input asset terms, so both
+		// legs report `INIT_AMOUNT - 1%`.
+		let expected_amount = INIT_AMOUNT - (NETWORK_FEE_RATE * INIT_AMOUNT);
+		let legs = Swapping::get_scheduled_swap_legs(Asset::Flip, Asset::Usdc);
+		assert_eq!(legs.len(), 2);
+		assert_eq!(legs[0].0.side, Side::Sell);
+		assert_eq!(legs[0].0.amount, expected_amount);
+		assert_eq!(legs[1].0.side, Side::Buy);
+		assert_eq!(legs[1].0.amount, expected_amount);
 	});
 }
 
@@ -1527,10 +1558,9 @@ fn can_handle_input_and_output_being_the_same_asset() {
 		})
 		.then_process_blocks_until_block(INIT_BLOCK + SWAP_DELAY_BLOCKS as u64)
 		.then_execute_with(|_| {
-			let network_fee_amount = NETWORK_FEE_RATE * AMOUNT * DEFAULT_SWAP_RATE;
-			// Its still a 2 leg swap, so the swap rate is applied twice.
-			let output_amount: AssetAmount =
-				((AMOUNT * DEFAULT_SWAP_RATE) - network_fee_amount) * DEFAULT_SWAP_RATE;
+			let network_fee_amount = NETWORK_FEE_RATE * AMOUNT;
+			// No swap needed, so just deduct the network fee.
+			let output_amount: AssetAmount = AMOUNT - network_fee_amount;
 
 			assert_event_sequence!(
 				Test,

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -571,7 +571,6 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				Asset::Usdc,
 				1000,
 				false,
-				false
 			),
 			500 // 1 leg swap, so 1/2 of input
 		);
@@ -582,7 +581,6 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				Asset::Usdc,
 				1000,
 				true,
-				false
 			),
 			505 // 1 leg swap + 1% network fee
 		);
@@ -593,7 +591,6 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				Asset::Dot,
 				1000,
 				false,
-				false
 			),
 			250 // 2 leg swap, so 1/4th of input
 		);
@@ -606,7 +603,6 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				Asset::Eth,
 				10_u128.pow(18),
 				false,
-				false
 			),
 			// So the result is half the Eth price, plus a small rounding error
 			1400 * 10_u128.pow(18) + 1
@@ -629,7 +625,6 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				Asset::Eth,
 				2 * 10u128.pow(18),
 				false,
-				false
 			),
 			14_000 * 10u128.pow(18) + 1 // 2 ETH ~= 14000 FLIP plus small rounding error
 		);
@@ -642,7 +637,6 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				Asset::Eth,
 				2 * 10u128.pow(18),
 				false,
-				false
 			),
 			6473989 // 2 ETH ~=  0.06473988439 BTC
 		);
@@ -654,7 +648,6 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				Asset::Eth,
 				2 * 10u128.pow(18),
 				true, // With network fee
-				false
 			),
 			6539382 // Same as above + 1% network fee
 		);
@@ -679,7 +672,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Eth,
 				2 * 10u128.pow(18),
 				false,
-				false
 			),
 			4_000 * 10u128.pow(6) + 16_000_000 // $4k + 40bps
 		);
@@ -690,7 +682,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Usdt,
 				1_000_000_000,
 				false,
-				false
 			),
 			1_000_000_000 + 600_181 // $1k + 6bps
 		);
@@ -701,7 +692,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Btc,
 				10u128.pow(8),
 				false,
-				false
 			),
 			15 * 10u128.pow(18) + 120481927710843374 // 15 ETH + 80bps
 		);
@@ -712,7 +702,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Btc,
 				10u128.pow(8),
 				true, // With network fee
-				false
 			),
 			// $30k + 40bps + 1% network fee - precision error
 			30_000_000_000 + 120_000_000 + 304242424 - 3
@@ -725,7 +714,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Btc,
 				10u128.pow(8),
 				false,
-				false
 			),
 			236220472441 + 944_881_890 // ~236 SOL + 40bps
 		);
@@ -738,7 +726,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Btc,
 				10u128.pow(8),
 				false,
-				false
 			),
 			// ~=15k + 40bps + rounding error
 			(15_000 + 60) * 10u128.pow(Asset::Flip.decimals()) + 1
@@ -752,7 +739,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Btc,
 				10u128.pow(8),
 				true, // With network fee
-				false
 			),
 			10u128.pow(8) + 1010101 // output + 1% network fee
 		);
@@ -764,7 +750,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				Asset::Eth,
 				0,
 				true,
-				false
 			),
 			0
 		);
@@ -774,7 +759,6 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 			Asset::Eth,
 			u128::MAX,
 			true,
-			false,
 		);
 	});
 }
@@ -1157,8 +1141,7 @@ fn test_get_network_fee() {
 			let fee = Pallet::<Test>::get_network_fee_for_swap(
 				input_asset_fee.0,
 				output_asset_fee.0,
-				is_internal,
-				true, // with minimum
+				if is_internal { NetworkFeeType::Internal } else { NetworkFeeType::Standard },
 			);
 
 			// Check that the fee rate and minimum are as expected

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -1015,7 +1015,7 @@ mod oracle_swaps {
 				AfterBrokerFee4 {
 					network_fee_taken: NETWORK_FEE,
 					broker_fee_taken: BROKER_FEE,
-					intermediate: Some(AssetAndAmount { asset: Asset::Usdc, amount: USDC_AMOUNT }),
+					intermediates: vec![AssetAndAmount { asset: Asset::Usdc, amount: USDC_AMOUNT }],
 					output_amount_before_fees: OUTPUT_AMOUNT + BROKER_FEE,
 					output_amount_after_fees: OUTPUT_AMOUNT,
 					input_amount_after_fees: INPUT_AMOUNT - NETWORK_FEE,

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -320,7 +320,7 @@ pub enum AccountRole {
 pub type EgressBatch<Amount, EgressAddress> = Vec<(Amount, EgressAddress)>;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo)]
-pub enum SwapLeg {
+pub enum LegacySwapLegDirection {
 	FromStable,
 	ToStable,
 }

--- a/state-chain/runtime/src/chainflip/simulate_swap.rs
+++ b/state-chain/runtime/src/chainflip/simulate_swap.rs
@@ -33,7 +33,7 @@ use cf_primitives::{
 	IngressOrEgress, OrderId,
 };
 use pallet_cf_ingress_egress::AmountAndFeesWithheld;
-use pallet_cf_swapping::{BatchExecutionError, FeeRateAndMinimum};
+use pallet_cf_swapping::{BatchExecutionError, FeeRateAndMinimum, NetworkFeeType};
 use sp_runtime::{
 	traits::{Saturating, UniqueSaturatedInto},
 	DispatchError, Permill,
@@ -112,8 +112,7 @@ pub fn simulate_swap(
 			pallet_cf_swapping::Pallet::<Runtime>::get_network_fee_for_swap(
 				input_asset,
 				output_asset,
-				is_internal,
-				true, // With minimum
+				if is_internal { NetworkFeeType::Internal } else { NetworkFeeType::Standard },
 			);
 		max(rate * amount_to_swap, minimum)
 	} else {
@@ -147,10 +146,14 @@ pub fn simulate_swap(
 	})?;
 
 	// Extrapolate the total by multiplying the chunk by the number of chunks
-	let intermediary = swap
-		.intermediate
-		.as_ref()
-		.map(|AssetAndAmount { asset: _, amount }| amount * number_of_chunks);
+	let intermediates = swap
+		.intermediates
+		.iter()
+		.map(|AssetAndAmount { asset, amount }| AssetAndAmount {
+			asset: *asset,
+			amount: amount * number_of_chunks,
+		})
+		.collect();
 	let output = swap.output_amount_after_fees * number_of_chunks;
 	let broker_fee = swap.broker_fee_taken * number_of_chunks;
 
@@ -169,7 +172,7 @@ pub fn simulate_swap(
 		};
 
 	Ok(SimulatedSwapInformation {
-		intermediary,
+		intermediates,
 		output,
 		network_fee: AssetAndAmount::new(input_asset, network_fee),
 		ingress_fee: AssetAndAmount::new(input_asset, ingress_fee),

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -418,7 +418,7 @@ pub enum FeeTypes {
 /// Struct that represents the estimated output of a Swap.
 #[derive(Encode, Decode, TypeInfo, Debug)]
 pub struct SimulatedSwapInformation {
-	pub intermediary: Option<AssetAmount>,
+	pub intermediates: Vec<AssetAndAmount<AssetAmount>>,
 	pub output: AssetAmount,
 	pub network_fee: AssetAndAmount<AssetAmount>,
 	pub ingress_fee: AssetAndAmount<AssetAmount>,

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -28,7 +28,7 @@ use crate::{
 	*,
 };
 use cf_amm::{
-	common::{AskBidMap, PoolPairsMap},
+	common::{AskBidMap, AssetPair, PoolPairsMap},
 	math::{Amount, Tick},
 	range_orders::Liquidity,
 };
@@ -46,7 +46,7 @@ use cf_chains::{
 use cf_primitives::{
 	chains::*, AccountRole, Affiliates, Asset, AssetAmount, BasisPoints, BlockNumber, BroadcastId,
 	ChannelId, DcaParameters, EpochIndex, FlipBalance, ForeignChain, IngressOrEgress,
-	NetworkEnvironment, SemVer, STABLE_ASSET,
+	NetworkEnvironment, SemVer,
 };
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, ChainflipWithTargetChain, EpochKey,
@@ -1224,8 +1224,8 @@ impl_runtime_apis! {
 		}
 
 		fn cf_scheduled_swaps(base_asset: Asset, quote_asset: Asset) -> Vec<(SwapLegInfo, BlockNumber)> {
-			assert_eq!(quote_asset, STABLE_ASSET, "Only USDC is supported as quote asset");
-			Swapping::get_scheduled_swap_legs(base_asset)
+			assert!(AssetPair::new(base_asset, quote_asset).is_some(), "Invalid asset pair: Pool does not exist.");
+			Swapping::get_scheduled_swap_legs(base_asset, quote_asset)
 		}
 
 		fn cf_failed_call_ethereum(broadcast_id: BroadcastId) -> Option<<cf_chains::Ethereum as cf_chains::Chain>::Transaction> {
@@ -2031,7 +2031,8 @@ impl_runtime_apis! {
 
 		fn cf_default_oracle_price_protection() -> AssetMap<Option<BasisPoints>>{
 			AssetMap::from_fn(|asset| {
-				pallet_cf_swapping::Pallet::<Runtime>::default_oracle_lpp_for_asset(asset)
+				// TODO JAMIE: This currently only supports USDC pools
+				pallet_cf_swapping::Pallet::<Runtime>::default_oracle_lpp_for_asset(pallet_cf_swapping::SwapLeg{ from: asset, to: Asset::Usdc})
 			})
 		}
 

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1093,7 +1093,6 @@ pub trait AssetConverter {
 			C::GAS_ASSET.into(),
 			required_gas.into(),
 			true,
-			false,
 		))
 		.unwrap_or_default()
 	}
@@ -1107,7 +1106,6 @@ pub trait AssetConverter {
 		output_asset: Asset,
 		desired_output_amount: AssetAmount,
 		with_network_fee: bool,
-		is_internal_swap: bool,
 	) -> AssetAmount;
 }
 

--- a/state-chain/traits/src/mocks/asset_converter.rs
+++ b/state-chain/traits/src/mocks/asset_converter.rs
@@ -49,7 +49,6 @@ impl AssetConverter for MockAssetConverter {
 			C::GAS_ASSET.into(),
 			required_gas.into(),
 			true,
-			false,
 		))
 		.unwrap()
 	}
@@ -59,7 +58,6 @@ impl AssetConverter for MockAssetConverter {
 		output_asset: Asset,
 		desired_output_amount: AssetAmount,
 		_with_network_fee: bool,
-		_is_internal: bool,
 	) -> AssetAmount {
 		// The following check is copied from the implementation in the swapping pallet
 		if desired_output_amount.is_zero() {


### PR DESCRIPTION
Note: this points at the non-usdc branch.

Putting up for early feedback and discussion. 

- Adds btc/wbtc route logic in the swapping pallet. (feature flagged for now)
- Adds multi-leg support to swapping for possible 4 leg (or more) routes in the future (not used atm).
- New grouping and execution logic.
   - New 4 phase execution for better swap grouping, prioritizing usdc pools.
   