### PR TITLE
feat: Remove unused broker_fee fields

### DIFF
--- a/bouncer/generated/events/lendingPools/liquidationFeeTaken.ts
+++ b/bouncer/generated/events/lendingPools/liquidationFeeTaken.ts
@@ -5,5 +5,4 @@ export const lendingPoolsLiquidationFeeTaken = z.object({
   loanId: numberOrHex,
   poolFee: numberOrHex,
   networkFee: numberOrHex,
-  brokerFee: numberOrHex,
 });

--- a/bouncer/generated/events/lendingPools/originationFeeTaken.ts
+++ b/bouncer/generated/events/lendingPools/originationFeeTaken.ts
@@ -5,5 +5,4 @@ export const lendingPoolsOriginationFeeTaken = z.object({
   loanId: numberOrHex,
   poolFee: numberOrHex,
   networkFee: numberOrHex,
-  brokerFee: numberOrHex,
 });

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1442,8 +1442,6 @@ pub fn fund_loan<T: Config>(
 		loan_id: loan.id,
 		pool_fee: origination_fee_pool,
 		network_fee: origination_fee_network,
-		// TODO: add support for broker fees (see https://linear.app/chainflip/issue/PRO-2851/decide-whether-to-support-broker-fees-from-origination-and-liquidation)
-		broker_fee: 0,
 	});
 
 	Ok(())

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -1053,8 +1053,6 @@ impl<T: Config> GeneralLoan<T> {
 					loan_id: self.id,
 					pool_fee: liquidation_fee_pool,
 					network_fee: liquidation_fee_network,
-					// TODO: add support for broker fees (see https://linear.app/chainflip/issue/PRO-2851/decide-whether-to-support-broker-fees-from-origination-and-liquidation)
-					broker_fee: 0,
 				});
 			}
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -1012,7 +1012,6 @@ fn basic_loan_aggregation() {
 					loan_id: LOAN_ID,
 					pool_fee,
 					network_fee,
-					broker_fee: 0,
 				}) if pool_fee == origination_fee_pool_2 && network_fee == origination_fee_network_2
 			);
 
@@ -1097,7 +1096,6 @@ fn basic_loan_aggregation() {
 					loan_id: LOAN_ID,
 					pool_fee: pool_fee_taken,
 					network_fee: network_fee_taken,
-					broker_fee: 0,
 				}) if pool_fee_taken == pool_fee && network_fee_taken == network_fee
 			);
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -430,7 +430,6 @@ fn basic_general_lending() {
 					loan_id: LOAN_ID,
 					pool_fee: origination_fee_pool,
 					network_fee: origination_fee_network,
-					broker_fee: 0,
 				},
 			));
 
@@ -1422,10 +1421,8 @@ fn basic_liquidation() {
 					loan_id: LOAN_ID,
 					pool_fee,
 					network_fee,
-					broker_fee
 				}) if pool_fee == liquidation_fee_pool_1 &&
-					network_fee == liquidation_fee_network_1 &&
-					broker_fee == 0,
+					network_fee == liquidation_fee_network_1,
 				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
 					loan_id: LOAN_ID,
 					amount,
@@ -1515,10 +1512,8 @@ fn basic_liquidation() {
 					loan_id: LOAN_ID,
 					pool_fee,
 					network_fee,
-					broker_fee
 				}) if pool_fee == liquidation_fee_pool_2 &&
-					network_fee == liquidation_fee_network_2 &&
-					broker_fee == 0,
+					network_fee == liquidation_fee_network_2,
 				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
 					loan_id: LOAN_ID,
 					action_type: LoanRepaidActionType::Liquidation {
@@ -1899,8 +1894,7 @@ fn liquidation_with_outstanding_principal() {
 					loan_id: LOAN_ID,
 					pool_fee,
 					network_fee,
-					broker_fee
-				}) if pool_fee == liquidation_fee_pool && network_fee == liquidation_fee_network && broker_fee == 0,
+				}) if pool_fee == liquidation_fee_pool && network_fee == liquidation_fee_network,
 				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
 					loan_id: LOAN_ID,
 					amount,

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -478,7 +478,6 @@ pub mod pallet {
 			loan_id: LoanId,
 			pool_fee: AssetAmount,
 			network_fee: AssetAmount,
-			broker_fee: AssetAmount,
 		},
 		InterestTaken {
 			loan_id: LoanId,

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -501,7 +501,6 @@ pub mod pallet {
 			loan_id: LoanId,
 			pool_fee: AssetAmount,
 			network_fee: AssetAmount,
-			broker_fee: AssetAmount,
 		},
 		LoanRepaid {
 			loan_id: LoanId,

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -537,7 +537,6 @@ fn basic_boosting() {
 				loan_id: LOAN_ID,
 				pool_fee: POOL_FEE,
 				network_fee: NETWORK_FEE,
-				broker_fee: 0,
 			}),
 		);
 
@@ -673,7 +672,6 @@ fn boosted_deposit_is_lost() {
 				loan_id: LOAN_ID,
 				pool_fee: POOL_FEE,
 				network_fee: NETWORK_FEE,
-				broker_fee: 0,
 			}),
 		);
 
@@ -1259,7 +1257,6 @@ mod hybrid_boosting {
 					loan_id: LOAN_ID,
 					pool_fee: LENDING_POOL_FEE,
 					network_fee: LENDING_NETWORK_FEE,
-					broker_fee: 0,
 				}),
 			);
 
@@ -1378,7 +1375,6 @@ mod hybrid_boosting {
 					loan_id: LOAN_ID,
 					pool_fee: LENDING_POOL_FEE,
 					network_fee: LENDING_NETWORK_FEE,
-					broker_fee: 0,
 				}),
 			);
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-2851

## Summary

Removed `broker_fee` field where it was not taken (origination and liquidation fees). Intended for 2.3. FYI @GabrielBuragev 

## API Changes

### Extrinsics & Events

- removed `broker_fee` field from `OriginationFeeTaken` and `LiquidationFeeTaken`

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.