### PR TITLE
feat: don't refund rejection below dust egress limit

### DIFF
--- a/bouncer/generated/events/arbitrumIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/arbitrumIngressEgress/transactionRejectionFailed.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
-import { cfChainsEvmDepositDetails } from '../common';
+import {
+  cfChainsEvmDepositDetails,
+  palletCfArbitrumIngressEgressRefundFailureReason,
+} from '../common';
 
 export const arbitrumIngressEgressTransactionRejectionFailed = z.object({
   txId: cfChainsEvmDepositDetails,
+  reason: palletCfArbitrumIngressEgressRefundFailureReason,
 });

--- a/bouncer/generated/events/assethubIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/assethubIngressEgress/transactionRejectionFailed.ts
@@ -1,3 +1,7 @@
 import { z } from 'zod';
+import { palletCfAssethubIngressEgressRefundFailureReason } from '../common';
 
-export const assethubIngressEgressTransactionRejectionFailed = z.object({ txId: z.number() });
+export const assethubIngressEgressTransactionRejectionFailed = z.object({
+  txId: z.number(),
+  reason: palletCfAssethubIngressEgressRefundFailureReason,
+});

--- a/bouncer/generated/events/bitcoinIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/bitcoinIngressEgress/transactionRejectionFailed.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod';
-import { cfChainsBtcUtxo } from '../common';
+import { cfChainsBtcUtxo, palletCfBitcoinIngressEgressRefundFailureReason } from '../common';
 
