### PR TITLE
test: bouncer checks for witnesser crashes

### DIFF
--- a/bouncer/shared/check_witnessing_task_restarts.ts
+++ b/bouncer/shared/check_witnessing_task_restarts.ts
@@ -1,0 +1,34 @@
+import prisma from 'shared/utils/prisma_client';
+import { TestContext } from 'shared/utils/test_context';
+
+// Whenever one of the engine's witnessing tasks crashes (panics or returns an unexpected error) it
+// is restarted by `spawn_with_restart`, and the validator submits the "SOS extrinsic"
+// (`validator.report_witnessing_task_restart`, see `submit_sos_extrinsic` in the engine) which
+// emits the `Validator.WitnessingTaskRestarted` event.
+//
+// A crash like this is always critical: it usually means some witnessing/voting code panicked,
+// including code that runs behind an RPC. The state chain keeps running when this happens, so
+// without this check the bouncer would happily pass even though a panic occurred. We make a single
+// query against the indexer to assert that no such event was emitted during the test run.
+const WITNESSING_TASK_RESTARTED_EVENT = 'Validator.WitnessingTaskRestarted';
+
+export async function checkNoWitnessingTaskRestarts(testContext: TestContext) {
+  testContext.info('Checking that no witnessing tasks crashed and restarted during the tests');
+
+  const restartEvents = await prisma.event.findMany({
+    where: { name: WITNESSING_TASK_RESTARTED_EVENT },
+    include: { block: true },
+    orderBy: { block: { height: 'asc' } },
+  });
+
+  if (restartEvents.length > 0) {
+    const occurrences = restartEvents
+      .map((event) => `block ${event.block.height}: ${JSON.stringify(event.args)}`)
+      .join(', ');
+    throw new Error(
+      `A witnessing task crashed and was restarted during the tests, emitting ` +
+        `${WITNESSING_TASK_RESTARTED_EVENT}. This indicates a panic or critical error in the ` +
+        `engine that must be investigated. Occurrences: ${occurrences}`,
+    );
+  }
+}

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -3,6 +3,7 @@ import { testBoostingSwap } from 'tests/boost';
 import { testVaultSwap } from 'tests/vault_swap_tests';
 import { checkSolEventAccountsClosure } from 'shared/vault_swap/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from 'shared/utils';
+import { checkNoWitnessingTaskRestarts } from 'shared/check_witnessing_task_restarts';
 import { testAllSwaps } from 'tests/all_swaps';
 import { testEvmDeposits } from 'tests/evm_deposits';
 import { testMultipleMembersGovernance } from 'tests/multiple_members_governance';
@@ -78,6 +79,7 @@ describe('ConcurrentTests', () => {
     checkAvailabilityAllSolanaNonces,
     5 * ciTimeoutFactor,
   );
+  serialTest('CheckNoWitnessingTaskRestarts', checkNoWitnessingTaskRestarts, 5 * ciTimeoutFactor);
 });
 
 // Run only the broker level screening tests

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -5,6 +5,7 @@ import { testRotationBarrier } from 'tests/rotation_barrier';
 import { testSolanaVaultSettingsGovernance } from 'tests/solana_vault_settings_governance';
 import { serialTest } from 'shared/utils/vitest';
 import { testSwapAfterDisconnection } from 'tests/swap_after_temp_disconnecting_chains';
+import { checkNoWitnessingTaskRestarts } from 'shared/check_witnessing_task_restarts';
 
 // Tests that are run by the ci-main-merge after the concurrent tests
 describe('SerialTests2', () => {
@@ -16,4 +17,7 @@ describe('SerialTests2', () => {
   if (process.env.LOCALNET) {
     serialTest('SwapAfterDisconnection', testSwapAfterDisconnection, 250);
   }
+
+  // Post test check: assert no witnessing task crashed during any of the tests run on this localnet.
+  serialTest('CheckNoWitnessingTaskRestarts', checkNoWitnessingTaskRestarts, 30);
 });


### PR DESCRIPTION
# Pull Request

Closes: PRO-2827

## Summary

A simple test that runs after the fast & full bouncer tests that checks for the `WitnessingTaskRestarted` event.