### PR TITLE
fix: emit log message when order fills fails to decode

### DIFF
--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -1488,6 +1488,20 @@ where
 		self.with_state_backend(hash, || M::iter().collect::<I>())
 	}
 
+	/// Like [`Self::collect_from_storage_map`], but collects only the keys. Useful when the values
+	/// may fail to decode (e.g. across a storage-layout change) but the keys are still needed.
+	pub fn collect_keys_from_storage_map<
+		M: frame_support::storage::IterableStorageMap<K, V> + 'static,
+		K: codec::FullEncode + codec::Decode,
+		V: codec::FullCodec,
+		I: FromIterator<K>,
+	>(
+		&self,
+		hash: <B as BlockT>::Hash,
+	) -> RpcResult<I> {
+		self.with_state_backend(hash, || M::iter_keys().collect::<I>())
+	}
+
 	/// Execute a function that requires access to the state backend externalities environment.
 	///
 	/// Note that anything that requires access to the state backend should be executed within this

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -58,6 +58,35 @@ where
 	let prev_pools = StorageQueryApi::new(client)
 		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(header.parent_hash)?;
 
+	// Pools present now but missing from the previous block can't yield a fill delta, so they're
+	// skipped below. Log why rather than dropping them silently: across a runtime upgrade the
+	// parent block's pool storage may not decode under the current `Pool` type.
+	let missing_prev_pools =
+		pools.keys().filter(|pair| !prev_pools.contains_key(*pair)).copied().collect::<Vec<_>>();
+	if !missing_prev_pools.is_empty() {
+		// Key present in the parent but value missing from `prev_pools` => decode failure;
+		// key absent => pool newly created. Only scan keys in this rare branch.
+		let prev_pool_keys = StorageQueryApi::new(client)
+			.collect_keys_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, HashSet<_>>(
+				header.parent_hash,
+			)?;
+		for pair in missing_prev_pools {
+			if prev_pool_keys.contains(&pair) {
+				log::warn!(
+					"order_fills: previous pool state for {pair:?} failed to decode at block #{} \
+					 ({hash:?}); skipping its order fills for this block.",
+					header.number,
+				);
+			} else {
+				log::debug!(
+					"order_fills: pool {pair:?} newly created at block #{}; no previous state, \
+					 skipping its order fills.",
+					header.number,
+				);
+			}
+		}
+	}
+
 	let lp_events = client.runtime_api().cf_lp_events(hash).map_err(CfApiError::from)?;
 
 	Ok(BlockUpdate::<OrderFills> {

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -61,8 +61,11 @@ where
 	// Pools present now but missing from the previous block can't yield a fill delta, so they're
 	// skipped below. Log why rather than dropping them silently: across a runtime upgrade the
 	// parent block's pool storage may not decode under the current `Pool` type.
-	let missing_prev_pools =
-		pools.keys().filter(|pair| !prev_pools.contains_key(*pair)).copied().collect::<Vec<_>>();
+	let missing_prev_pools = pools
+		.keys()
+		.filter(|pair| !prev_pools.contains_key(*pair))
+		.copied()
+		.collect::<Vec<_>>();
 	if !missing_prev_pools.is_empty() {
 		// Key present in the parent but value missing from `prev_pools` => decode failure;
 		// key absent => pool newly created. Only scan keys in this rare branch.
@@ -78,6 +81,8 @@ where
 					header.number,
 				);
 			} else {
+				// This should be almost impossible: requires creating the pool, adding and
+				// executing an order all within the same block.
 				log::debug!(
 					"order_fills: pool {pair:?} newly created at block #{}; no previous state, \
 					 skipping its order fills.",

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -52,11 +52,11 @@ where
 			internal_error(format!("Could not fetch block header for block {:?}", hash))
 		})?;
 
-	let pools = StorageQueryApi::new(client)
-		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(hash)?;
+	let pools: BTreeMap<_, _> = StorageQueryApi::new(client)
+		.collect_from_storage_map::<pallet_cf_pools::Pools<Runtime>, _, _, _>(hash)?;
 
-	let prev_pools = StorageQueryApi::new(client)
-		.collect_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, _>(header.parent_hash)?;
+	let prev_pools: BTreeMap<_, _> = StorageQueryApi::new(client)
+		.collect_from_storage_map::<pallet_cf_pools::Pools<Runtime>, _, _, _>(header.parent_hash)?;
 
 	// Pools present now but missing from the previous block can't yield a fill delta, so they're
 	// skipped below. Log why rather than dropping them silently: across a runtime upgrade the
@@ -70,7 +70,7 @@ where
 		// Key present in the parent but value missing from `prev_pools` => decode failure;
 		// key absent => pool newly created. Only scan keys in this rare branch.
 		let prev_pool_keys = StorageQueryApi::new(client)
-			.collect_keys_from_storage_map::<pallet_cf_pools::Pools<_>, _, _, HashSet<_>>(
+			.collect_keys_from_storage_map::<pallet_cf_pools::Pools<Runtime>, _, _, HashSet<_>>(
 				header.parent_hash,
 			)?;
 		for pair in missing_prev_pools {

--- a/state-chain/custom-rpc/src/order_fills.rs
+++ b/state-chain/custom-rpc/src/order_fills.rs
@@ -61,19 +61,19 @@ where
 	// Pools present now but missing from the previous block can't yield a fill delta, so they're
 	// skipped below. Log why rather than dropping them silently: across a runtime upgrade the
 	// parent block's pool storage may not decode under the current `Pool` type.
-	let missing_prev_pools = pools
+	let new_or_undecodable_pools = pools
 		.keys()
 		.filter(|pair| !prev_pools.contains_key(*pair))
 		.copied()
 		.collect::<Vec<_>>();
-	if !missing_prev_pools.is_empty() {
+	if !new_or_undecodable_pools.is_empty() {
 		// Key present in the parent but value missing from `prev_pools` => decode failure;
 		// key absent => pool newly created. Only scan keys in this rare branch.
 		let prev_pool_keys = StorageQueryApi::new(client)
 			.collect_keys_from_storage_map::<pallet_cf_pools::Pools<Runtime>, _, _, HashSet<_>>(
 				header.parent_hash,
 			)?;
-		for pair in missing_prev_pools {
+		for pair in new_or_undecodable_pools {
 			if prev_pool_keys.contains(&pair) {
 				log::warn!(
 					"order_fills: previous pool state for {pair:?} failed to decode at block #{} \
@@ -81,13 +81,10 @@ where
 					header.number,
 				);
 			} else {
-				// This should be almost impossible: requires creating the pool, adding and
-				// executing an order all within the same block.
-				log::debug!(
-					"order_fills: pool {pair:?} newly created at block #{}; no previous state, \
-					 skipping its order fills.",
-					header.number,
-				);
+				// Strictly speaking it might be logically possible that there are fills in the
+				// first block of a pool's existence, but is so unlikely that we can assume it won't
+				// happen in practice.
+				log::info!("order_fills: pool {pair:?} newly created at block #{}.", header.number,);
 			}
 		}
 	}


### PR DESCRIPTION
# Pull Request

This caused some confusion recently - the behaviour is ok but we should log a message when it happens. 