### PR TITLE
fix: cf_lp_total_balances no longer double counts supply funds

### DIFF
--- a/state-chain/cf-integration-tests/src/lending.rs
+++ b/state-chain/cf-integration-tests/src/lending.rs
@@ -168,3 +168,84 @@ fn basic_lending() {
 			);
 		});
 }
+
+/// `cf_lp_total_balances` should correctly sum an LP's holdings across every balance category
+/// (free, open orders, boost pools, trading strategies and lending supply/collateral). This is
+/// a regression test for PRO-2985 where supply and collateral added separately despite one already
+/// being included in the other.
+#[test]
+fn lp_total_balances_sums_all_categories() {
+	use std::collections::BTreeMap;
+
+	use pallet_cf_lending_pools::{BoostPoolId, BOOST_FEE};
+	use state_chain_runtime::runtime_apis::custom_api::runtime_decl_for_custom_runtime_api::CustomRuntimeApi;
+
+	type TradingStrategyPallet = state_chain_runtime::TradingStrategy;
+	use pallet_cf_trading_strategy::TradingStrategy as Strategy;
+
+	const LP: AccountId = AccountId::new([0xf8; 32]);
+
+	const ASSET: Asset = Asset::Eth;
+	const FREE_AMOUNT: AssetAmount = 100_000_000_000;
+	const ORDER_AMOUNT: AssetAmount = 200_000_000_000;
+	const BOOST_AMOUNT: AssetAmount = 400_000_000_000;
+	const STRATEGY_AMOUNT: AssetAmount = 800_000_000_000;
+	const SUPPLY_AMOUNT: AssetAmount = 1_600_000_000_000;
+	const EXPECTED_TOTAL: AssetAmount =
+		FREE_AMOUNT + ORDER_AMOUNT + BOOST_AMOUNT + STRATEGY_AMOUNT + SUPPLY_AMOUNT;
+
+	super::genesis::with_test_defaults()
+		.with_additional_accounts(&[(LP, AccountRole::LiquidityProvider, 5 * FLIPPERINOS_PER_FLIP)])
+		.build()
+		.execute_with(|| {
+			ChainlinkOracle::set_price(ASSET, Price::at_tick_zero());
+			register_refund_addresses(&LP);
+			new_pool(ASSET, 0, Price::at_tick_zero());
+
+			// Free balance: credit and leave untouched.
+			credit_account(&LP, ASSET, FREE_AMOUNT);
+
+			// Open a limit order.
+			credit_account(&LP, ASSET, ORDER_AMOUNT);
+			set_limit_order(&LP, ASSET, Asset::Usdc, 0, Some(0), ORDER_AMOUNT);
+
+			// Boost pool contribution.
+			assert_ok!(LendingPools::create_boost_pools(
+				pallet_cf_governance::RawOrigin::GovernanceApproval.into(),
+				vec![BoostPoolId { asset: ASSET, tier: BOOST_FEE }],
+			));
+			credit_account(&LP, ASSET, BOOST_AMOUNT);
+			assert_ok!(LendingPools::add_boost_funds(
+				RuntimeOrigin::signed(LP),
+				ASSET,
+				BOOST_AMOUNT,
+				BOOST_FEE,
+			));
+
+			// Trading strategy funds.
+			let no_threshold = BTreeMap::from_iter([(ASSET, 0), (Asset::Usdc, 0)]);
+			pallet_cf_trading_strategy::MinimumDeploymentAmountForStrategy::<Runtime>::set(
+				no_threshold.clone(),
+			);
+			pallet_cf_trading_strategy::MinimumAddedFundsToStrategy::<Runtime>::set(no_threshold);
+			credit_account(&LP, ASSET, STRATEGY_AMOUNT);
+			assert_ok!(TradingStrategyPallet::deploy_strategy(
+				RuntimeOrigin::signed(LP),
+				Strategy::TickZeroCentered { spread_tick: 1, base_asset: ASSET },
+				BTreeMap::from_iter([(ASSET, STRATEGY_AMOUNT)]),
+			));
+
+			// Lending supply (reported as collateral).
+			assert_ok!(LendingPools::new_lending_pool(ASSET));
+			credit_account(&LP, ASSET, SUPPLY_AMOUNT);
+			assert_ok!(LendingPools::add_lender_funds(
+				RuntimeOrigin::signed(LP),
+				ASSET,
+				SUPPLY_AMOUNT,
+			));
+
+			// The total must be the sum of every category, each counted exactly once.
+			let totals = Runtime::cf_lp_total_balances(LP);
+			assert_eq!(totals[ASSET], EXPECTED_TOTAL);
+		});
+}

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -40,8 +40,10 @@ pub use general_lending::config::{
 	NetworkFeeContributions,
 };
 
-pub use boost::{boost_pools_iter, get_boost_pool_details, BoostPoolDetails, OwedAmount};
-use boost::{BoostPool, BoostPoolId};
+use boost::BoostPool;
+pub use boost::{
+	boost_pools_iter, get_boost_pool_details, BoostPoolDetails, BoostPoolId, OwedAmount, BOOST_FEE,
+};
 
 pub mod migrations;
 pub mod weights;
@@ -78,7 +80,7 @@ use cf_runtime_utilities::log_or_panic;
 use frame_system::pallet_prelude::*;
 use weights::WeightInfo;
 
-use crate::{boost::BOOST_FEE, core_lending_pool::CoreLendingPool};
+use crate::core_lending_pool::CoreLendingPool;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	vec,

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -777,16 +777,8 @@ impl_runtime_apis! {
 				asset_map
 			};
 
-			let lending_supply_balances = AssetMap::from_fn(|asset| {
-
-				pallet_cf_lending_pools::GeneralLendingPools::<Runtime>::get(asset).and_then(|pool| {
-
-					pool.get_supply_position_for_account(&account_id).ok()
-
-				}).unwrap_or_default()
-
-			});
-
+			// Note that we don't add supply balances since they are already included
+			// in collateral.
 			let lending_collateral_balances = {
 				let mut asset_map = AssetMap::<AssetAmount>::default();
 
@@ -799,12 +791,10 @@ impl_runtime_apis! {
 				asset_map
 			};
 
-
 			free_balances
 				.saturating_add(open_order_balances)
 				.saturating_add(boost_pools_balances)
 				.saturating_add(trading_strategies_balances)
-				.saturating_add(lending_supply_balances)
 				.saturating_add(lending_collateral_balances)
 		}
 		fn cf_account_flip_balance(account_id: &AccountId) -> u128 {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2985

## Summary

A one line fix (removed the explicit `lending_supply_balances`, it is already a part of `lending_collateral_balances`) and a regression test.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [x] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
