### PR TITLE
feat: Collect outstanding interest on settlement

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/boost.rs
+++ b/state-chain/pallets/cf-lending-pools/src/boost.rs
@@ -347,7 +347,15 @@ impl<T: Config> BoostApi for Pallet<T> {
 				let boost_pool_total = boost_pool_contribution.map_or(0, |c| c.boosted_amount);
 				let lending_repayment = deposit_amount.saturating_sub(boost_pool_total);
 
-				loan.repay_principal(lending_repayment, LoanRepaidActionType::BoostFinalisation);
+				let repaid = {
+					let excess = loan.repay_principal(lending_repayment);
+					lending_repayment.saturating_sub(excess)
+				};
+				Self::deposit_event(Event::LoanRepaid {
+					loan_id,
+					amount: repaid,
+					action_type: LoanRepaidActionType::BoostFinalisation,
+				});
 
 				if loan.owed_principal > 0 {
 					log_or_panic!(

--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -96,6 +96,16 @@ pub struct InterestBreakdown {
 	low_ltv_penalty: ScaledAmountHP,
 }
 
+impl InterestBreakdown {
+	/// The total pending interest across all types.
+	fn total(&self) -> ScaledAmountHP {
+		self.network
+			.saturating_add(self.pool)
+			.saturating_add(self.broker)
+			.saturating_add(self.low_ltv_penalty)
+	}
+}
+
 #[derive(Clone, Copy, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq)]
 pub enum LiquidationCompletionReason {
 	/// Full liquidation (loans are fully repaid and/or all collateral has been swapped)
@@ -969,6 +979,13 @@ impl<T: Config> GeneralLoan<T> {
 		price_cache.usd_value_of(self.asset, self.owed_principal)
 	}
 
+	/// The total amount owed on the loan, in the loan's asset: the principal plus all pending
+	/// interest (whole units only — sub-unit interest remainders are excluded).
+	fn total_owed(&self) -> AssetAmount {
+		self.owed_principal
+			.saturating_add(self.pending_interest.total().into_asset_amount())
+	}
+
 	fn collect_pending_interest(&mut self) {
 		if self
 			.collect_pending_interest_if_above_threshold(None /* no threshold */)
@@ -1085,21 +1102,17 @@ impl<T: Config> GeneralLoan<T> {
 			provided_amount.saturating_sub(liquidation_fee)
 		};
 
-		self.repay_principal(
+		self.repay_principal_and_pending_interest(
 			provided_amount_after_fees,
 			LoanRepaidActionType::Liquidation { swap_request_id },
 		)
 	}
 
-	/// Repays (fully or partially) the loan with `provided_amount` (that was either debited from
-	/// the account or received during liquidation). Returns any unused amount. The caller is
-	/// responsible for making sure that all pending interest has already been collected (via
-	/// [collect_pending_interest]) and that the provided asset is the same as the loan's asset.
-	pub(super) fn repay_principal(
-		&mut self,
-		provided_amount: AssetAmount,
-		action_type: LoanRepaidActionType,
-	) -> AssetAmount {
+	/// Repays (fully or partially) the loan's principal with `provided_amount` (that was either
+	/// debited from the account or received during liquidation). Returns any unused amount. Does
+	/// NOT emit a `LoanRepaid` event — the caller is responsible for that (so several repayment
+	/// steps in one operation can be reported as a single event).
+	pub(super) fn repay_principal(&mut self, provided_amount: AssetAmount) -> AssetAmount {
 		// Making sure the user doesn't pay more than the total principal plus liquidation fee:
 		let repayment_amount = core::cmp::min(provided_amount, self.owed_principal);
 
@@ -1109,15 +1122,36 @@ impl<T: Config> GeneralLoan<T> {
 			});
 
 			self.owed_principal.saturating_reduce(repayment_amount);
+		}
 
+		provided_amount.saturating_sub(repayment_amount)
+	}
+
+	/// Repays the principal and any uncollected interest with `provided_amount`.
+	/// The total amount repaid is reported in a single `LoanRepaid` event. Returns any leftover
+	/// funds.
+	fn repay_principal_and_pending_interest(
+		&mut self,
+		provided_amount: AssetAmount,
+		action_type: LoanRepaidActionType,
+	) -> AssetAmount {
+		// First repayment ensures we have liquidity to collect interest
+		let excess = self.repay_principal(provided_amount);
+		// This "collects" interest by adding it to the owed principal
+		self.collect_pending_interest();
+		// Second repayment covers any outstanding interest
+		let excess = self.repay_principal(excess);
+
+		let repaid = provided_amount.saturating_sub(excess);
+		if repaid > 0 {
 			Pallet::<T>::deposit_event(Event::LoanRepaid {
 				loan_id: self.id,
-				amount: repayment_amount,
+				amount: repaid,
 				action_type,
 			});
 		}
 
-		provided_amount.saturating_sub(repayment_amount)
+		excess
 	}
 
 	#[transactional]
@@ -1626,16 +1660,16 @@ impl<T: Config> LendingApi for Pallet<T> {
 				fail!(Error::<T>::LoanNotFound);
 			};
 
-			loan.collect_pending_interest();
-
 			let config = LendingConfig::<T>::get();
 
 			let loan_asset = loan.asset;
 
+			let total_owed = loan.total_owed();
+
 			let repayment_amount = match repayment_amount {
-				RepaymentAmount::Full => loan.owed_principal,
+				RepaymentAmount::Full => total_owed,
 				RepaymentAmount::Exact(amount) => {
-					if amount < loan.owed_principal {
+					if amount < total_owed {
 						ensure!(
 							price_cache.usd_value_of_allow_stale(loan_asset, amount)? >=
 								config.minimum_update_loan_amount_usd,
@@ -1649,8 +1683,10 @@ impl<T: Config> LendingApi for Pallet<T> {
 
 			T::Balance::try_debit_account(borrower_id, loan_asset, repayment_amount)?;
 
-			let excess_amount =
-				loan.repay_principal(repayment_amount, LoanRepaidActionType::Manual);
+			let excess_amount = loan.repay_principal_and_pending_interest(
+				repayment_amount,
+				LoanRepaidActionType::Manual,
+			);
 
 			if excess_amount > 0 {
 				T::Balance::credit_account(borrower_id, loan_asset, excess_amount);

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -885,6 +885,273 @@ fn broker_fee_collected_after_pool_replenished() {
 		});
 }
 
+/// Interest the pool couldn't collect from its own liquidity (e.g. at full utilisation) is
+/// collected from the borrower's repayment when the loan is closed, rather than being forgiven.
+#[test]
+fn pending_interest_settled_from_repayment_on_close() {
+	use cf_primitives::{Beneficiary, BASIS_POINTS_PER_MILLION};
+
+	const PRINCIPAL: AssetAmount = 2_000_000_000_000;
+	const INIT_COLLATERAL: AssetAmount = (4 * PRINCIPAL / 3) * SWAP_RATE;
+	const ORIGINATION_FEE: AssetAmount = portion_of_amount(DEFAULT_ORIGINATION_FEE, PRINCIPAL);
+
+	const BROKER: u64 = 999;
+	const BROKER_BPS: u16 = 100; // 1% per year
+
+	let (origination_fee_network, _) = take_network_fee(ORIGINATION_FEE);
+
+	// Fund the pool with exactly the principal plus the network portion of the origination fee, so
+	// drawing the loan leaves zero available liquidity (100% utilisation) and the pool can't
+	// collect the network/broker interest as it accrues.
+	let init_pool_amount = PRINCIPAL + origination_fee_network;
+
+	// Interest accrued over interval 1, left pending because the pool can't collect it. The base
+	// for both is the loan's initial owed principal, `PRINCIPAL + ORIGINATION_FEE`.
+	let interest_base = ScaledAmountHP::from_asset_amount(PRINCIPAL + ORIGINATION_FEE);
+	let network_interest_scaled = interest_base *
+		CONFIG.derive_network_interest_rate_per_payment_interval(
+			CONFIG.interest_payment_interval_blocks,
+		);
+	let broker_interest_scaled = interest_base *
+		CONFIG.interest_per_year_to_per_payment_interval(
+			Permill::from_parts(BROKER_BPS as u32 * BASIS_POINTS_PER_MILLION),
+			CONFIG.interest_payment_interval_blocks,
+		);
+
+	let expected_network_interest = network_interest_scaled.into_asset_amount();
+	let expected_broker_interest = broker_interest_scaled.into_asset_amount();
+	assert!(
+		expected_network_interest > 0 && expected_broker_interest > 0,
+		"interest amounts must be non-zero for the test"
+	);
+
+	let first_interest_payment_block = INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64;
+
+	new_test_ext()
+		.with_funded_pool(init_pool_amount)
+		.then_execute_with(|_| {
+			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
+			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
+			register_as_broker(&BROKER);
+
+			assert_ok!(LendingPools::new_lending_pool(COLLATERAL_ASSET));
+			assert_ok!(supply_funds::<Test>(
+				BORROWER,
+				COLLATERAL_ASSET,
+				INIT_COLLATERAL,
+				SupplyAddedActionType::Manual,
+			));
+
+			assert_ok!(LendingPools::new_loan(
+				BORROWER,
+				LOAN_ASSET,
+				PRINCIPAL,
+				Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
+			));
+
+			// The pool is fully utilised, and only the network portion of the origination fee has
+			// been collected so far.
+			assert_eq!(GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount, 0);
+			assert_eq!(PendingNetworkFees::<Test>::get(LOAN_ASSET), origination_fee_network);
+		})
+		.then_process_blocks_until_block(first_interest_payment_block)
+		.then_execute_with(|_| {
+			let loan = LoanAccounts::<Test>::get(BORROWER).unwrap().loans[&LOAN_ID].clone();
+
+			// The network and broker interest for interval 1 is still pending (the pool had nothing
+			// to collect it with) and neither beneficiary has been paid yet.
+			assert_eq!(MockBalance::get_balance(&BROKER, LOAN_ASSET), 0);
+			assert_eq!(loan.pending_interest.network, network_interest_scaled);
+			assert_eq!(loan.pending_interest.broker, broker_interest_scaled);
+
+			// A full repayment now requires the principal plus all outstanding interest.
+			let total_to_repay = loan.total_owed();
+
+			let borrower_balance_before = MockBalance::get_balance(&BORROWER, LOAN_ASSET);
+			MockBalance::credit_account(&BORROWER, LOAN_ASSET, total_to_repay);
+
+			// Captured before the repayment because pending network fees are periodically swept.
+			let network_fees_before = PendingNetworkFees::<Test>::get(LOAN_ASSET);
+
+			System::reset_events();
+
+			assert_ok!(LendingPools::try_making_repayment(
+				&BORROWER,
+				LOAN_ID,
+				RepaymentAmount::Full
+			));
+
+			// The outstanding network and broker interest is collected and paid (rather than
+			// forgiven), and reported via an InterestTaken event:
+			assert_eq!(MockBalance::get_balance(&BROKER, LOAN_ASSET), expected_broker_interest);
+			assert_eq!(
+				PendingNetworkFees::<Test>::get(LOAN_ASSET),
+				network_fees_before + expected_network_interest
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::LendingPools(Event::<Test>::InterestTaken {
+					loan_id: LOAN_ID,
+					network_interest,
+					broker_interest,
+					..
+				}) if *network_interest == expected_network_interest &&
+					*broker_interest == expected_broker_interest,
+			);
+
+			// The interest was rolled into the principal and repaid; the whole repayment (principal
+			// plus the freshly collected interest) is reported in a single LoanRepaid event.
+			assert_matching_event_count!(
+				Test,
+				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid { .. }) => 1
+			);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::LendingPools(Event::<Test>::LoanRepaid {
+					loan_id: LOAN_ID,
+					amount,
+					action_type: LoanRepaidActionType::Manual,
+				}) if *amount ==
+					loan.owed_principal + expected_network_interest + expected_broker_interest,
+			);
+
+			// The loan is fully settled with no write-off:
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::LendingPools(Event::<Test>::LoanSettled {
+					loan_id: LOAN_ID,
+					outstanding_principal: 0,
+					..
+				}),
+			);
+			assert_eq!(LoanAccounts::<Test>::get(BORROWER), None);
+
+			// The borrower funded the principal and interest; `total_owed` floors the summed
+			// interest while collection floors each component, so any sub-unit dust is refunded.
+			let interest_dust = total_to_repay -
+				loan.owed_principal -
+				expected_network_interest -
+				expected_broker_interest;
+			assert_eq!(
+				MockBalance::get_balance(&BORROWER, LOAN_ASSET),
+				borrower_balance_before + interest_dust
+			);
+
+			// The pool is whole again: all principal repaid, nothing written off.
+			let pool = GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap();
+			assert_eq!(pool.available_amount, pool.total_amount);
+		});
+}
+
+/// Interest the pool couldn't collect (e.g. at full utilisation) is also paid from the liquidation
+/// proceeds when a loan is closed via liquidation, rather than being forgiven.
+#[test]
+fn pending_interest_settled_when_loan_liquidated() {
+	use cf_primitives::{Beneficiary, BASIS_POINTS_PER_MILLION};
+
+	const PRINCIPAL: AssetAmount = 2_000_000_000_000;
+	const INIT_COLLATERAL: AssetAmount = (4 * PRINCIPAL / 3) * SWAP_RATE; // 75% LTV
+	const ORIGINATION_FEE: AssetAmount = portion_of_amount(DEFAULT_ORIGINATION_FEE, PRINCIPAL);
+
+	const BROKER: u64 = 999;
+	const BROKER_BPS: u16 = 100; // 1% per year
+
+	// Doubling the loan asset price pushes the LTV well past the hard-liquidation threshold.
+	const NEW_SWAP_RATE: u128 = SWAP_RATE * 2;
+	// More than enough recovered loan asset to cover principal, fee and interest in full.
+	const RECOVERED: AssetAmount = PRINCIPAL + PRINCIPAL / 10;
+	const REMAINING_COLLATERAL: AssetAmount = INIT_COLLATERAL / 10;
+
+	let (origination_fee_network, _) = take_network_fee(ORIGINATION_FEE);
+
+	// 100% utilisation after the loan is drawn, so the pool can't collect the broker interest.
+	let init_pool_amount = PRINCIPAL + origination_fee_network;
+
+	let expected_broker_interest =
+		(ScaledAmountHP::from_asset_amount(PRINCIPAL + ORIGINATION_FEE) *
+			CONFIG.interest_per_year_to_per_payment_interval(
+				Permill::from_parts(BROKER_BPS as u32 * BASIS_POINTS_PER_MILLION),
+				CONFIG.interest_payment_interval_blocks,
+			))
+		.into_asset_amount();
+	assert!(expected_broker_interest > 0, "broker interest must be non-zero for the test");
+
+	let first_interest_payment_block = INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64;
+
+	new_test_ext()
+		.with_funded_pool(init_pool_amount)
+		.then_execute_with(|_| {
+			MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
+			MockLpRegistration::register_refund_address(BORROWER, LOAN_CHAIN);
+			register_as_broker(&BROKER);
+
+			assert_ok!(LendingPools::new_lending_pool(COLLATERAL_ASSET));
+			assert_ok!(supply_funds::<Test>(
+				BORROWER,
+				COLLATERAL_ASSET,
+				INIT_COLLATERAL,
+				SupplyAddedActionType::Manual,
+			));
+			assert_ok!(LendingPools::new_loan(
+				BORROWER,
+				LOAN_ASSET,
+				PRINCIPAL,
+				Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
+			));
+
+			assert_eq!(GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount, 0);
+		})
+		.then_process_blocks_until_block(first_interest_payment_block)
+		.then_execute_with(|_| {
+			// Broker interest accrued over interval 1 is pending (the pool couldn't collect it).
+			assert_eq!(MockBalance::get_balance(&BROKER, LOAN_ASSET), 0);
+			assert_eq!(
+				LoanAccounts::<Test>::get(BORROWER).unwrap().loans[&LOAN_ID]
+					.pending_interest
+					.broker
+					.into_asset_amount(),
+				expected_broker_interest
+			);
+
+			// Push the loan into liquidation.
+			MockPriceFeedApi::set_price_usd_fine(LOAN_ASSET, NEW_SWAP_RATE);
+		})
+		.then_execute_at_next_block(|_| {
+			// Read the liquidation swap id directly (a network-fee swap may have taken earlier
+			// ids).
+			let liquidation_swap_id =
+				match &LoanAccounts::<Test>::get(BORROWER).unwrap().liquidation_status {
+					LiquidationStatus::Liquidating { liquidation_swaps, .. } =>
+						*liquidation_swaps.keys().next().expect("a liquidation swap"),
+					other => panic!("expected liquidating, got {:?}", other),
+				};
+
+			// Simulate the liquidation swap producing more than enough loan asset to fully repay
+			// the loan; the swap is aborted and the loan settled at the next block.
+			MockSwapRequestHandler::<Test>::set_swap_request_progress(
+				liquidation_swap_id,
+				SwapExecutionProgress {
+					remaining_input_amount: REMAINING_COLLATERAL,
+					accumulated_output_amount: RECOVERED,
+				},
+			);
+		})
+		.then_execute_at_next_block(|_| {
+			// The broker interest is paid from the liquidation proceeds (not forgiven), and the
+			// loan is settled with no write-off.
+			assert_eq!(MockBalance::get_balance(&BROKER, LOAN_ASSET), expected_broker_interest);
+			assert_has_matching_event!(
+				Test,
+				RuntimeEvent::LendingPools(Event::<Test>::LoanSettled {
+					loan_id: LOAN_ID,
+					outstanding_principal: 0,
+					via_liquidation: true,
+				}),
+			);
+			assert_eq!(LoanAccounts::<Test>::get(BORROWER), None);
+		});
+}
+
 mod broker_fees {
 
 	use super::*;


### PR DESCRIPTION
# Pull Request

Closes: PRO-2931

## Summary

Changed loan repayment logic (both manual and via liquidation) to use provided funds for interest payment directly rather than relying on pool's available liquidity (which may not be sufficient right before the repayment).

I tried a few approaches and the cleanest way seems to be to call `repay_principal` twice: one before interest collection (to cover the principal fund the pool) and one time after (to cover the interest). Moved the `LoanRepaid` event outside so that we don't introduce unwanted side effects like emitting the event twice.

## *Checklist*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
