### PR TITLE
refactor: allow unions of EventDescriptor in `stepUntilEvent` and `expectEvent`

### DIFF
--- a/bouncer/shared/utils/chainflip_io.ts
+++ b/bouncer/shared/utils/chainflip_io.ts
@@ -327,10 +327,10 @@ export class ChainflipIO<Requirements> {
    *
    * @returns The data of the first matching event, well-typed according to the provided schema.
    */
-  async stepUntilEvent<Z extends z.ZodTypeAny = z.ZodTypeAny>({
+  async stepUntilEvent<Event extends EventDescriptor<EventName, z.ZodTypeAny>>({
     name,
     schema,
-  }: EventDescriptor<EventName, Z>): Promise<z.infer<Z>> {
+  }: Event): Promise<z.infer<SchemaFromEventDescriptor<Event>>> {
     return this.runExclusively('stepUntilEvent', async () => {
       const event = await this.waitFor(
         `event ${name} from block ${this.lastIoBlockHeight}`,
@@ -354,10 +354,10 @@ export class ChainflipIO<Requirements> {
    *
    * @returns The data of the first matching event, well-typed according to the schema.
    */
-  async expectEvent<Z extends z.ZodTypeAny = z.ZodTypeAny>({
+  async expectEvent<Event extends EventDescriptor<EventName, z.ZodTypeAny>>({
     name,
     schema,
-  }: EventDescriptor<EventName, Z>): Promise<z.infer<Z>> {
+  }: Event): Promise<z.infer<SchemaFromEventDescriptor<Event>>> {
     return this.runExclusively('expectEvent', async () => {
       this.debug(`Expecting event ${name} in block ${this.lastIoBlockHeight}`);
       const event = await findOneEventOfMany(
@@ -665,6 +665,11 @@ export function partialAccountFromUri(uri: `//${string}`): PartialAccount {
     keypair: createStateChainKeypair(uri),
   };
 }
+
+// ------------ Type helpers -------
+
+type SchemaFromEventDescriptor<Event extends EventDescriptor<EventName, z.ZodTypeAny>> =
+  Event extends EventDescriptor<EventName, infer Schema> ? Schema : never;
 
 // ------------ Other ---------------
 export type Severity = 'Error' | 'Warn' | 'Info' | 'Debug' | 'Trace';

--- a/bouncer/tests/gaslimit_ccm.test.ts
+++ b/bouncer/tests/gaslimit_ccm.test.ts
@@ -72,31 +72,12 @@ async function getChainFees<A = []>(
   cf: ChainflipIO<A>,
   chain: 'Ethereum' | 'Arbitrum' | 'Solana' | 'Bsc',
 ): Promise<{ baseFee: number; priorityFee: number }> {
-  switch (chain) {
-    case 'Ethereum': {
-      const { newChainState } = await cf.stepUntilEvent(
-        chainTrackingChainStateUpdatedEvent.Ethereum,
-      );
-      const { baseFee, priorityFee } = newChainState.trackedData;
-      return { baseFee: Number(baseFee), priorityFee: Number(priorityFee) };
-    }
-    case 'Arbitrum': {
-      const { newChainState } = await cf.stepUntilEvent(
-        chainTrackingChainStateUpdatedEvent.Arbitrum,
-      );
-      return { baseFee: Number(newChainState.trackedData.baseFee), priorityFee: 0 };
-    }
-    case 'Solana': {
-      const { newChainState } = await cf.stepUntilEvent(chainTrackingChainStateUpdatedEvent.Solana);
-      return { baseFee: 0, priorityFee: Number(newChainState.trackedData.priorityFee) };
-    }
-    case 'Bsc': {
-      const { newChainState } = await cf.stepUntilEvent(chainTrackingChainStateUpdatedEvent.Bsc);
-      return { baseFee: 0, priorityFee: Number(newChainState.trackedData.priorityFee) };
-    }
-    default:
-      throw new Error(`Chain ${chain} does not support CCM`);
-  }
+  const data = (await cf.stepUntilEvent(chainTrackingChainStateUpdatedEvent[chain])).newChainState
+    .trackedData;
+  return {
+    baseFee: 'baseFee' in data ? Number(data.baseFee) : 0,
+    priorityFee: 'priorityFee' in data ? Number(data.priorityFee) : 0,
+  };
 }
 
 async function executeAndTrackCcmSwap<A = []>(


### PR DESCRIPTION
# Pull Request

## Summary

This PR makes `stepUntilEvent` and `expectEvent` in `chainflip_io.ts` a bit more generic in their type. This allows these functions to be used in a context where the event descriptor is a union (of multiple event descriptors).

This makes it possible to *not* branch on chain in `getChainFees()` and we can restore it to its old (and more concise) implementation.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
