### PR TITLE
fix: assethub balance witnessing

### DIFF
--- a/bouncer/commands/setup_assethub_for_upgrade_test.ts
+++ b/bouncer/commands/setup_assethub_for_upgrade_test.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S pnpm tsx
+
+import { AddressOrPair } from '@polkadot/api/types';
+import { initializeAssethubChain } from 'shared/initialize_new_chains';
+import { DisposableApiPromise, getAssethubApi, observeEvent } from 'shared/utils/substrate';
+import { globalLogger } from 'shared/utils/logger';
+import { submitGovernanceExtrinsic } from 'shared/cf_governance';
+import { createLpPool } from 'shared/create_lp_pool';
+import { depositLiquidity } from 'shared/deposit_liquidity';
+import { rangeOrder } from 'shared/range_order';
+import { deferredPromise, handleSubstrateError, runWithTimeoutAndExit } from 'shared/utils';
+import { aliceKeyringPair } from 'shared/polkadot_keyring';
+import { createPolkadotVault } from 'commands/setup_vaults';
+import { fullAccountFromUri, newChainflipIO } from 'shared/utils/chainflip_io';
+
+export async function rotateAndFund(
+  api: DisposableApiPromise,
+  vault: AddressOrPair,
+  key: AddressOrPair,
+) {
+  const { promise, resolve } = deferredPromise<void>();
+  const alice = await aliceKeyringPair();
+  const rotation = api.tx.proxy.proxy(
+    api.createType('MultiAddress', vault),
+    null,
+    api.tx.utility.batchAll([
+      api.tx.proxy.addProxy(
+        api.createType('MultiAddress', key),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+      api.tx.proxy.removeProxy(
+        api.createType('MultiAddress', alice.address),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+    ]),
+  );
+
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.utility
+    .batchAll([
+      // Note the vault needs to be funded before we rotate.
+      api.tx.balances.transferKeepAlive(vault, 1000000000000),
+      api.tx.balances.transferKeepAlive(key, 1000000000000),
+      rotation,
+    ])
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        unsubscribe();
+        resolve();
+      }
+    });
+
+  await promise;
+}
+
+async function main(): Promise<void> {
+  const cf = (await newChainflipIO(globalLogger, {})).withChildLogger('setup_vaults');
+  await using assethub = await getAssethubApi();
+
+  await initializeAssethubChain(cf.logger);
+  await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
+  const hubActivationRequest = observeEvent(
+    cf.logger,
+    'assethubVault:AwaitingGovernanceActivation',
+  ).event;
+  const hubKey = (await hubActivationRequest).data.newPublicKey;
+  const { vaultAddress: hubVaultAddress } = await createPolkadotVault(assethub);
+  const hubProxyAdded = observeEvent(cf.logger, 'proxy:ProxyAdded', { chain: 'assethub' }).event;
+  const [, hubVaultEvent] = await Promise.all([
+    rotateAndFund(assethub, hubVaultAddress, hubKey),
+    hubProxyAdded,
+  ]);
+  cf.info('registering assethub vault on state chain');
+  await submitGovernanceExtrinsic((chainflip) =>
+    chainflip.tx.environment.witnessAssethubVaultCreation(hubVaultAddress, {
+      blockNumber: hubVaultEvent.block,
+      extrinsicIndex: hubVaultEvent.eventIndex,
+    }),
+  );
+
+  cf.info('creating pools for assethub assets');
+  await cf.all([
+    (subcf) => createLpPool(subcf.logger, 'HubDot', 10),
+    (subcf) => createLpPool(subcf.logger, 'HubUsdc', 1),
+    (subcf) => createLpPool(subcf.logger, 'HubUsdt', 1),
+  ]);
+
+  cf.info('funding pools with assethub assets');
+  await cf
+    .with({ account: fullAccountFromUri('//LP_1', 'LP') })
+    .all([
+      (subcf) => depositLiquidity(subcf, 'HubDot', 20000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdc', 250000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdt', 250000),
+    ]);
+
+  await cf
+    .with({ account: fullAccountFromUri('//LP_API', 'LP') })
+    .all([
+      (subcf) => depositLiquidity(subcf, 'HubDot', 20000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdc', 250000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdt', 250000),
+    ]);
+
+  cf.info('creating orders for assethub assets');
+  await cf
+    .with({ account: fullAccountFromUri('//LP1', 'LP') })
+    .all([
+      (subcf) => rangeOrder(subcf, 'HubDot', 20000 * 0.9999),
+      (subcf) => rangeOrder(subcf, 'HubUsdc', 250000 * 0.9999),
+      (subcf) => rangeOrder(subcf, 'HubUsdt', 250000 * 0.9999),
+    ]);
+}
+
+await runWithTimeoutAndExit(main(), 6000);

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -6,7 +6,17 @@
 // https://www.notion.so/chainflip/Polkadot-Vault-Initialisation-Steps-36d6ab1a24ed4343b91f58deed547559
 // For example: ./commands/setup_vaults.ts
 
-import { getBtcClient, getSolConnection, getWeb3, getTronWebClient } from 'shared/utils';
+import { AddressOrPair } from '@polkadot/api/types';
+import {
+  getBtcClient,
+  handleSubstrateError,
+  getWeb3,
+  getSolConnection,
+  deferredPromise,
+  runWithTimeout,
+  getTronWebClient,
+} from 'shared/utils';
+import { aliceKeyringPair } from 'shared/polkadot_keyring';
 import {
   initializeArbitrumChain,
   initializeArbitrumContracts,
@@ -14,8 +24,10 @@ import {
   initializeSolanaPrograms,
   initializeTronChain,
   initializeTronContracts,
+  initializeAssethubChain,
 } from 'shared/initialize_new_chains';
-import { globalLogger, loggerChild } from 'shared/utils/logger';
+import { globalLogger, Logger, loggerChild } from 'shared/utils/logger';
+import { getAssethubApi, observeEvent, DisposableApiPromise } from 'shared/utils/substrate';
 import { brokerApiEndpoint, lpApiEndpoint } from 'shared/json_rpc';
 import { updateDefaultPriceFeeds } from 'shared/update_price_feed';
 import { newChainflipIO } from 'shared/utils/chainflip_io';
@@ -23,9 +35,95 @@ import { bitcoinVaultAwaitingGovernanceActivation } from 'generated/events/bitco
 import { arbitrumVaultAwaitingGovernanceActivation } from 'generated/events/arbitrumVault/awaitingGovernanceActivation';
 import { solanaVaultAwaitingGovernanceActivation } from 'generated/events/solanaVault/awaitingGovernanceActivation';
 import { tronVaultAwaitingGovernanceActivation } from 'generated/events/tronVault/awaitingGovernanceActivation';
+import { assethubVaultAwaitingGovernanceActivation } from 'generated/events/assethubVault/awaitingGovernanceActivation';
 import { validatorNewEpoch } from 'generated/events/validator/newEpoch';
 import { validatorRotationPhaseUpdated } from 'generated/events/validator/rotationPhaseUpdated';
 import { validatorRotationAborted } from 'generated/events/validator/rotationAborted';
+
+export async function createPolkadotVault(api: DisposableApiPromise) {
+  const { promise, resolve } = deferredPromise<{
+    vaultAddress: AddressOrPair;
+    vaultExtrinsicIndex: number;
+  }>();
+
+  const alice = await aliceKeyringPair();
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.proxy
+    .createPure(api.createType('ProxyType', 'Any'), 0, 0)
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        // TODO: figure out type inference so we don't have to coerce using `any`
+        const pureCreated = result.findRecord('proxy', 'PureCreated')!;
+        resolve({
+          vaultAddress: pureCreated.event.data[0] as AddressOrPair,
+          vaultExtrinsicIndex: result.txIndex!,
+        });
+        unsubscribe();
+      }
+    });
+
+  return promise;
+}
+
+async function rotateAndFund(api: DisposableApiPromise, vault: AddressOrPair, key: AddressOrPair) {
+  const { promise, resolve } = deferredPromise<void>();
+  const alice = await aliceKeyringPair();
+  const rotation = api.tx.proxy.proxy(
+    api.createType('MultiAddress', vault),
+    null,
+    api.tx.utility.batchAll([
+      api.tx.proxy.addProxy(
+        api.createType('MultiAddress', key),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+      api.tx.proxy.removeProxy(
+        api.createType('MultiAddress', alice.address),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+    ]),
+  );
+
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.utility
+    .batchAll([
+      // Note the vault needs to be funded before we rotate.
+      api.tx.balances.transferKeepAlive(vault, 1000000000000),
+      api.tx.balances.transferKeepAlive(key, 1000000000000),
+      rotation,
+    ])
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        unsubscribe();
+        resolve();
+      }
+    });
+
+  await promise;
+}
+
+async function createAssetHubVault(
+  logger: Logger,
+  assethubApi: DisposableApiPromise,
+): Promise<AddressOrPair> {
+  // Step a
+  logger.info('Requesting Assethub Vault creation');
+  const { vaultAddress: hubVaultAddress } = await runWithTimeout(
+    createPolkadotVault(assethubApi),
+    90,
+    logger,
+    'Creating Assethub vault',
+  );
+  logger.info(`AssetHub vault created, address: ${hubVaultAddress}`);
+  return hubVaultAddress;
+}
 
 async function main(): Promise<void> {
   const cf = await newChainflipIO(loggerChild(globalLogger, 'setup_vaults'), []);
@@ -33,6 +131,8 @@ async function main(): Promise<void> {
   const arbClient = getWeb3('Arbitrum');
   const solClient = getSolConnection();
   const tronClient = getTronWebClient();
+
+  await using assethub = await getAssethubApi();
 
   cf.info(`LP endpoint set to: ${lpApiEndpoint}`);
   cf.info(`Broker endpoint set to: ${brokerApiEndpoint}`);
@@ -44,6 +144,7 @@ async function main(): Promise<void> {
     initializeArbitrumChain(cf.logger),
     initializeSolanaChain(cf.logger),
     initializeTronChain(cf.logger),
+    initializeAssethubChain(cf.logger),
   ]);
 
   // Step 2
@@ -67,6 +168,7 @@ async function main(): Promise<void> {
       `Initial setup_vaults forced rotation was ABORTED. Cannot continue with the test, please check the node logs for possible reasons.`,
     );
   }
+  const assetHubVaultCreateHandle = createAssetHubVault(cf.logger, assethub);
 
   // Step 3
   cf.info('Waiting for new keys');
@@ -87,15 +189,39 @@ async function main(): Promise<void> {
       name: 'TronVault.AwaitingGovernanceActivation',
       schema: tronVaultAwaitingGovernanceActivation,
     },
