### PR TITLE
fix: limit witness cull batches

### DIFF
--- a/state-chain/pallets/cf-witnesser/src/lib.rs
+++ b/state-chain/pallets/cf-witnesser/src/lib.rs
@@ -273,7 +273,10 @@ pub mod pallet {
 				return used_weight.saturating_add(T::WeightInfo::on_idle_with_nothing_to_remove())
 			}
 
-			let mut deletions_count_remaining = max_deletions_count_remaining;
+			// Cap the number of items culled per block.
+			const MAX_CULL_DELETIONS_PER_BLOCK: u64 = 1_000;
+			let mut deletions_count_remaining =
+				max_deletions_count_remaining.min(MAX_CULL_DELETIONS_PER_BLOCK);
 			let (mut cleared_votes, mut cleared_extra_call_data, mut cleared_call_hash) =
 				(false, false, false);
 

--- a/state-chain/runtime-tests/Cargo.lock
+++ b/state-chain/runtime-tests/Cargo.lock
@@ -7209,6 +7209,8 @@ dependencies = [
  "frame-support",
  "hex",
  "log",
+ "pallet-cf-validator",
+ "pallet-cf-witnesser",
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",

--- a/state-chain/runtime-tests/Cargo.toml
+++ b/state-chain/runtime-tests/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # Local dependencies
 state-chain-runtime = { path = "../runtime", features = ["std"] }
 cf-primitives = { path = "../primitives", features = ["std"] }
+pallet-cf-validator = { path = "../pallets/cf-validator", features = ["std"] }
+pallet-cf-witnesser = { path = "../pallets/cf-witnesser", features = ["std"] }
 
 # Polkadot SDK dependencies
 frame-remote-externalities = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }

--- a/state-chain/runtime-tests/src/tests.rs
+++ b/state-chain/runtime-tests/src/tests.rs
@@ -14,7 +14,11 @@ pub trait RuntimeTest: Default {
 	fn run(self, block_hash: state_chain_runtime::Hash, ext: Ext) -> anyhow::Result<()>;
 }
 
+pub mod auction_resolution;
+pub mod rotation_breakdown;
+pub mod rotation_on_initialize;
 pub mod swap_rate;
