### PR TITLE
chore: add transfer fallback bouncer check

### DIFF
--- a/bouncer/shared/check_transfer_fallbacks.ts
+++ b/bouncer/shared/check_transfer_fallbacks.ts
@@ -18,6 +18,21 @@ const TRANSFER_FALLBACK_EVENTS = EVM_VAULT_CHAINS.map(
 
 const INGRESS_EGRESS_STORAGE_PALLETS = EVM_VAULT_CHAINS.map(ingressEgressPalletForChain);
 
+// FailedForeignChainCalls is shared between transfer fallbacks and failed CCM broadcasts.
+// BroadcastActions is set to { ccmBroadcast: null } for CCM broadcasts and absent for
+// transfer fallbacks, so we use it to distinguish the two.
+async function isCcmBroadcast(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  palletQuery: any,
+  broadcastId: number,
+): Promise<boolean> {
+  const action = (await palletQuery.broadcastActions(broadcastId)).toJSON() as Record<
+    string,
+    unknown
+  > | null;
+  return action?.ccmBroadcast !== undefined;
+}
+
 export async function checkNoTransferFallbacks(testContext: TestContext) {
   testContext.info('Checking that no EVM vault transfer fallbacks occurred during the tests');
 
@@ -39,14 +54,25 @@ export async function checkNoTransferFallbacks(testContext: TestContext) {
   const chainflipApi = await getChainflipApi();
   for (const pallet of INGRESS_EGRESS_STORAGE_PALLETS) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const entries = await (chainflipApi.query as any)[pallet].failedForeignChainCalls.entries();
-    const nonEmpty = (entries as [unknown, { toJSON(): unknown[] }][]).filter(
-      ([, calls]) => calls.toJSON().length > 0,
+    const palletQuery = (chainflipApi.query as any)[pallet];
+    const entries = await palletQuery.failedForeignChainCalls.entries();
+    const allCalls = (entries as [unknown, { toJSON(): { broadcastId: number }[] }][]).flatMap(
+      ([, calls]) => calls.toJSON(),
     );
-    if (nonEmpty.length > 0) {
+
+    const transferFallbackCalls = (
+      await Promise.all(
+        allCalls.map(async (call) =>
+          (await isCcmBroadcast(palletQuery, call.broadcastId)) ? null : call,
+        ),
+      )
+    ).filter((call) => call !== null);
+
+    if (transferFallbackCalls.length > 0) {
       throw new Error(
-        `Pallet ${pallet} has ${nonEmpty.length} non-empty FailedForeignChainCalls ` +
-          `entries at end of test run. This indicates pending unresolved transfer fallback(s).`,
+        `Pallet ${pallet} has ${transferFallbackCalls.length} non-CCM FailedForeignChainCalls ` +
+          `entries at end of test run. This indicates pending unresolved transfer fallback(s): ` +
+          `${JSON.stringify(transferFallbackCalls)}`,
       );
     }
   }

--- a/bouncer/shared/check_transfer_fallbacks.ts
+++ b/bouncer/shared/check_transfer_fallbacks.ts
@@ -1,6 +1,7 @@
 import prisma from 'shared/utils/prisma_client';
 import { getChainflipApi } from 'shared/utils/substrate';
 import { TestContext } from 'shared/utils/test_context';
+import { Chains, ingressEgressPalletForChain } from 'shared/utils';
 
 // TransferNativeFailed and TransferTokenFailed are events emitted by the EVM vault contracts
 // when a transfer fails on-chain. The engine witnesses these and the State Chain responds by
@@ -8,17 +9,14 @@ import { TestContext } from 'shared/utils/test_context';
 // TransferFallbackRequested and storing the call in FailedForeignChainCalls storage.
 // Neither should ever happen during normal bouncer tests.
 
-const TRANSFER_FALLBACK_EVENTS = [
-  'EthereumIngressEgress.TransferFallbackRequested',
-  'ArbitrumIngressEgress.TransferFallbackRequested',
-  'TronIngressEgress.TransferFallbackRequested',
-];
+// Chains that have EVM vault contracts with the TransferFallbackRequested mechanism.
+const EVM_VAULT_CHAINS = [Chains.Ethereum, Chains.Arbitrum, Chains.Tron] as const;
 
-const FALLBACK_STORAGE_PALLETS = [
-  'ethereumIngressEgress',
-  'arbitrumIngressEgress',
-  'tronIngressEgress',
-] as const;
+const TRANSFER_FALLBACK_EVENTS = EVM_VAULT_CHAINS.map(
+  (chain) => `${chain}IngressEgress.TransferFallbackRequested`,
+);
+
+const INGRESS_EGRESS_STORAGE_PALLETS = EVM_VAULT_CHAINS.map(ingressEgressPalletForChain);
 
 export async function checkNoTransferFallbacks(testContext: TestContext) {
   testContext.info('Checking that no EVM vault transfer fallbacks occurred during the tests');
@@ -41,7 +39,7 @@ export async function checkNoTransferFallbacks(testContext: TestContext) {
   }
 
   const chainflipApi = await getChainflipApi();
-  for (const pallet of FALLBACK_STORAGE_PALLETS) {
+  for (const pallet of INGRESS_EGRESS_STORAGE_PALLETS) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entries = await (chainflipApi.query as any)[pallet].failedForeignChainCalls.entries();
     const nonEmpty = (entries as [unknown, { toJSON(): unknown[] }][]).filter(

--- a/bouncer/shared/check_transfer_fallbacks.ts
+++ b/bouncer/shared/check_transfer_fallbacks.ts
@@ -1,7 +1,7 @@
-import prisma from 'shared/utils/prisma_client';
 import { getChainflipApi } from 'shared/utils/substrate';
 import { TestContext } from 'shared/utils/test_context';
 import { Chains, ingressEgressPalletForChain } from 'shared/utils';
+import { findAllEventsByName } from 'shared/utils/indexer';
 
 // TransferNativeFailed and TransferTokenFailed are events emitted by the EVM vault contracts
 // when a transfer fails on-chain. The engine witnesses these and the State Chain responds by
@@ -21,11 +21,9 @@ const INGRESS_EGRESS_STORAGE_PALLETS = EVM_VAULT_CHAINS.map(ingressEgressPalletF
 export async function checkNoTransferFallbacks(testContext: TestContext) {
   testContext.info('Checking that no EVM vault transfer fallbacks occurred during the tests');
 
-  const fallbackEvents = await prisma.event.findMany({
-    where: { name: { in: TRANSFER_FALLBACK_EVENTS } },
-    include: { block: true },
-    orderBy: { block: { height: 'asc' } },
-  });
+  const fallbackEvents = (
+    await Promise.all(TRANSFER_FALLBACK_EVENTS.map(findAllEventsByName))
+  ).flat();
 
   if (fallbackEvents.length > 0) {
     const occurrences = fallbackEvents

--- a/bouncer/shared/check_transfer_fallbacks.ts
+++ b/bouncer/shared/check_transfer_fallbacks.ts
@@ -1,0 +1,57 @@
+import prisma from 'shared/utils/prisma_client';
+import { getChainflipApi } from 'shared/utils/substrate';
+import { TestContext } from 'shared/utils/test_context';
+
+// TransferNativeFailed and TransferTokenFailed are events emitted by the EVM vault contracts
+// when a transfer fails on-chain. The engine witnesses these and the State Chain responds by
+// creating a "transfer fallback" — a new threshold-signed retry transaction — emitting
+// TransferFallbackRequested and storing the call in FailedForeignChainCalls storage.
+// Neither should ever happen during normal bouncer tests.
+
+const TRANSFER_FALLBACK_EVENTS = [
+  'EthereumIngressEgress.TransferFallbackRequested',
+  'ArbitrumIngressEgress.TransferFallbackRequested',
+  'TronIngressEgress.TransferFallbackRequested',
+];
+
+const FALLBACK_STORAGE_PALLETS = [
+  'ethereumIngressEgress',
+  'arbitrumIngressEgress',
+  'tronIngressEgress',
+] as const;
+
+export async function checkNoTransferFallbacks(testContext: TestContext) {
+  testContext.info('Checking that no EVM vault transfer fallbacks occurred during the tests');
+
+  const fallbackEvents = await prisma.event.findMany({
+    where: { name: { in: TRANSFER_FALLBACK_EVENTS } },
+    include: { block: true },
+    orderBy: { block: { height: 'asc' } },
+  });
+
+  if (fallbackEvents.length > 0) {
+    const occurrences = fallbackEvents
+      .map((e) => `block ${e.block.height} [${e.name}]: ${JSON.stringify(e.args)}`)
+      .join('\n  ');
+    throw new Error(
+      `EVM vault transfer fallback(s) were triggered during the tests. This means a vault egress ` +
+        `transaction failed on-chain (TransferNativeFailed or TransferTokenFailed on the vault contract). ` +
+        `Occurrences:\n  ${occurrences}`,
+    );
+  }
+
+  const chainflipApi = await getChainflipApi();
+  for (const pallet of FALLBACK_STORAGE_PALLETS) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entries = await (chainflipApi.query as any)[pallet].failedForeignChainCalls.entries();
+    const nonEmpty = (entries as [unknown, { toJSON(): unknown[] }][]).filter(
+      ([, calls]) => calls.toJSON().length > 0,
+    );
+    if (nonEmpty.length > 0) {
+      throw new Error(
+        `Pallet ${pallet} has ${nonEmpty.length} non-empty FailedForeignChainCalls ` +
+          `entries at end of test run. This indicates pending unresolved transfer fallback(s).`,
+      );
+    }
+  }
+}

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -462,6 +462,7 @@ export function ingressEgressPalletForChain(chain: Chain) {
     case 'Arbitrum':
     case 'Assethub':
     case 'Solana':
+    case 'Tron':
       return `${toLowerCase(chain)}IngressEgress` as const;
     default:
       throw new Error(`Unsupported chain: ${chain}`);

--- a/bouncer/shared/utils/indexer.ts
+++ b/bouncer/shared/utils/indexer.ts
@@ -209,6 +209,14 @@ export const findOneEventOfMany = async <Descriptions extends EventDescriptions>
   return foundEventsKeyAndData[0];
 };
 
+export async function findAllEventsByName(name: string) {
+  return prisma.event.findMany({
+    where: { name },
+    include: { block: true },
+    orderBy: { block: { height: 'asc' } },
+  });
+}
+
 // ------------ General fix  ---------------
 // the following fixes the "TypeError: Do not know how to serialize a BigInt" error.
 // Whenever the indexer is used to find events it should be included, thus it's here in this file.

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -4,6 +4,7 @@ import { testVaultSwap } from 'tests/vault_swap_tests';
 import { checkSolEventAccountsClosure } from 'shared/vault_swap/sol_vault_swap';
 import { checkAvailabilityAllSolanaNonces } from 'shared/utils';
 import { checkNoWitnessingTaskRestarts } from 'shared/check_witnessing_task_restarts';
+import { checkNoTransferFallbacks } from 'shared/check_transfer_fallbacks';
 import { testAllSwaps, testSwapsToAssethub } from 'tests/all_swaps';
 import { testEvmDeposits } from 'tests/evm_deposits';
 import { testMultipleMembersGovernance } from 'tests/multiple_members_governance';
@@ -88,6 +89,7 @@ describe('ConcurrentTests', () => {
     5 * ciTimeoutFactor,
   );
   serialTest('CheckNoWitnessingTaskRestarts', checkNoWitnessingTaskRestarts, 5 * ciTimeoutFactor);
+  serialTest('CheckNoTransferFallbacks', checkNoTransferFallbacks, 10 * ciTimeoutFactor);
 });
 
 // Run only the broker level screening tests


### PR DESCRIPTION
# Pull Request

Closes: PRO-2904

## Summary

Add a low hanging fruit test to check that we have not witnessed a Transfer Fallback event nor build any transfer fallback calls for any of the tests during the normal bouncer runs. This is to prevent scenarios such as the one fixed in  #6627 .
It is implemented as a check at the end of the tests, same as for the Solana nonce checks. That is better than having to monitor for those events during all the concurrent tests.

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.