+    hub: {
+      name: 'AssethubVault.AwaitingGovernanceActivation',
+      schema: assethubVaultAwaitingGovernanceActivation,
+    },
   });
 
   const btcKey = keyEvents.btc.data.newPublicKey;
   const arbKey = keyEvents.arb.data.newPublicKey;
   const solKey = keyEvents.sol.data.newPublicKey;
   const tronKey = keyEvents.tron.data.newPublicKey;
+  const hubKey = keyEvents.hub.data.newPublicKey;
 
   // Step 4
-  cf.info('Setting up external chains (Arbitrum, Solana, Tron) with new keys');
+  cf.info('Setting up external chains (Arbitrum, Solana, Assethub, Tron) with new keys');
+
+  const createAssethubProxy = async () => {
+    // Wait for the assethub vault Promise to resolve
+    const hubVaultAddress = await assetHubVaultCreateHandle;
+
+    cf.info('Rotating Proxy and Funding Accounts on Assethub');
+    const hubProxyAdded = observeEvent(cf.logger, 'proxy:ProxyAdded', {
+      chain: 'assethub',
+      timeoutSeconds: 60,
+    }).event;
+    const [, hubVaultEvent] = await Promise.all([
+      rotateAndFund(assethub, hubVaultAddress, hubKey),
+      hubProxyAdded,
+    ]);
+
+    cf.debug(`Assethub Vault Proxy rotated and funded`);
+
+    return { hubVaultAddress, hubVaultEvent };
+  };
 
   const insertArbitrumKey = async () => {
     cf.info('Inserting Arbitrum key in the contracts');
@@ -115,7 +241,12 @@ async function main(): Promise<void> {
     cf.debug('Tron key inserted');
   };
 
-  await Promise.all([insertArbitrumKey(), insertSolanaKey(), insertTronKey()]);
+  const [{ hubVaultAddress, hubVaultEvent }] = await Promise.all([
+    createAssethubProxy(),
+    insertArbitrumKey(),
+    insertSolanaKey(),
+    insertTronKey(),
+  ]);
 
   // Step 7
   cf.info('Setting up price feeds');
@@ -125,6 +256,15 @@ async function main(): Promise<void> {
   cf.info('Registering Vaults with state chain');
 
   await cf.all([
+    (subcf) =>
+      subcf.submitGovernance({
+        extrinsic: (api) =>
+          api.tx.environment.witnessAssethubVaultCreation(hubVaultAddress, {
+            blockNumber: hubVaultEvent.block,
+            extrinsicIndex: hubVaultEvent.eventIndex,
+          }),
+        expectedEvent: { name: 'AssethubVault.VaultActivationCompleted' },
+      }),
     (subcf) =>
       subcf.submitGovernance({
         extrinsic: async (api) =>

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -43,6 +43,13 @@ export async function initializeTronChain(logger: Logger) {
   await tronInitializationRequest;
 }
 
+export async function initializeAssethubChain(logger: Logger) {
+  logger.info('Initializing Assethub');
+  const hubInitializationRequest = observeEvent(logger, 'assethubVault:ChainInitialized').event;
+  await submitGovernanceExtrinsic((chainflip) => chainflip.tx.assethubVault.initializeChain());
+  await hubInitializationRequest;
+}
+
 export async function initializeArbitrumContracts(
   logger: Logger,
   arbClient: Web3,

--- a/bouncer/shared/setup_swaps.ts
+++ b/bouncer/shared/setup_swaps.ts
@@ -20,6 +20,9 @@ export const deposits = new Map<Asset, number>([
   ['SolUsdt', 100000],
   ['Trx', 1000000],
   ['TrxUsdt', 100000],
+  ['HubDot', 10000],
+  ['HubUsdc', 250000],
+  ['HubUsdt', 250000],
 ]);
 
 export const price = new Map<Asset, number>([
@@ -37,6 +40,9 @@ export const price = new Map<Asset, number>([
   ['SolUsdt', 1],
   ['Trx', 1],
   ['TrxUsdt', 1],
+  ['HubDot', 10],
+  ['HubUsdc', 1],
+  ['HubUsdt', 1],
 ]);
 
 export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
@@ -56,6 +62,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
     createLpPool(cf.logger, 'SolUsdt', price.get('SolUsdt')!),
     createLpPool(cf.logger, 'Trx', price.get('Trx')!),
     createLpPool(cf.logger, 'TrxUsdt', price.get('Trx')!),
+    createLpPool(cf.logger, 'HubDot', price.get('HubDot')!),
+    createLpPool(cf.logger, 'HubUsdc', price.get('HubUsdc')!),
+    createLpPool(cf.logger, 'HubUsdt', price.get('HubUsdt')!),
   ]);
 
   // Set permissive default oracle slippage (100%) for all pools to prevent swap failures in tests.
@@ -108,6 +117,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => depositLiquidity(subcf, 'SolUsdt', deposits.get('SolUsdt')!),
         (subcf) => depositLiquidity(subcf, 'Trx', deposits.get('Trx')!),
         (subcf) => depositLiquidity(subcf, 'TrxUsdt', deposits.get('TrxUsdt')!),
+        (subcf) => depositLiquidity(subcf, 'HubDot', deposits.get('HubDot')!),
+        (subcf) => depositLiquidity(subcf, 'HubUsdc', deposits.get('HubUsdc')!),
+        (subcf) => depositLiquidity(subcf, 'HubUsdt', deposits.get('HubUsdt')!),
       ]);
 
   const lpApiDeposits = (parentCf: ChainflipIO<A>) =>
@@ -128,6 +140,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => depositLiquidity(subcf, 'SolUsdt', 1000),
         (subcf) => depositLiquidity(subcf, 'Trx', 10000),
         (subcf) => depositLiquidity(subcf, 'TrxUsdt', 1000),
+        (subcf) => depositLiquidity(subcf, 'HubDot', 2000),
+        (subcf) => depositLiquidity(subcf, 'HubUsdc', 1000),
+        (subcf) => depositLiquidity(subcf, 'HubUsdt', 1000),
       ]);
 
   cf.info('Depositing liquidity');
@@ -150,6 +165,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => rangeOrder(subcf, 'SolUsdt', deposits.get('SolUsdt')! * 0.9999),
         (subcf) => rangeOrder(subcf, 'Trx', deposits.get('Trx')! * 0.9999),
         (subcf) => rangeOrder(subcf, 'TrxUsdt', deposits.get('TrxUsdt')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubDot', deposits.get('HubDot')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubUsdc', deposits.get('HubUsdc')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubUsdt', deposits.get('HubUsdt')! * 0.9999),
       ]);
 
   cf.info('Setting up range orders');

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -11,6 +11,7 @@ import {
 } from 'shared/utils';
 import { TestContext } from 'shared/utils/test_context';
 import { manuallyAddTestToList, concurrentTest } from 'shared/utils/vitest';
+import { SwapContext } from 'shared/utils/swap_context';
 import { ChainflipIO, newChainflipIO } from 'shared/utils/chainflip_io';
 
 export async function initiateSwap(
@@ -73,8 +74,12 @@ export function testAllSwaps(timeoutPerSwap: number) {
     });
   }
 
-  // TODO: properly include BSC assets once it is fully integrated.
-  // If we include Assethub swaps (HubDot, HubUsdc, HubUsdt) in the all-to-all swaps,
+  function randomElement<Value>(items: Value[]): Value {
+    return items[Math.floor(Math.random() * items.length)];
+  }
+
+  // TODO: properly include TRON and BSC assets once they are fully integrated
+  // if we include Assethub swaps (HubDot, HubUsdc, HubUsdt) in the all-to-all swaps,
   // the test starts to randomly fail because the assethub node is overloaded.
   const AssetsWithoutAssethub = Object.values(Assets).filter(
     (id) => chainFromAsset(id) !== 'Assethub' && chainFromAsset(id) !== 'Bsc',
@@ -107,7 +112,25 @@ export function testAllSwaps(timeoutPerSwap: number) {
       });
   });
 
+  // Swaps from assethub paired with random chains.
+  // NOTE: we don't test swaps *to* assethub here, those tests are run sequentially in
+  // `testSwapsToAssethub`.
+  const assethubAssets = ['HubDot' as Asset, 'HubUsdc' as Asset, 'HubUsdt' as Asset];
+  assethubAssets.sort().forEach((hubAsset) => {
+    appendSwap(hubAsset, randomElement(AssetsWithoutAssethub), testSwap);
+  });
+
   for (const swap of allSwaps) {
     concurrentTest(`AllSwaps > ${swap.name}`, swap.test, timeoutPerSwap, 0, true);
+  }
+}
+
+export async function testSwapsToAssethub(testContext: TestContext) {
+  // we run three swaps to assethub in sequence. Otherwise, there can be nonce issues,
+  // which caused bouncer flakiness in the past.
+  for (const destinationAsset of ['HubDot', 'HubUsdc', 'HubUsdt'] as Asset[]) {
+    const logger = testContext.logger.child({ tag: `ArbEth to ${destinationAsset}` });
+    const cf = await newChainflipIO(logger, [] as []);
+    await testSwap(cf, 'ArbEth', destinationAsset, undefined, undefined, new SwapContext());
   }
 }

