### PR TITLE
feat: use dedicated enum to specify canonical patch version.

### DIFF
--- a/state-chain/cf-integration-tests/src/historical_compatibility.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility.rs
@@ -23,8 +23,11 @@ use std::collections::HashMap;
 
 use cf_primitives::FlipBalance;
 use cf_utilities::{
-	for_each_released_runtime_version,
-	migrations::{basics::Version, v20000, v20100, v20200},
+	for_each_runtime_version,
+	migrations::{
+		basics::{CanonicalPatchVersion, Version},
+		v20000, v20100, v20200,
+	},
 };
 use frame_support::sp_runtime::AccountId32;
 use state_chain_runtime::runtime_apis::custom_api::types::{
@@ -44,8 +47,11 @@ use crate::historical_compatibility::{
 pub fn offline_test_historical_compatibility_of_runtime_api() -> Result<(), String> {
 	check_incompatibilities(test_all_historical_runtime_calls(
 		&mut OfflineMetadataTester::default(),
-		|version| version >= 20100, /* runtimes older than that don't support the required V15
-		                             * metadata */
+		|version| match version {
+			CanonicalPatchVersion::Unreleased => false,
+			// runtimes older than that don't support the required V15 metadata
+			CanonicalPatchVersion::Released(version) => version >= 20100,
+		},
 	))
 }
 
@@ -61,7 +67,10 @@ pub fn online_test_historical_compatibility_of_runtime_api() -> Result<(), Strin
 			}),
 			node_url: "https://mainnet-archive.chainflip.io",
 		},
-		|_version| true,
+		|version| match version {
+			CanonicalPatchVersion::Unreleased => false,
+			CanonicalPatchVersion::Released(_) => true,
+		},
 	))
 }
 
@@ -127,7 +136,7 @@ fn check_incompatibilities(incompatibilities: Vec<TypeIncompatibilityInfo>) -> R
 
 fn test_all_historical_runtime_calls(
 	tester: &mut impl HistoricalCompatibilityTester,
-	should_check_version: impl Fn(u32) -> bool,
+	should_check_version: impl Fn(CanonicalPatchVersion) -> bool,
 ) -> Vec<TypeIncompatibilityInfo> {
 	let mut all_incompatibilities = Vec::new();
 
@@ -154,7 +163,7 @@ fn test_all_historical_runtime_calls(
 		};
 	}
 
-	for_each_released_runtime_version!(try_test_all_runtime_calls_at_version);
+	for_each_runtime_version!(try_test_all_runtime_calls_at_version);
 
 	all_incompatibilities
 }

--- a/state-chain/cf-integration-tests/src/historical_compatibility.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility.rs
@@ -26,7 +26,7 @@ use cf_utilities::{
 	for_each_runtime_version,
 	migrations::{
 		basics::{CanonicalPatchVersion, Version},
-		v20000, v20100, v20200,
+		v20000, v20100, v20200, v20300,
 	},
 };
 use frame_support::sp_runtime::AccountId32;
@@ -63,6 +63,7 @@ pub fn online_test_historical_compatibility_of_runtime_api() -> Result<(), Strin
 			get_blockhash_from_spec_version: Box::new(|spec_version| match spec_version {
 				20012 => Some("0xc2068ad859fc5c3b3c7c5ecb3bd84033f1b5a0ce60e8c3b52cab4d22840eec37"),
 				20119 => Some("0x2ad1dd83839b13039d1a4ee85932b439e041068bd3bb91acf43455db97d71bd0"),
+				20203 => Some("0xb7ac402940505ac776988b01c41a1154e6b38a46c9f839edf74939a2c2fc1c74"),
 				_ => None,
 			}),
 			node_url: "https://mainnet-archive.chainflip.io",

--- a/state-chain/cf-integration-tests/src/historical_compatibility/offline_metadata_tester.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility/offline_metadata_tester.rs
@@ -14,7 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_utilities::migrations::basics::{HasGenericVariant, HasVersion, Version};
+use cf_utilities::migrations::basics::{
+	CanonicalPatchVersion, HasGenericVariant, HasVersion, Version,
+};
 use codec::{Decode, Encode};
 use frame_metadata::{v15::RuntimeMetadataV15, RuntimeMetadata, RuntimeMetadataPrefixed};
 use proptest::arbitrary::Arbitrary;
