### PR TITLE
chore: re-add Assethub bouncer tests

### DIFF
--- a/bouncer/commands/setup_assethub_for_upgrade_test.ts
+++ b/bouncer/commands/setup_assethub_for_upgrade_test.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S pnpm tsx
+
+import { AddressOrPair } from '@polkadot/api/types';
+import { initializeAssethubChain } from 'shared/initialize_new_chains';
+import { DisposableApiPromise, getAssethubApi, observeEvent } from 'shared/utils/substrate';
+import { globalLogger } from 'shared/utils/logger';
+import { submitGovernanceExtrinsic } from 'shared/cf_governance';
+import { createLpPool } from 'shared/create_lp_pool';
+import { depositLiquidity } from 'shared/deposit_liquidity';
+import { rangeOrder } from 'shared/range_order';
+import { deferredPromise, handleSubstrateError, runWithTimeoutAndExit } from 'shared/utils';
+import { aliceKeyringPair } from 'shared/polkadot_keyring';
+import { createPolkadotVault } from 'commands/setup_vaults';
+import { fullAccountFromUri, newChainflipIO } from 'shared/utils/chainflip_io';
+
+export async function rotateAndFund(
+  api: DisposableApiPromise,
+  vault: AddressOrPair,
+  key: AddressOrPair,
+) {
+  const { promise, resolve } = deferredPromise<void>();
+  const alice = await aliceKeyringPair();
+  const rotation = api.tx.proxy.proxy(
+    api.createType('MultiAddress', vault),
+    null,
+    api.tx.utility.batchAll([
+      api.tx.proxy.addProxy(
+        api.createType('MultiAddress', key),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+      api.tx.proxy.removeProxy(
+        api.createType('MultiAddress', alice.address),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+    ]),
+  );
+
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.utility
+    .batchAll([
+      // Note the vault needs to be funded before we rotate.
+      api.tx.balances.transferKeepAlive(vault, 1000000000000),
+      api.tx.balances.transferKeepAlive(key, 1000000000000),
+      rotation,
+    ])
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        unsubscribe();
+        resolve();
+      }
+    });
+
+  await promise;
+}
+
+async function main(): Promise<void> {
+  const cf = (await newChainflipIO(globalLogger, {})).withChildLogger('setup_vaults');
+  await using assethub = await getAssethubApi();
+
+  await initializeAssethubChain(cf.logger);
+  await submitGovernanceExtrinsic((api) => api.tx.validator.forceRotation());
+  const hubActivationRequest = observeEvent(
+    cf.logger,
+    'assethubVault:AwaitingGovernanceActivation',
+  ).event;
+  const hubKey = (await hubActivationRequest).data.newPublicKey;
+  const { vaultAddress: hubVaultAddress } = await createPolkadotVault(assethub);
+  const hubProxyAdded = observeEvent(cf.logger, 'proxy:ProxyAdded', { chain: 'assethub' }).event;
+  const [, hubVaultEvent] = await Promise.all([
+    rotateAndFund(assethub, hubVaultAddress, hubKey),
+    hubProxyAdded,
+  ]);
+  cf.info('registering assethub vault on state chain');
+  await submitGovernanceExtrinsic((chainflip) =>
+    chainflip.tx.environment.witnessAssethubVaultCreation(hubVaultAddress, {
+      blockNumber: hubVaultEvent.block,
+      extrinsicIndex: hubVaultEvent.eventIndex,
+    }),
+  );
+
+  cf.info('creating pools for assethub assets');
+  await cf.all([
+    (subcf) => createLpPool(subcf.logger, 'HubDot', 10),
+    (subcf) => createLpPool(subcf.logger, 'HubUsdc', 1),
+    (subcf) => createLpPool(subcf.logger, 'HubUsdt', 1),
+  ]);
+
+  cf.info('funding pools with assethub assets');
+  await cf
+    .with({ account: fullAccountFromUri('//LP_1', 'LP') })
+    .all([
+      (subcf) => depositLiquidity(subcf, 'HubDot', 20000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdc', 250000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdt', 250000),
+    ]);
+
+  await cf
+    .with({ account: fullAccountFromUri('//LP_API', 'LP') })
+    .all([
+      (subcf) => depositLiquidity(subcf, 'HubDot', 20000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdc', 250000),
+      (subcf) => depositLiquidity(subcf, 'HubUsdt', 250000),
+    ]);
+
+  cf.info('creating orders for assethub assets');
+  await cf
+    .with({ account: fullAccountFromUri('//LP1', 'LP') })
+    .all([
+      (subcf) => rangeOrder(subcf, 'HubDot', 20000 * 0.9999),
+      (subcf) => rangeOrder(subcf, 'HubUsdc', 250000 * 0.9999),
+      (subcf) => rangeOrder(subcf, 'HubUsdt', 250000 * 0.9999),
+    ]);
+}
+
+await runWithTimeoutAndExit(main(), 6000);

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -6,7 +6,17 @@
 // https://www.notion.so/chainflip/Polkadot-Vault-Initialisation-Steps-36d6ab1a24ed4343b91f58deed547559
 // For example: ./commands/setup_vaults.ts
 
-import { getBtcClient, getSolConnection, getWeb3, getTronWebClient } from 'shared/utils';
+import { AddressOrPair } from '@polkadot/api/types';
+import {
+  getBtcClient,
+  handleSubstrateError,
+  getWeb3,
+  getSolConnection,
+  deferredPromise,
+  runWithTimeout,
+  getTronWebClient,
+} from 'shared/utils';
+import { aliceKeyringPair } from 'shared/polkadot_keyring';
 import {
   initializeArbitrumChain,
   initializeArbitrumContracts,
@@ -14,8 +24,10 @@ import {
   initializeSolanaPrograms,
   initializeTronChain,
   initializeTronContracts,
+  initializeAssethubChain,
 } from 'shared/initialize_new_chains';
-import { globalLogger, loggerChild } from 'shared/utils/logger';
+import { globalLogger, Logger, loggerChild } from 'shared/utils/logger';
+import { getAssethubApi, observeEvent, DisposableApiPromise } from 'shared/utils/substrate';
 import { brokerApiEndpoint, lpApiEndpoint } from 'shared/json_rpc';
 import { updateDefaultPriceFeeds } from 'shared/update_price_feed';
 import { newChainflipIO } from 'shared/utils/chainflip_io';
@@ -23,9 +35,95 @@ import { bitcoinVaultAwaitingGovernanceActivation } from 'generated/events/bitco
 import { arbitrumVaultAwaitingGovernanceActivation } from 'generated/events/arbitrumVault/awaitingGovernanceActivation';
 import { solanaVaultAwaitingGovernanceActivation } from 'generated/events/solanaVault/awaitingGovernanceActivation';
 import { tronVaultAwaitingGovernanceActivation } from 'generated/events/tronVault/awaitingGovernanceActivation';
+import { assethubVaultAwaitingGovernanceActivation } from 'generated/events/assethubVault/awaitingGovernanceActivation';
 import { validatorNewEpoch } from 'generated/events/validator/newEpoch';
 import { validatorRotationPhaseUpdated } from 'generated/events/validator/rotationPhaseUpdated';
 import { validatorRotationAborted } from 'generated/events/validator/rotationAborted';
+
+export async function createPolkadotVault(api: DisposableApiPromise) {
+  const { promise, resolve } = deferredPromise<{
+    vaultAddress: AddressOrPair;
+    vaultExtrinsicIndex: number;
+  }>();
+
+  const alice = await aliceKeyringPair();
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.proxy
+    .createPure(api.createType('ProxyType', 'Any'), 0, 0)
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        // TODO: figure out type inference so we don't have to coerce using `any`
+        const pureCreated = result.findRecord('proxy', 'PureCreated')!;
+        resolve({
+          vaultAddress: pureCreated.event.data[0] as AddressOrPair,
+          vaultExtrinsicIndex: result.txIndex!,
+        });
+        unsubscribe();
+      }
+    });
+
+  return promise;
+}
+
+async function rotateAndFund(api: DisposableApiPromise, vault: AddressOrPair, key: AddressOrPair) {
+  const { promise, resolve } = deferredPromise<void>();
+  const alice = await aliceKeyringPair();
+  const rotation = api.tx.proxy.proxy(
+    api.createType('MultiAddress', vault),
+    null,
+    api.tx.utility.batchAll([
+      api.tx.proxy.addProxy(
+        api.createType('MultiAddress', key),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+      api.tx.proxy.removeProxy(
+        api.createType('MultiAddress', alice.address),
+        api.createType('ProxyType', 'Any'),
+        0,
+      ),
+    ]),
+  );
+
+  const nonce = await api.rpc.system.accountNextIndex(alice.address);
+  const unsubscribe = await api.tx.utility
+    .batchAll([
+      // Note the vault needs to be funded before we rotate.
+      api.tx.balances.transferKeepAlive(vault, 1000000000000),
+      api.tx.balances.transferKeepAlive(key, 1000000000000),
+      rotation,
+    ])
+    .signAndSend(alice, { nonce }, (result) => {
+      if (result.isError) {
+        handleSubstrateError(api)(result);
+      }
+      if (result.isFinalized) {
+        unsubscribe();
+        resolve();
+      }
+    });
+
+  await promise;
+}
+
+async function createAssetHubVault(
+  logger: Logger,
+  assethubApi: DisposableApiPromise,
+): Promise<AddressOrPair> {
+  // Step a
+  logger.info('Requesting Assethub Vault creation');
+  const { vaultAddress: hubVaultAddress } = await runWithTimeout(
+    createPolkadotVault(assethubApi),
+    90,
+    logger,
+    'Creating Assethub vault',
+  );
+  logger.info(`AssetHub vault created, address: ${hubVaultAddress}`);
+  return hubVaultAddress;
+}
 
 async function main(): Promise<void> {
   const cf = await newChainflipIO(loggerChild(globalLogger, 'setup_vaults'), []);
@@ -33,6 +131,8 @@ async function main(): Promise<void> {
   const arbClient = getWeb3('Arbitrum');
   const solClient = getSolConnection();
   const tronClient = getTronWebClient();
+
+  await using assethub = await getAssethubApi();
 
   cf.info(`LP endpoint set to: ${lpApiEndpoint}`);
   cf.info(`Broker endpoint set to: ${brokerApiEndpoint}`);
@@ -44,6 +144,7 @@ async function main(): Promise<void> {
     initializeArbitrumChain(cf.logger),
     initializeSolanaChain(cf.logger),
     initializeTronChain(cf.logger),
+    initializeAssethubChain(cf.logger),
   ]);
 
   // Step 2
@@ -67,6 +168,7 @@ async function main(): Promise<void> {
       `Initial setup_vaults forced rotation was ABORTED. Cannot continue with the test, please check the node logs for possible reasons.`,
     );
   }
+  const assetHubVaultCreateHandle = createAssetHubVault(cf.logger, assethub);
 
   // Step 3
   cf.info('Waiting for new keys');
@@ -87,15 +189,39 @@ async function main(): Promise<void> {
       name: 'TronVault.AwaitingGovernanceActivation',
       schema: tronVaultAwaitingGovernanceActivation,
     },
+    hub: {
+      name: 'AssethubVault.AwaitingGovernanceActivation',
+      schema: assethubVaultAwaitingGovernanceActivation,
+    },
   });
 
   const btcKey = keyEvents.btc.data.newPublicKey;
   const arbKey = keyEvents.arb.data.newPublicKey;
   const solKey = keyEvents.sol.data.newPublicKey;
   const tronKey = keyEvents.tron.data.newPublicKey;
