### PR TITLE
feat: updated Tron refund multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes included in each Chainflip release will be documented in thi
 ### Fixes
 
 - Set ONLY_PREALLOCATE_FROM_POOL to true for Tron deposit channels.
+- Set Tron refund multiplier to 15.
 
 ## [2.2.3] - 2026-06-02
 

--- a/state-chain/pallets/cf-asset-balances/src/lib.rs
+++ b/state-chain/pallets/cf-asset-balances/src/lib.rs
@@ -24,6 +24,7 @@ use cf_traits::{
 	impl_pallet_safe_mode, AccountRoleRegistry, AssetWithholding, BalanceApi, Chainflip,
 	DeregistrationCheck, EgressApi, KeyProvider, LiabilityTracker, PoolApi, ScheduledEgressDetails,
 };
+use cf_utilities::derive_common_traits;
 use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::traits::{Saturating, Zero},
@@ -37,15 +38,14 @@ pub use pallet::*;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+pub mod migrations;
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod tests;
 
-pub const STORAGE_VERSION_U16: u16 = 1;
+pub const STORAGE_VERSION_U16: u16 = 2;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
-
-pub const REFUND_FEE_MULTIPLE: AssetAmount = 100;
 
 #[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
 pub enum ExternalOwner {
@@ -78,6 +78,13 @@ impl core::cmp::Ord for ExternalOwner {
 impl core::cmp::PartialOrd for ExternalOwner {
 	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
+	}
+}
+
+derive_common_traits! {
+	#[derive(TypeInfo)]
+	pub enum PalletConfigUpdate {
+		RefundFeeMultiple { chain: ForeignChain, multiple: Option<u32> },
 	}
 }
 
@@ -177,6 +184,10 @@ pub mod pallet {
 		AssetAmount,
 		ValueQuery,
 	>;
+
+	#[pallet::storage]
+	pub type RefundFeeMultiple<T> =
+		StorageMap<_, Twox64Concat, ForeignChain, u32, ValueQuery, ConstU32<100>>;
 }
 
 impl<T: Config> Pallet<T> {
@@ -190,7 +201,9 @@ impl<T: Config> Pallet<T> {
 				.map_err(Into::into)
 				.and_then(
 					|result @ ScheduledEgressDetails { egress_amount, fee_withheld, .. }| {
-						if egress_amount < REFUND_FEE_MULTIPLE * fee_withheld {
+						if egress_amount <
+							(RefundFeeMultiple::<T>::get(chain) as AssetAmount) * fee_withheld
+						{
 							Err(Error::<T>::RefundAmountTooLow.into())
 						} else {
 							Ok(result)

--- a/state-chain/pallets/cf-asset-balances/src/migrations.rs
+++ b/state-chain/pallets/cf-asset-balances/src/migrations.rs
@@ -1,0 +1,37 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
+
+use crate::{Pallet, STORAGE_VERSION_U16};
+
+mod set_tron_refund_multiple;
+
+pub type PalletMigration<T> = (
+	VersionedMigration<
+		1,
+		2,
+		set_tron_refund_multiple::Migration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<{ STORAGE_VERSION_U16 }, Pallet<T>>,
+);
+
+#[cfg(test)]
+const _: u16 =
+	<PalletMigration<crate::mock::Test> as cf_runtime_utilities::MigrationSequence>::FROM;

--- a/state-chain/pallets/cf-asset-balances/src/migrations/set_tron_refund_multiple.rs
+++ b/state-chain/pallets/cf-asset-balances/src/migrations/set_tron_refund_multiple.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Config, RefundFeeMultiple};
+use cf_chains::ForeignChain;
+use frame_support::{
+	traits::{Get, UncheckedOnRuntimeUpgrade},
+	weights::Weight,
+};
+use sp_std::marker::PhantomData;
+
+#[cfg(feature = "try-runtime")]
+use frame_support::{ensure, pallet_prelude::DispatchError};
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+/// The refund-fee multiple to apply to Tron, overriding the default of 100.
+const TRON_REFUND_FEE_MULTIPLE: u32 = 15;
+
+pub struct Migration<T: Config>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> Weight {
+		RefundFeeMultiple::<T>::insert(ForeignChain::Tron, TRON_REFUND_FEE_MULTIPLE);
+		T::DbWeight::get().writes(1)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_state: Vec<u8>) -> Result<(), DispatchError> {
+		ensure!(
+			RefundFeeMultiple::<T>::get(ForeignChain::Tron) == TRON_REFUND_FEE_MULTIPLE,
+			"Tron refund fee multiple should be set after migration"
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::*;
+
+	const REFUND_FEE_MULTIPLE_DEFAULT: u32 = 100;
+
+	#[test]
+	fn sets_only_tron_refund_fee_multiple() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				RefundFeeMultiple::<Test>::get(ForeignChain::Tron),
+				REFUND_FEE_MULTIPLE_DEFAULT
+			);
+			assert_eq!(
+				RefundFeeMultiple::<Test>::get(ForeignChain::Ethereum),
+				REFUND_FEE_MULTIPLE_DEFAULT
+			);
+
+			Migration::<Test>::on_runtime_upgrade();
+
+			assert_eq!(
+				RefundFeeMultiple::<Test>::get(ForeignChain::Tron),
+				TRON_REFUND_FEE_MULTIPLE
+			);
+			assert_eq!(
+				RefundFeeMultiple::<Test>::get(ForeignChain::Ethereum),
+				REFUND_FEE_MULTIPLE_DEFAULT
+			);
+		});
+	}
+}

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -460,6 +460,7 @@ type PalletMigrations = (
 	pallet_cf_ingress_egress::migrations::PalletMigration<Runtime, AssethubInstance>,
 	pallet_cf_ingress_egress::migrations::PalletMigration<Runtime, TronInstance>,
 	pallet_cf_pools::migrations::PalletMigration<Runtime>,
+	pallet_cf_asset_balances::migrations::PalletMigration<Runtime>,
 	pallet_cf_cfe_interface::migrations::PalletMigration<Runtime>,
 	pallet_cf_trading_strategy::migrations::PalletMigration<Runtime>,
 	pallet_cf_lending_pools::migrations::PalletMigration<Runtime>,


### PR DESCRIPTION
# Pull Request

Copies the fix from `main` but without the new extrinsic/events to maintain compatibility. Instead, sets the value through a migration.