@@ -135,6 +137,10 @@ impl HistoricalCompatibilityTester for OfflineMetadataTester {
 		method_name: &'static str,
 	) -> Vec<TypeIncompatibilityInfo> {
 		let spec_version = V::CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST
+            .and_then(|version| match version {
+                CanonicalPatchVersion::Unreleased => None,
+                CanonicalPatchVersion::Released(v) => Some(v),
+            })
             .expect("encountered a runtime version with `CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST = None` in a compatibility test.");
 
 		// the metadata has to be loaded if it isn't already

--- a/state-chain/cf-integration-tests/src/historical_compatibility/online_node_tester.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility/online_node_tester.rs
@@ -14,7 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_utilities::migrations::basics::{HasGenericVariant, HasVersion, Version};
+use cf_utilities::migrations::basics::{
+	CanonicalPatchVersion, HasGenericVariant, HasVersion, Version,
+};
 use codec::{Decode, Encode};
 use proptest::arbitrary::Arbitrary;
 use scale_info::TypeInfo;
@@ -48,9 +50,14 @@ impl HistoricalCompatibilityTester for OnlineNodeTester {
 		api_name: &'static str,
 		method_name: &'static str,
 	) -> Vec<TypeIncompatibilityInfo> {
-		let canonical_runtime_patch_version = V::CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST.expect(
-            "Encountered a runtime version with `CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST = None` in a compatibility test."
-        );
+		let canonical_runtime_patch_version = V::CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST
+            .and_then(|version| match version {
+                CanonicalPatchVersion::Unreleased => None,
+                CanonicalPatchVersion::Released(v) => Some(v),
+            })
+            .expect(
+                "Encountered a runtime version with `CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST = None` in a compatibility test."
+            );
 		let blockhash =
 			(self.get_blockhash_from_spec_version)(canonical_runtime_patch_version)
             .unwrap_or_else(|| panic!("No blockhash was specified for runtime version {canonical_runtime_patch_version} when trying to run compatibility test against online archive node."));

--- a/utilities/src/without_std/generate_module.rs
+++ b/utilities/src/without_std/generate_module.rs
@@ -76,7 +76,7 @@ macro_rules! generate_module {
             }
 
             // this extracts the From types (per field) from a CustomMigration
-            #[derive_where::derive_where(Debug; )]
+            #[derive_where::derive_where(Debug, Default; )]
             pub struct source_of_custom_migration<To: HistoricalTypesAt<V>, V: Version, M: CustomMigration<To, V>>(sp_std::marker::PhantomData<(To, V, M)>);
             impl<To: HistoricalTypesAt<V>, V: Version, M: CustomMigration<To, V>> Types for source_of_custom_migration<To, V, M> {
                 $(

--- a/utilities/src/without_std/migrations.rs
+++ b/utilities/src/without_std/migrations.rs
@@ -21,12 +21,13 @@ pub mod primitives;
 
 use self::basics::*;
 use crate::migrations::basics::Version;
+use CanonicalPatchVersion::*;
 
-macro_rules! define_all_released_runtime_versions {
+macro_rules! define_all_runtime_versions {
 	($(
 		{
 			release: $version:ident,
-			canonical_patch: $canonical_patch_version:literal,
+			canonical_patch: $canonical_patch_version:expr,
 			changelog_entry: $Migration:ident,
 		},
 	)*) => {
@@ -36,7 +37,7 @@ macro_rules! define_all_released_runtime_versions {
 			#[allow(nonstandard_style)]
 			pub struct $version;
 			impl Version for $version {
-				const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<u32> = Some($canonical_patch_version);
+				const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<CanonicalPatchVersion> = Some($canonical_patch_version);
 			}
 		)*
 
@@ -144,14 +145,14 @@ macro_rules! define_all_released_runtime_versions {
 		}
 
 		#[macro_export]
-		macro_rules! for_each_released_runtime_version {
+		macro_rules! for_each_runtime_version {
 			($$macro_name:ident) => {
 				$(
 					$$macro_name!{ $version }
 				)*
 			}
 		}
-		pub use for_each_released_runtime_version;
+		pub use for_each_runtime_version;
 	};
 }
 
@@ -182,28 +183,35 @@ macro_rules! generate_migration_helpers {
 // The table uses the following format:
 // 1. `release: vMajorMinor00`: this describes the chainflip release version. E.g. chainflip release
 //    2.1 is represented by v20100.
-// 2. `canonical_patch: MajorMinorPatch`: this is the exact patch of that chainflip release which
-//    should be used as canonical runtime providing the metadata which is tested against for
-//    historical type compatibility tests. For every canonical patch version >= 20100 that's listed
-//    here, there should be a metadata file called `runtime_{canonical_patch}.scale` located in
+// 2. `canonical_patch: Released(MajorMinorPatch) | Unreleased`: this is the exact patch of that
+//    chainflip release which should be used as canonical runtime providing the metadata which is
+//    tested against for historical type compatibility tests. For every canonical patch version >=
+//    20100 that's listed here, there should be a metadata file called
+//    `runtime_{canonical_patch}.scale` located in
 //    `state-chain/cf-integration-tests/historical_metadata`. It can be downloaded using the script
-//    in `bouncer/commands/download_metadata.ts`.
+//    in `bouncer/commands/download_metadata.ts`. Use `Unreleased` if this version isn't released
+//    yet.
 // 3. `changelog_entry: in_MajorMinor00`: this should match up with the first entry, and is the name
 //    of the changelog entry (in the `HasChangelog` type) for this release.
-define_all_released_runtime_versions! {
+define_all_runtime_versions! {
 	{
 		release: v20000,
-		canonical_patch: 20012,
+		canonical_patch: Released(20012),
 		changelog_entry: in_20000,
 	},
 	{
 		release: v20100,
-		canonical_patch: 20119,
+		canonical_patch: Released(20119),
 		changelog_entry: in_20100,
 	},
 	{
 		release: v20200,
-		canonical_patch: 20203,
+		canonical_patch: Released(20203),
 		changelog_entry: in_20200,
+	},
+	{
+		release: v20300,
+		canonical_patch: Unreleased,
+		changelog_entry: in_20300,
 	},
 }

--- a/utilities/src/without_std/migrations.rs
+++ b/utilities/src/without_std/migrations.rs
@@ -179,14 +179,14 @@ macro_rules! generate_migration_helpers {
     }
 }
 
-// All major runtime versions that have been released to at least one testnet.
+// All major runtime versions.
 // The table uses the following format:
 // 1. `release: vMajorMinor00`: this describes the chainflip release version. E.g. chainflip release
 //    2.1 is represented by v20100.
 // 2. `canonical_patch: Released(MajorMinorPatch) | Unreleased`: this is the exact patch of that
 //    chainflip release which should be used as canonical runtime providing the metadata which is
-//    tested against for historical type compatibility tests. For every canonical patch version >=
-//    20100 that's listed here, there should be a metadata file called
+//    tested against for historical type compatibility tests. For every canonical `Released(patch)`
+//    with `patch` >= 20100 that's listed here, there should be a metadata file called
 //    `runtime_{canonical_patch}.scale` located in
 //    `state-chain/cf-integration-tests/historical_metadata`. It can be downloaded using the script
 //    in `bouncer/commands/download_metadata.ts`. Use `Unreleased` if this version isn't released

--- a/utilities/src/without_std/migrations/basics.rs
+++ b/utilities/src/without_std/migrations/basics.rs
@@ -19,7 +19,12 @@
 use crate::migrations::HasChangelog;
 
 pub trait Version: Copy {
-	const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<u32>;
+	const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<CanonicalPatchVersion>;
+}
+
+pub enum CanonicalPatchVersion {
+	Unreleased,
+	Released(u32),
 }
 
 pub trait Migration<To: ?Sized, V: Version> {
@@ -106,7 +111,8 @@ pub type GetMigrationToHistoricalType<X: IsHistoricalTypeAt<V>, V: Version> =
 pub struct vCurrent;
 impl Version for vCurrent {
 	// There's no released runtime version associated.
-	const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<u32> = None;
+	const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<CanonicalPatchVersion> =
+		None;
 }
 
 pub trait HasGenericVariant: Sized {

--- a/utilities/src/without_std/migrations/primitives.rs
+++ b/utilities/src/without_std/migrations/primitives.rs
@@ -175,6 +175,7 @@ impl<X: HasChangelog> HasChangelog for Option<X> {
 	type in_20000 = MapMigration<X::in_20000>;
 	type in_20100 = MapMigration<X::in_20100>;
 	type in_20200 = MapMigration<X::in_20200>;
+	type in_20300 = MapMigration<X::in_20300>;
 }
 impl<X: HasGenericVariant> HasGenericVariant for Option<X> {
 	type GenericType = Option<X::GenericType>;
@@ -207,6 +208,7 @@ impl<X: HasChangelog> HasChangelog for Vec<X> {
 	type in_20000 = MapMigration<X::in_20000>;
 	type in_20100 = MapMigration<X::in_20100>;
 	type in_20200 = MapMigration<X::in_20200>;
+	type in_20300 = MapMigration<X::in_20300>;
 }
 impl<X: HasGenericVariant> HasGenericVariant for Vec<X> {
 	type GenericType = Vec<X::GenericType>;
@@ -248,6 +250,7 @@ impl<A: OrdMigrations + Ord, B: HasChangelog> HasChangelog for BTreeMap<A, B> {
 	type in_20000 = MapMigration<(A::in_20000, B::in_20000)>;
 	type in_20100 = MapMigration<(A::in_20100, B::in_20100)>;
 	type in_20200 = MapMigration<(A::in_20200, B::in_20200)>;
+	type in_20300 = MapMigration<(A::in_20300, B::in_20300)>;
 }
 impl<A: HasGenericVariant + Ord, B: HasGenericVariant> HasGenericVariant for BTreeMap<A, B>
 where
@@ -286,6 +289,7 @@ impl<A: HasChangelog, B: HasChangelog> HasChangelog for (A, B) {
 	type in_20000 = MapMigration<(A::in_20000, B::in_20000)>;
 	type in_20100 = MapMigration<(A::in_20100, B::in_20100)>;
 	type in_20200 = MapMigration<(A::in_20200, B::in_20200)>;
+	type in_20300 = MapMigration<(A::in_20300, B::in_20300)>;
 }
 impl<A: HasGenericVariant, B: HasGenericVariant> HasGenericVariant for (A, B) {
 	type GenericType = (A::GenericType, B::GenericType);


### PR DESCRIPTION
# Pull Request

Closes: PRO-2943

## Summary

This adds a distinction between released and unreleased versions. Both have to be specified since during development migrations target an unreleased version.

## API Changes

None

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
