### PR TITLE
fix: move lp agg stats update to on_idle hook

### DIFF
--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -143,76 +143,36 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn update_agg_stats_existing(m: Linear<0, 100>) {
-		// Generate m LPs with existing aggregate stats
-		let existing_lps = T::AccountRoleRegistry::generate_whitelisted_callers_with_role(
-			AccountRole::LiquidityProvider,
-			m,
-		)
-		.unwrap();
-
-		// Populate LpAggStats with existing LPs
-		for lp in &existing_lps {
-			pallet::LpAggStats::<T>::insert(
-				lp,
-				Asset::Eth,
-				pallet::AggStats::new(pallet::DeltaStats {
-					limit_orders_swap_usd_volume: FixedU128::from_u32(100),
-				}),
-			);
-		}
-
-		// Populate LpDeltaStats for existing LPs (they will be updated)
-		for lp in &existing_lps {
-			pallet::LpDeltaStats::<T>::insert(
-				lp,
-				Asset::Eth,
-				pallet::DeltaStats { limit_orders_swap_usd_volume: FixedU128::from_u32(50) },
-			);
-		}
+	fn update_agg_stats_item() {
+		let lp: T::AccountId = whitelisted_caller();
+		let agg_stats = pallet::AggStats::new(pallet::DeltaStats {
+			limit_orders_swap_usd_volume: FixedU128::from_u32(100),
+		});
+		pallet::LpDeltaStats::<T>::insert(
+			&lp,
+			Asset::Eth,
+			pallet::DeltaStats { limit_orders_swap_usd_volume: FixedU128::from_u32(50) },
+		);
 
 		#[block]
 		{
-			Pallet::<T>::update_agg_stats();
+			Pallet::<T>::process_one_agg_stats_entry(
+				&lp,
+				Asset::Eth,
+				agg_stats,
+				FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD),
+			);
 		}
 
-		// Verify existing LPs had their stats updated
-		for lp in &existing_lps {
-			assert!(pallet::LpAggStats::<T>::get(lp, Asset::Eth).is_some());
-		}
-		// Verify delta stats were drained
-		assert_eq!(pallet::LpDeltaStats::<T>::iter().count(), 0);
+		assert_eq!(pallet::LpDeltaStats::<T>::get(&lp, Asset::Eth), None);
 	}
 
 	#[benchmark]