+  const hubKey = keyEvents.hub.data.newPublicKey;
 
   // Step 4
-  cf.info('Setting up external chains (Arbitrum, Solana, Tron) with new keys');
+  cf.info('Setting up external chains (Arbitrum, Solana, Assethub, Tron) with new keys');
+
+  const createAssethubProxy = async () => {
+    // Wait for the assethub vault Promise to resolve
+    const hubVaultAddress = await assetHubVaultCreateHandle;
+
+    cf.info('Rotating Proxy and Funding Accounts on Assethub');
+    const hubProxyAdded = observeEvent(cf.logger, 'proxy:ProxyAdded', {
+      chain: 'assethub',
+      timeoutSeconds: 60,
+    }).event;
+    const [, hubVaultEvent] = await Promise.all([
+      rotateAndFund(assethub, hubVaultAddress, hubKey),
+      hubProxyAdded,
+    ]);
+
+    cf.debug(`Assethub Vault Proxy rotated and funded`);
+
+    return { hubVaultAddress, hubVaultEvent };
+  };
 
   const insertArbitrumKey = async () => {
     cf.info('Inserting Arbitrum key in the contracts');
@@ -115,7 +241,12 @@ async function main(): Promise<void> {
     cf.debug('Tron key inserted');
   };
 
-  await Promise.all([insertArbitrumKey(), insertSolanaKey(), insertTronKey()]);
+  const [{ hubVaultAddress, hubVaultEvent }] = await Promise.all([
+    createAssethubProxy(),
+    insertArbitrumKey(),
+    insertSolanaKey(),
+    insertTronKey(),
+  ]);
 
   // Step 7
   cf.info('Setting up price feeds');
@@ -125,6 +256,15 @@ async function main(): Promise<void> {
   cf.info('Registering Vaults with state chain');
 
   await cf.all([
+    (subcf) =>
+      subcf.submitGovernance({
+        extrinsic: (api) =>
+          api.tx.environment.witnessAssethubVaultCreation(hubVaultAddress, {
+            blockNumber: hubVaultEvent.block,
+            extrinsicIndex: hubVaultEvent.eventIndex,
+          }),
+        expectedEvent: { name: 'AssethubVault.VaultActivationCompleted' },
+      }),
     (subcf) =>
       subcf.submitGovernance({
         extrinsic: async (api) =>

--- a/bouncer/shared/initialize_new_chains.ts
+++ b/bouncer/shared/initialize_new_chains.ts
@@ -43,6 +43,13 @@ export async function initializeTronChain(logger: Logger) {
   await tronInitializationRequest;
 }
 
+export async function initializeAssethubChain(logger: Logger) {
+  logger.info('Initializing Assethub');
+  const hubInitializationRequest = observeEvent(logger, 'assethubVault:ChainInitialized').event;
+  await submitGovernanceExtrinsic((chainflip) => chainflip.tx.assethubVault.initializeChain());
+  await hubInitializationRequest;
+}
+
 export async function initializeArbitrumContracts(
   logger: Logger,
   arbClient: Web3,

--- a/bouncer/shared/setup_swaps.ts
+++ b/bouncer/shared/setup_swaps.ts
@@ -20,6 +20,9 @@ export const deposits = new Map<Asset, number>([
   ['SolUsdt', 100000],
   ['Trx', 1000000],
   ['TrxUsdt', 100000],
+  ['HubDot', 10000],
+  ['HubUsdc', 250000],
+  ['HubUsdt', 250000],
 ]);
 
 export const price = new Map<Asset, number>([
@@ -37,6 +40,9 @@ export const price = new Map<Asset, number>([
   ['SolUsdt', 1],
   ['Trx', 1],
   ['TrxUsdt', 1],
+  ['HubDot', 10],
+  ['HubUsdc', 1],
+  ['HubUsdt', 1],
 ]);
 
 export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
@@ -56,6 +62,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
     createLpPool(cf.logger, 'SolUsdt', price.get('SolUsdt')!),
     createLpPool(cf.logger, 'Trx', price.get('Trx')!),
     createLpPool(cf.logger, 'TrxUsdt', price.get('Trx')!),
+    createLpPool(cf.logger, 'HubDot', price.get('HubDot')!),
+    createLpPool(cf.logger, 'HubUsdc', price.get('HubUsdc')!),
+    createLpPool(cf.logger, 'HubUsdt', price.get('HubUsdt')!),
   ]);
 
   // Set permissive default oracle slippage (100%) for all pools to prevent swap failures in tests.
@@ -108,6 +117,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => depositLiquidity(subcf, 'SolUsdt', deposits.get('SolUsdt')!),
         (subcf) => depositLiquidity(subcf, 'Trx', deposits.get('Trx')!),
         (subcf) => depositLiquidity(subcf, 'TrxUsdt', deposits.get('TrxUsdt')!),
+        (subcf) => depositLiquidity(subcf, 'HubDot', deposits.get('HubDot')!),
+        (subcf) => depositLiquidity(subcf, 'HubUsdc', deposits.get('HubUsdc')!),
+        (subcf) => depositLiquidity(subcf, 'HubUsdt', deposits.get('HubUsdt')!),
       ]);
 
   const lpApiDeposits = (parentCf: ChainflipIO<A>) =>
@@ -128,6 +140,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => depositLiquidity(subcf, 'SolUsdt', 1000),
         (subcf) => depositLiquidity(subcf, 'Trx', 10000),
         (subcf) => depositLiquidity(subcf, 'TrxUsdt', 1000),
+        (subcf) => depositLiquidity(subcf, 'HubDot', 2000),
+        (subcf) => depositLiquidity(subcf, 'HubUsdc', 1000),
+        (subcf) => depositLiquidity(subcf, 'HubUsdt', 1000),
       ]);
 
   cf.info('Depositing liquidity');
@@ -150,6 +165,9 @@ export async function setupSwaps<A = []>(cf: ChainflipIO<A>): Promise<void> {
         (subcf) => rangeOrder(subcf, 'SolUsdt', deposits.get('SolUsdt')! * 0.9999),
         (subcf) => rangeOrder(subcf, 'Trx', deposits.get('Trx')! * 0.9999),
         (subcf) => rangeOrder(subcf, 'TrxUsdt', deposits.get('TrxUsdt')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubDot', deposits.get('HubDot')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubUsdc', deposits.get('HubUsdc')! * 0.9999),
+        (subcf) => rangeOrder(subcf, 'HubUsdt', deposits.get('HubUsdt')! * 0.9999),
       ]);
 
   cf.info('Setting up range orders');

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -11,6 +11,7 @@ import {
 } from 'shared/utils';
 import { TestContext } from 'shared/utils/test_context';
 import { manuallyAddTestToList, concurrentTest } from 'shared/utils/vitest';
+import { SwapContext } from 'shared/utils/swap_context';
 import { ChainflipIO, newChainflipIO } from 'shared/utils/chainflip_io';
 
 export async function initiateSwap(
@@ -73,8 +74,12 @@ export function testAllSwaps(timeoutPerSwap: number) {
     });
   }
 
-  // TODO: properly include BSC assets once it is fully integrated.
-  // If we include Assethub swaps (HubDot, HubUsdc, HubUsdt) in the all-to-all swaps,
+  function randomElement<Value>(items: Value[]): Value {
+    return items[Math.floor(Math.random() * items.length)];
+  }
+
+  // TODO: properly include TRON and BSC assets once they are fully integrated
+  // if we include Assethub swaps (HubDot, HubUsdc, HubUsdt) in the all-to-all swaps,
   // the test starts to randomly fail because the assethub node is overloaded.
   const AssetsWithoutAssethub = Object.values(Assets).filter(
     (id) => chainFromAsset(id) !== 'Assethub' && chainFromAsset(id) !== 'Bsc',
@@ -107,7 +112,25 @@ export function testAllSwaps(timeoutPerSwap: number) {
       });
   });
 
