### PR TITLE
feat: trading strategy on idle weight calculation

### DIFF
--- a/state-chain/pallets/cf-pools/src/lib.rs
+++ b/state-chain/pallets/cf-pools/src/lib.rs
@@ -28,7 +28,7 @@ use cf_primitives::{chains::assets::any, Asset, AssetAmount, OrderId, STABLE_ASS
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AccountRoleRegistry, BalanceApi, Chainflip, DeregistrationCheck,
-	LpOrdersWeightsProvider, LpStatsApi, PoolApi, SwapRequestHandler, SwappingApi,
+	LpStatsApi, PoolApi, SwapRequestHandler, SwappingApi,
 };
 use cf_utilities::select::Select;
 use sp_runtime::Saturating;
@@ -2545,12 +2545,6 @@ pub struct DeleteHistoricalEarnedFees<T: Config>(sp_std::marker::PhantomData<T>)
 impl<T: Config> OnKilledAccount<T::AccountId> for DeleteHistoricalEarnedFees<T> {
 	fn on_killed_account(who: &T::AccountId) {
 		let _ = HistoricalEarnedFees::<T>::clear_prefix(who, u32::MAX, None);
-	}
-}
-
-impl<T: Config> LpOrdersWeightsProvider for Pallet<T> {
-	fn update_limit_order_weight() -> Weight {
-		T::WeightInfo::update_limit_order()
 	}
 }
 

--- a/state-chain/pallets/cf-trading-strategy/src/benchmarking.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/benchmarking.rs
@@ -145,4 +145,68 @@ mod benchmarks {
 			BTreeMap::from_iter([(ASSET, 1000), (STABLE_ASSET, 1000)]),
 		);
 	}
+
+	/// Measures the full per-block cost of `on_idle` as a function of the number of
+	/// deployed strategies `n` — the single weight `on_idle` now charges per strategy.
+	///
+	/// Uses `OracleTracking`, the heaviest and most common strategy type, and measures
+	/// the *worst-case* per-strategy path: the O(n) scan, the prefetch of existing pool
+	/// orders, the oracle read, balance reads, order-sizing evaluation, and the cancel +
+	/// re-placement of all orders. To hit that path the strategies are funded and have
+	/// already placed orders (first pass), then the oracle is moved so the measured pass
+	/// must re-tick every order — which is the common case for oracle-tracking strategies.
+	#[benchmark]
+	fn on_idle(n: Linear<1, 100>) {
+		let caller = new_lp_account::<T>();
+
+		assert_ok!(T::PoolApi::create_pool(
+			ASSET,
+			STABLE_ASSET,
+			0,
+			Price::from_usd(STABLE_ASSET, 12345)
+		));
+		// Low thresholds so every strategy (re)places its orders.
+		LimitOrderUpdateThresholds::<T>::set(BTreeMap::from_iter([(ASSET, 1), (STABLE_ASSET, 1)]));
+		// A fresh relative price needs both legs, else the oracle path bails out early.
+		T::PriceFeedApi::set_price(ASSET, Price::from_usd(ASSET, 1));
+		T::PriceFeedApi::set_price(STABLE_ASSET, Price::from_usd(STABLE_ASSET, 1));
+
+		for i in 0..n {
+			let strategy_id: T::AccountId = account("strategy", i, 0u32);
+			if !frame_system::Pallet::<T>::account_exists(&strategy_id) {
+				let _ = frame_system::Provider::<T>::created(&strategy_id);
+			}
+			T::BalanceApi::credit_account(&strategy_id, ASSET, 2_000_000_000);
+			T::BalanceApi::credit_account(&strategy_id, STABLE_ASSET, 2_000_000_000);
+
+			// Vary the offsets so the strategies aren't bit-identical.
+			let offset: Tick = 1 + (i % 100) as Tick;
+			Strategies::<T>::insert(
+				&caller,
+				&strategy_id,
+				TradingStrategy::OracleTracking {
+					min_buy_offset_tick: -offset - 1,
+					max_buy_offset_tick: -1,
+					min_sell_offset_tick: 1,
+					max_sell_offset_tick: offset + 1,
+					base_asset: ASSET,
+					quote_asset: STABLE_ASSET,
+				},
+			);
+		}
+
+		// First pass places the initial orders.
+		Pallet::<T>::on_idle(1u32.into(), Weight::MAX);
+
+		// Move the oracle so the measured pass must cancel and re-place every strategy's
+		// orders (the worst case, and the common case for oracle-tracking strategies).
+		T::PriceFeedApi::set_price(ASSET, Price::from_usd(ASSET, 2));
+
+		#[block]
+		{
+			let _ = Pallet::<T>::on_idle(2u32.into(), Weight::MAX);
+		}
+
+		assert_eq!(Strategies::<T>::iter().count() as u32, n);
+	}
 }

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -36,7 +36,7 @@ use cf_primitives::{Asset, AssetAmount, OrderId, StablecoinDefaults, Tick, STABL
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
 	impl_pallet_safe_mode, AccountRoleRegistry, BalanceApi, Chainflip, DeregistrationCheck,
-	IncreaseOrDecrease, LpOrdersWeightsProvider, LpRegistration, PoolApi, PriceFeedApi, Side,
+	IncreaseOrDecrease, LpRegistration, PoolApi, PriceFeedApi, Side,
 };
 
 use frame_support::{
@@ -63,8 +63,6 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_
 // have fixed order ids (at least until we develop more advanced strategies).
 const STRATEGY_ORDER_ID_0: OrderId = 0;
 const STRATEGY_ORDER_ID_1: OrderId = 1;
-
-const MAX_NUMBER_OF_ORDERS_FOR_STRATEGY: u64 = 4;
 
 impl_pallet_safe_mode!(PalletSafeMode; strategy_updates_enabled, strategy_closure_enabled, strategy_execution_enabled);
 
@@ -181,16 +179,6 @@ impl TradingStrategy {
 		)
 	}
 