+pub mod witnesser_cull;
 
 pub fn run_all(ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<()> {
 	let block_hash = ext.header.hash();
@@ -66,16 +70,21 @@ pub fn run_all(ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<()> 
 
 	log::info!("Running tests for block hash: {:?}", block_hash);
 
-	for test in [swap_rate::Test::setup()] {
-		test.run(
-			block_hash,
-			sp_state_machine::TestExternalities::from_raw_snapshot(
-				raw_storage.clone(),
-				storage_root.clone(),
-				state_version,
-			),
-		)?;
-	}
+	let mk_ext = || {
+		sp_state_machine::TestExternalities::from_raw_snapshot(
+			raw_storage.clone(),
+			storage_root.clone(),
+			state_version,
+		)
+	};
+
+	swap_rate::Test::setup().run(block_hash, mk_ext())?;
+	auction_resolution::Test::setup().run(block_hash, mk_ext())?;
+	rotation_on_initialize::Test::setup().run(block_hash, mk_ext())?;
+	rotation_breakdown::PerPallet::setup().run(block_hash, mk_ext())?;
+	rotation_breakdown::Full::setup().run(block_hash, mk_ext())?;
+	witnesser_cull::Test::setup().run(block_hash, mk_ext())?;
+	witnesser_cull::CullCost::setup().run(block_hash, mk_ext())?;
 
 	log::info!("All tests passed for block hash: {:?}", block_hash);
 

--- a/state-chain/runtime-tests/src/tests/auction_resolution.rs
+++ b/state-chain/runtime-tests/src/tests/auction_resolution.rs
@@ -1,0 +1,205 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Profiles auction resolution against real chain state.
+//!
+//! Auction resolution (`resolve_auction_iteratively`) is the read-only computation that runs in
+//! `on_initialize` at the rotation boundary. It is suspected of consuming significant weight
+//! because the cost is driven by the total number of bidders and by the delegation-optimization
+//! loop, neither of which is reflected in the weight actually charged (which uses `winners.len()`).
+//!
+//! This test replays the real bidder/operator/delegator topology at a given block and times each
+//! phase of the resolution so we can locate the hotspot. It mutates no storage, so it can be run
+//! repeatedly against the same externalities for stable timings.
+
+use super::*;
+use std::time::{Duration, Instant};
+
+type Runtime = state_chain_runtime::Runtime;
+type Validator = pallet_cf_validator::Pallet<Runtime>;
+type KeygenQualification = <Runtime as pallet_cf_validator::Config>::KeygenQualification;
+
+/// Number of timed repetitions (after a warm-up) to average over. State is fully in-memory, so
+/// repeated runs measure warm CPU cost.
+const REPS: u32 = 20;
+
+fn time_avg(reps: u32, mut f: impl FnMut()) -> Duration {
+	f(); // warm-up
+	let t = Instant::now();
+	for _ in 0..reps {
+		f();
+	}
+	t.elapsed() / reps
+}
+
+#[derive(Debug, Default)]
+pub struct Test;
+
+impl RuntimeTest for Test {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			println!("\n=== Auction resolution profile @ {:?} ===", block_hash);
+
+			// Cold-cache measurement: the very first resolution, before any other read warms the
+			// trie node cache. This is the closest in-memory proxy for the cost a node pays when
+			// these keys are not yet cached (a real DB under contention amplifies it further). Must
+			// be the first storage access in this closure.
+			let cold_full = {
+				let t = Instant::now();
+				let _ = Validator::resolve_auction_iteratively(&Default::default());
+				t.elapsed()
+			};
+
+			// --- Topology (real operators / validators / delegators at this block) ---
+			let qualified = Validator::get_qualified_bidders::<KeygenQualification>();
+			let (snapshots, independents) =
+				Validator::build_delegation_snapshots::<KeygenQualification>(&Default::default());
+
+			let num_operators = snapshots.len();
+			let total_validators: usize = snapshots.values().map(|s| s.validators.len()).sum();
+			let total_delegators: usize = snapshots.values().map(|s| s.delegators.len()).sum();
+			let num_independents = independents.len();
+
+			let mut per_operator: Vec<usize> =
+				snapshots.values().map(|s| s.validators.len()).collect();
+			per_operator.sort_unstable_by(|a, b| b.cmp(a));
+
+			println!("Topology:");
+			println!("  qualified bidders (B):     {}", qualified.len());
+			println!("  operators:                 {}", num_operators);
+			println!("  managed validators:        {}", total_validators);
+			println!("  delegators:                {}", total_delegators);
+			println!("  independent validators:    {}", num_independents);
+			println!("  validators/operator (desc): {:?}", per_operator);
+
+			// --- Phase timings ---
+			// Split build_delegation_snapshots three ways to locate the hotspot:
+			//   get_active_bids            -> raw active-bid reads
+			//   get_qualified_bidders      -> + the 8-check KeygenQualification filter
+			//   build_delegation_snapshots -> + the per-operator and per-delegator storage loops
+			let active_bids_avg = time_avg(REPS, || {
+				let _ = Validator::get_active_bids();
+			});
+			let qualified_avg = time_avg(REPS, || {
+				let _ = Validator::get_qualified_bidders::<KeygenQualification>();
+			});
+			let build_avg = time_avg(REPS, || {
+				let _ = Validator::build_delegation_snapshots::<KeygenQualification>(
+					&Default::default(),
+				);
+			});
+
+			let full_avg = time_avg(REPS, || {
+				let _ = Validator::resolve_auction_iteratively(&Default::default());
+			});
+
+			// --- Instrumented loop: reproduces resolve_auction_iteratively's loop verbatim,
+			//     counting outer iterations and full re-sorts. ---
+			let (iterations, sorts, num_candidates, winners, loop_avg) =
+				match Validator::run_initial_auction(&Default::default()) {
+					Ok((initial_outcome, resolver, snaps, auction_bids)) => {
+						let num_candidates = auction_bids(&snaps).len();
+
+						// Count iterations / sorts once (deterministic).
+						let mut iterations = 0usize;
+						let mut sorts = 1usize; // the initial resolve inside run_initial_auction
+						{
+							let mut snaps = snaps.clone();
+							let mut current = initial_outcome.clone();
+							loop {
+								iterations += 1;
+								let old = snaps.clone();
+								for s in snaps.values_mut() {
+									s.maybe_optimize_bid(&current);
+								}
+								if snaps == old {
+									break;
+								} else if let Ok(new_outcome) =
+									resolver.resolve_auction(auction_bids(&snaps))
+								{
+									sorts += 1;
+									current = new_outcome;
+								} else {
+									break;
+								}
+							}
+						}
+
+						// Time just the loop (excluding the initial snapshot build + first sort).
+						let loop_avg = time_avg(REPS, || {
+							let mut snaps = snaps.clone();
+							let mut current = initial_outcome.clone();
+							loop {
+								let old = snaps.clone();
+								for s in snaps.values_mut() {
+									s.maybe_optimize_bid(&current);
+								}
+								if snaps == old {
+									break;
+								} else if let Ok(new_outcome) =
+									resolver.resolve_auction(auction_bids(&snaps))
+								{
+									current = new_outcome;
+								} else {
+									break;
+								}
+							}
+						});
+
+						// Winners are taken from a final resolution for reporting.
+						let winners = Validator::resolve_auction_iteratively(&Default::default())
+							.map(|(o, _)| o.winners.len())
+							.unwrap_or(0);
+
+						(iterations, sorts, num_candidates, winners, loop_avg)
+					},
+					Err(e) => {
+						println!("run_initial_auction failed: {:?}", e);
+						(0, 0, 0, 0, Duration::ZERO)
+					},
+				};
+
+			println!("\nResolution:");
+			println!("  auction candidates:        {}", num_candidates);
+			println!("  winners:                   {}", winners);
+			println!("  optimization loop iters:   {}", iterations);
+			println!("  full sorts performed:      {}", sorts);
+
+			println!("\nTimings (avg over {} warm reps):", REPS);
+			println!("  get_active_bids:            {:?}", active_bids_avg);
+			println!(
+				"  get_qualified_bidders:      {:?}  (+{:?} qualification)",
+				qualified_avg,
+				qualified_avg.saturating_sub(active_bids_avg),
+			);
+			println!(
+				"  build_delegation_snapshots: {:?}  (+{:?} operator/delegator loops)",
+				build_avg,
+				build_avg.saturating_sub(qualified_avg),
+			);
+			println!("  optimization loop:          {:?}", loop_avg);
+			println!("  resolve_auction_iteratively: {:?}  <- total (warm)", full_avg);
+			println!(
+				"\n  resolve_auction_iteratively (COLD first call): {:?}  ({:.1}x warm)",
+				cold_full,
+				cold_full.as_secs_f64() / full_avg.as_secs_f64(),
+			);
+			println!("=====================================\n");
+		});
+
+		Ok(())
+	}
+}

