### PR TITLE
chore: skip RUSTSEC-2026-0173

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -81,6 +81,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0114: wasmtime panic during memory allocation. Dependency of substrate.
 # - RUSTSEC-2026-0118: DoS vector in hickory-proto which is used by libp2p. Dependency of substrate, related to DNS resolution. Low risk.
 # - RUSTSEC-2026-0119: DoS vector in hickory-proto which is used by libp2p. Dependency of substrate, related to DNS resolution. Low risk.
+# - RUSTSEC-2026-0173: proc-macro-error2 unmaintained. Build-time proc-macro helper, transitive dependency of `subxt-macro`. Not a runtime security concern.
 
 #
 cf-audit = '''
@@ -129,6 +130,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0114
 	--ignore RUSTSEC-2026-0118
 	--ignore RUSTSEC-2026-0119
+	--ignore RUSTSEC-2026-0173
 '''
 
 [build]


### PR DESCRIPTION
# Pull Request

## Summary

This unblocks `cargo cf-audit` by allowing unmaintained `proc-macro-error2`. It is a transitive dependency, and is only used at build time.