-	/// Upper-bound weight estimate for one execution of this strategy.
-	fn max_weight_estimate(&self, limit_order_update_weight: Weight) -> Weight {
-		match self {
-			TradingStrategy::TickZeroCentered { .. } | TradingStrategy::SimpleBuySell { .. } =>
-				limit_order_update_weight * 2,
-			TradingStrategy::InventoryBased { .. } | TradingStrategy::OracleTracking { .. } =>
-				limit_order_update_weight * (MAX_NUMBER_OF_ORDERS_FOR_STRATEGY * 2),
-		}
-	}
-
 	fn validate_params<T: Config>(&self) -> Result<(), Error<T>> {
 		match self {
 			TradingStrategy::TickZeroCentered { spread_tick, base_asset } => {
@@ -292,7 +280,6 @@ pub mod pallet {
 
 		/// Benchmark weights
 		type WeightInfo: WeightInfo;
-		type LpOrdersWeights: LpOrdersWeightsProvider;
 	}
 
 	#[pallet::pallet]
@@ -359,11 +346,7 @@ pub mod pallet {
 				return weight_used
 			}
 
-			weight_used += T::DbWeight::get().reads(1);
 			let order_update_thresholds = LimitOrderUpdateThresholds::<T>::get();
-
-			weight_used += T::DbWeight::get().reads(1);
-			let limit_order_update_weight = T::LpOrdersWeights::update_limit_order_weight();
 
 			// Cache of orders per asset pair to avoid redundant reads
 			let mut order_cache: BTreeMap<AssetPair, Vec<StrategyLimitOrder<T::AccountId>>> =
@@ -387,13 +370,26 @@ pub mod pallet {
 				})
 				.collect::<Vec<_>>();
 
+			// Weight comes entirely from the `on_idle` benchmark: a fixed base plus a
+			// per-strategy cost covering the O(n) scan above, the order prefetch, the
+			// oracle/balance reads, and the worst-case order updates (benchmarked against
+			// OracleTracking, the heaviest and most common strategy type).
+			//
+			// NOTE: the scan is unconditional, so for very large strategy counts the loop
+			// stops early while the full scan was still paid — properly bounding this
+			// requires processing strategies incrementally from a stored cursor (follow-up).
+			let per_strategy = T::WeightInfo::on_idle(1).saturating_sub(T::WeightInfo::on_idle(0));
+			weight_used = T::WeightInfo::on_idle(0);
+
 			// Execute each strategy.
 			for (strategy_id, strategy) in strategies {
-				let new_weight_estimate = weight_used
-					.saturating_add(strategy.max_weight_estimate(limit_order_update_weight));
-				if remaining_weight.checked_sub(&new_weight_estimate).is_none() {
+				if remaining_weight
+					.checked_sub(&weight_used.saturating_add(per_strategy))
+					.is_none()
+				{
 					break;
 				}
+				weight_used = weight_used.saturating_add(per_strategy);
 
 				// Populate the order cache for strategies that require existing pool orders.
 				let existing_orders: Vec<&StrategyLimitOrder<T::AccountId>> = if strategy
@@ -409,7 +405,6 @@ pub mod pallet {
 					let base_asset = asset_pair.base();
 					let quote_asset = asset_pair.quote();
 					if let btree_map::Entry::Vacant(entry) = order_cache.entry(asset_pair) {
-						weight_used += T::DbWeight::get().reads(1);
 						match T::PoolApi::limit_orders(
 							base_asset,
 							quote_asset,
@@ -460,8 +455,6 @@ pub mod pallet {
 					&strategy_id,
 					&existing_orders,
 					&order_update_thresholds,
-					limit_order_update_weight,
-					&mut weight_used,
 				);
 			}
 
@@ -778,8 +771,6 @@ impl<T: Config> Pallet<T> {
 		strategy_id: &T::AccountId,
 		existing_orders: &[&StrategyLimitOrder<T::AccountId>],
 		thresholds: &BTreeMap<Asset, AssetAmount>,
-		limit_order_update_weight: Weight,
-		weight_used: &mut Weight,
 	) {
 		match strategy {
 			TradingStrategy::TickZeroCentered { spread_tick, base_asset } =>
@@ -789,8 +780,6 @@ impl<T: Config> Pallet<T> {
 					*spread_tick,
 					strategy_id,
 					thresholds,
-					limit_order_update_weight,
-					weight_used,
 				),
 			TradingStrategy::SimpleBuySell { buy_tick, sell_tick, base_asset } =>
 				Self::execute_simple_order(
@@ -799,8 +788,6 @@ impl<T: Config> Pallet<T> {
 					*sell_tick,
 					strategy_id,
 					thresholds,
-					limit_order_update_weight,
-					weight_used,
 				),
 			TradingStrategy::InventoryBased {
 				min_buy_tick,
@@ -817,8 +804,6 @@ impl<T: Config> Pallet<T> {
 				strategy_id,
 				existing_orders,
 				thresholds,
-				limit_order_update_weight,
-				weight_used,
 			),
 			TradingStrategy::OracleTracking {
 				min_buy_offset_tick,
@@ -837,8 +822,6 @@ impl<T: Config> Pallet<T> {
 				strategy_id,
 				existing_orders,
 				thresholds,
-				limit_order_update_weight,
-				weight_used,
 			),
 		}
 	}
@@ -853,13 +836,10 @@ impl<T: Config> Pallet<T> {
 		sell_tick: Tick,
 		strategy_id: &T::AccountId,
 		thresholds: &BTreeMap<Asset, AssetAmount>,
-		limit_order_update_weight: Weight,
-		weight_used: &mut Weight,
 	) {
 		for (side, tick) in [(Side::Buy, buy_tick), (Side::Sell, sell_tick)] {
 			let sell_asset = if side == Side::Buy { STABLE_ASSET } else { base_asset };
 
-			*weight_used += T::DbWeight::get().reads(1);
 			let balance = T::BalanceApi::get_balance(strategy_id, sell_asset);
 
 			// Minimum threshold of 1 to prevent updating with 0 amounts
@@ -867,8 +847,6 @@ impl<T: Config> Pallet<T> {
 				core::cmp::max(thresholds.get(&sell_asset).copied().unwrap_or(u128::MAX), 1);
 
 			if balance >= threshold {
-				*weight_used += limit_order_update_weight;
-
 				// We expect this to fail if the pool does not exist
 				let _result = T::PoolApi::update_limit_order(
 					strategy_id,
@@ -895,8 +873,6 @@ impl<T: Config> Pallet<T> {
 		strategy_id: &T::AccountId,
 		existing_orders: &[&StrategyLimitOrder<T::AccountId>],
 		thresholds: &BTreeMap<Asset, AssetAmount>,
-		limit_order_update_weight: Weight,
-		weight_used: &mut Weight,
 	) {
 		Self::execute_with_inventory_logic(
 			base_asset,
@@ -909,8 +885,6 @@ impl<T: Config> Pallet<T> {
 			strategy_id,
 			existing_orders,
 			thresholds,
-			limit_order_update_weight,
-			weight_used,
 		);
 	}
 
@@ -929,10 +903,7 @@ impl<T: Config> Pallet<T> {
 		strategy_id: &T::AccountId,
 		existing_orders: &[&StrategyLimitOrder<T::AccountId>],
 		thresholds: &BTreeMap<Asset, AssetAmount>,
-		limit_order_update_weight: Weight,
-		weight_used: &mut Weight,
 	) {
-		*weight_used += T::DbWeight::get().reads(1);
 		let pricing = match T::PriceFeedApi::get_relative_price(base_asset, quote_asset) {
 			None => {
 				log_or_panic!(
@@ -969,8 +940,6 @@ impl<T: Config> Pallet<T> {
 			strategy_id,
 			existing_orders,
 			thresholds,
-			limit_order_update_weight,
-			weight_used,
 		);
 	}
 
@@ -993,8 +962,6 @@ impl<T: Config> Pallet<T> {
 		strategy_id: &T::AccountId,
 		existing_orders: &[&StrategyLimitOrder<T::AccountId>],
 		thresholds: &BTreeMap<Asset, AssetAmount>,
-		limit_order_update_weight: Weight,
-		weight_used: &mut Weight,
 	) {
 		// This relies on autosweeping for limit orders
 		let orders_total_quote: AssetAmount = existing_orders
@@ -1011,7 +978,6 @@ impl<T: Config> Pallet<T> {
 		let base_balance_asset = T::BalanceApi::get_balance(strategy_id, base_asset);
 		let total_quote_asset = quote_balance_asset.saturating_add(orders_total_quote);
 		let total_base_asset = base_balance_asset.saturating_add(orders_total_base);
-		*weight_used += T::DbWeight::get().reads(2);
 
 		// Minimum threshold of 1 to prevent updating with 0 amounts
 		let base_threshold =
@@ -1075,7 +1041,6 @@ impl<T: Config> Pallet<T> {
 				);
 				return;
 			}
-			*weight_used += limit_order_update_weight * MAX_NUMBER_OF_ORDERS_FOR_STRATEGY;
 
 			// Create the new desired orders.
 			let mut remaining_base_amount = total_base_asset;
@@ -1114,7 +1079,6 @@ impl<T: Config> Pallet<T> {
 						quote_amount
 					};
 
-					*weight_used += limit_order_update_weight;
 					let _result = T::PoolApi::update_limit_order(
 						strategy_id,
 						base_asset,

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -64,6 +64,10 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_
 const STRATEGY_ORDER_ID_0: OrderId = 0;
 const STRATEGY_ORDER_ID_1: OrderId = 1;
 
+/// Percent of a block's leftover weight that `on_idle` will consume, leaving headroom
+/// for the other pallets' `on_idle` hooks (which run after this one on the remainder).
+const ON_IDLE_WEIGHT_PERCENT: u64 = 50;
+
 impl_pallet_safe_mode!(PalletSafeMode; strategy_updates_enabled, strategy_closure_enabled, strategy_execution_enabled);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -336,14 +340,33 @@ pub mod pallet {
 		StablecoinDefaults<10_000_000>, // $10 USD
 	>;
 
+	/// Cursor into `Strategies` for incremental `on_idle` processing: the raw storage
+	/// key of the last strategy processed, or `None` to (re)start from the beginning.
+	/// Bounds the per-block scan and ensures every strategy is eventually processed,
+	/// rather than always the first `max_strategies` (no starvation of the tail).
+	#[pallet::storage]
+	pub type NextStrategyCursor<T: Config> = StorageValue<_, Vec<u8>, OptionQuery>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_idle(_current_block: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
-			let mut weight_used: Weight = Weight::zero();
-
 			// We assume this consumes 0 weight since safe mode is likely in cache
 			if !T::SafeMode::get().strategy_execution_enabled {
-				return weight_used
+				return Weight::zero()
+			}
+
+			let base = T::WeightInfo::on_idle(0);
+			let per_strategy = T::WeightInfo::on_idle(1).saturating_sub(base);
+
+			// Use only a fraction of the block's leftover weight, so the other pallets'
+			// on_idle hooks (which run after this one on the remainder) keep some.
+			let budget = remaining_weight.ref_time().saturating_mul(ON_IDLE_WEIGHT_PERCENT) / 100;
+			let max_strategies = budget
+				.saturating_sub(base.ref_time())
+				.checked_div(per_strategy.ref_time().max(1))
+				.unwrap_or(0) as usize;
+			if max_strategies == 0 {
+				return base
 			}
 
 			let order_update_thresholds = LimitOrderUpdateThresholds::<T>::get();
@@ -351,12 +374,21 @@ pub mod pallet {
 			// Cache of orders per asset pair to avoid redundant reads
 			let mut order_cache: BTreeMap<AssetPair, Vec<StrategyLimitOrder<T::AccountId>>> =
 				BTreeMap::new();
-
-			// Grab all of the strategies and also group them by asset pair for efficient order
-			// fetching.
 			let mut fetch_orders_for_strategies: BTreeMap<AssetPair, BTreeSet<T::AccountId>> =
 				BTreeMap::new();
-			let strategies = Strategies::<T>::iter()
+
+			// Resume from where the previous block stopped so every strategy is eventually
+			// processed, rather than always the first `max_strategies` (no tail starvation).
+			let mut iter = match NextStrategyCursor::<T>::get() {
+				Some(raw_key) => Strategies::<T>::iter_from(raw_key),
+				None => Strategies::<T>::iter(),
+			};
+
+			// Read at most `max_strategies` from storage (the bounded scan) and group the
+			// prefetch strategies by asset pair for efficient order fetching.
+			let batch = iter
+				.by_ref()
+				.take(max_strategies)
 				.map(|(_, strategy_id, strategy)| {
 					if strategy.needs_order_prefetch() {
 						if let Some(asset_pair) = strategy.asset_pair() {
@@ -370,27 +402,18 @@ pub mod pallet {
 				})
 				.collect::<Vec<_>>();
 
-			// Weight comes entirely from the `on_idle` benchmark: a fixed base plus a
-			// per-strategy cost covering the O(n) scan above, the order prefetch, the
-			// oracle/balance reads, and the worst-case order updates (benchmarked against
-			// OracleTracking, the heaviest and most common strategy type).
-			//
-			// NOTE: the scan is unconditional, so for very large strategy counts the loop
-			// stops early while the full scan was still paid — properly bounding this
-			// requires processing strategies incrementally from a stored cursor (follow-up).
-			let per_strategy = T::WeightInfo::on_idle(1).saturating_sub(T::WeightInfo::on_idle(0));
-			weight_used = T::WeightInfo::on_idle(0);
+			// Fewer than the affordable maximum means we reached the end of the map, so wrap
+			// back to the start next block; otherwise resume after the last key the
+			// iterator returned (no re-hashing).
+			if batch.len() < max_strategies {
+				NextStrategyCursor::<T>::kill();
+			} else {
+				NextStrategyCursor::<T>::set(Some(iter.last_raw_key().to_vec()));
+			}
+			let processed = batch.len() as u32;
 
-			// Execute each strategy.
-			for (strategy_id, strategy) in strategies {
-				if remaining_weight
-					.checked_sub(&weight_used.saturating_add(per_strategy))
-					.is_none()
-				{
-					break;
-				}
-				weight_used = weight_used.saturating_add(per_strategy);
-
+			// Execute each strategy in the batch.
+			for (strategy_id, strategy) in batch {
 				// Populate the order cache for strategies that require existing pool orders.
 				let existing_orders: Vec<&StrategyLimitOrder<T::AccountId>> = if strategy
 					.needs_order_prefetch()
@@ -458,7 +481,7 @@ pub mod pallet {
 				);
 			}
 
-			weight_used
+			T::WeightInfo::on_idle(processed)
 		}
 	}
 

--- a/state-chain/pallets/cf-trading-strategy/src/mock.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/mock.rs
@@ -44,7 +44,6 @@ impl pallet_cf_trading_strategy::Config for Test {
 	type WeightInfo = ();
 	type BalanceApi = cf_traits::mocks::balance_api::MockBalance;
 	type PoolApi = MockPoolApi;
-	type LpOrdersWeights = MockPoolApi;
 	type LpRegistrationApi = MockLpRegistration;
 	type SafeMode = MockRuntimeSafeMode;
 	type PriceFeedApi = MockPriceFeedApi;

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -975,6 +975,47 @@ fn can_update_all_config_items() {
 	});
 }
 
+#[test]
+fn on_idle_scan_is_bounded_and_wraps_around() {
+	use crate::weights::WeightInfo;
+	use frame_support::weights::Weight;
+
+	new_test_ext().then_execute_with(|_| {
+		// Insert several strategies directly under one LP.
+		let n = 5u64;
+		for i in 0..n {
+			Strategies::<Test>::insert(LP, 1000 + i, STRATEGY);
+		}
+		assert_eq!(Strategies::<Test>::iter().count() as u64, n);
+
+		// Give on_idle enough leftover weight that, after its self-imposed cap, exactly
+		// two strategies fit per pass.
+		let base = <() as WeightInfo>::on_idle(0).ref_time();
+		let per = <() as WeightInfo>::on_idle(1).ref_time().saturating_sub(base);
+		let remaining = (base + 2 * per) * 100 / crate::ON_IDLE_WEIGHT_PERCENT;
+		let budget = Weight::from_parts(remaining, u64::MAX);
+
+		// A single pass processes only a bounded subset, leaving a cursor for the rest:
+		// the scan no longer grows with the total number of deployed strategies.
+		TradingStrategyPallet::on_idle(1, budget);
+		assert!(
+			NextStrategyCursor::<Test>::get().is_some(),
+			"expected a cursor: not all strategies fit in one block"
+		);
+
+		// Subsequent passes resume from the cursor until every strategy has been reached
+		// and the cursor wraps back to `None` (no starvation of the tail).
+		let mut passes = 1u64;
+		while NextStrategyCursor::<Test>::get().is_some() {
+			TradingStrategyPallet::on_idle(1, budget);
+			passes += 1;
+			assert!(passes <= n, "cursor failed to wrap: strategies starved");
+		}
+		// Five strategies at two per pass wraps within three passes.
+		assert_eq!(passes, 3);
+	});
+}
+
 mod safe_mode {
 
 	use cf_traits::SafeMode;

--- a/state-chain/pallets/cf-trading-strategy/src/weights.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/weights.rs
@@ -146,6 +146,37 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(10_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	/// Storage: `Environment::RuntimeSafeMode` (r:1 w:0)
+	/// Proof: `Environment::RuntimeSafeMode` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::LimitOrderUpdateThresholds` (r:1 w:0)
+	/// Proof: `TradingStrategy::LimitOrderUpdateThresholds` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::NextStrategyCursor` (r:1 w:1)
+	/// Proof: `TradingStrategy::NextStrategyCursor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::Strategies` (r:101 w:0)
+	/// Proof: `TradingStrategy::Strategies` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityPools::Pools` (r:2 w:1)
+	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
+	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `AssetBalances::FreeBalances` (r:200 w:200)
+	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `AccountRoles::AccountRoles` (r:100 w:0)
+	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// The range of component `n` is `[1, 100]`.
+	fn on_idle(n: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3146 + n * (758 ±0)`
+		//  Estimated: `9039 + n * (5709 ±0)`
+		// Minimum execution time: 1_948_000_000 picoseconds.
+		Weight::from_parts(2_060_000_000, 9039)
+			// Standard Error: 547_457_152
+			.saturating_add(Weight::from_parts(31_143_656_453, 0).saturating_mul(n.into()))
+			.saturating_add(T::DbWeight::get().reads(7_u64))
+			.saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(n.into())))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(n.into())))
+			.saturating_add(Weight::from_parts(0, 5709).saturating_mul(n.into()))
+	}
 }
 
 // For backwards compatibility and tests
@@ -238,5 +269,36 @@ impl WeightInfo for () {
 		Weight::from_parts(103_173_000, 13547)
 			.saturating_add(ParityDbWeight::get().reads(10_u64))
 			.saturating_add(ParityDbWeight::get().writes(4_u64))
+	}
+	/// Storage: `Environment::RuntimeSafeMode` (r:1 w:0)
+	/// Proof: `Environment::RuntimeSafeMode` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::LimitOrderUpdateThresholds` (r:1 w:0)
+	/// Proof: `TradingStrategy::LimitOrderUpdateThresholds` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::NextStrategyCursor` (r:1 w:1)
+	/// Proof: `TradingStrategy::NextStrategyCursor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `TradingStrategy::Strategies` (r:101 w:0)
+	/// Proof: `TradingStrategy::Strategies` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityPools::Pools` (r:2 w:1)
+	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
+	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `AssetBalances::FreeBalances` (r:200 w:200)
+	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `AccountRoles::AccountRoles` (r:100 w:0)
+	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// The range of component `n` is `[1, 100]`.
+	fn on_idle(n: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3146 + n * (758 ±0)`
+		//  Estimated: `9039 + n * (5709 ±0)`
+		// Minimum execution time: 1_948_000_000 picoseconds.
+		Weight::from_parts(2_060_000_000, 9039)
+			// Standard Error: 547_457_152
+			.saturating_add(Weight::from_parts(31_143_656_453, 0).saturating_mul(n.into()))
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
+			.saturating_add(ParityDbWeight::get().reads((4_u64).saturating_mul(n.into())))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().writes((2_u64).saturating_mul(n.into())))
+			.saturating_add(Weight::from_parts(0, 5709).saturating_mul(n.into()))
 	}
 }

--- a/state-chain/pallets/cf-trading-strategy/src/weights.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/weights.rs
@@ -24,19 +24,19 @@
 //! EXECUTION: , WASM-EXECUTION: Compiled, CHAIN: Some("dev-3"), DB CACHE: 1024
 
 // Executed Command:
-// ./chainflip-node
+// ./target/release/chainflip-node
 // benchmark
 // pallet
 // --pallet
 // pallet_cf_trading_strategy
 // --extrinsic
 // *
+// --template
+// state-chain/chainflip-weight-template.hbs
 // --output
 // state-chain/pallets/cf-trading-strategy/src/weights.rs
 // --steps=20
 // --repeat=10
-// --template=state-chain/chainflip-weight-template.hbs
-// --chain=dev-3
 
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
@@ -51,6 +51,7 @@ pub trait WeightInfo {
 	fn deploy_strategy() -> Weight;
 	fn close_strategy() -> Weight;
 	fn add_funds_to_strategy() -> Weight;
+	fn on_idle(n: u32, ) -> Weight;
 }
 
 /// Weights for pallet_cf_trading_strategy using the Substrate node and recommended hardware.

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -1233,7 +1233,6 @@ impl pallet_cf_elections::Config<Instance8> for Runtime {
 
 impl pallet_cf_trading_strategy::Config for Runtime {
 	type WeightInfo = pallet_cf_trading_strategy::weights::PalletWeight<Runtime>;
-	type LpOrdersWeights = LiquidityPools;
 	type BalanceApi = AssetBalances;
 	type SafeMode = RuntimeSafeMode;
 	type PoolApi = LiquidityPools;

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -70,7 +70,6 @@ use frame_support::{
 		Percent, RuntimeDebug,
 	},
 	traits::{ConstU32, EnsureOrigin, Get, IsType, UnfilteredDispatchable},
-	weights::Weight,
 	CloneNoBound, EqNoBound, Hashable, Parameter, PartialEqNoBound,
 };
 use scale_info::TypeInfo;
@@ -1370,11 +1369,6 @@ pub trait AffiliateRegistry {
 
 pub trait MinimumDeposit {
 	fn get(asset: Asset) -> AssetAmount;
-}
-
-// Used for exposing weights from the Pools pallet
-pub trait LpOrdersWeightsProvider {
-	fn update_limit_order_weight() -> Weight;
 }
 
 #[derive(

--- a/state-chain/traits/src/mocks/pool_api.rs
+++ b/state-chain/traits/src/mocks/pool_api.rs
@@ -28,16 +28,10 @@ use cf_amm::{
 use cf_chains::assets::any::AssetMap;
 use cf_primitives::{Asset, AssetAmount, OrderId, STABLE_ASSET};
 use codec::{Decode, DecodeWithMemTracking, Encode};
-use frame_support::{
-	sp_runtime::{DispatchError, DispatchResult},
-	weights::Weight,
-};
+use frame_support::sp_runtime::{DispatchError, DispatchResult};
 use scale_info::TypeInfo;
 
-use crate::{
-	mocks::balance_api::MockBalance, BalanceApi, IncreaseOrDecrease, LpOrdersWeightsProvider,
-	PoolApi,
-};
+use crate::{mocks::balance_api::MockBalance, BalanceApi, IncreaseOrDecrease, PoolApi};
 
 use super::{MockPallet, MockPalletStorage};
 
@@ -324,11 +318,5 @@ where
 		_initial_price: Price,
 	) -> DispatchResult {
 		unimplemented!()
-	}
-}
-
-impl<AccountId> LpOrdersWeightsProvider for MockPoolApi<AccountId> {
-	fn update_limit_order_weight() -> Weight {
-		Weight::zero()
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-2978

## Summary

This improves the benchmarking and weight consumption for trading strategies. 

1. Benchmark the full on_idle hook for n strategies: assume oracle strategies (realistic, worst case)
2. Introduce a cursor to iterate over strategies, solves PRO-2978

The only functional change is the introductio of the cursor: if we can't iterate *all* strategies during the on_idle hook, we continue where we left off. Previously, we would have continued by iterating from the beginning again, meaning the tail of the list would potentially never be processed. 

Apart from this the only change is to the benchmarking. Benchmarking on_idle directly has the benefit of removing a lot of manual weight additions and weight access traits that were being threaded through the code. This also makes it easier to estimate the actual weight consumed for a given number of strategies. 

## API Changes

*No API changes.*
