### PR TITLE
fix: apply message size limits in p2p protocol

### DIFF
--- a/engine/multisig/src/client/ceremony_manager.rs
+++ b/engine/multisig/src/client/ceremony_manager.rs
@@ -26,7 +26,7 @@ use std::{
 	marker::PhantomData,
 	sync::Arc,
 };
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, Receiver, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, info_span, trace, warn, Instrument};
 
 use crate::{
@@ -445,7 +445,7 @@ impl<Chain: ChainSigning> CeremonyManager<Chain> {
 	pub async fn run(
 		mut self,
 		mut ceremony_request_receiver: UnboundedReceiver<CeremonyRequest<Chain::CryptoScheme>>,
-		mut incoming_p2p_message_receiver: UnboundedReceiver<(AccountId, VersionedCeremonyMessage)>,
+		mut incoming_p2p_message_receiver: Receiver<(AccountId, VersionedCeremonyMessage)>,
 	) -> Result<()> {
 		task_scope(|scope| {
 			async {

--- a/engine/multisig/src/client/ceremony_manager/tests.rs
+++ b/engine/multisig/src/client/ceremony_manager/tests.rs
@@ -129,11 +129,11 @@ fn spawn_ceremony_manager<Chain: ChainSigning>(
 	latest_ceremony_id: CeremonyId,
 ) -> (
 	mpsc::UnboundedSender<CeremonyRequest<Chain::CryptoScheme>>,
-	mpsc::UnboundedSender<(AccountId32, VersionedCeremonyMessage)>,
+	mpsc::Sender<(AccountId32, VersionedCeremonyMessage)>,
 	mpsc::UnboundedReceiver<OutgoingMultisigStageMessages>,
 ) {
 	let (ceremony_request_sender, ceremony_request_receiver) = mpsc::unbounded_channel();
-	let (incoming_p2p_sender, incoming_p2p_receiver) = mpsc::unbounded_channel();
+	let (incoming_p2p_sender, incoming_p2p_receiver) = mpsc::channel(100);
 	let (outgoing_p2p_sender, outgoing_p2p_receiver) = mpsc::unbounded_channel();
 	let ceremony_manager =
 		CeremonyManager::<Chain>::new(our_account_id, outgoing_p2p_sender, latest_ceremony_id);
@@ -343,8 +343,7 @@ async fn should_cleanup_unauthorised_ceremony_if_not_participating() {
 			let our_account_id = ACCOUNT_IDS[0].clone();
 
 			// Create a ceremony manager but don't run it yet
-			let (_incoming_p2p_sender, incoming_p2p_receiver) =
-				tokio::sync::mpsc::unbounded_channel();
+			let (_incoming_p2p_sender, incoming_p2p_receiver) = tokio::sync::mpsc::channel(100);
 			let (ceremony_request_sender, ceremony_request_receiver) =
 				tokio::sync::mpsc::unbounded_channel();
 			let (outgoing_p2p_sender, _outgoing_p2p_receiver) =
@@ -462,6 +461,7 @@ async fn should_route_p2p_message() {
 			sender_account_id,
 			VersionedCeremonyMessage { version: CURRENT_PROTOCOL_VERSION, payload },
 		))
+		.await
 		.unwrap();
 
 	// Small delay to let the ceremony manager process the message

--- a/engine/p2p/src/core.rs
+++ b/engine/p2p/src/core.rs
@@ -51,7 +51,10 @@ use monitor::MonitorEvent;
 
 use crate::{EdPublicKey, OutgoingMultisigStageMessages, P2PKey, XPublicKey};
 
-use socket::{ConnectedOutgoingSocket, OutgoingSocket, RECONNECT_INTERVAL, RECONNECT_INTERVAL_MAX};
+use socket::{
+	ConnectedOutgoingSocket, OutgoingSocket, INCOMING_MESSAGES_BUFFER_SIZE, MAX_MESSAGE_SIZE,
+	RECONNECT_INTERVAL, RECONNECT_INTERVAL_MAX,
+};
 
 /// How long to keep the TCP connection open for while waiting
 /// for the client to authenticate themselves. We want to keep
@@ -628,6 +631,12 @@ impl P2PContext {
 		socket.set_curve_server(true).unwrap();
 		socket.set_curve_secretkey(&self.key.secret_key.to_bytes()).unwrap();
 		socket.set_handshake_ivl(HANDSHAKE_TIMEOUT.as_millis() as i32).unwrap();
+
+		// Disconnect any peer that sends a message larger than this. This mirrors the
+		// cap applied to outgoing DEALER sockets and bounds a single inbound allocation.
+		socket.set_maxmsgsize(MAX_MESSAGE_SIZE).unwrap();
+		// Bound how many messages ZMQ buffers per peer before dropping further input.
+		socket.set_rcvhwm(INCOMING_MESSAGES_BUFFER_SIZE).unwrap();
 
 		// Listen on all interfaces
 		let endpoint = format!("tcp://0.0.0.0:{port}");

--- a/engine/p2p/src/core.rs
+++ b/engine/p2p/src/core.rs
@@ -43,6 +43,8 @@ use cf_utilities::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use crate::fair_channel::{fair_channel, FairReceiver, FairSender, FairSendError};
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 use x25519_dalek::StaticSecret;
 
@@ -67,6 +69,15 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
 pub const MAX_INACTIVITY_THRESHOLD: Duration = Duration::from_secs(60 * 60);
 /// How often to check for "stale" connections
 pub const ACTIVITY_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Per-peer in-flight message limit for the incoming-path channels between the
+/// listening thread, the control loop and the muxer. These stages have fast
+/// consumers and stay near-empty in normal operation (~1 message per peer), so
+/// this allowance comfortably absorbs bursts from concurrent ceremonies while
+/// ensuring a single flooding peer can only ever fill its own slots and never
+/// crowd out honest peers. Messages over the limit are dropped rather than
+/// blocking.
+pub const INCOMING_MESSAGE_PER_PEER_LIMIT: usize = 100;
 
 #[derive(Clone)]
 pub struct X25519KeyPair {
@@ -268,7 +279,7 @@ struct P2PContext {
 	/// NOTE: we don't use BTreeMap here because XPublicKey doesn't implement Ord.
 	x25519_to_account_id: HashMap<XPublicKey, AccountId>,
 	/// Channel through which we send incoming messages to the multisig
-	incoming_message_sender: UnboundedSender<(AccountId, Vec<u8>)>,
+	incoming_message_sender: FairSender<AccountId, Vec<u8>>,
 	reconnect_context: ReconnectContext,
 	/// This is how we communicate with the "monitor" thread
 	monitor_handle: monitor::MonitorHandle,
@@ -295,7 +306,7 @@ pub async fn start(
 	port: Port,
 	current_peers: Vec<PeerInfo>,
 	our_account_id: AccountId,
-	incoming_message_sender: UnboundedSender<(AccountId, Vec<u8>)>,
+	incoming_message_sender: FairSender<AccountId, Vec<u8>>,
 	outgoing_message_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
 	peer_update_receiver: UnboundedReceiver<PeerUpdate>,
 ) -> anyhow::Result<()> {
@@ -354,7 +365,7 @@ impl P2PContext {
 	async fn control_loop(
 		mut self,
 		mut outgoing_message_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
-		mut incoming_message_receiver: UnboundedReceiver<(XPublicKey, Vec<u8>)>,
+		mut incoming_message_receiver: FairReceiver<XPublicKey, Vec<u8>>,
 		mut peer_update_receiver: UnboundedReceiver<PeerUpdate>,
 		mut monitor_event_receiver: UnboundedReceiver<MonitorEvent>,
 		mut reconnect_receiver: UnboundedReceiver<AccountId>,
@@ -446,7 +457,17 @@ impl P2PContext {
 	fn forward_incoming_message(&mut self, pubkey: XPublicKey, payload: Vec<u8>) {
 		if let Some(acc_id) = self.x25519_to_account_id.get(&pubkey) {
 			trace!("Received a message from {acc_id}");
-			self.incoming_message_sender.send((acc_id.clone(), payload)).unwrap();
+			// Drop rather than block the control loop. A peer over its in-flight
+			// limit can only crowd out its own messages.
+			match self.incoming_message_sender.try_send(acc_id.clone(), payload) {
+				Ok(()) => {},
+				Err(FairSendError::PeerQuotaExceeded) => {
+					P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
+					warn!("Dropping incoming p2p message from {acc_id}: over its in-flight limit");
+				},
+				// The receiver is dropped only when we are shutting down.
+				Err(FairSendError::Closed) => {},
+			}
 		} else {
 			P2P_BAD_MSG.inc(&["unknown_x25519_key"]);
 			warn!("Received a message for an unknown x25519 key: {}", pk_to_string(&pubkey));
@@ -623,7 +644,7 @@ impl P2PContext {
 	fn start_listening_thread(
 		&mut self,
 		port: Port,
-	) -> anyhow::Result<UnboundedReceiver<(XPublicKey, Vec<u8>)>> {
+	) -> anyhow::Result<FairReceiver<XPublicKey, Vec<u8>>> {
 		let socket = self.zmq_context.socket(zmq::SocketType::ROUTER).unwrap();
 
 		socket.set_router_mandatory(true).unwrap();
@@ -654,7 +675,7 @@ impl P2PContext {
 		info!("Started listening for incoming p2p connections on: {endpoint}");
 
 		let (incoming_message_sender, incoming_message_receiver) =
-			tokio::sync::mpsc::unbounded_channel();
+			fair_channel(INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 		let stop_thread = self.stop_thread.clone();
 
@@ -691,7 +712,20 @@ impl P2PContext {
 				let pubkey: [u8; 32] = hex::decode(pubkey).unwrap().try_into().unwrap();
 				let pubkey = XPublicKey::from(pubkey);
 
-				incoming_message_sender.send((pubkey, msg.to_vec())).unwrap();
+				// Drop the message rather than block the listening thread. A peer
+				// over its in-flight limit can only crowd out its own messages; a
+				// `Closed` error just means we are shutting down.
+				match incoming_message_sender.try_send(pubkey, msg.to_vec()) {
+					Ok(()) => {},
+					Err(FairSendError::PeerQuotaExceeded) => {
+						P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
+						warn!(
+							"Dropping incoming p2p message: sender {} is over its in-flight limit",
+							pk_to_string(&pubkey),
+						);
+					},
+					Err(FairSendError::Closed) => {},
+				}
 			} else {
 				P2P_BAD_MSG.inc(&["bad_number_of_parts"]);
 				warn!(

--- a/engine/p2p/src/core.rs
+++ b/engine/p2p/src/core.rs
@@ -44,7 +44,7 @@ use cf_utilities::{
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use crate::fair_channel::{fair_channel, FairReceiver, FairSender, FairSendError};
+use crate::fair_channel::{fair_channel, FairReceiver, FairSender};
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 use x25519_dalek::StaticSecret;
 
@@ -459,15 +459,10 @@ impl P2PContext {
 			trace!("Received a message from {acc_id}");
 			// Drop rather than block the control loop. A peer over its in-flight
 			// limit can only crowd out its own messages.
-			match self.incoming_message_sender.try_send(acc_id.clone(), payload) {
-				Ok(()) => {},
-				Err(FairSendError::PeerQuotaExceeded) => {
-					P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
-					warn!("Dropping incoming p2p message from {acc_id}: over its in-flight limit");
-				},
-				// The receiver is dropped only when we are shutting down.
-				Err(FairSendError::Closed) => {},
-			}
+			self.incoming_message_sender.try_send_or_drop(acc_id.clone(), payload, || {
+				P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
+				warn!("Dropping incoming p2p message from {acc_id}: over its in-flight limit");
+			});
 		} else {
 			P2P_BAD_MSG.inc(&["unknown_x25519_key"]);
 			warn!("Received a message for an unknown x25519 key: {}", pk_to_string(&pubkey));
@@ -715,17 +710,13 @@ impl P2PContext {
 				// Drop the message rather than block the listening thread. A peer
 				// over its in-flight limit can only crowd out its own messages; a
 				// `Closed` error just means we are shutting down.
-				match incoming_message_sender.try_send(pubkey, msg.to_vec()) {
-					Ok(()) => {},
-					Err(FairSendError::PeerQuotaExceeded) => {
-						P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
-						warn!(
-							"Dropping incoming p2p message: sender {} is over its in-flight limit",
-							pk_to_string(&pubkey),
-						);
-					},
-					Err(FairSendError::Closed) => {},
-				}
+				incoming_message_sender.try_send_or_drop(pubkey, msg.to_vec(), || {
+					P2P_BAD_MSG.inc(&["incoming_per_peer_limit"]);
+					warn!(
+						"Dropping incoming p2p message: sender {} is over its in-flight limit",
+						pk_to_string(&pubkey),
+					);
+				});
 			} else {
 				P2P_BAD_MSG.inc(&["bad_number_of_parts"]);
 				warn!(

--- a/engine/p2p/src/core/socket.rs
+++ b/engine/p2p/src/core/socket.rs
@@ -29,7 +29,13 @@ pub const RECONNECT_INTERVAL_MAX: Duration = Duration::from_secs(30);
 /// Maximum incoming message size: if a remote tries sending a message larger than
 /// this they get disconnected (TODO: make sure this is slightly more that the
 /// theoretical maximum needed for multisig; 2MB is a conservative estimate.)
-const MAX_MESSAGE_SIZE: i64 = 2 * 1024 * 1024;
+pub(crate) const MAX_MESSAGE_SIZE: i64 = 2 * 1024 * 1024;
+
+/// Receive high-water mark for the incoming (ROUTER) socket. ZMQ buffers at most
+/// this many messages *per connected peer* before dropping further incoming
+/// messages from that peer. This bounds the memory ZMQ itself holds while our
+/// receive thread is busy (e.g. blocked on a full downstream queue).
+pub(crate) const INCOMING_MESSAGES_BUFFER_SIZE: i32 = 250;
 
 /// How often should ZMQ send heartbeat messages in order to detect
 /// dead connections sooner (setting this to 0 disables heartbeats)

--- a/engine/p2p/src/core/tests.rs
+++ b/engine/p2p/src/core/tests.rs
@@ -17,15 +17,13 @@
 use super::{PeerInfo, PeerUpdate};
 use crate::{
 	core::{ACTIVITY_CHECK_INTERVAL, MAX_INACTIVITY_THRESHOLD},
+	fair_channel::{fair_channel, FairReceiver},
 	OutgoingMultisigStageMessages, P2PKey,
 };
 use cf_primitives::AccountId;
-use cf_utilities::{
-	testing::{expect_recv_with_timeout, recv_with_custom_timeout},
-	Port,
-};
+use cf_utilities::Port;
 use sp_core::ed25519::Public;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::{info_span, Instrument};
 
 fn create_node_info(id: AccountId, node_key: &ed25519_dalek::SigningKey, port: Port) -> PeerInfo {
@@ -46,7 +44,15 @@ struct Node {
 	account_id: AccountId,
 	msg_sender: UnboundedSender<OutgoingMultisigStageMessages>,
 	peer_update_sender: UnboundedSender<PeerUpdate>,
-	msg_receiver: UnboundedReceiver<(AccountId, Vec<u8>)>,
+	msg_receiver: FairReceiver<AccountId, Vec<u8>>,
+}
+
+/// Receive the next message from a node's incoming channel, or `None` on timeout.
+async fn recv_from_node(
+	receiver: &mut FairReceiver<AccountId, Vec<u8>>,
+	timeout: Duration,
+) -> Option<(AccountId, Vec<u8>)> {
+	tokio::time::timeout(timeout, receiver.recv()).await.ok().flatten()
 }
 
 fn spawn_node(
@@ -58,7 +64,7 @@ fn spawn_node(
 	let account_id = AccountId::new([idx as u8 + 1; 32]);
 
 	let (incoming_message_sender, incoming_message_receiver) =
-		tokio::sync::mpsc::unbounded_channel();
+		fair_channel(super::INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 	let (outgoing_message_sender, outgoing_message_receiver) =
 		tokio::sync::mpsc::unbounded_channel();
@@ -148,7 +154,9 @@ async fn connect_two_nodes() {
 		)]))
 		.unwrap();
 
-	let _ = expect_recv_with_timeout(&mut node2.msg_receiver).await;
+	recv_from_node(&mut node2.msg_receiver, MAX_CONNECTION_DELAY)
+		.await
+		.expect("timed out waiting for message");
 }
 
 async fn send_and_receive_message(from: &Node, to: &mut Node) -> Option<(AccountId, Vec<u8>)> {
@@ -159,7 +167,7 @@ async fn send_and_receive_message(from: &Node, to: &mut Node) -> Option<(Account
 		)]))
 		.unwrap();
 
-	recv_with_custom_timeout(&mut to.msg_receiver, MAX_CONNECTION_DELAY).await
+	recv_from_node(&mut to.msg_receiver, MAX_CONNECTION_DELAY).await
 }
 
 #[tokio::test]

--- a/engine/p2p/src/fair_channel.rs
+++ b/engine/p2p/src/fair_channel.rs
@@ -73,11 +73,23 @@ impl<K: Eq + Hash + Clone, T> FairSender<K, T> {
 	pub fn try_send(&self, key: K, value: T) -> Result<(), FairSendError> {
 		{
 			let mut counts = self.counts.lock().unwrap();
-			let in_flight = counts.entry(key.clone()).or_insert(0);
-			if *in_flight >= self.per_peer_capacity {
-				return Err(FairSendError::PeerQuotaExceeded);
+			// Check the quota without cloning the key, so the over-limit drop
+			// path (the adversarial flood case) does no work beyond a lookup.
+			// Only a peer's *first* in-flight message has to insert (and so
+			// clone) a key.
+			match counts.get_mut(&key) {
+				Some(in_flight) => {
+					if *in_flight >= self.per_peer_capacity {
+						return Err(FairSendError::PeerQuotaExceeded);
+					}
+					*in_flight += 1;
+				},
+				// `per_peer_capacity` is always >= 1, so a peer's first
+				// in-flight message is always within quota.
+				None => {
+					counts.insert(key.clone(), 1);
+				},
 			}
-			*in_flight += 1;
 		}
 		// A leaked count here is harmless: `Closed` only happens once the
 		// receiver is gone, i.e. the whole channel is being torn down.

--- a/engine/p2p/src/fair_channel.rs
+++ b/engine/p2p/src/fair_channel.rs
@@ -95,6 +95,15 @@ impl<K: Eq + Hash + Clone, T> FairSender<K, T> {
 		// receiver is gone, i.e. the whole channel is being torn down.
 		self.sender.send((key, value)).map_err(|_| FairSendError::Closed)
 	}
+
+	/// Send a message attributed to peer `key`, running `on_dropped` if the
+	/// peer is over its in-flight limit.
+	pub fn try_send_or_drop(&self, key: K, value: T, on_dropped: impl FnOnce()) {
+		match self.try_send(key, value) {
+			Ok(()) | Err(FairSendError::Closed) => {},
+			Err(FairSendError::PeerQuotaExceeded) => on_dropped(),
+		}
+	}
 }
 
 /// Receiving half of a [`fair_channel`].

--- a/engine/p2p/src/fair_channel.rs
+++ b/engine/p2p/src/fair_channel.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! A multi-producer, single-consumer channel that bounds the number of
+//! in-flight messages *per sender identity* rather than globally.
+//!
+//! Each message is attributed to the identity (`K`) of the peer it came from.
+//! A peer may have at most `per_peer_capacity` messages in flight (sent but
+//! not yet received) at once; once it reaches that limit, further messages
+//! from *that peer* are dropped while other peers are unaffected. This stops a
+//! single flooding peer from crowding honest peers out of a shared queue.
+
+use std::{
+	collections::HashMap,
+	hash::Hash,
+	sync::{Arc, Mutex},
+};
+
+use tokio::sync::mpsc;
+
+/// Per-peer count of messages currently in flight (sent but not yet received),
+/// shared between the sender and the receiver.
+type InFlightCounts<K> = Arc<Mutex<HashMap<K, usize>>>;
+
+/// Reason a message was not accepted by [`FairSender::try_send`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum FairSendError {
+	/// The sending peer already has `per_peer_capacity` messages in flight.
+	PeerQuotaExceeded,
+	/// The receiving end has been dropped.
+	Closed,
+}
+
+/// Create a fair channel in which each peer may have at most
+/// `per_peer_capacity` messages in flight at any one time.
+pub fn fair_channel<K, T>(per_peer_capacity: usize) -> (FairSender<K, T>, FairReceiver<K, T>) {
+	assert!(per_peer_capacity > 0, "per_peer_capacity must be non-zero");
+	// The underlying channel is unbounded: the total number of in-flight
+	// messages is already bounded by `per_peer_capacity` times the number of
+	// distinct senders, and it is the per-peer accounting that we rely on.
+	let (sender, receiver) = mpsc::unbounded_channel();
+	let counts: InFlightCounts<K> = Arc::new(Mutex::new(HashMap::new()));
+	(
+		FairSender { sender, counts: counts.clone(), per_peer_capacity },
+		FairReceiver { receiver, counts },
+	)
+}
+
+/// Sending half of a [`fair_channel`].
+pub struct FairSender<K, T> {
+	sender: mpsc::UnboundedSender<(K, T)>,
+	counts: InFlightCounts<K>,
+	per_peer_capacity: usize,
+}
+
+impl<K: Eq + Hash + Clone, T> FairSender<K, T> {
+	/// Send a message attributed to peer `key`, or drop it (returning an error)
+	/// if that peer already has `per_peer_capacity` messages in flight. Never
+	/// blocks.
+	pub fn try_send(&self, key: K, value: T) -> Result<(), FairSendError> {
+		{
+			let mut counts = self.counts.lock().unwrap();
+			let in_flight = counts.entry(key.clone()).or_insert(0);
+			if *in_flight >= self.per_peer_capacity {
+				return Err(FairSendError::PeerQuotaExceeded);
+			}
+			*in_flight += 1;
+		}
+		// A leaked count here is harmless: `Closed` only happens once the
+		// receiver is gone, i.e. the whole channel is being torn down.
+		self.sender.send((key, value)).map_err(|_| FairSendError::Closed)
+	}
+}
+
+/// Receiving half of a [`fair_channel`].
+pub struct FairReceiver<K, T> {
+	receiver: mpsc::UnboundedReceiver<(K, T)>,
+	counts: InFlightCounts<K>,
+}
+
+impl<K: Eq + Hash, T> FairReceiver<K, T> {
+	/// Receive the next message, freeing up one in-flight slot for its sender.
+	///
+	/// Cancel-safe: if the returned future is dropped before it completes, no
+	/// message is consumed and no count is changed.
+	pub async fn recv(&mut self) -> Option<(K, T)> {
+		let (key, value) = self.receiver.recv().await?;
+		{
+			let mut counts = self.counts.lock().unwrap();
+			if let Some(in_flight) = counts.get_mut(&key) {
+				*in_flight = in_flight.saturating_sub(1);
+				if *in_flight == 0 {
+					counts.remove(&key);
+				}
+			}
+		}
+		Some((key, value))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn drops_messages_once_peer_is_over_quota() {
+		let (sender, mut receiver) = fair_channel::<&str, u32>(2);
+
+		// A peer can fill its own quota...
+		assert_eq!(sender.try_send("alice", 1), Ok(()));
+		assert_eq!(sender.try_send("alice", 2), Ok(()));
+		// ...but not exceed it.
+		assert_eq!(sender.try_send("alice", 3), Err(FairSendError::PeerQuotaExceeded));
+
+		// A different peer is unaffected by the first peer's flood.
+		assert_eq!(sender.try_send("bob", 10), Ok(()));
+
+		// Receiving frees up a slot, so the peer can send again.
+		assert_eq!(receiver.recv().await, Some(("alice", 1)));
+		assert_eq!(sender.try_send("alice", 4), Ok(()));
+	}
+
+	#[tokio::test]
+	async fn in_flight_count_is_released_after_receive() {
+		let (sender, mut receiver) = fair_channel::<&str, u32>(1);
+
+		for i in 0..100 {
+			assert_eq!(sender.try_send("alice", i), Ok(()));
+			assert_eq!(receiver.recv().await, Some(("alice", i)));
+		}
+	}
+}

--- a/engine/p2p/src/lib.rs
+++ b/engine/p2p/src/lib.rs
@@ -20,7 +20,7 @@ use cf_chains::ChainCrypto;
 use cf_primitives::AccountId;
 use multisig::p2p::{OutgoingMultisigStageMessages, VersionedCeremonyMessage};
 use sp_core::ed25519;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{Receiver, UnboundedSender};
 
 use crate::core::{ed25519_secret_key_to_x25519_secret_key, X25519KeyPair};
 
@@ -64,12 +64,12 @@ impl<C: ChainCrypto> MultisigMessageSender<C> {
 	}
 }
 pub struct MultisigMessageReceiver<C: ChainCrypto>(
-	pub UnboundedReceiver<(AccountId, VersionedCeremonyMessage)>,
+	pub Receiver<(AccountId, VersionedCeremonyMessage)>,
 	PhantomData<C>,
 );
 
 impl<C: ChainCrypto> MultisigMessageReceiver<C> {
-	pub fn new(receiver: UnboundedReceiver<(AccountId, VersionedCeremonyMessage)>) -> Self {
+	pub fn new(receiver: Receiver<(AccountId, VersionedCeremonyMessage)>) -> Self {
 		MultisigMessageReceiver(receiver, PhantomData)
 	}
 }

--- a/engine/p2p/src/lib.rs
+++ b/engine/p2p/src/lib.rs
@@ -25,6 +25,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use crate::core::{ed25519_secret_key_to_x25519_secret_key, X25519KeyPair};
 
 pub mod core;
+pub mod fair_channel;
 pub mod muxer;
 
 type EdPublicKey = ed25519::Public;

--- a/engine/p2p/src/muxer.rs
+++ b/engine/p2p/src/muxer.rs
@@ -19,6 +19,8 @@ use cf_chains::{btc::BitcoinCrypto, dot::PolkadotCrypto, evm::EvmCrypto, sol::So
 use cf_primitives::AccountId;
 use futures::Future;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use crate::fair_channel::FairReceiver;
 use tracing::{info_span, trace, Instrument};
 
 use crate::{MultisigMessageReceiver, MultisigMessageSender, OutgoingMultisigStageMessages};
@@ -27,7 +29,7 @@ pub use multisig::p2p::{ProtocolVersion, VersionedCeremonyMessage, CURRENT_PROTO
 use multisig::ChainTag;
 
 pub struct P2PMuxer {
-	all_incoming_receiver: UnboundedReceiver<(AccountId, Vec<u8>)>,
+	all_incoming_receiver: FairReceiver<AccountId, Vec<u8>>,
 	all_outgoing_sender: UnboundedSender<OutgoingMultisigStageMessages>,
 	eth_incoming_sender: UnboundedSender<(AccountId, VersionedCeremonyMessage)>,
 	eth_outgoing_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
@@ -103,7 +105,7 @@ fn add_tag_and_current_version(data: &[u8], tag: ChainTag) -> Vec<u8> {
 impl P2PMuxer {
 	#[expect(clippy::type_complexity)]
 	pub fn start(
-		all_incoming_receiver: UnboundedReceiver<(AccountId, Vec<u8>)>,
+		all_incoming_receiver: FairReceiver<AccountId, Vec<u8>>,
 		all_outgoing_sender: UnboundedSender<OutgoingMultisigStageMessages>,
 	) -> (
 		MultisigMessageSender<EvmCrypto>,
@@ -249,7 +251,7 @@ mod tests {
 
 	use super::*;
 
-	use crate::OutgoingMultisigStageMessages;
+	use crate::{core::INCOMING_MESSAGE_PER_PEER_LIMIT, fair_channel::fair_channel, OutgoingMultisigStageMessages};
 
 	const ACC_1: AccountId = AccountId::new([b'A'; 32]);
 	const ACC_2: AccountId = AccountId::new([b'B'; 32]);
@@ -264,7 +266,8 @@ mod tests {
 	async fn correctly_prepends_chain_tag_broadcast() {
 		let (p2p_outgoing_sender, mut p2p_outgoing_receiver) =
 			tokio::sync::mpsc::unbounded_channel();
-		let (_, p2p_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
+		let (_p2p_incoming_sender, p2p_incoming_receiver) =
+			fair_channel(INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 		let (eth_outgoing_sender, .., muxer_future) =
 			P2PMuxer::start(p2p_incoming_receiver, p2p_outgoing_sender);
@@ -290,7 +293,8 @@ mod tests {
 	async fn correctly_prepends_chain_tag_private() {
 		let (p2p_outgoing_sender, mut p2p_outgoing_receiver) =
 			tokio::sync::mpsc::unbounded_channel();
-		let (_, p2p_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
+		let (_p2p_incoming_sender, p2p_incoming_receiver) =
+			fair_channel(INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 		let (eth_outgoing_sender, .., muxer_future) =
 			P2PMuxer::start(p2p_incoming_receiver, p2p_outgoing_sender);
@@ -329,7 +333,8 @@ mod tests {
 	#[tokio::test]
 	async fn should_parse_and_remove_headers() {
 		let (p2p_outgoing_sender, _p2p_outgoing_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let (p2p_incoming_sender, p2p_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
+		let (p2p_incoming_sender, p2p_incoming_receiver) =
+			fair_channel(INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 		let (_eth_outgoing_sender, mut eth_incoming_receiver, .., muxer_future) =
 			P2PMuxer::start(p2p_incoming_receiver, p2p_outgoing_sender);
@@ -338,7 +343,7 @@ mod tests {
 
 		let bytes = [VERSION_PREFIX, ETH_TAG_PREFIX, DATA_1].concat();
 
-		p2p_incoming_sender.send((ACC_1, bytes)).unwrap();
+		p2p_incoming_sender.try_send(ACC_1, bytes).unwrap();
 
 		let received = expect_recv_with_timeout(&mut eth_incoming_receiver.0).await;
 

--- a/engine/p2p/src/muxer.rs
+++ b/engine/p2p/src/muxer.rs
@@ -20,7 +20,7 @@ use cf_primitives::AccountId;
 use futures::Future;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
 
-use crate::fair_channel::{fair_channel, FairReceiver, FairSender, FairSendError};
+use crate::fair_channel::{fair_channel, FairReceiver, FairSendError, FairSender};
 use tracing::{info_span, trace, Instrument};
 
 use crate::{MultisigMessageReceiver, MultisigMessageSender, OutgoingMultisigStageMessages};
@@ -222,7 +222,7 @@ impl P2PMuxer {
 		)
 	}
 
-	async fn process_incoming(&mut self, account_id: AccountId, data: Vec<u8>) {
+	fn process_incoming(&mut self, account_id: AccountId, data: Vec<u8>) {
 		if let Ok(VersionedMessage { version, payload }) = VersionedMessage::deserialize(&data) {
 			// only version 1 is expected/supported
 			if version == CURRENT_PROTOCOL_VERSION {
@@ -285,7 +285,7 @@ impl P2PMuxer {
 		loop {
 			tokio::select! {
 				Some((account_id, data)) = self.all_incoming_receiver.recv() => {
-					self.process_incoming(account_id, data).await;
+					self.process_incoming(account_id, data);
 				}
 				Some(data) = self.eth_outgoing_receiver.recv() => {
 					self.process_outgoing(ChainTag::Ethereum, data).await;
@@ -311,7 +311,10 @@ mod tests {
 
 	use super::*;
 
-	use crate::{core::INCOMING_MESSAGE_PER_PEER_LIMIT, fair_channel::fair_channel, OutgoingMultisigStageMessages};
+	use crate::{
+		core::INCOMING_MESSAGE_PER_PEER_LIMIT, fair_channel::fair_channel,
+		OutgoingMultisigStageMessages,
+	};
 
 	const ACC_1: AccountId = AccountId::new([b'A'; 32]);
 	const ACC_2: AccountId = AccountId::new([b'B'; 32]);

--- a/engine/p2p/src/muxer.rs
+++ b/engine/p2p/src/muxer.rs
@@ -20,7 +20,7 @@ use cf_primitives::AccountId;
 use futures::Future;
 use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
 
-use crate::fair_channel::{fair_channel, FairReceiver, FairSendError, FairSender};
+use crate::fair_channel::{fair_channel, FairReceiver, FairSender};
 use tracing::{info_span, trace, Instrument};
 
 use crate::{MultisigMessageReceiver, MultisigMessageSender, OutgoingMultisigStageMessages};
@@ -236,18 +236,13 @@ impl P2PMuxer {
 							ChainTag::Bitcoin => &self.btc_incoming_sender,
 							ChainTag::Solana => &self.sol_incoming_sender,
 						};
-						match sender.try_send(account_id.clone(), message) {
-							Ok(()) => {},
-							Err(FairSendError::PeerQuotaExceeded) => {
-								P2P_BAD_MSG.inc(&["ceremony_per_peer_limit"]);
-								trace!(
-									"Dropping ceremony message from {account_id}: \
-									 over its in-flight limit",
-								);
-							},
-							// The receiver is dropped only when we are shutting down.
-							Err(FairSendError::Closed) => {},
-						}
+						sender.try_send_or_drop(account_id.clone(), message, || {
+							P2P_BAD_MSG.inc(&["ceremony_per_peer_limit"]);
+							trace!(
+								"Dropping ceremony message from {account_id}: \
+								 over its in-flight limit",
+							);
+						});
 					},
 					Err(e) => {
 						P2P_BAD_MSG.inc(&["deserialization_tagged_msg"]);

--- a/engine/p2p/src/muxer.rs
+++ b/engine/p2p/src/muxer.rs
@@ -18,9 +18,9 @@ use anyhow::{anyhow, Result};
 use cf_chains::{btc::BitcoinCrypto, dot::PolkadotCrypto, evm::EvmCrypto, sol::SolanaCrypto};
 use cf_primitives::AccountId;
 use futures::Future;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
 
-use crate::fair_channel::FairReceiver;
+use crate::fair_channel::{fair_channel, FairReceiver, FairSender, FairSendError};
 use tracing::{info_span, trace, Instrument};
 
 use crate::{MultisigMessageReceiver, MultisigMessageSender, OutgoingMultisigStageMessages};
@@ -28,16 +28,36 @@ use cf_utilities::metrics::P2P_BAD_MSG;
 pub use multisig::p2p::{ProtocolVersion, VersionedCeremonyMessage, CURRENT_PROTOCOL_VERSION};
 use multisig::ChainTag;
 
+/// Per-peer in-flight limit for ceremony messages awaiting processing by a
+/// ceremony manager. This is the receive-path stage with the slowest consumer,
+/// so it is where a real backlog forms; the per-peer limit ensures a flooding
+/// peer only ever delays its own ceremony messages.
+const CEREMONY_MESSAGE_PER_PEER_LIMIT: usize = 250;
+
+/// Capacity of the small bounded channel between each forwarder and its
+/// ceremony manager.
+///
+/// This is the only buffer on the receive path that is not per-peer accounted,
+/// so it is deliberately kept tiny: it cannot drop messages (the forwarder
+/// blocks rather than dropping), but every slot is unaccounted shared buffer,
+/// so a larger value would only add head-of-line delay for honest messages and
+/// unaccounted memory. Its sole purpose is to let the forwarder run a couple of
+/// messages ahead so the ceremony manager is not stalled on a forwarder wakeup
+/// after every message. That benefit saturates almost immediately, so this is a
+/// fixed small constant and does not scale with peer count or load. The real
+/// per-peer buffering happens upstream in the fair channel.
+const FORWARDER_BUFFER_SIZE: usize = 4;
+
 pub struct P2PMuxer {
 	all_incoming_receiver: FairReceiver<AccountId, Vec<u8>>,
 	all_outgoing_sender: UnboundedSender<OutgoingMultisigStageMessages>,
-	eth_incoming_sender: UnboundedSender<(AccountId, VersionedCeremonyMessage)>,
+	eth_incoming_sender: FairSender<AccountId, VersionedCeremonyMessage>,
 	eth_outgoing_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
-	dot_incoming_sender: UnboundedSender<(AccountId, VersionedCeremonyMessage)>,
+	dot_incoming_sender: FairSender<AccountId, VersionedCeremonyMessage>,
 	dot_outgoing_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
-	btc_incoming_sender: UnboundedSender<(AccountId, VersionedCeremonyMessage)>,
+	btc_incoming_sender: FairSender<AccountId, VersionedCeremonyMessage>,
 	btc_outgoing_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
-	sol_incoming_sender: UnboundedSender<(AccountId, VersionedCeremonyMessage)>,
+	sol_incoming_sender: FairSender<AccountId, VersionedCeremonyMessage>,
 	sol_outgoing_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
 }
 
@@ -102,6 +122,22 @@ fn add_tag_and_current_version(data: &[u8], tag: ChainTag) -> Vec<u8> {
 	VersionedMessage { version: CURRENT_PROTOCOL_VERSION, payload: &with_tag }.serialize()
 }
 
+/// Drain a per-peer fair channel into the bounded channel that feeds a
+/// ceremony manager. Awaiting the bounded `send` applies backpressure: while
+/// the ceremony manager is busy, messages accumulate in the fair channel,
+/// where they are bounded per sender. Returns when either channel is closed.
+async fn forward(
+	mut fair_receiver: FairReceiver<AccountId, VersionedCeremonyMessage>,
+	out_sender: Sender<(AccountId, VersionedCeremonyMessage)>,
+) {
+	while let Some(message) = fair_receiver.recv().await {
+		if out_sender.send(message).await.is_err() {
+			// The ceremony manager has gone away.
+			break;
+		}
+	}
+}
+
 impl P2PMuxer {
 	#[expect(clippy::type_complexity)]
 	pub fn start(
@@ -119,16 +155,35 @@ impl P2PMuxer {
 		impl Future<Output = ()>,
 	) {
 		let (eth_outgoing_sender, eth_outgoing_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let (eth_incoming_sender, eth_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
-
 		let (dot_outgoing_sender, dot_outgoing_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let (dot_incoming_sender, dot_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
-
 		let (btc_outgoing_sender, btc_outgoing_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let (btc_incoming_sender, btc_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
-
 		let (sol_outgoing_sender, sol_outgoing_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let (sol_incoming_sender, sol_incoming_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+		// Each incoming ceremony channel is split into a per-peer fair channel
+		// (where a backlog buffers, accounted per sender) and a small bounded
+		// channel feeding the ceremony manager. A forwarder task moves messages
+		// between them, blocking on the bounded channel so that a slow ceremony
+		// manager applies backpressure to the fair channel rather than letting
+		// it grow without limit.
+		let (eth_incoming_sender, eth_incoming_fair_receiver) =
+			fair_channel(CEREMONY_MESSAGE_PER_PEER_LIMIT);
+		let (eth_forwarder_sender, eth_incoming_receiver) =
+			tokio::sync::mpsc::channel(FORWARDER_BUFFER_SIZE);
+
+		let (dot_incoming_sender, dot_incoming_fair_receiver) =
+			fair_channel(CEREMONY_MESSAGE_PER_PEER_LIMIT);
+		let (dot_forwarder_sender, dot_incoming_receiver) =
+			tokio::sync::mpsc::channel(FORWARDER_BUFFER_SIZE);
+
+		let (btc_incoming_sender, btc_incoming_fair_receiver) =
+			fair_channel(CEREMONY_MESSAGE_PER_PEER_LIMIT);
+		let (btc_forwarder_sender, btc_incoming_receiver) =
+			tokio::sync::mpsc::channel(FORWARDER_BUFFER_SIZE);
+
+		let (sol_incoming_sender, sol_incoming_fair_receiver) =
+			fair_channel(CEREMONY_MESSAGE_PER_PEER_LIMIT);
+		let (sol_forwarder_sender, sol_incoming_receiver) =
+			tokio::sync::mpsc::channel(FORWARDER_BUFFER_SIZE);
 
 		let muxer = P2PMuxer {
 			all_incoming_receiver,
@@ -143,7 +198,16 @@ impl P2PMuxer {
 			sol_incoming_sender,
 		};
 
-		let muxer_fut = muxer.run().instrument(info_span!("P2PMuxer"));
+		let muxer_fut = async move {
+			futures::join!(
+				muxer.run(),
+				forward(eth_incoming_fair_receiver, eth_forwarder_sender),
+				forward(dot_incoming_fair_receiver, dot_forwarder_sender),
+				forward(btc_incoming_fair_receiver, btc_forwarder_sender),
+				forward(sol_incoming_fair_receiver, sol_forwarder_sender),
+			);
+		}
+		.instrument(info_span!("P2PMuxer"));
 
 		(
 			MultisigMessageSender::<EvmCrypto>::new(eth_outgoing_sender),
@@ -166,27 +230,23 @@ impl P2PMuxer {
 					Ok(TagPlusMessage { tag, payload }) => {
 						let message =
 							VersionedCeremonyMessage { version, payload: payload.to_vec() };
-						match tag {
-							ChainTag::Ethereum => {
-								self.eth_incoming_sender
-									.send((account_id, message))
-									.expect("eth receiver dropped");
+						let sender = match tag {
+							ChainTag::Ethereum => &self.eth_incoming_sender,
+							ChainTag::Polkadot => &self.dot_incoming_sender,
+							ChainTag::Bitcoin => &self.btc_incoming_sender,
+							ChainTag::Solana => &self.sol_incoming_sender,
+						};
+						match sender.try_send(account_id.clone(), message) {
+							Ok(()) => {},
+							Err(FairSendError::PeerQuotaExceeded) => {
+								P2P_BAD_MSG.inc(&["ceremony_per_peer_limit"]);
+								trace!(
+									"Dropping ceremony message from {account_id}: \
+									 over its in-flight limit",
+								);
 							},
-							ChainTag::Polkadot => {
-								self.dot_incoming_sender
-									.send((account_id, message))
-									.expect("polkadot receiver dropped");
-							},
-							ChainTag::Bitcoin => {
-								self.btc_incoming_sender
-									.send((account_id, message))
-									.expect("bitcoin receiver dropped");
-							},
-							ChainTag::Solana => {
-								self.sol_incoming_sender
-									.send((account_id, message))
-									.expect("solana receiver dropped");
-							},
+							// The receiver is dropped only when we are shutting down.
+							Err(FairSendError::Closed) => {},
 						}
 					},
 					Err(e) => {
@@ -345,7 +405,11 @@ mod tests {
 
 		p2p_incoming_sender.try_send(ACC_1, bytes).unwrap();
 
-		let received = expect_recv_with_timeout(&mut eth_incoming_receiver.0).await;
+		let received =
+			tokio::time::timeout(std::time::Duration::from_secs(1), eth_incoming_receiver.0.recv())
+				.await
+				.expect("timed out waiting for message")
+				.expect("channel closed");
 
 		assert_eq!(received.0, ACC_1);
 		assert_eq!(received.1.payload, DATA_1.to_vec());

--- a/engine/src/p2p.rs
+++ b/engine/src/p2p.rs
@@ -92,7 +92,7 @@ where
 	let own_peer_info = current_peers.iter().find(|pi| pi.account_id == our_account_id).cloned();
 
 	let (incoming_message_sender, incoming_message_receiver) =
-		tokio::sync::mpsc::unbounded_channel();
+		engine_p2p::fair_channel::fair_channel(engine_p2p::core::INCOMING_MESSAGE_PER_PEER_LIMIT);
 
 	let (outgoing_message_sender, outgoing_message_receiver) =
 		tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
# Pull Request

Closes: PRO-2876

The incoming P2P ROUTER socket did not apply the MAX_MESSAGE_SIZE cap
that is configured on outgoing DEALER sockets, and placed no bound on
how many messages ZMQ buffers per peer.

Set maxmsgsize so an oversized inbound frame disconnects the offending
peer rather than forcing an arbitrarily large allocation, and set
rcvhwm so ZMQ-layer buffering is bounded per peer.
