### PR TITLE
chore: bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Bumps `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock` to resolve [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared`), which was failing `cargo cf-audit` in CI.

Transitive dependency only — `cargo update -p crossbeam-epoch`, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)