### PR TITLE
chore: Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![codecov](https://codecov.io/gh/chainflip-io/chainflip-backend/branch/main/graph/badge.svg?token=20X24B8IXC)](https://codecov.io/gh/chainflip-io/chainflip-backend)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/chainflip-io/chainflip-backend)
 
 # Chainflip
 


### PR DESCRIPTION
Adding this allows deepwiki to auto-reindex the repo.