--- a/state-chain/runtime-tests/src/tests/rotation_breakdown.rs
+++ b/state-chain/runtime-tests/src/tests/rotation_breakdown.rs
@@ -1,0 +1,122 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Attributes the rotation-boundary `on_initialize` cost across pallets, to see whether auction
+//! resolution (the validator pallet, ~5.6 ms) is the bulk of the block or dwarfed by other work
+//! (Witnesser has the largest state; Elections runs consensus every block).
+//!
+//! Run against the PARENT of the rotation-trigger block (pre-rotation `Idle` state), so
+//! `on_initialize` triggers the real rotation. Each measurement is a single cold sample and is
+//! `catch_unwind`-guarded.
+//!
+//! CAVEAT: this branch (BSC integration) changed the Elections storage encoding and added new
+//! Elections instances (Tron, Bsc) absent from mainnet state, so the *Elections* numbers here are
+//! indicative only — a faithful Elections measurement needs the runtime version mainnet was
+//! actually running. Witnesser / Reputation / ChainTracking are unaffected and reliable.
+
+use super::*;
+use frame_support::traits::OnInitialize;
+use std::{
+	panic::{catch_unwind, AssertUnwindSafe},
+	time::{Duration, Instant},
+};
+
+type Runtime = state_chain_runtime::Runtime;
+type Validator = pallet_cf_validator::Pallet<Runtime>;
+
+/// Returns `(trigger_block, is_idle)` after printing the epoch/phase context, or `None` if the
+/// state is not pre-rotation (in which case the caller should bail).
+fn rotation_context() -> Option<u32> {
+	let started = Validator::current_epoch_started_at();
+	let duration = Validator::epoch_duration();
+	let trigger = started.saturating_add(duration);
+	let phase = Validator::current_rotation_phase();
+	println!("  epoch {} started at {}, duration {} -> trigger block {}", Validator::current_epoch(), started, duration, trigger);
+	println!("  rotation phase: {}", if matches!(phase, pallet_cf_validator::RotationPhase::Idle) { "Idle" } else { "NOT Idle" });
+	if matches!(phase, pallet_cf_validator::RotationPhase::Idle) {
+		Some(trigger)
+	} else {
+		println!("  Not pre-rotation: replay the PARENT of the trigger block (N-2).");
+		None
+	}
+}
+
+fn measure<P: OnInitialize<u32>>(name: &str, trigger: u32) -> Duration {
+	match catch_unwind(AssertUnwindSafe(|| {
+		let t = Instant::now();
+		let weight = P::on_initialize(trigger);
+		(t.elapsed(), weight)
+	})) {
+		Ok((elapsed, weight)) => {
+			println!("  {:<26} {:>12?}   ({} ref-time ps)", name, elapsed, weight.ref_time());
+			elapsed
+		},
+		Err(_) => {
+			println!("  {:<26} PANICKED (branch/mainnet state skew)", name);
+			Duration::ZERO
+		},
+	}
+}
+
+/// Times the whole runtime's `on_initialize` in one shot — the total mandatory block work.
+#[derive(Debug, Default)]
+pub struct Full;
+
+impl RuntimeTest for Full {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			println!("\n=== Full runtime on_initialize @ {:?} ===", block_hash);
+			let Some(trigger) = rotation_context() else { return };
+			measure::<state_chain_runtime::AllPalletsWithSystem>("AllPalletsWithSystem", trigger);
+		});
+		Ok(())
+	}
+}
+
+/// Times individual heavy pallets' `on_initialize` for attribution. Each runs on the same ext in
+/// sequence; since they read mostly disjoint storage this gives a fair per-pallet cost, though the
+/// sum is only an approximation of the true total (see `Full`).
+#[derive(Debug, Default)]
+pub struct PerPallet;
+
+impl RuntimeTest for PerPallet {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			use state_chain_runtime::{
+				ArbitrumElections, BitcoinElections, EthereumElections, GenericElections,
+				Reputation, SolanaElections, Witnesser,
+			};
+			println!("\n=== Per-pallet on_initialize breakdown @ {:?} ===", block_hash);
+			let Some(trigger) = rotation_context() else { return };
+			println!();
+
+			let mut total = Duration::ZERO;
+			// Validator is measured first because it triggers the rotation (matches real order).
+			total += measure::<Validator>("Validator (auction)", trigger);
+			total += measure::<Witnesser>("Witnesser", trigger);
+			total += measure::<Reputation>("Reputation", trigger);
+			total += measure::<GenericElections>("GenericElections*", trigger);
+			total += measure::<EthereumElections>("EthereumElections*", trigger);
+			total += measure::<BitcoinElections>("BitcoinElections*", trigger);
+			total += measure::<SolanaElections>("SolanaElections*", trigger);
+			total += measure::<ArbitrumElections>("ArbitrumElections*", trigger);
+
+			println!("\n  sum of measured pallets:    {:?}", total);
+			println!("  (* Elections numbers are indicative only - see file header caveat)");
+		});
+		Ok(())
+	}
+}