-	fn update_agg_stats_new(n: Linear<0, 100>) {
-		// Generate n LPs that only have delta stats (new LPs)
-		let new_lps = T::AccountRoleRegistry::generate_whitelisted_callers_with_role(
-			AccountRole::LiquidityProvider,
-			n,
-		)
-		.unwrap();
-
-		// Populate LpDeltaStats for new LPs (they will be inserted as new agg entries)
-		for lp in &new_lps {
-			pallet::LpDeltaStats::<T>::insert(
-				lp,
-				Asset::Eth,
-				pallet::DeltaStats { limit_orders_swap_usd_volume: FixedU128::from_u32(25) },
-			);
-		}
-
+	fn on_idle_nothing_to_do() {
 		#[block]
 		{
-			Pallet::<T>::update_agg_stats();
+			Pallet::<T>::on_idle(0u32.into(), frame_support::weights::Weight::zero());
 		}
-
-		// Verify new LPs were added to agg stats
-		for lp in &new_lps {
-			assert!(pallet::LpAggStats::<T>::get(lp, Asset::Eth).is_some());
-		}
-		// Verify delta stats were drained
-		assert_eq!(pallet::LpDeltaStats::<T>::iter().count(), 0);
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -144,8 +144,6 @@ mod benchmarks {
 
 	#[benchmark]
 	fn update_agg_stats_existing(m: Linear<0, 100>) {
-		use sp_std::collections::btree_map::BTreeMap;
-
 		// Generate m LPs with existing aggregate stats
 		let existing_lps = T::AccountRoleRegistry::generate_whitelisted_callers_with_role(
 			AccountRole::LiquidityProvider,
@@ -154,19 +152,15 @@ mod benchmarks {
 		.unwrap();
 
 		// Populate LpAggStats with existing LPs
-		let mut agg_stats_map: BTreeMap<T::AccountId, BTreeMap<Asset, pallet::AggStats>> =
-			BTreeMap::new();
 		for lp in &existing_lps {
-			let mut lp_stats: BTreeMap<Asset, pallet::AggStats> = BTreeMap::new();
-			lp_stats.insert(
+			pallet::LpAggStats::<T>::insert(
+				lp,
 				Asset::Eth,
 				pallet::AggStats::new(pallet::DeltaStats {
 					limit_orders_swap_usd_volume: FixedU128::from_u32(100),
 				}),
 			);
-			agg_stats_map.insert(lp.clone(), lp_stats);
 		}
-		pallet::LpAggStats::<T>::put(agg_stats_map);
 
 		// Populate LpDeltaStats for existing LPs (they will be updated)
 		for lp in &existing_lps {
@@ -183,9 +177,8 @@ mod benchmarks {
 		}
 
 		// Verify existing LPs had their stats updated
-		let updated_agg_stats = pallet::LpAggStats::<T>::get();
 		for lp in &existing_lps {
-			assert!(updated_agg_stats.contains_key(lp));
+			assert!(pallet::LpAggStats::<T>::get(lp, Asset::Eth).is_some());
 		}
 		// Verify delta stats were drained
 		assert_eq!(pallet::LpDeltaStats::<T>::iter().count(), 0);
@@ -193,19 +186,12 @@ mod benchmarks {
 
 	#[benchmark]
 	fn update_agg_stats_new(n: Linear<0, 100>) {
-		use sp_std::collections::btree_map::BTreeMap;
-
 		// Generate n LPs that only have delta stats (new LPs)
 		let new_lps = T::AccountRoleRegistry::generate_whitelisted_callers_with_role(
 			AccountRole::LiquidityProvider,
 			n,
 		)
 		.unwrap();
-
-		// Ensure LpAggStats is empty
-		pallet::LpAggStats::<T>::put(
-			BTreeMap::<T::AccountId, BTreeMap<Asset, pallet::AggStats>>::new(),
-		);
 
 		// Populate LpDeltaStats for new LPs (they will be inserted as new agg entries)
 		for lp in &new_lps {
@@ -222,9 +208,8 @@ mod benchmarks {
 		}
 
 		// Verify new LPs were added to agg stats
-		let updated_agg_stats = pallet::LpAggStats::<T>::get();
 		for lp in &new_lps {
-			assert!(updated_agg_stats.contains_key(lp));
+			assert!(pallet::LpAggStats::<T>::get(lp, Asset::Eth).is_some());
 		}
 		// Verify delta stats were drained
 		assert_eq!(pallet::LpDeltaStats::<T>::iter().count(), 0);

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -663,15 +663,7 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		// Any left-over deltas correspond to LPs that didn't have Aggregate entries yet
-		let mut extra_lps_count: u32 = 0;
-		for (lp, asset, delta) in LpDeltaStats::<T>::drain() {
-			extra_lps_count = extra_lps_count.saturating_add(1);
-			LpAggStats::<T>::insert(&lp, asset, AggStats::new(delta));
-		}
-
 		T::WeightInfo::update_agg_stats_existing(existing_lps_count)
-			.saturating_add(T::WeightInfo::update_agg_stats_new(extra_lps_count))
 	}
 
 	#[frame_support::transactional]
@@ -747,11 +739,21 @@ impl<T: Config> LpStatsApi for Pallet<T> {
 
 	fn on_limit_order_filled(who: &Self::AccountId, asset: &Asset, usd_value: AssetAmount) {
 		if usd_value != AssetAmount::zero() {
-			LpDeltaStats::<T>::mutate(who, asset, |maybe_stats| {
-				let delta_stats = maybe_stats.get_or_insert_default();
+			if LpAggStats::<T>::contains_key(who, asset) {
+				LpDeltaStats::<T>::mutate(who, asset, |maybe_stats| {
+					let delta_stats = maybe_stats.get_or_insert_default();
 
-				delta_stats.accrue_usd(FixedU128::from_inner(usd_value));
-			});
+					delta_stats.accrue_usd(FixedU128::from_inner(usd_value));
+				});
+			} else {
+				LpAggStats::<T>::insert(
+					who,
+					asset,
+					AggStats::new(DeltaStats {
+						limit_orders_swap_usd_volume: FixedU128::from_inner(usd_value),
+					}),
+				);
+			}
 		}
 	}
 }

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -28,7 +28,7 @@ use cf_traits::{
 use frame_support::{
 	fail,
 	pallet_prelude::*,
-	sp_runtime::{traits::Zero, DispatchResult, FixedU128, Perbill},
+	sp_runtime::{traits::Zero, DispatchResult, FixedU128, Perbill, Saturating},
 };
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
@@ -355,20 +355,31 @@ pub mod pallet {
 	pub type LpAggStats<T: Config> =
 		StorageDoubleMap<_, Identity, T::AccountId, Twox64Concat, Asset, AggStats>;
 
+	/// Resumable raw-storage-key cursor for the periodic `LpAggStats` decay/prune pass. `Some`
+	/// while a pass is in progress (potentially spanning many blocks); `None` when idle, in which
+	/// case `on_idle` waits for `STATS_UPDATE_INTERVAL_IN_BLOCKS` to elapse before starting a new
+	/// one.
+	#[pallet::storage]
+	pub type StatsUpdateCursor<T: Config> = StorageValue<_, Vec<u8>, OptionQuery>;
+
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_initialize(current_block: BlockNumberFor<T>) -> Weight {
-			let mut weight_used: Weight = T::DbWeight::get().reads(1);
+		fn on_idle(current_block: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
+			let overhead = T::DbWeight::get().reads(1);
 
-			let blocks_elapsed = current_block.saturating_sub(StatsLastUpdatedAt::<T>::get());
-
-			if blocks_elapsed.saturated_into::<u64>() >= STATS_UPDATE_INTERVAL_IN_BLOCKS {
-				weight_used += Self::update_agg_stats();
-
-				StatsLastUpdatedAt::<T>::put(current_block);
-				weight_used += T::DbWeight::get().writes(1);
+			let cursor = StatsUpdateCursor::<T>::get();
+			if cursor.is_none() {
+				let blocks_elapsed = current_block.saturating_sub(StatsLastUpdatedAt::<T>::get());
+				if blocks_elapsed.saturated_into::<u64>() < STATS_UPDATE_INTERVAL_IN_BLOCKS {
+					return overhead
+				}
 			}
-			weight_used
+
+			overhead.saturating_add(Self::update_agg_stats(
+				current_block,
+				cursor,
+				remaining_weight.saturating_sub(overhead),
+			))
 		}
 	}
 
@@ -567,6 +578,10 @@ pub mod pallet {
 	}
 }
 
+/// Hard ceiling on how many `LpAggStats` entries a single `update_agg_stats` call processes,
+/// regardless of leftover weight.
+pub const MAX_STATS_UPDATES_PER_CALL: u32 = 100;
+
 impl<T: Config> Pallet<T> {
 	pub fn transfer_or_withdraw(
 		origin: OriginFor<T>,
@@ -649,21 +664,57 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	fn update_agg_stats() -> Weight {
-		let prune_threshold = FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD);
-		let mut existing_lps_count: u32 = 0;
+	fn update_agg_stats(
+		current_block: BlockNumberFor<T>,
+		cursor: Option<Vec<u8>>,
+		remaining_weight: Weight,
+	) -> Weight {
+		let per_item_weight = T::WeightInfo::update_agg_stats_item();
+		let max_items = remaining_weight
+			.ref_time()
+			.checked_div(per_item_weight.ref_time())
+			.unwrap_or(u64::MAX)
+			.min(MAX_STATS_UPDATES_PER_CALL as u64);
 
-		for (lp, asset, mut agg_stats) in LpAggStats::<T>::iter().collect::<Vec<_>>() {
-			existing_lps_count = existing_lps_count.saturating_add(1);
-			agg_stats.update(&LpDeltaStats::<T>::take(&lp, asset).unwrap_or_default());
-			if agg_stats.is_below_pruning_threshold(prune_threshold) {
-				LpAggStats::<T>::remove(&lp, asset);
-			} else {
-				LpAggStats::<T>::insert(&lp, asset, agg_stats);
-			}
+		if max_items == 0 {
+			StatsUpdateCursor::<T>::set(cursor);
+			return Weight::zero()
 		}
 
-		T::WeightInfo::update_agg_stats_existing(existing_lps_count)
+		let prune_threshold = FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD);
+		let mut iter = cursor
+			.map(|cursor| LpAggStats::<T>::iter_from(cursor))
+			.unwrap_or_else(|| LpAggStats::<T>::iter());
+		let mut processed: u64 = 0;
+
+		while processed < max_items {
+			let (lp, asset, agg_stats) = if let Some(next) = iter.next() {
+				next
+			} else {
+				StatsUpdateCursor::<T>::kill();
+				StatsLastUpdatedAt::<T>::put(current_block);
+				return per_item_weight.saturating_mul(processed)
+			};
+			Self::process_one_agg_stats_entry(&lp, asset, agg_stats, prune_threshold);
+			processed.saturating_accrue(1);
+		}
+
+		StatsUpdateCursor::<T>::put(iter.last_raw_key());
+		per_item_weight.saturating_mul(processed)
+	}
+
+	fn process_one_agg_stats_entry(
+		lp: &T::AccountId,
+		asset: Asset,
+		mut agg_stats: AggStats,
+		prune_threshold: FixedU128,
+	) {
+		agg_stats.update(&LpDeltaStats::<T>::take(lp, asset).unwrap_or_default());
+		if agg_stats.is_below_pruning_threshold(prune_threshold) {
+			LpAggStats::<T>::remove(lp, asset);
+		} else {
+			LpAggStats::<T>::insert(lp, asset, agg_stats);
+		}
 	}
 
 	#[frame_support::transactional]

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -682,9 +682,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		let prune_threshold = FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD);
-		let mut iter = cursor
-			.map(|cursor| LpAggStats::<T>::iter_from(cursor))
-			.unwrap_or_else(|| LpAggStats::<T>::iter());
+		let mut iter = cursor.map(LpAggStats::<T>::iter_from).unwrap_or_else(LpAggStats::<T>::iter);
 		let mut processed: u64 = 0;
 
 		while processed < max_items {

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -33,7 +33,7 @@ use frame_support::{
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::vec::Vec;
 
 mod benchmarking;
 
@@ -48,7 +48,7 @@ pub use weights::WeightInfo;
 
 use cf_chains::address::EncodedAddress;
 
-pub const STORAGE_VERSION_U16: u16 = 3;
+pub const STORAGE_VERSION_U16: u16 = 4;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
 
 impl_pallet_safe_mode!(PalletSafeMode; deposit_enabled, withdrawal_enabled, internal_swaps_enabled);
@@ -353,7 +353,7 @@ pub mod pallet {
 	/// Stores exponential moving average stats for liquidity providers per asset
 	#[pallet::storage]
 	pub type LpAggStats<T: Config> =
-		StorageValue<_, BTreeMap<T::AccountId, BTreeMap<Asset, AggStats>>, ValueQuery>;
+		StorageDoubleMap<_, Identity, T::AccountId, Twox64Concat, Asset, AggStats>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -650,39 +650,28 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn update_agg_stats() -> Weight {
-		LpAggStats::<T>::mutate(|agg_stats_map| {
-			let prune_threshold = FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD);
-			let mut empty_lps: Vec<T::AccountId> = Vec::new();
+		let prune_threshold = FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD);
+		let mut existing_lps_count: u32 = 0;
 
-			// For every existing Lp, update their Aggregate stats from accumulated delta stats
-			let existing_lps_count = agg_stats_map.len() as u32;
-			for (lp, lp_stats) in agg_stats_map.iter_mut() {
-				for (asset, agg_stats) in lp_stats.iter_mut() {
-					agg_stats.update(&LpDeltaStats::<T>::take(lp, asset).unwrap_or_default());
-				}
-				lp_stats
-					.retain(|_, agg_stats| !agg_stats.is_below_pruning_threshold(prune_threshold));
-				if lp_stats.is_empty() {
-					empty_lps.push(lp.clone());
-				}
+		for (lp, asset, mut agg_stats) in LpAggStats::<T>::iter().collect::<Vec<_>>() {
+			existing_lps_count = existing_lps_count.saturating_add(1);
+			agg_stats.update(&LpDeltaStats::<T>::take(&lp, asset).unwrap_or_default());
+			if agg_stats.is_below_pruning_threshold(prune_threshold) {
+				LpAggStats::<T>::remove(&lp, asset);
+			} else {
+				LpAggStats::<T>::insert(&lp, asset, agg_stats);
 			}
+		}
 
-			// Any left-over deltas correspond to LPs that didn't have Aggregate entries yet
-			let mut extra_lps_count = 0;
-			for (lp, asset, delta) in LpDeltaStats::<T>::drain() {
-				agg_stats_map.entry(lp.clone()).or_default().insert(asset, AggStats::new(delta));
-				extra_lps_count += 1;
-			}
+		// Any left-over deltas correspond to LPs that didn't have Aggregate entries yet
+		let mut extra_lps_count: u32 = 0;
+		for (lp, asset, delta) in LpDeltaStats::<T>::drain() {
+			extra_lps_count = extra_lps_count.saturating_add(1);
+			LpAggStats::<T>::insert(&lp, asset, AggStats::new(delta));
+		}
 
-			for lp in empty_lps {
-				agg_stats_map.remove(&lp);
-			}
-
-			T::WeightInfo::update_agg_stats_existing(existing_lps_count)
-				.saturating_add(T::WeightInfo::update_agg_stats_new(extra_lps_count))
-				// Subtract the overhead that is measured twice in the benchmarking
-				.saturating_sub(T::WeightInfo::update_agg_stats_new(0))
-		})
+		T::WeightInfo::update_agg_stats_existing(existing_lps_count)
+			.saturating_add(T::WeightInfo::update_agg_stats_new(extra_lps_count))
 	}
 
 	#[frame_support::transactional]

--- a/state-chain/pallets/cf-lp/src/migrations.rs
+++ b/state-chain/pallets/cf-lp/src/migrations.rs
@@ -16,8 +16,20 @@
 
 use crate::{Pallet, STORAGE_VERSION_U16};
 use cf_runtime_utilities::PlaceholderMigration;
+use frame_support::migrations::VersionedMigration;
 
-pub type PalletMigration<T> = PlaceholderMigration<{ STORAGE_VERSION_U16 }, Pallet<T>>;
+mod lp_agg_stats_map;
+
+pub type PalletMigration<T> = (
+	VersionedMigration<
+		3,
+		4,
+		lp_agg_stats_map::Migration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	PlaceholderMigration<{ STORAGE_VERSION_U16 }, Pallet<T>>,
+);
 
 #[cfg(test)]
 const _: u16 =

--- a/state-chain/pallets/cf-lp/src/migrations/lp_agg_stats_map.rs
+++ b/state-chain/pallets/cf-lp/src/migrations/lp_agg_stats_map.rs
@@ -1,0 +1,126 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{AggStats, Config};
+use frame_support::{
+	pallet_prelude::Weight,
+	sp_runtime::Saturating,
+	traits::{Get, UncheckedOnRuntimeUpgrade},
+};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData};
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::pallet_prelude::DispatchError;
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+mod old {
+	use super::*;
+	use cf_primitives::Asset;
+	use frame_support::{pallet_prelude::ValueQuery, storage_alias};
+
+	#[storage_alias]
+	pub type LpAggStats<T: crate::Config> = StorageValue<
+		crate::Pallet<T>,
+		BTreeMap<<T as frame_system::Config>::AccountId, BTreeMap<Asset, AggStats>>,
+		ValueQuery,
+	>;
+}
+
+pub struct Migration<T>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let old_map = old::LpAggStats::<T>::take();
+		let mut entries_migrated: u64 = 0;
+
+		for (lp, per_asset) in old_map {
+			for (asset, agg_stats) in per_asset {
+				crate::LpAggStats::<T>::insert(&lp, asset, agg_stats);
+				entries_migrated.saturating_accrue(1);
+			}
+		}
+
+		T::DbWeight::get().reads_writes(1, entries_migrated.saturating_add(1))
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let old_map = old::LpAggStats::<T>::get();
+		let entry_count: u64 = old_map.values().map(|per_asset| per_asset.len() as u64).sum();
+		Ok(entry_count.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let expected_count = u64::decode(&mut &state[..])
+			.map_err(|_| DispatchError::Other("failed to decode pre_upgrade state"))?;
+		let actual_count = crate::LpAggStats::<T>::iter().count() as u64;
+		frame_support::ensure!(
+			actual_count == expected_count,
+			DispatchError::Other("LpAggStats entry count changed across migration")
+		);
+		frame_support::ensure!(
+			old::LpAggStats::<T>::get().is_empty(),
+			DispatchError::Other("old LpAggStats StorageValue was not cleared")
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{new_test_ext, Test, LP_ACCOUNT, LP_ACCOUNT_2};
+	use cf_primitives::Asset;
+	use sp_runtime::FixedU128;
+
+	#[test]
+	fn migrates_all_entries_and_clears_old_storage() {
+		new_test_ext().execute_with(|| {
+			let stats_1 = AggStats::new(crate::DeltaStats {
+				limit_orders_swap_usd_volume: FixedU128::from_u32(100),
+			});
+			let stats_2 = AggStats::new(crate::DeltaStats {
+				limit_orders_swap_usd_volume: FixedU128::from_u32(200),
+			});
+
+			let mut old_map = BTreeMap::new();
+			old_map.insert(LP_ACCOUNT, BTreeMap::from([(Asset::Eth, stats_1)]));
+			old_map.insert(
+				LP_ACCOUNT_2,
+				BTreeMap::from([(Asset::Flip, stats_2), (Asset::Usdc, stats_1)]),
+			);
+			old::LpAggStats::<Test>::put(old_map);
+
+			#[cfg(feature = "try-runtime")]
+			let state = Migration::<Test>::pre_upgrade().unwrap();
+
+			Migration::<Test>::on_runtime_upgrade();
+
+			#[cfg(feature = "try-runtime")]
+			Migration::<Test>::post_upgrade(state).unwrap();
+
+			assert_eq!(crate::LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth), Some(stats_1));
+			assert_eq!(crate::LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip), Some(stats_2));
+			assert_eq!(crate::LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Usdc), Some(stats_1));
+			assert_eq!(crate::LpAggStats::<Test>::iter().count(), 3);
+			assert!(old::LpAggStats::<Test>::get().is_empty());
+		});
+	}
+}

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -580,6 +580,12 @@ fn on_limit_order_filled_updates_delta_stats() {
 
 		const USD_AMOUNT: AssetAmount = 1_500_000;
 
+		// Pre-seed LpAggStats entries so on_limit_order_filled accrues into LpDeltaStats instead
+		// of eagerly seeding a new entry (that path is covered by
+		// `on_limit_order_filled_seeds_new_lp_agg_stats_entry_immediately`).
+		LpAggStats::<Test>::insert(LP_ACCOUNT, Asset::Eth, AggStats::default());
+		LpAggStats::<Test>::insert(LP_ACCOUNT_2, Asset::Eth, AggStats::default());
+
 		// round 1
 		assert!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_none());
 		for _ in 0..3 {
@@ -609,19 +615,30 @@ fn update_agg_stats_updates_correctly() {
 
 		LpAggStats::<Test>::insert(LP_ACCOUNT, Asset::Eth, pre_existing_eth_stats);
 
-		// on_limit_order_filled for LP_ACCOUNT with pre-existing AggStats
+		// on_limit_order_filled for LP_ACCOUNT with pre-existing AggStats: accrues a delta, does
+		// not touch LpAggStats directly.
 		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 700_000_000u128); // 700 usd
 		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 700_000_000u128); // 700 usd
+		assert_eq!(
+			LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth)
+				.unwrap()
+				.limit_orders_swap_usd_volume,
+			FixedU128::from_inner(1_400_000_000u128)
+		);
 
-		// on_limit_order_filled for LP_ACCOUNT_2 (no pre-existing AggStats; should create new EMA
-		// equal to delta)
+		// on_limit_order_filled for LP_ACCOUNT_2 (no pre-existing AggStats): seeds a new entry
+		// immediately, unblended.
 		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT_2, &Asset::Flip, 500_000_000u128); // 500 usd
-
-		// Call the update function and verify that delta stats are deleted after the update
-		LiquidityProvider::update_agg_stats();
-		// After calling update_agg_stats(), all Delta stats should be deleted
-		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
+		let lp2_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).unwrap();
+		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.one_day), 500f64);
+		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.seven_days), 500f64);
+		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.thirty_days), 500f64);
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip), None);
+
+		// Call the update function and verify that LP_ACCOUNT's pre-existing entry decays
+		// correctly and its delta stats are deleted after the update.
+		LiquidityProvider::update_agg_stats();
+		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
 
 		let lp1_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).unwrap();
 		assert!(is_within_tiny_error(
@@ -649,11 +666,58 @@ fn update_agg_stats_updates_correctly() {
 			)
 		));
 
