### PR TITLE
chore: adjust Tron fees following mainnet behaviour

### DIFF
--- a/state-chain/chains/src/tron.rs
+++ b/state-chain/chains/src/tron.rs
@@ -22,10 +22,10 @@ pub mod benchmarking;
 pub mod fees {
 	pub const ENERGY_BASE_COST_PER_BATCH: u128 = 40_000; // Base energy transaction cost
 	pub const ENERGY_COST_PER_FETCH_NATIVE: u128 = 5_000; // Cost to fetch tokens from deposit channel
-	pub const ENERGY_COST_PER_FETCH_TOKEN: u128 = 65_000; // Cost to fetch tokens from deposit channel
-	pub const ENERGY_COST_PER_TRANSFER_NATIVE: u128 = 10_000; // Native TRX transfer
-	pub const ENERGY_COST_PER_TRANSFER_TOKEN: u128 = 75_000; // TRC-20 token transfer
-	pub const ENERGY_CCM_OVERHEAD: u128 = 40_000;
+	pub const ENERGY_COST_PER_FETCH_TOKEN: u128 = 66_000; // Cost to fetch tokens from deposit channel
+	pub const ENERGY_COST_PER_TRANSFER_NATIVE: u128 = 15_000; // Native TRX transfer
+	pub const ENERGY_COST_PER_TRANSFER_TOKEN: u128 = 80_000; // TRC-20 token transfer
+	pub const ENERGY_CCM_OVERHEAD: u128 = 45_000;
 
 	// Bandwidth in out case depends on the length. Both types of fetches have the same length
 	// and transferring and fetching is the same length for native and token assets.


### PR DESCRIPTION
# Pull Request

## Summary

Adjust (slight increase) of fees looking at mainnet behaviour. The ratio of unfunded/funded destination address seems to be less favorable than predicted. Also, adjust more accurately the energy estimation for the fetch token.

After this tweak we should just adjust further with the multiplier as needed.

Marked as pick-to-release for the next minor release since we will need a runtime upgrade anyway for #6676 .

---

## *Checklist*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.