### PR TITLE
feat: Reject loan origination when pool can't cover network fee

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -4,6 +4,7 @@ use crate::{
 	core_lending_pool::{CoreLendingPool, CoreLoanId},
 	general_lending::{check_pool_caps_after_borrow, create_new_loan, fund_loan, OraclePriceCache},
 };
+use frame_support::sp_runtime::{helpers_128bit::multiply_by_rational_with_rounding, Rounding};
 use sp_std::collections::btree_set::BTreeSet;
 
 use super::*;
@@ -178,13 +179,31 @@ impl<T: Config> BoostApi for Pallet<T> {
 			.and_then(|pool| CorePools::<T>::get(asset, pool.core_pool_id))
 			.map_or(0, |p| p.available_amount.into_asset_amount());
 
-		let (lending_pool_principal, boost_pool_principal) = try_split_required_amount(
-			required_amount,
-			lending_available,
-			boost_available,
-			BoostConfig::<T>::get().min_lending_pool_share,
-		)
-		.map_err(Error::<T>::from)?;
+		// Two-step split: first allocate proportionally using the lending pool's *full*
+		// available balance (so we don't bias toward the legacy boost pool when utilisation
+		// is healthy), then cap the lending pool's contribution to leave room for the
+		// network portion of the origination fee. The cap only kicks in when the
+		// proportional allocation would push the lending pool past what `fund_loan` can
+		// accept (i.e. near 100% utilisation) — otherwise the split is unchanged. Any
+		// overflow at the cap shifts to the boost pool.
+		let (lending_pool_principal, boost_pool_principal) = {
+			let (lending_pool_principal, boost_pool_principal) = try_split_required_amount(
+				required_amount,
+				lending_available,
+				boost_available,
+				BoostConfig::<T>::get().min_lending_pool_share,
+			)
+			.map_err(Error::<T>::from)?;
+
+			cap_lending_principal_for_fee::<T>(
+				lending_pool_principal,
+				boost_pool_principal,
+				lending_available,
+				boost_available,
+				required_amount,
+				total_fee,
+			)?
+		};
 
 		let lending_pool_fee =
 			Permill::from_rational(lending_pool_principal, required_amount) * total_fee;
@@ -421,6 +440,57 @@ impl<T: Config> From<SplitRequiredAmountError> for Error<T> {
 	fn from(_: SplitRequiredAmountError) -> Self {
 		Error::<T>::InsufficientBoostLiquidity
 	}
+}
+
+/// Largest principal the lending pool may fund without `fund_loan` rejecting the loan
+/// for failing to cover the network portion of the origination fee from `available_amount`.
+///
+/// For principal `p`, the network portion is `network_fee_full * p/required`, where
+/// `network_fee_full = split_between_network_and_pool(total_fee).0` is the network portion
+/// if the lending pool covered all of `required_amount`. `fund_loan` enforces
+/// `p + (p/required) * network_fee_full <= lending_available`, which solves to
+/// `p <= lending_available * required / (required + network_fee_full)`.
+fn lending_principal_cap_for_fee<T: Config>(
+	lending_available: AssetAmount,
+	total_fee: AssetAmount,
+	required_amount: AssetAmount,
+) -> AssetAmount {
+	if required_amount == 0 {
+		return lending_available;
+	}
+	let (network_fee_full, _) = split_between_network_and_pool::<T>(total_fee);
+	// Note: we use `multiply_by_rational_with_rounding` rather than the `Permill::from_rational`
+	// pattern used elsewhere for fee calculations because the cap is a hard liquidity
+	// constraint — `Permill`'s 1e-6 precision loss can shrink the cap enough to push the
+	// boost pool past its available balance when buffers are tight.
+	multiply_by_rational_with_rounding(
+		lending_available,
+		required_amount,
+		required_amount.saturating_add(network_fee_full),
+		Rounding::Down,
+	)
+	.unwrap_or(0)
+}
+
+/// If the proportional split would push the lending pool past the cap that leaves room for
+/// the origination network fee, shift the overflow to the boost pool. Fails if the boost
+/// pool can't absorb it.
+fn cap_lending_principal_for_fee<T: Config>(
+	lending_pool_principal: AssetAmount,
+	boost_pool_principal: AssetAmount,
+	lending_available: AssetAmount,
+	boost_available: AssetAmount,
+	required_amount: AssetAmount,
+	total_fee: AssetAmount,
+) -> Result<(AssetAmount, AssetAmount), DispatchError> {
+	let cap = lending_principal_cap_for_fee::<T>(lending_available, total_fee, required_amount);
+	if lending_pool_principal <= cap {
+		return Ok((lending_pool_principal, boost_pool_principal));
+	}
+	let overflow = lending_pool_principal.saturating_sub(cap);
+	let new_boost_pool_principal = boost_pool_principal.saturating_add(overflow);
+	ensure!(new_boost_pool_principal <= boost_available, Error::<T>::InsufficientBoostLiquidity);
+	Ok((cap, new_boost_pool_principal))
 }
 
 /// Split `required_amount` between the lending pool and the legacy boost pool

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1414,7 +1414,9 @@ pub(super) fn initiate_network_fee_swap<T: Config>(asset: Asset, fee_amount: Ass
 ///
 /// Emits [`Event::OriginationFeeTaken`].
 ///
-/// Fails if the pool for `loan.asset` does not exist or has insufficient available funds.
+/// Fails with `InsufficientLiquidity` if the pool's available balance can't cover both the
+/// principal and the network portion of the origination fee, or if the pool for `loan.asset`
+/// does not exist.
 pub fn fund_loan<T: Config>(
 	loan: &mut GeneralLoan<T>,
 	principal: AssetAmount,
@@ -1423,6 +1425,14 @@ pub fn fund_loan<T: Config>(
 ) -> Result<(), DispatchError> {
 	GeneralLendingPools::<T>::try_mutate(loan.asset, |pool| {
 		let pool = pool.as_mut().ok_or(Error::<T>::PoolDoesNotExist)?;
+
+		// The pool must hold enough liquid funds to cover both the principal *and* the
+		// network portion of the origination fee. If it can't, origination is rejected
+		// outright rather than leaving a partial obligation to the network.
+		ensure!(
+			pool.available_amount >= principal.saturating_add(origination_fee_network),
+			Error::<T>::InsufficientLiquidity,
+		);
 
 		pool.provide_funds_for_loan(principal).map_err(Error::<T>::from)?;
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -3134,10 +3134,7 @@ fn origination_rejected_when_pool_cant_cover_network_fee() {
 		// Borrowing the full PRINCIPAL succeeds: the pool was funded with exactly the
 		// network-fee headroom for this principal. After the loan, `available` is zero.
 		assert_ok!(LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None));
-		assert_eq!(
-			GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount,
-			0,
-		);
+		assert_eq!(GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount, 0,);
 	});
 }
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -1910,123 +1910,6 @@ fn liquidation_with_outstanding_principal() {
 		});
 }
 
-#[test]
-fn liquidation_with_outstanding_principal_and_owed_network_fees() {
-	// Same as in `liquidation_with_outstanding_principal`, we test a scenario where a loan is
-	// liquidated and the recovered principal isn't enough to cover the total loan amount. Here
-	// utilisation is 100% so the pool has an outstanding network IOU at the time of write-off;
-	// the IOU should be forgiven up to the written-off amount rather than left for future
-	// lender liquidity to cover.
-
-	const PRINCIPAL: AssetAmount = INIT_POOL_AMOUNT;
-	const INIT_COLLATERAL: AssetAmount = (4 * PRINCIPAL / 3) * SWAP_RATE; // 75% LTV
-
-	const RECOVERED_PRINCIPAL: AssetAmount = 3 * PRINCIPAL / 4;
-
-	const NEW_SWAP_RATE: u128 = SWAP_RATE * 2;
-
-	const LIQUIDATION_SWAP_1: SwapRequestId = SwapRequestId(0);
-
-	const ORIGINATION_FEE: AssetAmount = portion_of_amount(DEFAULT_ORIGINATION_FEE, PRINCIPAL);
-	let (origination_fee_network, origination_fee_pool) = take_network_fee(ORIGINATION_FEE);
-
-	new_test_ext().with_funded_pool(INIT_POOL_AMOUNT)
-		.execute_with(|| {
-
-			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
-			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-
-			assert_eq!(
-				create_loan_and_supply_collateral(
-					BORROWER,
-					LOAN_ASSET,
-					PRINCIPAL,
-					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
-				),
-				Ok(LOAN_ID)
-			);
-
-			// Update oracle price to trigger liquidation
-			MockPriceFeedApi::set_price_usd_fine(LOAN_ASSET, NEW_SWAP_RATE);
-		})
-		.then_execute_at_next_block(|_| {
-			assert!(MockSwapRequestHandler::<Test>::get_swap_requests()
-				.contains_key(&LIQUIDATION_SWAP_1));
-
-			System::reset_events();
-
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: INIT_POOL_AMOUNT + origination_fee_pool,
-					available_amount: 0,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: origination_fee_network,
-				}
-			);
-
-			LendingPools::process_loan_swap_outcome(
-				LIQUIDATION_SWAP_1,
-				LendingSwapType::Liquidation { borrower_id: BORROWER, loan_id: LOAN_ID },
-				RECOVERED_PRINCIPAL,
-			);
-
-			let liquidation_fee = CONFIG.liquidation_fee(LOAN_ASSET) * RECOVERED_PRINCIPAL;
-			let (liquidation_fee_network, liquidation_fee_pool) =
-				take_network_fee(liquidation_fee);
-
-			let repaid_principal = RECOVERED_PRINCIPAL - liquidation_fee;
-			let expected_outstanding_principal = PRINCIPAL + ORIGINATION_FEE - repaid_principal;
-
-			assert_event_sequence!(
-				Test,
-				RuntimeEvent::LendingPools(Event::<Test>::LiquidationCompleted {
-					borrower_id: BORROWER,
-					reason: LiquidationCompletionReason::FullySwapped,
-				}),
-				RuntimeEvent::LendingPools(Event::<Test>::LiquidationFeeTaken {
-					loan_id: LOAN_ID,
-					pool_fee,
-					network_fee,
-					broker_fee
-				}) if pool_fee == liquidation_fee_pool && network_fee == liquidation_fee_network && broker_fee == 0,
-				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
-					loan_id: LOAN_ID,
-					action_type: LoanRepaidActionType::Liquidation { swap_request_id: LIQUIDATION_SWAP_1 },
-					amount
-				}) if amount == RECOVERED_PRINCIPAL - liquidation_fee,
-				RuntimeEvent::LendingPools(Event::<Test>::LoanSettled {
-					loan_id: LOAN_ID,
-					outstanding_principal,
-					via_liquidation: true,
-				}) if outstanding_principal == expected_outstanding_principal
-			);
-
-			assert_eq!(MockBalance::get_balance(&BORROWER, LOAN_ASSET), PRINCIPAL);
-			assert_eq!(MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET), 0);
-
-			// The pool has lost outstanding principal (but has accrued origination and liquidation fees).
-			// The defaulted loan's outstanding network fees are forgiven against the network's IOU
-			// rather than charged to lenders, so `total_amount` only absorbs the portion of the
-			// write-off that exceeds the network IOU.
-			let new_total_amount = INIT_POOL_AMOUNT + origination_fee_pool + liquidation_fee_pool -
-				(expected_outstanding_principal - origination_fee_network);
-
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: new_total_amount,
-					available_amount: new_total_amount,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: 0,
-				}
-			);
-
-			// The account is removed as it has no loans and no supplied collateral:
-			assert_eq!(LoanAccounts::<Test>::get(BORROWER), None);
-		});
-}
-
 mod multi_asset_collateral_liquidation {
 
 	use super::*;
@@ -3219,162 +3102,43 @@ fn borrowing_disallowed_during_liquidation() {
 }
 
 #[test]
-fn network_fees_under_full_utilisation() {
-	// Here we test we correctly record how much is owed to the network
-	// so that if utilisation is 100% and it is not possible for the
-	// network to take earnings from the pool, we can still collect
-	// the full owed amount when some pool funds become available.
-
-	// The loan will request all available funds
+fn origination_rejected_when_pool_cant_cover_network_fee() {
+	// `fund_loan` refuses to originate a loan when the pool's `available_amount` can't
+	// cover both the principal and the network portion of the origination fee. Fund the
+	// pool with exactly `PRINCIPAL + origination_fee_network`: borrowing `PRINCIPAL` fits
+	// exactly, while `PRINCIPAL + 1` does not.
 	const PRINCIPAL: AssetAmount = INIT_POOL_AMOUNT;
+	const ORIGINATION_FEE: AssetAmount = portion_of_amount(DEFAULT_ORIGINATION_FEE, PRINCIPAL);
 	const INIT_COLLATERAL: AssetAmount = (4 * PRINCIPAL / 3) * SWAP_RATE; // 75% LTV
 
-	// Additional funds that will be added to the pool later:
-	const EXTRA_POOL_AMOUNT: AssetAmount = INIT_POOL_AMOUNT / 2;
+	let (origination_fee_network, _) = take_network_fee(ORIGINATION_FEE);
+	let pool_funds = PRINCIPAL + origination_fee_network;
 
-	const ORIGINATION_FEE: AssetAmount = portion_of_amount(DEFAULT_ORIGINATION_FEE, PRINCIPAL);
+	new_test_ext().with_funded_pool(pool_funds).execute_with(|| {
+		// Supply collateral up front so loan attempts only differ in the requested principal.
+		MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
+		MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
+		LendingPools::new_lending_pool(COLLATERAL_ASSET).unwrap();
+		assert_ok!(LendingPools::add_lender_funds(
+			RuntimeOrigin::signed(BORROWER),
+			COLLATERAL_ASSET,
+			INIT_COLLATERAL,
+		));
 
-	let (origination_fee_network, origination_fee_pool) = take_network_fee(ORIGINATION_FEE);
+		// One unit beyond what the pool's headroom can fund → rejected.
+		assert_noop!(
+			LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL + 1, None),
+			Error::<Test>::InsufficientLiquidity,
+		);
 
-	let mut interest = Interest::new();
-
-	let utilisation_1 = Permill::from_rational(
-		PRINCIPAL + ORIGINATION_FEE,
-		INIT_POOL_AMOUNT + origination_fee_pool,
-	);
-
-	// Confirming that utilisation is 100% (in fact it is technically slightly higher due network
-	// fee depth, but it will be clamped at 100%):
-	assert_eq!(utilisation_1, Permill::from_percent(100));
-
-	// First interest payment:
-	interest.accrue_interest(
-		PRINCIPAL + ORIGINATION_FEE,
-		utilisation_1,
-		CONFIG.interest_payment_interval_blocks,
-	);
-
-	let (pool_interest_1, network_interest_1) = interest.collect();
-
-	let utilisation_2 = Permill::from_rational(
-		PRINCIPAL + ORIGINATION_FEE + pool_interest_1 + network_interest_1,
-		INIT_POOL_AMOUNT + EXTRA_POOL_AMOUNT + origination_fee_pool + pool_interest_1,
-	);
-
-	// Second interest payment:
-	interest.accrue_interest(
-		PRINCIPAL + ORIGINATION_FEE + pool_interest_1 + network_interest_1,
-		utilisation_2,
-		CONFIG.interest_payment_interval_blocks,
-	);
-
-	let (pool_interest_2, network_interest_2) = interest.collect();
-
-	new_test_ext()
-		.with_funded_pool(INIT_POOL_AMOUNT)
-		.execute_with(|| {
-			// Set a low collection threshold so we can more easily check the collected amount
-			assert_ok!(Pallet::<Test>::update_pallet_config(
-				RuntimeOrigin::root(),
-				bounded_vec![PalletConfigUpdate::SetInterestCollectionThresholdUsd(1)],
-			));
-
-			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
-			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
-
-			assert_eq!(
-				create_loan_and_supply_collateral(
-					BORROWER,
-					LOAN_ASSET,
-					PRINCIPAL,
-					BTreeMap::from([(COLLATERAL_ASSET, INIT_COLLATERAL)])
-				),
-				Ok(LOAN_ID)
-			);
-
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: INIT_POOL_AMOUNT + origination_fee_pool,
-					available_amount: 0,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: origination_fee_network,
-				}
-			);
-		})
-		.then_process_blocks_until_block(
-			INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
-		)
-		.then_execute_with(|_| {
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: INIT_POOL_AMOUNT + origination_fee_pool + pool_interest_1,
-					available_amount: 0,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: origination_fee_network + network_interest_1,
-				}
-			);
-
-			// LP Adds additional funds, they will (partially) be used to repay the network
-			// upon next interest collection
-			MockBalance::credit_account(&LENDER, LOAN_ASSET, EXTRA_POOL_AMOUNT);
-			assert_ok!(LendingPools::add_lender_funds(
-				RuntimeOrigin::signed(LENDER),
-				LOAN_ASSET,
-				EXTRA_POOL_AMOUNT
-			));
-
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: INIT_POOL_AMOUNT +
-						EXTRA_POOL_AMOUNT + origination_fee_pool +
-						pool_interest_1,
-					available_amount: EXTRA_POOL_AMOUNT,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: origination_fee_network + network_interest_1,
-				}
-			);
-
-			// Note that we expose `network_interest_1` in the event despite it not technically
-			// accessible to the network yet
-			assert_has_event::<Test>(RuntimeEvent::LendingPools(Event::<Test>::InterestTaken {
-				loan_id: LOAN_ID,
-				pool_interest: pool_interest_1,
-				network_interest: network_interest_1,
-				broker_interest: 0,
-				low_ltv_penalty: 0,
-			}));
-		})
-		.then_process_blocks_until_block(
-			INIT_BLOCK + 2 * CONFIG.interest_payment_interval_blocks as u64,
-		)
-		.then_execute_with(|_| {
-			// Expecting the second interest charge + fees payed to the network to be repaid in
-			// full.
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
-				LendingPool {
-					total_amount: INIT_POOL_AMOUNT +
-						EXTRA_POOL_AMOUNT + origination_fee_pool +
-						pool_interest_1 + pool_interest_2,
-					available_amount: EXTRA_POOL_AMOUNT -
-						origination_fee_network -
-						network_interest_1 - network_interest_2,
-					lender_shares: BTreeMap::from([(LENDER, Perquintill::one())]),
-					owed_to_network: 0,
-				}
-			);
-
-			assert_has_event::<Test>(RuntimeEvent::LendingPools(Event::<Test>::InterestTaken {
-				loan_id: LOAN_ID,
-				pool_interest: pool_interest_2,
-				network_interest: network_interest_2,
-				broker_interest: 0,
-				low_ltv_penalty: 0,
-			}));
-		});
+		// Borrowing the full PRINCIPAL succeeds: the pool was funded with exactly the
+		// network-fee headroom for this principal. After the loan, `available` is zero.
+		assert_ok!(LendingPools::new_loan(BORROWER, LOAN_ASSET, PRINCIPAL, None));
+		assert_eq!(
+			GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount,
+			0,
+		);
+	});
 }
 
 #[test]

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -1202,7 +1202,7 @@ mod hybrid_boosting {
 			// of the origination fee from `available_amount` at borrow time.
 			const LENDING_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2 + LENDING_NETWORK_FEE; // 99_960_000
 			const LEGACY_POOL_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
-			// Principal actually contributed by each pool (50/50 of required_amount).
+															   // Principal actually contributed by each pool (50/50 of required_amount).
 			const LENDING_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
 			const LEGACY_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT - LENDING_PRINCIPAL; // 99_950_000
 
@@ -1264,10 +1264,7 @@ mod hybrid_boosting {
 			// LENDING_FUNDS (99_960_000), so available is now zero and `owed_to_network` is
 			// zero (the network fee was collected up-front rather than left as an IOU).
 			assert_eq!(GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().available_amount, 0);
-			assert_eq!(
-				GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().owed_to_network,
-				0
-			);
+			assert_eq!(GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().owed_to_network, 0);
 			assert_eq!(PendingNetworkFees::<Test>::get(BOOST_ASSET), LENDING_NETWORK_FEE);
 
 			assert_eq!(
@@ -1549,8 +1546,7 @@ mod hybrid_boosting {
 			const REQUIRED_AMOUNT: AssetAmount = DEPOSIT_AMOUNT - TOTAL_FEE; // 199_900_000
 
 			const LENDING_FEE_TOTAL: AssetAmount = TOTAL_FEE / 2; // 50_000
-			const LENDING_NETWORK_FEE: AssetAmount =
-				LENDING_FEE_TOTAL * NETWORK_FEE_PERCENT / 100; // 10_000
+			const LENDING_NETWORK_FEE: AssetAmount = LENDING_FEE_TOTAL * NETWORK_FEE_PERCENT / 100; // 10_000
 
 			// Equal liquidity in both pools produces a clean 50/50 split. The lending pool
 			// gets a small buffer beyond half the required amount so fund_loan can also

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -1188,10 +1188,6 @@ mod hybrid_boosting {
 			const TOTAL_FEE: AssetAmount = DEPOSIT_AMOUNT * BOOST_FEE_BPS as u128 / 10_000; // 100_000
 			const REQUIRED_AMOUNT: AssetAmount = DEPOSIT_AMOUNT - TOTAL_FEE; // 199_900_000
 
-			// Equal liquidity in both pools produces a clean 50/50 split.
-			const LENDING_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
-			const LEGACY_POOL_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
-
 			// Total fee is split 50/50 between the two pools (each contributes half the principal).
 			const LENDING_FEE_TOTAL: AssetAmount = TOTAL_FEE / 2; // 50_000
 			const LEGACY_FEE_TOTAL: AssetAmount = TOTAL_FEE - LENDING_FEE_TOTAL; // 50_000
@@ -1200,6 +1196,15 @@ mod hybrid_boosting {
 			const LENDING_POOL_FEE: AssetAmount = LENDING_FEE_TOTAL - LENDING_NETWORK_FEE; // 40_000
 			const LEGACY_NETWORK_FEE: AssetAmount = LEGACY_FEE_TOTAL * NETWORK_FEE_PERCENT / 100; // 10_000
 			const LEGACY_POOL_FEE: AssetAmount = LEGACY_FEE_TOTAL - LEGACY_NETWORK_FEE; // 40_000
+
+			// Equal liquidity in both pools produces a clean 50/50 split. The lending pool
+			// gets a tiny extra buffer so that fund_loan can also collect the network portion
+			// of the origination fee from `available_amount` at borrow time.
+			const LENDING_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2 + LENDING_NETWORK_FEE; // 99_960_000
+			const LEGACY_POOL_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
+			// Principal actually contributed by each pool (50/50 of required_amount).
+			const LENDING_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
+			const LEGACY_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT - LENDING_PRINCIPAL; // 99_950_000
 
 			setup_both_pools();
 
@@ -1227,8 +1232,8 @@ mod hybrid_boosting {
 				LendingPools::try_boosting(DEPOSIT_ID, BOOST_ASSET, DEPOSIT_AMOUNT, BOOST_FEE_BPS,),
 				Ok(BoostOutcome {
 					amounts: [
-						(BoostSource::LendingPool, LENDING_FUNDS + LENDING_FEE_TOTAL),
-						(BoostSource::BoostPool, LEGACY_POOL_FUNDS + LEGACY_FEE_TOTAL),
+						(BoostSource::LendingPool, LENDING_PRINCIPAL + LENDING_FEE_TOTAL),
+						(BoostSource::BoostPool, LEGACY_PRINCIPAL + LEGACY_FEE_TOTAL),
 					]
 					.into(),
 					fees: [
@@ -1245,7 +1250,7 @@ mod hybrid_boosting {
 					loan_id: LOAN_ID,
 					loan_type: LoanType::Boost(DEPOSIT_ID),
 					asset: BOOST_ASSET,
-					principal_amount: LENDING_FUNDS,
+					principal_amount: LENDING_PRINCIPAL,
 				}),
 				RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 					loan_id: LOAN_ID,
@@ -1255,15 +1260,15 @@ mod hybrid_boosting {
 				}),
 			);
 
-			// Boost should have consumed all available funds:
+			// Lending pool: principal (99_950_000) + network fee (10_000) consumed the full
+			// LENDING_FUNDS (99_960_000), so available is now zero and `owed_to_network` is
+			// zero (the network fee was collected up-front rather than left as an IOU).
 			assert_eq!(GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().available_amount, 0);
-
-			// Because lending pool has 0 available funds, its network fee portion is recorded
-			// but not yet credited to the network:
 			assert_eq!(
 				GeneralLendingPools::<Test>::get(BOOST_ASSET).unwrap().owed_to_network,
-				LENDING_NETWORK_FEE
+				0
 			);
+			assert_eq!(PendingNetworkFees::<Test>::get(BOOST_ASSET), LENDING_NETWORK_FEE);
 
 			assert_eq!(
 				BoostedDeposits::<Test>::get(BOOST_ASSET, DEPOSIT_ID),
@@ -1273,7 +1278,7 @@ mod hybrid_boosting {
 					boost_pool_contribution: Some(BoostPoolContribution {
 						core_pool_id: CorePoolId(0),
 						loan_id: CoreLoanId(0),
-						boosted_amount: (REQUIRED_AMOUNT - LENDING_FUNDS) + LEGACY_FEE_TOTAL,
+						boosted_amount: LEGACY_PRINCIPAL + LEGACY_FEE_TOTAL,
 						network_fee: LEGACY_NETWORK_FEE,
 					}),
 				})
@@ -1288,7 +1293,7 @@ mod hybrid_boosting {
 				BoostFinalisationOutcome { network_fee: LEGACY_NETWORK_FEE }
 			);
 
-			const LENDING_REPAYMENT: AssetAmount = LENDING_FUNDS + LENDING_FEE_TOTAL;
+			const LENDING_REPAYMENT: AssetAmount = LENDING_PRINCIPAL + LENDING_FEE_TOTAL;
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
@@ -1305,7 +1310,9 @@ mod hybrid_boosting {
 
 			assert_eq!(BoostedDeposits::<Test>::get(BOOST_ASSET, DEPOSIT_ID), None);
 
-			// Lending pool earns the lending pool's portion of the fee (excludes the network fee).
+			// Lender keeps their full deposit (LENDING_FUNDS) and earns the pool's share of
+			// the origination fee (LENDING_POOL_FEE). The network portion of the fee was paid
+			// out at borrow time from the buffer the lender deposited specifically to cover it.
 			assert_eq!(
 				get_supply_position(BOOST_ASSET, BOOSTER_1),
 				Some(LENDING_FUNDS + LENDING_POOL_FEE)
@@ -1541,16 +1548,21 @@ mod hybrid_boosting {
 			const TOTAL_FEE: AssetAmount = DEPOSIT_AMOUNT * BOOST_FEE_BPS as u128 / 10_000; // 100_000
 			const REQUIRED_AMOUNT: AssetAmount = DEPOSIT_AMOUNT - TOTAL_FEE; // 199_900_000
 
-			// Equal liquidity in both pools => 50/50 split.
-			const LENDING_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
-			const LEGACY_POOL_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
-
 			const LENDING_FEE_TOTAL: AssetAmount = TOTAL_FEE / 2; // 50_000
+			const LENDING_NETWORK_FEE: AssetAmount =
+				LENDING_FEE_TOTAL * NETWORK_FEE_PERCENT / 100; // 10_000
+
+			// Equal liquidity in both pools produces a clean 50/50 split. The lending pool
+			// gets a small buffer beyond half the required amount so fund_loan can also
+			// collect the origination network fee from `available_amount`.
+			const LENDING_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2 + LENDING_NETWORK_FEE; // 99_960_000
+			const LEGACY_POOL_FUNDS: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
+			const LENDING_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT / 2; // 99_950_000
 
 			// Total funds taken from the boost pool:
-			const LEGACY_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT - LENDING_FUNDS; // 99_950_000
+			const LEGACY_PRINCIPAL: AssetAmount = REQUIRED_AMOUNT - LENDING_PRINCIPAL; // 99_950_000
 
-			const LENDING_OWED_PRINCIPAL: AssetAmount = LENDING_FUNDS + LENDING_FEE_TOTAL; // 100_000_000
+			const LENDING_OWED_PRINCIPAL: AssetAmount = LENDING_PRINCIPAL + LENDING_FEE_TOTAL; // 100_000_000
 
 			setup_both_pools();
 


### PR DESCRIPTION
# Pull Request

This PR is in preparation for PRO-2850

## Summary

This PR introduces a subtle behavioural change (we can discuss whether we want this or not of course, but this was easy to implement and seem like the most correct solution): in the past lending pool would accept a loan even if it pushed utilisation to 100% and network's portion of origination fee could not be collected. `owed_to_network` was meant to handle this case, but in PRO-2850 we want to remove this field in favour of keeping uncollected fees in `pending_interest` like we do for broker fees. However, while working on PRO-2850, I realised that this is not a nice solution for origination fees: at 100% utilisation it would extrenally appear as though origination fee was 0 and instead it would be counted towards interest. The alternative seems to be to require that the pool has enough funds to cover the origination fee (and unlike interest we *can* enforce this at loan creation), which is what I implemented here. In practice I don't think this makes any difference: we are much more likely to hit utilisation cap limit before we hit the "can't cover origination fee" limit.

@GabrielBuragev how would this affect the product?

I also realised that `owed_to_network` didn't quite work for boost: the boost fees will be recorded in `owed_to_network`, but never collected, so this indirectly solves this problem too. 


---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.