### PR TITLE
feat: support more types in migration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,6 +1812,7 @@ version = "0.1.0"
 dependencies = [
  "cf-proc-macros",
  "derive-where",
+ "duplicate",
  "frame-support",
  "hex",
  "n-functor",
@@ -17377,7 +17378,9 @@ dependencies = [
  "async-broadcast",
  "async-channel 1.9.0",
  "bs58",
+ "cf-proc-macros",
  "clap",
+ "derive-where",
  "duplicate",
  "futures",
  "futures-util",

--- a/state-chain/cf-integration-tests/src/historical_compatibility.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility.rs
@@ -21,7 +21,7 @@ pub mod type_describer;
 
 use std::collections::HashMap;
 
-use cf_primitives::FlipBalance;
+use cf_primitives::{Asset, FlipBalance};
 use cf_utilities::{
 	for_each_runtime_version,
 	migrations::{
@@ -147,18 +147,28 @@ fn test_all_historical_runtime_calls(
 				$version::CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST
 					.expect("Encountered `CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST = None` when trying to run compatibility tests for historical runtime.")
 			) {
-                let mut incompatibilities = [
-                    tester.test_call::<$version, (), NetworkFees>($version, "CustomRuntimeApi", "cf_network_fees"),
-                    tester
+                let mut incompatibilities = Vec::new();
+                incompatibilities.append(
+                    &mut tester.test_call::<$version, (), NetworkFees>($version, "CustomRuntimeApi", "cf_network_fees")
+                );
+                incompatibilities.append(
+                    &mut tester
                         .test_call::<$version, (AccountId32, ShouldSweep), RpcAccountInfoCommonItems<FlipBalance>>(
                             $version,
                             "CustomRuntimeApi",
                             "cf_common_account_info",
-                        ),
-                ]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>();
+                        )
+                );
+                if match $version::CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST.unwrap() {
+                    CanonicalPatchVersion::Released(v) => Some(v),
+                    CanonicalPatchVersion::Unreleased => None,
+                }.unwrap() > 20200 {
+                    // the `cf_supported_assets` call only exists in versions >= 20200
+                    incompatibilities.append(
+                        &mut tester.test_call::<$version, (), Vec<Asset>>($version, "CustomRuntimeApi", "cf_supported_assets"),
+                    );
+                }
+
                 all_incompatibilities.append(&mut incompatibilities);
             }
 		};

--- a/state-chain/cf-integration-tests/src/historical_compatibility/offline_metadata_tester.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility/offline_metadata_tester.rs
@@ -14,8 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_utilities::migrations::basics::{
-	CanonicalPatchVersion, HasGenericVariant, HasVersion, Version,
+use cf_utilities::{
+	migrations::basics::{CanonicalPatchVersion, HasGenericVariant, HasVersion, Version},
+	type_introspection::HasTypeIntrospection,
 };
 use codec::{Decode, Encode};
 use frame_metadata::{v15::RuntimeMetadataV15, RuntimeMetadata, RuntimeMetadataPrefixed};
@@ -124,11 +125,24 @@ impl OfflineMetadataTester {
 impl HistoricalCompatibilityTester for OfflineMetadataTester {
 	fn test_call<
 		V: Version,
-		I: HasVersion<V, HistoricalType: Encode + std::fmt::Debug + TypeInfo + 'static + Arbitrary>
-			+ HasGenericVariant<GenericType: Arbitrary>,
+		I: HasVersion<
+				V,
+				HistoricalType: Encode
+				                    + std::fmt::Debug
+				                    + TypeInfo
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
+			> + HasGenericVariant<GenericType: Arbitrary>,
 		O: HasVersion<
 				V,
-				HistoricalType: Encode + Decode + TypeInfo + std::fmt::Debug + 'static + Arbitrary,
+				HistoricalType: Encode
+				                    + Decode
+				                    + TypeInfo
+				                    + std::fmt::Debug
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
 			> + HasGenericVariant<GenericType: Arbitrary>,
 	>(
 		&mut self,

--- a/state-chain/cf-integration-tests/src/historical_compatibility/online_node_tester.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility/online_node_tester.rs
@@ -14,8 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_utilities::migrations::basics::{
-	CanonicalPatchVersion, HasGenericVariant, HasVersion, Version,
+use cf_utilities::{
+	migrations::basics::{CanonicalPatchVersion, HasGenericVariant, HasVersion, Version},
+	type_introspection::HasTypeIntrospection,
 };
 use codec::{Decode, Encode};
 use proptest::arbitrary::Arbitrary;
@@ -38,11 +39,24 @@ pub struct OnlineNodeTester {
 impl HistoricalCompatibilityTester for OnlineNodeTester {
 	fn test_call<
 		V: Version,
-		I: HasVersion<V, HistoricalType: Encode + std::fmt::Debug + TypeInfo + 'static + Arbitrary>
-			+ HasGenericVariant<GenericType: Arbitrary>,
+		I: HasVersion<
+				V,
+				HistoricalType: Encode
+				                    + std::fmt::Debug
+				                    + TypeInfo
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
+			> + HasGenericVariant<GenericType: Arbitrary>,
 		O: HasVersion<
 				V,
-				HistoricalType: Encode + Decode + TypeInfo + std::fmt::Debug + 'static + Arbitrary,
+				HistoricalType: Encode
+				                    + Decode
+				                    + TypeInfo
+				                    + std::fmt::Debug
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
 			> + HasGenericVariant<GenericType: Arbitrary>,
 	>(
 		&mut self,

--- a/state-chain/cf-integration-tests/src/historical_compatibility/tester_trait.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility/tester_trait.rs
@@ -16,7 +16,10 @@
 
 use std::cell::RefCell;
 
-use cf_utilities::migrations::basics::{HasGenericVariant, HasVersion, Version};
+use cf_utilities::{
+	migrations::basics::{HasGenericVariant, HasVersion, Version},
+	type_introspection::HasTypeIntrospection,
+};
 use codec::{Decode, Encode};
 use proptest::{
 	arbitrary::Arbitrary,
@@ -30,11 +33,24 @@ use similar::{ChangeTag, TextDiff};
 pub trait HistoricalCompatibilityTester {
 	fn test_call<
 		V: Version,
-		I: HasVersion<V, HistoricalType: Encode + std::fmt::Debug + TypeInfo + 'static + Arbitrary>
-			+ HasGenericVariant<GenericType: Arbitrary>,
+		I: HasVersion<
+				V,
+				HistoricalType: Encode
+				                    + std::fmt::Debug
+				                    + TypeInfo
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
+			> + HasGenericVariant<GenericType: Arbitrary>,
 		O: HasVersion<
 				V,
-				HistoricalType: Encode + Decode + TypeInfo + std::fmt::Debug + 'static + Arbitrary,
+				HistoricalType: Encode
+				                    + Decode
+				                    + TypeInfo
+				                    + std::fmt::Debug
+				                    + 'static
+				                    + Arbitrary
+				                    + HasTypeIntrospection,
 			> + HasGenericVariant<GenericType: Arbitrary>,
 	>(
 		&mut self,
@@ -221,7 +237,7 @@ pub struct SubTypeIncompatibility {
 	pub error: String,
 }
 
-pub fn fuzzy_test_encode_decode_compatibility<T1: Encode>(
+pub fn fuzzy_test_encode_decode_compatibility<T1: Encode + HasTypeIntrospection>(
 	cases: u32,
 	strategy: &impl Strategy<Value = T1>,
 	encode: &impl Fn(T1) -> Result<Vec<u8>, SubTypeIncompatibility>,
@@ -233,30 +249,39 @@ pub fn fuzzy_test_encode_decode_compatibility<T1: Encode>(
 
 	let incompatibility = RefCell::new(None);
 
+	// the test function
+	let test_value = |value: T1| {
+		encode(value).and_then(|encoded| {
+			let mut slice: &[u8] = &encoded;
+			let cursor: &mut &[u8] = &mut slice;
+			decode(cursor).and_then(|_| {
+				if cursor.is_empty() {
+					Ok(())
+				} else {
+					Err(SubTypeIncompatibility {
+						sub_type_details: type_details.clone(),
+						error: format!(
+							"Encoding mismatch: {} trailing bytes remain after decoding",
+							cursor.len(),
+						),
+					})
+				}
+			})
+		})
+	};
+
+	// -------------------- HasTypeIntrospection based sampling ------------------------
+	for sample in T1::sample_all_shapes() {
+		test_value(sample)?;
+	}
+
+	// -------------------- Arbitrary based sampling ------------------------
 	runner
 		.run(strategy, |value1| {
-			encode(value1)
-				.and_then(|encoded| {
-					let mut slice: &[u8] = &encoded;
-					let cursor: &mut &[u8] = &mut slice;
-					decode(cursor).and_then(|_| {
-						if cursor.is_empty() {
-							Ok(())
-						} else {
-							Err(SubTypeIncompatibility {
-								sub_type_details: type_details.clone(),
-								error: format!(
-									"Encoding mismatch: {} trailing bytes remain after decoding",
-									cursor.len(),
-								),
-							})
-						}
-					})
-				})
-				.map_err(|err| {
-					incompatibility.replace(Some(err));
-					TestCaseError::Fail("".into())
-				})
+			test_value(value1).map_err(|err| {
+				incompatibility.replace(Some(err));
+				TestCaseError::Fail("".into())
+			})
 		})
 		.map_err(|err| match err {
 			proptest::test_runner::TestError::Abort(reason) =>

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -48,7 +48,10 @@ use cf_rpc_apis::{
 	RefundParametersRpc, RpcApiError, RpcResult,
 };
 use cf_utilities::{
-	migrations::{basics::migrate_from_historical_type, v20000, v20100},
+	migrations::{
+		basics::{migrate_from_historical_type, try_migrate_from_historical_type},
+		v20000, v20100,
+	},
 	rpc::NumberOrHex,
 };
 use core::ops::Range;
@@ -2284,16 +2287,30 @@ where
 
 				let common_items = if api_version < 16 {
 					#[expect(deprecated)]
-					migrate_from_historical_type(
+					try_migrate_from_historical_type(
 						v20000,
 						api.cf_common_account_info_before_version_16(hash, &account_id)?,
 					)
+					.map_err(|_err| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InternalError.code(),
+							"Error when migrating runtime api reply",
+							None::<()>,
+						))
+					})?
 				} else if api_version < 17 {
 					#[expect(deprecated)]
-					migrate_from_historical_type(
+					try_migrate_from_historical_type(
 						v20100,
 						api.cf_common_account_info_before_version_17(hash, &account_id)?,
 					)
+					.map_err(|_err| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InternalError.code(),
+							"Error when migrating runtime api reply",
+							None::<()>,
+						))
+					})?
 				} else if api_version < 19 {
 					#[expect(deprecated)]
 					api.cf_common_account_info_before_version_19(

--- a/state-chain/pallets/cf-swapping/Cargo.toml
+++ b/state-chain/pallets/cf-swapping/Cargo.toml
@@ -67,7 +67,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
-	"pallet-cf-environment/std",
 	"scale-info/std",
 	"sp-arithmetic/std",
 	"sp-std/std",
@@ -75,7 +74,6 @@ std = [
 	"serde/std",
 	"cf-runtime-utilities/std",
 	"itertools/use_std",
-	"pallet-cf-environment/std",
 ]
 runtime-benchmarks = [
 	"cf-chains/runtime-benchmarks",

--- a/state-chain/primitives/Cargo.toml
+++ b/state-chain/primitives/Cargo.toml
@@ -27,6 +27,7 @@ scale-info = { workspace = true, features = ["derive"] }
 cf-utilities = { workspace = true }
 cf-proc-macros = { workspace = true }
 
+duplicate = { workspace = true }
 derive-where = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/state-chain/primitives/src/chains/assets.rs
+++ b/state-chain/primitives/src/chains/assets.rs
@@ -90,28 +90,29 @@ macro_rules! assets {
 			use core::ops::{Index, IndexMut};
 			use core::iter::FromIterator;
 
-			#[derive(
-				Copy,
-				Clone,
-				Debug,
-				PartialEq,
-				Eq,
-				Encode,
-				Decode,
-				DecodeWithMemTracking,
-				TypeInfo,
-				MaxEncodedLen,
-				Hash,
-				PartialOrd,
-				Ord,
-				EnumIter,
-			)]
-			#[repr(u32)]
-			pub enum Asset {
-				$(
-					$($asset_variant = $asset_index,)+
-				)+
-			}
+            #[cf_proc_macros::generate_module]
+            #[derive(
+                Copy,
+                Clone,
+                Debug,
+                PartialEq,
+                Eq,
+                Encode,
+                Decode,
+                DecodeWithMemTracking,
+                TypeInfo,
+                MaxEncodedLen,
+                Hash,
+                PartialOrd,
+                Ord,
+                EnumIter,
+            )]
+            #[repr(u32)]
+            pub enum Asset {
+                $(
+                    $($asset_variant = $asset_index,)+
+                )+
+            }
 			impl TryFrom<u32> for Asset {
 				type Error = &'static str;
 

--- a/state-chain/primitives/src/chains/assets_migrations.rs
+++ b/state-chain/primitives/src/chains/assets_migrations.rs
@@ -16,6 +16,8 @@
 
 use cf_utilities::migrations::{basics::HasVersion, v20100, v20200, v20300, HasChangelog};
 
+use crate::{chains::assets::any::_Asset, Asset};
+
 use super::assets::*;
 
 // -------------- HasChangelog ---------------- //
@@ -78,4 +80,12 @@ where
 		any::_AssetMap::see_field_changelogs_and_also<any::_AssetMap::field::tron::Added>;
 	type in_20300 =
 		any::_AssetMap::see_field_changelogs_and_also<any::_AssetMap::field::bsc::Added>;
+}
+
+impl HasChangelog for Asset {
+	type if_unspecified = _Asset::see_variant_changelogs;
+	type in_20300 = _Asset::see_variant_changelogs_and_also<(
+		_Asset::variant::Bnb::Added,
+		_Asset::variant::BscUsdt::Added,
+	)>;
 }

--- a/state-chain/primitives/src/lib.rs
+++ b/state-chain/primitives/src/lib.rs
@@ -18,6 +18,11 @@
 #![feature(int_roundings)]
 #![feature(associated_type_defaults)]
 #![feature(trait_alias)]
+#![feature(decl_macro)]
+#![feature(never_type)]
+#![feature(lazy_type_alias)]
+#![feature(macro_metavar_expr)]
+#![allow(incomplete_features)]
 
 //! Chainflip Primitives
 //!

--- a/state-chain/runtime/src/chainflip/missed_authorship_slots.rs
+++ b/state-chain/runtime/src/chainflip/missed_authorship_slots.rs
@@ -72,7 +72,7 @@ mod test_missed_authorship_slots {
 	use sp_consensus_aura::ed25519::AuthorityId;
 	use sp_core::ConstBool;
 
-	type Block = frame_system::mocking::MockBlock<Test>;
+	pub type Block = frame_system::mocking::MockBlock<Test>;
 
 	fn current_aura_slot() -> Slot {
 		pallet_aura::CurrentSlot::<crate::Runtime>::get()

--- a/state-chain/runtime/src/chainflip/witnessing/pallet_hooks.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/pallet_hooks.rs
@@ -34,7 +34,7 @@ pub trait Config<I: 'static> = pallet_cf_ingress_egress::Config<I>
 	+ pallet_cf_vaults::Config<I>
 	+ pallet_cf_broadcast::Config<I>;
 
-type VaultDepositInput<T, I> =
+type VaultDepositInput<T: pallet_cf_ingress_egress::Config<I>, I: 'static> =
 	(BlockWitnesserEvent<VaultDepositWitness<T, I>>, TargetChainBlockNumber<T, I>);
 
 define_empty_struct! {

--- a/state-chain/runtime/src/chainflip/witnessing/solana_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/solana_elections.rs
@@ -23,7 +23,7 @@ use crate::{
 use cf_chains::{
 	address::EncodedAddress,
 	assets::{any::Asset, sol::Asset as SolAsset},
-	instances::{ChainInstanceAlias, SolanaInstance},
+	instances::SolanaInstance,
 	sol::{
 		api::{
 			AltWitnessingConsensusResult, SolanaApi, SolanaTransactionBuildingError,
@@ -72,8 +72,6 @@ use electoral_systems::liveness::Liveness;
 
 use crate::chainflip::SolEnvironment;
 
-type Instance = <Solana as ChainInstanceAlias>::Instance;
-
 pub type SolanaElectoralSystemRunner = CompositeRunner<
 	(
 		SolanaBlockHeightTracking,
@@ -97,7 +95,7 @@ pub fn initial_state(
 	usdt_token_mint_pubkey: SolAddress,
 	swap_endpoint_data_account_address: SolAddress,
 	shared_data_reference_lifetime: BlockNumberFor<Runtime>,
-) -> InitialStateOf<Runtime, Instance> {
+) -> InitialStateOf<Runtime, SolanaInstance> {
 	InitialState {
 		unsynchronised_state: (
 			// The initial chain tracking value does not matter, as we don't care about the vault
@@ -153,7 +151,7 @@ impl DerivedIngressSink<SolAddress, VaultSwapOrDepositChannelId> for DerivedDepo
 
 pub type SolanaIngressTracking =
 	electoral_systems::blockchain::delta_based_ingress::DeltaBasedIngress<
-		pallet_cf_ingress_egress::Pallet<Runtime, Instance>,
+		pallet_cf_ingress_egress::Pallet<Runtime, SolanaInstance>,
 		DerivedDepositDetails,
 		SolanaIngressSettings,
 		<Runtime as Chainflip>::ValidatorId,

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -701,9 +701,9 @@ impl pallet_aura::Config for Runtime {
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
-type KeyOwnerIdentification<T, Id> =
+pub type KeyOwnerIdentification<T: KeyOwnerProofSystem<(KeyTypeId, Id)>, Id> =
 	<T as KeyOwnerProofSystem<(KeyTypeId, Id)>>::IdentificationTuple;
-type GrandpaOffenceReporter<T> = pallet_cf_reputation::ChainflipOffenceReportingAdapter<
+pub type GrandpaOffenceReporter<T> = pallet_cf_reputation::ChainflipOffenceReportingAdapter<
 	T,
 	pallet_grandpa::EquivocationOffence<
 		KeyOwnerIdentification<CurrentSessionProofSystem, GrandpaId>,

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -18,6 +18,8 @@
 #![feature(step_trait)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(associated_type_defaults)]
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "512"]
 
@@ -419,7 +421,7 @@ pub type PalletExecutionOrder = (
 /// - Housekeeping migrations. Don't remove this - check individual housekeeping migrations and
 ///   remove them when they are no longer needed.
 /// - Release-specific migrations: remove these if they are no longer needed.
-type AllMigrations = (
+pub type AllMigrations = (
 	// This ClearEvents should only be run at the start of all migrations. This is in case another
 	// migration needs to trigger an event like a Broadcast for example.
 	pallet_cf_cfe_interface::migrations::ClearEvents<Runtime>,
@@ -434,7 +436,7 @@ type AllMigrations = (
 /// All the pallet-specific migrations and migrations that depend on pallet migration order. Do not
 /// comment out or remove pallet migrations. Prefer to delete the migration at the pallet level and
 /// replace with a dummy migration.
-type PalletMigrations = (
+pub type PalletMigrations = (
 	pallet_cf_environment::migrations::PalletMigration<Runtime>,
 	pallet_cf_funding::migrations::PalletMigration<Runtime>,
 	pallet_cf_account_roles::migrations::PalletMigration<Runtime>,
@@ -532,7 +534,7 @@ macro_rules! instanced_migrations {
 }
 
 // Add version-specific migrations here.
-type MigrationsForV2_3 = (
+pub type MigrationsForV2_3 = (
 	migrations::safe_mode::SafeModeMigration,
 	migrations::bsc_integration::BscElectionsInit,
 	migrations::bsc_integration::BscIngressEgressInit,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -581,7 +581,7 @@ pub enum TransactionScreeningEvent<TxId, DepositDetails, Address> {
 	},
 }
 
-pub type BrokerRejectionEventFor<C> = TransactionScreeningEvent<
+pub type BrokerRejectionEventFor<C: Chain> = TransactionScreeningEvent<
 	<<C as Chain>::ChainCrypto as ChainCrypto>::TransactionInId,
 	<C as Chain>::DepositDetails,
 	<C as Chain>::ChainAccount,
@@ -863,7 +863,9 @@ pub enum RuntimeApiAccountInfo {
 	Operator(Box<OperatorInfo<FlipBalance>>),
 }
 
-#[derive(Encode, Decode, TypeInfo, PartialEq, Debug, Default)]
+#[derive(
+	Encode, Decode, TypeInfo, PartialEq, Debug, Default, cf_proc_macros::HasTypeIntrospection,
+)]
 #[cfg_attr(
 	any(test, all(feature = "proptest", feature = "std")),
 	derive(proptest_derive::Arbitrary)

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
@@ -14,7 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use cf_utilities::migrations::{basics::migrate_from_historical_type, v20000};
+use cf_utilities::migrations::{
+	basics::migrate_from_historical_type, v20000, v20100, v20200, v20300,
+};
 
 #[derive(Encode, Decode, TypeInfo, Clone)]
 pub struct VaultAddresses {
@@ -57,10 +59,19 @@ impl From<VaultAddresses> for super::VaultAddresses {
 	}
 }
 
-pub type RpcAccountInfoCommonItems<Balance> =
-	<super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20000>>::HistoricalType;
+pub type RpcAccountInfoCommonItems<Balance: HasChangelog + Default>
+	= <super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20000>>::HistoricalType
+where
+	<Balance as HasVersion<v20300>>::HistoricalType: Default,
+	<Balance as HasVersion<v20200>>::HistoricalType: Default,
+	<Balance as HasVersion<v20100>>::HistoricalType: Default;
 
-pub type AssetMap<T> = <super::AssetMap<T> as HasVersion<v20000>>::HistoricalType;
+pub type AssetMap<T: HasChangelog + Default>
+	= <super::AssetMap<T> as HasVersion<v20000>>::HistoricalType
+where
+	<T as HasVersion<v20300>>::HistoricalType: Default,
+	<T as HasVersion<v20200>>::HistoricalType: Default,
+	<T as HasVersion<v20100>>::HistoricalType: Default;
 
 #[derive(Encode, Decode, TypeInfo, Default)]
 pub struct LiquidityProviderInfo {

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -19,7 +19,7 @@ use cf_chains::instances::{
 	EvmInstance, PolkadotCryptoInstance, PolkadotInstance, SolanaCryptoInstance, SolanaInstance,
 };
 use cf_traits::{lending::LoanId, SafeModeSet};
-use cf_utilities::migrations::{basics::HasVersion, v20100};
+use cf_utilities::migrations::{basics::HasVersion, v20100, v20200, v20300};
 use codec::{DecodeWithMemTracking, MaxEncodedLen};
 use frame_support::sp_runtime::Percent;
 use pallet_cf_lending_pools::{LendingPoolConfiguration, NetworkFeeContributions};
@@ -256,8 +256,12 @@ impl From<LiquidityProviderInfo> for super::LiquidityProviderInfo {
 	}
 }
 
-pub type RpcAccountInfoCommonItems<Balance> =
-	<super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20100>>::HistoricalType;
+pub type RpcAccountInfoCommonItems<Balance: HasChangelog + Default>
+	= <super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20100>>::HistoricalType
+where
+	<Balance as HasVersion<v20300>>::HistoricalType: Default,
+	<Balance as HasVersion<v20200>>::HistoricalType: Default,
+	<Balance as HasVersion<v20100>>::HistoricalType: Default;
 
 // VaultAddresses as returned by api_version 16 runtimes: has usdt fields added in v16
 // but lacks the tron field added in v17.

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -53,10 +53,13 @@ scale-json = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
+cf-proc-macros = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true, default-features = true }
 tempfile = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
+derive-where = { workspace = true }
 
 [features]
 std = [

--- a/utilities/proc-macros/Cargo.toml
+++ b/utilities/proc-macros/Cargo.toml
@@ -9,6 +9,6 @@ version = "0.1.0"
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["full"] }
+syn = { workspace = true, features = ["full", "visit-mut"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/utilities/proc-macros/src/arbitrary.rs
+++ b/utilities/proc-macros/src/arbitrary.rs
@@ -1,0 +1,260 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse::Parse, punctuated::Punctuated, token::Comma, Data, DeriveInput, Fields, Type};
+
+/// Maximum number of elements in a single strategy tuple (proptest supports up to 12).
+const CHUNK_SIZE: usize = 10;
+
+/// Returns true if a type looks like `PhantomData<...>` (possibly qualified).
+fn is_phantom_data(ty: &Type) -> bool {
+	match ty {
+		Type::Path(type_path) => {
+			let last_segment = type_path.path.segments.last();
+			last_segment.is_some_and(|seg| seg.ident == "PhantomData")
+		},
+		_ => false,
+	}
+}
+
+/// Parsed contents of `#[arbitrary(bound = "...")]`.
+struct BoundAttr {
+	predicates: Punctuated<syn::WherePredicate, Comma>,
+}
+
+impl Parse for BoundAttr {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let predicates = Punctuated::parse_terminated(input)?;
+		Ok(BoundAttr { predicates })
+	}
+}
+
+/// Parse the `#[arbitrary(...)]` attributes from a derive input.
+/// Returns `Ok(Some(predicates))` if an explicit bound was given, `Ok(None)` if not.
+///
+/// Supports two syntaxes:
+/// - `#[arbitrary(bound = "T: Trait, U: Other")]` — string literal (for direct use)
+/// - `#[arbitrary(bound(T: Trait, U: Other))]` — raw tokens (for use inside declarative macros)
+fn parse_arbitrary_attrs(input: &DeriveInput) -> syn::Result<Option<Vec<syn::WherePredicate>>> {
+	let mut bounds: Option<Vec<syn::WherePredicate>> = None;
+
+	for attr in &input.attrs {
+		if !attr.path().is_ident("arbitrary") {
+			continue;
+		}
+
+		let nested = attr.parse_args_with(Punctuated::<syn::Meta, Comma>::parse_terminated)?;
+
+		for meta in nested {
+			match &meta {
+				syn::Meta::NameValue(nv) if nv.path.is_ident("bound") => {
+					// #[arbitrary(bound = "T: Trait, ...")]
+					let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(lit), .. }) = &nv.value
+					else {
+						return Err(syn::Error::new_spanned(
+							&nv.value,
+							"expected string literal for `bound`",
+						));
+					};
+					let parsed: BoundAttr = lit.parse()?;
+					let predicates: Vec<_> = parsed.predicates.into_iter().collect();
+					match &mut bounds {
+						Some(existing) => existing.extend(predicates),
+						None => bounds = Some(predicates),
+					}
+				},
+				syn::Meta::List(list) if list.path.is_ident("bound") => {
+					// #[arbitrary(bound(T: Trait, ...))]
+					let parsed: BoundAttr = syn::parse2(list.tokens.clone())?;
+					let predicates: Vec<_> = parsed.predicates.into_iter().collect();
+					match &mut bounds {
+						Some(existing) => existing.extend(predicates),
+						None => bounds = Some(predicates),
+					}
+				},
+				_ => {
+					return Err(syn::Error::new_spanned(
+						&meta,
+						"unknown arbitrary attribute, expected `bound`",
+					));
+				},
+			}
+		}
+	}
+
+	Ok(bounds)
+}
+
+/// Generates a strategy expression and destructuring pattern for a chunk of fields.
+/// Returns (strategy_expr, pattern_bindings) for a flat tuple of `any::<T>()` calls.
+fn generate_chunk_strategy(
+	field_types: &[&Type],
+	binding_idents: &[syn::Ident],
+) -> (TokenStream, TokenStream) {
+	let strategies: Vec<_> = field_types
+		.iter()
+		.map(|ty| quote! { proptest::arbitrary::any::<#ty>() })
+		.collect();
+	let bindings: Vec<_> = binding_idents.iter().map(|id| quote! { #id }).collect();
+
+	(quote! { ( #(#strategies),* ) }, quote! { ( #(#bindings),* ) })
+}
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let name = &input.ident;
+	let generics = &input.generics;
+
+	let fields = match &input.data {
+		Data::Struct(data) => match &data.fields {
+			Fields::Named(fields) => &fields.named,
+			Fields::Unnamed(_) | Fields::Unit => {
+				return syn::Error::new_spanned(
+					name,
+					"ArbitraryWithBounds can only be derived for structs with named fields",
+				)
+				.to_compile_error();
+			},
+		},
+		Data::Enum(_) | Data::Union(_) => {
+			return syn::Error::new_spanned(
+				name,
+				"ArbitraryWithBounds can only be derived for structs",
+			)
+			.to_compile_error();
+		},
+	};
+
+	// Parse bound attribute
+	let explicit_bounds = match parse_arbitrary_attrs(&input) {
+		Ok(b) => b,
+		Err(e) => return e.to_compile_error(),
+	};
+
+	// Partition fields into "real" (need strategy) and "phantom" (use Default)
+	let mut real_fields: Vec<(&syn::Ident, &Type)> = Vec::new();
+	let mut phantom_fields: Vec<&syn::Ident> = Vec::new();
+
+	for field in fields.iter() {
+		let ident = field.ident.as_ref().expect("named fields have identifiers");
+		if is_phantom_data(&field.ty) {
+			phantom_fields.push(ident);
+		} else {
+			real_fields.push((ident, &field.ty));
+		}
+	}
+
+	// Generate the where clause
+	let (impl_generics, ty_generics, existing_where_clause) = generics.split_for_impl();
+
+	let where_predicates: Vec<TokenStream> = if let Some(ref bounds) = explicit_bounds {
+		bounds.iter().map(|pred| quote! { #pred }).collect()
+	} else {
+		// Default: require Arbitrary + 'static for each real field type, 'static for generics
+		let mut preds: Vec<TokenStream> = Vec::new();
+		for param in generics.type_params() {
+			let ident = &param.ident;
+			preds.push(quote! { #ident: 'static });
+		}
+		for (_, ty) in &real_fields {
+			preds.push(quote! { #ty: proptest::arbitrary::Arbitrary + 'static });
+		}
+		preds
+	};
+
+	// Combine existing where clause predicates with ours
+	let existing_preds: Vec<TokenStream> = existing_where_clause
+		.map(|wc| wc.predicates.iter().map(|p| quote! { #p }).collect())
+		.unwrap_or_default();
+
+	let all_preds: Vec<&TokenStream> =
+		existing_preds.iter().chain(where_predicates.iter()).collect();
+
+	// Generate the strategy body
+	let body = if real_fields.is_empty() {
+		// No real fields — all phantom. Just return a constant.
+		let phantom_inits: Vec<_> =
+			phantom_fields.iter().map(|id| quote! { #id: Default::default() }).collect();
+		quote! {
+			use proptest::strategy::Strategy;
+			proptest::strategy::Just(Self { #(#phantom_inits),* }).boxed()
+		}
+	} else {
+		// Generate binding identifiers for each real field
+		let binding_idents: Vec<syn::Ident> =
+			real_fields.iter().enumerate().map(|(i, _)| format_ident!("__f{}", i)).collect();
+
+		let real_field_types: Vec<&Type> = real_fields.iter().map(|(_, ty)| *ty).collect();
+
+		// Chunk the fields into groups of CHUNK_SIZE
+		let type_chunks: Vec<&[&Type]> = real_field_types.chunks(CHUNK_SIZE).collect();
+		let ident_chunks: Vec<&[syn::Ident]> = binding_idents.chunks(CHUNK_SIZE).collect();
+
+		// Build the strategy expression and pattern
+		let (strategy_expr, pattern) = if type_chunks.len() == 1 {
+			// Single chunk — flat tuple
+			generate_chunk_strategy(type_chunks[0], ident_chunks[0])
+		} else {
+			// Multiple chunks — nested tuple of tuples
+			let mut strategy_parts = Vec::new();
+			let mut pattern_parts = Vec::new();
+			for (types, idents) in type_chunks.iter().zip(ident_chunks.iter()) {
+				let (s, p) = generate_chunk_strategy(types, idents);
+				strategy_parts.push(s);
+				pattern_parts.push(p);
+			}
+			(quote! { ( #(#strategy_parts),* ) }, quote! { ( #(#pattern_parts),* ) })
+		};
+
+		// Build the struct construction
+		let field_inits: Vec<TokenStream> = real_fields
+			.iter()
+			.enumerate()
+			.map(|(i, (field_name, _))| {
+				let binding = &binding_idents[i];
+				quote! { #field_name: #binding }
+			})
+			.collect();
+		let phantom_inits: Vec<TokenStream> =
+			phantom_fields.iter().map(|id| quote! { #id: Default::default() }).collect();
+
+		quote! {
+			use proptest::strategy::Strategy;
+
+			#strategy_expr
+				.prop_map(|#pattern| Self {
+					#(#field_inits,)*
+					#(#phantom_inits,)*
+				})
+				.boxed()
+		}
+	};
+
+	quote! {
+		impl #impl_generics proptest::arbitrary::Arbitrary for #name #ty_generics
+		where
+			#(#all_preds),*
+		{
+			type Parameters = ();
+			type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+			fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+				#body
+			}
+		}
+	}
+}

--- a/utilities/proc-macros/src/generate_module.rs
+++ b/utilities/proc-macros/src/generate_module.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+pub fn expand(item_clone: TokenStream, parsed: syn::Item) -> TokenStream {
+	let (item_for_generate_module, mod_name) = match &parsed {
+		syn::Item::Struct(item_struct) => (item_clone, format_ident!("_{}", item_struct.ident)),
+		syn::Item::Enum(item_enum) =>
+			(enum_with_tuple_field_names(item_enum), format_ident!("_{}", item_enum.ident)),
+		_ => {
+			return syn::Error::new_spanned(
+				parsed,
+				"#[generate_module] can only be applied to structs or enums",
+			)
+			.to_compile_error();
+		},
+	};
+
+	quote! {
+		cf_utilities::generate_module! {
+			#item_for_generate_module
+			mod #mod_name { #![migrations] }
+		}
+	}
+}
+
+fn enum_with_tuple_field_names(item_enum: &syn::ItemEnum) -> TokenStream {
+	let attrs = &item_enum.attrs;
+	let vis = &item_enum.vis;
+	let enum_ident = &item_enum.ident;
+	let generics = &item_enum.generics;
+	let variants = item_enum.variants.iter().map(|variant| {
+		let attrs = &variant.attrs;
+		let variant_ident = &variant.ident;
+		let fields = match &variant.fields {
+			syn::Fields::Unit => quote! {},
+			syn::Fields::Named(fields) => {
+				let fields = fields.named.iter().map(|field| {
+					let field_ident = field.ident.as_ref().expect("named fields have identifiers");
+					let ty = &field.ty;
+					quote! { #field_ident: #ty, }
+				});
+				quote! { { #( #fields )* } }
+			},
+			syn::Fields::Unnamed(fields) => {
+				let fields = fields.unnamed.iter().enumerate().map(|(index, field)| {
+					let field_ident = format_ident!("_{}", index);
+					let ty = &field.ty;
+					quote! { #field_ident: #ty }
+				});
+				quote! { ( #( #fields ),* ) }
+			},
+		};
+		let discriminant = variant.discriminant.as_ref().map(|(_, expr)| quote! { = #expr });
+
+		quote! {
+			#( #attrs )*
+			#variant_ident #fields #discriminant,
+		}
+	});
+
+	quote! {
+		#( #attrs )*
+		#vis enum #enum_ident #generics {
+			#( #variants )*
+		}
+	}
+}

--- a/utilities/proc-macros/src/generic_modules.rs
+++ b/utilities/proc-macros/src/generic_modules.rs
@@ -1,0 +1,1079 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+	braced, parenthesized,
+	parse::{Parse, ParseStream},
+	token,
+	visit_mut::{self, VisitMut},
+	Attribute, ExprPath, GenericArgument, Generics, Ident, Item, ItemEnum, ItemImpl, ItemMacro,
+	ItemMod, ItemStruct, ItemTrait, ItemType, ItemUse, PathArguments, Token, TraitBound, Type,
+	TypeParam, UseTree, Visibility, WherePredicate,
+};
+
+// ─── Input parsing ────────────────────────────────────────────────────────────
+
+/// Top-level input: a sequence of Rust items plus optional telescope scopes like
+/// `mod (A: Trait) (B: Trait) { ... }`.
+pub struct Input {
+	pub items: Vec<ModuleItem>,
+}
+
+/// Items that can appear inside a `generic_modules!` block.
+pub enum ModuleItem {
+	TypeAlias(ItemType),
+	Struct(ItemStruct),
+	Enum(ItemEnum),
+	Trait(ItemTrait),
+	Impl(ItemImpl),
+	Mod(ItemMod),
+	PlainMod(PlainMod),
+	TelescopeMod(TelescopeMod),
+	Use(ItemUse),
+	MacroCall(ItemMacro),
+	Conditional(Conditional),
+	Other(Item),
+}
+
+/// `mod foo { ... }` or `mod foo;` parsed with `generic_modules` items in the body.
+pub struct PlainMod {
+	pub attrs: Vec<Attribute>,
+	pub vis: Visibility,
+	pub ident: Ident,
+	pub items: Option<Vec<ModuleItem>>,
+}
+
+/// `mod (A: Trait) (B: Trait) where (A: Bound) { ... }`
+pub struct TelescopeMod {
+	pub telescope: Vec<TypeParam>,
+	pub where_predicates: Vec<WherePredicate>,
+	pub items: Vec<ModuleItem>,
+}
+
+/// `if (condition) { ... } else { ... }` or `if () { ... } else { ... }`
+pub struct Conditional {
+	pub condition: Option<TokenStream>,
+	pub true_branch: Vec<ModuleItem>,
+	pub false_branch: Vec<ModuleItem>,
+}
+
+// ─── Parsing implementations ──────────────────────────────────────────────────
+
+impl Parse for Input {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		let items = parse_module_items(input)?;
+
+		Ok(Input { items })
+	}
+}
+
+fn parse_telescope_mod(input: ParseStream) -> syn::Result<TelescopeMod> {
+	input.parse::<Token![mod]>()?;
+
+	// Parse telescope: (A: Trait) (B: Trait) ...
+	let mut telescope = Vec::new();
+	while input.peek(token::Paren) {
+		let content;
+		parenthesized!(content in input);
+		telescope.push(content.parse::<TypeParam>()?);
+	}
+
+	let mut where_predicates = Vec::new();
+	if input.peek(Token![where]) {
+		input.parse::<Token![where]>()?;
+		while input.peek(token::Paren) {
+			let content;
+			parenthesized!(content in input);
+			where_predicates.push(content.parse::<WherePredicate>()?);
+		}
+	}
+
+	// Parse braced body
+	let body;
+	braced!(body in input);
+	let items = parse_module_items(&body)?;
+
+	Ok(TelescopeMod { telescope, where_predicates, items })
+}
+
+fn parse_plain_mod(input: ParseStream) -> syn::Result<PlainMod> {
+	let attrs = input.call(Attribute::parse_outer)?;
+	let vis = input.parse::<Visibility>()?;
+	input.parse::<Token![mod]>()?;
+	let ident = input.parse::<Ident>()?;
+
+	let items = if input.peek(Token![;]) {
+		input.parse::<Token![;]>()?;
+		None
+	} else {
+		let body;
+		braced!(body in input);
+		Some(parse_module_items(&body)?)
+	};
+
+	Ok(PlainMod { attrs, vis, ident, items })
+}
+
+fn parse_module_items(input: ParseStream) -> syn::Result<Vec<ModuleItem>> {
+	let mut items = Vec::new();
+	while !input.is_empty() {
+		items.push(parse_module_item(input)?);
+	}
+	Ok(items)
+}
+
+fn parse_module_item(input: ParseStream) -> syn::Result<ModuleItem> {
+	// Check for `if` conditional
+	if input.peek(Token![if]) {
+		return Ok(ModuleItem::Conditional(parse_conditional(input)?));
+	}
+
+	{
+		let fork = input.fork();
+		let attrs = fork.call(Attribute::parse_outer)?;
+		let vis = fork.parse::<Visibility>()?;
+
+		if fork.peek(Token![type]) {
+			return Ok(ModuleItem::TypeAlias(parse_type_alias(input)?));
+		}
+
+		if fork.peek(Token![mod]) {
+			fork.parse::<Token![mod]>()?;
+			if fork.peek(token::Paren) || fork.peek(Token![where]) || fork.peek(token::Brace) {
+				if attrs.is_empty() && matches!(vis, Visibility::Inherited) {
+					return Ok(ModuleItem::TelescopeMod(parse_telescope_mod(input)?));
+				}
+			} else {
+				return Ok(ModuleItem::PlainMod(parse_plain_mod(input)?));
+			}
+		}
+	}
+
+	// Otherwise parse as a standard Rust item and classify
+	let item: Item = input.parse()?;
+	Ok(match item {
+		Item::Type(t) => ModuleItem::TypeAlias(t),
+		Item::Struct(s) => ModuleItem::Struct(s),
+		Item::Enum(e) => ModuleItem::Enum(e),
+		Item::Trait(t) => ModuleItem::Trait(t),
+		Item::Impl(i) => ModuleItem::Impl(i),
+		Item::Mod(m) => ModuleItem::Mod(m),
+		Item::Use(u) => ModuleItem::Use(u),
+		Item::Macro(m) => ModuleItem::MacroCall(m),
+		other => ModuleItem::Other(other),
+	})
+}
+
+fn parse_type_alias(input: ParseStream) -> syn::Result<ItemType> {
+	let attrs = input.call(Attribute::parse_outer)?;
+	let vis = input.parse::<Visibility>()?;
+	let type_token = input.parse::<Token![type]>()?;
+	let ident = input.parse::<Ident>()?;
+	let mut generics = input.parse::<Generics>()?;
+	let eq_token = input.parse::<Token![=]>()?;
+	let ty = input.parse::<Type>()?;
+
+	if input.peek(Token![where]) {
+		if generics.where_clause.is_some() {
+			return Err(input.error("duplicate where clause in type alias"));
+		}
+		generics.where_clause = Some(input.parse()?);
+	}
+
+	let semi_token = input.parse::<Token![;]>()?;
+
+	Ok(ItemType { attrs, vis, type_token, ident, generics, eq_token, ty: Box::new(ty), semi_token })
+}
+
+fn parse_conditional(input: ParseStream) -> syn::Result<Conditional> {
+	input.parse::<Token![if]>()?;
+
+	// Parse condition in parentheses
+	let cond_content;
+	parenthesized!(cond_content in input);
+	let condition: TokenStream = cond_content.parse()?;
+	let condition = if condition.is_empty() { None } else { Some(condition) };
+
+	// Parse true branch
+	let true_body;
+	braced!(true_body in input);
+	let true_branch = parse_module_items(&true_body)?;
+
+	// Parse else branch
+	input.parse::<Token![else]>()?;
+	let false_body;
+	braced!(false_body in input);
+	let false_branch = parse_module_items(&false_body)?;
+
+	Ok(Conditional { condition, true_branch, false_branch })
+}
+
+// ─── Code generation ──────────────────────────────────────────────────────────
+
+type ScopePath = Vec<String>;
+
+#[derive(Clone)]
+enum ImportTarget {
+	Definition(DefinitionInfo),
+	Module(ScopePath),
+}
+
+#[derive(Clone)]
+struct DefinitionInfo {
+	telescope_params: Vec<Ident>,
+	explicit_generic_count: usize,
+}
+
+/// Tracks local items produced by the macro. Definitions are keyed by module
+/// path so qualified paths can be resolved before telescope params are added.
+#[derive(Clone, Default)]
+struct Definitions {
+	definitions: HashMap<ScopePath, DefinitionInfo>,
+	modules: HashSet<ScopePath>,
+	imports: HashMap<ScopePath, HashMap<String, ImportTarget>>,
+}
+
+impl Definitions {
+	fn register(
+		&mut self,
+		scope: &[String],
+		name: &Ident,
+		tele_params: &[&TypeParam],
+		explicit_generic_count: usize,
+	) {
+		let info = DefinitionInfo {
+			telescope_params: tele_params.iter().map(|p| p.ident.clone()).collect(),
+			explicit_generic_count,
+		};
+		let mut path = scope.to_vec();
+		path.push(name.to_string());
+		self.definitions.insert(path, info);
+	}
+
+	fn register_module(&mut self, scope: &[String], name: &Ident) -> ScopePath {
+		let mut path = scope.to_vec();
+		path.push(name.to_string());
+		self.modules.insert(path.clone());
+		path
+	}
+
+	fn register_use(&mut self, scope: &[String], item: &ItemUse) {
+		let mut prefix = Vec::new();
+		self.register_use_tree(scope, &mut prefix, &item.tree);
+	}
+
+	fn register_use_tree(&mut self, scope: &[String], prefix: &mut ScopePath, tree: &UseTree) {
+		match tree {
+			UseTree::Path(path) => {
+				prefix.push(path.ident.to_string());
+				self.register_use_tree(scope, prefix, &path.tree);
+				prefix.pop();
+			},
+			UseTree::Name(name) => {
+				let mut target = prefix.clone();
+				target.push(name.ident.to_string());
+				self.register_import(scope, name.ident.to_string(), &target);
+			},
+			UseTree::Rename(rename) => {
+				let mut target = prefix.clone();
+				target.push(rename.ident.to_string());
+				self.register_import(scope, rename.rename.to_string(), &target);
+			},
+			UseTree::Glob(_) =>
+				if let Some(module_path) = self.resolve_module_path(scope, prefix) {
+					for (path, params) in self.definitions.clone() {
+						if path.len() == module_path.len() + 1 && path.starts_with(&module_path) {
+							if let Some(name) = path.last() {
+								self.imports
+									.entry(scope.to_vec())
+									.or_default()
+									.insert(name.clone(), ImportTarget::Definition(params));
+							}
+						}
+					}
+					for path in self.modules.clone() {
+						if path.len() == module_path.len() + 1 && path.starts_with(&module_path) {
+							if let Some(name) = path.last() {
+								self.imports
+									.entry(scope.to_vec())
+									.or_default()
+									.insert(name.clone(), ImportTarget::Module(path));
+							}
+						}
+					}
+				},
+			UseTree::Group(group) =>
+				for tree in &group.items {
+					self.register_use_tree(scope, prefix, tree);
+				},
+		}
+	}
+
+	fn register_import(&mut self, scope: &[String], alias: String, target: &[String]) {
+		if let Some(params) = self.resolve_definition_path(scope, target) {
+			self.imports
+				.entry(scope.to_vec())
+				.or_default()
+				.insert(alias, ImportTarget::Definition(params));
+		} else if let Some(module_path) = self.resolve_module_path(scope, target) {
+			self.imports
+				.entry(scope.to_vec())
+				.or_default()
+				.insert(alias, ImportTarget::Module(module_path));
+		}
+	}
+
+	fn resolve_path_prefix(
+		&self,
+		scope: &[String],
+		path: &syn::Path,
+		generic_idents: &[Ident],
+	) -> Option<(usize, DefinitionInfo)> {
+		if path.leading_colon.is_some() {
+			return None;
+		}
+
+		let segments: Vec<String> = path.segments.iter().map(|seg| seg.ident.to_string()).collect();
+		if segments.is_empty() {
+			return None;
+		}
+
+		if segments.len() > 1 && generic_idents.iter().any(|ident| ident == &path.segments[0].ident)
+		{
+			return None;
+		}
+
+		for len in (1..=segments.len()).rev() {
+			if let Some(params) = self.resolve_definition_path(scope, &segments[..len]) {
+				return Some((len - 1, params));
+			}
+		}
+
+		None
+	}
+
+	fn resolve_definition_path(
+		&self,
+		scope: &[String],
+		segments: &[String],
+	) -> Option<DefinitionInfo> {
+		if segments.is_empty() {
+			return None;
+		}
+
+		if segments.len() == 1 {
+			if let Some(params) =
+				self.definitions.get(&scope.iter().chain(segments).cloned().collect::<Vec<_>>())
+			{
+				return Some(params.clone());
+			}
+
+			if let Some(ImportTarget::Definition(params)) =
+				self.imports.get(scope).and_then(|imports| imports.get(&segments[0]))
+			{
+				return Some(params.clone());
+			}
+			return None;
+		}
+
+		if let Some(resolved) = self.resolve_path_starting_with_import(scope, segments) {
+			return self.definitions.get(&resolved).cloned();
+		}
+
+		let candidate = scope.iter().chain(segments).cloned().collect::<Vec<_>>();
+		self.definitions.get(&candidate).cloned()
+	}
+
+	fn resolve_module_path(&self, scope: &[String], segments: &[String]) -> Option<ScopePath> {
+		if segments.is_empty() {
+			return Some(scope.to_vec());
+		}
+
+		if let Some(resolved) = self.resolve_path_starting_with_import(scope, segments) {
+			if self.modules.contains(&resolved) {
+				return Some(resolved);
+			}
+		}
+
+		let candidate = scope.iter().chain(segments).cloned().collect::<Vec<_>>();
+		if self.modules.contains(&candidate) {
+			return Some(candidate);
+		}
+
+		None
+	}
+
+	fn resolve_path_starting_with_import(
+		&self,
+		scope: &[String],
+		segments: &[String],
+	) -> Option<ScopePath> {
+		match segments.first().map(String::as_str) {
+			Some("self") => Some(scope.iter().chain(segments.iter().skip(1)).cloned().collect()),
+			Some("super") => {
+				let mut resolved = scope.to_vec();
+				let mut rest = segments;
+				while matches!(rest.first().map(String::as_str), Some("super")) {
+					resolved.pop();
+					rest = &rest[1..];
+				}
+				resolved.extend(rest.iter().cloned());
+				Some(resolved)
+			},
+			Some("crate") => None,
+			Some(first) => match self.imports.get(scope).and_then(|imports| imports.get(first)) {
+				Some(ImportTarget::Module(module_path)) =>
+					Some(module_path.iter().chain(segments.iter().skip(1)).cloned().collect()),
+				_ => None,
+			},
+			None => None,
+		}
+	}
+}
+
+/// Visitor that rewrites type paths: if a path segment matches a known
+/// definition, append its telescope params as generic arguments.
+struct RewriteVisitor<'a> {
+	defs: &'a Definitions,
+	scope: &'a [String],
+	generic_idents: Vec<Ident>,
+}
+
+impl VisitMut for RewriteVisitor<'_> {
+	fn visit_trait_bound_mut(&mut self, trait_bound: &mut TraitBound) {
+		visit_mut::visit_trait_bound_mut(self, trait_bound);
+		self.rewrite_path(&mut trait_bound.path);
+	}
+
+	fn visit_item_impl_mut(&mut self, item_impl: &mut ItemImpl) {
+		visit_mut::visit_item_impl_mut(self, item_impl);
+
+		if let Some((_bang, trait_path, _for_token)) = &mut item_impl.trait_ {
+			self.rewrite_path(trait_path);
+		}
+	}
+
+	fn visit_type_path_mut(&mut self, type_path: &mut syn::TypePath) {
+		// Visit nested types first
+		visit_mut::visit_type_path_mut(self, type_path);
+
+		if type_path.qself.is_some() {
+			return;
+		}
+
+		self.rewrite_path(&mut type_path.path);
+	}
+
+	fn visit_expr_path_mut(&mut self, expr_path: &mut ExprPath) {
+		visit_mut::visit_expr_path_mut(self, expr_path);
+
+		if expr_path.qself.is_some() {
+			return;
+		}
+
+		self.rewrite_path(&mut expr_path.path);
+	}
+}
+
+impl RewriteVisitor<'_> {
+	fn rewrite_path(&self, path: &mut syn::Path) {
+		let Some((segment_index, definition)) =
+			self.defs.resolve_path_prefix(self.scope, path, &self.generic_idents)
+		else {
+			return;
+		};
+
+		if definition.telescope_params.is_empty() {
+			return;
+		}
+
+		if let Some(segment) = path.segments.iter_mut().nth(segment_index) {
+			let (mut retained_args, explicit_telescope_args) = match &segment.arguments {
+				PathArguments::None => (Vec::new(), Vec::new()),
+				PathArguments::AngleBracketed(existing) => {
+					let args: Vec<GenericArgument> = existing.args.iter().cloned().collect();
+					let split_index = definition.explicit_generic_count.min(args.len());
+					(args[..split_index].to_vec(), args[split_index..].to_vec())
+				},
+				PathArguments::Parenthesized(_) => return,
+			};
+
+			let mut explicit_telescope_args = explicit_telescope_args.into_iter().peekable();
+			for ident in &definition.telescope_params {
+				let in_scope =
+					self.generic_idents.iter().any(|generic_ident| generic_ident == ident);
+				if in_scope {
+					let arg: GenericArgument = syn::parse_quote! { #ident };
+					if explicit_telescope_args
+						.peek()
+						.is_some_and(|explicit| same_tokens(explicit, &arg))
+					{
+						explicit_telescope_args.next();
+					}
+					retained_args.push(arg);
+				} else if let Some(arg) = explicit_telescope_args.next() {
+					retained_args.push(arg);
+				} else {
+					return;
+				}
+			}
+			retained_args.extend(explicit_telescope_args);
+
+			let args: syn::AngleBracketedGenericArguments = syn::parse_quote! {
+				< #(#retained_args),* >
+			};
+			segment.arguments = PathArguments::AngleBracketed(args);
+		}
+	}
+}
+
+fn same_tokens(left: &GenericArgument, right: &GenericArgument) -> bool {
+	quote! { #left }.to_string() == quote! { #right }.to_string()
+}
+
+fn generic_idents(telescope: &[TypeParam], generics: &Generics) -> Vec<Ident> {
+	telescope
+		.iter()
+		.map(|param| param.ident.clone())
+		.chain(generics.type_params().map(|param| param.ident.clone()))
+		.collect()
+}
+
+fn rewrite_item_type_with_telescope(
+	item: &mut ItemType,
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	scope: &[String],
+) {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, &item.generics) };
+	visitor.visit_item_type_mut(item);
+}
+
+fn rewrite_where_predicates(
+	where_predicates: &[WherePredicate],
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	generics: &Generics,
+	scope: &[String],
+) -> Vec<WherePredicate> {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, generics) };
+	where_predicates
+		.iter()
+		.cloned()
+		.map(|mut predicate| {
+			visitor.visit_where_predicate_mut(&mut predicate);
+			predicate
+		})
+		.collect()
+}
+
+fn add_where_predicates(
+	generics: &mut Generics,
+	where_predicates: impl IntoIterator<Item = WherePredicate>,
+) {
+	for predicate in where_predicates {
+		generics.make_where_clause().predicates.push(predicate);
+	}
+}
+
+fn predicate_mentions_any_telescope_param(
+	predicate: &WherePredicate,
+	telescope_params: &[&TypeParam],
+) -> bool {
+	let tokens = quote! { #predicate };
+	telescope_params.iter().any(|param| tokens_contain_ident(&tokens, &param.ident))
+}
+
+fn type_alias_dependency_tokens(item: &ItemType) -> TokenStream {
+	let generics = &item.generics;
+	let ty = &item.ty;
+	quote! { #generics #ty }
+}
+
+fn quote_item_type(item: &ItemType) -> TokenStream {
+	let attrs = &item.attrs;
+	let vis = &item.vis;
+	let type_token = &item.type_token;
+	let ident = &item.ident;
+	let mut generics = item.generics.clone();
+	let where_clause = generics.where_clause.take();
+	let eq_token = &item.eq_token;
+	let ty = &item.ty;
+	let semi_token = &item.semi_token;
+
+	quote! {
+		#(#attrs)*
+		#vis #type_token #ident #generics #eq_token #ty #where_clause #semi_token
+	}
+}
+
+fn rewrite_item_struct(
+	item: &mut ItemStruct,
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	scope: &[String],
+) {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, &item.generics) };
+	visitor.visit_item_struct_mut(item);
+}
+
+fn rewrite_item_enum(
+	item: &mut ItemEnum,
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	scope: &[String],
+) {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, &item.generics) };
+	visitor.visit_item_enum_mut(item);
+}
+
+fn rewrite_item_trait(
+	item: &mut ItemTrait,
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	scope: &[String],
+) {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, &item.generics) };
+	visitor.visit_item_trait_mut(item);
+}
+
+fn rewrite_item_impl(
+	item: &mut ItemImpl,
+	defs: &Definitions,
+	telescope: &[TypeParam],
+	scope: &[String],
+) {
+	let mut visitor =
+		RewriteVisitor { defs, scope, generic_idents: generic_idents(telescope, &item.generics) };
+	visitor.visit_item_impl_mut(item);
+}
+
+/// Returns true if `ident` appears as a whole word anywhere in `tokens`.
+fn tokens_contain_ident(tokens: &TokenStream, ident: &Ident) -> bool {
+	let s = tokens.to_string();
+	let id = ident.to_string();
+	s.split(|c: char| !c.is_alphanumeric() && c != '_').any(|word| word == id)
+}
+
+/// Filter telescope params to only those whose ident appears in `tokens`.
+fn used_telescope_params<'a>(
+	telescope: &'a [TypeParam],
+	tokens: &TokenStream,
+) -> Vec<&'a TypeParam> {
+	telescope.iter().filter(|p| tokens_contain_ident(tokens, &p.ident)).collect()
+}
+
+pub fn expand(input: Input) -> TokenStream {
+	let mut defs = Definitions::default();
+	defs.modules.insert(Vec::new());
+	expand_items(&[], &[], &input.items, &mut defs, &[])
+}
+
+fn expand_items(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	items: &[ModuleItem],
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut output = TokenStream::new();
+	for item in items {
+		output.extend(expand_item(telescope, where_predicates, item, defs, scope));
+	}
+	output
+}
+
+fn expand_item(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ModuleItem,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	match item {
+		ModuleItem::TypeAlias(t) => expand_type_alias(telescope, where_predicates, t, defs, scope),
+		ModuleItem::Struct(s) => expand_struct(telescope, where_predicates, s, defs, scope),
+		ModuleItem::Enum(e) => expand_enum(telescope, where_predicates, e, defs, scope),
+		ModuleItem::Trait(t) => expand_trait(telescope, where_predicates, t, defs, scope),
+		ModuleItem::Impl(i) => expand_impl(telescope, where_predicates, i, defs, scope),
+		ModuleItem::Mod(m) => expand_mod(telescope, where_predicates, m, defs, scope),
+		ModuleItem::PlainMod(m) => expand_plain_mod(telescope, where_predicates, m, defs, scope),
+		ModuleItem::TelescopeMod(m) =>
+			expand_telescope_mod(telescope, where_predicates, m, defs, scope),
+		ModuleItem::Use(u) => expand_use(u, defs, scope),
+		ModuleItem::MacroCall(m) => expand_macro_call(telescope, where_predicates, m, defs, scope),
+		ModuleItem::Conditional(c) =>
+			expand_conditional(telescope, where_predicates, c, defs, scope),
+		ModuleItem::Other(item) => quote! { #item },
+	}
+}
+
+fn expand_plain_mod(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &PlainMod,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let attrs = &item.attrs;
+	let vis = &item.vis;
+	let ident = &item.ident;
+	match &item.items {
+		Some(items) => {
+			let inner_scope = defs.register_module(scope, ident);
+			let expanded = expand_items(telescope, where_predicates, items, defs, &inner_scope);
+
+			quote! {
+				#(#attrs)*
+				#vis mod #ident {
+					#expanded
+				}
+			}
+		},
+		None => quote! { #(#attrs)* #vis mod #ident; },
+	}
+}
+
+fn expand_telescope_mod(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &TelescopeMod,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut combined_telescope = telescope.to_vec();
+	combined_telescope.extend(item.telescope.iter().cloned());
+	let mut combined_where_predicates = where_predicates.to_vec();
+	combined_where_predicates.extend(item.where_predicates.iter().cloned());
+	expand_items(&combined_telescope, &combined_where_predicates, &item.items, defs, scope)
+}
+
+fn expand_type_alias(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemType,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// First rewrite references to previously defined items
+	rewrite_item_type_with_telescope(&mut item, defs, telescope, scope);
+
+	// Only add telescope params that appear in the (rewritten) type definition,
+	// including generic bounds and where clauses.
+	let ty_tokens = type_alias_dependency_tokens(&item);
+	let used = used_telescope_params(telescope, &ty_tokens);
+
+	// Register this definition before adding params to generics
+	defs.register(scope, &item.ident, &used, item.generics.params.len());
+
+	for param in &used {
+		item.generics.params.push(syn::GenericParam::Type((*param).clone()));
+	}
+
+	let rewritten_where_predicates =
+		rewrite_where_predicates(where_predicates, defs, telescope, &item.generics, scope);
+	add_where_predicates(
+		&mut item.generics,
+		rewritten_where_predicates
+			.into_iter()
+			.filter(|predicate| predicate_mentions_any_telescope_param(predicate, &used)),
+	);
+
+	quote_item_type(&item)
+}
+
+fn expand_struct(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemStruct,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// First rewrite references to previously defined items in field types
+	rewrite_item_struct(&mut item, defs, telescope, scope);
+
+	// Register this definition with ALL telescope params
+	let all_params: Vec<&TypeParam> = telescope.iter().collect();
+	defs.register(scope, &item.ident, &all_params, item.generics.params.len());
+
+	// Determine which telescope params are used in the struct fields
+	let fields_tokens = match &item.fields {
+		syn::Fields::Named(f) => quote! { #f },
+		syn::Fields::Unnamed(f) => quote! { #f },
+		syn::Fields::Unit => TokenStream::new(),
+	};
+	let fields_str = fields_tokens.to_string();
+
+	// Add ALL telescope type params to generics
+	for param in telescope {
+		item.generics.params.push(syn::GenericParam::Type(param.clone()));
+	}
+	let rewritten_where_predicates =
+		rewrite_where_predicates(where_predicates, defs, telescope, &item.generics, scope);
+	add_where_predicates(&mut item.generics, rewritten_where_predicates);
+
+	// Always add PhantomData for telescope types that are NOT used in fields. Use
+	// an empty tuple when all telescope types already occur in the fields, so the
+	// generated struct shape is stable for callers.
+	let unused_idents: Vec<&Ident> = telescope
+		.iter()
+		.map(|p| &p.ident)
+		.filter(|id| {
+			!fields_str.split(|c: char| !c.is_alphanumeric() && c != '_').any(|w| *id == w)
+		})
+		.collect();
+
+	if let syn::Fields::Named(ref mut fields) = item.fields {
+		let phantom_type: syn::Type = syn::parse_quote! {
+			core::marker::PhantomData<( #(#unused_idents,)* )>
+		};
+
+		let mut phantom_index = 1usize;
+		let phantom_ident = loop {
+			let candidate = if phantom_index == 1 {
+				format_ident!("_phantom")
+			} else {
+				format_ident!("_phantom{}", phantom_index)
+			};
+
+			if !fields
+				.named
+				.iter()
+				.any(|field| field.ident.as_ref().is_some_and(|ident| ident == &candidate))
+			{
+				break candidate;
+			}
+
+			phantom_index += 1;
+		};
+
+		let phantom_field: syn::Field = syn::parse_quote! {
+			#phantom_ident: #phantom_type
+		};
+		fields.named.push(phantom_field);
+	}
+
+	quote! { #item }
+}
+
+fn expand_enum(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemEnum,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// First rewrite references to previously defined items in variant fields.
+	rewrite_item_enum(&mut item, defs, telescope, scope);
+
+	// Register this definition with ALL telescope params, matching structs.
+	let all_params: Vec<&TypeParam> = telescope.iter().collect();
+	defs.register(scope, &item.ident, &all_params, item.generics.params.len());
+
+	// Add ALL telescope type params to generics.
+	for param in telescope {
+		item.generics.params.push(syn::GenericParam::Type(param.clone()));
+	}
+	let rewritten_where_predicates =
+		rewrite_where_predicates(where_predicates, defs, telescope, &item.generics, scope);
+	add_where_predicates(&mut item.generics, rewritten_where_predicates);
+
+	let mut phantom_index = 1usize;
+	let phantom_ident = loop {
+		let candidate = if phantom_index == 1 {
+			format_ident!("_phantom")
+		} else {
+			format_ident!("_phantom{}", phantom_index)
+		};
+
+		if !item.variants.iter().any(|variant| variant.ident == candidate) {
+			break candidate;
+		}
+
+		phantom_index += 1;
+	};
+
+	let telescope_idents = telescope.iter().map(|param| &param.ident);
+	let phantom_variant: syn::Variant = syn::parse_quote! {
+		#phantom_ident(cf_utilities::never::Never, core::marker::PhantomData<( #(#telescope_idents,)* )>)
+	};
+	item.variants.push(phantom_variant);
+
+	quote! { #item }
+}
+
+fn expand_trait(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemTrait,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// First rewrite references to previously defined items in bounds and trait items.
+	rewrite_item_trait(&mut item, defs, telescope, scope);
+
+	// Traits inherit all telescope params, matching structs. This keeps the trait's
+	// arity stable even when a macro-generated body is empty.
+	let all_params: Vec<&TypeParam> = telescope.iter().collect();
+
+	defs.register(scope, &item.ident, &all_params, item.generics.params.len());
+
+	for param in &all_params {
+		item.generics.params.push(syn::GenericParam::Type((*param).clone()));
+	}
+	let rewritten_where_predicates =
+		rewrite_where_predicates(where_predicates, defs, telescope, &item.generics, scope);
+	add_where_predicates(&mut item.generics, rewritten_where_predicates);
+
+	quote! { #item }
+}
+
+fn expand_impl(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemImpl,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// Rewrite references (self type, trait path, body)
+	rewrite_item_impl(&mut item, defs, telescope, scope);
+	let rewritten_where_predicates =
+		rewrite_where_predicates(where_predicates, defs, telescope, &item.generics, scope);
+	add_where_predicates(&mut item.generics, rewritten_where_predicates);
+
+	// Determine which telescope params are used in the (rewritten) impl
+	let impl_tokens = quote! { #item };
+	let used = used_telescope_params(telescope, &impl_tokens);
+
+	for param in used {
+		item.generics.params.push(syn::GenericParam::Type(param.clone()));
+	}
+
+	quote! { #item }
+}
+
+fn expand_mod(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemMod,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let vis = &item.vis;
+	let ident = &item.ident;
+
+	// Separate outer attributes (before `mod`) from inner attributes (inside braces)
+	let outer_attrs: Vec<_> =
+		item.attrs.iter().filter(|a| matches!(a.style, syn::AttrStyle::Outer)).collect();
+	let inner_attrs: Vec<_> = item
+		.attrs
+		.iter()
+		.filter(|a| matches!(a.style, syn::AttrStyle::Inner(_)))
+		.collect();
+
+	match &item.content {
+		Some((_brace, items)) => {
+			let inner_scope = defs.register_module(scope, ident);
+			let inner: Vec<ModuleItem> = items.iter().map(|i| classify_item(i.clone())).collect();
+			let expanded = expand_items(telescope, where_predicates, &inner, defs, &inner_scope);
+
+			quote! {
+				#(#outer_attrs)*
+				#vis mod #ident {
+					#(#inner_attrs)*
+					#expanded
+				}
+			}
+		},
+		None => quote! { #(#outer_attrs)* #vis mod #ident; },
+	}
+}
+
+fn expand_use(item: &ItemUse, defs: &mut Definitions, scope: &[String]) -> TokenStream {
+	defs.register_use(scope, item);
+	quote! { #item }
+}
+
+fn expand_conditional(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	cond: &Conditional,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let branch = match &cond.condition {
+		Some(_) => &cond.true_branch,
+		None => &cond.false_branch,
+	};
+	expand_items(telescope, where_predicates, branch, defs, scope)
+}
+
+fn expand_macro_call(
+	telescope: &[TypeParam],
+	where_predicates: &[WherePredicate],
+	item: &ItemMacro,
+	defs: &mut Definitions,
+	scope: &[String],
+) -> TokenStream {
+	let mut item = item.clone();
+
+	// Try to parse the macro body as a sequence of items and process them.
+	// If parsing succeeds, re-emit the macro with the processed body.
+	// If it fails, emit the macro verbatim.
+	let body_tokens = item.mac.tokens.clone();
+	let parsed: syn::Result<syn::File> = syn::parse2(quote! { #body_tokens });
+
+	if let Ok(file) = parsed {
+		let module_items: Vec<ModuleItem> = file.items.into_iter().map(classify_item).collect();
+		let expanded_body = expand_items(telescope, where_predicates, &module_items, defs, scope);
+		item.mac.tokens = expanded_body;
+	}
+
+	quote! { #item }
+}
+
+fn classify_item(item: Item) -> ModuleItem {
+	match item {
+		Item::Type(t) => ModuleItem::TypeAlias(t),
+		Item::Struct(s) => ModuleItem::Struct(s),
+		Item::Enum(e) => ModuleItem::Enum(e),
+		Item::Trait(t) => ModuleItem::Trait(t),
+		Item::Impl(i) => ModuleItem::Impl(i),
+		Item::Mod(m) => ModuleItem::Mod(m),
+		Item::Use(u) => ModuleItem::Use(u),
+		Item::Macro(m) => ModuleItem::MacroCall(m),
+		other => ModuleItem::Other(other),
+	}
+}

--- a/utilities/proc-macros/src/intro_elim.rs
+++ b/utilities/proc-macros/src/intro_elim.rs
@@ -1,0 +1,196 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields};
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	match &input.data {
+		Data::Struct(_) => derive_struct(input),
+		Data::Enum(_) => derive_enum(input),
+		Data::Union(_) =>
+			syn::Error::new_spanned(&input.ident, "IntroElim cannot be derived for unions")
+				.to_compile_error(),
+	}
+}
+
+fn derive_struct(input: DeriveInput) -> TokenStream {
+	let name = &input.ident;
+	let generics = &input.generics;
+	let fields = match &input.data {
+		Data::Struct(data) => match &data.fields {
+			Fields::Named(fields) => fields,
+			Fields::Unnamed(_) | Fields::Unit => {
+				return syn::Error::new_spanned(
+					name,
+					"IntroElim can only be derived for structs with named fields",
+				)
+				.to_compile_error();
+			},
+		},
+		Data::Enum(_) | Data::Union(_) => unreachable!(),
+	};
+
+	let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+	let intro_args = fields.named.iter().map(|field| {
+		let ident = field.ident.as_ref().expect("named fields have identifiers");
+		let ty = &field.ty;
+		quote! { #ident: #ty }
+	});
+	let field_inits = fields.named.iter().map(|field| {
+		let ident = field.ident.as_ref().expect("named fields have identifiers");
+		quote! { #ident }
+	});
+
+	quote! {
+		impl #impl_generics #name #ty_generics #where_clause {
+			#[allow(clippy::too_many_arguments)]
+			pub fn intro(#(#intro_args),*) -> Self {
+				Self {
+					#(#field_inits,)*
+				}
+			}
+		}
+	}
+}
+
+fn derive_enum(input: DeriveInput) -> TokenStream {
+	let enum_ident = input.ident;
+	let generics = input.generics;
+	let variants = match input.data {
+		Data::Enum(data) => data.variants,
+		Data::Struct(_) | Data::Union(_) => unreachable!(),
+	};
+
+	let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+	let output = format_ident!("__IntroElimOutput");
+
+	let handler_args = variants.iter().enumerate().map(|(variant_index, variant)| {
+		let handler = handler_ident(variant_index);
+		let field_types = variant.fields.iter().map(|field| &field.ty);
+		quote! {
+			#handler: impl Fn(#(#field_types),*) -> #output
+		}
+	});
+
+	let handler_args_ref = variants.iter().enumerate().map(|(variant_index, variant)| {
+		let handler = handler_ident(variant_index);
+		let field_types = variant.fields.iter().map(|field| {
+			let ty = &field.ty;
+			quote! { &#ty }
+		});
+		quote! {
+			#handler: impl Fn(#(#field_types),*) -> #output
+		}
+	});
+
+	let match_arms = variants.iter().enumerate().map(|(variant_index, variant)| {
+		let variant_ident = &variant.ident;
+		let handler = handler_ident(variant_index);
+		let field_bindings = (0..variant.fields.len())
+			.map(|field_index| field_ident(variant_index, field_index))
+			.collect::<Vec<_>>();
+
+		match &variant.fields {
+			Fields::Named(fields) => {
+				let patterns =
+					fields.named.iter().zip(field_bindings.iter()).map(|(field, binding)| {
+						let field_ident =
+							field.ident.as_ref().expect("named fields have identifiers");
+						quote! { #field_ident: #binding }
+					});
+				quote! {
+					Self::#variant_ident { #(#patterns),* } => #handler(#(#field_bindings),*)
+				}
+			},
+			Fields::Unnamed(_) => {
+				quote! {
+					Self::#variant_ident(#(#field_bindings),*) => #handler(#(#field_bindings),*)
+				}
+			},
+			Fields::Unit => {
+				quote! {
+					Self::#variant_ident => #handler()
+				}
+			},
+		}
+	});
+
+	let match_arms_ref = variants.iter().enumerate().map(|(variant_index, variant)| {
+		let variant_ident = &variant.ident;
+		let handler = handler_ident(variant_index);
+		let field_bindings = (0..variant.fields.len())
+			.map(|field_index| field_ident(variant_index, field_index))
+			.collect::<Vec<_>>();
+
+		match &variant.fields {
+			Fields::Named(fields) => {
+				let patterns =
+					fields.named.iter().zip(field_bindings.iter()).map(|(field, binding)| {
+						let field_ident =
+							field.ident.as_ref().expect("named fields have identifiers");
+						quote! { #field_ident: #binding }
+					});
+				quote! {
+					Self::#variant_ident { #(#patterns),* } => #handler(#(#field_bindings),*)
+				}
+			},
+			Fields::Unnamed(_) => {
+				quote! {
+					Self::#variant_ident(#(#field_bindings),*) => #handler(#(#field_bindings),*)
+				}
+			},
+			Fields::Unit => {
+				quote! {
+					Self::#variant_ident => #handler()
+				}
+			},
+		}
+	});
+
+	quote! {
+		impl #impl_generics #enum_ident #ty_generics #where_clause {
+			#[allow(clippy::too_many_arguments)]
+			pub fn elim<#output>(
+				self,
+				#(#handler_args,)*
+			) -> #output {
+				match self {
+					#(#match_arms,)*
+				}
+			}
+
+			#[allow(clippy::too_many_arguments)]
+			pub fn elim_ref<#output>(
+				&self,
+				#(#handler_args_ref,)*
+			) -> #output {
+				match self {
+					#(#match_arms_ref,)*
+				}
+			}
+		}
+	}
+}
+
+fn handler_ident(index: usize) -> Ident {
+	format_ident!("__elim_handler_{}", index)
+}
+
+fn field_ident(variant_index: usize, field_index: usize) -> Ident {
+	format_ident!("__elim_{}_{}", variant_index, field_index)
+}

--- a/utilities/proc-macros/src/lib.rs
+++ b/utilities/proc-macros/src/lib.rs
@@ -16,6 +16,95 @@
 
 use proc_macro::TokenStream;
 
+mod arbitrary;
+mod generate_module;
+mod generic_modules;
+mod intro_elim;
+mod type_introspection;
+
+/// Proc macro for writing groups of local items under a shared type-parameter
+/// telescope without repeating those parameters at every local reference.
+///
+/// A telescope scope is written as `mod (A: Bound) (B) { ... }`. It is not emitted
+/// as a Rust module. Instead, its type parameters are threaded into generated
+/// structs, traits, impls, and aliases inside the scope. Telescope scopes can
+/// appear anywhere in the macro input, can be empty (`mod { ... }`), and can be
+/// nested. Nested scopes inherit the outer telescope parameters and append their
+/// own.
+///
+/// Local definitions are tracked by scope. When a later local path refers to one
+/// of them, `generic_modules!` adds the definition's telescope arguments for you:
+///
+/// ```ignore
+/// generic_modules! {
+///     mod (A: Trait) {
+///         pub struct Local { value: A::Value }
+///         pub type Alias = Local; // expands as Local<A>
+///     }
+/// }
+/// ```
+///
+/// If a local definition is referenced outside the telescope that introduced one
+/// of its parameters, that parameter is not in scope anymore. In that case an
+/// explicitly supplied generic argument is used for the out-of-scope telescope
+/// parameter instead:
+///
+/// ```ignore
+/// generic_modules! {
+///     mod (A: Trait) {
+///         pub struct Local { value: A::Value }
+///     }
+///
+///     pub type Concrete<X: Trait> = Local<X>;
+/// }
+/// ```
+///
+/// Telescope scopes can also carry additional where predicates:
+/// `mod (A: Trait) where (A::Value: Clone) { ... }`. Each predicate is wrapped in
+/// parentheses, matching the type-parameter syntax. These predicates are added to
+/// generated structs, traits, and impls, preserving any user-written where
+/// clauses. For type aliases, telescope where predicates are added only when the
+/// alias actually inherits one of the telescope parameters mentioned by the
+/// predicate.
+///
+/// The macro also supports local `use` imports, nested real Rust modules,
+/// expression paths in impl bodies, trait bounds, and lazy type aliases with a
+/// `where` clause after the aliased type.
+///
+/// Usage:
+/// ```ignore
+/// generic_modules! {
+///     pub type Plain = u8;
+///
+///     mod (A: Trait) (B: Trait) where (A::Assoc: Clone) (B: Copy) {
+///         pub type Alias = (A::Assoc, B::Assoc);
+///
+///         mod (C: OtherTrait) {
+///             pub type Nested = (Alias, C::Assoc);
+///         }
+///
+///         pub struct Foo {
+///             field: A::Assoc,
+///         }
+///
+///         impl SomeTrait for Foo {
+///             // ...
+///         }
+///
+///         if (condition) {
+///             // emitted when condition is non-empty
+///         } else {
+///             // emitted when condition is empty
+///         }
+///     }
+/// }
+/// ```
+#[proc_macro]
+pub fn generic_modules(input: TokenStream) -> TokenStream {
+	let input = syn::parse_macro_input!(input as generic_modules::Input);
+	generic_modules::expand(input).into()
+}
+
 /// Attribute macro that wraps the annotated struct in a `cf_utilities::generate_module!`
 /// invocation, automatically generating the module name as `_StructName`.
 ///
@@ -39,14 +128,108 @@ use proc_macro::TokenStream;
 #[proc_macro_attribute]
 pub fn generate_module(_attr: TokenStream, item: TokenStream) -> TokenStream {
 	let item_clone: proc_macro2::TokenStream = item.clone().into();
-	let parsed: syn::ItemStruct =
-		syn::parse(item).expect("#[generate_module] can only be applied to structs");
-	let mod_name = quote::format_ident!("_{}", parsed.ident);
-	let output = quote::quote! {
-		cf_utilities::generate_module! {
-			#item_clone
-			mod #mod_name { #![migrations] }
-		}
-	};
-	output.into()
+	let parsed = syn::parse_macro_input!(item as syn::Item);
+	generate_module::expand(item_clone, parsed).into()
+}
+
+/// Derive macro that implements `cf_utilities::type_introspection::HasTypeIntrospection`.
+///
+/// The trait exposes two pieces of structural information:
+///
+/// - `is_empty_type()` returns whether the type has no constructible values.
+/// - `sample_all_shapes()` returns example values that enumerate every possible structural shape.
+///
+/// For structs, a type is empty when any field type is empty. Shape samples are built from the full
+/// Cartesian product of every field's samples.
+///
+/// For enums, a type is empty only when all variants are empty. Shape samples are built by sampling
+/// each variant independently and concatenating those variant samples. Unit variants contribute one
+/// sample, while variants containing an empty field contribute none.
+///
+/// Unions are not supported.
+///
+/// ## Example
+///
+/// ```ignore
+/// #[derive(cf_proc_macros::HasTypeIntrospection)]
+/// enum Value {
+///     Empty(Never),
+///     One(u8),
+///     Pair { left: bool, right: Option<u8> },
+/// }
+/// ```
+#[proc_macro_derive(HasTypeIntrospection)]
+pub fn derive_has_type_introspection(input: TokenStream) -> TokenStream {
+	let input = syn::parse_macro_input!(input as syn::DeriveInput);
+	type_introspection::derive(input).into()
+}
+
+/// Derive macro that adds simple constructor/destructor helpers.
+///
+/// For structs with named fields, this generates an `intro(...) -> Self` constructor with one
+/// argument per field. Tuple structs and unit structs are not supported.
+///
+/// For enums, this generates an `elim(...) -> Output` method. The method consumes `self` and takes
+/// one handler closure per variant. Each handler receives the fields of its corresponding variant.
+/// Unit variants receive a zero-argument handler.
+///
+/// ## Examples
+///
+/// ```ignore
+/// #[derive(cf_proc_macros::IntroElim)]
+/// struct Pair {
+///     left: u8,
+///     right: u16,
+/// }
+///
+/// let pair = Pair::intro(1, 2);
+/// ```
+///
+/// ```ignore
+/// #[derive(cf_proc_macros::IntroElim)]
+/// enum Value {
+///     None,
+///     One(u8),
+///     Pair { left: u8, right: u16 },
+/// }
+///
+/// let output = value.elim(
+///     || 0,
+///     |one| one as u16,
+///     |left, right| left as u16 + right,
+/// );
+/// ```
+#[proc_macro_derive(IntroElim)]
+pub fn derive_intro_elim(input: TokenStream) -> TokenStream {
+	let input = syn::parse_macro_input!(input as syn::DeriveInput);
+	intro_elim::derive(input).into()
+}
+
+/// Derive macro that implements `proptest::arbitrary::Arbitrary` for a struct.
+///
+/// Handles structs with any number of fields (not limited to 12) by chunking
+/// fields into nested strategy tuples. `PhantomData` fields are automatically
+/// filled with `Default::default()`.
+///
+/// ## Attributes
+///
+/// - `#[arbitrary(bound = "T: Trait, U: OtherTrait")]` — Override the default where-clause bounds
+///   on the generated impl. When not specified, each non-phantom field type gets an `Arbitrary +
+///   'static` bound and each type parameter gets `'static`.
+///
+/// ## Example
+///
+/// ```ignore
+/// #[derive(cf_proc_macros::ArbitraryWithBounds)]
+/// #[arbitrary(bound = "Ty: 'static, Ty::amount: Arbitrary + 'static")]
+/// pub struct MyStruct<Ty: Types> {
+///     pub amount: Ty::amount,
+///     pub count: Ty::count,
+///     _phantom: PhantomData<(Ty,)>,
+/// }
+/// ```
+#[proc_macro_derive(ArbitraryWithBounds, attributes(arbitrary))]
+pub fn derive_arbitrary_with_bounds(input: TokenStream) -> TokenStream {
+	let input = syn::parse_macro_input!(input as syn::DeriveInput);
+	arbitrary::derive(input).into()
 }

--- a/utilities/proc-macros/src/type_introspection.rs
+++ b/utilities/proc-macros/src/type_introspection.rs
@@ -1,0 +1,232 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields};
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let name = &input.ident;
+	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+	// Collect all field types to add HasTypeIntrospection bounds on them.
+	let field_types = collect_field_types(&input.data);
+
+	// Build the where clause: existing bounds + HasTypeIntrospection for each field type.
+	let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::parse_quote!(where));
+	for ty in &field_types {
+		where_clause
+			.predicates
+			.push(syn::parse_quote!(#ty: cf_utilities::type_introspection::HasTypeIntrospection));
+	}
+
+	let is_empty_body = match &input.data {
+		Data::Struct(data) => struct_body(&data.fields),
+		Data::Enum(data) =>
+			if data.variants.is_empty() {
+				quote! { true }
+			} else {
+				let variant_checks: Vec<TokenStream> =
+					data.variants.iter().map(|v| variant_is_empty(&v.fields)).collect();
+				quote! { #( (#variant_checks) )&&* }
+			},
+		Data::Union(_) => {
+			return syn::Error::new_spanned(
+				name,
+				"HasTypeIntrospection cannot be derived for unions",
+			)
+			.to_compile_error();
+		},
+	};
+	let sample_all_shapes_body = match &input.data {
+		Data::Struct(data) => struct_sample_all_shapes(&data.fields),
+		Data::Enum(data) => enum_sample_all_shapes(data),
+		Data::Union(_) => unreachable!(),
+	};
+
+	quote! {
+		impl #impl_generics cf_utilities::type_introspection::HasTypeIntrospection for #name #ty_generics #where_clause {
+			fn is_empty_type() -> bool {
+				#is_empty_body
+			}
+
+			fn sample_all_shapes() -> sp_std::vec::Vec<Self> {
+				#sample_all_shapes_body
+			}
+		}
+	}
+}
+
+/// Collect all field types from the data structure (struct or enum).
+fn collect_field_types(data: &Data) -> Vec<syn::Type> {
+	let mut types = Vec::new();
+	match data {
+		Data::Struct(data) => {
+			collect_from_fields(&data.fields, &mut types);
+		},
+		Data::Enum(data) =>
+			for variant in &data.variants {
+				collect_from_fields(&variant.fields, &mut types);
+			},
+		Data::Union(_) => {},
+	}
+	types
+}
+
+fn collect_from_fields(fields: &Fields, types: &mut Vec<syn::Type>) {
+	match fields {
+		Fields::Named(f) =>
+			for field in &f.named {
+				types.push(field.ty.clone());
+			},
+		Fields::Unnamed(f) =>
+			for field in &f.unnamed {
+				types.push(field.ty.clone());
+			},
+		Fields::Unit => {},
+	}
+}
+
+/// A struct is empty if ANY field's type is empty.
+fn struct_body(fields: &Fields) -> TokenStream {
+	field_types_any_empty(fields)
+}
+
+/// A variant is empty if ANY of its field types is empty.
+/// A unit variant (no fields) is never empty — it's always constructible.
+fn variant_is_empty(fields: &Fields) -> TokenStream {
+	field_types_any_empty(fields)
+}
+
+/// Returns an expression that is `true` if any field type is empty.
+/// For no fields (unit struct/variant), returns `false`.
+fn field_types_any_empty(fields: &Fields) -> TokenStream {
+	let field_types: Vec<_> = match fields {
+		Fields::Named(f) => f.named.iter().map(|f| &f.ty).collect(),
+		Fields::Unnamed(f) => f.unnamed.iter().map(|f| &f.ty).collect(),
+		Fields::Unit => return quote! { false },
+	};
+
+	if field_types.is_empty() {
+		return quote! { false };
+	}
+
+	quote! {
+		#( <#field_types as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() )||*
+	}
+}
+
+fn enum_sample_all_shapes(data: &syn::DataEnum) -> TokenStream {
+	let variant_samples = data.variants.iter().map(|variant| {
+		let ident = &variant.ident;
+		let constructor = construct_value(&variant.fields, quote! { Self::#ident });
+		append_field_samples(&variant.fields, constructor)
+	});
+
+	quote! {
+		let mut __samples: sp_std::vec::Vec<Self> = Default::default();
+		#( #variant_samples )*
+		__samples
+	}
+}
+
+fn struct_sample_all_shapes(fields: &Fields) -> TokenStream {
+	let constructor = construct_value(fields, quote! { Self });
+	let field_samples = append_field_samples(fields, constructor);
+
+	quote! {
+		let mut __samples: sp_std::vec::Vec<Self> = Default::default();
+		#field_samples
+		__samples
+	}
+}
+
+fn append_field_samples(fields: &Fields, constructor: TokenStream) -> TokenStream {
+	let field_types: Vec<_> = match fields {
+		Fields::Named(f) => f.named.iter().map(|f| &f.ty).collect(),
+		Fields::Unnamed(f) => f.unnamed.iter().map(|f| &f.ty).collect(),
+		Fields::Unit => Vec::new(),
+	};
+
+	if field_types.is_empty() {
+		return quote! {
+			__samples.push(#constructor);
+		};
+	}
+
+	let count_idents: Vec<_> = (0..field_types.len())
+		.map(|index| format_ident!("__shape_count_{index}"))
+		.collect();
+	let index_idents: Vec<_> = (0..field_types.len())
+		.map(|index| format_ident!("__shape_index_{index}"))
+		.collect();
+	let value_idents: Vec<_> = (0..field_types.len())
+		.map(|index| format_ident!("__shape_value_{index}"))
+		.collect();
+
+	let push_sample = quote! {
+		match (
+			#(
+				<#field_types as cf_utilities::type_introspection::HasTypeIntrospection>::sample_all_shapes()
+					.into_iter()
+					.nth(#index_idents),
+			)*
+		) {
+			( #( Some(#value_idents), )* ) => __samples.push(#constructor),
+			_ => {},
+		}
+	};
+
+	let nested_loops = index_idents.iter().zip(count_idents.iter()).rfold(
+		push_sample,
+		|body, (index_ident, count_ident)| {
+			quote! {
+				for #index_ident in 0..#count_ident {
+					#body
+				}
+			}
+		},
+	);
+
+	quote! {
+		{
+			#(
+				let #count_idents = <#field_types as cf_utilities::type_introspection::HasTypeIntrospection>::sample_all_shapes().len();
+			)*
+			#nested_loops
+		}
+	}
+}
+
+fn construct_value(fields: &Fields, prefix: TokenStream) -> TokenStream {
+	let value_idents: Vec<_> = match fields {
+		Fields::Named(f) =>
+			(0..f.named.len()).map(|index| format_ident!("__shape_value_{index}")).collect(),
+		Fields::Unnamed(f) => (0..f.unnamed.len())
+			.map(|index| format_ident!("__shape_value_{index}"))
+			.collect(),
+		Fields::Unit => Vec::new(),
+	};
+
+	match fields {
+		Fields::Named(f) => {
+			let field_names = f.named.iter().map(|field| &field.ident);
+			quote! { #prefix { #( #field_names: #value_idents ),* } }
+		},
+		Fields::Unnamed(_) => quote! { #prefix( #( #value_idents ),* ) },
+		Fields::Unit => quote! { #prefix },
+	}
+}

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -27,6 +27,10 @@
 #![feature(macro_metavar_expr)]
 #![allow(incomplete_features)]
 
+// This is required so that cf_proc_macros (which refer to this crate) can be called from this
+// crate.
+extern crate self as cf_utilities;
+
 #[cfg(feature = "std")]
 mod with_std;
 #[cfg(feature = "std")]

--- a/utilities/src/without_std/generate_module.rs
+++ b/utilities/src/without_std/generate_module.rs
@@ -18,7 +18,7 @@
 macro_rules! generate_module {
     (
 		$(#[$($Attributes:tt)*])*
-        $vis:vis struct $struct:ident$(<$T:ident $(: $TBound:path)?>)? {
+        $vis:vis struct $struct:ident$(< $($T:ident $(: $TBound:path)?),+ >)? {
             $(
 		        $(#[$($Field_Attributes:tt)*])*
                 $field_vis:vis $field:ident: $field_ty:ty,
@@ -29,7 +29,7 @@ macro_rules! generate_module {
         $(
             #[$($Attributes)*]
         )*
-        $vis struct $struct$(<$T $(: $TBound)?>)? {
+        $vis struct $struct$(< $($T $(: $TBound)?),+ >)? {
             $(
                 $( #[$($Field_Attributes)*])*
                 $field_vis $field: $field_ty,
@@ -120,32 +120,32 @@ macro_rules! generate_module {
             #[derive_where(Eq; $(Ty::$field: Eq),*)]
             #[cfg_attr(any(test, all(feature = "proptest", feature = "std")), derive(proptest_derive::Arbitrary))]
             #[scale_info(skip_type_params(Ty))]
-            pub struct Struct<Ty: Types, $( $T $(: $TBound)?, )? > {
+            pub struct Struct<Ty: Types, $( $($T $(: $TBound)?,)+ )? > {
                 $(
                     pub $field: Ty::$field,
                 )+
                 // In order for `proptest_derive::Arbitrary` to work, we're not allowed to mention `sp_std` in the following type,
                 // since the macro has manual filters for `std::marker::PhantomData`, and `PhantomData`, but not for `sp_std::...`.
                 // That's why we import it above.
-                pub _phantom: PhantomData<($($T,)?)>,
+                pub _phantom: PhantomData<($($($T,)+)?)>,
             }
 
-            impl<$( $T $(: $TBound)?, )? Ty: Types<$($field: IsHistoricalType,)*>> IsHistoricalType for Struct<Ty, $($T)?>
-            where $struct$(<$T>)?: HasChangelog
+            impl<$( $($T $(: $TBound)?,)+ )? Ty: Types<$($field: IsHistoricalType,)*>> IsHistoricalType for Struct<Ty, $($($T,)+)?>
+            where $struct$(< $($T,)+ >)?: HasChangelog
             {
-                type GetCurrentType = $struct$(<$T>)?;
+                type GetCurrentType = $struct$(< $($T,)+ >)?;
             }
 
             pub type see_field_changelogs = see_field_changelogs_and_also<()>;
             pub struct see_field_changelogs_and_also<M>(M);
 
-            impl<M: CustomMigration<To, V>, $( $T $(: $TBound)?, )? To: HistoricalTypesAt<V>, V: Version> Migration<Struct<To, $($T)?>, V> for see_field_changelogs_and_also<M>
+            impl<M: CustomMigration<To, V>, $( $($T $(: $TBound)?,)+ )? To: HistoricalTypesAt<V>, V: Version> Migration<Struct<To, $($($T,)+)?>, V> for see_field_changelogs_and_also<M>
             where
-                Struct< source_of_custom_migration<To, V, M> , $($T)?  >: IsHistoricalType
+                Struct< source_of_custom_migration<To, V, M> , $($($T,)+)?  >: IsHistoricalType
             {
-                type From = Struct< source_of_custom_migration<To, V, M> , $($T)?  >;
+                type From = Struct< source_of_custom_migration<To, V, M> , $($($T,)+)?  >;
 
-                fn forwards(x: Self::From) -> Struct<To, $($T)?> {
+                fn forwards(x: Self::From) -> Struct<To, $($($T,)+)?> {
                     Struct {
                         $(
                             $field: <ResolveCustomMigration::<To, V, M> as Types>::$field::forwards(x.$field),
@@ -154,7 +154,7 @@ macro_rules! generate_module {
                     }
                 }
 
-                fn backwards(x: Struct<To, $($T)?>) -> Self::From {
+                fn backwards(x: Struct<To, $($($T,)+)?>) -> Self::From {
                     Struct {
                         $(
                             $field: <ResolveCustomMigration::<To, V, M> as Types>::$field::backwards(x.$field),
@@ -184,45 +184,45 @@ macro_rules! generate_module {
 
             // ----------------- connection with default struct ------------------ //
 
-            pub struct DefaultTypes$(<$T $(: $TBound)?>)?($($T)?);
+            pub struct DefaultTypes$(< $($T $(: $TBound)?),+ >)?($($($T,)+)?);
 
-            impl$(<$T $(: $TBound)?>)? Types for DefaultTypes$(<$T>)? {
+            impl$(< $($T $(: $TBound)?),+ >)? Types for DefaultTypes$(< $($T,)+ >)? {
                 $(
                     type $field = $field_ty;
                 )*
             }
 
-            impl $(< $T $(: $TBound)?, >)? HasGenericVariant for $struct $(<$T>)?
+            impl $(< $($T $(: $TBound)?),+ >)? HasGenericVariant for $struct $(< $($T,)+ >)?
             where $( $field_ty: HasGenericVariant,)*
                 Struct<(
                     $(
                         GetGenericVariant<$field_ty>,
                     )*
-                ), $($T)?>: IsHistoricalType
+                ), $($($T,)+)?>: IsHistoricalType
             {
                 type GenericType = Struct<(
                     $(
                         GetGenericVariant<$field_ty>,
                     )*
-                ), $($T)?>;
+                ), $($($T,)+)?>;
                 type MigrationFromGeneric = GlobalMigrationFromGeneric;
             }
 
-            impl $(< $T $(: $TBound)? >)? Migration<$struct $(<$T>)?, vCurrent> for GlobalMigrationFromGeneric
+            impl $(< $($T $(: $TBound)?),+ >)? Migration<$struct $(< $($T,)+ >)?, vCurrent> for GlobalMigrationFromGeneric
             where $( $field_ty: HasGenericVariant,)*
                 Struct<(
                     $(
                         GetGenericVariant<$field_ty>,
                     )*
-                ), $($T)?>: IsHistoricalType
+                ), $($($T,)+)?>: IsHistoricalType
             {
                 type From = Struct<(
                     $(
                         GetGenericVariant<$field_ty>,
                     )*
-                ), $($T)?>;
+                ), $($($T,)+)?>;
 
-                fn forwards(x: Self::From) -> $struct $(<$T>)? {
+                fn forwards(x: Self::From) -> $struct $(< $($T,)+ >)? {
                     $struct {
                         $(
                             $field: <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::forwards(x.$field),
@@ -230,7 +230,7 @@ macro_rules! generate_module {
                     }
                 }
 
-                fn backwards(x: $struct $(<$T>)?) -> Self::From {
+                fn backwards(x: $struct $(< $($T,)+ >)?) -> Self::From {
                     Struct {
                         $(
                             $field: <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::backwards(x.$field),

--- a/utilities/src/without_std/generate_module.rs
+++ b/utilities/src/without_std/generate_module.rs
@@ -16,19 +16,24 @@
 
 #[macro_export]
 macro_rules! generate_module {
+    // ///////////////////////////////////////////////////////////////////////////////////
+    // ////////////////////////////////// Struct /////////////////////////////////////////
+    // ///////////////////////////////////////////////////////////////////////////////////
     (
 		$(#[$($Attributes:tt)*])*
         $vis:vis struct $struct:ident$(< $($T:ident $(: $TBound:path)?),+ >)? {
             $(
 		        $(#[$($Field_Attributes:tt)*])*
-                $field_vis:vis $field:ident: $field_ty:ty,
-            )*
+                $field_vis:vis $field:ident: $field_ty:ty
+            ),*
+            $(,)?
         }
         mod $mod:ident { #![migrations] }
     ) => {
         $(
             #[$($Attributes)*]
         )*
+        #[derive(cf_proc_macros::IntroElim)]
         $vis struct $struct$(< $($T $(: $TBound)?),+ >)? {
             $(
                 $( #[$($Field_Attributes)*])*
@@ -54,11 +59,6 @@ macro_rules! generate_module {
                     $field: IsHistoricalTypeAt<V>,
                 )*
             >;
-            pub trait DebugTypes = Types<
-                $(
-                    $field: sp_std::fmt::Debug,
-                )+
-            >;
 
             impl< $( $field,)* > Types for ( $($field,)* ) {
                 $(
@@ -66,180 +66,749 @@ macro_rules! generate_module {
                 )*
             }
 
-            pub trait CustomMigration<
-                To: HistoricalTypesAt<V>,
-                V: Version,
-            > {
-                $(
-                    type $field: MaybeMigration<To::$field, V> = DefaultMigration;
-                )+
+            cf_proc_macros::generic_modules! {
+                mod $( $( ($T $(: $TBound)?) )+ )? {
+                    mod (Ty: Types) {
+
+                        #[derive(Hash, codec::Encode, codec::Decode, codec::DecodeWithMemTracking, scale_info::TypeInfo, codec::MaxEncodedLen, Default)]
+                        #[derive_where::derive_where(Debug; $(Ty::$field: sp_std::fmt::Debug),*)]
+                        #[derive_where(Copy; $(Ty::$field: Copy),*)]
+                        #[derive_where(Clone; $(Ty::$field: Clone),*)]
+                        #[derive_where(PartialEq; $(Ty::$field: PartialEq),*)]
+                        #[derive_where(Eq; $(Ty::$field: Eq),*)]
+                        #[scale_info(skip_type_params(Ty))]
+                        #[derive(cf_proc_macros::HasTypeIntrospection)]
+                        #[derive(cf_proc_macros::IntroElim)]
+                        #[cfg_attr(any(test, all(feature = "proptest", feature = "std")), derive(cf_proc_macros::ArbitraryWithBounds))]
+                        #[cfg_attr(any(test, all(feature = "proptest", feature = "std")), arbitrary(bound(Ty: 'static, $( $($T: 'static,)+ )? $( Ty::$field: sp_std::fmt::Debug + proptest::arbitrary::Arbitrary + 'static ),* )))]
+
+                        pub struct Struct {
+                            $(
+                                pub $field: Ty::$field,
+                            )*
+                        }
+
+                        impl IsHistoricalType for Struct where
+                            $( Ty::$field: IsHistoricalType,)*
+                        {
+                            type GetCurrentType = $struct$(< $($T,)+ >)?;
+                        }
+                    }
+
+                    // ----------------- connection with default struct ------------------ //
+                    pub type UserStruct = $struct $(< $($T,)+ >)?;
+
+                    impl HasGenericVariant for $struct $(< $($T,)+ >)? // UserStruct
+                    where
+                        $( $field_ty: HasChangelog, )*
+                        $( $field_ty: HasGenericVariant<GenericType: IsHistoricalType>, )*
+                        Struct<( $( < $field_ty as HasGenericVariant>::GenericType,)*)>: IsHistoricalType
+                    {
+                        type GenericType = Struct<(
+                            $(
+                                < $field_ty as HasGenericVariant>::GenericType,
+                            )*
+                        )>;
+                        type MigrationFromGeneric = GlobalMigrationFromGeneric;
+                    }
+
+                    impl Migration<$struct $(< $($T,)+ >)?, vCurrent> for GlobalMigrationFromGeneric
+                    where
+                        $( $field_ty: HasChangelog, )*
+                        $( $field_ty: HasGenericVariant<GenericType: IsHistoricalType>, )*
+                        Struct<( $( < $field_ty as HasGenericVariant>::GenericType,)*)>: IsHistoricalType
+                    {
+                        type From = Struct<(
+                            $(
+                                < $field_ty as HasGenericVariant>::GenericType,
+                            )*
+                        )>;
+                        type ForwardsError = cf_utilities::never::Never;
+                        type BackwardsError = cf_utilities::never::Never;
+
+                        fn try_forwards(x: Self::From) -> Result<$struct $(< $($T,)+ >)?, Self::ForwardsError> {
+                            Ok(
+                                $struct {
+                                    $(
+                                        $field: <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::try_forwards(x.$field)?,
+                                    )*
+                                }
+                            )
+                        }
+
+                        fn try_backwards(x: $struct $(< $($T,)+ >)?) -> Result<Self::From, Self::BackwardsError> {
+                            Ok(
+                                Struct::intro(
+                                    $(
+                                        <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::try_backwards(x.$field)?,
+                                    )*
+                                    Default::default(),
+                                )
+                            )
+                        }
+                    }
+                }
             }
 
-            // this extracts the From types (per field) from a CustomMigration
-            #[derive_where::derive_where(Debug, Default; )]
-            pub struct source_of_custom_migration<To: HistoricalTypesAt<V>, V: Version, M: CustomMigration<To, V>>(sp_std::marker::PhantomData<(To, V, M)>);
-            impl<To: HistoricalTypesAt<V>, V: Version, M: CustomMigration<To, V>> Types for source_of_custom_migration<To, V, M> {
-                $(
-                    type $field = <
-                        <M::$field as MaybeMigration<To::$field, V>>::GetWithDefault<GetMigrationToHistoricalType<To::$field, V>>
-                        as Migration<To::$field, V>
-                    >::From;
-                )+
-            }
-
-            type ResolveCustomMigration<To: HistoricalTypesAt<V>, V: Version, M: CustomMigration<To, V>> = (
-                $(
-                    <M::$field as MaybeMigration<To::$field, V>>::GetWithDefault<GetMigrationToHistoricalType<To::$field, V>>,
-                )+
-            );
-
-            impl <
-                To: HistoricalTypesAt<V>,
-                V: Version
-            > CustomMigration<To, V> for () {}
-
-            impl<To: HistoricalTypesAt<V>, V: Version, M1: CustomMigration<To, V>, M2: CustomMigration<To, V>>
-            CustomMigration<To,V>
-            for (M1, M2)
-            {
-                $(
-                    type $field = (M1::$field, M2::$field);
-                )+
-            }
-
-            // This has to be used here because of how the `proptest_derive::Arbitrary` derive macro works.
-            use sp_std::marker::PhantomData;
-
-            /// This is purely used for backwards compatibility with older runtimes, and won't be exposed on the
-            /// rpc layer. So there's intentionally no Serialize/Deserialize implementation
-            #[derive(Hash, Encode, Decode, codec::DecodeWithMemTracking, TypeInfo, codec::MaxEncodedLen, Default)]
-            #[derive_where::derive_where(Debug; $(Ty::$field: sp_std::fmt::Debug),*)]
-            #[derive_where(Copy; $(Ty::$field: Copy),*)]
-            #[derive_where(Clone; $(Ty::$field: Clone),*)]
-            #[derive_where(PartialEq; $(Ty::$field: PartialEq),*)]
-            #[derive_where(Eq; $(Ty::$field: Eq),*)]
-            #[cfg_attr(any(test, all(feature = "proptest", feature = "std")), derive(proptest_derive::Arbitrary))]
-            #[scale_info(skip_type_params(Ty))]
-            pub struct Struct<Ty: Types, $( $($T $(: $TBound)?,)+ )? > {
-                $(
-                    pub $field: Ty::$field,
-                )+
-                // In order for `proptest_derive::Arbitrary` to work, we're not allowed to mention `sp_std` in the following type,
-                // since the macro has manual filters for `std::marker::PhantomData`, and `PhantomData`, but not for `sp_std::...`.
-                // That's why we import it above.
-                pub _phantom: PhantomData<($($($T,)+)?)>,
-            }
-
-            impl<$( $($T $(: $TBound)?,)+ )? Ty: Types<$($field: IsHistoricalType,)*>> IsHistoricalType for Struct<Ty, $($($T,)+)?>
-            where $struct$(< $($T,)+ >)?: HasChangelog
-            {
-                type GetCurrentType = $struct$(< $($T,)+ >)?;
-            }
 
             pub type see_field_changelogs = see_field_changelogs_and_also<()>;
             pub struct see_field_changelogs_and_also<M>(M);
 
-            impl<M: CustomMigration<To, V>, $( $($T $(: $TBound)?,)+ )? To: HistoricalTypesAt<V>, V: Version> Migration<Struct<To, $($($T,)+)?>, V> for see_field_changelogs_and_also<M>
-            where
-                Struct< source_of_custom_migration<To, V, M> , $($($T,)+)?  >: IsHistoricalType
-            {
-                type From = Struct< source_of_custom_migration<To, V, M> , $($($T,)+)?  >;
-
-                fn forwards(x: Self::From) -> Struct<To, $($($T,)+)?> {
-                    Struct {
+            cf_proc_macros::generic_modules! {
+                mod (To: HistoricalTypesAt<V>) (V: Version)
+                {
+                    pub trait FieldCustomMigration {
                         $(
-                            $field: <ResolveCustomMigration::<To, V, M> as Types>::$field::forwards(x.$field),
-                        )+
-                        _phantom: Default::default(),
+                            type $field: MaybeMigration<To::$field, V> = DefaultMigration;
+                        )*
+                    }
+
+                    impl FieldCustomMigration for () {}
+
+                    impl<M1: FieldCustomMigration, M2: FieldCustomMigration> FieldCustomMigration for (M1, M2) {
+                        $(
+                            type $field = (M1::$field, M2::$field);
+                        )*
+                    }
+
+                    mod (M: FieldCustomMigration<To, V>)
+                    {
+                        mod field_migrations {
+                            use super::*;
+                            $(
+                                pub type $field = <M::$field as MaybeMigration<To::$field, V>>::GetWithDefault<GetMigrationToHistoricalType<To::$field, V>>;
+                            )*
+                            pub type TyFrom = (
+                                $(
+                                    <field_migrations::$field as Migration<To::$field, V>>::From,
+                                )*
+                            );
+
+                            #[derive(cf_proc_macros::IntroElim)]
+                            pub enum StructForwardsError {
+                                $(
+                                    $field(<$field as Migration<To::$field, V>>::ForwardsError),
+                                )*
+                            }
+
+                            #[derive(cf_proc_macros::IntroElim)]
+                            pub enum StructBackwardsError {
+                                $(
+                                    $field(<$field as Migration<To::$field, V>>::BackwardsError),
+                                )*
+                            }
+
+                            impl cf_utilities::never::IsEmptyType for StructForwardsError
+                                where $(
+                                    <$field as Migration<To::$field, V>>::ForwardsError: cf_utilities::never::IsEmptyType,
+                                )*
+                            {
+                                fn as_never(&self) -> cf_utilities::never::Never {
+                                    self.elim_ref(
+                                        $(
+                                            |err: &<$field as Migration<To::$field, V>>::ForwardsError| err.as_never(),
+                                        )*
+                                        |never, _phantom| never.as_never(),
+                                    )
+                                }
+                            }
+
+                            impl cf_utilities::never::IsEmptyType for StructBackwardsError
+                                where $(
+                                    <$field as Migration<To::$field, V>>::BackwardsError: cf_utilities::never::IsEmptyType,
+                                )*
+                            {
+                                fn as_never(&self) -> cf_utilities::never::Never {
+                                    self.elim_ref(
+                                        $(
+                                            |err: &<$field as Migration<To::$field, V>>::BackwardsError| err.as_never(),
+                                        )*
+                                        |never, _phantom| never.as_never(),
+                                    )
+                                }
+                            }
+
+                            mod $( $( ($T $(: $TBound)?) )+ )? {
+                                pub type StructVariant<Target: Types> = Struct<$($($T,)+)? Target>;
+
+                                impl Migration<Struct<$($($T,)+)? To>, V> for see_field_changelogs_and_also<M> where
+                                    StructVariant<TyFrom>: IsHistoricalType,
+                                    $struct<$($($T,)+)?>: HasChangelog
+                                {
+                                    type ForwardsError = StructForwardsError;
+                                    type BackwardsError = StructBackwardsError;
+
+                                    type From = StructVariant<TyFrom>;
+
+                                    fn try_forwards(x: Self::From) -> Result<StructVariant<To>, Self::ForwardsError> {
+                                        Ok(Struct::intro(
+                                            $(
+                                                $field::try_forwards(x.$field)
+                                                    .map_err(StructForwardsError::$field)?,
+                                            )*
+                                            Default::default(),
+                                        ))
+                                    }
+
+                                    fn try_backwards(x: StructVariant<To>) -> Result<Self::From, Self::BackwardsError> {
+                                        Ok(Struct::intro(
+                                            $(
+                                                $field::try_backwards(x.$field)
+                                                    .map_err(StructBackwardsError::$field)?,
+                                            )*
+                                            Default::default(),
+                                        ))
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-
-                fn backwards(x: Struct<To, $($($T,)+)?>) -> Self::From {
-                    Struct {
-                        $(
-                            $field: <ResolveCustomMigration::<To, V, M> as Types>::$field::backwards(x.$field),
-                        )+
-                        _phantom: Default::default(),
-                    }
-                }
-
             }
 
             // ----------------- predefined migrations ------------------ //
             pub mod field {
                 $(
                     pub mod $field {
-                        use super::super::{OverrideMigrationWith, Version, HistoricalTypesAt, CustomMigration, NewFieldWithDefault};
+                        use super::super::{OverrideMigrationWith, Version, HistoricalTypesAt, FieldCustomMigration, NewFieldWithDefault};
 
                         #[derive(Debug)]
                         pub struct Added;
                         impl<V: Version, TargetFieldsTypes: HistoricalTypesAt<V, $field: Default>>
-                            CustomMigration<TargetFieldsTypes, V> for Added
+                            FieldCustomMigration<TargetFieldsTypes, V> for Added
                         {
                             type $field = OverrideMigrationWith<NewFieldWithDefault>;
                         }
                     }
-                )+
+                )*
             }
+        }
+    };
 
-            // ----------------- connection with default struct ------------------ //
+    // ///////////////////////////////////////////////////////////////////////////////////
+    // /////////////////////////////////// Enum //////////////////////////////////////////
+    // ///////////////////////////////////////////////////////////////////////////////////
+    (
+		$(#[$($Attributes:tt)*])*
+        $vis:vis enum $enum:ident$(< $($T:ident $(: $TBound:path)?),+ >)? {
+            $(
+		        $(#[$($Variant_Attributes:tt)*])*
+                $variant:ident
+                    $( ( $($variant_tuple_entry:ident : $variant_ty:ty),* ) )?
+                    $( { $($variant_field:ident : $variant_field_ty:ty ,)* } )?
+                    $(= $variant_discriminant:literal)?
+                    ,
+            )*
+        }
+        mod $mod:ident { #![migrations] }
+    ) => {
 
-            pub struct DefaultTypes$(< $($T $(: $TBound)?),+ >)?($($($T,)+)?);
+        $(#[$($Attributes)*])*
+        #[derive(cf_proc_macros::IntroElim)]
+        $vis enum $enum$(< $($T $(: $TBound)?),+ >)? {
+            $(
+                $( #[$($Variant_Attributes)*])*
+                $variant
+                    $( ( $($variant_ty),* ) )?
+                    $( { $($variant_field : $variant_field_ty ,)* } )?
+                    $(= $variant_discriminant)?
+                    ,
+            )*
+        }
 
-            impl$(< $($T $(: $TBound)?),+ >)? Types for DefaultTypes$(< $($T,)+ >)? {
+        pub mod $mod {
+            #![allow(nonstandard_style)]
+            #![allow(unused)]
+
+            use super::*;
+            use cf_utilities::migrations::*;
+            use cf_utilities::migrations::basics::*;
+
+            pub trait Types {
                 $(
-                    type $field = $field_ty;
+                    type $variant;
                 )*
             }
 
-            impl $(< $($T $(: $TBound)?),+ >)? HasGenericVariant for $struct $(< $($T,)+ >)?
-            where $( $field_ty: HasGenericVariant,)*
-                Struct<(
-                    $(
-                        GetGenericVariant<$field_ty>,
-                    )*
-                ), $($($T,)+)?>: IsHistoricalType
-            {
-                type GenericType = Struct<(
-                    $(
-                        GetGenericVariant<$field_ty>,
-                    )*
-                ), $($($T,)+)?>;
-                type MigrationFromGeneric = GlobalMigrationFromGeneric;
+            pub trait HistoricalTypesAt<V: Version> = Types<
+                $(
+                    $variant: IsHistoricalTypeAt<V>,
+                )*
+            >;
+
+            impl< $( $variant,)* > Types for ( $($variant,)* ) {
+                $(
+                    type $variant = $variant;
+                )*
             }
 
-            impl $(< $($T $(: $TBound)?),+ >)? Migration<$struct $(< $($T,)+ >)?, vCurrent> for GlobalMigrationFromGeneric
-            where $( $field_ty: HasGenericVariant,)*
-                Struct<(
-                    $(
-                        GetGenericVariant<$field_ty>,
-                    )*
-                ), $($($T,)+)?>: IsHistoricalType
-            {
-                type From = Struct<(
-                    $(
-                        GetGenericVariant<$field_ty>,
-                    )*
-                ), $($($T,)+)?>;
+            cf_proc_macros::generic_modules! {
+                mod $( $( ($T $(: $TBound)?) )+ )? {
+                    mod (Ty: Types) {
 
-                fn forwards(x: Self::From) -> $struct $(< $($T,)+ >)? {
-                    $struct {
-                        $(
-                            $field: <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::forwards(x.$field),
-                        )*
+                        #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+                        #[derive_where::derive_where(Debug; $(Ty::$variant: sp_std::fmt::Debug),*)]
+                        #[derive(cf_proc_macros::HasTypeIntrospection)]
+                        pub enum Enum {
+                            $(
+                                $variant(Ty::$variant),
+                            )*
+                        }
+
+                        impl IsHistoricalType for Enum where
+                            $( Ty::$variant: IsHistoricalType,)*
+                        {
+                            type GetCurrentType = $enum$(< $($T,)+ >)?;
+                        }
+
+                        mod where $( (Ty::$variant: cf_utilities::type_introspection::HasTypeIntrospection) )* {
+                            //
+                            // TypeInfo
+                            //
+                            // Implemented manually so that the variant indices in the type registry match
+                            // the actual Encode/Decode discriminants (which skip empty variants and respect
+                            // user-provided discriminant values). The `_phantom` variant is excluded from
+                            // the type info since it's not a real variant.
+                            impl scale_info::TypeInfo for Enum
+                            where
+                                Ty: 'static,
+                                $( $($T: 'static,)+ )?
+                                $(
+                                    Ty::$variant: scale_info::TypeInfo + 'static,
+                                )*
+                            {
+                                type Identity = Self;
+
+                                fn type_info() -> scale_info::Type {
+                                    let mut _disc: u8 = 0;
+                                    let mut variants = scale_info::build::Variants::new();
+                                    $(
+                                        if !<Ty::$variant as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() {
+                                            $( _disc = $variant_discriminant as u8; )?
+                                            let disc = _disc;
+                                            variants = variants.variant(stringify!($variant), |v| {
+                                                v.index(disc)
+                                                .fields(scale_info::build::Fields::unnamed()
+                                                    .field(|f| f.ty::<Ty::$variant>()))
+                                            });
+                                            _disc += 1;
+                                        }
+                                    )*
+
+                                    scale_info::Type::builder()
+                                        .path(scale_info::Path::new(stringify!(Enum), module_path!()))
+                                        .variant(variants)
+                                }
+                            }
+
+                            //
+                            // Encode / Decode / DecodeWithMemTracking
+                            //
+                            // These traits have to be implemented manually because empty variants (containing the `Never` type)
+                            // must be completely skipped and must not consume discriminant indices.
+                            //
+                            // Discriminant handling: when variants have explicit discriminants (`= N`), those values
+                            // are used as SCALE encoding indices (matching parity-scale-codec's derive behavior).
+                            // Empty variants are treated as if removed from the source code: they don't consume a
+                            // discriminant slot, and subsequent implicit discriminants are computed from the last
+                            // non-empty variant.
+                            impl codec::Encode for Enum
+                                where $( Ty::$variant: codec::Encode,)*
+                            {
+
+                                fn size_hint(&self) -> usize {
+                                    match self {
+                                        $(
+                                            Self::$variant(val) => 1usize + codec::Encode::size_hint(val),
+                                        )*
+                                        Self::_phantom(never, _) => match *never {},
+                                    }
+                                }
+
+                                fn encode_to<__W: codec::Output + ?Sized>(&self, dest: &mut __W) {
+                                    let mut _disc: u8 = 0;
+                                    $(
+                                        let $variant;
+                                        if !<Ty::$variant as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() {
+                                            $( _disc = $variant_discriminant as u8; )?
+                                            $variant = _disc;
+                                            _disc += 1;
+                                        } else {
+                                            $variant = 0; // dummy value, variant will never be encoded
+                                        }
+                                    )*
+
+                                    match self {
+                                        $(
+                                            Self::$variant(val) => {
+                                                codec::Encode::encode_to(&$variant, dest);
+                                                codec::Encode::encode_to(val, dest);
+                                            }
+                                        )*
+                                        Self::_phantom(never, _) => match *never {}
+                                    }
+                                }
+                            }
+
+                            impl codec::Decode for Enum
+                                where $( Ty::$variant: codec::Decode,)*
+                            {
+                                fn decode<__I: codec::Input>(input: &mut __I) -> Result<Self, codec::Error> {
+                                    let idx = <u8 as codec::Decode>::decode(input)?;
+                                    let mut _disc: u8 = 0;
+                                    $(
+                                        if !<Ty::$variant as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() {
+                                            $( _disc = $variant_discriminant as u8; )?
+                                            if idx == _disc {
+                                                return Ok(Self::$variant(<Ty::$variant as codec::Decode>::decode(input)?));
+                                            }
+                                            _disc += 1;
+                                        }
+                                    )*
+                                    Err(codec::Error::from("Invalid variant index"))
+                                }
+                            }
+
+                            impl codec::DecodeWithMemTracking for Enum
+                                where
+                                    $( Ty::$variant: codec::DecodeWithMemTracking,)*
+                                    Self: codec::Decode,
+                            {}
+
+                            impl codec::MaxEncodedLen for Enum
+                                where
+                                    $( Ty::$variant: codec::MaxEncodedLen,)*
+                                    Self: codec::Encode,
+                            {
+                                fn max_encoded_len() -> usize {
+                                    let mut max_variant_size: usize = 0;
+                                    $(
+                                        if !<Ty::$variant as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() {
+                                            let size = <Ty::$variant as codec::MaxEncodedLen>::max_encoded_len();
+                                            if size > max_variant_size {
+                                                max_variant_size = size;
+                                            }
+                                        }
+                                    )*
+                                    // 1 byte for the discriminant + max variant payload
+                                    1usize + max_variant_size
+                                }
+                            }
+
+                            //
+                            // Arbitrary
+                            //
+                            // This trait has to be implemented manually because the standard derive doesn't properly deal with variants that
+                            // cannot be instantiated (e.g. because they contain `!`, the "Never" type).
+                            #[cfg(any(test, all(feature = "proptest", feature = "std")))]
+                            impl proptest::arbitrary::Arbitrary for Enum
+                            where
+                                Ty: 'static,
+                                $( $($T: 'static,)+ )?
+                                $(
+                                    Ty::$variant: proptest::arbitrary::Arbitrary + sp_std::fmt::Debug + 'static,
+                                )*
+                            {
+                                type Parameters = ();
+                                type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+                                fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+                                    use proptest::strategy::Strategy;
+
+                                    let mut strategies: Vec<proptest::strategy::BoxedStrategy<Self>> = Vec::new();
+                                    $(
+                                        if !<Ty::$variant as cf_utilities::type_introspection::HasTypeIntrospection>::is_empty_type() {
+                                            strategies.push(
+                                                proptest::arbitrary::any::<Ty::$variant>()
+                                                    .prop_map(|val| Enum::$variant(val))
+                                                    .boxed()
+                                            );
+                                        }
+                                    )*
+                                    assert!(!strategies.is_empty(), "All variants of Enum are empty types — cannot generate arbitrary values");
+                                    proptest::strategy::Union::new(strategies).boxed()
+                                }
+                            }
+                        }
                     }
                 }
+            }
 
-                fn backwards(x: $struct $(< $($T,)+ >)?) -> Self::From {
-                    Struct {
+            pub type see_variant_changelogs = see_variant_changelogs_and_also<()>;
+            pub struct see_variant_changelogs_and_also<M>(M);
+
+            cf_proc_macros::generic_modules! {
+                mod (To: HistoricalTypesAt<V>) (V: Version)
+                {
+                    pub trait VariantCustomMigration {
                         $(
-                            $field: <<$field_ty as HasGenericVariant>::MigrationFromGeneric as Migration<$field_ty, vCurrent>>::backwards(x.$field),
-                        )*
-                        _phantom: Default::default(),
+                            type $variant: MaybeMigration<To::$variant, V> = DefaultMigration;
+                        )+
                     }
+
+                    impl VariantCustomMigration for () {}
+
+                    impl<M1: VariantCustomMigration, M2: VariantCustomMigration> VariantCustomMigration for (M1, M2) {
+                        $(
+                            type $variant = (M1::$variant, M2::$variant);
+                        )+
+                    }
+
+                    mod (M: VariantCustomMigration<To, V>)
+                    {
+                        mod variant_migrations {
+                            use super::*;
+                            $(
+                                pub type $variant = <M::$variant as MaybeMigration<To::$variant, V>>::GetWithDefault<GetMigrationToHistoricalType<To::$variant, V>>;
+                            )*
+                            pub type From = (
+                                $(
+                                    <variant_migrations::$variant as Migration<To::$variant, V>>::From,
+                                )*
+                            );
+
+                            #[derive(cf_proc_macros::IntroElim)]
+                            pub enum EnumForwardsError {
+                                $(
+                                    $variant(<$variant as Migration<To::$variant, V>>::ForwardsError),
+                                )*
+                            }
+
+                            #[derive(cf_proc_macros::IntroElim)]
+                            pub enum EnumBackwardsError {
+                                $(
+                                    $variant(<$variant as Migration<To::$variant, V>>::BackwardsError),
+                                )*
+                            }
+
+                            impl cf_utilities::never::IsEmptyType for EnumForwardsError
+                                where $(
+                                    <$variant as Migration<To::$variant, V>>::ForwardsError: cf_utilities::never::IsEmptyType,
+                                )*
+                            {
+                                fn as_never(&self) -> cf_utilities::never::Never {
+                                    self.elim_ref(
+                                        $(
+                                            |err: &<$variant as Migration<To::$variant, V>>::ForwardsError| err.as_never(),
+                                        )*
+                                        |never, _phantom| never.as_never(),
+                                    )
+                                }
+                            }
+
+                            impl cf_utilities::never::IsEmptyType for EnumBackwardsError
+                                where $(
+                                    <$variant as Migration<To::$variant, V>>::BackwardsError: cf_utilities::never::IsEmptyType,
+                                )*
+                            {
+                                fn as_never(&self) -> cf_utilities::never::Never {
+                                    self.elim_ref(
+                                        $(
+                                            |err: &<$variant as Migration<To::$variant, V>>::BackwardsError| err.as_never(),
+                                        )*
+                                        |never, _phantom| never.as_never(),
+                                    )
+                                }
+                            }
+
+                            mod $( $( ($T $(: $TBound)?) )+ )? {
+                                pub type EnumVariant<Target: Types> = Enum<$($($T,)+)? Target>;
+
+                                impl Migration<Enum<$($($T,)+)? To>, V> for see_variant_changelogs_and_also<M> where
+                                    EnumVariant<From>: IsHistoricalType,
+                                    $enum<$($($T,)+)?>: HasChangelog
+                                {
+                                    type From = EnumVariant<From>;
+                                    type ForwardsError = EnumForwardsError;
+                                    type BackwardsError = EnumBackwardsError;
+
+                                    fn try_forwards(x: Self::From) -> Result<EnumVariant<To>, Self::ForwardsError> {
+                                        Ok(match x {
+                                            $(
+                                                Enum::$variant(val) => Enum::$variant(
+                                                    $variant::try_forwards(val)
+                                                        .map_err(EnumForwardsError::$variant)?
+                                                ),
+                                            )*
+                                            Enum::_phantom(never, _) => Enum::_phantom(never, Default::default()),
+                                        })
+                                    }
+
+                                    fn try_backwards(x: EnumVariant<To>) -> Result<Self::From, Self::BackwardsError> {
+                                        Ok(match x {
+                                            $(
+                                                Enum::$variant(val) => Enum::$variant(
+                                                    $variant::try_backwards(val)
+                                                        .map_err(EnumBackwardsError::$variant)?
+                                                ),
+                                            )*
+                                            Enum::_phantom(never, _) => Enum::_phantom(never, Default::default()),
+                                        })
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ----------------- predefined migrations ------------------ //
+            pub mod variant {
+                $(
+                    pub mod $variant {
+                        use super::super::{OverrideMigrationWith, Version, HistoricalTypesAt, VariantCustomMigration, NewVariant};
+
+                        #[derive(Debug)]
+                        pub struct Added;
+                        impl<V: Version, TargetVariantTypes: HistoricalTypesAt<V>>
+                            VariantCustomMigration<TargetVariantTypes, V> for Added
+                        {
+                            type $variant = OverrideMigrationWith<NewVariant>;
+                        }
+                    }
+                )*
+            }
+
+
+            // ----------------- connection with default enum ------------------ //
+
+            cf_proc_macros::generic_modules! {
+                mod $( $( ($T $(: $TBound)?) )+ )?
+                {
+                    pub type RealEnum = $enum $(< $($T,)+ >)?;
+
+                    pub mod variants {
+                        use super::*;
+                        pub mod __impls {
+                            use super::*;
+                            $(
+                                pub mod $variant {
+                                    use super::*;
+                                    $crate::generate_module! {
+                                        pub struct variant_struct {
+                                            $( $( pub $variant_tuple_entry: $variant_ty,)*)?
+                                            $( $( pub $variant_field: $variant_field_ty,)*)?
+                                        }
+                                        mod variant_mod { #![migrations] }
+                                    }
+                                    impl HasChangelog for variant_struct
+                                    where
+                                        $( $( $variant_ty: HasChangelog, )* )?
+                                        $( $( $variant_field_ty: HasChangelog, )* )?
+                                    {
+                                        type if_unspecified = variant_mod::see_field_changelogs;
+                                    }
+                                }
+                            )*
+                        }
+
+                        $(
+                            pub type $variant = __impls::$variant::variant_struct;
+
+                            impl From<$variant> for RealEnum {
+                                fn from(this: $variant) -> RealEnum {
+                                    $enum::$variant
+                                    $(
+                                        {
+                                            $( $variant_field: this.$variant_field, )*
+                                        }
+                                    )?
+                                    $(
+                                        (
+                                            $( this.$variant_tuple_entry, )*
+                                        )
+                                    )?
+                                }
+                            }
+                        )*
+                    }
+
+                    pub struct DefaultTypes {}
+
+                    impl Types for DefaultTypes {
+                        $(
+                            type $variant = variants::$variant;
+                        )*
+                    }
+
+                    impl HasGenericVariant for RealEnum
+                        where
+                            $(
+                                $( $( $variant_ty: HasChangelog, )* )?
+                                $( $( $variant_ty: HasGenericVariant<GenericType: IsHistoricalType>, )* )?
+                                $( $( $variant_field_ty: HasChangelog, )* )?
+                                $( $( $variant_field_ty: HasGenericVariant<GenericType: IsHistoricalType>, )* )?
+                            )*
+                            $enum<$($($T,)+)?>: HasChangelog,
+                            Enum<$($($T,)+)? (
+                                $(
+                                    GetGenericVariant<variants::$variant>,
+                                )*
+                            )>: IsHistoricalType
+                    {
+                        type GenericType = Enum<$($($T,)+)? (
+                            $(
+                                GetGenericVariant<variants::$variant>,
+                            )*
+                        )>;
+                        type MigrationFromGeneric = GlobalMigrationFromGeneric;
+                    }
+
+
+                    impl Migration<RealEnum, vCurrent> for GlobalMigrationFromGeneric
+                    where
+                            $(
+                                $( $( $variant_ty: HasChangelog, )* )?
+                                $( $( $variant_ty: HasGenericVariant<GenericType: IsHistoricalType>, )* )?
+                                $( $( $variant_field_ty: HasChangelog, )* )?
+                                $( $( $variant_field_ty: HasGenericVariant<GenericType: IsHistoricalType>, )* )?
+                            )*
+                            $enum<$($($T,)+)?>: HasChangelog,
+                        Enum<$($($T,)+)? (
+                            $(
+                                GetGenericVariant<variants::$variant>,
+                            )*
+                        )>: IsHistoricalType
+                    {
+                        type From = Enum<$($($T,)+)? (
+                            $(
+                                GetGenericVariant<variants::$variant>,
+                            )*
+                        )>;
+                        type ForwardsError = cf_utilities::never::Never;
+                        type BackwardsError = cf_utilities::never::Never;
+
+                        fn try_forwards(x: Self::From) -> Result<RealEnum, Self::ForwardsError> {
+                            Ok(
+                                match x {
+                                    $(
+                                        Enum::$variant(val) =>
+                                            (<<variants::$variant as HasGenericVariant>::MigrationFromGeneric as Migration<variants::$variant, vCurrent>>::try_forwards(val)?).into(),
+                                    )*
+                                    Enum::_phantom(never, _) => match never {},
+                                }
+                            )
+                        }
+
+                        fn try_backwards(x: RealEnum) -> Result<Self::From, Self::BackwardsError> {
+                            x.elim(
+                                $(
+                                    |$($($variant_tuple_entry: $variant_ty,)*)? $($($variant_field: $variant_field_ty,)*)?|
+                                    <<variants::$variant as HasGenericVariant>::MigrationFromGeneric as Migration<variants::$variant, vCurrent>>::try_backwards(
+                                        variants::$variant::intro(
+                                            $( $( $variant_tuple_entry, )*)?
+                                            $( $( $variant_field, )*)?
+                                            Default::default(),
+                                        )
+                                    ).map(Enum::$variant),
+                                )*
+                            )
+                        }
+                    }
+
                 }
             }
         }
-    }
+    };
 }
 pub use generate_module;

--- a/utilities/src/without_std/migrations.rs
+++ b/utilities/src/without_std/migrations.rs
@@ -88,6 +88,17 @@ macro_rules! define_all_runtime_versions {
         /// }
         /// ```
         ///
+        /// For enums, newly added variants can be marked in the same style:
+        ///
+        /// ```ignore
+        /// impl HasChangelog for RpcEnum {
+        ///     type if_unspecified = _RpcEnum::see_variant_changelogs;
+        ///     type in_20200 = _RpcEnum::see_variant_changelogs_and_also<
+        ///         _RpcEnum::variant::NewVariant::Added,
+        ///     >;
+        /// }
+        /// ```
+        ///
         /// ## Migration sequence
         ///
         /// The migrations specified in the changelog form a sequence. Every migration targets the `Migration::From` type

--- a/utilities/src/without_std/migrations/basics.rs
+++ b/utilities/src/without_std/migrations/basics.rs
@@ -16,7 +16,7 @@
 
 // ---------- definition of migrations ------------
 
-use crate::migrations::HasChangelog;
+use crate::never::{IsEmptyType, Never};
 
 pub trait Version: Copy {
 	const CANONICAL_RUNTIME_PATCH_VERSION_FOR_COMPATIBILITY_TEST: Option<CanonicalPatchVersion>;
@@ -27,27 +27,54 @@ pub enum CanonicalPatchVersion {
 	Released(u32),
 }
 
-pub trait Migration<To: ?Sized, V: Version> {
+pub trait Migration<To, V: Version> {
 	type From: IsHistoricalType;
-	fn forwards(x: Self::From) -> To;
-	fn backwards(x: To) -> Self::From;
+	type ForwardsError = Never;
+	type BackwardsError = Never;
+	fn try_forwards(_x: Self::From) -> Result<To, Self::ForwardsError>;
+	fn try_backwards(_x: To) -> Result<Self::From, Self::BackwardsError>;
 }
 
-pub trait HasVersion<V: Version> {
+pub trait HasVersion<V: Version>: Sized {
 	type HistoricalType;
 	type HistoricalMigration: Migration<Self::HistoricalType, V>;
 	type MigrationToCurrent: Migration<Self, vCurrent, From = Self::HistoricalType>;
 }
 
-pub fn migrate_from_historical_type<V: Version, X: HasVersion<V>>(
+pub fn try_migrate_from_historical_type<V: Version, X: HasVersion<V>>(
 	_v: V,
 	x: X::HistoricalType,
-) -> X {
-	X::MigrationToCurrent::forwards(x)
+) -> Result<X, <X::MigrationToCurrent as Migration<X, vCurrent>>::ForwardsError> {
+	X::MigrationToCurrent::try_forwards(x)
 }
 
-pub fn migrate_to_historical_type<V: Version, X: HasVersion<V>>(_v: V, x: X) -> X::HistoricalType {
-	X::MigrationToCurrent::backwards(x)
+pub fn try_migrate_to_historical_type<V: Version, X: HasVersion<V>>(
+	_v: V,
+	x: X,
+) -> Result<X::HistoricalType, <X::MigrationToCurrent as Migration<X, vCurrent>>::BackwardsError> {
+	X::MigrationToCurrent::try_backwards(x)
+}
+
+pub fn migrate_from_historical_type<V: Version, X: HasVersion<V>>(_v: V, x: X::HistoricalType) -> X
+where
+	<X::MigrationToCurrent as Migration<X, vCurrent>>::ForwardsError: IsEmptyType,
+{
+	match X::MigrationToCurrent::try_forwards(x) {
+		Ok(x) => x,
+		#[allow(unreachable_code)]
+		Err(empty) => match empty.as_never() {},
+	}
+}
+
+pub fn migrate_to_historical_type<V: Version, X: HasVersion<V>>(_v: V, x: X) -> X::HistoricalType
+where
+	<X::MigrationToCurrent as Migration<X, vCurrent>>::BackwardsError: IsEmptyType,
+{
+	match X::MigrationToCurrent::try_backwards(x) {
+		Ok(x) => x,
+		#[allow(unreachable_code)]
+		Err(empty) => match empty.as_never() {},
+	}
 }
 // -------- identity migration --------
 pub struct IdentityMigration;
@@ -55,27 +82,46 @@ pub struct IdentityMigration;
 impl<X: IsHistoricalType, V: Version> Migration<X, V> for IdentityMigration {
 	type From = X;
 
-	fn forwards(x: Self::From) -> X {
-		x
+	fn try_forwards(x: Self::From) -> Result<X, Self::ForwardsError> {
+		Ok(x)
 	}
 
-	fn backwards(x: X) -> Self::From {
-		x
+	fn try_backwards(x: X) -> Result<Self::From, Self::BackwardsError> {
+		Ok(x)
 	}
 }
 
 // -------- composition of migrations --------
+
+pub enum ComposedMigrationFailed<A, B> {
+	First(A),
+	Second(B),
+}
+
+impl<A: IsEmptyType, B: IsEmptyType> IsEmptyType for ComposedMigrationFailed<A, B> {
+	fn as_never(&self) -> Never {
+		match self {
+			Self::First(error) => error.as_never(),
+			Self::Second(error) => error.as_never(),
+		}
+	}
+}
+
 impl<V: Version, W: Version, X, A: Migration<B::From, W>, B: Migration<X, V>> Migration<X, V>
 	for (A, W, B)
 {
 	type From = A::From;
+	type ForwardsError = ComposedMigrationFailed<A::ForwardsError, B::ForwardsError>;
+	type BackwardsError = ComposedMigrationFailed<A::BackwardsError, B::BackwardsError>;
 
-	fn forwards(x: Self::From) -> X {
-		B::forwards(A::forwards(x))
+	fn try_forwards(x: Self::From) -> Result<X, Self::ForwardsError> {
+		let x = A::try_forwards(x).map_err(ComposedMigrationFailed::First)?;
+		B::try_forwards(x).map_err(ComposedMigrationFailed::Second)
 	}
 
-	fn backwards(x: X) -> Self::From {
-		A::backwards(B::backwards(x))
+	fn try_backwards(x: X) -> Result<Self::From, Self::BackwardsError> {
+		let x = B::try_backwards(x).map_err(ComposedMigrationFailed::Second)?;
+		A::try_backwards(x).map_err(ComposedMigrationFailed::First)
 	}
 }
 
@@ -85,17 +131,39 @@ pub struct NewFieldWithDefault;
 impl<T: Default, V: Version> Migration<T, V> for NewFieldWithDefault {
 	type From = ();
 
-	fn forwards(_x: Self::From) -> T {
-		Default::default()
+	fn try_forwards(_x: Self::From) -> Result<T, Self::ForwardsError> {
+		Ok(Default::default())
 	}
 
-	fn backwards(_x: T) -> Self::From {}
+	fn try_backwards(_x: T) -> Result<Self::From, Self::BackwardsError> {
+		Ok(())
+	}
+}
+
+// ------- migration for new enum variant --------
+
+pub struct NewVariant;
+
+#[derive(Debug)]
+pub struct NewVariantBackwardsError;
+
+impl<T, V: Version> Migration<T, V> for NewVariant {
+	type From = Never;
+	type BackwardsError = NewVariantBackwardsError;
+
+	fn try_forwards(x: Self::From) -> Result<T, Self::ForwardsError> {
+		match x {}
+	}
+
+	fn try_backwards(_x: T) -> Result<Self::From, Self::BackwardsError> {
+		Err(NewVariantBackwardsError)
+	}
 }
 
 // ----------- lookups ------------
 
 pub trait IsHistoricalType {
-	type GetCurrentType: HasChangelog;
+	type GetCurrentType;
 }
 pub trait IsHistoricalTypeAt<V: Version> =
 	IsHistoricalType<GetCurrentType: HasVersion<V, HistoricalType = Self>>;
@@ -117,7 +185,13 @@ impl Version for vCurrent {
 
 pub trait HasGenericVariant: Sized {
 	type GenericType;
-	type MigrationFromGeneric: Migration<Self, vCurrent, From = Self::GenericType>;
+	type MigrationFromGeneric: Migration<
+		Self,
+		vCurrent,
+		From = Self::GenericType,
+		ForwardsError = Never,
+		BackwardsError = Never,
+	>;
 }
 
 pub type GetGenericVariant<X: HasGenericVariant> =
@@ -125,12 +199,20 @@ pub type GetGenericVariant<X: HasGenericVariant> =
 
 pub struct GlobalMigrationFromGeneric;
 
-pub fn migrate_from_generic_type<X: HasGenericVariant>(x: X::GenericType) -> X {
-	X::MigrationFromGeneric::forwards(x)
+pub fn try_migrate_from_generic_type<X: HasGenericVariant>(x: X::GenericType) -> X {
+	match X::MigrationFromGeneric::try_forwards(x) {
+		Ok(x) => x,
+		#[allow(unreachable_code)]
+		Err(err) => match err.as_never() {},
+	}
 }
 
-pub fn migrate_to_generic_type<X: HasGenericVariant>(x: X) -> X::GenericType {
-	X::MigrationFromGeneric::backwards(x)
+pub fn try_migrate_to_generic_type<X: HasGenericVariant>(x: X) -> X::GenericType {
+	match X::MigrationFromGeneric::try_backwards(x) {
+		Ok(x) => x,
+		#[allow(unreachable_code)]
+		Err(err) => match err.as_never() {},
+	}
 }
 
 // ----------- maybe migrations (for horizontal composition) ---------

--- a/utilities/src/without_std/migrations/primitives.rs
+++ b/utilities/src/without_std/migrations/primitives.rs
@@ -16,11 +16,16 @@
 
 // --------- primitives --------
 
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, vec::Vec};
 
-use crate::migrations::{
-	basics::{IdentityMigration, Migration, Version},
-	with_all_runtime_migrations, HasChangelog, HasGenericVariant, IsHistoricalType, OrdMigrations,
+use crate::{
+	migrations::{
+		basics::{vCurrent, IdentityMigration, Migration, Version},
+		with_all_runtime_migrations, HasChangelog, HasGenericVariant, IsHistoricalType,
+		OrdMigrations,
+	},
+	never::{IsEmptyType, Never},
+	type_introspection::HasTypeIntrospection,
 };
 
 // ----------- identity migrations -------------
@@ -44,7 +49,20 @@ macro_rules! impl_identity_migrations {
     };
 }
 
-impl_identity_migrations! {(), u8, u16, u32, u64, u128, bool,}
+impl_identity_migrations! {(), bool, u16, u32, u64, u128, u8, Never, }
+
+impl<T> IsHistoricalType for PhantomData<T> {
+	type GetCurrentType = Self;
+}
+
+impl<T> HasGenericVariant for PhantomData<T> {
+	type GenericType = Self;
+	type MigrationFromGeneric = IdentityMigration;
+}
+
+impl<T> HasChangelog for PhantomData<T> {
+	type if_unspecified = IdentityMigration;
+}
 
 // ----------- wrapped types -------------
 
@@ -77,12 +95,12 @@ macro_rules! impl_identity_migrations_with_wrapper {
 		impl Migration<$Ty, crate::migrations::vCurrent> for WrapMigration {
 			type From = $Wrapper;
 
-			fn forwards(x: Self::From) -> $Ty {
-				x.0
+			fn try_forwards(x: Self::From) -> Result<$Ty, Self::ForwardsError> {
+				Ok(x.0)
 			}
 
-			fn backwards(x: $Ty) -> Self::From {
-				$Wrapper(x)
+			fn try_backwards(x: $Ty) -> Result<Self::From, Self::BackwardsError> {
+				Ok($Wrapper(x))
 			}
 		}
 
@@ -110,6 +128,22 @@ macro_rules! impl_identity_migrations_with_wrapper {
 				type Strategy = impl proptest::strategy::Strategy<Value = Self>;
 			}
 		)?
+
+        $(
+            // This implementation assumes the inner type has a Default implementation
+            impl HasTypeIntrospection for $Wrapper
+                where $Inner: Default
+            {
+                fn is_empty_type() -> bool {
+                    false
+                }
+
+                fn sample_all_shapes() -> Vec<Self> {
+                    let $var = <$Inner as Default>::default();
+                    sp_std::vec![$Wrapper($ctr)]
+                }
+            }
+        )?
 	};
 }
 
@@ -129,7 +163,14 @@ impl_identity_migrations_with_wrapper! {
 
 // ----------- simple migration that introduces a new type -------------
 
-#[derive(codec::Encode, codec::Decode, scale_info::TypeInfo, PartialEq, Debug)]
+#[derive(
+	codec::Encode,
+	codec::Decode,
+	scale_info::TypeInfo,
+	PartialEq,
+	Debug,
+	cf_proc_macros::HasTypeIntrospection,
+)]
 #[cfg_attr(all(feature = "proptest", feature = "std"), derive(proptest_derive::Arbitrary))]
 pub struct HistoricalEmptyPlaceholder<T>(sp_std::marker::PhantomData<T>);
 impl<T: HasGenericVariant + HasChangelog> IsHistoricalType for HistoricalEmptyPlaceholder<T> {
@@ -140,12 +181,12 @@ pub struct NewTypeWithDefault;
 impl<V: Version, T: HasChangelog + Default> Migration<T, V> for NewTypeWithDefault {
 	type From = HistoricalEmptyPlaceholder<T>;
 
-	fn forwards(_: Self::From) -> T {
-		Default::default()
+	fn try_forwards(_: Self::From) -> Result<T, Self::ForwardsError> {
+		Ok(Default::default())
 	}
 
-	fn backwards(_: T) -> Self::From {
-		HistoricalEmptyPlaceholder(Default::default())
+	fn try_backwards(_: T) -> Result<Self::From, Self::BackwardsError> {
+		Ok(HistoricalEmptyPlaceholder(Default::default()))
 	}
 }
 
@@ -153,13 +194,69 @@ impl<V: Version, T: HasChangelog + Default> Migration<T, V> for NewTypeWithDefau
 
 pub struct MapMigration<X>(X);
 
+pub struct GenericMapMigration<X>(X);
+
+pub enum OptionMigrationFailed<E> {
+	Some(E),
+}
+
+pub enum VecMigrationFailed<E> {
+	Element { index: usize, error: E },
+}
+
+pub enum TupleWith1EntryMigrationFailed<E> {
+	First(E),
+}
+
+pub enum TupleWith2EntriesMigrationFailed<A, B> {
+	First(A),
+	Second(B),
+}
+
+impl<E: IsEmptyType> IsEmptyType for OptionMigrationFailed<E> {
+	fn as_never(&self) -> Never {
+		match self {
+			Self::Some(error) => error.as_never(),
+		}
+	}
+}
+
+impl<E: IsEmptyType> IsEmptyType for VecMigrationFailed<E> {
+	fn as_never(&self) -> Never {
+		match self {
+			Self::Element { error, .. } => error.as_never(),
+		}
+	}
+}
+
+impl<E: IsEmptyType> IsEmptyType for TupleWith1EntryMigrationFailed<E> {
+	fn as_never(&self) -> Never {
+		match self {
+			Self::First(error) => error.as_never(),
+		}
+	}
+}
+
+impl<A: IsEmptyType, B: IsEmptyType> IsEmptyType for TupleWith2EntriesMigrationFailed<A, B> {
+	fn as_never(&self) -> Never {
+		match self {
+			Self::First(error) => error.as_never(),
+			Self::Second(error) => error.as_never(),
+		}
+	}
+}
+
 macro_rules! impl_migrations_for_container {
     (
         $container:ident<$($ty:ident $(: ($($ty_path:tt)*))?),+>,
         $container_macro:ident,
         [$($var_M:ident $(where From: ($($from_path:tt)*) )?),+],
-        |$var_f:ident| $expr_f:expr,
-        |$var_b:ident| $expr_b:expr,
+		type ForwardsError = $forwards_error:ty,
+		type BackwardsError = $backwards_error:ty,
+		try_forwards |$var_try_f:ident| $expr_try_f:expr,
+		try_backwards |$var_try_b:ident| $expr_try_b:expr,
+		generic_try_forwards |$var_generic_try_f:ident| $expr_generic_try_f:expr,
+		generic_try_backwards |$var_generic_try_b:ident| $expr_generic_try_b:expr,
     ) => {
         macro_rules! $container_macro {
             ($$($$migration:ident, )*) => {
@@ -176,19 +273,33 @@ macro_rules! impl_migrations_for_container {
 
         impl<$($ty $(: $($ty_path)* )? ,)+  V: Version, $($var_M: Migration<$ty, V $(, From: $($from_path)*)?>),+> Migration<$container<$($ty),+>, V> for MapMigration<($($var_M, )+)> {
             type From = $container<$($var_M::From),+>;
+			type ForwardsError = $forwards_error;
+			type BackwardsError = $backwards_error;
 
-            fn forwards($var_f: Self::From) -> $container<$($ty),+> {
-                $expr_f
-            }
+			fn try_forwards($var_try_f: Self::From) -> Result<$container<$($ty),+>, Self::ForwardsError> {
+				$expr_try_f
+			}
 
-            fn backwards($var_b: $container<$($ty),+>) -> Self::From {
-                $expr_b
-            }
+			fn try_backwards($var_try_b: $container<$($ty),+>) -> Result<Self::From, Self::BackwardsError> {
+				$expr_try_b
+			}
         }
+
+		impl<$($ty $(: $($ty_path)* )? ,)+ $($var_M: Migration<$ty, vCurrent, ForwardsError = Never, BackwardsError = Never $(, From: $($from_path)*)?>),+> Migration<$container<$($ty),+>, vCurrent> for GenericMapMigration<($($var_M, )+)> {
+			type From = $container<$($var_M::From),+>;
+
+			fn try_forwards($var_generic_try_f: Self::From) -> Result<$container<$($ty),+>, Self::ForwardsError> {
+				$expr_generic_try_f
+			}
+
+			fn try_backwards($var_generic_try_b: $container<$($ty),+>) -> Result<Self::From, Self::BackwardsError> {
+				$expr_generic_try_b
+			}
+		}
 
         impl<$($ty: HasGenericVariant $(+ $($ty_path)*)?),+ > HasGenericVariant for $container<$($ty),+> {
             type GenericType = $container<$($ty::GenericType),+>;
-            type MigrationFromGeneric = MapMigration<($($ty::MigrationFromGeneric, )+)>;
+            type MigrationFromGeneric = GenericMapMigration<($($ty::MigrationFromGeneric, )+)>;
         }
         impl<$($ty: IsHistoricalType $(+ $($ty_path)*)?),+> IsHistoricalType for $container<$($ty),+> {
             type GetCurrentType = $container<$($ty::GetCurrentType),+>;
@@ -200,16 +311,108 @@ impl_migrations_for_container! {
 	Option<X>,
 	impl_changelog_for_option,
 	[M],
-	|x| x.map(M::forwards),
-	|x| x.map(M::backwards),
+	type ForwardsError = OptionMigrationFailed<M::ForwardsError>,
+	type BackwardsError = OptionMigrationFailed<M::BackwardsError>,
+	try_forwards |x| {
+		match x {
+			Some(x) => M::try_forwards(x).map_err(OptionMigrationFailed::Some).map(Some),
+			None => Ok(None),
+		}
+	},
+	try_backwards |x| {
+		match x {
+			Some(x) => M::try_backwards(x).map_err(OptionMigrationFailed::Some).map(Some),
+			None => Ok(None),
+		}
+	},
+	generic_try_forwards |x| {
+		match x {
+			Some(x) => match M::try_forwards(x) {
+				Ok(x) => Ok(Some(x)),
+				Err(error) => match error {},
+			},
+			None => Ok(None),
+		}
+	},
+	generic_try_backwards |x| {
+		match x {
+			Some(x) => match M::try_backwards(x) {
+				Ok(x) => Ok(Some(x)),
+				Err(error) => match error {},
+			},
+			None => Ok(None),
+		}
+	},
 }
 
 impl_migrations_for_container! {
 	Vec<X>,
 	impl_changelog_for_vector,
 	[M],
-	|x| x.into_iter().map(M::forwards).collect(),
-	|x| x.into_iter().map(M::backwards).collect(),
+	type ForwardsError = VecMigrationFailed<M::ForwardsError>,
+	type BackwardsError = VecMigrationFailed<M::BackwardsError>,
+	try_forwards |x| {
+		let mut result = Vec::with_capacity(x.len());
+
+		for (index, x) in x.into_iter().enumerate() {
+			result.push(
+				M::try_forwards(x).map_err(|error| VecMigrationFailed::Element { index, error })?,
+			);
+		}
+
+		Ok(result)
+	},
+	try_backwards |x| {
+		let mut result = Vec::with_capacity(x.len());
+
+		for (index, x) in x.into_iter().enumerate() {
+			result.push(
+				M::try_backwards(x).map_err(|error| VecMigrationFailed::Element { index, error })?,
+			);
+		}
+
+		Ok(result)
+	},
+	generic_try_forwards |x| {
+		let mut result = Vec::with_capacity(x.len());
+
+		for x in x {
+			result.push(M::try_forwards(x)?);
+		}
+
+		Ok(result)
+	},
+	generic_try_backwards |x| {
+		let mut result = Vec::with_capacity(x.len());
+
+		for x in x {
+			result.push(M::try_backwards(x)?);
+		}
+
+		Ok(result)
+	},
+}
+
+pub type TupleWith1Entry<A> = (A,);
+
+impl_migrations_for_container! {
+	TupleWith1Entry<A>,
+	impl_changelog_for_tuple1,
+	[M1],
+	type ForwardsError = TupleWith1EntryMigrationFailed<M1::ForwardsError>,
+	type BackwardsError = TupleWith1EntryMigrationFailed<M1::BackwardsError>,
+	try_forwards |x| {
+		Ok((M1::try_forwards(x.0).map_err(TupleWith1EntryMigrationFailed::First)?,))
+	},
+	try_backwards |x| {
+		Ok((M1::try_backwards(x.0).map_err(TupleWith1EntryMigrationFailed::First)?,))
+	},
+	generic_try_forwards |x| {
+		Ok((M1::try_forwards(x.0)?,))
+	},
+	generic_try_backwards |x| {
+		Ok((M1::try_backwards(x.0)?,))
+	},
 }
 
 pub type TupleWith2Entries<A, B> = (A, B);
@@ -218,13 +421,37 @@ impl_migrations_for_container! {
 	TupleWith2Entries<A,B>,
 	impl_changelog_for_tuple,
 	[M1,M2],
-	|x| (M1::forwards(x.0), M2::forwards(x.1)),
-	|x| (M1::backwards(x.0), M2::backwards(x.1)),
+	type ForwardsError = TupleWith2EntriesMigrationFailed<M1::ForwardsError, M2::ForwardsError>,
+	type BackwardsError = TupleWith2EntriesMigrationFailed<M1::BackwardsError, M2::BackwardsError>,
+	try_forwards |x| {
+		Ok((
+			M1::try_forwards(x.0).map_err(TupleWith2EntriesMigrationFailed::First)?,
+			M2::try_forwards(x.1).map_err(TupleWith2EntriesMigrationFailed::Second)?,
+		))
+	},
+	try_backwards |x| {
+		Ok((
+			M1::try_backwards(x.0).map_err(TupleWith2EntriesMigrationFailed::First)?,
+			M2::try_backwards(x.1).map_err(TupleWith2EntriesMigrationFailed::Second)?,
+		))
+	},
+	generic_try_forwards |x| {
+		Ok((M1::try_forwards(x.0)?, M2::try_forwards(x.1)?))
+	},
+	generic_try_backwards |x| {
+		Ok((M1::try_backwards(x.0)?, M2::try_backwards(x.1)?))
+	},
 }
 
 // ---- btreemap ----
 // the bounds are quite messy and difficult to replicate with the `impl_migrations_for_container`
 // macro, so we use a manual implementation:
+
+pub enum BTreeMapMigrationFailed<KeyError, ValueError> {
+	Key(KeyError),
+	Value(ValueError),
+	KeyCollision,
+}
 
 macro_rules! impl_changelog_for_btreemap {
     ($($migration:ident,)*) => {
@@ -248,13 +475,77 @@ impl<
 	> Migration<BTreeMap<A, B>, V> for MapMigration<(M1, M2)>
 {
 	type From = BTreeMap<M1::From, M2::From>;
+	type ForwardsError = BTreeMapMigrationFailed<M1::ForwardsError, M2::ForwardsError>;
+	type BackwardsError = BTreeMapMigrationFailed<M1::BackwardsError, M2::BackwardsError>;
 
-	fn forwards(x: Self::From) -> BTreeMap<A, B> {
-		x.into_iter().map(|(a, b)| (M1::forwards(a), M2::forwards(b))).collect()
+	fn try_forwards(x: Self::From) -> Result<BTreeMap<A, B>, Self::ForwardsError> {
+		let mut result = BTreeMap::new();
+
+		for (a, b) in x {
+			let a = M1::try_forwards(a).map_err(BTreeMapMigrationFailed::Key)?;
+			let b = M2::try_forwards(b).map_err(BTreeMapMigrationFailed::Value)?;
+
+			if result.insert(a, b).is_some() {
+				return Err(BTreeMapMigrationFailed::KeyCollision);
+			}
+		}
+
+		Ok(result)
 	}
 
-	fn backwards(x: BTreeMap<A, B>) -> Self::From {
-		x.into_iter().map(|(a, b)| (M1::backwards(a), M2::backwards(b))).collect()
+	fn try_backwards(x: BTreeMap<A, B>) -> Result<Self::From, Self::BackwardsError> {
+		let mut result = BTreeMap::new();
+
+		for (a, b) in x {
+			let a = M1::try_backwards(a).map_err(BTreeMapMigrationFailed::Key)?;
+			let b = M2::try_backwards(b).map_err(BTreeMapMigrationFailed::Value)?;
+
+			if result.insert(a, b).is_some() {
+				return Err(BTreeMapMigrationFailed::KeyCollision);
+			}
+		}
+
+		Ok(result)
+	}
+}
+
+impl<
+		A: Ord,
+		B,
+		M1: Migration<
+			A,
+			vCurrent,
+			From: IsHistoricalType<GetCurrentType: OrdMigrations + Ord> + Ord,
+			ForwardsError = Never,
+			BackwardsError = Never,
+		>,
+		M2: Migration<B, vCurrent, ForwardsError = Never, BackwardsError = Never>,
+	> Migration<BTreeMap<A, B>, vCurrent> for GenericMapMigration<(M1, M2)>
+{
+	type From = BTreeMap<M1::From, M2::From>;
+
+	fn try_forwards(x: Self::From) -> Result<BTreeMap<A, B>, Self::ForwardsError> {
+		let mut result = BTreeMap::new();
+
+		for (a, b) in x {
+			let a = M1::try_forwards(a)?;
+			let b = M2::try_forwards(b)?;
+			result.insert(a, b);
+		}
+
+		Ok(result)
+	}
+
+	fn try_backwards(x: BTreeMap<A, B>) -> Result<Self::From, Self::BackwardsError> {
+		let mut result = BTreeMap::new();
+
+		for (a, b) in x {
+			let a = M1::try_backwards(a)?;
+			let b = M2::try_backwards(b)?;
+			result.insert(a, b);
+		}
+
+		Ok(result)
 	}
 }
 
@@ -263,7 +554,8 @@ where
 	A: HasGenericVariant<GenericType: Ord + IsHistoricalTypeOrd>,
 {
 	type GenericType = BTreeMap<A::GenericType, B::GenericType>;
-	type MigrationFromGeneric = MapMigration<(A::MigrationFromGeneric, B::MigrationFromGeneric)>;
+	type MigrationFromGeneric =
+		GenericMapMigration<(A::MigrationFromGeneric, B::MigrationFromGeneric)>;
 }
 impl<A: IsHistoricalType<GetCurrentType: OrdMigrations + Ord>, B: IsHistoricalType> IsHistoricalType
 	for BTreeMap<A, B>

--- a/utilities/src/without_std/never.rs
+++ b/utilities/src/without_std/never.rs
@@ -1,0 +1,72 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::type_introspection::HasTypeIntrospection;
+use sp_std::vec::Vec;
+
+/// Uninhabited type used as a placeholder for enum variants that cannot be constructed.
+///
+/// Unlike `!`, this implements `Encode`, `Decode`, `DecodeWithMemTracking`, `HasTypeIntrospection`,
+/// `Arbitrary`, and all standard derives, so it satisfies all bounds required by the migration
+/// system's generic `Enum` type.
+#[derive(
+	Copy,
+	Clone,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Hash,
+	Debug,
+	codec::Encode,
+	codec::Decode,
+	codec::DecodeWithMemTracking,
+	codec::MaxEncodedLen,
+	scale_info::TypeInfo,
+	serde::Serialize,
+	serde::Deserialize,
+)]
+pub enum Never {}
+
+impl HasTypeIntrospection for Never {
+	fn is_empty_type() -> bool {
+		true
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		Vec::new()
+	}
+}
+
+#[cfg(any(test, all(feature = "proptest", feature = "std")))]
+impl proptest::arbitrary::Arbitrary for Never {
+	type Parameters = ();
+	type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+	fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+		panic!("Cannot generate arbitrary values for uninhabited type Never")
+	}
+}
+
+pub trait IsEmptyType: Sized {
+	fn as_never(&self) -> Never;
+}
+
+impl IsEmptyType for Never {
+	fn as_never(&self) -> Never {
+		match *self {}
+	}
+}

--- a/utilities/src/without_std/tests.rs
+++ b/utilities/src/without_std/tests.rs
@@ -14,16 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bounded_vec;
-pub mod conditional;
 pub mod generate_module;
-pub mod migrations;
-pub mod never;
-pub mod select;
-#[cfg(test)]
-mod tests;
+pub mod generic_modules;
 pub mod type_introspection;
-
-pub const fn bs58_array<const S: usize>(s: &'static str) -> [u8; S] {
-	bs58::decode(s.as_bytes()).into_array_const_unwrap()
-}

--- a/utilities/src/without_std/tests/generate_module.rs
+++ b/utilities/src/without_std/tests/generate_module.rs
@@ -1,0 +1,123 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(test)]
+
+use crate::migrations::HasChangelog;
+
+#[cf_proc_macros::generate_module]
+pub struct MyS<T> {
+	pub a: T,
+}
+
+impl<T: HasChangelog> HasChangelog for MyS<T> {
+	type if_unspecified = _MyS::see_field_changelogs;
+}
+
+pub trait T1 {
+	type XY;
+}
+
+mod enum1 {
+	use super::T1;
+
+	cf_utilities::generate_module! {
+		pub enum MyTestValuesWithoutChangelog<T: T1> {
+			Variant1(_0: T::XY),
+			VariantNone{_0: u8,_1: u16, _2: u8,},
+			Variant3(_0: T::XY),
+		}
+		mod _MyTestValuesWithoutChangelog { #![migrations] }
+	}
+}
+
+mod enum2 {
+	use super::T1;
+	cf_utilities::generate_module! {
+	pub enum MyTestValuesWithoutChangelog2<T: T1> {
+		Variant1(_0: T::XY),
+		VariantNone{_0: u8,_1: u16, _2: u8,},
+		Variant5 {
+			myfield: u8,
+		},
+	}
+		mod _MyTestValuesWithoutChangelog2 { #![migrations] }
+	}
+}
+
+mod enum3 {
+	use super::T1;
+	cf_utilities::generate_module! {
+	pub enum MyTestValuesWithoutChangelog3<T: T1> {
+		Variant1(_0: T::XY),
+		VariantNone{_0: u8,_1: u16, _2: u8,},
+		Variant3(_0: T::XY),
+		Variant5 {
+			myfield: u8,
+			field2: (T::XY, T::XY),
+		},
+	}
+		mod _MyTestValuesWithoutChangelog3 { #![migrations] }
+	}
+}
+
+mod enum4 {
+	use super::{HasChangelog, T1};
+	cf_utilities::generate_module! {
+	pub enum MyTestValues<T: T1> {
+		Variant1(_0: T::XY),
+		Variant2{_0: u8, _1: u16, _2: u8, _3: u8, _4: u8, _5: u8, _6: u16, _7: u8, },
+		Variant3 {_0: T::XY, _1: T::XY,},
+		Variant4 {
+			field2: T::XY,
+			field3: T::XY,
+			field4: T::XY,
+			field5: T::XY,
+		},
+		Variant5 (
+			field2: u16,
+			field3: u8,
+			field4: u8,
+			field5: u8,
+			field6: u8,
+			field7: u8,
+			field8: u8,
+			field9: u8,
+			field10: u8,
+			field11: u8,
+			field12: u8,
+			field13: u8
+		),
+		Variant6 {
+			myfield: u8,
+			field2: u16,
+			field3: T::XY,
+			field4: T::XY,
+			field5: T::XY,
+		},
+	}
+		mod _MyTestValues { #![migrations] }
+	}
+
+	impl<T: T1 + HasChangelog> HasChangelog for MyTestValues<T>
+	where
+		T::XY: HasChangelog,
+	{
+		type if_unspecified = _MyTestValues::see_variant_changelogs;
+		type in_20100 =
+			_MyTestValues::see_variant_changelogs_and_also<_MyTestValues::variant::Variant2::Added>;
+	}
+}

--- a/utilities/src/without_std/tests/generic_modules.rs
+++ b/utilities/src/without_std/tests/generic_modules.rs
@@ -14,16 +14,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bounded_vec;
-pub mod conditional;
-pub mod generate_module;
-pub mod migrations;
-pub mod never;
-pub mod select;
-#[cfg(test)]
-mod tests;
-pub mod type_introspection;
+#![cfg(test)]
+#![allow(unused)]
 
-pub const fn bs58_array<const S: usize>(s: &'static str) -> [u8; S] {
-	bs58::decode(s.as_bytes()).into_array_const_unwrap()
+pub trait T1 {
+	type XY;
+}
+
+trait Good {
+	type Bad;
+}
+
+cf_proc_macros::generic_modules! {
+	mod (A: T1) {
+		type MyType = A::XY;
+		type Bla = u16;
+		struct ThisIsS {
+			value: A::XY,
+		}
+		mod (B: Clone) where (B: Clone) {
+			struct InnerWithBoth {
+				a: A,
+				b: B,
+			}
+			type MyVal = InnerWithBoth;
+		}
+		struct Without {
+			value: bool,
+		}
+		impl Good for ThisIsS {
+			type Bad = u8;
+		}
+	}
 }

--- a/utilities/src/without_std/tests/type_introspection.rs
+++ b/utilities/src/without_std/tests/type_introspection.rs
@@ -1,0 +1,151 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(test)]
+#![allow(unused)]
+
+use crate::{never::Never, type_introspection::HasTypeIntrospection};
+
+// --------------- is_empty_type ----------------
+#[test]
+fn test_is_empty_type() {
+	#![allow(clippy::bool_assert_comparison)]
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum NotEmpty0 {
+		Var0 { a: bool },
+	}
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum NotEmpty1 {
+		Var0,
+	}
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum NotEmpty2 {
+		Other { a: u16 },
+		MyBranch { a: u8, b: Never },
+	}
+
+	assert_eq!(NotEmpty0::is_empty_type(), false);
+	assert_eq!(NotEmpty1::is_empty_type(), false);
+	assert_eq!(NotEmpty2::is_empty_type(), false);
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum Empty0 {}
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum Empty1 {
+		Var0 { a: Never },
+	}
+
+	#[derive(cf_proc_macros::HasTypeIntrospection)]
+	enum Empty2 {
+		Var0 { a: Never },
+		Var1 { a: u8, b: Never },
+	}
+
+	assert_eq!(Empty0::is_empty_type(), true);
+	assert_eq!(Empty1::is_empty_type(), true);
+	assert_eq!(Empty2::is_empty_type(), true);
+}
+
+// --------------- sample_all_shapes ----------------
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+enum Empty {}
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+struct Singleton {}
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+enum BinaryShape {
+	First,
+	Second,
+}
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+enum TernaryShape {
+	First,
+	Second,
+	Third,
+}
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+struct NamedProduct {
+	binary: BinaryShape,
+	ternary: TernaryShape,
+}
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+struct TupleProduct(BinaryShape, TernaryShape);
+
+#[derive(PartialEq, Debug, cf_proc_macros::HasTypeIntrospection)]
+enum SumShape {
+	Unit,
+	Tuple(BinaryShape, TernaryShape),
+	Named { ternary: TernaryShape },
+	EmptyTuple(BinaryShape, Never),
+	EmptyNamed { never: Never },
+}
+
+#[test]
+fn structs_sample_the_cartesian_product_of_field_shapes() {
+	assert_eq!(Singleton::sample_all_shapes(), vec![Singleton {}]);
+	assert_eq!(
+		NamedProduct::sample_all_shapes(),
+		vec![
+			NamedProduct { binary: BinaryShape::First, ternary: TernaryShape::First },
+			NamedProduct { binary: BinaryShape::First, ternary: TernaryShape::Second },
+			NamedProduct { binary: BinaryShape::First, ternary: TernaryShape::Third },
+			NamedProduct { binary: BinaryShape::Second, ternary: TernaryShape::First },
+			NamedProduct { binary: BinaryShape::Second, ternary: TernaryShape::Second },
+			NamedProduct { binary: BinaryShape::Second, ternary: TernaryShape::Third },
+		],
+	);
+
+	assert_eq!(
+		TupleProduct::sample_all_shapes(),
+		vec![
+			TupleProduct(BinaryShape::First, TernaryShape::First),
+			TupleProduct(BinaryShape::First, TernaryShape::Second),
+			TupleProduct(BinaryShape::First, TernaryShape::Third),
+			TupleProduct(BinaryShape::Second, TernaryShape::First),
+			TupleProduct(BinaryShape::Second, TernaryShape::Second),
+			TupleProduct(BinaryShape::Second, TernaryShape::Third),
+		],
+	);
+}
+
+#[test]
+fn enums_sample_the_sum_of_variant_shapes() {
+	assert_eq!(Empty::sample_all_shapes(), vec![]);
+
+	assert_eq!(
+		SumShape::sample_all_shapes(),
+		vec![
+			SumShape::Unit,
+			SumShape::Tuple(BinaryShape::First, TernaryShape::First),
+			SumShape::Tuple(BinaryShape::First, TernaryShape::Second),
+			SumShape::Tuple(BinaryShape::First, TernaryShape::Third),
+			SumShape::Tuple(BinaryShape::Second, TernaryShape::First),
+			SumShape::Tuple(BinaryShape::Second, TernaryShape::Second),
+			SumShape::Tuple(BinaryShape::Second, TernaryShape::Third),
+			SumShape::Named { ternary: TernaryShape::First },
+			SumShape::Named { ternary: TernaryShape::Second },
+			SumShape::Named { ternary: TernaryShape::Third },
+		],
+	);
+}

--- a/utilities/src/without_std/type_introspection.rs
+++ b/utilities/src/without_std/type_introspection.rs
@@ -1,0 +1,122 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use sp_std::{collections::btree_map::BTreeMap, vec, vec::Vec};
+
+pub trait HasTypeIntrospection: Sized {
+	fn is_empty_type() -> bool;
+	fn sample_all_shapes() -> Vec<Self>;
+}
+
+// -------------- primitives ---------------
+
+#[duplicate::duplicate_item(Type; [()]; [bool]; [u8]; [u16]; [u32]; [u64]; [u128])]
+impl HasTypeIntrospection for Type {
+	fn is_empty_type() -> bool {
+		false
+	}
+	fn sample_all_shapes() -> Vec<Self> {
+		vec![Default::default()]
+	}
+}
+
+impl<A> HasTypeIntrospection for sp_std::marker::PhantomData<A> {
+	fn is_empty_type() -> bool {
+		false
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		vec![Default::default()]
+	}
+}
+
+// -------------- containers ---------------
+
+impl<A: HasTypeIntrospection> HasTypeIntrospection for Option<A> {
+	fn is_empty_type() -> bool {
+		false // because None is always constructible
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		A::sample_all_shapes().into_iter().map(Some).chain([None]).collect()
+	}
+}
+
+impl<A: HasTypeIntrospection> HasTypeIntrospection for Vec<A> {
+	fn is_empty_type() -> bool {
+		false // because vec![] is always constructible
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		A::sample_all_shapes().into_iter().map(|a| vec![a]).chain([vec![]]).collect()
+	}
+}
+
+impl<A: HasTypeIntrospection + Clone, B: HasTypeIntrospection> HasTypeIntrospection for (A, B) {
+	fn is_empty_type() -> bool {
+		A::is_empty_type() || B::is_empty_type()
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		A::sample_all_shapes()
+			.into_iter()
+			.flat_map(move |a| {
+				let a = a.clone();
+				B::sample_all_shapes().into_iter().map(move |b| (a.clone(), b))
+			})
+			.collect()
+	}
+}
+
+impl<A: HasTypeIntrospection + Ord + Clone, B: HasTypeIntrospection> HasTypeIntrospection
+	for BTreeMap<A, B>
+{
+	fn is_empty_type() -> bool {
+		false // because empty map is always constructible
+	}
+
+	fn sample_all_shapes() -> Vec<Self> {
+		A::sample_all_shapes()
+			.into_iter()
+			.flat_map(move |a| {
+				let a = a.clone();
+				B::sample_all_shapes().into_iter().map(move |b| (a.clone(), b))
+			})
+			.map(|(a, b)| BTreeMap::from_iter([(a, b)]))
+			.chain([BTreeMap::new()])
+			.collect()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+
+	use crate::type_introspection::HasTypeIntrospection;
+
+	#[test]
+	fn test_containers() {
+		assert_eq!(Option::<bool>::sample_all_shapes(), vec![Some(false), None]);
+		assert_eq!(Vec::<bool>::sample_all_shapes(), vec![vec![false], vec![]]);
+		assert_eq!(
+			BTreeMap::<u8, bool>::sample_all_shapes()
+				.into_iter()
+				.map(|map| map.into_iter().collect::<Vec<_>>())
+				.collect::<Vec<_>>(),
+			vec![vec![(0, false)], vec![]]
+		);
+	}
+}


### PR DESCRIPTION
# Pull Request

## Summary

This contains two changes:
 - PRO-2942: extends the `generate_module!` macro to support multiple type parameters. This one's quite simple.
 - PRO-2954: extends the `generate_module!` macro to support enums. This was quite an effort, see the [PR](https://github.com/chainflip-io/chainflip-backend/pull/6701) for an overview.


## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.
