### PR TITLE
fix: Correctly finalise boosted vault deposits when lost

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1007,6 +1007,18 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
+	/// Expirty blocks (in external chain's block height) of boosted vault transactions awaiting
+	/// full witnessing. Additionally stores the boosted asset required to finalise the boost.
+	///
+	/// Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
+	/// that a lost boosted deposit is correctly accounted for.
+	#[pallet::storage]
+	pub type BoostedVaultTransactionExpiry<T: Config<I>, I: 'static = ()> = StorageValue<
+		_,
+		BTreeMap<TransactionInIdFor<T, I>, (TargetChainBlockNumber<T, I>, TargetChainAsset<T, I>)>,
+		ValueQuery,
+	>;
+
 	#[pallet::storage]
 	pub(super) type PendingPrewitnessedDeposits<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
@@ -1247,6 +1259,16 @@ pub mod pallet {
 		fn on_idle(now: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
 			let mut used_weight = Weight::zero();
 
+			let external_height = match TargetChainOf::<T, I>::get() {
+				ForeignChain::Arbitrum |
+				ForeignChain::Bitcoin |
+				ForeignChain::Ethereum |
+				ForeignChain::Tron |
+				ForeignChain::Bsc => ProcessedUpTo::<T, I>::get(),
+				ForeignChain::Assethub | ForeignChain::Polkadot | ForeignChain::Solana =>
+					T::ChainTracking::get_block_height(),
+			};
+
 			// Approximate weight calculation: r/w DepositChannelLookup + w DepositChannelPool
 			let recycle_weight_per_address =
 				frame_support::weights::constants::ParityDbWeight::get().reads_writes(1, 2);
@@ -1258,33 +1280,24 @@ pub mod pallet {
 				.saturated_into::<usize>();
 
 			// In some instances, like Solana, the channel lifetime is managed by the electoral
-			// system.
+			// system (channels are recycled via `IngressSink::on_channel_closed` instead).
 			if T::MANAGE_CHANNEL_LIFETIME {
-				let addresses_to_recycle = DepositChannelRecycleBlocks::<T, I>::mutate(
-					|recycle_queue| {
+				if matches!(TargetChainOf::<T, I>::get(), ForeignChain::Solana) {
+					log_or_panic!("MANAGE_CHANNEL_LIFETIME = false for solana, this branch should be unreachable");
+				}
+
+				let addresses_to_recycle =
+					DepositChannelRecycleBlocks::<T, I>::mutate(|recycle_queue| {
 						if recycle_queue.is_empty() {
 							vec![]
 						} else {
 							Self::take_recyclable_addresses(
 								recycle_queue,
 								maximum_addresses_to_recycle,
-								match TargetChainOf::<T, I>::get() {
-									ForeignChain::Arbitrum |
-									ForeignChain::Bitcoin |
-									ForeignChain::Ethereum |
-									ForeignChain::Tron |
-									ForeignChain::Bsc => ProcessedUpTo::<T, I>::get(),
-									ForeignChain::Assethub | ForeignChain::Polkadot =>
-										T::ChainTracking::get_block_height(),
-									ForeignChain::Solana => {
-										log_or_panic!("MANAGE_CHANNEL_LIFETIME = false for solana, this branch should be unreachable");
-										Default::default()
-									},
-								},
+								external_height,
 							)
 						}
-					},
-				);
+					});
 
 				// Add weight for the DepositChannelRecycleBlocks read/write plus the
 				// DepositChannelLookup read/writes in the for loop below
@@ -1299,6 +1312,13 @@ pub mod pallet {
 					Self::recycle_channel(&mut used_weight, address);
 				}
 			}
+
+			// For boosted vault deposits (which have no channel to recycle) we check for their
+			// expiry separately:
+			used_weight = used_weight.saturating_add(Self::expire_boosted_vault_transactions(
+				external_height,
+				remaining_weight.saturating_sub(used_weight),
+			));
 
 			if T::AllowTransactionReports::get() {
 				// A report gets cleaned up after approx 1 hour and needs to be re-reported by the
@@ -1879,6 +1899,72 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				})
 			}
 		}