-export const bitcoinIngressEgressTransactionRejectionFailed = z.object({ txId: cfChainsBtcUtxo });
+export const bitcoinIngressEgressTransactionRejectionFailed = z.object({
+  txId: cfChainsBtcUtxo,
+  reason: palletCfBitcoinIngressEgressRefundFailureReason,
+});

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -1047,6 +1047,24 @@ export const cfChainsAllBatchError = z.discriminatedUnion('__kind', [
 
 export const cfTraitsLendingBoostSource = simpleEnum(['LendingPool', 'BoostPool']);
 
+export const cfChainsRejectError = simpleEnum([
+  'NotSupportedForAsset',
+  'NotRequired',
+  'Other',
+  'FailedToBuildRejection',
+]);
+
+export const palletCfEthereumIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
+
 export const palletCfEthereumIngressEgressPalletConfigUpdateEthereum = z.discriminatedUnion(
   '__kind',
   [
@@ -1164,6 +1182,17 @@ export const cfTraitsScheduledEgressDetailsPolkadot = z.object({
   feeWithheld: numberOrHex,
 });
 
+export const palletCfPolkadotIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
+
 export const palletCfPolkadotIngressEgressPalletConfigUpdatePolkadot = z.discriminatedUnion(
   '__kind',
   [
@@ -1280,6 +1309,17 @@ export const cfTraitsScheduledEgressDetailsBitcoin = z.object({
   egressAmount: numberOrHex,
   feeWithheld: numberOrHex,
 });
+
+export const palletCfBitcoinIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
 
 export const palletCfBitcoinIngressEgressPalletConfigUpdateBitcoin = z.discriminatedUnion(
   '__kind',
@@ -1449,6 +1489,17 @@ export const cfTraitsScheduledEgressDetailsArbitrum = z.object({
   feeWithheld: numberOrHex,
 });
 
+export const palletCfArbitrumIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
+
 export const palletCfArbitrumIngressEgressPalletConfigUpdateArbitrum = z.discriminatedUnion(
   '__kind',
   [
@@ -1614,6 +1665,17 @@ export const cfTraitsScheduledEgressDetailsSolana = z.object({
   feeWithheld: numberOrHex,
 });
 
+export const palletCfSolanaIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
+
 export const palletCfSolanaIngressEgressPalletConfigUpdateSolana = z.discriminatedUnion('__kind', [
   z.object({ __kind: z.literal('ChannelOpeningFeeSolana'), fee: numberOrHex }),
   z.object({
@@ -1755,6 +1817,17 @@ export const cfTraitsScheduledEgressDetailsAssethub = z.object({
   egressAmount: numberOrHex,
   feeWithheld: numberOrHex,
 });
+
+export const palletCfAssethubIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
 
 export const palletCfAssethubIngressEgressPalletConfigUpdateAssethub = z.discriminatedUnion(
   '__kind',
@@ -2113,6 +2186,17 @@ export const cfTraitsScheduledEgressDetailsTron = z.object({
   egressAmount: numberOrHex,
   feeWithheld: numberOrHex,
 });
+
+export const palletCfTronIngressEgressRefundFailureReason = z.discriminatedUnion('__kind', [
+  z.object({ __kind: z.literal('BelowDustLimit') }),
+  z.object({ __kind: z.literal('InvalidRefundAddress') }),
+  z.object({ __kind: z.literal('FailedToBuildRejectCall'), value: cfChainsRejectError }),
+  z.object({
+    __kind: z.literal('FailedToBuildExecutexSwapAndCall'),
+    value: cfChainsExecutexSwapAndCallError,
+  }),
+  z.object({ __kind: z.literal('SolanaCcmWithAltsNotSupported') }),
+]);
 
 export const palletCfTronIngressEgressPalletConfigUpdateTron = z.discriminatedUnion('__kind', [
   z.object({ __kind: z.literal('ChannelOpeningFeeTron'), fee: numberOrHex }),

--- a/bouncer/generated/events/ethereumIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/ethereumIngressEgress/transactionRejectionFailed.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
-import { cfChainsEvmDepositDetails } from '../common';
+import {
+  cfChainsEvmDepositDetails,
+  palletCfEthereumIngressEgressRefundFailureReason,
+} from '../common';
 
 export const ethereumIngressEgressTransactionRejectionFailed = z.object({
   txId: cfChainsEvmDepositDetails,
+  reason: palletCfEthereumIngressEgressRefundFailureReason,
 });

--- a/bouncer/generated/events/polkadotIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/polkadotIngressEgress/transactionRejectionFailed.ts
@@ -1,3 +1,7 @@
 import { z } from 'zod';
+import { palletCfPolkadotIngressEgressRefundFailureReason } from '../common';
 
-export const polkadotIngressEgressTransactionRejectionFailed = z.object({ txId: z.number() });
+export const polkadotIngressEgressTransactionRejectionFailed = z.object({
+  txId: z.number(),
+  reason: palletCfPolkadotIngressEgressRefundFailureReason,
+});

--- a/bouncer/generated/events/solanaIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/solanaIngressEgress/transactionRejectionFailed.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
-import { cfChainsSolVaultSwapOrDepositChannelId } from '../common';
+import {
+  cfChainsSolVaultSwapOrDepositChannelId,
+  palletCfSolanaIngressEgressRefundFailureReason,
+} from '../common';
 
 export const solanaIngressEgressTransactionRejectionFailed = z.object({
   txId: cfChainsSolVaultSwapOrDepositChannelId,
+  reason: palletCfSolanaIngressEgressRefundFailureReason,
 });

--- a/bouncer/generated/events/tronIngressEgress/transactionRejectionFailed.ts
+++ b/bouncer/generated/events/tronIngressEgress/transactionRejectionFailed.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
-import { cfChainsEvmDepositDetails } from '../common';
+import { cfChainsEvmDepositDetails, palletCfTronIngressEgressRefundFailureReason } from '../common';
 
 export const tronIngressEgressTransactionRejectionFailed = z.object({
   txId: cfChainsEvmDepositDetails,
+  reason: palletCfTronIngressEgressRefundFailureReason,
 });

--- a/state-chain/chains/src/lib.rs
+++ b/state-chain/chains/src/lib.rs
@@ -913,7 +913,7 @@ pub enum ConsolidationError {
 	Other,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Encode, Decode, TypeInfo, DecodeWithMemTracking)]
 pub enum RejectError {
 	NotSupportedForAsset,
 	NotRequired,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -226,15 +226,15 @@ enum FullWitnessDepositOutcome {
 
 enum RejectionRefundDidntSucceed {
 	RetryLater,
-	RecordFailureAndAbortRefund(RejectionRefundReason),
+	RecordFailureAndAbortRefund(RefundFailureReason),
 }
 #[derive(Clone, Debug, PartialEq, Encode, Decode, TypeInfo, DecodeWithMemTracking)]
-pub enum RejectionRefundReason {
+pub enum RefundFailureReason {
 	BelowDustLimit,
 	InvalidRefundAddress,
 	FailedToBuildRejectCall(RejectError),
 	FailedToBuildExecutexSwapAndCall(ExecutexSwapAndCallError),
-	SolanaCCMWithALTsNotSupported,
+	SolanaCcmWithAltsNotSupported,
 }
 
 mod deposit_origin {
@@ -1181,7 +1181,7 @@ pub mod pallet {
 		},
 		TransactionRejectionFailed {
 			tx_id: <T::TargetChain as Chain>::DepositDetails,
-			reason: RejectionRefundReason,
+			reason: RefundFailureReason,
 		},
 		UnknownBroker {
 			broker_id: T::AccountId,
@@ -1454,7 +1454,7 @@ pub mod pallet {
 						Ok(refund_address)
 					} else {
 						Err(RejectionRefundDidntSucceed::RecordFailureAndAbortRefund(
-							RejectionRefundReason::InvalidRefundAddress,
+							RefundFailureReason::InvalidRefundAddress,
 						))
 					}
 				};
@@ -1857,7 +1857,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				.amount_after_fees;
 
 		if amount_to_refund < EgressDustLimit::<T, I>::get(tx.asset).unique_saturated_into() {
-			return Err(RecordFailureAndAbortRefund(RejectionRefundReason::BelowDustLimit))
+			return Err(RecordFailureAndAbortRefund(RefundFailureReason::BelowDustLimit))
 		}
 
 		// this is the function we use to broadcast, used multiple times below
@@ -1890,7 +1890,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						amount: amount_to_refund,
 					},
 				)
-				.map_err(|err| RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildRejectCall(err)))
+				.map_err(|err| RecordFailureAndAbortRefund(RefundFailureReason::FailedToBuildRejectCall(err)))
 				.map(broadcast_and_finalise_fetch)
 			},
 			// Case 2: ccm refund
@@ -1909,7 +1909,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					.map(broadcast_and_finalise_fetch) {
 						Ok(_fetch_broadcast_id) => (),
 						Err(RejectError::NotRequired) => (),
-						Err(err) => return Err(RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildRejectCall(err)))
+						Err(err) => return Err(RecordFailureAndAbortRefund(RefundFailureReason::FailedToBuildRejectCall(err)))
 				}
 
 				// Solana CCM refunds with ALT is not supported, since we don't want to witness ALTs
@@ -1922,7 +1922,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					.unwrap_or(false)
 				{
 					debug_assert!(false, "Solana refund CCM with ALTs is not supported");
-					return Err(RecordFailureAndAbortRefund(RejectionRefundReason::SolanaCCMWithALTsNotSupported));
+					return Err(RecordFailureAndAbortRefund(RefundFailureReason::SolanaCcmWithAltsNotSupported));
 				}
 
 				// We try to construct the call and broadcast it. If the call can't be constructed,
@@ -1939,7 +1939,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					ccm_refund_metadata.channel_metadata.message.to_vec(),
 					ccm_refund_metadata.channel_metadata.ccm_additional_data.clone(),
 				)
-				.map_err(|err| RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildExecutexSwapAndCall(err)))
+				.map_err(|err| RecordFailureAndAbortRefund(RefundFailureReason::FailedToBuildExecutexSwapAndCall(err)))
 				.map(broadcast_and_finalise_fetch)
 			},
 		}

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -227,6 +227,7 @@ enum FullWitnessDepositOutcome {
 enum RejectionRefundDidntSucceed {
 	RetryLater,
 	RecordFailureAndAbortRefund,
+	AbortRefundBelowDustLimit,
 }
 
 mod deposit_origin {
@@ -1193,6 +1194,11 @@ pub mod pallet {
 			account_id: T::AccountId,
 			deposit_address: TargetChainAccount<T, I>,
 		},
+		TransactionRejectionRefundBelowDustLimit {
+			tx_id: <T::TargetChain as Chain>::DepositDetails,
+			asset: TargetChainAsset<T, I>,
+			amount: TargetChainAmount<T, I>,
+		},
 	}
 
 	#[derive(CloneNoBound, PartialEqNoBound, EqNoBound)]
@@ -1504,6 +1510,15 @@ pub mod pallet {
 							Self::deposit_event(Event::<T, I>::TransactionRejectionFailed {
 								tx_id: tx.deposit_details.clone(),
 							});
+						},
+						Err(RejectionRefundDidntSucceed::AbortRefundBelowDustLimit) => {
+							Self::deposit_event(
+								Event::<T, I>::TransactionRejectionRefundBelowDustLimit {
+									tx_id: tx.deposit_details,
+									asset: tx.asset,
+									amount: tx.amount,
+								},
+							);
 						},
 					}
 				}
@@ -1843,6 +1858,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let amount_to_refund =
 			Self::withhold_ingress_or_egress_fee(egress_type, tx.asset, amount_after_ingress_fees)
 				.amount_after_fees;
+
+		if amount_to_refund < EgressDustLimit::<T, I>::get(tx.asset).unique_saturated_into() {
+			return Err(AbortRefundBelowDustLimit)
+		}
 
 		// this is the function we use to broadcast, used multiple times below
 		let broadcast_and_finalise_fetch = |api_call| {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -226,8 +226,15 @@ enum FullWitnessDepositOutcome {
 
 enum RejectionRefundDidntSucceed {
 	RetryLater,
-	RecordFailureAndAbortRefund,
-	AbortRefundBelowDustLimit,
+	RecordFailureAndAbortRefund(RejectionRefundReason),
+}
+#[derive(Clone, Debug, PartialEq, Encode, Decode, TypeInfo, DecodeWithMemTracking)]
+pub enum RejectionRefundReason {
+	BelowDustLimit,
+	InvalidRefundAddress,
+	FailedToBuildRejectCall(RejectError),
+	FailedToBuildExecutexSwapAndCall(ExecutexSwapAndCallError),
+	SolanaCCMWithALTsNotSupported,
 }
 
 mod deposit_origin {
@@ -1174,6 +1181,7 @@ pub mod pallet {
 		},
 		TransactionRejectionFailed {
 			tx_id: <T::TargetChain as Chain>::DepositDetails,
+			reason: RejectionRefundReason,
 		},
 		UnknownBroker {
 			broker_id: T::AccountId,
@@ -1193,11 +1201,6 @@ pub mod pallet {
 		ChannelRejectionRequestReceived {
 			account_id: T::AccountId,
 			deposit_address: TargetChainAccount<T, I>,
-		},
-		TransactionRejectionRefundBelowDustLimit {
-			tx_id: <T::TargetChain as Chain>::DepositDetails,
-			asset: TargetChainAsset<T, I>,
-			amount: TargetChainAmount<T, I>,
 		},
 	}
 
@@ -1450,7 +1453,9 @@ pub mod pallet {
 					if let Ok(refund_address) = tx.refund_address.clone().try_into() {
 						Ok(refund_address)
 					} else {
-						Err(RejectionRefundDidntSucceed::RecordFailureAndAbortRefund)
+						Err(RejectionRefundDidntSucceed::RecordFailureAndAbortRefund(
+							RejectionRefundReason::InvalidRefundAddress,
+						))
 					}
 				};
 
@@ -1505,20 +1510,12 @@ pub mod pallet {
 						Err(RejectionRefundDidntSucceed::RetryLater) => {
 							deferred_rejections.push(tx);
 						},
-						Err(RejectionRefundDidntSucceed::RecordFailureAndAbortRefund) => {
+						Err(RejectionRefundDidntSucceed::RecordFailureAndAbortRefund(reason)) => {
 							FailedRejections::<T, I>::append(tx.clone());
 							Self::deposit_event(Event::<T, I>::TransactionRejectionFailed {
 								tx_id: tx.deposit_details.clone(),
+								reason,
 							});
-						},
-						Err(RejectionRefundDidntSucceed::AbortRefundBelowDustLimit) => {
-							Self::deposit_event(
-								Event::<T, I>::TransactionRejectionRefundBelowDustLimit {
-									tx_id: tx.deposit_details,
-									asset: tx.asset,
-									amount: tx.amount,
-								},
-							);
 						},
 					}
 				}
@@ -1860,7 +1857,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				.amount_after_fees;
 
 		if amount_to_refund < EgressDustLimit::<T, I>::get(tx.asset).unique_saturated_into() {
-			return Err(AbortRefundBelowDustLimit)
+			return Err(RecordFailureAndAbortRefund(RejectionRefundReason::BelowDustLimit))
 		}
 
 		// this is the function we use to broadcast, used multiple times below
@@ -1893,7 +1890,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						amount: amount_to_refund,
 					},
 				)
-				.map_err(|_| RecordFailureAndAbortRefund)
+				.map_err(|err| RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildRejectCall(err)))
 				.map(broadcast_and_finalise_fetch)
 			},
 			// Case 2: ccm refund
@@ -1912,7 +1909,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					.map(broadcast_and_finalise_fetch) {
 						Ok(_fetch_broadcast_id) => (),
 						Err(RejectError::NotRequired) => (),
-						Err(_) => return Err(RecordFailureAndAbortRefund)
+						Err(err) => return Err(RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildRejectCall(err)))
 				}
 
 				// Solana CCM refunds with ALT is not supported, since we don't want to witness ALTs
@@ -1925,7 +1922,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					.unwrap_or(false)
 				{
 					debug_assert!(false, "Solana refund CCM with ALTs is not supported");
-					return Err(RecordFailureAndAbortRefund);
+					return Err(RecordFailureAndAbortRefund(RejectionRefundReason::SolanaCCMWithALTsNotSupported));
 				}
 
 				// We try to construct the call and broadcast it. If the call can't be constructed,
@@ -1942,7 +1939,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					ccm_refund_metadata.channel_metadata.message.to_vec(),
 					ccm_refund_metadata.channel_metadata.ccm_additional_data.clone(),
 				)
-				.map_err(|_| RecordFailureAndAbortRefund)
+				.map_err(|err| RecordFailureAndAbortRefund(RejectionRefundReason::FailedToBuildExecutexSwapAndCall(err)))
 				.map(broadcast_and_finalise_fetch)
 			},
 		}

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3251,7 +3251,7 @@ fn additional_action_correctly_prefund_and_create_account() {
 mod evm_transaction_rejection {
 	use super::*;
 	use crate::{
-		RejectionRefundReason, ScheduledTransactionsForRejection, TransactionRejectionDetails,
+		RefundFailureReason, ScheduledTransactionsForRejection, TransactionRejectionDetails,
 		TransactionRejectionStatus, TransactionsMarkedForRejection,
 	};
 	use cf_chains::{
@@ -3496,7 +3496,7 @@ mod evm_transaction_rejection {
 				RuntimeEvent::EthereumIngressEgress(
 					crate::Event::<Test, Instance1>::TransactionRejectionFailed {
 						tx_id: event_tx_id,
-						reason: RejectionRefundReason::BelowDustLimit
+						reason: RefundFailureReason::BelowDustLimit
 					}
 				) if event_tx_id.deposit_ids().unwrap().contains(&tx_id)
 			);

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3437,6 +3437,74 @@ mod evm_transaction_rejection {
 	}
 
 	#[test]
+	fn refund_below_dust_limit_is_dropped() {
+		new_test_ext().execute_with(|| {
+			// Set the egress dust limit above the deposit amount so the refund (deposit minus
+			// fees) is guaranteed to be below the dust limit.
+			EgressDustLimit::<Test, Instance1>::set(ETH, DEFAULT_DEPOSIT_AMOUNT + 1);
+
+			let tx_id = EvmHash::from_str(
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			)
+			.unwrap();
+			let (_, deposit_address, block, _) =
+				EthereumIngressEgress::request_liquidity_deposit_address(
+					BROKER,
+					BROKER,
+					ETH,
+					0,
+					ForeignChainAddress::Eth(Default::default()),
+					None,
+				)
+				.unwrap();
+			let deposit_address: <Ethereum as Chain>::ChainAccount =
+				deposit_address.try_into().unwrap();
+			let deposit_details = DepositDetails { tx_hashes: Some(vec![tx_id]) };
+
+			assert_ok!(EthereumIngressEgress::mark_transaction_for_rejection(
+				OriginTrait::signed(BROKER),
+				tx_id,
+			));
+
+			EthereumIngressEgress::process_channel_deposit_full_witness(
+				DepositWitness {
+					deposit_address,
+					asset: ETH,
+					amount: DEFAULT_DEPOSIT_AMOUNT,
+					deposit_details,
+				},
+				block,
+			);
+
+			// The rejection is scheduled regardless of the egress dust limit.
+			assert_eq!(ScheduledTransactionsForRejection::<Test, Instance1>::get().len(), 1);
+
+			EthereumIngressEgress::on_finalize(2);
+
+			// The dust guard fired: the rejection was dropped (not re-queued), not recorded as
+			// a failure, and nothing was broadcast (neither a fetch nor a refund).
+			assert!(ScheduledTransactionsForRejection::<Test, Instance1>::get().is_empty());
+			assert!(FailedRejections::<Test, Instance1>::get().is_empty());
+			assert!(MockEgressBroadcasterEth::get_pending_api_calls().is_empty());
+
+			// A dedicated event is emitted instead of TransactionRejectedByBroker, for the
+			// rejected tx_id.
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::EthereumIngressEgress(
+					crate::Event::<Test, Instance1>::TransactionRejectionRefundBelowDustLimit {
+						tx_id: event_tx_id,
+						asset,
+						amount,
+					}
+				) if event_tx_id.deposit_ids().unwrap().contains(&tx_id) &&
+					*asset == ETH &&
+					*amount == DEFAULT_DEPOSIT_AMOUNT
+			);
+		});
+	}
+
+	#[test]
 	fn whitelisted_broker_can_mark_tx_for_rejection_for_lp() {
 		new_test_ext().execute_with(|| {
 			let tx_id = EvmHash::from_str(

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3251,8 +3251,8 @@ fn additional_action_correctly_prefund_and_create_account() {
 mod evm_transaction_rejection {
 	use super::*;
 	use crate::{
-		ScheduledTransactionsForRejection, TransactionRejectionDetails, TransactionRejectionStatus,
-		TransactionsMarkedForRejection,
+		RejectionRefundReason, ScheduledTransactionsForRejection, TransactionRejectionDetails,
+		TransactionRejectionStatus, TransactionsMarkedForRejection,
 	};
 	use cf_chains::{
 		assets::eth::Asset as EthAsset, evm::Hash as EvmHash, ChannelLifecycleHooks,
@@ -3481,25 +3481,24 @@ mod evm_transaction_rejection {
 
 			EthereumIngressEgress::on_finalize(2);
 
-			// The dust guard fired: the rejection was dropped (not re-queued), not recorded as
-			// a failure, and nothing was broadcast (neither a fetch nor a refund).
+			// The dust guard fired: the refund was dropped (not re-queued) and nothing was
+			// broadcast (neither a fetch nor a refund), the rejection is recorded as a
+			// failed rejection with reason BelowDustLimit.
 			assert!(ScheduledTransactionsForRejection::<Test, Instance1>::get().is_empty());
-			assert!(FailedRejections::<Test, Instance1>::get().is_empty());
 			assert!(MockEgressBroadcasterEth::get_pending_api_calls().is_empty());
 
-			// A dedicated event is emitted instead of TransactionRejectedByBroker, for the
-			// rejected tx_id.
+			let failed_rejections = FailedRejections::<Test, Instance1>::get();
+			assert_eq!(failed_rejections.len(), 1);
+			assert!(failed_rejections[0].deposit_details.deposit_ids().unwrap().contains(&tx_id));
+
 			assert_has_matching_event!(
 				Test,
 				RuntimeEvent::EthereumIngressEgress(
-					crate::Event::<Test, Instance1>::TransactionRejectionRefundBelowDustLimit {
+					crate::Event::<Test, Instance1>::TransactionRejectionFailed {
 						tx_id: event_tx_id,
-						asset,
-						amount,
+						reason: RejectionRefundReason::BelowDustLimit
 					}
-				) if event_tx_id.deposit_ids().unwrap().contains(&tx_id) &&
-					*asset == ETH &&
-					*amount == DEFAULT_DEPOSIT_AMOUNT
+				) if event_tx_id.deposit_ids().unwrap().contains(&tx_id)
 			);
 		});
 	}


### PR DESCRIPTION
# Pull Request

Closes: PRO-2887

## Summary

Perform the same `DustEgreeLimit` check we do in `schedule_egress` when performing a rejection refund. No fetch action is ever dispatched in this situation.

### Extrinsics & Events

Added a new event `TransactionRejectionRefundBelowDustLimit` emitted when a rejection is skipped because the post-fee amount was below the dust limit. The amount contained in the event is the gross amount, before fee deduction.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.