### PR TITLE
chore: reduce CI discord spam

### DIFF
--- a/.github/workflows/_03_release_checks.yml
+++ b/.github/workflows/_03_release_checks.yml
@@ -100,19 +100,3 @@ jobs:
           echo "Tagged commit (${COMMIT}) is not reachable from release/${MAJOR_MINOR} or release/${TAG}."
           echo "Tags must be created from commits on the corresponding release/X.Y or release/X.Y.Z branch."
           exit 1
-
-  notify-discord-on-failure:
-    runs-on: namespace-profile-default-light
-    needs: [check-version, check-changelog, check-tag-on-legit-branch]
-    if: failure()
-    steps:
-      - name: Notify on failed bouncer 📢
-        env:
-          DISCORD_USERNAME: "WaBouncer"
-          DISCORD_WEBHOOK: ${{ secrets.CF_DISCORD_ALERTS_RELEASE }}
-        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
-        with:
-          args: |
-            ❗️❗️❗️❗️ Hey **${{ github.actor }}**, seems like our CI just took a detour through the land of broken builds. ❗️❗️❗️❗️
-            There was an issue with release checks on `${{ github.ref_name }}`
-            🔗 Link to job: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -298,18 +298,6 @@ jobs:
         run: |
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
 
-      - name: Notify on failed bouncer 📢
-        if: failure() && github.ref_name == 'main' || cancelled() && github.ref_name == 'main' || failure() && contains(github.ref_name, 'release/') || cancelled() && contains(github.ref_name, 'release/')
-        env:
-          DISCORD_USERNAME: "HEUTE LEIDER NICHT"
-          DISCORD_WEBHOOK: ${{ secrets.CF_DISCORD_ALERTS_CRITICAL }}
-        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
-        with:
-          args: |
-            ❗️❗️❗️❗️ Sorry **${{ github.actor }}**, the Bouncer has rejected you ❗️❗️❗️❗️
-            The Bouncer has rejected the build on branch `${{ github.ref_name }}`
-            👾 Link to job: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
-
   chainspec-compatibility:
     runs-on: namespace-profile-default
     strategy:

--- a/.github/workflows/ci-cherry-pick.yml
+++ b/.github/workflows/ci-cherry-pick.yml
@@ -51,19 +51,8 @@ jobs:
             Please review and merge if appropriate.
             Original PR: ${{ github.event.pull_request.html_url }}
           branch: pick/non-breaking
-          base: '${{ env.RELEASE_BRANCH }}'
-          reviewers: 'dandanlen'
+          base: "${{ env.RELEASE_BRANCH }}"
+          reviewers: "dandanlen"
           labels: cherry-pick
           branch-suffix: timestamp
           delete-branch: true
-
-      - name: Notify on failed cherry-pick
-        if: failure() || cancelled()
-        env:
-          DISCORD_USERNAME: "Release Picker"
-          DISCORD_WEBHOOK: ${{ secrets.CF_DISCORD_ALERTS_CRITICAL }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: |
-            🍒⚠️ Sorry **${{ github.actor }}**, The attempt to cherry-pick `${{ env.COMMIT_SHA }}` on to `${{ env.RELEASE_BRANCH }}` was unsuccessful
-            Please check the [GitHub job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to see what went wrong.

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -402,14 +402,3 @@ jobs:
           ls -alR /tmp/chainflip
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" logs
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
-
-      - name: Notify on failed upgrade test 🚨
-        if: failure() && github.ref_name == 'main' || cancelled() && github.ref_name == 'main'
-        env:
-          DISCORD_USERNAME: "Upgrade Test"
-          DISCORD_WEBHOOK: ${{ secrets.CF_DISCORD_ALERTS_CRITICAL }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: |
-            ❗️❗️❗️❗️ Sorry **${{ github.actor }}**, The Upgrade Test has not passed ❗️❗️❗️❗️
-            👾 Link to job: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>


### PR DESCRIPTION
# Pull Request

This removes the CI notifications via discord. We already get notified inside Github, adding discord notifications has little value, is spammy, and a potential vector for unwanted access. 