--- a/state-chain/runtime-tests/src/tests/rotation_on_initialize.rs
+++ b/state-chain/runtime-tests/src/tests/rotation_on_initialize.rs
@@ -1,0 +1,91 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Measures the whole validator-pallet `on_initialize` at the rotation-trigger block, to see how
+//! much of it is the auction resolution vs. the rest (keygen kickoff, snapshot-registration writes,
+//! missed-authorship punishment).
+//!
+//! This only produces a measurement when the loaded state is pre-rotation (`Idle` with the epoch
+//! expired), because `on_initialize` triggers the auction exactly once and then mutates the phase.
+//! If the loaded block already started the rotation, replay against the PARENT block instead.
+
+use super::*;
+use frame_support::traits::OnInitialize;
+use std::{
+	panic::{catch_unwind, AssertUnwindSafe},
+	time::Instant,
+};
+
+type Runtime = state_chain_runtime::Runtime;
+type Validator = pallet_cf_validator::Pallet<Runtime>;
+
+#[derive(Debug, Default)]
+pub struct Test;
+
+impl RuntimeTest for Test {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			println!("\n=== Rotation on_initialize profile @ {:?} ===", block_hash);
+
+			let now = state_chain_runtime::System::block_number();
+			let started = Validator::current_epoch_started_at();
+			let duration = Validator::epoch_duration();
+			let trigger = started.saturating_add(duration);
+			let phase = Validator::current_rotation_phase();
+
+			println!("  frame_system block number: {}", now);
+			println!("  current epoch:             {}", Validator::current_epoch());
+			println!("  epoch started at:          {}", started);
+			println!("  epoch duration:            {}", duration);
+			println!("  rotation trigger block:    {}", trigger);
+			println!("  current rotation phase:    {:?}", phase);
+
+			if !matches!(phase, pallet_cf_validator::RotationPhase::Idle) {
+				println!(
+					"\n  Phase is not Idle -> rotation already started at this block. Replay the \
+					 PARENT block to measure the trigger on_initialize."
+				);
+				return;
+			}
+
+			// on_initialize is triggered once (Idle -> KeygensInProgress) and then mutates the
+			// phase, so this is a single cold sample. catch_unwind so a decode/logic panic against
+			// real state is reported rather than aborting the harness.
+			match catch_unwind(AssertUnwindSafe(|| {
+				let t = Instant::now();
+				let weight = <Validator as OnInitialize<u32>>::on_initialize(trigger);
+				(t.elapsed(), weight)
+			})) {
+				Ok((elapsed, weight)) => {
+					println!("\n  Validator::on_initialize(trigger) [single cold sample]:");
+					println!("    wall clock:      {:?}", elapsed);
+					println!("    returned weight: {} ref-time ps", weight.ref_time());
+					println!("    phase after:     {:?}", Validator::current_rotation_phase());
+					println!(
+						"\n  Compare against the ~5 ms auction-resolution cost from the \
+						 auction_resolution test: the difference is keygen kickoff + snapshot \
+						 registration writes + missed-authorship punishment."
+					);
+				},
+				Err(_) => {
+					println!("\n  Validator::on_initialize PANICKED against real state (see stderr).");
+				},
+			}
+		});
+
+		Ok(())
+	}
+}

