### PR TITLE
feat: add broker fee bps to LoanCreated

### DIFF
--- a/bouncer/generated/events/lendingPools/loanCreated.ts
+++ b/bouncer/generated/events/lendingPools/loanCreated.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  accountId,
+  cfPrimitivesBeneficiaryAccountId32,
   cfPrimitivesChainsAssetsAnyAsset,
   numberOrHex,
   palletCfLendingPoolsGeneralLendingLoanType,
@@ -11,5 +11,5 @@ export const lendingPoolsLoanCreated = z.object({
   asset: cfPrimitivesChainsAssetsAnyAsset,
   loanType: palletCfLendingPoolsGeneralLendingLoanType,
   principalAmount: numberOrHex,
-  brokerId: accountId.nullish(),
+  broker: cfPrimitivesBeneficiaryAccountId32.nullish(),
 });

--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -203,7 +203,7 @@ impl<T: Config> BoostApi for Pallet<T> {
 				loan_type: LoanType::Boost(deposit_id),
 				asset,
 				principal_amount: lending_pool_principal,
-				broker_id: None,
+				broker: None,
 			});
 
 			fund_loan::<T>(&mut loan, lending_pool_principal, pool_fee, network_fee)?;

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1474,10 +1474,8 @@ impl<T: Config> LendingApi for Pallet<T> {
 			Error::<T>::AmountBelowMinimum
 		);
 
-		let broker_id = broker.as_ref().map(|b| b.account.clone());
-
 		// Creating a loan with 0 principal first, then using `expand_loan_inner` to update it
-		let loan = create_new_loan::<T>(asset, broker);
+		let loan = create_new_loan::<T>(asset, broker.clone());
 		let loan_id = loan.id;
 
 		let collateral_assets = LoanAccounts::<T>::mutate(
@@ -1491,7 +1489,7 @@ impl<T: Config> LendingApi for Pallet<T> {
 					loan_type: LoanType::User(borrower_id.clone()),
 					asset,
 					principal_amount: amount_to_borrow,
-					broker_id,
+					broker,
 				});
 
 				account.expand_loan_inner(loan, amount_to_borrow, &price_cache)?;

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -418,7 +418,7 @@ fn basic_general_lending() {
 					loan_type: LoanType::User(BORROWER),
 					asset: LOAN_ASSET,
 					principal_amount: PRINCIPAL,
-					broker_id: None,
+					broker: None,
 				}),
 				RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 					loan_id: LOAN_ID,
@@ -694,15 +694,15 @@ fn broker_interest_credited_to_broker() {
 				Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
 			));
 
-			// The loan's `LoanCreated` event records the broker's account id.
+			// The loan's `LoanCreated` event records the broker's account id and bps.
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::LendingPools(Event::<Test>::LoanCreated {
 					loan_id: LOAN_ID,
 					loan_type: LoanType::User(BORROWER),
-					broker_id,
+					broker,
 					..
-				}) if *broker_id == Some(BROKER),
+				}) if *broker == Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
 			);
 
 			assert_eq!(MockBalance::get_balance(&BROKER, LOAN_ASSET), 0);

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -468,7 +468,7 @@ pub mod pallet {
 			asset: Asset,
 			loan_type: LoanType<T::AccountId>,
 			principal_amount: AssetAmount,
-			broker_id: Option<T::AccountId>,
+			broker: Option<Beneficiary<T::AccountId>>,
 		},
 		LoanUpdated {
 			loan_id: LoanId,

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -531,7 +531,7 @@ fn basic_boosting() {
 				loan_type: LoanType::Boost(DEPOSIT_ID),
 				asset: BOOST_ASSET,
 				principal_amount: REQUIRED_AMOUNT,
-				broker_id: None,
+				broker: None,
 			}),
 			RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 				loan_id: LOAN_ID,
@@ -667,7 +667,7 @@ fn boosted_deposit_is_lost() {
 				loan_type: LoanType::Boost(DEPOSIT_ID),
 				asset: BOOST_ASSET,
 				principal_amount: REQUIRED_AMOUNT,
-				broker_id: None,
+				broker: None,
 			}),
 			RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 				loan_id: LOAN_ID,
@@ -1248,7 +1248,7 @@ mod hybrid_boosting {
 					loan_type: LoanType::Boost(DEPOSIT_ID),
 					asset: BOOST_ASSET,
 					principal_amount: LENDING_FUNDS,
-					broker_id: None,
+					broker: None,
 				}),
 				RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 					loan_id: LOAN_ID,
@@ -1368,7 +1368,7 @@ mod hybrid_boosting {
 					loan_type: LoanType::Boost(DEPOSIT_ID),
 					asset: BOOST_ASSET,
 					principal_amount: REQUIRED_AMOUNT,
-					broker_id: None,
+					broker: None,
 				}),
 				RuntimeEvent::LendingPools(Event::<Test>::OriginationFeeTaken {
 					loan_id: LOAN_ID,


### PR DESCRIPTION
# Pull Request

## Summary

As requested, in addition to broker_id, we now also expose the broker fee (all part of `Beneficiary` struct).