### PR TITLE
fix: track screening report cleanup weights

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1302,31 +1302,78 @@ pub mod pallet {
 			if T::AllowTransactionReports::get() {
 				// A report gets cleaned up after approx 1 hour and needs to be re-reported by the
 				// broker if necessary. This is needed as some kind of garbage collection mechanism.
-				for (account_id, tx_id) in ReportExpiresAt::<T, I>::take(now) {
-					let _ = TransactionsMarkedForRejection::<T, I>::try_mutate(
+				//
+				// The cleanup is metered against the remaining on_idle weight: only as many
+				// entries as fit in the budget are processed and any remainder is deferred to the
+				// next block. This stops a broker from scheduling an unbounded amount of "free"
+				// cleanup work onto a single future block.
+				//
+				// Per-entry worst case: read the status, plus a possible reschedule append for a
+				// report whose expiry was extended after this index entry was queued.
+				let cleanup_weight_per_entry =
+					frame_support::weights::constants::ParityDbWeight::get().reads_writes(2, 2);
+				let bookkeeping_weight =
+					frame_support::weights::constants::ParityDbWeight::get().reads_writes(1, 1);
+
+				let mut expiring = ReportExpiresAt::<T, I>::take(now);
+				// Account for the take above.
+				used_weight = used_weight.saturating_add(bookkeeping_weight);
+
+				// Reserve one bookkeeping write for the possible requeue below, so the cleanup
+				// never exceeds the remaining budget.
+				let to_process = remaining_weight
+					.saturating_sub(used_weight)
+					.saturating_sub(bookkeeping_weight)
+					.ref_time()
+					.checked_div(cleanup_weight_per_entry.ref_time())
+					.unwrap_or_default()
+					.saturated_into::<usize>()
+					.min(expiring.len());
+
+				for (account_id, tx_id) in expiring.drain(..to_process) {
+					// `Err(Some(new_expiry))` signals that the report was extended and its single
+					// index entry must be rescheduled rather than dropped.
+					let outcome = TransactionsMarkedForRejection::<T, I>::try_mutate(
 						&account_id,
 						&tx_id,
-						|status| {
-							match status.take() {
-								Some(TransactionRejectionStatus { prewitnessed, expires_at })
-									if !prewitnessed && expires_at == now =>
-								{
-									Self::deposit_event(
-										Event::<T, I>::TransactionRejectionRequestExpired {
-											account_id: account_id.clone(),
-											tx_id: tx_id.clone(),
-										},
-									);
-									Ok(())
-								},
-								_ => {
-									// Don't apply the mutation. We expect the pre-witnessed
-									// transaction to eventually be fully witnessed.
-									Err(())
-								},
-							}
+						|status| match status.take() {
+							Some(TransactionRejectionStatus { prewitnessed, expires_at })
+								if !prewitnessed && expires_at <= now =>
+							{
+								Self::deposit_event(
+									Event::<T, I>::TransactionRejectionRequestExpired {
+										account_id: account_id.clone(),
+										tx_id: tx_id.clone(),
+									},
+								);
+								Ok(())
+							},
+							// The report was extended after this entry was queued: keep the mark
+							// (Err rolls back the take) and reschedule the index entry.
+							Some(TransactionRejectionStatus {
+								prewitnessed: false,
+								expires_at,
+							}) => Err(Some(expires_at)),
+							// Pre-witnessed (await full witness) or already gone: keep the mark and
+							// drop this stale index entry.
+							_ => Err(None),
 						},
 					);
+					if let Err(Some(new_expiry)) = outcome {
+						ReportExpiresAt::<T, I>::append(new_expiry, (&account_id, &tx_id));
+					}
+				}
+				used_weight = used_weight
+					.saturating_add(cleanup_weight_per_entry.saturating_mul(to_process as u64));
+
+				// Defer any entries we couldn't afford to process to the next block, so the
+				// remaining cleanup is retried within budget rather than dropped.
+				if !expiring.is_empty() {
+					ReportExpiresAt::<T, I>::mutate(
+						now.saturating_add(BlockNumberFor::<T>::from(1u32)),
+						|next| next.append(&mut expiring),
+					);
+					used_weight = used_weight.saturating_add(bookkeeping_weight);
 				}
 			}
 
@@ -1736,16 +1783,28 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		};
 		let expires_at = <frame_system::Pallet<T>>::block_number()
 			.saturating_add(BlockNumberFor::<T>::from(MARKED_TX_EXPIRATION_BLOCKS));
-		TransactionsMarkedForRejection::<T, I>::try_mutate(&lookup_id, &tx_id, |opt| {
-			ensure!(
-				!opt.replace(TransactionRejectionStatus { prewitnessed: false, expires_at })
-					.map(|s| s.prewitnessed)
-					.unwrap_or_default(),
-				Error::<T, I>::TransactionAlreadyPrewitnessed
-			);
-			Ok::<_, DispatchError>(())
-		})?;
-		ReportExpiresAt::<T, I>::append(expires_at, (&lookup_id, &tx_id));
+		// Re-marking an already-marked transaction extends its expiry window, but must not add
+		// a second ReportExpiresAt entry. The single existing index entry is rescheduled to the
+		// new expiry when its current bucket is processed in `on_idle`, so repeated reports for
+		// the same transaction can't multiply the future cleanup work.
+		let is_new = TransactionsMarkedForRejection::<T, I>::try_mutate(
+			&lookup_id,
+			&tx_id,
+			|opt| match opt {
+				Some(status) => {
+					ensure!(!status.prewitnessed, Error::<T, I>::TransactionAlreadyPrewitnessed);
+					status.expires_at = expires_at;
+					Ok::<_, DispatchError>(false)
+				},
+				None => {
+					*opt = Some(TransactionRejectionStatus { prewitnessed: false, expires_at });
+					Ok(true)
+				},
+			},
+		)?;
+		if is_new {
+			ReportExpiresAt::<T, I>::append(expires_at, (&lookup_id, &tx_id));
+		}
 		Self::deposit_event(Event::<T, I>::TransactionRejectionRequestReceived {
 			account_id,
 			tx_id,

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1309,9 +1309,9 @@ pub mod pallet {
 				// cleanup work onto a single future block.
 				//
 				// Per-entry worst case: read the status, plus a possible reschedule append for a
-				// report whose expiry was extended after this index entry was queued.
-				let cleanup_weight_per_entry =
-					frame_support::weights::constants::ParityDbWeight::get().reads_writes(2, 2);
+				// report whose expiry was extended after this index entry was queued. This is the
+				// same cost charged up-front when the report is marked.
+				let cleanup_weight_per_entry = Self::report_cleanup_weight();
 				let bookkeeping_weight =
 					frame_support::weights::constants::ParityDbWeight::get().reads_writes(1, 1);
 
@@ -1701,7 +1701,12 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(12)]
-		#[pallet::weight(T::WeightInfo::mark_transaction_for_rejection())]
+		// The base benchmark covers the on-chain mark; the surcharge pre-pays the deferred
+		// `on_idle` cleanup that this report schedules (see `Pallet::report_cleanup_weight`).
+		#[pallet::weight(
+			T::WeightInfo::mark_transaction_for_rejection()
+				.saturating_add(Pallet::<T, I>::report_cleanup_weight())
+		)]
 		pub fn mark_transaction_for_rejection(
 			origin: OriginFor<T>,
 			tx_id: TransactionInIdFor<T, I>,
@@ -1770,6 +1775,11 @@ impl<T: Config<I>, I: 'static> IngressSink for Pallet<T, I> {
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Weight to clean up a single expired transaction-rejection report in `on_idle`.
+	fn report_cleanup_weight() -> Weight {
+		frame_support::weights::constants::ParityDbWeight::get().reads_writes(2, 2)
+	}
+
 	fn mark_transaction_for_rejection_inner(
 		account_id: T::AccountId,
 		tx_id: TransactionInIdFor<T, I>,

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -407,6 +407,24 @@ fn repeated_reports_do_not_multiply_expiry_entries() {
 }
 
 #[test]
+fn mark_transaction_for_rejection_charges_for_deferred_cleanup() {
+	use frame_support::{dispatch::GetDispatchInfo, weights::constants::ParityDbWeight};
+	// Marking a transaction schedules one expiry-cleanup entry that runs later in `on_idle`.
+	// The extrinsic's declared weight must include that deferred per-entry cleanup cost so the
+	// reporting broker pays for the work they queue rather than offloading it onto the network.
+	let declared = crate::Call::<Test, Instance2>::mark_transaction_for_rejection {
+		tx_id: Hash::random(),
+	}
+	.get_dispatch_info()
+	.call_weight;
+	assert_eq!(
+		declared,
+		<() as crate::WeightInfo>::mark_transaction_for_rejection()
+			.saturating_add(ParityDbWeight::get().reads_writes(2, 2)),
+	);
+}
+
+#[test]
 fn can_not_report_transaction_after_witnessing() {
 	new_test_ext().execute_with(|| {
 		let unreported = Hash::random();

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -320,6 +320,93 @@ fn do_not_expire_marked_transactions_if_prewitnessed() {
 }
 
 #[test]
+fn report_expiry_cleanup_respects_remaining_weight() {
+	use frame_support::weights::constants::ParityDbWeight;
+	new_test_ext().execute_with(|| {
+		let expiry_at = 100u64;
+		System::set_block_number(expiry_at);
+
+		let tx_ids = [Hash::random(), Hash::random(), Hash::random()];
+		for tx_id in tx_ids {
+			TransactionsMarkedForRejection::<Test, Instance2>::insert(
+				BROKER,
+				tx_id,
+				TransactionRejectionStatus { prewitnessed: false, expires_at: expiry_at },
+			);
+		}
+		ReportExpiresAt::<Test, Instance2>::insert(
+			expiry_at,
+			tx_ids.iter().map(|tx_id| (BROKER, *tx_id)).collect::<Vec<_>>(),
+		);
+
+		// Budget large enough for the recycling overhead + the take + a couple of entries,
+		// but not all three.
+		let budget = ParityDbWeight::get().reads_writes(7, 7);
+		let used = BitcoinIngressEgress::on_idle(expiry_at, budget);
+
+		// The hook must stay within its budget (allowing a single bookkeeping op for the
+		// requeue write) rather than draining the whole bucket unconditionally.
+		assert!(
+			used.ref_time() <=
+				budget
+					.ref_time()
+					.saturating_add(ParityDbWeight::get().reads_writes(1, 1).ref_time()),
+			"on_idle used {used:?} which exceeds the budget {budget:?}",
+		);
+
+		// The current bucket is drained...
+		assert!(ReportExpiresAt::<Test, Instance2>::get(expiry_at).is_empty());
+		// ...but not every entry was processed: the remainder is deferred to the next block
+		// instead of being cleaned up for free this block.
+		let requeued = ReportExpiresAt::<Test, Instance2>::get(expiry_at + 1);
+		assert!(!requeued.is_empty(), "unprocessed entries must be requeued");
+		assert!(requeued.len() < tx_ids.len());
+
+		// Deferred entries are still marked (not yet expired).
+		assert_eq!(
+			tx_ids
+				.iter()
+				.filter(|tx_id| TransactionsMarkedForRejection::<Test, Instance2>::contains_key(
+					BROKER, tx_id
+				))
+				.count(),
+			requeued.len(),
+		);
+
+		// The next block drains the requeued remainder.
+		System::set_block_number(expiry_at + 1);
+		BitcoinIngressEgress::on_idle(expiry_at + 1, Weight::MAX);
+
+		assert!(ReportExpiresAt::<Test, Instance2>::get(expiry_at + 1).is_empty());
+		for tx_id in tx_ids {
+			assert!(!TransactionsMarkedForRejection::<Test, Instance2>::contains_key(
+				BROKER, tx_id
+			));
+		}
+	});
+}
+
+#[test]
+fn repeated_reports_do_not_multiply_expiry_entries() {
+	new_test_ext().execute_with(|| {
+		let tx_id = Hash::random();
+		let expiry_at = System::block_number() + MARKED_TX_EXPIRATION_BLOCKS as u64;
+
+		// Report the same transaction repeatedly within the same block.
+		for _ in 0..5 {
+			assert_ok!(BitcoinIngressEgress::mark_transaction_for_rejection(
+				OriginTrait::signed(BROKER),
+				tx_id,
+			));
+		}
+
+		// The expiry index must not accumulate duplicate cleanup work.
+		assert_eq!(ReportExpiresAt::<Test, Instance2>::get(expiry_at).len(), 1);
+		assert!(TransactionsMarkedForRejection::<Test, Instance2>::contains_key(BROKER, tx_id));
+	});
+}
+
+#[test]
 fn can_not_report_transaction_after_witnessing() {
 	new_test_ext().execute_with(|| {
 		let unreported = Hash::random();
@@ -393,62 +480,55 @@ fn send_funds_back_after_they_have_been_rejected() {
 }
 
 #[test]
-fn test_mark_transaction_expiry_and_deposit() {
-	let tx_id = Hash::random();
+fn remarking_a_transaction_extends_expiry_without_duplicating() {
+	new_test_ext().execute_with(|| {
+		let tx_id = Hash::random();
+		let first_expiry = System::block_number() + MARKED_TX_EXPIRATION_BLOCKS as u64;
 
-	let ext = new_test_ext()
-		// Mark a transaction
-		.then_apply_extrinsics(|_| {
-			[(
-				OriginTrait::signed(BROKER),
-				crate::Call::<Test, Instance2>::mark_transaction_for_rejection { tx_id },
-				Ok(()),
-			)]
-		})
-		// Advance 10 blocks
-		.then_process_blocks(10)
-		// Mark the same transaction again
-		.then_apply_extrinsics(|_| {
-			[(
-				OriginTrait::signed(BROKER),
-				crate::Call::<Test, Instance2>::mark_transaction_for_rejection { tx_id },
-				Ok(()),
-			)]
-		})
-		// Get expiry block of the first report
-		.then_execute_with(|_| {
-			let mut expiries = ReportExpiresAt::<Test, Instance2>::iter().collect::<Vec<_>>();
-			expiries.sort_by_key(|(block, _)| *block);
-			(expiries[0].0, expiries[1].0)
-		});
-	let (first_expiry, second_expiry) = *ext.context();
+		assert_ok!(BitcoinIngressEgress::mark_transaction_for_rejection(
+			OriginTrait::signed(BROKER),
+			tx_id,
+		));
 
-	ext
-		// Advance to the block after expiry block
-		.then_execute_at_block(first_expiry, |_| {
-			// First expiry should be triggered, but ignored.
-		})
-		.then_process_events(|_, event| {
-			if let RuntimeEvent::BitcoinIngressEgress(Event::TransactionRejectionRequestExpired {
-				..
-			}) = event
-			{
-				panic!("Rejection Request Expired prematurely");
-			}
-			None::<()>
-		})
-		.then_execute_at_block(second_expiry, |_| {
-			// Second expiry should be triggered, expiry is processed.
-		})
-		.then_execute_with_keep_context(|_| {
-			assert_has_matching_event!(
-				Test,
-				RuntimeEvent::BitcoinIngressEgress(Event::TransactionRejectionRequestExpired {
-					account_id: BROKER,
-					..
-				})
-			);
-		});
+		// Re-mark the same transaction ten blocks later: this extends the window to a fresh
+		// expiry.
+		System::set_block_number(System::block_number() + 10);
+		let second_expiry = System::block_number() + MARKED_TX_EXPIRATION_BLOCKS as u64;
+		assert_ok!(BitcoinIngressEgress::mark_transaction_for_rejection(
+			OriginTrait::signed(BROKER),
+			tx_id,
+		));
+
+		// Still exactly one index entry (at the original block), and the status now carries
+		// the extended expiry.
+		let entries = ReportExpiresAt::<Test, Instance2>::iter().collect::<Vec<_>>();
+		assert_eq!(entries.len(), 1);
+		assert_eq!(entries[0].0, first_expiry);
+		assert_eq!(
+			TransactionsMarkedForRejection::<Test, Instance2>::get(BROKER, tx_id)
+				.unwrap()
+				.expires_at,
+			second_expiry,
+		);
+
+		// At the original expiry the mark is NOT expired; its index entry is rescheduled to
+		// the extended expiry.
+		System::set_block_number(first_expiry);
+		BitcoinIngressEgress::on_idle(first_expiry, Weight::MAX);
+
+		assert!(TransactionsMarkedForRejection::<Test, Instance2>::contains_key(BROKER, tx_id));
+		assert!(ReportExpiresAt::<Test, Instance2>::get(first_expiry).is_empty());
+		assert_eq!(ReportExpiresAt::<Test, Instance2>::get(second_expiry), vec![(BROKER, tx_id)],);
+
+		// At the extended expiry the mark is finally removed.
+		System::set_block_number(second_expiry);
+		BitcoinIngressEgress::on_idle(second_expiry, Weight::MAX);
+
+		assert!(!TransactionsMarkedForRejection::<Test, Instance2>::contains_key(BROKER, tx_id));
+		assert_has_event::<Test>(RuntimeEvent::BitcoinIngressEgress(
+			Event::TransactionRejectionRequestExpired { account_id: BROKER, tx_id },
+		));
+	});
 }
 
 #[test]

--- a/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/screening.rs
@@ -412,11 +412,10 @@ fn mark_transaction_for_rejection_charges_for_deferred_cleanup() {
 	// Marking a transaction schedules one expiry-cleanup entry that runs later in `on_idle`.
 	// The extrinsic's declared weight must include that deferred per-entry cleanup cost so the
 	// reporting broker pays for the work they queue rather than offloading it onto the network.
-	let declared = crate::Call::<Test, Instance2>::mark_transaction_for_rejection {
-		tx_id: Hash::random(),
-	}
-	.get_dispatch_info()
-	.call_weight;
+	let declared =
+		crate::Call::<Test, Instance2>::mark_transaction_for_rejection { tx_id: Hash::random() }
+			.get_dispatch_info()
+			.call_weight;
 	assert_eq!(
 		declared,
 		<() as crate::WeightInfo>::mark_transaction_for_rejection()


### PR DESCRIPTION
# Pull Request

Closes: PRO-2877

## Summary

Fixes the linked issue by measuring the required work and limiting it to the available weight in the on_idle hook. 

As per the copilot comment below, I decided to charge the full fee up front to minimize the chance of unbounded work in the on_idle hook. 

I long-term mitigation is possible but a lot more work: we could create a new storage map that supports 'paging' through the full Vec of items. Something similar already exists in substrate but unfortunately doesn't quite fit our use case. (It works with a single Vector value but not with a map of Vectors). 