+  // Swaps from assethub paired with random chains.
+  // NOTE: we don't test swaps *to* assethub here, those tests are run sequentially in
+  // `testSwapsToAssethub`.
+  const assethubAssets = ['HubDot' as Asset, 'HubUsdc' as Asset, 'HubUsdt' as Asset];
+  assethubAssets.sort().forEach((hubAsset) => {
+    appendSwap(hubAsset, randomElement(AssetsWithoutAssethub), testSwap);
+  });
+
   for (const swap of allSwaps) {
     concurrentTest(`AllSwaps > ${swap.name}`, swap.test, timeoutPerSwap, 0, true);
+  }
+}
+
+export async function testSwapsToAssethub(testContext: TestContext) {
+  // we run three swaps to assethub in sequence. Otherwise, there can be nonce issues,
+  // which caused bouncer flakiness in the past.
+  for (const destinationAsset of ['HubDot', 'HubUsdc', 'HubUsdt'] as Asset[]) {
+    const logger = testContext.logger.child({ tag: `ArbEth to ${destinationAsset}` });
+    const cf = await newChainflipIO(logger, [] as []);
+    await testSwap(cf, 'ArbEth', destinationAsset, undefined, undefined, new SwapContext());
   }
 }

--- a/bouncer/tests/create_and_delete_multiple_orders.ts
+++ b/bouncer/tests/create_and_delete_multiple_orders.ts
@@ -43,6 +43,7 @@ export async function createAndDeleteMultipleOrders<A extends WithLpAccount>(
     // provide liquidity to lpUri
     (subcf) => depositLiquidity(subcf, 'Usdc', 10000),
     (subcf) => depositLiquidity(subcf, 'Eth', deposits.get('Eth')!),
+    (subcf) => depositLiquidity(subcf, 'HubDot', deposits.get('HubDot')!),
     (subcf) => depositLiquidity(subcf, 'Btc', deposits.get('Btc')!),
     (subcf) => depositLiquidity(subcf, 'Flip', deposits.get('Flip')!),
     (subcf) => depositLiquidity(subcf, 'Usdt', deposits.get('Usdt')!),

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -3,7 +3,7 @@ import { testBoostingSwap } from 'tests/boost';
 import { testVaultSwap } from 'tests/vault_swap_tests';
 import { checkSolEventAccountsClosure } from 'shared/vault_swap/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from 'shared/utils';
-import { testAllSwaps } from 'tests/all_swaps';
+import { testAllSwaps, testSwapsToAssethub } from 'tests/all_swaps';
 import { testEvmDeposits } from 'tests/evm_deposits';
 import { testMultipleMembersGovernance } from 'tests/multiple_members_governance';
 import { testLpApi } from 'tests/lp_api_test';
@@ -38,6 +38,7 @@ describe('ConcurrentTests', () => {
   // test to reduce contention, for example, the BrokerLevelScreeningTest is delayed to not end up
   // in situations where the deposit monitor is slow in flagging transactions.
   testAllSwaps(singleSwapTimeout * ciTimeoutFactor);
+  concurrentTest('SwapsToAssethub', testSwapsToAssethub, 330 * ciTimeoutFactor);
   concurrentTest('EvmDeposits', testEvmDeposits, 280 * ciTimeoutFactor);
   concurrentTest('FundRedeem', testFundRedeem, 350 * ciTimeoutFactor);
   concurrentTest('LpApi', testLpApi, 280 * ciTimeoutFactor);
@@ -67,6 +68,10 @@ describe('ConcurrentTests', () => {
     265 * ciTimeoutFactor,
   );
   concurrentTest('RpcCalls', testRpcCalls, 160 * ciTimeoutFactor);
+
+  // Test this separately because it has a swap to HubDot which causes flakiness when run in
+  // parallel with the Assethub tests in `SwapsToAssethub`.
+  // serialTest('SwapLessThanED', swapLessThanED, 350 * ciTimeoutFactor);
 
   // Test this separately since some other tests rely on single member governance.
   serialTest('MultipleMembersGovernance', testMultipleMembersGovernance, 60 * ciTimeoutFactor);

--- a/bouncer/tests/fill_or_kill.ts
+++ b/bouncer/tests/fill_or_kill.ts
@@ -230,6 +230,7 @@ export async function testFillOrKill(testContext: TestContext) {
   await cf.all([
     (subcf) => testMinPriceRefund(subcf, Assets.Flip, 500),
     (subcf) => testMinPriceRefund(subcf, Assets.Eth, 1),
+    // subcf => testMinPriceRefund(subcf, Assets.HubDot, 100), // flaky, so we don't test HubDot
     (subcf) => testMinPriceRefund(subcf, Assets.Btc, 0.1),
     (subcf) => testMinPriceRefund(subcf, Assets.Usdc, 1000),
     (subcf) => testMinPriceRefund(subcf, Assets.Sol, 10),

--- a/bouncer/tests/full_bouncer.test.ts
+++ b/bouncer/tests/full_bouncer.test.ts
@@ -4,6 +4,7 @@ import { testRotatesThroughBtcSwap } from 'tests/rotates_through_btc_swap';
 import { testRotationBarrier } from 'tests/rotation_barrier';
 import { testSolanaVaultSettingsGovernance } from 'tests/solana_vault_settings_governance';
 import { serialTest } from 'shared/utils/vitest';
+import { testMinimumDeposit } from 'tests/minimum_deposit';
 import { testSwapAfterDisconnection } from 'tests/swap_after_temp_disconnecting_chains';
 
 // Tests that are run by the ci-main-merge after the concurrent tests
@@ -11,6 +12,7 @@ describe('SerialTests2', () => {
   serialTest('RotatesThroughBtcSwap', testRotatesThroughBtcSwap, 360);
   serialTest('BtcUtxoConsolidation', testBtcUtxoConsolidation, 200);
   serialTest('RotationBarrier', testRotationBarrier, 320);
+  serialTest('MinimumDeposit', testMinimumDeposit, 150);
   serialTest('SolanaVaultSettingsGovernance', testSolanaVaultSettingsGovernance, 120);
 
   if (process.env.LOCALNET) {

--- a/bouncer/tests/minimum_deposit.ts
+++ b/bouncer/tests/minimum_deposit.ts
@@ -1,0 +1,27 @@
+import { requestNewSwap } from 'shared/perform_swap';
+import { setMinimumDeposit } from 'shared/set_minimum_deposit';
+import { observeEvent } from 'shared/utils/substrate';
+import { TestContext } from 'shared/utils/test_context';
+import { sendHubAsset } from 'shared/send_hubasset';
+import { newChainflipIO } from 'shared/utils/chainflip_io';
+
+export async function testMinimumDeposit(testContext: TestContext) {
+  const cf = await newChainflipIO(testContext.logger, []);
+  await setMinimumDeposit(cf.logger, 'HubDot', BigInt(200000000000));
+  cf.debug('Set minimum deposit to 20 DOT');
+  const depositAddress = (
+    await requestNewSwap(cf, 'HubDot', 'Eth', '0xd92bd8c144b8edba742b07909c04f8b93d875d93')
+  ).depositAddress;
+  const depositFailed = observeEvent(cf.logger, ':DepositFailed');
+  await sendHubAsset(testContext.logger, 'HubDot', depositAddress, '19');
+  cf.debug('Sent 19 DOT');
+  await depositFailed.event;
+  cf.debug('Deposit was ignored');
+  const depositSuccess = observeEvent(cf.logger, ':DepositFinalised');
+  await sendHubAsset(testContext.logger, 'HubDot', depositAddress, '21');
+  cf.debug('Sent 21 DOT');
+  await depositSuccess.event;
+  cf.debug('Deposit was successful');
+  await setMinimumDeposit(cf.logger, 'HubDot', BigInt(0));
+  cf.debug('Reset minimum deposit to 0 DOT');
+}

--- a/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
+++ b/bouncer/tests/request_swap_deposit_address_with_affiliates.ts
@@ -266,6 +266,7 @@ export async function depositChannelCreation(testContext: TestContext) {
     Arbitrum: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
     Solana: ['3yKDHJgzS2GbZB9qruoadRYtq8597HZifnRju7fHpdRC'],
     Tron: ['0xa56A6be23b6Cf39D9448FF6e897C29c41c8fbDFF'],
+    Assethub: ['1yMmfLti1k3huRQM2c47WugwonQMqTvQ2GUFxnU7Pcs7xPo'],
   } as const;
 
   const entries = Object.entries as <T>(o: T) => [keyof T, T[keyof T]][];

--- a/bouncer/tests/swap_after_temp_disconnecting_chains.ts
+++ b/bouncer/tests/swap_after_temp_disconnecting_chains.ts
@@ -8,7 +8,11 @@ import { newChainflipIO } from 'shared/utils/chainflip_io';
 export async function testSwapAfterDisconnection(testContext: TestContext) {
   const cf = await newChainflipIO(testContext.logger, []);
   const networkName = 'chainflip-localnet_default';
-  const allExternalNodes = ['bitcoin', 'geth'];
+  // We use assethub here to test that it applies to assethub, and Polkadot by proxy.
+  // We don't test Polkadot directly, since shutting down the Polkadot node in this way causes sync issues between
+  // Polkadot and AssetHub which can take some time to resolve. Given AssetHub shares most of the same code as Polkadot,
+  // this is a good proxy.
+  const allExternalNodes = ['bitcoin', 'geth', 'assethub'];
 
   await Promise.all(
     allExternalNodes.map((container) =>
@@ -27,5 +31,6 @@ export async function testSwapAfterDisconnection(testContext: TestContext) {
   await cf.all([
     (subcf) => testSwap(subcf, 'Btc', 'Flip', undefined, undefined, testContext.swapContext),
     (subcf) => testSwap(subcf, 'Eth', 'Usdc', undefined, undefined, testContext.swapContext),
+    (subcf) => testSwap(subcf, 'HubDot', 'Btc', undefined, undefined, testContext.swapContext),
   ]);
 }


### PR DESCRIPTION
# Pull Request

closes: PRO-2891

## Summary

This PR re-instantiates the Assethub bouncer tests.

There's one test that's commented out (`SwapLessThanED`) because it was flaky before so we probably don't want to re-enable that one.

**NOTE**: this PR targets the `fix/assethub-balances-witnessing` branch which fixes how we witness vested transfers.

## API Changes

None.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