--- a/bouncer/tests/create_and_delete_multiple_orders.ts
+++ b/bouncer/tests/create_and_delete_multiple_orders.ts
@@ -43,6 +43,7 @@ export async function createAndDeleteMultipleOrders<A extends WithLpAccount>(
     // provide liquidity to lpUri
     (subcf) => depositLiquidity(subcf, 'Usdc', 10000),
     (subcf) => depositLiquidity(subcf, 'Eth', deposits.get('Eth')!),
+    (subcf) => depositLiquidity(subcf, 'HubDot', deposits.get('HubDot')!),
     (subcf) => depositLiquidity(subcf, 'Btc', deposits.get('Btc')!),
     (subcf) => depositLiquidity(subcf, 'Flip', deposits.get('Flip')!),
     (subcf) => depositLiquidity(subcf, 'Usdt', deposits.get('Usdt')!),

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -4,7 +4,7 @@ import { testVaultSwap } from 'tests/vault_swap_tests';
 import { checkSolEventAccountsClosure } from 'shared/vault_swap/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from 'shared/utils';
 import { checkNoWitnessingTaskRestarts } from 'shared/check_witnessing_task_restarts';
-import { testAllSwaps } from 'tests/all_swaps';
+import { testAllSwaps, testSwapsToAssethub } from 'tests/all_swaps';
 import { testEvmDeposits } from 'tests/evm_deposits';
 import { testMultipleMembersGovernance } from 'tests/multiple_members_governance';
 import { testLpApi } from 'tests/lp_api_test';
@@ -39,6 +39,7 @@ describe('ConcurrentTests', () => {
   // test to reduce contention, for example, the BrokerLevelScreeningTest is delayed to not end up
   // in situations where the deposit monitor is slow in flagging transactions.
   testAllSwaps(singleSwapTimeout * ciTimeoutFactor);
+  concurrentTest('SwapsToAssethub', testSwapsToAssethub, 330 * ciTimeoutFactor);
   concurrentTest('EvmDeposits', testEvmDeposits, 280 * ciTimeoutFactor);
   concurrentTest('FundRedeem', testFundRedeem, 350 * ciTimeoutFactor);
   concurrentTest('LpApi', testLpApi, 280 * ciTimeoutFactor);
@@ -71,6 +72,10 @@ describe('ConcurrentTests', () => {
     );
   }
   concurrentTest('RpcCalls', testRpcCalls, 160 * ciTimeoutFactor);
+
+  // Test this separately because it has a swap to HubDot which causes flakiness when run in
+  // parallel with the Assethub tests in `SwapsToAssethub`.
+  // serialTest('SwapLessThanED', swapLessThanED, 350 * ciTimeoutFactor);
 
   // Test this separately since some other tests rely on single member governance.
   serialTest('MultipleMembersGovernance', testMultipleMembersGovernance, 60 * ciTimeoutFactor);

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -230,6 +230,7 @@ export async function testFillOrKill(testContext: TestContext) {
   await cf.all([
     (subcf) => testMinPriceRefund(subcf, Assets.Flip, 500),
     (subcf) => testMinPriceRefund(subcf, Assets.Eth, 1),
+    // subcf => testMinPriceRefund(subcf, Assets.HubDot, 100), // flaky, so we don't test HubDot
     (subcf) => testMinPriceRefund(subcf, Assets.Btc, 0.1),
     (subcf) => testMinPriceRefund(subcf, Assets.Usdc, 1000),
     (subcf) => testMinPriceRefund(subcf, Assets.Sol, 10),

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -4,6 +4,7 @@ import { testRotatesThroughBtcSwap } from 'tests/rotates_through_btc_swap';
 import { testRotationBarrier } from 'tests/rotation_barrier';
 import { testSolanaVaultSettingsGovernance } from 'tests/solana_vault_settings_governance';
 import { serialTest } from 'shared/utils/vitest';
+import { testMinimumDeposit } from 'tests/minimum_deposit';
 import { testSwapAfterDisconnection } from 'tests/swap_after_temp_disconnecting_chains';
 import { checkNoWitnessingTaskRestarts } from 'shared/check_witnessing_task_restarts';
 
@@ -12,6 +13,7 @@ describe('SerialTests2', () => {
   serialTest('RotatesThroughBtcSwap', testRotatesThroughBtcSwap, 360);
   serialTest('BtcUtxoConsolidation', testBtcUtxoConsolidation, 200);
   serialTest('RotationBarrier', testRotationBarrier, 320);
+  serialTest('MinimumDeposit', testMinimumDeposit, 150);
   serialTest('SolanaVaultSettingsGovernance', testSolanaVaultSettingsGovernance, 120);
 
   if (process.env.LOCALNET) {

--- a/bouncer/tests/minimum_deposit.ts
+++ b/bouncer/tests/minimum_deposit.ts
@@ -1,0 +1,27 @@
+import { requestNewSwap } from 'shared/perform_swap';
+import { setMinimumDeposit } from 'shared/set_minimum_deposit';
+import { observeEvent } from 'shared/utils/substrate';
+import { TestContext } from 'shared/utils/test_context';
+import { sendHubAsset } from 'shared/send_hubasset';
+import { newChainflipIO } from 'shared/utils/chainflip_io';
+
+export async function testMinimumDeposit(testContext: TestContext) {
+  const cf = await newChainflipIO(testContext.logger, []);
+  await setMinimumDeposit(cf.logger, 'HubDot', BigInt(200000000000));
+  cf.debug('Set minimum deposit to 20 DOT');
+  const depositAddress = (
+    await requestNewSwap(cf, 'HubDot', 'Eth', '0xd92bd8c144b8edba742b07909c04f8b93d875d93')
+  ).depositAddress;
+  const depositFailed = observeEvent(cf.logger, ':DepositFailed');
+  await sendHubAsset(testContext.logger, 'HubDot', depositAddress, '19');
+  cf.debug('Sent 19 DOT');
+  await depositFailed.event;
+  cf.debug('Deposit was ignored');
+  const depositSuccess = observeEvent(cf.logger, ':DepositFinalised');
+  await sendHubAsset(testContext.logger, 'HubDot', depositAddress, '21');
+  cf.debug('Sent 21 DOT');
+  await depositSuccess.event;
+  cf.debug('Deposit was successful');
+  await setMinimumDeposit(cf.logger, 'HubDot', BigInt(0));
+  cf.debug('Reset minimum deposit to 0 DOT');
+}

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -266,6 +266,7 @@ export async function depositChannelCreation(testContext: TestContext) {
     Arbitrum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
     Solana: ['3yKDHJgzS2GbZB9qruoadRYtq8597HZifnRju7fHpdRC'],
     Tron: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+    Assethub: ['1yMmfLti1k3huRQM2c47WugwonQMqTvQ2GUFxnU7Pcs7xPo'],
   } as const;
 
   const entries = Object.entries as <T>(o: T) => [keyof T, T[keyof T]][];

--- a/bouncer/tests/swap_after_temp_disconnecting_chains.ts
+++ b/bouncer/tests/swap_after_temp_disconnecting_chains.ts
@@ -8,7 +8,11 @@ import { newChainflipIO } from 'shared/utils/chainflip_io';
 export async function testSwapAfterDisconnection(testContext: TestContext) {
   const cf = await newChainflipIO(testContext.logger, []);
   const networkName = 'chainflip-localnet_default';
-  const allExternalNodes = ['bitcoin', 'geth'];
+  // We use assethub here to test that it applies to assethub, and Polkadot by proxy.
+  // We don't test Polkadot directly, since shutting down the Polkadot node in this way causes sync issues between
+  // Polkadot and AssetHub which can take some time to resolve. Given AssetHub shares most of the same code as Polkadot,
+  // this is a good proxy.
+  const allExternalNodes = ['bitcoin', 'geth', 'assethub'];
 
   await Promise.all(
     allExternalNodes.map((container) =>
@@ -27,5 +31,6 @@ export async function testSwapAfterDisconnection(testContext: TestContext) {
   await cf.all([
     (subcf) => testSwap(subcf, 'Btc', 'Flip', undefined, undefined, testContext.swapContext),
     (subcf) => testSwap(subcf, 'Eth', 'Usdc', undefined, undefined, testContext.swapContext),
+    (subcf) => testSwap(subcf, 'HubDot', 'Btc', undefined, undefined, testContext.swapContext),
   ]);
 }

--- a/engine/src/dot/http_rpc.rs
+++ b/engine/src/dot/http_rpc.rs
@@ -16,8 +16,11 @@
 
 use std::sync::{Arc, OnceLock};
 
-use cf_chains::dot::RuntimeVersion;
-use cf_primitives::PolkadotBlockNumber;
+use cf_chains::dot::{PolkadotAccountId, RuntimeVersion};
+use cf_primitives::{
+	chains::assets::hub::Asset as HubAsset, PolkadotBlockNumber, ASSETHUB_USDC_ASSET_ID,
+	ASSETHUB_USDT_ASSET_ID,
+};
 use http::uri::Uri;
 use jsonrpsee::{
 	core::{client::ClientT, traits::ToRpcParams},
@@ -43,7 +46,10 @@ use cf_utilities::{make_periodic_tick, redact_endpoint_secret::SecretUrl};
 use codec::Decode;
 use tracing::{error, warn};
 
-use crate::constants::RPC_RETRY_CONNECTION_INTERVAL;
+use crate::{
+	constants::RPC_RETRY_CONNECTION_INTERVAL,
+	witness::hub::assethub::{self, runtime_types::pallet_assets::types::AccountStatus},
+};
 
 use super::rpc::DotRpcApi;
 
@@ -339,6 +345,54 @@ impl DotRpcApi for DotRpcClient {
 		.await?;
 
 		Ok(success.extrinsic_hash())
+	}
+
+	async fn liquid_account_balance(
+		&self,
+		account_id: PolkadotAccountId,
+		asset: HubAsset,
+		block_hash: PolkadotHash,
+	) -> Result<u128> {
+		let account_id = account_id.0.into();
+		Ok(match asset {
+			HubAsset::HubDot => {
+				let query = assethub::storage().system().account(&account_id);
+				self.online_client
+					.storage()
+					.at(block_hash)
+					.fetch(&query)
+					.await?
+					.map(|account_info| {
+						account_info.data.free.saturating_sub(account_info.data.frozen)
+					})
+					// No account => no balance
+					.unwrap_or_default()
+			},
+			other => {
+				let id = match other {
+					HubAsset::HubUsdc => ASSETHUB_USDC_ASSET_ID,
+					HubAsset::HubUsdt => ASSETHUB_USDT_ASSET_ID,
+					HubAsset::HubDot => unreachable!(),
+				};
+				let query = assethub::storage().assets().account(id, &account_id);
+				self.online_client
+					.storage()
+					.at(block_hash)
+					.fetch(&query)
+					.await?
+					.map(|asset_account| {
+						// `AccountStatus` is a subxt-generated enum that does not derive
+						// `PartialEq`, so use `matches!` rather than `==`.
+						if matches!(asset_account.status, AccountStatus::Liquid) {
+							asset_account.balance
+						} else {
+							0
+						}
+					})
+					// No account => no balance
+					.unwrap_or_default()
+			},
+		})
 	}
 }
 

--- a/engine/src/dot/retry_rpc.rs
+++ b/engine/src/dot/retry_rpc.rs
@@ -21,8 +21,11 @@ use crate::{
 	settings::{NodeContainer, WsHttpEndpoints},
 	witness::common::chain_source::{ChainClient, Header},
 };
-use cf_chains::{dot::RuntimeVersion, Polkadot};
-use cf_primitives::PolkadotBlockNumber;
+use cf_chains::{
+	dot::{PolkadotAccountId, RuntimeVersion},
+	Polkadot,
+};
+use cf_primitives::{chains::assets::hub::Asset as HubAsset, PolkadotBlockNumber};
 use cf_utilities::task_scope::Scope;
 use core::time::Duration;
 use futures_core::Stream;
@@ -120,6 +123,13 @@ pub trait DotRetryRpcApi: Clone {
 		&self,
 		encoded_bytes: Vec<u8>,
 	) -> anyhow::Result<PolkadotHash>;
+
+	async fn liquid_account_balance(
+		&self,
+		account_id: PolkadotAccountId,
+		asset: HubAsset,
+		block_hash: PolkadotHash,
+	) -> u128;
 }
 
 #[async_trait::async_trait]
@@ -201,6 +211,31 @@ impl DotRetryRpcApi for DotRetryRpcClient {
 					})
 				}),
 				MAX_BROADCAST_RETRIES,
+			)
+			.await
+	}
+
+	async fn liquid_account_balance(
+		&self,
+		account_id: PolkadotAccountId,
+		asset: HubAsset,
+		block_hash: PolkadotHash,
+	) -> u128 {
+		self.rpc_retry_client
+			.request(
+				RequestLog::new(
+					"liquid_account_balance".to_string(),
+					Some(format!("{account_id:?}, {asset:?}, {block_hash:?}")),
+				),
+				Box::pin(move |client| {
+					Box::pin(async move {
+						client
+							.http_client()
+							.await
+							.liquid_account_balance(account_id, asset, block_hash)
+							.await
+					})
+				}),
 			)
 			.await
 	}
@@ -321,6 +356,13 @@ pub mod mocks {
 				&self,
 				encoded_bytes: Vec<u8>,
 			) -> anyhow::Result<PolkadotHash>;
+
+			async fn liquid_account_balance(
+				&self,
+				account_id: PolkadotAccountId,
+				asset: HubAsset,
+				block_hash: PolkadotHash,
+			) -> u128;
 		}
 
 	}

--- a/engine/src/dot/rpc.rs
+++ b/engine/src/dot/rpc.rs
@@ -17,8 +17,8 @@
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use cf_chains::dot::RuntimeVersion;
-use cf_primitives::PolkadotBlockNumber;
+use cf_chains::dot::{PolkadotAccountId, RuntimeVersion};
+use cf_primitives::{chains::assets::hub::Asset as HubAsset, PolkadotBlockNumber};
 use cf_utilities::redact_endpoint_secret::SecretUrl;
 use futures::{Stream, StreamExt, TryStreamExt};
 use subxt::{
@@ -63,6 +63,13 @@ pub trait DotRpcApi: Send + Sync {
 	async fn runtime_version(&self, at: Option<PolkadotHash>) -> Result<RuntimeVersion>;
 
 	async fn submit_raw_encoded_extrinsic(&self, encoded_bytes: Vec<u8>) -> Result<PolkadotHash>;
+
+	async fn liquid_account_balance(
+		&self,
+		account_id: PolkadotAccountId,
+		asset: HubAsset,
+		block_hash: PolkadotHash,
+	) -> Result<u128>;
 }
 
 #[derive(Clone)]

--- a/engine/src/witness/hub.rs
+++ b/engine/src/witness/hub.rs
@@ -338,7 +338,7 @@ pub fn start<StateChainClient, ProcessCall, ProcessingFut>(
 							)
 							.await
 							// Deposit witnessing
-							.hub_deposits(process_call.clone())
+							.hub_deposits(process_call.clone(), hub_client.clone())
 							// Proxy added witnessing
 							.then(proxy_added_witnessing)
 							// Broadcast success

--- a/engine/src/witness/hub/hub_deposits.rs
+++ b/engine/src/witness/hub/hub_deposits.rs
@@ -128,7 +128,7 @@ fn address_and_details_to_addresses(
 
 /// The liquid budget for one (address, asset) over this block:
 ///
-///     budget = max(0, current_liquid - parent_liquid + outgoing_in_block)
+/// `budget = max(0, current_liquid - parent_liquid + outgoing_in_block)`
 ///
 /// i.e. the net new spendable funds for the pair, after compensating for funds the
 /// address sent out in the same block.

--- a/engine/src/witness/hub/hub_deposits.rs
+++ b/engine/src/witness/hub/hub_deposits.rs
@@ -36,6 +36,7 @@ use cf_primitives::{
 };
 use futures_core::Future;
 use pallet_cf_ingress_egress::{DepositChannelDetails, DepositWitness};
+use sp_runtime::traits::Saturating;
 use state_chain_runtime::AssethubInstance;
 use std::collections::BTreeMap;
 use subxt::events::Phase;
@@ -125,26 +126,65 @@ fn address_and_details_to_addresses(
 		.collect()
 }
 
-async fn balance_increase<Client: DotRetryRpcApi + Send + Sync>(
+/// The liquid budget for one (address, asset) over this block:
+///
+///     budget = max(0, current_liquid - parent_liquid + outgoing_in_block)
+///
+/// i.e. the net new spendable funds for the pair, after compensating for funds the
+/// address sent out in the same block.
+async fn liquid_budget<Client: DotRetryRpcApi + Send + Sync>(
 	hub_client: &Client,
 	address: PolkadotAccountId,
 	asset: HubAsset,
 	block_hash: PolkadotHash,
 	parent_hash: Option<PolkadotHash>,
+	outgoing_in_block: u128,
 ) -> u128 {
-	let (current_block_balance, previous_block_balance): (u128, u128) =
+	let (current, parent_balance): (u128, u128) =
 		futures::join!(hub_client.liquid_account_balance(address, asset, block_hash), async move {
-			if let Some(parent_hash) = parent_hash {
-				hub_client.liquid_account_balance(address, asset, parent_hash).await
-			} else {
-				0
+			match parent_hash {
+				Some(parent_hash) =>
+					hub_client.liquid_account_balance(address, asset, parent_hash).await,
+				None => 0,
 			}
 		});
-	current_block_balance.saturating_sub(previous_block_balance)
+	current.saturating_add(outgoing_in_block).saturating_sub(parent_balance)
 }
 
-// Return the deposit witnesses and the extrinsic indices of transfers we want
-// to confirm the broadcast of.
+/// Interpret an [`EventWrapper`] as an Asset Hub asset transfer, if it is one.
+/// Returns `None` for non-transfer events and for transfers in assets we don't witness.
+fn event_as_transfer(
+	event: &EventWrapper,
+) -> Option<(PolkadotAccountId, PolkadotAccountId, u128, HubAsset)> {
+	let (asset, from, to, amount) = match event {
+		EventWrapper::BalancesTransfer { from, to, amount } => (HubAsset::HubDot, from, to, amount),
+		EventWrapper::AssetsTransfer { asset_id, from, to, amount } => {
+			let asset = match *asset_id {
+				ASSETHUB_USDT_ASSET_ID => HubAsset::HubUsdt,
+				ASSETHUB_USDC_ASSET_ID => HubAsset::HubUsdc,
+				_ => return None,
+			};
+			(asset, from, to, amount)
+		},
+		_ => return None,
+	};
+	Some((
+		PolkadotAccountId::from_aliased(from.0),
+		PolkadotAccountId::from_aliased(to.0),
+		*amount,
+		asset,
+	))
+}
+
+// Aggregate all transfer events involving monitored addresses into one DepositWitness
+// per (address, asset). The witnessed amount is the sum of incoming Transfer events,
+// clamped to the net liquid increase for the pair (see `liquid_budget`). `deposit_details` is
+// the earliest contributing extrinsic index.
+//
+// Note: aggregating sacrifices per-extrinsic attribution. If we later add deposit
+// monitoring that rejects individual extrinsics, this approach can misattribute funds
+// between transfers when a vested transfer shares a block with a legitimate one. The
+// witnessed total is still bounded by the real liquid increase.
 async fn deposit_witnesses<Client: DotRetryRpcApi + Send + Sync>(
 	block_hash: PolkadotHash,
 	parent_hash: Option<PolkadotHash>,
@@ -152,106 +192,48 @@ async fn deposit_witnesses<Client: DotRetryRpcApi + Send + Sync>(
 	monitored_addresses: Vec<PolkadotAccountId>,
 	events: &Vec<(Phase, EventWrapper)>,
 ) -> Vec<DepositWitness<Assethub>> {
-	// First we check for any outgoing transfers from the monitored addresses (fetches) so
-	// we can take these into account when calculating balance changes.
-	let mut outgoing_balance_changes = BTreeMap::default();
+	// Sum incoming (with earliest extrinsic index) and outgoing per (address, asset).
+	let mut incoming: BTreeMap<(PolkadotAccountId, HubAsset), (u128, u32)> = BTreeMap::default();
+	let mut outgoing_in_block: BTreeMap<(PolkadotAccountId, HubAsset), u128> = BTreeMap::default();
 	for (phase, wrapped_event) in events {
-		if let Phase::ApplyExtrinsic(_) = phase {
-			match wrapped_event {
-				EventWrapper::BalancesTransfer { amount, from, .. } => {
-					let from = PolkadotAccountId::from_aliased(from.0);
-					if monitored_addresses.contains(&from) {
-						*outgoing_balance_changes.entry((from, HubAsset::HubDot)).or_insert(0) +=
-							*amount;
-					}
-				},
-				EventWrapper::AssetsTransfer { asset_id, amount, from, .. } => {
-					let from = PolkadotAccountId::from_aliased(from.0);
-					let asset = match *asset_id {
-						ASSETHUB_USDT_ASSET_ID => HubAsset::HubUsdt,
-						ASSETHUB_USDC_ASSET_ID => HubAsset::HubUsdc,
-						_ => continue,
-					};
-					if monitored_addresses.contains(&from) {
-						*outgoing_balance_changes.entry((from, asset)).or_insert(0) += *amount;
-					}
-				},
-				_ => continue,
-			}
+		let Phase::ApplyExtrinsic(extrinsic_index) = phase else {
+			continue;
+		};
+		let Some((from, to, amount, asset)) = event_as_transfer(wrapped_event) else {
+			continue;
+		};
+		if monitored_addresses.contains(&from) {
+			outgoing_in_block.entry((from, asset)).or_insert(0).saturating_accrue(amount);
+		}
+		if monitored_addresses.contains(&to) {
+			incoming
+				.entry((to, asset))
+				.and_modify(|(sum, _first_idx)| sum.saturating_accrue(amount))
+				.or_insert((amount, *extrinsic_index));
 		}
 	}
-	// We track the available liquid balance for each address and asset as we go through the events,
-	// so that if there are multiple transfers to the same address in the same block, we can
-	// correctly witness them up to the amount of liquid balance available. Tracking this prevents
-	// a scenario is necessary to correctly handle two specific edge cases:
-	// 1) Transfer of vesting funds: for this reason, we need track *liquid* balances changes.
-	// 2) Multiple transfers in the same block to the same address: without tracking liquid balance
-	//    changes.
+
+	// Emit one witness per incoming (address, asset), clamped to the liquid budget.
 	let mut deposit_witnesses = vec![];
-	let mut available_liquid_balances = BTreeMap::default();
-	for (phase, wrapped_event) in events {
-		if let Phase::ApplyExtrinsic(extrinsic_index) = phase {
-			let (asset, deposit_address, amount) = match wrapped_event {
-				EventWrapper::BalancesTransfer { to, amount, from: _ } => {
-					let deposit_address = PolkadotAccountId::from_aliased(to.0);
-					if !monitored_addresses.contains(&deposit_address) {
-						continue;
-					} else {
-						(HubAsset::HubDot, deposit_address, *amount)
-					}
-				},
-				EventWrapper::AssetsTransfer { asset_id, to, amount, from: _ } => {
-					let deposit_address = PolkadotAccountId::from_aliased(to.0);
-					if !monitored_addresses.contains(&deposit_address) {
-						continue;
-					} else {
-						(
-							match *asset_id {
-								ASSETHUB_USDT_ASSET_ID => HubAsset::HubUsdt,
-								ASSETHUB_USDC_ASSET_ID => HubAsset::HubUsdc,
-								_ => continue,
-							},
-							deposit_address,
-							*amount,
-						)
-					}
-				},
-				_ => continue,
-			};
-			let available_balance = if let Some(balance) =
-				available_liquid_balances.get(&(deposit_address, asset))
-			{
-				*balance
-			} else {
-				let balance =
-					balance_increase(hub_client, deposit_address, asset, block_hash, parent_hash)
-						.await
-						.saturating_add(
-							outgoing_balance_changes
-								.get(&(deposit_address, asset))
-								.copied()
-								.unwrap_or_default(),
-						);
-				available_liquid_balances.insert((deposit_address, asset), balance);
-				balance
-			};
-			let amount = amount.min(available_balance);
-			available_liquid_balances
-				.entry((deposit_address, asset))
-				.and_modify(|balance| *balance = balance.saturating_sub(amount));
-			if amount > 0 {
-				deposit_witnesses.push(DepositWitness {
-					deposit_address,
-					asset,
-					amount,
-					deposit_details: *extrinsic_index,
-				});
-			} else {
-				tracing::warn!(
-					"Detected transfer to monitored address {:?} of asset {:?} with amount {} in block {:?}, but no liquid balance increase was available to witness after accounting for outgoing transfers and previous events in the same block. This transfer will not be witnessed.",
-					deposit_address, asset, amount, block_hash
-				);
-			}
+	for ((deposit_address, asset), (incoming_sum, first_extrinsic_index)) in incoming {
+		let outgoing =
+			outgoing_in_block.get(&(deposit_address, asset)).copied().unwrap_or_default();
+		let budget =
+			liquid_budget(hub_client, deposit_address, asset, block_hash, parent_hash, outgoing)
+				.await;
+		let amount = incoming_sum.min(budget);
+		if amount > 0 {
+			deposit_witnesses.push(DepositWitness {
+				deposit_address,
+				asset,
+				amount,
+				deposit_details: first_extrinsic_index,
+			});
+		} else {
+			tracing::warn!(
+				"Incoming transfers to monitored address {:?} of asset {:?} totalling {} in block {:?} clamped to zero by liquid budget. Likely vested or otherwise locked.",
+				deposit_address, asset, incoming_sum, block_hash
+			);
 		}
 	}
 	deposit_witnesses
@@ -428,14 +410,9 @@ mod test {
 				DepositWitness {
 					deposit_address: transfer_2_deposit_address,
 					asset: HubAsset::HubDot,
-					amount: TRANSFER_2_AMOUNT,
+					// Same asset transfers are aggregated into one witness.
+					amount: TRANSFER_2_AMOUNT + TRANSFER_TO_SELF_AMOUNT,
 					deposit_details: TRANSFER_2_INDEX
-				},
-				DepositWitness {
-					deposit_address: transfer_3_deposit_address,
-					asset: HubAsset::HubUsdc,
-					amount: TRANSFER_3_AMOUNT,
-					deposit_details: TRANSFER_3_INDEX
 				},
 				DepositWitness {
 					deposit_address: transfer_4_deposit_address,
@@ -444,11 +421,11 @@ mod test {
 					deposit_details: TRANSFER_4_INDEX
 				},
 				DepositWitness {
-					deposit_address: transfer_2_deposit_address,
-					asset: HubAsset::HubDot,
-					amount: TRANSFER_TO_SELF_AMOUNT,
-					deposit_details: TRANSFER_TO_SELF_INDEX
-				}
+					deposit_address: transfer_3_deposit_address,
+					asset: HubAsset::HubUsdc,
+					amount: TRANSFER_3_AMOUNT,
+					deposit_details: TRANSFER_3_INDEX
+				},
 			]
 		);
 	}
@@ -513,10 +490,11 @@ mod test {
 		client
 	}
 
-	/// Two regular transfers to the same address in the same block. The recipient's
-	/// liquid balance increases by the full sum, so both witnesses are credited in full.
+	/// Two regular transfers to the same (address, asset) in the same block are
+	/// aggregated into a single witness with the summed amount and the earliest
+	/// contributing extrinsic index.
 	#[tokio::test]
-	async fn two_regular_transfers_same_address_both_credited() {
+	async fn two_regular_transfers_same_address_aggregated() {
 		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
 		const TRANSFER_A_INDEX: u32 = 1;
 		const TRANSFER_A_AMOUNT: PolkadotBalance = 10_000;
@@ -564,106 +542,125 @@ mod test {
 
 		assert_eq!(
 			witnesses,
-			vec![
-				DepositWitness {
-					deposit_address,
-					asset: HubAsset::HubDot,
-					amount: TRANSFER_A_AMOUNT,
-					deposit_details: TRANSFER_A_INDEX,
-				},
-				DepositWitness {
-					deposit_address,
-					asset: HubAsset::HubDot,
-					amount: TRANSFER_B_AMOUNT,
-					deposit_details: TRANSFER_B_INDEX,
-				},
-			]
+			vec![DepositWitness {
+				deposit_address,
+				asset: HubAsset::HubDot,
+				amount: TRANSFER_A_AMOUNT + TRANSFER_B_AMOUNT,
+				deposit_details: TRANSFER_A_INDEX,
+			}]
 		);
 	}
 
-	/// A regular transfer followed by a vested transfer in the same block. The liquid
-	/// balance only increases by the regular amount; the total credited must match.
+	/// A regular transfer and a vested transfer to the same address in the same block:
+	/// the aggregated incoming sum is clamped to the real liquid increase, so only the
+	/// regular amount is credited regardless of event order. `deposit_details` is the
+	/// earliest contributing extrinsic index — which depends on event order.
 	#[tokio::test]
-	async fn regular_then_vested_transfer_same_address() {
-		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
-		const REGULAR_INDEX: u32 = 1;
+	async fn vested_transfer_is_clamped_regardless_of_order() {
 		const REGULAR_AMOUNT: PolkadotBalance = 10_000;
-		const VESTED_INDEX: u32 = 2;
 		const VESTED_AMOUNT: PolkadotBalance = 40_000_000_000;
+		const REGULAR_FIRST: u32 = 1;
+		const VESTED_SECOND: u32 = 2;
+		const VESTED_FIRST: u32 = 3;
+		const REGULAR_SECOND: u32 = 4;
 
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
 		let block_hash = PolkadotHash::from([1u8; 32]);
 		let parent_hash = PolkadotHash::from([0u8; 32]);
 
 		// Liquid balance rises by exactly the regular transfer amount; the vested
-		// transfer raises `free` and `frozen` by the same amount, contributing 0.
+		// transfer raises `free` and `frozen` together, contributing 0.
 		let hub_client = mock_client_with_balances(block_hash, parent_hash, REGULAR_AMOUNT, 0);
 
-		let events = phase_and_events(vec![
+		let make_regular = |idx: u32| {
 			(
-				REGULAR_INDEX,
+				idx,
 				mock_transfer(
 					&PolkadotAccountId::from_aliased([7; 32]),
 					&deposit_address,
 					REGULAR_AMOUNT,
 				),
-			),
+			)
+		};
+		let make_vested = |idx: u32| {
 			(
-				VESTED_INDEX,
+				idx,
 				mock_transfer(
 					&PolkadotAccountId::from_aliased([8; 32]),
 					&deposit_address,
 					VESTED_AMOUNT,
 				),
+			)
+		};
+
+		// The earliest contributing extrinsic index is whichever event came first in
+		// the block. The witness amount is always clamped to REGULAR_AMOUNT regardless.
+		for (events, expected_index) in [
+			(
+				phase_and_events(vec![make_regular(REGULAR_FIRST), make_vested(VESTED_SECOND)]),
+				REGULAR_FIRST,
 			),
-		]);
-
-		let witnesses = deposit_witnesses(
-			block_hash,
-			Some(parent_hash),
-			&hub_client,
-			vec![deposit_address],
-			&events,
-		)
-		.await;
-
-		// The first (regular) event exhausts the available liquid budget. The second
-		// (vested) event clamps to zero and is suppressed.
-		assert_eq!(witnesses.len(), 1);
-		assert_eq!(witnesses[0].amount, REGULAR_AMOUNT);
-		assert_eq!(witnesses[0].deposit_details, REGULAR_INDEX);
+			(
+				phase_and_events(vec![make_vested(VESTED_FIRST), make_regular(REGULAR_SECOND)]),
+				VESTED_FIRST,
+			),
+		] {
+			let witnesses = deposit_witnesses(
+				block_hash,
+				Some(parent_hash),
+				&hub_client,
+				vec![deposit_address],
+				&events,
+			)
+			.await;
+			assert_eq!(
+				witnesses,
+				vec![DepositWitness {
+					deposit_address,
+					asset: HubAsset::HubDot,
+					amount: REGULAR_AMOUNT,
+					deposit_details: expected_index,
+				}],
+			);
+		}
 	}
 
-	/// Vested transfer first, then a regular transfer. Ordering changes the distribution
-	/// across the two witnesses, but the total credited must still equal the liquid
-	/// increase (i.e. the regular amount only).
+	/// A small vested transfer in the same block as a larger
+	/// legitimate deposit. Aggregation sums incoming (vested + legit), clamps to the
+	/// real liquid increase, and emits one witness for the legit amount. The user's
+	/// funds are fully credited on the (address, asset) total — but `deposit_details`
+	/// is the earliest contributing extrinsic, which is the smaller vesting
+	/// extrinsic if it comes first in the block.
 	#[tokio::test]
-	async fn vested_then_regular_transfer_same_address() {
-		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+	async fn small_vested_transfer_does_not_block_larger_legit_deposit() {
+		const SMALL_VESTED_AMOUNT: PolkadotBalance = 1;
+		const LARGE_LEGIT_AMOUNT: PolkadotBalance = 100;
 		const VESTED_INDEX: u32 = 1;
-		const VESTED_AMOUNT: PolkadotBalance = 40_000_000_000;
-		const REGULAR_INDEX: u32 = 2;
-		const REGULAR_AMOUNT: PolkadotBalance = 10_000;
+		const LEGIT_INDEX: u32 = 2;
 
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
 		let block_hash = PolkadotHash::from([1u8; 32]);
 		let parent_hash = PolkadotHash::from([0u8; 32]);
 
-		let hub_client = mock_client_with_balances(block_hash, parent_hash, REGULAR_AMOUNT, 0);
+		// Liquid balance rises by exactly the legit amount; the vested transfer raises
+		// `free` and `frozen` together.
+		let hub_client = mock_client_with_balances(block_hash, parent_hash, LARGE_LEGIT_AMOUNT, 0);
 
 		let events = phase_and_events(vec![
 			(
 				VESTED_INDEX,
 				mock_transfer(
-					&PolkadotAccountId::from_aliased([7; 32]),
+					&PolkadotAccountId::from_aliased([8; 32]),
 					&deposit_address,
-					VESTED_AMOUNT,
+					SMALL_VESTED_AMOUNT,
 				),
 			),
 			(
-				REGULAR_INDEX,
+				LEGIT_INDEX,
 				mock_transfer(
-					&PolkadotAccountId::from_aliased([8; 32]),
+					&PolkadotAccountId::from_aliased([7; 32]),
 					&deposit_address,
-					REGULAR_AMOUNT,
+					LARGE_LEGIT_AMOUNT,
 				),
 			),
 		]);
@@ -677,12 +674,18 @@ mod test {
 		)
 		.await;
 
-		// FIFO: the vested event arrives first and absorbs the entire liquid budget
-		// (REGULAR_AMOUNT). The regular event that follows clamps to zero and is
-		// suppressed. The aggregate credited still equals the real liquid increase.
-		assert_eq!(witnesses.len(), 1);
-		assert_eq!(witnesses[0].amount, REGULAR_AMOUNT);
-		assert_eq!(witnesses[0].deposit_details, VESTED_INDEX);
+		// Aggregated incoming = SMALL_VESTED + LARGE_LEGIT, clamped to the liquid
+		// budget = LARGE_LEGIT. The legit amount is fully credited, but attributed to
+		// VESTED_INDEX because the vested event appears first in the block.
+		assert_eq!(
+			witnesses,
+			vec![DepositWitness {
+				deposit_address,
+				asset: HubAsset::HubDot,
+				amount: LARGE_LEGIT_AMOUNT,
+				deposit_details: VESTED_INDEX,
+			}],
+		);
 	}
 
 	/// Pre-existing liquid balance at the parent block must not be counted towards the
@@ -884,9 +887,9 @@ mod test {
 
 	/// A new deposit arrives, then a vault sweep takes both the prior balance and
 	/// the new deposit out of the account in the same block. The current liquid
-	/// balance drops below the parent — so `saturating_sub` clamps the delta to zero
-	/// — but the deposit is real and must be credited in full once the outgoing
-	/// transfers are added back to the budget.
+	/// balance drops below the parent (so the naive `current - parent` clamps to
+	/// zero), but the deposit is real and must be credited in full once the
+	/// outgoing sum is added back to the budget.
 	#[tokio::test]
 	async fn incoming_then_outgoing_same_block_with_balance_drop_credits_in_full() {
 		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);

--- a/engine/src/witness/hub/hub_deposits.rs
+++ b/engine/src/witness/hub/hub_deposits.rs
@@ -14,18 +14,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_primitives::{
-	EpochIndex, PolkadotBlockNumber, ASSETHUB_USDC_ASSET_ID, ASSETHUB_USDT_ASSET_ID,
-};
-use futures_core::Future;
-use pallet_cf_ingress_egress::{DepositChannelDetails, DepositWitness};
-use state_chain_runtime::AssethubInstance;
-
 use super::super::common::chunked_chain_source::chunked_by_vault::{
 	builder::ChunkedByVaultBuilder, ChunkedByVault,
 };
 use crate::{
-	dot::PolkadotHash,
+	dot::{
+		retry_rpc::{DotRetryRpcApi, DotRetryRpcClient},
+		PolkadotHash,
+	},
 	witness::{
 		common::{
 			chunked_chain_source::chunked_by_vault::deposit_addresses::Addresses,
@@ -34,13 +30,21 @@ use crate::{
 		hub::EventWrapper,
 	},
 };
-use cf_chains::{assets::hub::Asset, dot::PolkadotAccountId, Assethub};
+use cf_chains::{assets::hub::Asset as HubAsset, dot::PolkadotAccountId, Assethub};
+use cf_primitives::{
+	EpochIndex, PolkadotBlockNumber, ASSETHUB_USDC_ASSET_ID, ASSETHUB_USDT_ASSET_ID,
+};
+use futures_core::Future;
+use pallet_cf_ingress_egress::{DepositChannelDetails, DepositWitness};
+use state_chain_runtime::AssethubInstance;
+use std::collections::BTreeMap;
 use subxt::events::Phase;
 
 impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 	pub fn hub_deposits<ProcessCall, ProcessingFut>(
 		self,
 		process_call: ProcessCall,
+		hub_client: DotRetryRpcClient,
 	) -> ChunkedByVaultBuilder<
 		impl ChunkedByVault<
 			Index = PolkadotBlockNumber,
@@ -72,12 +76,20 @@ impl<Inner: ChunkedByVault> ChunkedByVaultBuilder<Inner> {
 	{
 		self.then(move |epoch, header| {
 			let process_call = process_call.clone();
+			let hub_client = hub_client.clone();
 			async move {
 				let (events, addresses_and_details) = header.data;
 
 				let addresses = address_and_details_to_addresses(addresses_and_details);
 
-				let deposit_witnesses = deposit_witnesses(addresses, &events);
+				let deposit_witnesses = deposit_witnesses(
+					header.hash,
+					header.parent_hash,
+					&hub_client,
+					addresses,
+					&events,
+				)
+				.await;
 
 				if !deposit_witnesses.is_empty() {
 					process_call(
@@ -104,57 +116,141 @@ fn address_and_details_to_addresses(
 		.into_iter()
 		.map(|deposit_channel_details| {
 			assert!(
-				deposit_channel_details.deposit_channel.asset == Asset::HubDot ||
-					deposit_channel_details.deposit_channel.asset == Asset::HubUsdc ||
-					deposit_channel_details.deposit_channel.asset == Asset::HubUsdt
+				deposit_channel_details.deposit_channel.asset == HubAsset::HubDot ||
+					deposit_channel_details.deposit_channel.asset == HubAsset::HubUsdc ||
+					deposit_channel_details.deposit_channel.asset == HubAsset::HubUsdt
 			);
 			deposit_channel_details.deposit_channel.address
 		})
 		.collect()
 }
 
+async fn balance_increase<Client: DotRetryRpcApi + Send + Sync>(
+	hub_client: &Client,
+	address: PolkadotAccountId,
+	asset: HubAsset,
+	block_hash: PolkadotHash,
+	parent_hash: Option<PolkadotHash>,
+) -> u128 {
+	let (current_block_balance, previous_block_balance): (u128, u128) =
+		futures::join!(hub_client.liquid_account_balance(address, asset, block_hash), async move {
+			if let Some(parent_hash) = parent_hash {
+				hub_client.liquid_account_balance(address, asset, parent_hash).await
+			} else {
+				0
+			}
+		});
+	current_block_balance.saturating_sub(previous_block_balance)
+}
+
 // Return the deposit witnesses and the extrinsic indices of transfers we want
 // to confirm the broadcast of.
-fn deposit_witnesses(
+async fn deposit_witnesses<Client: DotRetryRpcApi + Send + Sync>(
+	block_hash: PolkadotHash,
+	parent_hash: Option<PolkadotHash>,
+	hub_client: &Client,
 	monitored_addresses: Vec<PolkadotAccountId>,
 	events: &Vec<(Phase, EventWrapper)>,
 ) -> Vec<DepositWitness<Assethub>> {
+	// First we check for any outgoing transfers from the monitored addresses (fetches) so
+	// we can take these into account when calculating balance changes.
+	let mut outgoing_balance_changes = BTreeMap::default();
+	for (phase, wrapped_event) in events {
+		if let Phase::ApplyExtrinsic(_) = phase {
+			match wrapped_event {
+				EventWrapper::BalancesTransfer { amount, from, .. } => {
+					let from = PolkadotAccountId::from_aliased(from.0);
+					if monitored_addresses.contains(&from) {
+						*outgoing_balance_changes.entry((from, HubAsset::HubDot)).or_insert(0) +=
+							*amount;
+					}
+				},
+				EventWrapper::AssetsTransfer { asset_id, amount, from, .. } => {
+					let from = PolkadotAccountId::from_aliased(from.0);
+					let asset = match *asset_id {
+						ASSETHUB_USDT_ASSET_ID => HubAsset::HubUsdt,
+						ASSETHUB_USDC_ASSET_ID => HubAsset::HubUsdc,
+						_ => continue,
+					};
+					if monitored_addresses.contains(&from) {
+						*outgoing_balance_changes.entry((from, asset)).or_insert(0) += *amount;
+					}
+				},
+				_ => continue,
+			}
+		}
+	}
+	// We track the available liquid balance for each address and asset as we go through the events,
+	// so that if there are multiple transfers to the same address in the same block, we can
+	// correctly witness them up to the amount of liquid balance available. Tracking this prevents
+	// a scenario is necessary to correctly handle two specific edge cases:
+	// 1) Transfer of vesting funds: for this reason, we need track *liquid* balances changes.
+	// 2) Multiple transfers in the same block to the same address: without tracking liquid balance
+	//    changes.
 	let mut deposit_witnesses = vec![];
+	let mut available_liquid_balances = BTreeMap::default();
 	for (phase, wrapped_event) in events {
 		if let Phase::ApplyExtrinsic(extrinsic_index) = phase {
-			match wrapped_event {
+			let (asset, deposit_address, amount) = match wrapped_event {
 				EventWrapper::BalancesTransfer { to, amount, from: _ } => {
 					let deposit_address = PolkadotAccountId::from_aliased(to.0);
-					if monitored_addresses.contains(&deposit_address) {
-						deposit_witnesses.push(DepositWitness {
-							deposit_address,
-							asset: Asset::HubDot,
-							amount: *amount,
-							deposit_details: *extrinsic_index,
-						});
+					if !monitored_addresses.contains(&deposit_address) {
+						continue;
+					} else {
+						(HubAsset::HubDot, deposit_address, *amount)
 					}
 				},
-
 				EventWrapper::AssetsTransfer { asset_id, to, amount, from: _ } => {
 					let deposit_address = PolkadotAccountId::from_aliased(to.0);
-
-					if let Some(asset) = match *asset_id {
-						ASSETHUB_USDT_ASSET_ID => Some(Asset::HubUsdt),
-						ASSETHUB_USDC_ASSET_ID => Some(Asset::HubUsdc),
-						_ => None,
-					} {
-						if monitored_addresses.contains(&deposit_address) {
-							deposit_witnesses.push(DepositWitness {
-								deposit_address,
-								asset,
-								amount: *amount,
-								deposit_details: *extrinsic_index,
-							});
-						}
+					if !monitored_addresses.contains(&deposit_address) {
+						continue;
+					} else {
+						(
+							match *asset_id {
+								ASSETHUB_USDT_ASSET_ID => HubAsset::HubUsdt,
+								ASSETHUB_USDC_ASSET_ID => HubAsset::HubUsdc,
+								_ => continue,
+							},
+							deposit_address,
+							*amount,
+						)
 					}
 				},
-
-				_ => (),
+				_ => continue,
+			};
+			let available_balance = if let Some(balance) =
+				available_liquid_balances.get(&(deposit_address, asset))
+			{
+				*balance
+			} else {
+				let balance =
+					balance_increase(hub_client, deposit_address, asset, block_hash, parent_hash)
+						.await
+						.saturating_add(
+							outgoing_balance_changes
+								.get(&(deposit_address, asset))
+								.copied()
+								.unwrap_or_default(),
+						);
+				available_liquid_balances.insert((deposit_address, asset), balance);
+				balance
+			};
+			let amount = amount.min(available_balance);
+			available_liquid_balances
+				.entry((deposit_address, asset))
+				.and_modify(|balance| *balance = balance.saturating_sub(amount));
+			if amount > 0 {
+				deposit_witnesses.push(DepositWitness {
+					deposit_address,
+					asset,
+					amount,
+					deposit_details: *extrinsic_index,
+				});
+			} else {
+				tracing::warn!(
+					"Detected transfer to monitored address {:?} of asset {:?} with amount {} in block {:?}, but no liquid balance increase was available to witness after accounting for outgoing transfers and previous events in the same block. This transfer will not be witnessed.",
+					deposit_address, asset, amount, block_hash
+				);
 			}
 		}
 	}
@@ -166,7 +262,10 @@ mod test {
 	use cf_chains::dot::PolkadotBalance;
 	use cf_primitives::ASSETHUB_USDC_ASSET_ID;
 
-	use crate::witness::hub::{test::phase_and_events, HubAssetId};
+	use crate::{
+		dot::retry_rpc::mocks::MockDotRpcClient,
+		witness::hub::{test::phase_and_events, HubAssetId},
+	};
 
 	use super::*;
 
@@ -196,8 +295,23 @@ mod test {
 		}
 	}
 
-	#[test]
-	fn witness_deposits_for_addresses_we_monitor() {
+	/// Returns a mock client whose `liquid_account_balance` reports a huge unlocked
+	/// balance at the current block and zero at the parent — i.e. every transfer is
+	/// fully liquid, so witness amounts are not clamped.
+	fn mock_client_all_liquid(block_hash: PolkadotHash) -> MockDotRpcClient {
+		let mut client = MockDotRpcClient::new();
+		client.expect_liquid_account_balance().returning(move |_, _, hash| {
+			if hash == block_hash {
+				u128::MAX / 2
+			} else {
+				0
+			}
+		});
+		client
+	}
+
+	#[tokio::test]
+	async fn witness_deposits_for_addresses_we_monitor() {
 		let our_vault = PolkadotAccountId::from_aliased([0; 32]);
 
 		// We want two monitors, one sent through at start, and one sent through channel
@@ -289,45 +403,578 @@ mod test {
 			),
 		]);
 
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+		let hub_client = mock_client_all_liquid(block_hash);
+
 		let deposit_witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
 			vec![transfer_1_deposit_address, transfer_2_deposit_address],
 			&block_event_details,
-		);
+		)
+		.await;
 
 		assert_eq!(
 			deposit_witnesses,
 			vec![
 				DepositWitness {
 					deposit_address: transfer_1_deposit_address,
-					asset: Asset::HubDot,
+					asset: HubAsset::HubDot,
 					amount: TRANSFER_1_AMOUNT,
 					deposit_details: TRANSFER_1_INDEX
 				},
 				DepositWitness {
 					deposit_address: transfer_2_deposit_address,
-					asset: Asset::HubDot,
+					asset: HubAsset::HubDot,
 					amount: TRANSFER_2_AMOUNT,
 					deposit_details: TRANSFER_2_INDEX
 				},
 				DepositWitness {
 					deposit_address: transfer_3_deposit_address,
-					asset: Asset::HubUsdc,
+					asset: HubAsset::HubUsdc,
 					amount: TRANSFER_3_AMOUNT,
 					deposit_details: TRANSFER_3_INDEX
 				},
 				DepositWitness {
 					deposit_address: transfer_4_deposit_address,
-					asset: Asset::HubUsdt,
+					asset: HubAsset::HubUsdt,
 					amount: TRANSFER_4_AMOUNT,
 					deposit_details: TRANSFER_4_INDEX
 				},
 				DepositWitness {
 					deposit_address: transfer_2_deposit_address,
-					asset: Asset::HubDot,
+					asset: HubAsset::HubDot,
 					amount: TRANSFER_TO_SELF_AMOUNT,
 					deposit_details: TRANSFER_TO_SELF_INDEX
 				}
 			]
 		);
+	}
+
+	/// A vested transfer increases the recipient's `free` and `frozen` balance by the same
+	/// amount, so the *liquid* balance increase is zero. The witness must therefore credit
+	/// zero, not the raw transfer amount.
+	#[tokio::test]
+	async fn vested_transfer_credits_only_liquid_increase() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const TRANSFER_INDEX: u32 = 1;
+		const TRANSFER_AMOUNT: PolkadotBalance = 40_000_000_000; // 4 DOT, as in the report
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Liquid balance is zero at both blocks because the incoming funds are
+		// fully locked by a vesting schedule.
+		let mut hub_client = MockDotRpcClient::new();
+		hub_client.expect_liquid_account_balance().returning(|_, _, _| 0);
+
+		let events = phase_and_events(vec![(
+			TRANSFER_INDEX,
+			mock_transfer(
+				&PolkadotAccountId::from_aliased([7; 32]),
+				&deposit_address,
+				TRANSFER_AMOUNT,
+			),
+		)]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		// The clamped deposit is zero, so no witness is emitted (a warning is logged).
+		assert!(witnesses.is_empty());
+	}
+
+	/// Builds a mock that reports the recipient's liquid balance as `parent_liquid` at the
+	/// parent block and `current_liquid` at the current block (any other hash → 0).
+	fn mock_client_with_balances(
+		block_hash: PolkadotHash,
+		parent_hash: PolkadotHash,
+		current_liquid: u128,
+		parent_liquid: u128,
+	) -> MockDotRpcClient {
+		let mut client = MockDotRpcClient::new();
+		client.expect_liquid_account_balance().returning(move |_, _, hash| {
+			if hash == block_hash {
+				current_liquid
+			} else if hash == parent_hash {
+				parent_liquid
+			} else {
+				0
+			}
+		});
+		client
+	}
+
+	/// Two regular transfers to the same address in the same block. The recipient's
+	/// liquid balance increases by the full sum, so both witnesses are credited in full.
+	#[tokio::test]
+	async fn two_regular_transfers_same_address_both_credited() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const TRANSFER_A_INDEX: u32 = 1;
+		const TRANSFER_A_AMOUNT: PolkadotBalance = 10_000;
+		const TRANSFER_B_INDEX: u32 = 2;
+		const TRANSFER_B_AMOUNT: PolkadotBalance = 25_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Parent block: 0 liquid. Current block: full sum of both transfers liquid.
+		let hub_client = mock_client_with_balances(
+			block_hash,
+			parent_hash,
+			TRANSFER_A_AMOUNT + TRANSFER_B_AMOUNT,
+			0,
+		);
+
+		let events = phase_and_events(vec![
+			(
+				TRANSFER_A_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([7; 32]),
+					&deposit_address,
+					TRANSFER_A_AMOUNT,
+				),
+			),
+			(
+				TRANSFER_B_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([8; 32]),
+					&deposit_address,
+					TRANSFER_B_AMOUNT,
+				),
+			),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		assert_eq!(
+			witnesses,
+			vec![
+				DepositWitness {
+					deposit_address,
+					asset: HubAsset::HubDot,
+					amount: TRANSFER_A_AMOUNT,
+					deposit_details: TRANSFER_A_INDEX,
+				},
+				DepositWitness {
+					deposit_address,
+					asset: HubAsset::HubDot,
+					amount: TRANSFER_B_AMOUNT,
+					deposit_details: TRANSFER_B_INDEX,
+				},
+			]
+		);
+	}
+
+	/// A regular transfer followed by a vested transfer in the same block. The liquid
+	/// balance only increases by the regular amount; the total credited must match.
+	#[tokio::test]
+	async fn regular_then_vested_transfer_same_address() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const REGULAR_INDEX: u32 = 1;
+		const REGULAR_AMOUNT: PolkadotBalance = 10_000;
+		const VESTED_INDEX: u32 = 2;
+		const VESTED_AMOUNT: PolkadotBalance = 40_000_000_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Liquid balance rises by exactly the regular transfer amount; the vested
+		// transfer raises `free` and `frozen` by the same amount, contributing 0.
+		let hub_client = mock_client_with_balances(block_hash, parent_hash, REGULAR_AMOUNT, 0);
+
+		let events = phase_and_events(vec![
+			(
+				REGULAR_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([7; 32]),
+					&deposit_address,
+					REGULAR_AMOUNT,
+				),
+			),
+			(
+				VESTED_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([8; 32]),
+					&deposit_address,
+					VESTED_AMOUNT,
+				),
+			),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		// The first (regular) event exhausts the available liquid budget. The second
+		// (vested) event clamps to zero and is suppressed.
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, REGULAR_AMOUNT);
+		assert_eq!(witnesses[0].deposit_details, REGULAR_INDEX);
+	}
+
+	/// Vested transfer first, then a regular transfer. Ordering changes the distribution
+	/// across the two witnesses, but the total credited must still equal the liquid
+	/// increase (i.e. the regular amount only).
+	#[tokio::test]
+	async fn vested_then_regular_transfer_same_address() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const VESTED_INDEX: u32 = 1;
+		const VESTED_AMOUNT: PolkadotBalance = 40_000_000_000;
+		const REGULAR_INDEX: u32 = 2;
+		const REGULAR_AMOUNT: PolkadotBalance = 10_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		let hub_client = mock_client_with_balances(block_hash, parent_hash, REGULAR_AMOUNT, 0);
+
+		let events = phase_and_events(vec![
+			(
+				VESTED_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([7; 32]),
+					&deposit_address,
+					VESTED_AMOUNT,
+				),
+			),
+			(
+				REGULAR_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([8; 32]),
+					&deposit_address,
+					REGULAR_AMOUNT,
+				),
+			),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		// FIFO: the vested event arrives first and absorbs the entire liquid budget
+		// (REGULAR_AMOUNT). The regular event that follows clamps to zero and is
+		// suppressed. The aggregate credited still equals the real liquid increase.
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, REGULAR_AMOUNT);
+		assert_eq!(witnesses[0].deposit_details, VESTED_INDEX);
+	}
+
+	/// Pre-existing liquid balance at the parent block must not be counted towards the
+	/// deposit — only the delta (current - parent) is credited.
+	#[tokio::test]
+	async fn pre_existing_balance_is_not_credited() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const TRANSFER_INDEX: u32 = 1;
+		const TRANSFER_AMOUNT: PolkadotBalance = 1_000;
+		const PRE_EXISTING: PolkadotBalance = 9_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// The account already held PRE_EXISTING liquid funds before the block. After
+		// the transfer it holds PRE_EXISTING + TRANSFER_AMOUNT. Only the delta should
+		// be credited.
+		let hub_client = mock_client_with_balances(
+			block_hash,
+			parent_hash,
+			PRE_EXISTING + TRANSFER_AMOUNT,
+			PRE_EXISTING,
+		);
+
+		let events = phase_and_events(vec![(
+			TRANSFER_INDEX,
+			mock_transfer(
+				&PolkadotAccountId::from_aliased([7; 32]),
+				&deposit_address,
+				TRANSFER_AMOUNT,
+			),
+		)]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, TRANSFER_AMOUNT);
+	}
+
+	/// At the genesis block there is no parent. The previous-balance fetch must be
+	/// skipped (not silently queried with some bogus hash), and the full liquid
+	/// balance at the current block is credited.
+	#[tokio::test]
+	async fn genesis_block_has_no_parent_hash() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const TRANSFER_INDEX: u32 = 1;
+		const TRANSFER_AMOUNT: PolkadotBalance = 5_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+
+		// The mock panics if it is called with any hash other than `block_hash`,
+		// which would mean the code tried to fetch a previous-block balance even
+		// though no parent was supplied.
+		let mut hub_client = MockDotRpcClient::new();
+		hub_client
+			.expect_liquid_account_balance()
+			.withf(move |_, _, hash| *hash == block_hash)
+			.returning(move |_, _, _| TRANSFER_AMOUNT);
+
+		let events = phase_and_events(vec![(
+			TRANSFER_INDEX,
+			mock_transfer(
+				&PolkadotAccountId::from_aliased([7; 32]),
+				&deposit_address,
+				TRANSFER_AMOUNT,
+			),
+		)]);
+
+		let witnesses =
+			deposit_witnesses(block_hash, None, &hub_client, vec![deposit_address], &events).await;
+
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, TRANSFER_AMOUNT);
+	}
+
+	/// Two transfers to the same address in the same block, but in different assets
+	/// (HubDot and HubUsdc). The liquid-balance budget is per `(address, asset)`,
+	/// so the two transfers must not share a budget and both must be credited in full.
+	#[tokio::test]
+	async fn same_address_different_assets_tracked_independently() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		const DOT_INDEX: u32 = 1;
+		const DOT_AMOUNT: PolkadotBalance = 1_000;
+		const USDC_INDEX: u32 = 2;
+		const USDC_AMOUNT: PolkadotBalance = 2_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Each asset has exactly its transfer amount as liquid increase at the
+		// current block, and zero at the parent.
+		let mut hub_client = MockDotRpcClient::new();
+		hub_client.expect_liquid_account_balance().returning(move |_, asset, hash| {
+			if hash == block_hash {
+				match asset {
+					HubAsset::HubDot => DOT_AMOUNT,
+					HubAsset::HubUsdc => USDC_AMOUNT,
+					HubAsset::HubUsdt => 0,
+				}
+			} else {
+				0
+			}
+		});
+
+		let events = phase_and_events(vec![
+			(
+				DOT_INDEX,
+				mock_transfer(
+					&PolkadotAccountId::from_aliased([7; 32]),
+					&deposit_address,
+					DOT_AMOUNT,
+				),
+			),
+			(
+				USDC_INDEX,
+				mock_assets_transfer(
+					ASSETHUB_USDC_ASSET_ID,
+					&PolkadotAccountId::from_aliased([7; 32]),
+					&deposit_address,
+					USDC_AMOUNT,
+				),
+			),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		assert_eq!(
+			witnesses,
+			vec![
+				DepositWitness {
+					deposit_address,
+					asset: HubAsset::HubDot,
+					amount: DOT_AMOUNT,
+					deposit_details: DOT_INDEX,
+				},
+				DepositWitness {
+					deposit_address,
+					asset: HubAsset::HubUsdc,
+					amount: USDC_AMOUNT,
+					deposit_details: USDC_INDEX,
+				},
+			]
+		);
+	}
+
+	/// A vault sweep removes prior liquid funds in the same block as a new deposit
+	/// arrives. The liquid delta `current - parent` understates the incoming amount,
+	/// so the outgoing transfer must be added back to the budget for the deposit to
+	/// be fully credited.
+	#[tokio::test]
+	async fn outgoing_then_incoming_same_block_credits_in_full() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		let vault = PolkadotAccountId::from_aliased([7; 32]);
+		const SWEEP_INDEX: u32 = 1;
+		const SWEEP_AMOUNT: PolkadotBalance = 50;
+		const DEPOSIT_INDEX: u32 = 2;
+		const DEPOSIT_AMOUNT: PolkadotBalance = 100;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Parent held SWEEP_AMOUNT liquid; after the sweep + deposit the account holds
+		// DEPOSIT_AMOUNT. The naive delta is DEPOSIT_AMOUNT - SWEEP_AMOUNT; the outgoing
+		// transfer is added back so the full deposit is credited.
+		let hub_client =
+			mock_client_with_balances(block_hash, parent_hash, DEPOSIT_AMOUNT, SWEEP_AMOUNT);
+
+		let events = phase_and_events(vec![
+			(SWEEP_INDEX, mock_transfer(&deposit_address, &vault, SWEEP_AMOUNT)),
+			(DEPOSIT_INDEX, mock_transfer(&vault, &deposit_address, DEPOSIT_AMOUNT)),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, DEPOSIT_AMOUNT);
+	}
+
+	/// A new deposit arrives, then a vault sweep takes both the prior balance and
+	/// the new deposit out of the account in the same block. The current liquid
+	/// balance drops below the parent — so `saturating_sub` clamps the delta to zero
+	/// — but the deposit is real and must be credited in full once the outgoing
+	/// transfers are added back to the budget.
+	#[tokio::test]
+	async fn incoming_then_outgoing_same_block_with_balance_drop_credits_in_full() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		let vault = PolkadotAccountId::from_aliased([7; 32]);
+		const PARENT_LIQUID: PolkadotBalance = 50;
+		const DEPOSIT_INDEX: u32 = 1;
+		const DEPOSIT_AMOUNT: PolkadotBalance = 100;
+		const SWEEP_INDEX: u32 = 2;
+		const SWEEP_AMOUNT: PolkadotBalance = PARENT_LIQUID + DEPOSIT_AMOUNT;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Parent: PARENT_LIQUID. After deposit + sweep-of-everything, current = 0.
+		// Without the outgoing-sum compensation the deposit would silently witness
+		// as zero, because `saturating_sub(0, 50)` is 0.
+		let hub_client = mock_client_with_balances(block_hash, parent_hash, 0, PARENT_LIQUID);
+
+		let events = phase_and_events(vec![
+			(DEPOSIT_INDEX, mock_transfer(&vault, &deposit_address, DEPOSIT_AMOUNT)),
+			(SWEEP_INDEX, mock_transfer(&deposit_address, &vault, SWEEP_AMOUNT)),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		assert_eq!(witnesses.len(), 1);
+		assert_eq!(witnesses[0].amount, DEPOSIT_AMOUNT);
+	}
+
+	/// An outgoing transfer in one asset must not inflate the budget for a different
+	/// asset on the same address. The budget map is keyed by `(address, asset)` on
+	/// both the incoming and outgoing sides.
+	#[tokio::test]
+	async fn outgoing_in_one_asset_does_not_inflate_other_asset_budget() {
+		let deposit_address = PolkadotAccountId::from_aliased([1; 32]);
+		let vault = PolkadotAccountId::from_aliased([7; 32]);
+		const DOT_SWEEP_INDEX: u32 = 1;
+		const DOT_SWEEP_AMOUNT: PolkadotBalance = 1_000;
+		// A vested USDC-like deposit: the event amount is large, but the liquid
+		// delta is zero. If the DOT outgoing were leaking into the USDC budget,
+		// this would be credited as DOT_SWEEP_AMOUNT instead of zero.
+		const USDC_DEPOSIT_INDEX: u32 = 2;
+		const USDC_DEPOSIT_AMOUNT: PolkadotBalance = 5_000;
+
+		let block_hash = PolkadotHash::from([1u8; 32]);
+		let parent_hash = PolkadotHash::from([0u8; 32]);
+
+		// Parent: DOT_SWEEP_AMOUNT in HubDot, zero in USDC. Current: zero in both
+		// (DOT swept out, USDC arrived but is fully locked → zero liquid).
+		let mut hub_client = MockDotRpcClient::new();
+		hub_client.expect_liquid_account_balance().returning(move |_, asset, hash| {
+			match (asset, hash) {
+				(HubAsset::HubDot, h) if h == parent_hash => DOT_SWEEP_AMOUNT,
+				_ => 0,
+			}
+		});
+
+		let events = phase_and_events(vec![
+			(DOT_SWEEP_INDEX, mock_transfer(&deposit_address, &vault, DOT_SWEEP_AMOUNT)),
+			(
+				USDC_DEPOSIT_INDEX,
+				mock_assets_transfer(
+					ASSETHUB_USDC_ASSET_ID,
+					&vault,
+					&deposit_address,
+					USDC_DEPOSIT_AMOUNT,
+				),
+			),
+		]);
+
+		let witnesses = deposit_witnesses(
+			block_hash,
+			Some(parent_hash),
+			&hub_client,
+			vec![deposit_address],
+			&events,
+		)
+		.await;
+
+		// The USDC event clamps to zero (its liquid delta is zero and the DOT outgoing
+		// must not bleed across asset budgets), so no witness is emitted.
+		assert!(witnesses.is_empty());
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2888

## Summary

This is a fix for the balance witnessing issue, where we could incorrectly witness eg. vesting funds.

The fix is quite inelegant but I don't think there's a better way:
- read the *liquid* account balance at the current and previous blocks
- check for any *outgoing* transfers in case there was a fetch
- derive the net inflow of funds to the address based on the net increase
- for each incoming transfer event, decrease the available liquid funds
- as long as the available funds are non-zero, generate a deposit