-		// Verify new EMA was created for LP_ACCOUNT_2 and is initialized correctly
+		// LP_ACCOUNT_2's freshly-seeded entry already exists in LpAggStats by the time
+		// update_agg_stats() runs, so it's included in the same iter() pass: with no pending
+		// delta, it decays toward zero like any other existing entry with no activity this
+		// period (same as LP_ACCOUNT's entry would if it had no delta).
 		let lp2_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).unwrap();
-		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.one_day), 500f64);
-		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.seven_days), 500f64);
-		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.thirty_days), 500f64);
+		assert!(is_within_tiny_error(
+			fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.one_day),
+			expected_ema(500f64, 0f64, 1u32)
+		));
+		assert!(is_within_tiny_error(
+			fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.seven_days),
+			expected_ema(500f64, 0f64, 7u32)
+		));
+		assert!(is_within_tiny_error(
+			fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.thirty_days),
+			expected_ema(500f64, 0f64, 30u32)
+		));
+	});
+}
+
+#[test]
+fn on_limit_order_filled_seeds_new_lp_agg_stats_entry_immediately() {
+	new_test_ext().execute_with(|| {
+		assert!(LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_none());
+
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 1_000_000_000u128); // 1000 usd
+
+		// The entry exists immediately, without update_agg_stats() ever running.
+		let agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).unwrap();
+		assert_eq!(fixed_u128_to_f64(agg_stats.avg_limit_usd_volume.one_day), 1000f64);
+		assert_eq!(fixed_u128_to_f64(agg_stats.avg_limit_usd_volume.seven_days), 1000f64);
+		assert_eq!(fixed_u128_to_f64(agg_stats.avg_limit_usd_volume.thirty_days), 1000f64);
+		// No delta was recorded for this first fill — it was consumed directly into the seed.
+		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
+
+		// A second fill for the SAME (Lp, Asset), now that an entry exists, accrues as a delta
+		// instead of overwriting the seed.
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 500_000_000u128); // 500 usd
+		assert_eq!(
+			LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth)
+				.unwrap()
+				.limit_orders_swap_usd_volume,
+			FixedU128::from_inner(500_000_000u128)
+		);
+		// The seeded aggregate is unchanged until the next update_agg_stats() pass.
+		assert_eq!(
+			LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth)
+				.unwrap()
+				.avg_limit_usd_volume
+				.one_day,
+			FixedU128::from_inner(1_000_000_000u128)
+		);
 	});
 }
 

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -16,8 +16,9 @@
 
 use crate::{
 	mock::*, AggStats, DeltaStats, Error, Event, LiquidityRefundAddress, LpAggStats, LpDeltaStats,
-	Pallet, PalletSafeMode, WindowedEma, ALPHA_HALF_LIFE_1_DAY, ALPHA_HALF_LIFE_30_DAYS,
-	ALPHA_HALF_LIFE_7_DAYS, EMA_PRUNE_THRESHOLD_USD, STATS_UPDATE_INTERVAL_IN_BLOCKS,
+	Pallet, PalletSafeMode, StatsLastUpdatedAt, StatsUpdateCursor, WindowedEma,
+	ALPHA_HALF_LIFE_1_DAY, ALPHA_HALF_LIFE_30_DAYS, ALPHA_HALF_LIFE_7_DAYS,
+	EMA_PRUNE_THRESHOLD_USD, STATS_UPDATE_INTERVAL_IN_BLOCKS,
 };
 use std::collections::BTreeMap;
 
