### PR TITLE
chore: remove unnnecessary logging

### DIFF
--- a/engine/src/tron/rpc.rs
+++ b/engine/src/tron/rpc.rs
@@ -288,9 +288,9 @@ impl EvmRpcApi for TronRpcClient {
 #[async_trait::async_trait]
 impl TronRpcApi for TronRpcClient {
 	async fn get_transaction_info_by_id(&self, tx_id: H256) -> anyhow::Result<TransactionInfo> {
-		let tx_id = format!("{:x}", tx_id);
+		let tx_id_hex = format!("{:x}", tx_id);
 		let response = self
-			.call_http_api("/gettransactioninfobyid", Some(serde_json::json!({"value": tx_id})))
+			.call_http_api("/gettransactioninfobyid", Some(serde_json::json!({"value": tx_id_hex})))
 			.await?;
 
 		// If the transaction exists but is not yet included or has low number of confirmations it
@@ -299,7 +299,7 @@ impl TronRpcApi for TronRpcClient {
 		if let Some(obj) = response.as_object() {
 			if obj.is_empty() {
 				return Err(anyhow!(
-					"Transaction info not available yet for tx_id: {}. The transaction may still be processing or does not exist.",
+					"Transaction info not available yet for tx_id: {:#x}. The transaction may still be processing or does not exist.",
 					tx_id
 				));
 			}
@@ -312,11 +312,11 @@ impl TronRpcApi for TronRpcClient {
 	}
 
 	async fn get_transaction_by_id(&self, tx_id: H256) -> anyhow::Result<Transaction> {
-		let tx_id = format!("{:x}", tx_id);
+		let tx_id_hex = format!("{:x}", tx_id);
 		let response = self
 			.call_http_api(
 				"/gettransactionbyid",
-				Some(serde_json::json!({"value": tx_id, "visible": false})),
+				Some(serde_json::json!({"value": tx_id_hex, "visible": false})),
 			)
 			.await?;
 
@@ -326,7 +326,7 @@ impl TronRpcApi for TronRpcClient {
 		if let Some(obj) = response.as_object() {
 			if obj.is_empty() {
 				return Err(anyhow!(
-					"Transaction info not available yet for tx_id: {}. The transaction may still be processing or does not exist.",
+					"Transaction info not available yet for tx_id: {:#x}. The transaction may still be processing or does not exist.",
 					tx_id
 				));
 			}

--- a/engine/src/witness/tron/tron_deposits.rs
+++ b/engine/src/witness/tron/tron_deposits.rs
@@ -68,14 +68,8 @@ where
 
 	// Iterate over transaction balance traces
 	'transaction_loop: for tx_trace in block_balance.transaction_balance_trace {
-		// Skip transactions that are not successful, they should be successful since the balance
-		// changed
+		// Skip transactions that are not successful (reverted, out-of-gas, etc.).
 		if tx_trace.status != "SUCCESS" {
-			tracing::warn!(
-				"Skipping Tron transaction with non-success status, expected success: tx_id={}, status={}",
-				tx_trace.transaction_identifier,
-				tx_trace.status
-			);
 			continue;
 		}
 


### PR DESCRIPTION
# Pull Request


## Summary

Remove unnecessary logging of reverted transactions. These are transactions that are not even filtered for being related to our monitored addresses so it doesn't make sense to log them at all.
Also improved another log to see the full transaction id.

---

## *Checklist*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