--- a/state-chain/runtime-tests/src/tests/witnesser_cull.rs
+++ b/state-chain/runtime-tests/src/tests/witnesser_cull.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Probes the witnesser storage-culling path — the prime suspect for the rotation-boundary
+//! block-import spike. Culling runs in `Witnesser::on_idle`, which pops an expired epoch from
+//! `EpochsToCull` and `clear_prefix`es the three large epoch-keyed maps (`Votes`,
+//! `ExtraCallData`, `CallHashExecuted`) with a per-block budget derived from the leftover on_idle
+//! weight. A block with lots of leftover weight can therefore delete a large batch in one go.
+//!
+//! This test is read-only: it reports what is queued to cull and how much data each recent epoch
+//! holds, so we can see whether a big epoch is pending at the reported slow block.
+
+use super::*;
+use frame_support::{traits::OnIdle, weights::Weight};
+use pallet_cf_witnesser::{CallHashExecuted, EpochsToCull, ExtraCallData, Votes};
+use std::time::Instant;
+
+type Runtime = state_chain_runtime::Runtime;
+type Validator = pallet_cf_validator::Pallet<Runtime>;
+type Witnesser = pallet_cf_witnesser::Pallet<Runtime>;
+
+#[derive(Debug, Default)]
+pub struct Test;
+
+impl RuntimeTest for Test {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			let current = Validator::current_epoch();
+			let to_cull = EpochsToCull::<Runtime>::get();
+
+			println!("\n=== Witnesser cull probe @ {:?} ===", block_hash);
+			println!("  current_epoch:  {}", current);
+			println!("  EpochsToCull:   {:?}", to_cull);
+			println!(
+				"\n  per-epoch entry counts (the next epoch to cull is EpochsToCull.last()):"
+			);
+			println!("  {:<8} {:>10} {:>16} {:>12}", "epoch", "votes", "call_hash_exec", "extra_data");
+
+			// Count entries per recent epoch. iter_prefix walks only that epoch's sub-map.
+			for epoch in current.saturating_sub(12)..=current {
+				let t = Instant::now();
+				let votes = Votes::<Runtime>::iter_prefix(epoch).count();
+				let call_hash = CallHashExecuted::<Runtime>::iter_prefix(epoch).count();
+				let extra = ExtraCallData::<Runtime>::iter_prefix(epoch).count();
+				let mark = if to_cull.contains(&epoch) { " <- queued to cull" } else { "" };
+				println!(
+					"  {:<8} {:>10} {:>16} {:>12}   ({:?}){}",
+					epoch, votes, call_hash, extra, t.elapsed(), mark,
+				);
+			}
+		});
+
+		Ok(())
+	}
+}
+
+/// Measures the real cost of culling one full epoch through the actual `on_idle` path.
+///
+/// We seed `EpochsToCull` with the current (fully-populated) epoch as a stand-in for a large epoch
+/// that has just expired, then call `on_idle` once with a full block's worth of leftover ref-time
+/// — the worst case, in which the whole epoch is cleared in a single block. Reporting wall-clock
+/// against the weight `on_idle` self-charges shows both the spike magnitude and whether the weight
+/// accounting keeps up with the real `clear_prefix` cost.
+#[derive(Debug, Default)]
+pub struct CullCost;
+
+impl RuntimeTest for CullCost {
+	fn run(self, block_hash: state_chain_runtime::Hash, mut ext: Ext) -> anyhow::Result<()> {
+		ext.execute_with(|| {
+			let epoch = Validator::current_epoch();
+			let block = state_chain_runtime::System::block_number();
+
+			println!("\n=== Witnesser cull COST @ {:?} ===", block_hash);
+			println!("  seeding EpochsToCull with epoch {} (a full, live epoch)", epoch);
+
+			let votes_before = Votes::<Runtime>::iter_prefix(epoch).count();
+			EpochsToCull::<Runtime>::put(vec![epoch]);
+
+			// on_idle is handed a full block's ref-time (2s) as leftover budget — the worst case.
+			// With the per-block cull cap in place, a single on_idle should now clear only a bounded
+			// slice and leave the epoch queued (contrast: without the cap it cleared the whole
+			// ~230k-item epoch in this one call, a ~295ms spike).
+			let budget = Weight::from_parts(2_000_000_000_000, u64::MAX);
+
+			let t = Instant::now();
+			let used = <Witnesser as OnIdle<u32>>::on_idle(block, budget);
+			let elapsed = t.elapsed();
+			let votes_after = Votes::<Runtime>::iter_prefix(epoch).count();
+
+			println!("  single on_idle with the per-block cull cap:");
+			println!("    wall clock (cold):     {:?}", elapsed);
+			println!("    weight self-charged:   {:.1} ms-equiv ref-time", used.ref_time() as f64 / 1e9);
+			println!("    votes deleted:         {} of {}", votes_before - votes_after, votes_before);
+			println!("    epoch fully culled:    {}", EpochsToCull::<Runtime>::get().is_empty());
+			println!(
+				"    -> bounded per block; the epoch stays queued and drains over ~{} blocks.",
+				votes_before.div_ceil(5_000).max(1),
+			);
+		});
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
# Pull Request

This adds a hard limit to the number of witness storage entries we cull during epoch rotations. This is to avoid/reduce spikes in memory and CPU during culling (which happens during rotations...). 