@@ -636,8 +637,13 @@ fn update_agg_stats_updates_correctly() {
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip), None);
 
 		// Call the update function and verify that LP_ACCOUNT's pre-existing entry decays
-		// correctly and its delta stats are deleted after the update.
-		LiquidityProvider::update_agg_stats();
+		// correctly and its delta stats are deleted after the update. Ample weight so the whole
+		// (tiny) pass completes in a single call.
+		LiquidityProvider::update_agg_stats(
+			1,
+			Vec::new(),
+			frame_support::weights::Weight::from_parts(u64::MAX, u64::MAX),
+		);
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
 
 		let lp1_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).unwrap();
@@ -744,7 +750,12 @@ fn update_agg_stats_prunes_below_threshold() {
 		LpAggStats::<Test>::insert(LP_ACCOUNT, Asset::Eth, below_threshold);
 		LpAggStats::<Test>::insert(LP_ACCOUNT_2, Asset::Flip, above_threshold);
 
-		LiquidityProvider::update_agg_stats();
+		// Ample weight so the whole (tiny) pass completes in a single call.
+		LiquidityProvider::update_agg_stats(
+			1,
+			Vec::new(),
+			frame_support::weights::Weight::from_parts(u64::MAX, u64::MAX),
+		);
 
 		assert!(LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_none());
 		assert!(LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).is_some());