+	}
+
+	/// Deems boosted vault swaps lost once their expiry height is reached, within the given weight
+	/// budget (any remainder is retried on subsequent blocks). Returns the weight consumed.
+	fn expire_boosted_vault_transactions(
+		current_height: TargetChainBlockNumber<T, I>,
+		available_weight: Weight,
+	) -> Weight {
+		let db_weight = frame_support::weights::constants::ParityDbWeight::get();
+
+		// On the common path nothing is boosted (or nothing is due), so read the queue and bail
+		// out before touching storage again. This avoids writing an (empty) map back on every
+		// block, which for chains that never boost would otherwise create and rewrite a redundant
+		// storage entry indefinitely.
+		let mut expiry_queue = BoostedVaultTransactionExpiry::<T, I>::get();
+		if expiry_queue.is_empty() {
+			return db_weight.reads(1);
+		}
+
+		let expire_weight_per_tx = db_weight.reads_writes(1, 1);
+		let maximum_to_expire: usize = available_weight
+			.ref_time()
+			.checked_div(expire_weight_per_tx.ref_time())
+			.unwrap_or_default()
+			.unique_saturated_into();
+
+		// The map only holds in-flight boosts plus any not-yet-swept lost ones (finalised deposits
+		// are removed eagerly), so it stays small enough to scan in full for those whose expiry
+		// height has been reached, capped by the weight budget.
+		let due: Vec<_> = expiry_queue
+			.iter()
+			.filter(|(_, (expiry_height, _))| *expiry_height <= current_height)
+			.take(maximum_to_expire)
+			.map(|(tx_id, (_, asset))| (tx_id.clone(), *asset))
+			.collect();
+
+		let num_expired = due.len() as u64;
+		for (tx_id, asset) in due {
+			expiry_queue.remove(&tx_id);
+
+			// A no-op if the transaction was fully witnessed (and thus finalised) before it
+			// expired. Otherwise release the reserved booster/lender liquidity.
+			if let BoostStatus::Boosted { prewitnessed_deposit_id, amount } =
+				BoostedVaultTransactions::<T, I>::take(&tx_id)
+			{
+				T::BoostApi::process_deposit_as_lost(prewitnessed_deposit_id, asset.into());
+
+				Self::deposit_event(Event::<T, I>::BoostedDepositLost {
+					prewitnessed_deposit_id,
+					amount,
+				});
+			}
+		}
+
+		if num_expired == 0 {
+			// Nothing was due yet, so the queue is unchanged: skip the write-back.
+			return db_weight.reads(1);
+		}
+
+		BoostedVaultTransactionExpiry::<T, I>::put(expiry_queue);
+
+		// Weight for the queue read and write-back plus the per-transaction
+		// BoostedVaultTransactions read/writes in the loop above.
+		db_weight
+			.reads_writes(1, 1)
+			.saturating_add(expire_weight_per_tx.saturating_mul(num_expired))
 	}
 
 	fn try_broadcast_rejection_refund(
@@ -2765,6 +2851,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				boost_fee,
 			) {
 				Ok(BoostOutcome { amounts, fees }) => {
+					// If it is a vault deposit, schedule its expiry so we can detect and clean up
+					// if the corresponding full witness never arrives. (Deposit channels
+					// don't need this — they are cleaned up via recycling.)
+					if let DepositOrigin::Vault { tx_id, .. } = &origin {
+						let expiry_height = Self::expiry_and_recycle_block_height().2;
+						BoostedVaultTransactionExpiry::<T, I>::mutate(|expiry_queue| {
+							expiry_queue.insert(tx_id.clone(), (expiry_height, asset));
+						});
+					}
+
 					let total_boost_fee: AssetAmount = fees.values().copied().sum();
 					let amount_after_boost_fee =
 						amount.saturating_sub(total_boost_fee.unique_saturated_into());
@@ -3308,7 +3404,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						_ => {},
 					}
 
-					BoostedVaultTransactions::<T, I>::take(&tx_id);
+					// The transaction is finalised and can no longer be lost, so drop its expiry
+					// entry (a no-op for a consumed pending boost, which has none scheduled).
+					BoostedVaultTransactionExpiry::<T, I>::mutate(|expiry_queue| {
+						expiry_queue.remove(&tx_id);
+					});
 				},
 			Err(reason) => {
 				Self::deposit_event(Event::<T, I>::DepositFailed {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -1013,13 +1013,13 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
-	/// Expirty blocks (in external chain's block height) of boosted vault transactions awaiting
+	/// Timeout blocks (in external chain's block height) of boosted vault transactions awaiting
 	/// full witnessing. Additionally stores the boosted asset required to finalise the boost.
 	///
 	/// Unlike deposit channels, vault swaps have no channel to recycle, so this is what guarantees
 	/// that a lost boosted deposit is correctly accounted for.
 	#[pallet::storage]
-	pub type BoostedVaultTransactionExpiry<T: Config<I>, I: 'static = ()> = StorageValue<
+	pub type BoostedVaultTransactionTimeout<T: Config<I>, I: 'static = ()> = StorageValue<
 		_,
 		BTreeMap<TransactionInIdFor<T, I>, (TargetChainBlockNumber<T, I>, TargetChainAsset<T, I>)>,
 		ValueQuery,
@@ -1265,6 +1265,8 @@ pub mod pallet {
 		fn on_idle(now: BlockNumberFor<T>, remaining_weight: Weight) -> Weight {
 			let mut used_weight = Weight::zero();
 
+			// Conservative external-chain progress height. It is not guaranteed to be
+			// current or reorg-safe, but is safe to use for channel/boost expiry.
 			let external_height = match TargetChainOf::<T, I>::get() {
 				ForeignChain::Arbitrum |
 				ForeignChain::Bitcoin |
@@ -1320,11 +1322,12 @@ pub mod pallet {
 			}
 
 			// For boosted vault deposits (which have no channel to recycle) we check for their
-			// expiry separately:
-			used_weight = used_weight.saturating_add(Self::expire_boosted_vault_transactions(
-				external_height,
-				remaining_weight.saturating_sub(used_weight),
-			));
+			// timeout separately:
+			used_weight =
+				used_weight.saturating_add(Self::process_timed_out_boosted_vault_transactions(
+					external_height,
+					remaining_weight.saturating_sub(used_weight),
+				));
 
 			if T::AllowTransactionReports::get() {
 				// A report gets cleaned up after approx 1 hour and needs to be re-reported by the
@@ -1907,9 +1910,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	/// Deems boosted vault swaps lost once their expiry height is reached, within the given weight
+	/// Deems boosted vault swaps lost once their timeout height is reached, within the given weight
 	/// budget (any remainder is retried on subsequent blocks). Returns the weight consumed.
-	fn expire_boosted_vault_transactions(
+	fn process_timed_out_boosted_vault_transactions(
 		current_height: TargetChainBlockNumber<T, I>,
 		available_weight: Weight,
 	) -> Weight {
@@ -1919,8 +1922,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		// out before touching storage again. This avoids writing an (empty) map back on every
 		// block, which for chains that never boost would otherwise create and rewrite a redundant
 		// storage entry indefinitely.
-		let mut expiry_queue = BoostedVaultTransactionExpiry::<T, I>::get();
-		if expiry_queue.is_empty() {
+		let mut timeout_queue = BoostedVaultTransactionTimeout::<T, I>::get();
+		if timeout_queue.is_empty() {
 			return db_weight.reads(1);
 		}
 
@@ -1934,16 +1937,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		// The map only holds in-flight boosts plus any not-yet-swept lost ones (finalised deposits
 		// are removed eagerly), so it stays small enough to scan in full for those whose expiry
 		// height has been reached, capped by the weight budget.
-		let due: Vec<_> = expiry_queue
+		let due: Vec<_> = timeout_queue
 			.iter()
-			.filter(|(_, (expiry_height, _))| *expiry_height <= current_height)
+			.filter(|(_, (timeout_height, _))| *timeout_height <= current_height)
 			.take(maximum_to_expire)
 			.map(|(tx_id, (_, asset))| (tx_id.clone(), *asset))
 			.collect();
 
 		let num_expired = due.len() as u64;
 		for (tx_id, asset) in due {
-			expiry_queue.remove(&tx_id);
+			timeout_queue.remove(&tx_id);
 
 			// A no-op if the transaction was fully witnessed (and thus finalised) before it
 			// expired. Otherwise release the reserved booster/lender liquidity.
@@ -1964,7 +1967,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			return db_weight.reads(1);
 		}
 
-		BoostedVaultTransactionExpiry::<T, I>::put(expiry_queue);
+		BoostedVaultTransactionTimeout::<T, I>::put(timeout_queue);
 
 		// Weight for the queue read and write-back plus the per-transaction
 		// BoostedVaultTransactions read/writes in the loop above.
@@ -2857,13 +2860,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				boost_fee,
 			) {
 				Ok(BoostOutcome { amounts, fees }) => {
-					// If it is a vault deposit, schedule its expiry so we can detect and clean up
+					// If it is a vault deposit, schedule its timeout so we can detect and clean up
 					// if the corresponding full witness never arrives. (Deposit channels
 					// don't need this — they are cleaned up via recycling.)
 					if let DepositOrigin::Vault { tx_id, .. } = &origin {
-						let expiry_height = Self::expiry_and_recycle_block_height().recycles_at;
-						BoostedVaultTransactionExpiry::<T, I>::mutate(|expiry_queue| {
-							expiry_queue.insert(tx_id.clone(), (expiry_height, asset));
+						let timeout_height = Self::expiry_and_recycle_block_height().recycles_at;
+						BoostedVaultTransactionTimeout::<T, I>::mutate(|timeout_queue| {
+							timeout_queue.insert(tx_id.clone(), (timeout_height, asset));
 						});
 					}
 
@@ -3410,10 +3413,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						_ => {},
 					}
 
-					// The transaction is finalised and can no longer be lost, so drop its expiry
+					// The transaction is finalised and can no longer be lost, so drop its timeout
 					// entry (a no-op for a consumed pending boost, which has none scheduled).
-					BoostedVaultTransactionExpiry::<T, I>::mutate(|expiry_queue| {
-						expiry_queue.remove(&tx_id);
+					BoostedVaultTransactionTimeout::<T, I>::mutate(|timeout_queue| {
+						timeout_queue.remove(&tx_id);
 					});
 				},
 			Err(reason) => {

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -78,6 +78,12 @@ pub use weights::WeightInfo;
 
 const MARKED_TX_EXPIRATION_BLOCKS: u32 = 3600 / SECONDS_PER_BLOCK as u32;
 
+struct ChannelLifecycle<T: Config<I>, I: 'static> {
+	opened_at: TargetChainBlockNumber<T, I>,
+	expires_at: TargetChainBlockNumber<T, I>,
+	recycles_at: TargetChainBlockNumber<T, I>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, Default)]
 pub enum BoostStatus<ChainAmount, BlockNumber> {
 	// If a (pre-witnessed) deposit on a channel has been boosted, we record
@@ -2855,7 +2861,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					// if the corresponding full witness never arrives. (Deposit channels
 					// don't need this — they are cleaned up via recycling.)
 					if let DepositOrigin::Vault { tx_id, .. } = &origin {
-						let expiry_height = Self::expiry_and_recycle_block_height().2;
+						let expiry_height = Self::expiry_and_recycle_block_height().recycles_at;
 						BoostedVaultTransactionExpiry::<T, I>::mutate(|expiry_queue| {
 							expiry_queue.insert(tx_id.clone(), (expiry_height, asset));
 						});
@@ -3422,9 +3428,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	fn expiry_and_recycle_block_height(
-	) -> (TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>, TargetChainBlockNumber<T, I>)
-	{
+	fn expiry_and_recycle_block_height() -> ChannelLifecycle<T, I> {
 		// Goals:
 		// 1. When chain tracking reaches a particular block number, we want to be able to process
 		//   that block immediately on the CFE.
@@ -3457,7 +3461,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		debug_assert!(current_height < expiry_height);
 		debug_assert!(expiry_height < recycle_height);
 
-		(current_height, expiry_height, recycle_height)
+		ChannelLifecycle {
+			opened_at: current_height,
+			expires_at: expiry_height,
+			recycles_at: recycle_height,
+		}
 	}
 
 	/// Generates a new deposit channel for the given asset
@@ -3544,12 +3552,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Ok::<_, DispatchError>(deposit_channel)
 		})?;
 
-		let (current_height, expiry_height, recycle_height) =
+		let ChannelLifecycle { opened_at, expires_at, recycles_at } =
 			Self::expiry_and_recycle_block_height();
 
 		if T::MANAGE_CHANNEL_LIFETIME {
 			DepositChannelRecycleBlocks::<T, I>::append((
-				recycle_height,
+				recycles_at,
 				deposit_channel.address.clone(),
 			));
 		}
@@ -3559,8 +3567,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			DepositChannelDetails {
 				owner: requester.clone(),
 				deposit_channel: deposit_channel.clone(),
-				opened_at: current_height,
-				expires_at: expiry_height,
+				opened_at,
+				expires_at,
 				action,
 				boost_fee,
 				boost_status: BoostStatus::NotBoosted,
@@ -3570,11 +3578,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		<T::IngressSource as IngressSource>::open_channel(
 			deposit_channel.address.clone(),
 			deposit_channel.asset,
-			expiry_height,
+			expires_at,
 			<frame_system::Pallet<T>>::block_number(),
 		)?;
 
-		Ok((deposit_channel, expiry_height, channel_opening_fee))
+		Ok((deposit_channel, expires_at, channel_opening_fee))
 	}
 
 	pub fn get_failed_call(broadcast_id: BroadcastId) -> Option<FailedForeignChainCall> {

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -581,7 +581,8 @@ fn addresses_are_getting_reused() {
 			channels
 		})
 		.then_execute_at_next_block(|channels| {
-			let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+			let recycle_block =
+				EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 			set_eth_processed_up_to(recycle_block);
 
 			channels[0].clone()
@@ -625,7 +626,7 @@ fn proof_address_pool_integrity() {
 		for broadcast_id in broadcast_ids {
 			EthereumIngressEgress::on_broadcast_success(broadcast_id, Default::default());
 		}
-		let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+		let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 		set_eth_processed_up_to(recycle_block);
 
 		EthereumIngressEgress::on_idle(1, Weight::MAX);
@@ -652,7 +653,7 @@ fn create_new_address_while_pool_is_empty() {
 		for broadcast_id in broadcast_ids {
 			EthereumIngressEgress::on_broadcast_success(broadcast_id, Default::default());
 		}
-		let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+		let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 		set_eth_processed_up_to(recycle_block);
 		EthereumIngressEgress::on_idle(1, Weight::MAX);
 
@@ -768,7 +769,7 @@ fn multi_deposit_includes_deposit_beyond_recycle_height() {
 			)
 			.unwrap();
 			let address: <Ethereum as Chain>::ChainAccount = address.try_into().unwrap();
-			let recycles_at = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+			let recycles_at = EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 			(address, recycles_at)
 		})
 		.then_execute_at_next_block(|(address, recycles_at)| {
@@ -871,7 +872,8 @@ fn multi_use_deposit_address_different_blocks() {
 				MockBalance::get_balance(&ALICE, ETH.into()) > 0,
 				"LP account hasn't earned fees!"
 			);
-			let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+			let recycle_block =
+				EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 			set_eth_processed_up_to(recycle_block);
 
 			deposit_address
@@ -1302,7 +1304,8 @@ fn channel_reuse_with_different_assets() {
 			);
 		})
 		.then_execute_at_next_block(|(_, channel_id, _)| {
-			let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+			let recycle_block =
+				EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 			set_eth_processed_up_to(recycle_block);
 			channel_id
 		})
@@ -1349,7 +1352,7 @@ fn ingress_finalisation_succeeds_after_channel_expired_but_not_recycled() {
 		request_address_and_deposit(ALICE, EthAsset::Eth);
 
 		// Because we're only *expiring* and not recycling, we should still be able to fetch.
-		let expiry_block = EthereumIngressEgress::expiry_and_recycle_block_height().1;
+		let expiry_block = EthereumIngressEgress::expiry_and_recycle_block_height().expires_at;
 		BlockHeightProvider::<MockEthereum>::set_block_height(expiry_block);
 
 		EthereumIngressEgress::on_idle(1, Weight::MAX);

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -610,9 +610,43 @@ fn taking_network_fee_from_boost_fee() {
 
 mod vault_swaps {
 	use super::*;
-	use crate::BoostedVaultTransactions;
+	use crate::{BoostedVaultTransactionExpiry, BoostedVaultTransactions};
 	use cf_chains::AccountOrAddress;
+	use cf_test_utilities::assert_no_matching_event;
 	use cf_traits::{PriceLimitsAndExpiry, SwapOutputAction};
+	use sp_core::H256;
+
+	fn boostable_vault_deposit(
+		tx_id: H256,
+		deposit_amount: AssetAmount,
+	) -> VaultDepositWitness<Test, Instance1> {
+		let output_address = ForeignChainAddress::Eth([1; 20].into());
+		VaultDepositWitness {
+			input_asset: Asset::Eth.try_into().unwrap(),
+			deposit_address: Some([1; 20].into()),
+			channel_id: Some(1),
+			deposit_amount,
+			deposit_details: Default::default(),
+			output_asset: Asset::Flip,
+			destination_address: MockAddressConverter::to_encoded_address(output_address),
+			deposit_metadata: None,
+			tx_id,
+			broker_fee: Some(Beneficiary { account: BROKER, bps: 5 }),
+			affiliate_fees: Default::default(),
+			refund_params: ChannelRefundParametersForChain::<Ethereum> {
+				retry_duration: 2,
+				refund_address: [2; 20].into(),
+				min_price: Default::default(),
+				refund_ccm_metadata: Default::default(),
+				max_oracle_price_slippage: Default::default(),
+			},
+			dca_params: Some(DcaParameters {
+				number_of_chunks: 1,
+				chunk_interval: SWAP_DELAY_BLOCKS,
+			}),
+			boost_fee: 5,
+		}
+	}
 
 	#[test]
 	fn vault_swap_boosting() {
@@ -621,7 +655,6 @@ mod vault_swaps {
 			let output_address = ForeignChainAddress::Eth([1; 20].into());
 
 			let block_height = 10;
-			let deposit_address = [1; 20].into();
 
 			const DEPOSIT_AMOUNT: AssetAmount = 100_000_000;
 			const INPUT_ASSET: Asset = Asset::Eth;
@@ -642,33 +675,7 @@ mod vault_swaps {
 			// Initially tx is not recorded as boosted
 			assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
 
-			let deposit = VaultDepositWitness {
-				input_asset: INPUT_ASSET.try_into().unwrap(),
-				deposit_address: Some(deposit_address),
-				channel_id: Some(CHANNEL_ID),
-				deposit_amount: DEPOSIT_AMOUNT,
-				deposit_details: Default::default(),
-				output_asset: OUTPUT_ASSET,
-				destination_address: MockAddressConverter::to_encoded_address(
-					output_address.clone(),
-				),
-				deposit_metadata: None,
-				tx_id,
-				broker_fee: Some(Beneficiary { account: BROKER, bps: 5 }),
-				affiliate_fees: Default::default(),
-				refund_params: ChannelRefundParametersForChain::<Ethereum> {
-					retry_duration: 2,
-					refund_address: [2; 20].into(),
-					min_price: Default::default(),
-					refund_ccm_metadata: Default::default(),
-					max_oracle_price_slippage: Default::default(),
-				},
-				dca_params: Some(DcaParameters {
-					number_of_chunks: 1,
-					chunk_interval: SWAP_DELAY_BLOCKS,
-				}),
-				boost_fee: 5,
-			};
+			let deposit = boostable_vault_deposit(tx_id, DEPOSIT_AMOUNT);
 
 			// Prewitnessing a deposit for the first time should result in a boost:
 			{
@@ -814,6 +821,86 @@ mod vault_swaps {
 				assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
 			}
 		});
+	}
+
+	#[test]
+	fn boosted_vault_swap_is_deemed_lost_on_timeout() {
+		const DEPOSIT_AMOUNT: AssetAmount = 100_000_000;
+		const PREWITNESS_DEPOSIT_ID: PrewitnessedDepositId = PrewitnessedDepositId(1);
+		let tx_id = [9u8; 32].into();
+
+		new_test_ext()
+			.execute_with(|| {
+				MockAssetConverter::set_price(Asset::Flip, Asset::Eth, 1);
+				setup();
+				MockBoostApi::set_available_amount(DEPOSIT_AMOUNT * 10);
+
+				// Boosting a vault swap via prewitness schedules it for expiry:
+				EthereumIngressEgress::process_vault_swap_request_prewitness(
+					10,
+					boostable_vault_deposit(tx_id, DEPOSIT_AMOUNT),
+				);
+				assert!(MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
+				assert!(BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
+				assert!(
+					BoostedVaultTransactionExpiry::<Test, Instance1>::get().contains_key(&tx_id)
+				);
+			})
+			.then_execute_at_next_block(|_| {
+				// The deposit is never fully witnessed. Raise the processed height to its expiry
+				// so that on_idle (run at the end of this block) deems it lost:
+				let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+				set_eth_processed_up_to(recycle_block);
+			})
+			.then_execute_with(|_| {
+				assert!(!MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
+				assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
+				assert!(BoostedVaultTransactionExpiry::<Test, Instance1>::get().is_empty());
+
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::EthereumIngressEgress(Event::BoostedDepositLost {
+						prewitnessed_deposit_id: PREWITNESS_DEPOSIT_ID,
+						amount: DEPOSIT_AMOUNT,
+					})
+				);
+			});
+	}
+
+	#[test]
+	fn finalising_boosted_vault_swap_removes_expiry_entry() {
+		const DEPOSIT_AMOUNT: AssetAmount = 100_000_000;
+		let tx_id = [9u8; 32].into();
+
+		new_test_ext()
+			.execute_with(|| {
+				MockAssetConverter::set_price(Asset::Flip, Asset::Eth, 1);
+				setup();
+				MockBoostApi::set_available_amount(DEPOSIT_AMOUNT * 10);
+
+				let deposit = boostable_vault_deposit(tx_id, DEPOSIT_AMOUNT);
+				EthereumIngressEgress::process_vault_swap_request_prewitness(10, deposit.clone());
+				assert!(
+					BoostedVaultTransactionExpiry::<Test, Instance1>::get().contains_key(&tx_id)
+				);
+
+				// Fully witnessing the boosted deposit finalises the boost and eagerly removes
+				// the expiry entry, without waiting for the timeout:
+				EthereumIngressEgress::process_vault_swap_request_full_witness_inner(10, deposit);
+				assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
+				assert!(BoostedVaultTransactionExpiry::<Test, Instance1>::get().is_empty());
+			})
+			.then_execute_at_next_block(|_| {
+				// Reaching the would-be expiry height must not deem the finalised deposit lost:
+				let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+				set_eth_processed_up_to(recycle_block);
+			})
+			.then_execute_with(|_| {
+				assert_no_matching_event!(
+					Test,
+					RuntimeEvent::EthereumIngressEgress(Event::BoostedDepositLost { .. })
+				);
+			});
 	}
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -412,7 +412,8 @@ fn lost_funds_are_acknowledged_by_boost_pool() {
 		// When the channel expires, the record holding amounts owed to boosters
 		// from the deposit is cleared:
 		{
-			let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+			let recycle_block =
+				EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 			set_eth_processed_up_to(recycle_block);
 			EthereumIngressEgress::on_idle(recycle_block, Weight::MAX);
 
@@ -847,9 +848,20 @@ mod vault_swaps {
 				);
 			})
 			.then_execute_at_next_block(|_| {
+				// Raise the processed height just before to its expiry to make sure we haven't
+				// processed it as lost prematurely:
+				let recycle_block =
+					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
+				set_eth_processed_up_to(recycle_block - 1);
+			})
+			.then_execute_with(|_| {
+				assert!(MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
+			})
+			.then_execute_at_next_block(|_| {
 				// The deposit is never fully witnessed. Raise the processed height to its expiry
 				// so that on_idle (run at the end of this block) deems it lost:
-				let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+				let recycle_block =
+					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 				set_eth_processed_up_to(recycle_block);
 			})
 			.then_execute_with(|_| {
@@ -892,7 +904,8 @@ mod vault_swaps {
 			})
 			.then_execute_at_next_block(|_| {
 				// Reaching the would-be expiry height must not deem the finalised deposit lost:
-				let recycle_block = EthereumIngressEgress::expiry_and_recycle_block_height().2;
+				let recycle_block =
+					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 				set_eth_processed_up_to(recycle_block);
 			})
 			.then_execute_with(|_| {

--- a/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests/boost.rs
@@ -611,7 +611,7 @@ fn taking_network_fee_from_boost_fee() {
 
 mod vault_swaps {
 	use super::*;
-	use crate::{BoostedVaultTransactionExpiry, BoostedVaultTransactions};
+	use crate::{BoostedVaultTransactionTimeout, BoostedVaultTransactions};
 	use cf_chains::AccountOrAddress;
 	use cf_test_utilities::assert_no_matching_event;
 	use cf_traits::{PriceLimitsAndExpiry, SwapOutputAction};
@@ -836,7 +836,7 @@ mod vault_swaps {
 				setup();
 				MockBoostApi::set_available_amount(DEPOSIT_AMOUNT * 10);
 
-				// Boosting a vault swap via prewitness schedules it for expiry:
+				// Boosting a vault swap via prewitness schedules its timeout:
 				EthereumIngressEgress::process_vault_swap_request_prewitness(
 					10,
 					boostable_vault_deposit(tx_id, DEPOSIT_AMOUNT),
@@ -844,30 +844,29 @@ mod vault_swaps {
 				assert!(MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
 				assert!(BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
 				assert!(
-					BoostedVaultTransactionExpiry::<Test, Instance1>::get().contains_key(&tx_id)
+					BoostedVaultTransactionTimeout::<Test, Instance1>::get().contains_key(&tx_id)
 				);
 			})
 			.then_execute_at_next_block(|_| {
-				// Raise the processed height just before to its expiry to make sure we haven't
+				// Raise the processed height just before its timeout to make sure we haven't
 				// processed it as lost prematurely:
-				let recycle_block =
-					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
-				set_eth_processed_up_to(recycle_block - 1);
+				let timeout_height =
+					BoostedVaultTransactionTimeout::<Test, Instance1>::get().get(&tx_id).unwrap().0;
+				set_eth_processed_up_to(timeout_height - 1);
+				timeout_height
 			})
-			.then_execute_with(|_| {
+			.then_execute_with_keep_context(|_| {
 				assert!(MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
 			})
-			.then_execute_at_next_block(|_| {
-				// The deposit is never fully witnessed. Raise the processed height to its expiry
+			.then_execute_at_next_block(|timeout_height| {
+				// The deposit is never fully witnessed. Raise the processed height to its timeout
 				// so that on_idle (run at the end of this block) deems it lost:
-				let recycle_block =
-					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
-				set_eth_processed_up_to(recycle_block);
+				set_eth_processed_up_to(timeout_height);
 			})
 			.then_execute_with(|_| {
 				assert!(!MockBoostApi::is_deposit_boosted(PREWITNESS_DEPOSIT_ID));
 				assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
-				assert!(BoostedVaultTransactionExpiry::<Test, Instance1>::get().is_empty());
+				assert!(BoostedVaultTransactionTimeout::<Test, Instance1>::get().is_empty());
 
 				assert_has_matching_event!(
 					Test,
@@ -893,17 +892,17 @@ mod vault_swaps {
 				let deposit = boostable_vault_deposit(tx_id, DEPOSIT_AMOUNT);
 				EthereumIngressEgress::process_vault_swap_request_prewitness(10, deposit.clone());
 				assert!(
-					BoostedVaultTransactionExpiry::<Test, Instance1>::get().contains_key(&tx_id)
+					BoostedVaultTransactionTimeout::<Test, Instance1>::get().contains_key(&tx_id)
 				);
 
 				// Fully witnessing the boosted deposit finalises the boost and eagerly removes
-				// the expiry entry, without waiting for the timeout:
+				// the timeout entry, without waiting for the timeout:
 				EthereumIngressEgress::process_vault_swap_request_full_witness_inner(10, deposit);
 				assert!(!BoostedVaultTransactions::<Test, Instance1>::contains_key(tx_id));
-				assert!(BoostedVaultTransactionExpiry::<Test, Instance1>::get().is_empty());
+				assert!(BoostedVaultTransactionTimeout::<Test, Instance1>::get().is_empty());
 			})
 			.then_execute_at_next_block(|_| {
-				// Reaching the would-be expiry height must not deem the finalised deposit lost:
+				// Reaching the would-be timeout height must not deem the finalised deposit lost:
 				let recycle_block =
 					EthereumIngressEgress::expiry_and_recycle_block_height().recycles_at;
 				set_eth_processed_up_to(recycle_block);


### PR DESCRIPTION
# Pull Request

Closes: PRO-2965

## Summary

Now if a boosted vault depost is lost we will correctly finalise/acknowledge this like we already do for deposit channels.

- Added `BoostedVaultTransactionExpiry` storage to keep track of each boosted deposit's expiration (decided against merging it with `BoostedVaultTransactions` to avoid migrating storage and some other unwanted side effects).
- `on_idle` checks `BoostedVaultTransactionExpiry` to see if any boost "exire" and need to be cleaned up (boost liftetime is the same as in deposit channels, uses target chain's block height).
- Successful finalisation eagerly removes no longer requried entries from `BoostedVaultTransactionExpiry`.
- All codes paths are tested (boosted -> finalised, boosted -> expired).

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
