### PR TITLE
ci: add licence check to ensure all files have license header

### DIFF
--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Check licence headers 📜
         run: |
-          missing=$(grep -rL "SPDX-License-Identifier: Apache-2.0" --include="*.rs" . | grep -v "^./target/")
+          missing=$(grep -rL "SPDX-License-Identifier: Apache-2.0" --include="*.rs" . | grep -v "^./target/" || true)
           if [ -n "$missing" ]; then
             echo "The following Rust files are missing the Apache-2.0 SPDX licence header:"
             echo "$missing"

--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -91,6 +91,21 @@ jobs:
         working-directory: bouncer
         run: pnpm tsc --noEmit
 
+  check-license-headers:
+    runs-on: namespace-profile-default-light
+    steps:
+      - name: Checkout 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Check licence headers 📜
+        run: |
+          missing=$(grep -rL "SPDX-License-Identifier: Apache-2.0" --include="*.rs" . | grep -v "^./target/")
+          if [ -n "$missing" ]; then
+            echo "The following Rust files are missing the Apache-2.0 SPDX licence header:"
+            echo "$missing"
+            exit 1
+          fi
+
   lint-ci-workflows:
     runs-on: namespace-profile-default-light
     steps:


### PR DESCRIPTION
# Pull Request

Adds a CI job to the pre-checks that ensures all rust files have a license header.