@@ -754,6 +765,91 @@ fn update_agg_stats_prunes_below_threshold() {
 			lp2_stats.avg_limit_usd_volume.pruning_weighted_score() >=
 				FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD)
 		);
+	});
+}
+
+#[test]
+fn update_agg_stats_resumes_across_multiple_capped_calls() {
+	new_test_ext().execute_with(|| {
+		use crate::weights::WeightInfo as _;
+
+		const NUM_LPS: u64 = 5;
+		for lp in 0..NUM_LPS {
+			// Two fills per Lp: the first seeds the entry, the second leaves a pending delta for
+			// update_agg_stats to apply.
+			LiquidityProvider::on_limit_order_filled(&lp, &Asset::Eth, 1_000_000_000u128); // 1000 usd
+			LiquidityProvider::on_limit_order_filled(&lp, &Asset::Eth, 200_000_000u128); // 200 usd
+		}
+		assert_eq!(LpAggStats::<Test>::iter().count(), NUM_LPS as usize);
+
+		// Budget exactly one item's worth of weight per call (computed from the real WeightInfo,
+		// so this test stays correct however that weight is defined) to force the pass to span
+		// multiple calls. Each of the first NUM_LPS calls processes exactly one entry; the pass
+		// only recognises it's exhausted (and clears the cursor) on the following call, once
+		// `iter.next()` comes back empty — so completion takes NUM_LPS + 1 calls, not NUM_LPS.
+		let per_item_weight = <Test as crate::Config>::WeightInfo::update_agg_stats_item();
+
+		let mut cursor = Vec::new();
+		let mut calls = 0u64;
+		loop {
+			calls += 1;
+			assert!(calls <= NUM_LPS + 1, "pass should complete within NUM_LPS + 1 calls");
+			LiquidityProvider::update_agg_stats(calls, cursor.clone(), per_item_weight);
+			match StatsUpdateCursor::<Test>::get() {
+				Some(next_cursor) => cursor = next_cursor,
+				None => break,
+			}
+		}
+		assert_eq!(calls, NUM_LPS + 1, "the pass should take one extra call to detect completion");
+
+		for lp in 0..NUM_LPS {
+			assert_eq!(LpDeltaStats::<Test>::get(lp, Asset::Eth), None);
+			let agg_stats = LpAggStats::<Test>::get(lp, Asset::Eth).unwrap();
+			assert!(is_within_tiny_error(
+				fixed_u128_to_f64(agg_stats.avg_limit_usd_volume.one_day),
+				expected_ema(1000f64, 200f64, 1u32)
+			));
+		}
+	});
+}
+
+#[test]
+fn on_idle_does_nothing_before_interval_elapses() {
+	new_test_ext().execute_with(|| {
+		use frame_support::{traits::Hooks, weights::Weight};
+
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 1_000_000_000u128);
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 500_000_000u128);
+		StatsLastUpdatedAt::<Test>::put(0u64);
+
+		LiquidityProvider::on_idle(
+			STATS_UPDATE_INTERVAL_IN_BLOCKS - 1,
+			Weight::from_parts(u64::MAX, u64::MAX),
+		);
+
+		// Not due yet: the pending delta is untouched and no pass has started.
+		assert!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_some());
+		assert!(StatsUpdateCursor::<Test>::get().is_none());
+	});
+}
+
+#[test]
+fn on_idle_runs_and_completes_the_pass_once_due() {
+	new_test_ext().execute_with(|| {
+		use frame_support::{traits::Hooks, weights::Weight};
+
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 1_000_000_000u128);
+		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 500_000_000u128);
+		StatsLastUpdatedAt::<Test>::put(0u64);
+
+		LiquidityProvider::on_idle(
+			STATS_UPDATE_INTERVAL_IN_BLOCKS,
+			Weight::from_parts(u64::MAX, u64::MAX),
+		);
+
+		assert!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_none());
+		assert!(StatsUpdateCursor::<Test>::get().is_none());
+		assert_eq!(StatsLastUpdatedAt::<Test>::get(), STATS_UPDATE_INTERVAL_IN_BLOCKS);
 	});
 }
 

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -641,7 +641,7 @@ fn update_agg_stats_updates_correctly() {
 		// (tiny) pass completes in a single call.
 		LiquidityProvider::update_agg_stats(
 			1,
-			Vec::new(),
+			None,
 			frame_support::weights::Weight::from_parts(u64::MAX, u64::MAX),
 		);
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
@@ -753,7 +753,7 @@ fn update_agg_stats_prunes_below_threshold() {
 		// Ample weight so the whole (tiny) pass completes in a single call.
 		LiquidityProvider::update_agg_stats(
 			1,
-			Vec::new(),
+			None,
 			frame_support::weights::Weight::from_parts(u64::MAX, u64::MAX),
 		);
 
@@ -789,15 +789,15 @@ fn update_agg_stats_resumes_across_multiple_capped_calls() {
 		// `iter.next()` comes back empty — so completion takes NUM_LPS + 1 calls, not NUM_LPS.
 		let per_item_weight = <Test as crate::Config>::WeightInfo::update_agg_stats_item();
 
-		let mut cursor = Vec::new();
+		let mut cursor: Option<Vec<u8>> = None;
 		let mut calls = 0u64;
 		loop {
 			calls += 1;
 			assert!(calls <= NUM_LPS + 1, "pass should complete within NUM_LPS + 1 calls");
 			LiquidityProvider::update_agg_stats(calls, cursor.clone(), per_item_weight);
-			match StatsUpdateCursor::<Test>::get() {
-				Some(next_cursor) => cursor = next_cursor,
-				None => break,
+			cursor = StatsUpdateCursor::<Test>::get();
+			if cursor.is_none() {
+				break;
 			}
 		}
 		assert_eq!(calls, NUM_LPS + 1, "the pass should take one extra call to detect completion");

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -814,6 +814,86 @@ fn update_agg_stats_resumes_across_multiple_capped_calls() {
 }
 
 #[test]
+fn update_agg_stats_tolerates_new_entry_inserted_mid_pass() {
+	new_test_ext().execute_with(|| {
+		use crate::weights::WeightInfo as _;
+
+		// `frame_support`'s iteration docs warn that adding/removing values in the map "while
+		// doing this" gives "undefined results". Our reading of the actual mechanism (`next_key`
+		// is a live point-query against current storage, not a snapshot) says a fresh insertion
+		// elsewhere in the map between two `update_agg_stats` calls is safe: it can't skip or
+		// re-visit any entry that already existed when the pass started. This test proves that
+		// empirically for the concrete scenario that matters here — a limit order filling for a
+		// brand-new (Lp, Asset) pair (the eager-seed path) while a decay pass is genuinely
+		// in-progress (a persisted, non-empty cursor) — rather than relying only on that reading.
+		const NUM_LPS: u64 = 3;
+		for lp in 0..NUM_LPS {
+			LiquidityProvider::on_limit_order_filled(&lp, &Asset::Eth, 1_000_000_000u128); // 1000 usd
+			LiquidityProvider::on_limit_order_filled(&lp, &Asset::Eth, 200_000_000u128); // 200 usd
+		}
+		assert_eq!(LpAggStats::<Test>::iter().count(), NUM_LPS as usize);
+
+		let per_item_weight = <Test as crate::Config>::WeightInfo::update_agg_stats_item();
+		const NEW_LP: u64 = 999;
+
+		let mut cursor: Option<Vec<u8>> = None;
+		let mut calls = 0u64;
+		let mut new_entry_seeded_mid_pass = false;
+		loop {
+			calls += 1;
+			// Generous bound: the mid-pass insertion may or may not add one more call depending
+			// on where its key falls relative to the cursor. The property under test is
+			// termination, not the exact count (already covered by the test above).
+			assert!(calls <= NUM_LPS + 3, "pass should terminate in a bounded number of calls");
+			LiquidityProvider::update_agg_stats(calls, cursor.clone(), per_item_weight);
+			cursor = StatsUpdateCursor::<Test>::get();
+
+			if calls == 1 {
+				assert!(cursor.is_some(), "pass should still be genuinely in progress");
+				// Simulate a fill landing in an intervening block, for a brand-new (Lp, Asset)
+				// pair — this exercises the eager-seed path inserting a new LpAggStats entry
+				// while the cursor above is persisted mid-pass.
+				LiquidityProvider::on_limit_order_filled(&NEW_LP, &Asset::Eth, 700_000_000u128); // 700 usd
+				assert!(LpAggStats::<Test>::get(NEW_LP, Asset::Eth).is_some());
+				new_entry_seeded_mid_pass = true;
+			}
+
+			if cursor.is_none() {
+				break;
+			}
+		}
+		assert!(new_entry_seeded_mid_pass);
+
+		// Every entry that existed when the pass started was still reached and correctly
+		// decayed exactly once — the mid-pass insertion caused no skip.
+		for lp in 0..NUM_LPS {
+			assert_eq!(LpDeltaStats::<Test>::get(lp, Asset::Eth), None);
+			let agg_stats = LpAggStats::<Test>::get(lp, Asset::Eth).unwrap();
+			assert!(is_within_tiny_error(
+				fixed_u128_to_f64(agg_stats.avg_limit_usd_volume.one_day),
+				expected_ema(1000f64, 200f64, 1u32)
+			));
+		}
+
+		// The mid-pass-inserted entry is intact either way: it was either swept into this same
+		// pass (decayed once from its seed with a zero delta, since it has no pending delta of
+		// its own) if its key fell ahead of the cursor, or left untouched, waiting for the next
+		// pass, if its key fell behind. Both are correct outcomes — what matters is that it's
+		// neither lost nor double-processed.
+		let new_lp_stats = LpAggStats::<Test>::get(NEW_LP, Asset::Eth).unwrap();
+		let seeded_value = 700f64;
+		let decayed_once = expected_ema(seeded_value, 0f64, 1u32);
+		let one_day = fixed_u128_to_f64(new_lp_stats.avg_limit_usd_volume.one_day);
+		assert!(
+			is_within_tiny_error(one_day, seeded_value) ||
+				is_within_tiny_error(one_day, decayed_once),
+			"new entry should be either untouched ({seeded_value}) or decayed exactly once \
+			 ({decayed_once}), got {one_day}"
+		);
+	});
+}
+
+#[test]
 fn on_idle_does_nothing_before_interval_elapses() {
 	new_test_ext().execute_with(|| {
 		use frame_support::{traits::Hooks, weights::Weight};

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -598,7 +598,6 @@ fn on_limit_order_filled_updates_delta_stats() {
 		assert_eq!(deltas_2.limit_orders_swap_usd_volume, FixedU128::from_inner(USD_AMOUNT));
 	});
 }
-// rust
 #[test]
 fn update_agg_stats_updates_correctly() {
 	new_test_ext().execute_with(|| {
@@ -608,10 +607,7 @@ fn update_agg_stats_updates_correctly() {
 			limit_orders_swap_usd_volume: FixedU128::from_inner(1_000_000_000u128),
 		}); // Avg: 1000 USD
 
-		LpAggStats::<Test>::mutate(|agg_stats_map| {
-			let lp_stats = agg_stats_map.entry(LP_ACCOUNT).or_default();
-			lp_stats.insert(Asset::Eth, pre_existing_eth_stats);
-		});
+		LpAggStats::<Test>::insert(LP_ACCOUNT, Asset::Eth, pre_existing_eth_stats);
 
 		// on_limit_order_filled for LP_ACCOUNT with pre-existing AggStats
 		LiquidityProvider::on_limit_order_filled(&LP_ACCOUNT, &Asset::Eth, 700_000_000u128); // 700 usd
@@ -627,8 +623,7 @@ fn update_agg_stats_updates_correctly() {
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT, Asset::Eth), None);
 		assert_eq!(LpDeltaStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip), None);
 
-		let agg_stats_map = LpAggStats::<Test>::get();
-		let lp1_agg_stats = agg_stats_map.get(&LP_ACCOUNT).unwrap().get(&Asset::Eth).unwrap();
+		let lp1_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).unwrap();
 		assert!(is_within_tiny_error(
 			fixed_u128_to_f64(lp1_agg_stats.avg_limit_usd_volume.one_day),
 			expected_ema(
@@ -655,8 +650,7 @@ fn update_agg_stats_updates_correctly() {
 		));
 
 		// Verify new EMA was created for LP_ACCOUNT_2 and is initialized correctly
-		let agg_stats_map = LpAggStats::<Test>::get();
-		let lp2_agg_stats = agg_stats_map.get(&LP_ACCOUNT_2).unwrap().get(&Asset::Flip).unwrap();
+		let lp2_agg_stats = LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).unwrap();
 		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.one_day), 500f64);
 		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.seven_days), 500f64);
 		assert_eq!(fixed_u128_to_f64(lp2_agg_stats.avg_limit_usd_volume.thirty_days), 500f64);
@@ -683,26 +677,15 @@ fn update_agg_stats_prunes_below_threshold() {
 			},
 		};
 
