### PR TITLE
chore: dont convert tron address in utils.

### DIFF
--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -17,7 +17,6 @@ import {
   AssetAndChain,
   AssetSymbol,
 } from '@chainflip/utils/chainflip';
-import { hexToTronAddress } from '@chainflip/utils/tron';
 import Web3 from 'web3';
 import { TronWeb } from 'tronweb';
 import { Connection, Keypair, PublicKey } from '@solana/web3.js';
@@ -530,17 +529,11 @@ export async function observeSwapEvents(
         case swapRequestedEvent: {
           const channel = data.origin.DepositChannel;
 
-          const eventAddressKind = channel
-            ? (Object.keys(channel.depositAddress)[0] as string)
-            : undefined;
           const eventDepositAddress = channel
             ? (Object.values(channel.depositAddress)[0] as string)
             : undefined;
           const depositAddressMatches =
-            eventDepositAddress !== undefined &&
-            (eventAddressKind === 'Tron'
-              ? hexToTronAddress(eventDepositAddress as `0x${string}`) === depositAddress
-              : eventDepositAddress === depositAddress);
+            eventDepositAddress !== undefined && eventDepositAddress === depositAddress;
 
           if (
             channel &&


### PR DESCRIPTION
# Pull Request

I don't think the current conversion was doing what was intended. Both `eventDepositAddress` and `eventDepositAddress`  are already in evm format, this means that the conversion
```
hexToTronAddress(eventDepositAddress as `0x${string}`) === depositAddress
```
compared a tron address on the left side with a hex address on the right side.

Since bouncer passes *with* this conversion, this means that possibly the gating condition `eventAddressKind === 'Tron'` was never actually true (maybe it's lower case `'tron'`?).

Anyways since both `eventDepositAddress` and `eventDepositAddress` are in evm hex format it seems to me that there is no need for a tron special-case check.

CI passes now *without* the conversion, so AFAICT we can remove it.