### PR TITLE
refactor: is oracle supported function for price feed api

### DIFF
--- a/state-chain/cf-integration-tests/src/swapping.rs
+++ b/state-chain/cf-integration-tests/src/swapping.rs
@@ -50,7 +50,7 @@ use cf_primitives::{
 use cf_test_utilities::{assert_events_eq, assert_events_match, assert_has_matching_event};
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, EpochInfo, PoolApi, PoolPairsMap,
-	SwapType,
+	PriceFeedApi, SwapType,
 };
 use frame_support::{
 	assert_ok,
@@ -66,7 +66,7 @@ use sp_core::{H160, U256};
 use state_chain_runtime::{
 	chainflip::{
 		address_derivation::AddressDerivation, simulate_swap::simulate_swap, ChainAddressConverter,
-		EthTransactionBuilder, EvmEnvironment,
+		ChainlinkOracle, EthTransactionBuilder, EvmEnvironment,
 	},
 	AssetBalances, EthereumBroadcaster, EthereumChainTracking, EthereumIngressEgress,
 	EthereumInstance, LiquidityPools, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Swapping,
@@ -1090,6 +1090,11 @@ mod swap_simulation {
 			// 1:1 ratio for easy calculations
 			setup_pool_and_accounts(vec![INPUT_ASSET, OUTPUT_ASSET], OrderType::LimitOrder);
 
+			// Set the oracle's to 1 so that the network fee estimation in the swap simulation uses
+			// the oracle.
+			ChainlinkOracle::set_price(STABLE_ASSET, Price::from_usd(STABLE_ASSET, 1));
+			ChainlinkOracle::set_price(INPUT_ASSET, Price::from_usd(INPUT_ASSET, 1));
+
 			pallet_cf_swapping::NetworkFee::<Runtime>::put(FeeRateAndMinimum {
 				rate: network_fee_rate,
 				minimum: 0,
@@ -1151,6 +1156,11 @@ mod swap_simulation {
 			// Using the same price for both assets and Limit orders so the swap will execute at a
 			// 1:1 ratio for easy calculations
 			setup_pool_and_accounts(vec![INPUT_ASSET, OUTPUT_ASSET], OrderType::LimitOrder);
+
+			// Set the oracle's to 1 so that the network fee estimation in the swap simulation uses
+			// the oracle.
+			ChainlinkOracle::set_price(STABLE_ASSET, Price::from_usd(STABLE_ASSET, 1));
+			ChainlinkOracle::set_price(INPUT_ASSET, Price::from_usd(INPUT_ASSET, 1));
 
 			pallet_cf_swapping::NetworkFee::<Runtime>::put(FeeRateAndMinimum {
 				rate: network_fee_rate,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -3371,30 +3371,32 @@ pub mod pallet {
 				// Get the price of both assets using oracles or simulated swap, both with fallback
 				// to hard coded prices
 				let get_usd_price = |asset, side: Side| -> Price {
-					if !T::PriceFeedApi::is_oracle_supported(asset) {
-						let asset_price =
-							Self::estimate_usdc_price_using_simulated_swap_or_fallback(asset, side); // USDC / Asset
+					if let Some(oracle) = T::PriceFeedApi::get_price(asset) {
+						// Apply a hard coded slippage in the correct direction.
+						let slippage_bps = if asset == STABLE_ASSET {
+							0
+						} else if asset.is_usd_stablecoin() {
+							ORACLE_SLIPPAGE_STABLE
+						} else {
+							ORACLE_SLIPPAGE
+						};
+						// Using stale prices here is fine as its just for fees/gas.
+						oracle.price.adjust_by_bps(slippage_bps, side == Side::Buy)
+					} else {
 						let usdc_price = T::PriceFeedApi::get_price(STABLE_ASSET) // USD / USDC
 							// Ignore staleness because it will always be less stale
 							// than hard-coded prices.
 							.map(|price_data| price_data.price)
 							.unwrap_or_else(Price::one);
-						asset_price.multiply_by(usdc_price) // USD / Asset
-					} else {
-						// Using stale prices here is fine as its just for fees/gas
-						T::PriceFeedApi::get_price(asset)
-							.map(|price_data| {
-								// Apply a hard coded slippage in the correct direction
-								let slippage_bps = if asset == STABLE_ASSET {
-									0
-								} else if asset.is_usd_stablecoin() {
-									ORACLE_SLIPPAGE_STABLE
-								} else {
-									ORACLE_SLIPPAGE
-								};
-								price_data.price.adjust_by_bps(slippage_bps, side == Side::Buy)
-							})
-							.unwrap_or_else(|| utilities::hard_coded_price_for_asset(asset))
+						if asset == STABLE_ASSET {
+							usdc_price
+						} else {
+							let asset_price =
+								Self::estimate_usdc_price_using_simulated_swap_or_fallback(
+									asset, side,
+								); // USDC / Asset
+							asset_price.multiply_by(usdc_price) // USD / Asset
+						}
 					}
 				};
 				let output_price = get_usd_price(output_asset, Side::Buy); // USD / output_asset

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -3055,7 +3055,9 @@ pub mod pallet {
 		/// Returns the configured default oracle price slippage protection for a single pool leg.
 		/// Returns `None` if the asset has no oracle price feed or no valid pool pair.
 		pub fn default_oracle_lpp_for_asset(asset: Asset) -> Option<BasisPoints> {
-			T::PriceFeedApi::get_price(asset)?;
+			if !T::PriceFeedApi::is_oracle_supported(asset) {
+				return None;
+			}
 			Some(DefaultOraclePriceSlippageProtection::<T>::get(AssetPair::new(
 				asset,
 				STABLE_ASSET,
@@ -3369,7 +3371,7 @@ pub mod pallet {
 				// Get the price of both assets using oracles or simulated swap, both with fallback
 				// to hard coded prices
 				let get_usd_price = |asset, side: Side| -> Price {
-					if asset == Asset::Flip || asset == Asset::Dot || asset == Asset::Trx {
+					if !T::PriceFeedApi::is_oracle_supported(asset) {
 						let asset_price =
 							Self::estimate_usdc_price_using_simulated_swap_or_fallback(asset, side); // USDC / Asset
 						let usdc_price = T::PriceFeedApi::get_price(STABLE_ASSET) // USD / USDC
@@ -3489,10 +3491,10 @@ impl<T: Config> SwapParameterValidation for Pallet<T> {
 			return Err(DispatchError::from(Error::<T>::RetryDurationTooHigh));
 		}
 
-		// Check that the oracle prices are available for the assets.
+		// Check that the oracle prices are supported for the assets.
 		if let Some(_max_oracle_price_slippage) = max_oracle_price_slippage {
-			if T::PriceFeedApi::get_price(input_asset).is_none() ||
-				T::PriceFeedApi::get_price(output_asset).is_none()
+			if !T::PriceFeedApi::is_oracle_supported(input_asset) ||
+				!T::PriceFeedApi::is_oracle_supported(output_asset)
 			{
 				return Err(DispatchError::from(Error::<T>::OraclePriceNotAvailable));
 			}

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use core::cell::Cell;
+use core::cell::RefCell;
 
 use crate::{self as pallet_cf_swapping, PalletSafeMode, WeightInfo};
 use cf_chains::AnyChain;
@@ -64,19 +64,35 @@ parameter_types! {
 	pub storage NextChannelId: u64 = 0;
 }
 
+/// Controls which swaps the [`MockSwappingApi`] should make fail.
+#[derive(Clone, Default)]
+pub enum SwapFailureMode {
+	/// Every swap fails.
+	All,
+	/// Only swaps involving any of the listed assets fail (matched on either leg of the swap).
+	Assets(Vec<Asset>),
+	/// No swaps fail.
+	#[default]
+	None,
+}
+
 thread_local! {
-	pub static SWAPS_SHOULD_FAIL: Cell<bool> = Cell::new(false);
+	pub static SWAP_FAILURE_MODE: RefCell<SwapFailureMode> = RefCell::new(SwapFailureMode::None);
 }
 
 pub struct MockSwappingApi;
 
 impl MockSwappingApi {
-	pub fn set_swaps_should_fail(should_fail: bool) {
-		SWAPS_SHOULD_FAIL.with(|cell| cell.set(should_fail));
+	pub fn set_swaps_should_fail(mode: SwapFailureMode) {
+		SWAP_FAILURE_MODE.with(|cell| *cell.borrow_mut() = mode);
 	}
 
-	fn swaps_should_fail() -> bool {
-		SWAPS_SHOULD_FAIL.with(|cell| cell.get())
+	fn swap_should_fail(from: Asset, to: Asset) -> bool {
+		SWAP_FAILURE_MODE.with(|cell| match &*cell.borrow() {
+			SwapFailureMode::All => true,
+			SwapFailureMode::Assets(assets) => assets.contains(&from) || assets.contains(&to),
+			SwapFailureMode::None => false,
+		})
 	}
 
 	pub fn add_liquidity(asset: Asset, amount: AssetAmount) {
@@ -100,7 +116,7 @@ impl SwappingApi for MockSwappingApi {
 		to: Asset,
 		input_amount: AssetAmount,
 	) -> Result<AssetAmount, DispatchError> {
-		if Self::swaps_should_fail() {
+		if Self::swap_should_fail(from, to) {
 			return Err(DispatchError::from("Test swap failed"))
 		}
 		assert!(

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -1040,7 +1040,7 @@ fn swaps_get_retried_after_failure() {
 		.then_execute_at_next_block(|_| {
 			// First group of swaps will be processed at the end of this block,
 			// but we force them to fail:
-			MockSwappingApi::set_swaps_should_fail(true);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		})
 		.then_execute_with(|_| {
 			assert_eq!(System::block_number(), 3);
@@ -1070,7 +1070,7 @@ fn swaps_get_retried_after_failure() {
 			assert_eq!(System::block_number(), 4);
 			// The swaps originally scheduled for block 4 should be executed now,
 			// and should succeed.
-			MockSwappingApi::set_swaps_should_fail(false);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::None);
 		})
 		.then_execute_with(|_| {
 			assert_event_sequence!(
@@ -1157,7 +1157,7 @@ fn fee_swap_is_retried_after_failure() {
 			);
 
 			// Make sure that the swap initially fails:
-			MockSwappingApi::set_swaps_should_fail(true);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		})
 		.then_process_blocks_until_block(EXECUTE_AT_BLOCK)
 		.then_execute_with(|_| {
@@ -1173,7 +1173,7 @@ fn fee_swap_is_retried_after_failure() {
 			assert_eq!(get_scheduled_swap_block(SwapId(1)), Some(RETRY_AT_BLOCK));
 
 			// Make sure that the swap will now succeed:
-			MockSwappingApi::set_swaps_should_fail(false);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::None);
 		})
 		.then_process_blocks_until_block(RETRY_AT_BLOCK)
 		.then_execute_with(|_| {

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -551,6 +551,7 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 		);
 
 		// Using a combination of swap simulation (flip) and hard coded price (Eth).
+		MockSwappingApi::set_swaps_should_fail(SwapFailureMode::Assets(vec![Asset::Eth]));
 		SwapRate::set(0.000000000002_f64); // Flip will be worth $2 via swap simulation
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
@@ -574,7 +575,7 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 		NetworkFee::<Test>::set(FeeRateAndMinimum { rate: Permill::from_percent(1), minimum: 0 });
 
 		// Fallback to hard coded prices when swap simulation fails
-		MockSwappingApi::set_swaps_should_fail(true);
+		MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
 				Asset::Flip,
@@ -681,7 +682,9 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 			30_000_000_000 + 120_000_000 + 304242424 - 3
 		);
 
-		// Using both a hard coded price (Sol) and an oracle price (Btc)
+		// Using both a hard coded price (Sol) and an oracle price (Btc).
+		// We make swaps fail so the hard coded price for Sol is used.
+		MockSwappingApi::set_swaps_should_fail(SwapFailureMode::Assets(vec![Asset::Sol]));
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
 				Asset::Sol,
@@ -1224,9 +1227,7 @@ fn test_refund_fee_calculation() {
 		assert_eq!(take_refund_fee(5, Asset::Usdc, false), (0, 5));
 		assert_eq!(take_refund_fee(u128::MAX, Asset::Usdc, false), (u128::MAX - 10, 10));
 
-		// Conversion needed, so the refund fee is 10 / DEFAULT_SWAP_RATE = 5
-		// Note: Using Flip here because it uses swap simulation for conversion instead of
-		// oracle price.
+		// Conversion needed, no oracle price set, so the refund fee is 10 / DEFAULT_SWAP_RATE = 5
 		assert_eq!(take_refund_fee(1000, Asset::Flip, false), (995, 5));
 		assert_eq!(take_refund_fee(0, Asset::Flip, false), (0, 0));
 		assert_eq!(take_refund_fee(3, Asset::Flip, false), (0, 3));

--- a/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fill_or_kill.rs
@@ -405,7 +405,7 @@ fn fok_swap_gets_refunded_due_to_price_impact_protection(is_ccm: bool) {
 		})
 		.then_execute_at_block(SWAPS_SCHEDULED_FOR_BLOCK, |_| {
 			// This simulates not having enough liquidity/triggering price impact protection
-			MockSwappingApi::set_swaps_should_fail(true);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		})
 		.then_execute_with(|_| {
 			// Both swaps should fail here and be rescheduled for a later block
@@ -478,7 +478,7 @@ fn fok_test_zero_refund_duration(is_ccm: bool) {
 		})
 		.then_execute_at_block(SWAPS_SCHEDULED_FOR_BLOCK, |_| {
 			// This simulates not having enough liquidity/triggering price impact protection
-			MockSwappingApi::set_swaps_should_fail(true);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		})
 		.then_execute_with(|_| {
 			// The swap should fail and be refunded immediately instead of being retried
@@ -562,7 +562,7 @@ fn test_zero_refund_amount_remaining() {
 		})
 		.then_execute_at_block(SWAPS_SCHEDULED_FOR_BLOCK, |_| {
 			// Trigger a refund
-			MockSwappingApi::set_swaps_should_fail(true);
+			MockSwappingApi::set_swaps_should_fail(SwapFailureMode::All);
 		})
 		.then_execute_with(|_| {
 			// The refund should ignored and all of the swap amount should be swapped for fees

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -239,7 +239,7 @@ impl TradingStrategy {
 				ensure!(*base_asset != STABLE_ASSET, Error::<T>::InvalidAssetsForStrategy);
 				ensure!(*quote_asset == STABLE_ASSET, Error::<T>::InvalidAssetsForStrategy);
 				ensure!(
-					T::PriceFeedApi::get_relative_price(*base_asset, *quote_asset).is_some(),
+					T::PriceFeedApi::is_oracle_supported(*base_asset),
 					Error::<T>::InvalidAssetsForStrategy
 				);
 			},

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -36,7 +36,9 @@ pub mod vault_swaps;
 
 use crate::{
 	chainflip::witnessing::{
-		generic_elections::{decode_and_get_latest_oracle_price, is_oracle_supported, Chainlink},
+		generic_elections::{
+			decode_and_get_latest_oracle_price, get_chainlink_assetpair, Chainlink,
+		},
 		solana_elections::SolanaChainTrackingProvider,
 	},
 	constants::common::YEAR,
@@ -1225,7 +1227,7 @@ impl CcmAdditionalDataHandler for CfCcmAdditionalDataHandler {
 pub struct ChainlinkOracle;
 impl cf_traits::PriceFeedApi for ChainlinkOracle {
 	fn is_oracle_supported(asset: Asset) -> bool {
-		is_oracle_supported(asset)
+		get_chainlink_assetpair(asset).is_some()
 	}
 
 	fn get_price(asset: assets::any::Asset) -> Option<OraclePrice> {

--- a/state-chain/runtime/src/chainflip.rs
+++ b/state-chain/runtime/src/chainflip.rs
@@ -36,7 +36,7 @@ pub mod vault_swaps;
 
 use crate::{
 	chainflip::witnessing::{
-		generic_elections::{decode_and_get_latest_oracle_price, Chainlink},
+		generic_elections::{decode_and_get_latest_oracle_price, is_oracle_supported, Chainlink},
 		solana_elections::SolanaChainTrackingProvider,
 	},
 	constants::common::YEAR,
@@ -1224,6 +1224,10 @@ impl CcmAdditionalDataHandler for CfCcmAdditionalDataHandler {
 
 pub struct ChainlinkOracle;
 impl cf_traits::PriceFeedApi for ChainlinkOracle {
+	fn is_oracle_supported(asset: Asset) -> bool {
+		is_oracle_supported(asset)
+	}
+
 	fn get_price(asset: assets::any::Asset) -> Option<OraclePrice> {
 		decode_and_get_latest_oracle_price::<Chainlink>(asset)
 	}

--- a/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
@@ -58,7 +58,7 @@ use pallet_cf_elections::{
 	RunnerStorageAccess,
 };
 
-fn get_chainlink_assetpair(asset: any::Asset) -> Option<ChainlinkAssetpair> {
+pub(crate) fn get_chainlink_assetpair(asset: any::Asset) -> Option<ChainlinkAssetpair> {
 	use ChainlinkAssetpair::*;
 
 	match asset {
@@ -84,10 +84,6 @@ fn get_chainlink_assetpair(asset: any::Asset) -> Option<ChainlinkAssetpair> {
 }
 
 //--------------- api provided to other pallets -------------
-
-pub fn is_oracle_supported(asset: any::Asset) -> bool {
-	get_chainlink_assetpair(asset).is_some()
-}
 
 pub fn decode_and_get_latest_oracle_price<T: OPTypes>(asset: any::Asset) -> Option<OraclePrice> {
 	use PriceStatus::*;

--- a/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
@@ -58,20 +58,10 @@ use pallet_cf_elections::{
 	RunnerStorageAccess,
 };
 
-//--------------- api provided to other pallets -------------
-
-pub fn decode_and_get_latest_oracle_price<T: OPTypes>(asset: any::Asset) -> Option<OraclePrice> {
+fn get_chainlink_assetpair(asset: any::Asset) -> Option<ChainlinkAssetpair> {
 	use ChainlinkAssetpair::*;
-	use PriceStatus::*;
 
-	let state = DerivedElectoralAccess::<
-			_,
-			ChainlinkOraclePriceES,
-			RunnerStorageAccess<Runtime, ()>,
-		>::unsynchronised_state()
-		.inspect_err(|_| log_or_panic!("Failed to get election state for the ChainlinkOraclePrice ES due to corrupted storage")).ok()?;
-
-	let asset = match asset {
+	match asset {
 		any::Asset::Eth => Some(EthUsd),
 		any::Asset::Flip => None,
 		any::Asset::Usdc => Some(UsdcUsd),
@@ -90,7 +80,26 @@ pub fn decode_and_get_latest_oracle_price<T: OPTypes>(asset: any::Asset) -> Opti
 		any::Asset::HubUsdc => Some(UsdcUsd),
 		any::Asset::Trx => None,
 		any::Asset::TrxUsdt => Some(UsdtUsd),
-	}?;
+	}
+}
+
+//--------------- api provided to other pallets -------------
+
+pub fn is_oracle_supported(asset: any::Asset) -> bool {
+	get_chainlink_assetpair(asset).is_some()
+}
+
+pub fn decode_and_get_latest_oracle_price<T: OPTypes>(asset: any::Asset) -> Option<OraclePrice> {
+	use PriceStatus::*;
+
+	let state = DerivedElectoralAccess::<
+			_,
+			ChainlinkOraclePriceES,
+			RunnerStorageAccess<Runtime, ()>,
+		>::unsynchronised_state()
+		.inspect_err(|_| log_or_panic!("Failed to get election state for the ChainlinkOraclePrice ES due to corrupted storage")).ok()?;
+
+	let asset = get_chainlink_assetpair(asset)?;
 
 	get_latest_price_with_statechain_encoding(&state, asset).map(|(price, staleness)| OraclePrice {
 		price,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -1447,12 +1447,16 @@ pub struct OraclePrice {
 }
 
 pub trait PriceFeedApi {
+	/// Whether the given asset is supported by the oracle price ES.
+	fn is_oracle_supported(asset: Asset) -> bool;
+
 	/// The price of the given asset.
 	///
 	/// Price is the amount of USD obtained for 1 unit of the asset.
 	///
 	/// In buy/sell terms, this is the USD-denominated sell price of the asset.
 	fn get_price(asset: Asset) -> Option<OraclePrice>;
+
 	/// Get the relative price of asset1 in terms of asset2.
 	///
 	/// If asset1 price rises or asset2 price drops, the relative price increases.
@@ -1467,6 +1471,7 @@ pub trait PriceFeedApi {
 			None
 		}
 	}
+
 	/// Get a fresh (non-stale) buy price of input_asset in terms of output_asset.
 	///
 	/// If the input price drops or output price rises, the buy price increases, meaning more
@@ -1482,6 +1487,7 @@ pub trait PriceFeedApi {
 			}
 		})
 	}
+
 	/// Get a fresh (non-stale) sell price of input_asset in terms of output_asset.
 	///
 	/// If the input price rises or output price drops, the sell price increases, meaning more
@@ -1497,6 +1503,7 @@ pub trait PriceFeedApi {
 			}
 		})
 	}
+
 	#[cfg(any(feature = "runtime-benchmarks", feature = "runtime-integration-tests"))]
 	fn set_price(asset: Asset, price: Price);
 }

--- a/state-chain/traits/src/mocks/price_feed_api.rs
+++ b/state-chain/traits/src/mocks/price_feed_api.rs
@@ -36,6 +36,10 @@ impl MockPriceFeedApi {
 }
 
 impl PriceFeedApi for MockPriceFeedApi {
+	fn is_oracle_supported(asset: Asset) -> bool {
+		Self::get_price(asset).is_some()
+	}
+
 	fn get_price(asset: Asset) -> Option<OraclePrice> {
 		let stale = Self::get_storage::<_, bool>(ORACLE_STALE, asset).unwrap_or_default();
 		Self::get_storage::<_, Option<Price>>(ORACLE_PRICE, asset)


### PR DESCRIPTION
# Pull Request

Closes: PRO-2869

## Summary

Added a `is_oracle_supported` to the price feed api. It re-uses the logic from the get_price code.

---

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