-		LpAggStats::<Test>::mutate(|agg_stats_map| {
-			let lp_stats = agg_stats_map.entry(LP_ACCOUNT).or_default();
-			lp_stats.insert(Asset::Eth, below_threshold);
-			let lp_stats = agg_stats_map.entry(LP_ACCOUNT_2).or_default();
-			lp_stats.insert(Asset::Flip, above_threshold);
-		});
+		LpAggStats::<Test>::insert(LP_ACCOUNT, Asset::Eth, below_threshold);
+		LpAggStats::<Test>::insert(LP_ACCOUNT_2, Asset::Flip, above_threshold);
 
 		LiquidityProvider::update_agg_stats();
 
-		let agg_stats_map = LpAggStats::<Test>::get();
-		assert!(agg_stats_map
-			.get(&LP_ACCOUNT)
-			.and_then(|stats| stats.get(&Asset::Eth))
-			.is_none());
-		assert!(agg_stats_map
-			.get(&LP_ACCOUNT_2)
-			.and_then(|stats| stats.get(&Asset::Flip))
-			.is_some());
+		assert!(LpAggStats::<Test>::get(LP_ACCOUNT, Asset::Eth).is_none());
+		assert!(LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).is_some());
 
-		let lp2_stats = agg_stats_map.get(&LP_ACCOUNT_2).unwrap().get(&Asset::Flip).unwrap();
+		let lp2_stats = LpAggStats::<Test>::get(LP_ACCOUNT_2, Asset::Flip).unwrap();
 		assert!(
 			lp2_stats.avg_limit_usd_volume.pruning_weighted_score() >=
 				FixedU128::from_inner(EMA_PRUNE_THRESHOLD_USD)

--- a/state-chain/pallets/cf-lp/src/weights.rs
+++ b/state-chain/pallets/cf-lp/src/weights.rs
@@ -203,85 +203,36 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn schedule_swap() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2120`
-		//  Estimated: `8060`
-		// Minimum execution time: 79_816_000 picoseconds.
-		Weight::from_parts(81_115_000, 8060)
-			.saturating_add(T::DbWeight::get().reads(13_u64))
-			.saturating_add(T::DbWeight::get().writes(5_u64))
+		//  Measured:  `2011`
+		//  Estimated: `0`
+		// Minimum execution time: 81_602_000 picoseconds.
+		Weight::from_parts(82_797_000, 0)
 	}
-	/// Storage: `LiquidityProvider::LpAggStats` (r:1 w:1)
-	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
+	/// Storage: `LiquidityProvider::LpDeltaStats` (r:1 w:1)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// The range of component `m` is `[0, 100]`.
-	fn update_agg_stats_item(m: u32, ) -> Weight {
+	/// Storage: `LiquidityProvider::LpAggStats` (r:0 w:1)
+	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn update_agg_stats_item() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `267 + m * (144 ±0)`
-		//  Estimated: `3729 + m * (2620 ±0)`
-		// Minimum execution time: 10_848_000 picoseconds.
-		Weight::from_parts(13_016_086, 3729)
-			// Standard Error: 17_914
-			.saturating_add(Weight::from_parts(6_950_050, 0).saturating_mul(m.into()))
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(m.into())))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(m.into())))
-			.saturating_add(Weight::from_parts(0, 2620).saturating_mul(m.into()))
+		//  Measured:  `296`
+		//  Estimated: `3761`
+		// Minimum execution time: 8_000_000 picoseconds.
+		Weight::from_parts(9_000_000, 3761)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
-	/// Storage: `LiquidityProvider::LpAggStats` (r:1 w:1)
-	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
-	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// The range of component `n` is `[0, 100]`.
-	fn update_agg_stats_new(n: u32, ) -> Weight {
+	/// Storage: `LiquidityProvider::StatsUpdateCursor` (r:1 w:0)
+	/// Proof: `LiquidityProvider::StatsUpdateCursor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityProvider::StatsLastUpdatedAt` (r:1 w:0)
+	/// Proof: `LiquidityProvider::StatsLastUpdatedAt` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn on_idle_nothing_to_do() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `263 + n * (62 ±0)`
-		//  Estimated: `3726 + n * (2538 ±0)`
-		// Minimum execution time: 10_890_000 picoseconds.
-		Weight::from_parts(8_210_835, 3726)
-			// Standard Error: 17_346
-			.saturating_add(Weight::from_parts(5_088_133, 0).saturating_mul(n.into()))
+		//  Measured:  `213`
+		//  Estimated: `1698`
+		// Minimum execution time: 3_000_000 picoseconds.
+		Weight::from_parts(5_000_000, 1698)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-			.saturating_add(Weight::from_parts(0, 2538).saturating_mul(n.into()))
 	}
-	/// Storage: `AccountRoles::AccountRoles` (r:100 w:0)
-	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LiquidityRefundAddress` (r:100 w:0)
-	/// Proof: `LiquidityProvider::LiquidityRefundAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityPools::Pools` (r:3 w:0)
-	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `AssetBalances::FreeBalances` (r:100 w:100)
-	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::EgressIdCounter` (r:1 w:1)
-	/// Proof: `EthereumIngressEgress::EgressIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumChainTracking::CurrentChainState` (r:1 w:0)
-	/// Proof: `EthereumChainTracking::CurrentChainState` (`max_values`: Some(1), `max_size`: Some(40), added: 535, mode: `MaxEncodedLen`)
-	/// Storage: `EthereumChainTracking::FeeMultiplier` (r:1 w:0)
-	/// Proof: `EthereumChainTracking::FeeMultiplier` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	/// Storage: `AssetBalances::WithheldAssets` (r:1 w:1)
-	/// Proof: `AssetBalances::WithheldAssets` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::EgressDustLimit` (r:3 w:0)
-	/// Proof: `EthereumIngressEgress::EgressDustLimit` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::ScheduledEgressFetchOrTransfer` (r:1 w:1)
-	/// Proof: `EthereumIngressEgress::ScheduledEgressFetchOrTransfer` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::NetworkFee` (r:1 w:0)
-	/// Proof: `Swapping::NetworkFee` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::NetworkFeeForAsset` (r:3 w:0)
-	/// Proof: `Swapping::NetworkFeeForAsset` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
-	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapRequestIdCounter` (r:1 w:1)
-	/// Proof: `Swapping::SwapRequestIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapIdCounter` (r:1 w:1)
-	/// Proof: `Swapping::SwapIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::ScheduledSwaps` (r:1 w:1)
-	/// Proof: `Swapping::ScheduledSwaps` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapRequests` (r:0 w:66)
-	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `n` is `[1, 100]`.
 	fn purge_balances(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
@@ -442,85 +393,36 @@ impl WeightInfo for () {
 	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn schedule_swap() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2120`
-		//  Estimated: `8060`
-		// Minimum execution time: 79_816_000 picoseconds.
-		Weight::from_parts(81_115_000, 8060)
-			.saturating_add(ParityDbWeight::get().reads(13_u64))
-			.saturating_add(ParityDbWeight::get().writes(5_u64))
+		//  Measured:  `2011`
+		//  Estimated: `0`
+		// Minimum execution time: 81_602_000 picoseconds.
+		Weight::from_parts(82_797_000, 0)
 	}
-	/// Storage: `LiquidityProvider::LpAggStats` (r:1 w:1)
-	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
+	/// Storage: `LiquidityProvider::LpDeltaStats` (r:1 w:1)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// The range of component `m` is `[0, 100]`.
-	fn update_agg_stats_item(m: u32, ) -> Weight {
+	/// Storage: `LiquidityProvider::LpAggStats` (r:0 w:1)
+	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn update_agg_stats_item() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `267 + m * (144 ±0)`
-		//  Estimated: `3729 + m * (2620 ±0)`
-		// Minimum execution time: 10_848_000 picoseconds.
-		Weight::from_parts(13_016_086, 3729)
-			// Standard Error: 17_914
-			.saturating_add(Weight::from_parts(6_950_050, 0).saturating_mul(m.into()))
-			.saturating_add(ParityDbWeight::get().reads(2_u64))
-			.saturating_add(ParityDbWeight::get().reads((1_u64).saturating_mul(m.into())))
-			.saturating_add(ParityDbWeight::get().writes(1_u64))
-			.saturating_add(ParityDbWeight::get().writes((1_u64).saturating_mul(m.into())))
-			.saturating_add(Weight::from_parts(0, 2620).saturating_mul(m.into()))
+		//  Measured:  `296`
+		//  Estimated: `3761`
+		// Minimum execution time: 8_000_000 picoseconds.
+		Weight::from_parts(9_000_000, 3761)
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
-	/// Storage: `LiquidityProvider::LpAggStats` (r:1 w:1)
-	/// Proof: `LiquidityProvider::LpAggStats` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
-	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// The range of component `n` is `[0, 100]`.
-	fn update_agg_stats_new(n: u32, ) -> Weight {
+	/// Storage: `LiquidityProvider::StatsUpdateCursor` (r:1 w:0)
+	/// Proof: `LiquidityProvider::StatsUpdateCursor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityProvider::StatsLastUpdatedAt` (r:1 w:0)
+	/// Proof: `LiquidityProvider::StatsLastUpdatedAt` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn on_idle_nothing_to_do() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `263 + n * (62 ±0)`
-		//  Estimated: `3726 + n * (2538 ±0)`
-		// Minimum execution time: 10_890_000 picoseconds.
-		Weight::from_parts(8_210_835, 3726)
-			// Standard Error: 17_346
-			.saturating_add(Weight::from_parts(5_088_133, 0).saturating_mul(n.into()))
+		//  Measured:  `213`
+		//  Estimated: `1698`
+		// Minimum execution time: 3_000_000 picoseconds.
+		Weight::from_parts(5_000_000, 1698)
 			.saturating_add(ParityDbWeight::get().reads(2_u64))
-			.saturating_add(ParityDbWeight::get().reads((1_u64).saturating_mul(n.into())))
-			.saturating_add(ParityDbWeight::get().writes(1_u64))
-			.saturating_add(ParityDbWeight::get().writes((1_u64).saturating_mul(n.into())))
-			.saturating_add(Weight::from_parts(0, 2538).saturating_mul(n.into()))
 	}
-	/// Storage: `AccountRoles::AccountRoles` (r:100 w:0)
-	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityProvider::LiquidityRefundAddress` (r:100 w:0)
-	/// Proof: `LiquidityProvider::LiquidityRefundAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `LiquidityPools::Pools` (r:3 w:0)
-	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `AssetBalances::FreeBalances` (r:100 w:100)
-	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::EgressIdCounter` (r:1 w:1)
-	/// Proof: `EthereumIngressEgress::EgressIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumChainTracking::CurrentChainState` (r:1 w:0)
-	/// Proof: `EthereumChainTracking::CurrentChainState` (`max_values`: Some(1), `max_size`: Some(40), added: 535, mode: `MaxEncodedLen`)
-	/// Storage: `EthereumChainTracking::FeeMultiplier` (r:1 w:0)
-	/// Proof: `EthereumChainTracking::FeeMultiplier` (`max_values`: Some(1), `max_size`: Some(16), added: 511, mode: `MaxEncodedLen`)
-	/// Storage: `AssetBalances::WithheldAssets` (r:1 w:1)
-	/// Proof: `AssetBalances::WithheldAssets` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::EgressDustLimit` (r:3 w:0)
-	/// Proof: `EthereumIngressEgress::EgressDustLimit` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `EthereumIngressEgress::ScheduledEgressFetchOrTransfer` (r:1 w:1)
-	/// Proof: `EthereumIngressEgress::ScheduledEgressFetchOrTransfer` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::NetworkFee` (r:1 w:0)
-	/// Proof: `Swapping::NetworkFee` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::NetworkFeeForAsset` (r:3 w:0)
-	/// Proof: `Swapping::NetworkFeeForAsset` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `GenericElections::ElectoralUnsynchronisedState` (r:1 w:0)
-	/// Proof: `GenericElections::ElectoralUnsynchronisedState` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapRequestIdCounter` (r:1 w:1)
-	/// Proof: `Swapping::SwapRequestIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapIdCounter` (r:1 w:1)
-	/// Proof: `Swapping::SwapIdCounter` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::ScheduledSwaps` (r:1 w:1)
-	/// Proof: `Swapping::ScheduledSwaps` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `Swapping::SwapRequests` (r:0 w:66)
-	/// Proof: `Swapping::SwapRequests` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `n` is `[1, 100]`.
 	fn purge_balances(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:

--- a/state-chain/pallets/cf-lp/src/weights.rs
+++ b/state-chain/pallets/cf-lp/src/weights.rs
@@ -54,8 +54,8 @@ pub trait WeightInfo {
 	fn deregister_lp_account() -> Weight;
 	fn register_liquidity_refund_address() -> Weight;
 	fn schedule_swap() -> Weight;
-	fn update_agg_stats_existing(m: u32, ) -> Weight;
-	fn update_agg_stats_new(n: u32, ) -> Weight;
+	fn update_agg_stats_item() -> Weight;
+	fn on_idle_nothing_to_do() -> Weight;
 	fn purge_balances(n: u32, ) -> Weight;
 }
 
@@ -215,7 +215,7 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `m` is `[0, 100]`.
-	fn update_agg_stats_existing(m: u32, ) -> Weight {
+	fn update_agg_stats_item(m: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `267 + m * (144 ±0)`
 		//  Estimated: `3729 + m * (2620 ±0)`
@@ -454,7 +454,7 @@ impl WeightInfo for () {
 	/// Storage: `LiquidityProvider::LpDeltaStats` (r:101 w:100)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// The range of component `m` is `[0, 100]`.
-	fn update_agg_stats_existing(m: u32, ) -> Weight {
+	fn update_agg_stats_item(m: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `267 + m * (144 ±0)`
 		//  Estimated: `3729 + m * (2620 ±0)`


### PR DESCRIPTION
# Pull Request

Closes: PRO-2986

## Summary

Replaces the BTreeMap storage with a StorageMap for LP stats updates. 

This makes iteration slower *but* it make the cost easier to measuer and allows us to cancel and resume, which in turn allow us to spread the work out over multiple blocks, preventing a weight bomb from accruing over time. 

This requires the addition of a cursor storage item to track the current iteration state. In addition the number of updates per block has been limited to 100.

The approach is similar to what was taken in #6705. 

