### PR TITLE
fix: implement on_idle hook for pruning expired vault start block numbers

### DIFF
--- a/state-chain/pallets/cf-vaults/src/lib.rs
+++ b/state-chain/pallets/cf-vaults/src/lib.rs
@@ -23,7 +23,7 @@ use cf_primitives::EpochIndex;
 use cf_runtime_utilities::EnumVariant;
 use cf_traits::{
 	AsyncResult, Broadcaster, CfeMultisigRequest, ChainflipWithTargetChain, CurrentEpochIndex,
-	EpochTransitionHandler, GetBlockHeight, SafeMode, SetSafeMode, VaultKeyWitnessedHandler,
+	EpochInfo, GetBlockHeight, SafeMode, SetSafeMode, VaultKeyWitnessedHandler,
 };
 use cf_utilities::derive_common_traits_no_bounds;
 use frame_support::{pallet_prelude::*, traits::StorageVersion};
@@ -117,7 +117,11 @@ pub mod pallet {
 
 	/// Pallet implements [`Hooks`] trait
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+		fn on_idle(_n: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
+			Self::prune_expired_vault_start_block_numbers(remaining_weight)
+		}
+	}
 
 	/// A map of starting block number of vaults by epoch.
 	#[pallet::storage]
@@ -243,7 +247,43 @@ derive_common_traits_no_bounds! {
 	}
 }
 
+/// The maximum number of expired [`VaultStartBlockNumbers`] entries to prune in a single
+/// block. This bounds the one-off cost of draining a large backlog (e.g. for a chain that
+/// was previously not being pruned).
+const MAX_EXPIRED_VAULTS_PRUNED_PER_BLOCK: u64 = 10;
+
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Remove [`VaultStartBlockNumbers`] entries for epochs that have already expired.
+	///
+	/// Runs from the pallet's own `on_idle` hook.
+	fn prune_expired_vault_start_block_numbers(remaining_weight: Weight) -> Weight {
+		let db = T::DbWeight::get();
+		// Approximate worst case is ~1 read/write per entry.
+		if remaining_weight.any_lt(
+			db.reads_writes(
+				MAX_EXPIRED_VAULTS_PRUNED_PER_BLOCK,
+				MAX_EXPIRED_VAULTS_PRUNED_PER_BLOCK,
+			),
+		) {
+			return Weight::zero();
+		}
+		let mut reads = 0;
+		let mut writes = 0;
+		let last_expired_epoch = T::EpochInfo::last_expired_epoch();
+		let expired = VaultStartBlockNumbers::<T, I>::iter_keys()
+			.inspect(|_| {
+				reads += 1;
+			})
+			.filter(|epoch| *epoch <= last_expired_epoch)
+			.take(MAX_EXPIRED_VAULTS_PRUNED_PER_BLOCK as usize)
+			.collect::<Vec<EpochIndex>>();
+		for epoch in &expired {
+			VaultStartBlockNumbers::<T, I>::remove(epoch);
+			writes += 1;
+		}
+		db.reads_writes(reads, writes)
+	}
+
 	fn activate_new_key_for_chain(block_number: ChainBlockNumberFor<T, I>) {
 		PendingVaultActivation::<T, I>::put(VaultActivationStatus::<T, I>::Complete);
 		VaultStartBlockNumbers::<T, I>::insert(
@@ -284,17 +324,6 @@ impl<T: Config<I>, I: 'static> VaultKeyWitnessedHandler<T::TargetChain> for Pall
 		PendingVaultActivation::<T, I>::put(VaultActivationStatus::<T, I>::AwaitingActivation {
 			new_public_key: cf_chains::benchmarking_value::BenchmarkValue::benchmark_value(),
 		});
-	}
-}
-
-impl<T: Config<I>, I: 'static> EpochTransitionHandler for Pallet<T, I> {
-	fn on_expired_epoch(expired_epoch: EpochIndex) {
-		for epoch in VaultStartBlockNumbers::<T, I>::iter_keys()
-			.filter(|epoch| *epoch <= expired_epoch)
-			.collect::<Vec<EpochIndex>>()
-		{
-			VaultStartBlockNumbers::<T, I>::remove(epoch);
-		}
 	}
 }
 

--- a/state-chain/pallets/cf-vaults/src/mock.rs
+++ b/state-chain/pallets/cf-vaults/src/mock.rs
@@ -31,7 +31,9 @@ use cf_traits::{
 		cfe_interface_mock::MockCfeInterface,
 	},
 };
