### PR TITLE
fix: submission finality block

### DIFF
--- a/engine/sc-client/src/extrinsic_api/signed.rs
+++ b/engine/sc-client/src/extrinsic_api/signed.rs
@@ -194,7 +194,6 @@ impl SignedExtrinsicClient {
 							scope,
 							signer,
 							account_nonce,
-							state_chain_stream.cache().hash,
 							state_chain_stream.cache().number,
 							latest_finalized_block_watcher,
 							base_rpc_client.runtime_version(None).await?,

--- a/engine/sc-client/src/extrinsic_api/signed.rs
+++ b/engine/sc-client/src/extrinsic_api/signed.rs
@@ -33,10 +33,10 @@ use futures::StreamExt;
 use futures_util::FutureExt;
 use sp_core::H256;
 use state_chain_runtime::{AccountId, Nonce};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::trace;
 
-use crate::SIGNED_EXTRINSIC_LIFETIME;
+use crate::{BlockInfo, SIGNED_EXTRINSIC_LIFETIME};
 
 mod submission_watcher;
 
@@ -174,6 +174,7 @@ impl SignedExtrinsicClient {
 		signer: signer::PairSigner<sp_core::sr25519::Pair>,
 		genesis_hash: H256,
 		state_chain_stream: &mut BlockStream,
+		latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	) -> Result<Self> {
 		const REQUEST_BUFFER: usize = 16;
 
@@ -195,6 +196,7 @@ impl SignedExtrinsicClient {
 							account_nonce,
 							state_chain_stream.cache().hash,
 							state_chain_stream.cache().number,
+							latest_finalized_block_watcher,
 							base_rpc_client.runtime_version(None).await?,
 							genesis_hash,
 							SIGNED_EXTRINSIC_LIFETIME,

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -404,10 +404,8 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 							}
 							warn!(target: "state_chain_client", request_id = request.id, "Submission failed due to a bad proof: {obj:?}. Refreshing runtime version and resubmitting (attempt {recovery_resubmissions}/{MAX_RECOVERY_RESUBMISSIONS}).");
 
-							// Refetch the runtime version at most once per finalized block. Use the best known 
-							// finalized hash, not the stream's latest, to avoid reading a stale runtime version.
-							if self.last_runtime_version_refresh_block != Some(latest_finalized.number)
-							{
+							// Refetch the runtime version at most once per finalized block (it only changes on runtime upgrades).
+							if self.last_runtime_version_refresh_block != Some(latest_finalized.number) {
 								self.last_runtime_version_refresh_block = Some(latest_finalized.number);
 								let new_runtime_version =
 									self.base_rpc_client.runtime_version(None).await?;

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -154,7 +154,6 @@ pub struct SubmissionWatcher<
 		FutureMap<(RequestID, SubmissionID), task_scope::ScopedJoinHandle<SubmissionStatus>>,
 	signer: signer::PairSigner<sp_core::sr25519::Pair>,
 	finalized_nonce: Nonce,
-	finalized_block_hash: state_chain_runtime::Hash,
 	finalized_block_number: BlockNumber,
 	// Node's latest finalized block, kept fresh by a dedicated subscription task. Used only as
 	// the era (mortality) anchor when signing, so it can't go stale behind the contiguous
@@ -282,7 +281,6 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		scope: &'a Scope<'env, anyhow::Error>,
 		signer: signer::PairSigner<sp_core::sr25519::Pair>,
 		finalized_nonce: Nonce,
-		finalized_block_hash: state_chain_runtime::Hash,
 		finalized_block_number: BlockNumber,
 		latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 		runtime_version: sp_version::RuntimeVersion,
@@ -298,7 +296,6 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				submission_status_futures: Default::default(),
 				signer,
 				finalized_nonce,
-				finalized_block_hash,
 				finalized_block_number,
 				latest_finalized_block_watcher,
 				runtime_version,
@@ -535,12 +532,13 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 			self.base_rpc_client.runtime_version(Some(hash)),
 		)?;
 
+		let latest_finalized = *self.latest_finalized_block_watcher.borrow();
 		let (signed_extrinsic, _) = self.signer.new_signed_extrinsic(
 			call.clone(),
 			&runtime_version,
 			self.genesis_hash,
-			self.finalized_block_hash,
-			self.finalized_block_number,
+			latest_finalized.hash,
+			latest_finalized.number,
 			self.extrinsic_lifetime,
 			account_info.nonce,
 		);
@@ -792,7 +790,6 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		} else {
 			// Update the finalized data
 			self.finalized_block_number = block.header.number;
-			self.finalized_block_hash = block_hash;
 			self.finalized_nonce = nonce;
 
 			for (extrinsic_index, extrinsic_events) in events

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -162,6 +162,9 @@ pub struct SubmissionWatcher<
 	// back-pressure).
 	latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	runtime_version: sp_version::RuntimeVersion,
+	// Finalized block at which `runtime_version` was last refetched, to rate-limit the refetch in
+	// the recovery path to once per block (the version only changes on a runtime upgrade).
+	last_runtime_version_refresh_block: Option<BlockNumber>,
 	genesis_hash: state_chain_runtime::Hash,
 	extrinsic_lifetime: BlockNumber,
 	#[expect(clippy::type_complexity)]
@@ -186,6 +189,9 @@ pub enum SubmissionLogicError {
 	NonceTooLow,
 	StateDiscarded,
 	ImmediatelyDropped,
+	/// A `BadProof`/`AncientBirthBlock` persisted across recovery resubmissions despite
+	/// refreshing the runtime version and era anchor. Retriable (with backoff), not fatal.
+	RecoveryExhausted,
 }
 
 impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
@@ -296,6 +302,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				finalized_block_number,
 				latest_finalized_block_watcher,
 				runtime_version,
+				last_runtime_version_refresh_block: None,
 				genesis_hash,
 				extrinsic_lifetime,
 				block_cache: Default::default(),
@@ -316,16 +323,20 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		request: &mut Request,
 		nonce: Nonce,
 	) -> Result<Result<H256, SubmissionLogicError>, anyhow::Error> {
-		let latest_finalized = *self.latest_finalized_block_watcher.borrow();
-		let mut era_block_hash = latest_finalized.hash;
-		let mut era_block_number = latest_finalized.number;
+		// Recovery resubmissions for this nonce before giving up to the outer loop's backoff.
+		const MAX_RECOVERY_RESUBMISSIONS: usize = 3;
+		let mut recovery_resubmissions: usize = 0;
 		loop {
+			// Era (mortality) anchor: the node's latest finalized block, re-read each attempt so
+			// every (re)submission signs against the freshest anchor — never the contiguous
+			// `finalized_block_*` scan position, which lags under back-pressure.
+			let latest_finalized = *self.latest_finalized_block_watcher.borrow();
 			let (signed_extrinsic, lifetime) = self.signer.new_signed_extrinsic(
 				request.call.clone(),
 				&self.runtime_version,
 				self.genesis_hash,
-				era_block_hash,
-				era_block_number,
+				latest_finalized.hash,
+				latest_finalized.number,
 				self.extrinsic_lifetime,
 				nonce,
 			);
@@ -383,36 +394,48 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 							warn!(target: "state_chain_client", request_id = request.id, "Submission failed as the transaction is stale: {obj:?}");
 							break Ok(Err(SubmissionLogicError::NonceTooLow))
 						},
+						// BadProof = bad signature. Assuming no issues with the crypto, the only
+						// possible explanation is that the implicit Tx Metadata is invalid. At the time
+						// of writing this implies one of:
+						// - runtime upgrade (runtime version changed)
+						// - era anchor (mortality) block hash changed (can happen if the submission is delayed for a long time)
 						ClientError::Call(obj)
 							if obj == invalid_err_obj(InvalidTransaction::BadProof) =>
 						{
-							warn!(target: "state_chain_client", request_id = request.id, "Submission failed due to a bad proof: {obj:?}. Refetching the runtime version.");
-
-							// TODO: Check if hash and block number should also be updated
-							// here
-
-							let new_runtime_version =
-								self.base_rpc_client.runtime_version(None).await?;
-							if new_runtime_version == self.runtime_version {
-								// break, as the error is now very unlikely to be solved by
-								// fetching again
-								return Err(anyhow!("Fetched RuntimeVersion of {:?} is the same as the previous RuntimeVersion. This is not expected.", self.runtime_version))
+							recovery_resubmissions += 1;
+							if recovery_resubmissions > MAX_RECOVERY_RESUBMISSIONS {
+								warn!(target: "state_chain_client", request_id = request.id, "Submission still failing with a bad proof after {MAX_RECOVERY_RESUBMISSIONS} resubmissions: {obj:?}. Giving up on this nonce; will retry with backoff.");
+								break Ok(Err(SubmissionLogicError::RecoveryExhausted))
 							}
+							warn!(target: "state_chain_client", request_id = request.id, "Submission failed due to a bad proof: {obj:?}. Refreshing runtime version and resubmitting (attempt {recovery_resubmissions}/{MAX_RECOVERY_RESUBMISSIONS}).");
 
-							self.runtime_version = new_runtime_version;
+							// Refetch the runtime version at most once per finalized block. The era
+							// anchor is refreshed automatically when the loop re-reads the watch.
+							if self.last_runtime_version_refresh_block !=
+								Some(self.finalized_block_number)
+							{
+								self.last_runtime_version_refresh_block =
+									Some(self.finalized_block_number);
+								let new_runtime_version =
+									self.base_rpc_client.runtime_version(None).await?;
+								if new_runtime_version != self.runtime_version {
+									self.runtime_version = new_runtime_version;
+								}
+							}
 						},
-						// AncientBirthBlock can fire transiently during tx pool re-validation.
-						// Handle gracefully by resubmitting with the updated era anchor.
-						// We deliberately leave `self.finalized_block_*` untouched, since
-						// `on_block_finalized` asserts strictly-increasing finalized block numbers.
+						// AncientBirthBlock can fire transiently during tx pool re-validation. The loop
+						// re-reads the era anchor from the watch on resubmit; bounded so it can't
+						// tight-loop if the watch hasn't advanced yet (the outer backoff lets it
+						// catch up).
 						ClientError::Call(obj)
 							if obj == invalid_err_obj(InvalidTransaction::AncientBirthBlock) =>
 						{
-							warn!(target: "state_chain_client", request_id = request.id, "Submission failed with AncientBirthBlock: {obj:?}. Refreshing era anchor.");
-							era_block_hash =
-								self.base_rpc_client.latest_finalized_block_hash().await?;
-							era_block_number =
-								self.base_rpc_client.block_header(era_block_hash).await?.number;
+							recovery_resubmissions += 1;
+							if recovery_resubmissions > MAX_RECOVERY_RESUBMISSIONS {
+								warn!(target: "state_chain_client", request_id = request.id, "Submission still failing with AncientBirthBlock after {MAX_RECOVERY_RESUBMISSIONS} resubmissions: {obj:?}. Giving up on this nonce; will retry with backoff.");
+								break Ok(Err(SubmissionLogicError::RecoveryExhausted))
+							}
+							warn!(target: "state_chain_client", request_id = request.id, "Submission failed with AncientBirthBlock: {obj:?}. Resubmitting with refreshed era anchor (attempt {recovery_resubmissions}/{MAX_RECOVERY_RESUBMISSIONS}).");
 						},
 						ClientError::Call(obj)
 							if obj.code() == 1002 &&
@@ -462,9 +485,10 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 					);
 					self.invalidate_best_nonce();
 					match err {
-						SubmissionLogicError::ImmediatelyDropped => {
-							// ImmediatelyDropped implies that the mempool was full. In this case,
-							// we wait for block duration and try again.
+						SubmissionLogicError::ImmediatelyDropped |
+						SubmissionLogicError::RecoveryExhausted => {
+							// Mempool full, or version/era anchor still stale: wait ~one block
+							// (lets the finalized-head watch advance) and retry.
 							timeout = Some(Duration::from_secs(6));
 						},
 						SubmissionLogicError::NonceTooLow |

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -324,9 +324,8 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		const MAX_RECOVERY_RESUBMISSIONS: usize = 3;
 		let mut recovery_resubmissions: usize = 0;
 		loop {
-			// Era (mortality) anchor: the node's latest finalized block, re-read each attempt so
-			// every (re)submission signs against the freshest anchor — never the contiguous
-			// `finalized_block_*` scan position, which lags under back-pressure.
+			// Era (mortality) anchor: re-read from the watch on each attempt to ensure it stays
+			// fresh.
 			let latest_finalized = *self.latest_finalized_block_watcher.borrow();
 			let (signed_extrinsic, lifetime) = self.signer.new_signed_extrinsic(
 				request.call.clone(),
@@ -405,13 +404,11 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 							}
 							warn!(target: "state_chain_client", request_id = request.id, "Submission failed due to a bad proof: {obj:?}. Refreshing runtime version and resubmitting (attempt {recovery_resubmissions}/{MAX_RECOVERY_RESUBMISSIONS}).");
 
-							// Refetch the runtime version at most once per finalized block. The era
-							// anchor is refreshed automatically when the loop re-reads the watch.
-							if self.last_runtime_version_refresh_block !=
-								Some(self.finalized_block_number)
+							// Refetch the runtime version at most once per finalized block. Use the best known 
+							// finalized hash, not the stream's latest, to avoid reading a stale runtime version.
+							if self.last_runtime_version_refresh_block != Some(latest_finalized.number)
 							{
-								self.last_runtime_version_refresh_block =
-									Some(self.finalized_block_number);
+								self.last_runtime_version_refresh_block = Some(latest_finalized.number);
 								let new_runtime_version =
 									self.base_rpc_client.runtime_version(None).await?;
 								if new_runtime_version != self.runtime_version {

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -38,7 +38,7 @@ use sp_runtime::{
 };
 use state_chain_runtime::{BlockNumber, Nonce, RuntimeEvent, UncheckedExtrinsic};
 use thiserror::Error;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tracing::{debug, error, info, warn};
 
 use cf_node_client::{error_decoder, signer, ExtrinsicData};
@@ -47,7 +47,7 @@ use crate::{
 	base_rpc_api,
 	extrinsic_api::common::{invalid_err_obj, POOL_ALREADY_IMPORTED, POOL_TOO_LOW_PRIORITY},
 	storage_api::{CheckBlockCompatibility, StorageApi},
-	SUBSTRATE_BEHAVIOUR,
+	BlockInfo, SUBSTRATE_BEHAVIOUR,
 };
 use futures::StreamExt;
 use jsonrpsee::{core::ClientError, types::ErrorObjectOwned};
@@ -156,6 +156,11 @@ pub struct SubmissionWatcher<
 	finalized_nonce: Nonce,
 	finalized_block_hash: state_chain_runtime::Hash,
 	finalized_block_number: BlockNumber,
+	// Node's latest finalized block, kept fresh by a dedicated subscription task. Used only as
+	// the era (mortality) anchor when signing, so it can't go stale behind the contiguous
+	// `finalized_block_*` scan position above (which advances one block at a time and lags under
+	// back-pressure).
+	latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	runtime_version: sp_version::RuntimeVersion,
 	genesis_hash: state_chain_runtime::Hash,
 	extrinsic_lifetime: BlockNumber,
@@ -273,6 +278,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		finalized_nonce: Nonce,
 		finalized_block_hash: state_chain_runtime::Hash,
 		finalized_block_number: BlockNumber,
+		latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 		runtime_version: sp_version::RuntimeVersion,
 		genesis_hash: state_chain_runtime::Hash,
 		extrinsic_lifetime: BlockNumber,
@@ -288,6 +294,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				finalized_nonce,
 				finalized_block_hash,
 				finalized_block_number,
+				latest_finalized_block_watcher,
 				runtime_version,
 				genesis_hash,
 				extrinsic_lifetime,
@@ -309,10 +316,9 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 		request: &mut Request,
 		nonce: Nonce,
 	) -> Result<Result<H256, SubmissionLogicError>, anyhow::Error> {
-		// The era block hash and number used as anchor when signing the extrinsic. Stored as
-		// local copies so we can overwrite them on AncientBirthBlock failure.
-		let mut era_block_hash = self.finalized_block_hash;
-		let mut era_block_number = self.finalized_block_number;
+		let latest_finalized = *self.latest_finalized_block_watcher.borrow();
+		let mut era_block_hash = latest_finalized.hash;
+		let mut era_block_number = latest_finalized.number;
 		loop {
 			let (signed_extrinsic, lifetime) = self.signer.new_signed_extrinsic(
 				request.call.clone(),

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -337,7 +337,6 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 				self.extrinsic_lifetime,
 				nonce,
 			);
-			assert!(lifetime.contains(&(self.finalized_block_number + 1)));
 
 			let tx_hash: H256 = {
 				let encoded = signed_extrinsic.encode();

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
@@ -77,6 +77,21 @@ async fn should_update_version_on_bad_proof() {
 					Ok(new_runtime_version)
 				});
 
+				// The BadProof handler also refreshes the era anchor from the node.
+				mock_rpc_api
+					.expect_latest_finalized_block_hash()
+					.times(1)
+					.return_once(move || Ok(H256::from_low_u64_be(0xABCDEF)));
+				mock_rpc_api.expect_block_header().times(1).return_once(move |_| {
+					Ok(state_chain_runtime::Header {
+						parent_hash: H256::default(),
+						number: 1,
+						state_root: H256::default(),
+						extrinsics_root: H256::default(),
+						digest: Default::default(),
+					})
+				});
+
 				// On the retry, return a success.
 				mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(1));
 
@@ -114,6 +129,7 @@ async fn should_remove_terminated_submission_from_tracking() {
 				INITIAL_NONCE,
 				H256::default(),
 				0,
+				finalized_watch(0),
 				Default::default(),
 				H256::default(),
 				SIGNED_EXTRINSIC_LIFETIME,
@@ -240,6 +256,7 @@ async fn should_retry_after_dropped_on_next_finalized_block() {
 				0,
 				H256::default(),
 				0,
+				finalized_watch(0),
 				Default::default(),
 				H256::default(),
 				SIGNED_EXTRINSIC_LIFETIME,
@@ -560,6 +577,7 @@ async fn dropped_submission_invalidates_nonce_so_next_submission_refills_gap() {
 				GAP_NONCE,
 				H256::default(),
 				0,
+				finalized_watch(0),
 				Default::default(),
 				H256::default(),
 				SIGNED_EXTRINSIC_LIFETIME,
@@ -637,6 +655,11 @@ async fn new_watcher_and_submit_test_extrinsic<'a, 'env>(
 	watcher
 }
 
+// A watch seeded with a finalized block at `number` (sender dropped; `borrow()` still returns it).
+fn finalized_watch(number: state_chain_runtime::BlockNumber) -> watch::Receiver<BlockInfo> {
+	watch::channel(BlockInfo { parent_hash: H256::default(), hash: H256::default(), number }).1
+}
+
 async fn new_watcher_with_mock_rpc_api<'a, 'env>(
 	scope: &'a Scope<'env, anyhow::Error>,
 	mock_rpc_api: MockBaseRpcApi,
@@ -649,6 +672,7 @@ async fn new_watcher_with_mock_rpc_api<'a, 'env>(
 		finalized_nonce,
 		H256::default(),
 		finalized_block_number,
+		finalized_watch(finalized_block_number),
 		Default::default(),
 		H256::default(),
 		SIGNED_EXTRINSIC_LIFETIME,

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
@@ -77,21 +77,6 @@ async fn should_update_version_on_bad_proof() {
 					Ok(new_runtime_version)
 				});
 
-				// The BadProof handler also refreshes the era anchor from the node.
-				mock_rpc_api
-					.expect_latest_finalized_block_hash()
-					.times(1)
-					.return_once(move || Ok(H256::from_low_u64_be(0xABCDEF)));
-				mock_rpc_api.expect_block_header().times(1).return_once(move |_| {
-					Ok(state_chain_runtime::Header {
-						parent_hash: H256::default(),
-						number: 1,
-						state_root: H256::default(),
-						extrinsics_root: H256::default(),
-						digest: Default::default(),
-					})
-				});
-
 				// On the retry, return a success.
 				mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(1));
 
@@ -108,6 +93,49 @@ async fn should_update_version_on_bad_proof() {
 	)
 	.await
 	.expect("runtime version refresh path should not hang")
+	.unwrap();
+}
+
+/// A burst of BadProofs within one finalized block must refetch the runtime version at most once
+/// (it only changes on a runtime upgrade), not once per failure.
+#[tokio::test]
+async fn bad_proof_burst_refetches_version_once_per_block() {
+	task_scope(|scope| {
+		async {
+			let mut mock_rpc_api = MockBaseRpcApi::new();
+
+			mock_rpc_api.expect_next_account_nonce().return_once(move |_| Ok(1));
+
+			// Two BadProofs then success, all within the same (initial) finalized block.
+			let submit_calls = Arc::new(AtomicU8::new(0));
+			mock_rpc_api.expect_submit_and_watch_extrinsic().times(3).returning(move |_| {
+				match submit_calls.fetch_add(1, Ordering::Relaxed) {
+					0 | 1 => Err(ErrorObject::owned(
+						1010,
+						"Invalid Transaction",
+						Some("Transaction has a bad signature"),
+					)
+					.into()),
+					_ => Ok(Box::pin(stream::empty()) as WatchExtrinsicStream),
+				}
+			});
+
+			// Rate-limited: refetched once despite two BadProofs in the same block.
+			mock_rpc_api
+				.expect_runtime_version()
+				.times(1)
+				.returning(move |_| Ok(Default::default()));
+
+			let mut watcher =
+				new_watcher_with_mock_rpc_api(scope, mock_rpc_api, INITIAL_NONCE, 0).await;
+			let mut request = new_test_request(0, false);
+			watcher.submit_extrinsic(&mut request).await.unwrap();
+
+			Ok(())
+		}
+		.boxed()
+	})
+	.await
 	.unwrap();
 }
 
@@ -292,7 +320,8 @@ async fn should_retry_after_dropped_on_next_finalized_block() {
 }
 
 /// AncientBirthBlock should be recoverable:
-///  - the retry is signed with the *refreshed* era anchor (not the stale one),
+///  - the retry is signed with the era anchor from the latest-finalized watch (the fresher
+///    REFRESHED block), not the stale scan position,
 ///  - the watcher's tracked finalized block (`self.finalized_block_*`) is NOT mutated — that cursor
 ///    must only advance through `on_block_finalized`, otherwise its strictly-increasing invariant
 ///    breaks.
@@ -320,37 +349,25 @@ async fn should_recover_from_ancient_birth_block() {
 					.into())
 				});
 
-				let refreshed_finalized_hash = H256::from_low_u64_be(0xABCDEF);
-				mock_rpc_api
-					.expect_latest_finalized_block_hash()
-					.times(1)
-					.return_once(move || Ok(refreshed_finalized_hash));
-				mock_rpc_api
-					.expect_block_header()
-					.withf(move |hash| *hash == refreshed_finalized_hash)
-					.times(1)
-					.return_once(move |_| {
-						Ok(state_chain_runtime::Header {
-							parent_hash: H256::default(),
-							number: REFRESHED_FINALIZED_BLOCK_NUMBER,
-							state_root: H256::default(),
-							extrinsics_root: H256::default(),
-							digest: Default::default(),
-						})
-					});
-
 				// On the retry, return a success.
 				mock_rpc_api
 					.expect_submit_and_watch_extrinsic()
 					.return_once(move |_| Ok(Box::pin(stream::empty()) as WatchExtrinsicStream));
 
-				let mut watcher = new_watcher_with_mock_rpc_api(
+				// Scan position stays at the (stale) INITIAL block; the era anchor is sourced from
+				// the latest-finalized watch, seeded at the fresher REFRESHED block.
+				let (mut watcher, _requests) = SubmissionWatcher::new(
 					scope,
-					mock_rpc_api,
+					signer::PairSigner::new(sp_core::Pair::generate().0),
 					INITIAL_NONCE,
+					H256::default(),
 					INITIAL_FINALIZED_BLOCK_NUMBER,
-				)
-				.await;
+					finalized_watch(REFRESHED_FINALIZED_BLOCK_NUMBER),
+					Default::default(),
+					H256::default(),
+					SIGNED_EXTRINSIC_LIFETIME,
+					Arc::new(mock_rpc_api),
+				);
 				let mut request = new_test_request(0, false);
 				watcher.submit_extrinsic(&mut request).await.unwrap();
 
@@ -359,10 +376,10 @@ async fn should_recover_from_ancient_birth_block() {
 				assert_eq!(watcher.finalized_block_hash, H256::default());
 				assert_eq!(watcher.finalized_block_number, INITIAL_FINALIZED_BLOCK_NUMBER);
 
-				// The successful retry must have been signed with the REFRESHED era
-				// anchor. The stored submission lifetime is `..era.death(anchor)`,
-				// so we compare against what Era::mortal would produce for the
-				// refreshed anchor.
+				// The successful retry must have been signed with the era anchor from the
+				// watch (REFRESHED block), not the stale scan position. The stored submission
+				// lifetime is `..era.death(anchor)`, so we compare against what Era::mortal
+				// would produce for the watch's anchor.
 				let tracked_submission = watcher
 					.submissions_by_nonce
 					.get(&NONCE)

--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher/tests.rs
@@ -155,7 +155,6 @@ async fn should_remove_terminated_submission_from_tracking() {
 				scope,
 				signer::PairSigner::new(sp_core::Pair::generate().0),
 				INITIAL_NONCE,
-				H256::default(),
 				0,
 				finalized_watch(0),
 				Default::default(),
@@ -282,7 +281,6 @@ async fn should_retry_after_dropped_on_next_finalized_block() {
 				scope,
 				signer::PairSigner::new(sp_core::Pair::generate().0),
 				0,
-				H256::default(),
 				0,
 				finalized_watch(0),
 				Default::default(),
@@ -360,7 +358,6 @@ async fn should_recover_from_ancient_birth_block() {
 					scope,
 					signer::PairSigner::new(sp_core::Pair::generate().0),
 					INITIAL_NONCE,
-					H256::default(),
 					INITIAL_FINALIZED_BLOCK_NUMBER,
 					finalized_watch(REFRESHED_FINALIZED_BLOCK_NUMBER),
 					Default::default(),
@@ -371,9 +368,8 @@ async fn should_recover_from_ancient_birth_block() {
 				let mut request = new_test_request(0, false);
 				watcher.submit_extrinsic(&mut request).await.unwrap();
 
-				// The watcher's tracked finalized block must NOT have changed — only
+				// The watcher's tracked finalized block (scan cursor) must NOT have changed — only
 				// `on_block_finalized` is allowed to advance it.
-				assert_eq!(watcher.finalized_block_hash, H256::default());
 				assert_eq!(watcher.finalized_block_number, INITIAL_FINALIZED_BLOCK_NUMBER);
 
 				// The successful retry must have been signed with the era anchor from the
@@ -592,7 +588,6 @@ async fn dropped_submission_invalidates_nonce_so_next_submission_refills_gap() {
 				scope,
 				signer::PairSigner::new(sp_core::Pair::generate().0),
 				GAP_NONCE,
-				H256::default(),
 				0,
 				finalized_watch(0),
 				Default::default(),
@@ -687,7 +682,6 @@ async fn new_watcher_with_mock_rpc_api<'a, 'env>(
 		scope,
 		signer::PairSigner::new(sp_core::Pair::generate().0),
 		finalized_nonce,
-		H256::default(),
 		finalized_block_number,
 		finalized_watch(finalized_block_number),
 		Default::default(),

--- a/engine/sc-client/src/lib.rs
+++ b/engine/sc-client/src/lib.rs
@@ -94,6 +94,57 @@ impl From<state_chain_runtime::Header> for BlockInfo {
 	}
 }
 
+/// Spawns a task that keeps the returned watch populated with the node's latest finalized block,
+/// independent of the gap-filled / back-pressured block stream. Restarts the subscription if no
+/// header arrives within the timeout (stall watchdog).
+fn spawn_latest_finalized_block_head_watcher<
+	BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static,
+>(
+	scope: &Scope<'_, anyhow::Error>,
+	base_rpc_client: Arc<BaseRpcClient>,
+	initial: BlockInfo,
+) -> watch::Receiver<BlockInfo> {
+	// Restart the subscription if no finalized header arrives within this window.
+	const HEAD_TIMEOUT: Duration = Duration::from_secs(20);
+	const RESTART_DELAY: Duration = Duration::from_secs(6);
+
+	let (sender, receiver) = watch::channel(initial);
+	scope.spawn(async move {
+		let mut latest = initial.number;
+		loop {
+			match base_rpc_client.subscribe_finalized_block_headers().await {
+				Ok(mut stream) => loop {
+					match tokio::time::timeout(HEAD_TIMEOUT, stream.next()).await {
+						Ok(Some(Ok(header))) => {
+							let block: BlockInfo = header.into();
+							// Sparse subscription: only advance, never regress on reconnect.
+							if block.number > latest {
+								latest = block.number;
+								let _ = sender.send(block);
+							}
+						},
+						Ok(Some(Err(error))) => {
+							warn!("Finalized-head subscription error: {error}. Restarting.");
+							break
+						},
+						Ok(None) => {
+							warn!("Finalized-head subscription ended. Restarting.");
+							break
+						},
+						Err(_elapsed) => {
+							warn!("No finalized head within {HEAD_TIMEOUT:?}; restarting subscription.");
+							break
+						},
+					}
+				},
+				Err(error) => warn!("Failed to subscribe to finalized heads: {error}. Retrying."),
+			}
+			tokio::time::sleep(RESTART_DELAY).await;
+		}
+	});
+	receiver
+}
+
 pub type DefaultRpcClient = base_rpc_api::BaseRpcClient<jsonrpsee::ws_client::WsClient>;
 pub(crate) type RpcResult<T> = Result<T, ClientError>;
 
@@ -456,7 +507,10 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 		let genesis_hash = base_rpc_client.block_hash(0).await?.expect(SUBSTRATE_BEHAVIOUR);
 
 		let (
-			latest_finalized_block_watcher,
+			// Superseded by the dedicated `latest_finalized_block_watcher` below, which tracks the
+			// node's latest finalized head independent of this (gap-filled, back-pressured)
+			// stream.
+			_gap_filled_finalized_block_watcher,
 			mut finalized_state_chain_stream,
 			finalized_block_stream_request_sender,
 		) = Self::create_block_stream(
@@ -577,6 +631,15 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 		)
 		.await?;
 
+		// Dedicated finalized-head watcher: keeps `latest_finalized_block()` and the submission era
+		// anchor tracking the node's latest finalized block, independent of the gap-filled /
+		// back-pressured block stream above.
+		let latest_finalized_block_watcher = spawn_latest_finalized_block_head_watcher(
+			scope,
+			base_rpc_client.clone(),
+			*finalized_state_chain_stream.cache(),
+		);
+
 		let state_chain_client = Arc::new(StateChainClient {
 			genesis_hash,
 			signed_extrinsic_client: signed_extrinsic_client_builder
@@ -585,6 +648,7 @@ impl<BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static, SignedExtr
 					base_rpc_client.clone(),
 					genesis_hash,
 					&mut finalized_state_chain_stream,
+					latest_finalized_block_watcher.clone(),
 				)
 				.await?,
 			unsigned_extrinsic_client: unsigned::UnsignedExtrinsicClient::new(
@@ -635,6 +699,7 @@ trait SignedExtrinsicClientBuilderTrait {
 		base_rpc_client: Arc<BaseRpcClient>,
 		genesis_hash: state_chain_runtime::Hash,
 		state_chain_stream: &mut BlockStream,
+		latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	) -> Result<Self::Client>;
 }
 
@@ -663,6 +728,7 @@ impl SignedExtrinsicClientBuilderTrait for () {
 		_base_rpc_client: Arc<BaseRpcClient>,
 		_genesis_hash: state_chain_runtime::Hash,
 		_block_stream: &mut BlockStream,
+		_latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	) -> Result<Self::Client> {
 		Ok(())
 	}
@@ -911,10 +977,19 @@ impl SignedExtrinsicClientBuilderTrait for SignedExtrinsicClientBuilder {
 		base_rpc_client: Arc<BaseRpcClient>,
 		genesis_hash: state_chain_runtime::Hash,
 		state_chain_stream: &mut BlockStream,
+		latest_finalized_block_watcher: watch::Receiver<BlockInfo>,
 	) -> Result<Self::Client> {
 		let (nonce, signer) = self.nonce_and_signer.expect("The function pre_compatibility should be run exactly once successfully before build is called");
-		Self::Client::new(scope, base_rpc_client, nonce, signer, genesis_hash, state_chain_stream)
-			.await
+		Self::Client::new(
+			scope,
+			base_rpc_client,
+			nonce,
+			signer,
+			genesis_hash,
+			state_chain_stream,
+			latest_finalized_block_watcher,
+		)
+		.await
 	}
 }
 


### PR DESCRIPTION
# Pull Request

This fixes a couple of issues discovered during investigation of recent engine crashes due to repeated BadProof errors. 

1: The `latest_finalized_head` watcher was being populated from the same async loop as the one that pushed to the finalized block stream. This meant that back-pressure on the stream, or even waiting for the gap-fill mechanism during catch-up, could cause the latest_finalized_head to lag. The first commit decouples this, giving the watcher its own subscription instance and threading this throug to the submission-watcher, using this for extrinsic submission rather than the stream's finalized block, which might be lagging.

2: Refresh the latest_finalized hash and number (for mortality) on every iteration of the submission loop. If we get a BadProof error, refresh the runtime metadata and rely on the implicit update of the finalized hash to retry up to 3 times. Otherwise exit the loop and rely on the existing resubmit mechanism (with backoff) rather than panicking the engine. Runtime versino refresh is rate-limited to once per block to prevent the case where many txs are invalidated in a batch (which is what was observed in the logs). 


There is a related issue that was discovered and has been logged for triage as PRO-2944: it seems like stream back-pressure can propagate to the witnesser (this may be low-priority assuming the elections based witnessing works independently of this - needs more investigation). 