### PR TITLE
fix: treat AncientBirthBlock as recoverable in submission_watcher

### DIFF
--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Run tests 🧪
         run: |
           cargo ${{ matrix.cargo-profile }} --locked
-        timeout-minutes: 25
+        timeout-minutes: 30

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -309,11 +309,8 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		request: &mut Request,
 		nonce: Nonce,
 	) -> Result<Result<H256, SubmissionLogicError>, anyhow::Error> {
-		// The era anchor used to sign the extrinsic. Initialised from the
-		// watcher's tracked finalized block, but may be refreshed locally on
-		// AncientBirthBlock without touching `self.finalized_block_*` — the
-		// watcher's bookkeeping must only advance through `on_block_finalized`
-		// to preserve the strictly-increasing invariant it asserts on.
+		// The era block hash and number used as anchor when signing the extrinsic. Stored as
+		// local copies so we can overwrite them on AncientBirthBlock failure.
 		let mut era_block_hash = self.finalized_block_hash;
 		let mut era_block_number = self.finalized_block_number;
 		loop {
@@ -398,13 +395,10 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 
 							self.runtime_version = new_runtime_version;
 						},
-						// AncientBirthBlock can fire transiently when the tx pool re-validates
-						// a submission against a slightly inconsistent best-block snapshot.
-						// Refresh the local era anchor and retry on the next loop iteration
-						// rather than tearing down the engine. Note we deliberately do not
-						// touch `self.finalized_block_*` — `on_block_finalized` enforces
-						// strictly-increasing finalized block numbers via assert, and
-						// leapfrogging that cursor here would violate it.
+						// AncientBirthBlock can fire transiently during tx pool re-validation.
+						// Handle gracefully by resubmitting with the updated era anchor.
+						// We deliberately leave `self.finalized_block_*` untouched, since
+						// `on_block_finalized` asserts strictly-increasing finalized block numbers.
 						ClientError::Call(obj)
 							if obj == invalid_err_obj(InvalidTransaction::AncientBirthBlock) =>
 						{

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -309,13 +309,20 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		request: &mut Request,
 		nonce: Nonce,
 	) -> Result<Result<H256, SubmissionLogicError>, anyhow::Error> {
+		// The era anchor used to sign the extrinsic. Initialised from the
+		// watcher's tracked finalized block, but may be refreshed locally on
+		// AncientBirthBlock without touching `self.finalized_block_*` — the
+		// watcher's bookkeeping must only advance through `on_block_finalized`
+		// to preserve the strictly-increasing invariant it asserts on.
+		let mut era_block_hash = self.finalized_block_hash;
+		let mut era_block_number = self.finalized_block_number;
 		loop {
 			let (signed_extrinsic, lifetime) = self.signer.new_signed_extrinsic(
 				request.call.clone(),
 				&self.runtime_version,
 				self.genesis_hash,
-				self.finalized_block_hash,
-				self.finalized_block_number,
+				era_block_hash,
+				era_block_number,
 				self.extrinsic_lifetime,
 				nonce,
 			);
@@ -393,18 +400,19 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 						},
 						// AncientBirthBlock can fire transiently when the tx pool re-validates
 						// a submission against a slightly inconsistent best-block snapshot.
-						// Refresh our finalized block reference and retry on the next loop
-						// iteration rather than tearing down the engine.
+						// Refresh the local era anchor and retry on the next loop iteration
+						// rather than tearing down the engine. Note we deliberately do not
+						// touch `self.finalized_block_*` — `on_block_finalized` enforces
+						// strictly-increasing finalized block numbers via assert, and
+						// leapfrogging that cursor here would violate it.
 						ClientError::Call(obj)
 							if obj == invalid_err_obj(InvalidTransaction::AncientBirthBlock) =>
 						{
-							warn!(target: "state_chain_client", request_id = request.id, "Submission failed with AncientBirthBlock: {obj:?}. Refreshing finalized block reference.");
-							let new_finalized_block_hash =
+							warn!(target: "state_chain_client", request_id = request.id, "Submission failed with AncientBirthBlock: {obj:?}. Refreshing era anchor.");
+							era_block_hash =
 								self.base_rpc_client.latest_finalized_block_hash().await?;
-							let new_finalized_header =
-								self.base_rpc_client.block_header(new_finalized_block_hash).await?;
-							self.finalized_block_hash = new_finalized_block_hash;
-							self.finalized_block_number = new_finalized_header.number;
+							era_block_number =
+								self.base_rpc_client.block_header(era_block_hash).await?.number;
 						},
 						ClientError::Call(obj)
 							if obj.code() == 1002 &&

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -391,6 +391,21 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 
 							self.runtime_version = new_runtime_version;
 						},
+						// AncientBirthBlock can fire transiently when the tx pool re-validates
+						// a submission against a slightly inconsistent best-block snapshot.
+						// Refresh our finalized block reference and retry on the next loop
+						// iteration rather than tearing down the engine.
+						ClientError::Call(obj)
+							if obj == invalid_err_obj(InvalidTransaction::AncientBirthBlock) =>
+						{
+							warn!(target: "state_chain_client", request_id = request.id, "Submission failed with AncientBirthBlock: {obj:?}. Refreshing finalized block reference.");
+							let new_finalized_block_hash =
+								self.base_rpc_client.latest_finalized_block_hash().await?;
+							let new_finalized_header =
+								self.base_rpc_client.block_header(new_finalized_block_hash).await?;
+							self.finalized_block_hash = new_finalized_block_hash;
+							self.finalized_block_number = new_finalized_header.number;
+						},
 						ClientError::Call(obj)
 							if obj.code() == 1002 &&
 								obj.message()

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
@@ -274,6 +274,66 @@ async fn should_retry_after_dropped_on_next_finalized_block() {
 	.expect("runtime version refresh path should not hang");
 }
 
+/// AncientBirthBlock should be treated as recoverable: refresh the finalized block
+/// reference and retry on the next loop iteration rather than tearing the engine down.
+#[tokio::test]
+async fn should_recover_from_ancient_birth_block() {
+	tokio::time::timeout(
+		Duration::from_secs(5),
+		task_scope(|scope| {
+			async {
+				let mut mock_rpc_api = MockBaseRpcApi::new();
+
+				mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(1));
+				mock_rpc_api.expect_submit_and_watch_extrinsic().times(1).returning(move |_| {
+					Err(ErrorObject::owned(
+						1010,
+						"Invalid Transaction",
+						Some(<&'static str>::from(InvalidTransaction::AncientBirthBlock)),
+					)
+					.into())
+				});
+
+				let refreshed_finalized_hash = H256::from_low_u64_be(0xABCDEF);
+				let refreshed_finalized_number: state_chain_runtime::BlockNumber = 42;
+				mock_rpc_api
+					.expect_latest_finalized_block_hash()
+					.times(1)
+					.return_once(move || Ok(refreshed_finalized_hash));
+				mock_rpc_api
+					.expect_block_header()
+					.withf(move |hash| *hash == refreshed_finalized_hash)
+					.times(1)
+					.return_once(move |_| {
+						Ok(state_chain_runtime::Header {
+							parent_hash: H256::default(),
+							number: refreshed_finalized_number,
+							state_root: H256::default(),
+							extrinsics_root: H256::default(),
+							digest: Default::default(),
+						})
+					});
+
+				// On the retry, return a success.
+				mock_rpc_api
+					.expect_submit_and_watch_extrinsic()
+					.return_once(move |_| Ok(Box::pin(stream::empty()) as WatchExtrinsicStream));
+
+				let watcher = new_watcher_and_submit_test_extrinsic(scope, mock_rpc_api).await;
+
+				assert_eq!(watcher.finalized_block_hash, refreshed_finalized_hash);
+				assert_eq!(watcher.finalized_block_number, refreshed_finalized_number);
+
+				Ok(())
+			}
+			.boxed()
+		}),
+	)
+	.await
+	.expect("ancient birth block recovery path should not hang")
+	.unwrap();
+}
+
 fn test_call() -> state_chain_runtime::RuntimeCall {
 	state_chain_runtime::RuntimeCall::Witnesser(pallet_cf_witnesser::Call::witness_at_epoch {
 		call: Box::new(state_chain_runtime::RuntimeCall::PolkadotChainTracking(

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
@@ -274,17 +274,26 @@ async fn should_retry_after_dropped_on_next_finalized_block() {
 	.expect("runtime version refresh path should not hang");
 }
 
-/// AncientBirthBlock should be treated as recoverable: refresh the finalized block
-/// reference and retry on the next loop iteration rather than tearing the engine down.
+/// AncientBirthBlock should be recoverable:
+///  - the retry is signed with the *refreshed* era anchor (not the stale one),
+///  - the watcher's tracked finalized block (`self.finalized_block_*`) is NOT mutated — that cursor
+///    must only advance through `on_block_finalized`, otherwise its strictly-increasing invariant
+///    breaks.
 #[tokio::test]
 async fn should_recover_from_ancient_birth_block() {
+	use sp_runtime::generic::Era;
+
+	const INITIAL_FINALIZED_BLOCK_NUMBER: state_chain_runtime::BlockNumber = 5;
+	const REFRESHED_FINALIZED_BLOCK_NUMBER: state_chain_runtime::BlockNumber = 42;
+	const NONCE: state_chain_runtime::Nonce = 1;
+
 	tokio::time::timeout(
 		Duration::from_secs(5),
 		task_scope(|scope| {
 			async {
 				let mut mock_rpc_api = MockBaseRpcApi::new();
 
-				mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(1));
+				mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(NONCE));
 				mock_rpc_api.expect_submit_and_watch_extrinsic().times(1).returning(move |_| {
 					Err(ErrorObject::owned(
 						1010,
@@ -295,7 +304,6 @@ async fn should_recover_from_ancient_birth_block() {
 				});
 
 				let refreshed_finalized_hash = H256::from_low_u64_be(0xABCDEF);
-				let refreshed_finalized_number: state_chain_runtime::BlockNumber = 42;
 				mock_rpc_api
 					.expect_latest_finalized_block_hash()
 					.times(1)
@@ -307,7 +315,7 @@ async fn should_recover_from_ancient_birth_block() {
 					.return_once(move |_| {
 						Ok(state_chain_runtime::Header {
 							parent_hash: H256::default(),
-							number: refreshed_finalized_number,
+							number: REFRESHED_FINALIZED_BLOCK_NUMBER,
 							state_root: H256::default(),
 							extrinsics_root: H256::default(),
 							digest: Default::default(),
@@ -319,10 +327,51 @@ async fn should_recover_from_ancient_birth_block() {
 					.expect_submit_and_watch_extrinsic()
 					.return_once(move |_| Ok(Box::pin(stream::empty()) as WatchExtrinsicStream));
 
-				let watcher = new_watcher_and_submit_test_extrinsic(scope, mock_rpc_api).await;
+				let mut watcher = new_watcher_with_mock_rpc_api(
+					scope,
+					mock_rpc_api,
+					INITIAL_NONCE,
+					INITIAL_FINALIZED_BLOCK_NUMBER,
+				)
+				.await;
+				let mut request = new_test_request(0, false);
+				watcher.submit_extrinsic(&mut request).await.unwrap();
 
-				assert_eq!(watcher.finalized_block_hash, refreshed_finalized_hash);
-				assert_eq!(watcher.finalized_block_number, refreshed_finalized_number);
+				// The watcher's tracked finalized block must NOT have changed — only
+				// `on_block_finalized` is allowed to advance it.
+				assert_eq!(watcher.finalized_block_hash, H256::default());
+				assert_eq!(watcher.finalized_block_number, INITIAL_FINALIZED_BLOCK_NUMBER);
+
+				// The successful retry must have been signed with the REFRESHED era
+				// anchor. The stored submission lifetime is `..era.death(anchor)`,
+				// so we compare against what Era::mortal would produce for the
+				// refreshed anchor.
+				let tracked_submission = watcher
+					.submissions_by_nonce
+					.get(&NONCE)
+					.and_then(|v| v.first())
+					.expect("submission should be tracked on successful retry");
+				let expected_death = Era::mortal(
+					SIGNED_EXTRINSIC_LIFETIME as u64,
+					REFRESHED_FINALIZED_BLOCK_NUMBER as u64,
+				)
+				.death(REFRESHED_FINALIZED_BLOCK_NUMBER as u64)
+					as state_chain_runtime::BlockNumber;
+				assert_eq!(
+					tracked_submission.lifetime,
+					..expected_death,
+					"retry must be signed with refreshed era anchor"
+				);
+
+				// Sanity: the stale-era lifetime would have been a *different* value;
+				// otherwise the assertion above is vacuous.
+				let stale_death = Era::mortal(
+					SIGNED_EXTRINSIC_LIFETIME as u64,
+					INITIAL_FINALIZED_BLOCK_NUMBER as u64,
+				)
+				.death(INITIAL_FINALIZED_BLOCK_NUMBER as u64)
+					as state_chain_runtime::BlockNumber;
+				assert_ne!(expected_death, stale_death);
 
 				Ok(())
 			}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2886

## Summary

Now if the engine hits AncientBirthBlock, it will refetch latest finalised block and retry instead of panicking. (Panicking is problematic as it, for example, aborts all ceremonies, including keygen ceremonies leading to exclusion from authority set.)