-use frame_support::{construct_runtime, derive_impl, parameter_types};
+use frame_support::{
+	construct_runtime, derive_impl, parameter_types, weights::constants::RocksDbWeight,
+};
 
 thread_local! {
 	pub static SET_AGG_KEY_WITH_AGG_KEY_REQUIRED: RefCell<bool> = const { RefCell::new(true) };
@@ -49,6 +51,8 @@ construct_runtime!(
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
 	type Block = Block;
+	// A non-zero DbWeight so that weight-gated logic (e.g. `on_idle` cleanup) is exercised.
+	type DbWeight = RocksDbWeight;
 }
 
 impl_mock_chainflip!(Test);

--- a/state-chain/pallets/cf-vaults/src/tests.rs
+++ b/state-chain/pallets/cf-vaults/src/tests.rs
@@ -22,11 +22,10 @@ use crate::{
 use cf_chains::mocks::{MockAggKey, MockEthereum};
 use cf_test_utilities::last_event;
 use cf_traits::{
-	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo,
-	EpochTransitionHandler, VaultActivator,
+	mocks::block_height_provider::BlockHeightProvider, AsyncResult, EpochInfo, VaultActivator,
 };
 use cf_utilities::assert_matches;
-use frame_support::assert_noop;
+use frame_support::{assert_noop, traits::OnIdle, weights::Weight};
 use std::collections::BTreeSet;
 
 pub const NEW_AGG_PUBKEY: MockAggKey = MockAggKey(*b"newk");
@@ -118,7 +117,7 @@ fn only_governance_can_initialize_chain() {
 }
 
 #[test]
-fn cleanup_start_block_numbers_up_to_expired_epoch() {
+fn prunes_start_block_numbers_up_to_expired_epoch_on_idle() {
 	new_test_ext_no_key().execute_with(|| {
 		let init_epoch = MockEpochInfo::epoch_index();
 		VaultStartBlockNumbers::<Test, _>::insert(init_epoch, 0);
@@ -131,7 +130,18 @@ fn cleanup_start_block_numbers_up_to_expired_epoch() {
 			BTreeSet::from([0, 1001, 2001, 3001])
 		);
 
-		VaultsPallet::on_expired_epoch(init_epoch.saturating_add(2));
+		// Epochs up to and including `init_epoch + 2` have expired.
+		MockEpochInfo::set_last_expired_epoch(init_epoch.saturating_add(2));
+
+		// Cleanup is non-essential: with no spare block weight it is skipped entirely.
+		VaultsPallet::on_idle(System::block_number(), Weight::zero());
+		assert_eq!(
+			VaultStartBlockNumbers::<Test, _>::iter_values().collect::<BTreeSet<_>>(),
+			BTreeSet::from([0, 1001, 2001, 3001])
+		);
+
+		// Given spare weight, the pallet prunes the expired entries.
+		VaultsPallet::on_idle(System::block_number(), Weight::MAX);
 		assert_eq!(
 			VaultStartBlockNumbers::<Test, _>::iter_values().collect::<BTreeSet<_>>(),
 			BTreeSet::from([3001])

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -14,22 +14,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::AssetBalances;
+use crate::{AssetBalances, Witnesser};
 use cf_primitives::EpochIndex;
 use cf_traits::EpochTransitionHandler;
-
-use crate::{ArbitrumVault, BitcoinVault, EthereumVault, PolkadotVault, SolanaVault, Witnesser};
 
 pub struct ChainflipEpochTransitions;
 
 impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_expired_epoch(expired: EpochIndex) {
 		<Witnesser as EpochTransitionHandler>::on_expired_epoch(expired);
-		<EthereumVault as EpochTransitionHandler>::on_expired_epoch(expired);
-		<PolkadotVault as EpochTransitionHandler>::on_expired_epoch(expired);
-		<BitcoinVault as EpochTransitionHandler>::on_expired_epoch(expired);
-		<ArbitrumVault as EpochTransitionHandler>::on_expired_epoch(expired);
-		<SolanaVault as EpochTransitionHandler>::on_expired_epoch(expired);
 	}
 	fn on_new_epoch(_new: EpochIndex) {
 		AssetBalances::trigger_reconciliation();


### PR DESCRIPTION
# Pull Request

This moves the responsiblity for pruning VaultStartBlockNumbers into the vault pallet. 

Previously i was in a hook, we forgot to update the hook for Tron and Assethub, leading to some zombie state. 

Now we can't forget it any more. 