### PR TITLE
Feat/distribute batch

### DIFF
--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -34,7 +34,6 @@ pub mod migrations;
 mod mock;
 mod tests;
 
-use cf_traits::EpochInfo;
 use frame_support::{
 	sp_runtime::{
 		traits::{AtLeast32BitUnsigned, UniqueSaturatedInto, Zero},

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -21,7 +21,7 @@
 use cf_chains::{eth::api::StateChainGatewayAddressProvider, UpdateFlipSupply};
 use cf_primitives::{AssetAmount, EgressId};
 use cf_traits::{
-	impl_pallet_safe_mode, Broadcaster, EgressApi, FlipBurnOrMoveInfo, Issuance,
+	impl_pallet_safe_mode, Broadcaster, EgressApi, EpochInfo, FlipBurnOrMoveInfo, Issuance,
 	RewardsDistribution, ScheduledEgressDetails,
 };
 use codec::MaxEncodedLen;
@@ -355,7 +355,11 @@ impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>>
 				epoch_index,
 				reward_amount,
 				&author,
-				T::Issuance::mint,
+				|account, amount| {
+					if !amount.is_zero() {
+						T::Issuance::mint(account, amount);
+					}
+				},
 			);
 		}
 	}

--- a/state-chain/pallets/cf-emissions/src/mock.rs
+++ b/state-chain/pallets/cf-emissions/src/mock.rs
@@ -163,6 +163,14 @@ impl RewardsDistribution for FlipDistribution {
 	) {
 		pallet_cf_flip::FlipIssuance::<Test>::mint(beneficiary, reward_amount);
 	}
+
+	fn distribute_all(
+		_epoch_index: cf_primitives::EpochIndex,
+		_total_amount: Self::Balance,
+		_settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
+		unimplemented!("not used by the emissions pallet");
+	}
 }
 
 impl pallet_cf_emissions::Config for Test {

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -557,10 +557,7 @@ impl<T: Config> Pallet<T> {
 			.offset(Self::deposit_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount));
 	}
 
-	pub fn trigger_flip_reward_distribution(
-		epoch_index: EpochIndex,
-		authorities: BTreeSet<T::AccountId>,
-	) -> T::Balance {
+	pub fn trigger_flip_reward_distribution(epoch_index: EpochIndex) -> T::Balance {
 		// Bridge in any pending offchain rewards and deposit them into the distribution reserve so
 		// that everything is distributed from a single source.
 		let offchain_flip_to_distribute = FlipToDistribute::<T>::take();
@@ -580,7 +577,6 @@ impl<T: Config> Pallet<T> {
 		T::RewardsDistribution::distribute_all(
 			epoch_index,
 			Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID),
-			&authorities,
 			|account, amount| {
 				// Skip zero-value settlements: `distribute_all` calls this for every reward-pool
 				// participant, including ones with nothing due; avoid the wasted withdrawal/event

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -56,11 +56,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use on_charge_transaction::CallIndexFor;
-use sp_std::{
-	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
-	marker::PhantomData,
-	prelude::*,
-};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
 
 pub use pallet::*;
 
@@ -580,32 +576,29 @@ impl<T: Config> Pallet<T> {
 			Zero::zero()
 		};
 
-		// Distribute evenly from the combined reserve. Any remainder stays for the next epoch.
-		let per_authority_reward = Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID) /
-			(authorities.len() as u128).into();
-
 		let mut flip_distributed_map = BTreeMap::new();
-		for authority in &authorities {
-			T::RewardsDistribution::distribute(
-				epoch_index,
-				per_authority_reward,
-				authority,
-				|account, amount| {
-					Pallet::<T>::settle(
-						account,
-						Pallet::<T>::withdraw_reserves(
-							ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID,
-							amount,
-						)
+		T::RewardsDistribution::distribute_all(
+			epoch_index,
+			Reserve::<T>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID),
+			&authorities,
+			|account, amount| {
+				// Skip zero-value settlements: `distribute_all` calls this for every reward-pool
+				// participant, including ones with nothing due; avoid the wasted withdrawal/event
+				// noise here rather than baking that policy into the shared distribution logic.
+				if amount.is_zero() {
+					return;
+				}
+				Pallet::<T>::settle(
+					account,
+					Pallet::<T>::withdraw_reserves(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID, amount)
 						.into(),
-					);
-					flip_distributed_map
-						.entry(account.clone())
-						.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
-						.or_insert(amount);
-				},
-			);
-		}
+				);
+				flip_distributed_map
+					.entry(account.clone())
+					.and_modify(|e: &mut T::Balance| *e = e.saturating_add(amount))
+					.or_insert(amount);
+			},
+		);
 
 		Self::deposit_event(Event::FlipDistributed {
 			amounts: flip_distributed_map.into_iter().collect(),

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -736,7 +736,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
@@ -762,7 +763,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(1i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(201u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// All authorities get the same truncated share — no winner receives the remainder
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
@@ -785,7 +787,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// Only onchain: 100 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -808,7 +811,8 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
-			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 
 			// 100 offchain each, 0 onchain
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -838,7 +842,8 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
 
-			let bridged = Flip::trigger_flip_reward_distribution(0, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(0, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(0);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 0);
 
@@ -856,7 +861,8 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), AMOUNT);
 
-			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+			MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+			let bridged = Flip::trigger_flip_reward_distribution(1);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
@@ -904,7 +910,8 @@ mod test_flip_reward_distribution {
 
 				let total_funds_before = total_funds();
 
-				let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
+				MockRewardsDistribution::<Test>::set_beneficiaries(1, vec![ALICE, BOB, CHARLIE]);
+				let bridged = Flip::trigger_flip_reward_distribution(1);
 
 				// Distribution only moves funds between the reserve, validator balances, and the
 				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.

--- a/state-chain/pallets/cf-flip/src/tests.rs
+++ b/state-chain/pallets/cf-flip/src/tests.rs
@@ -736,10 +736,7 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 
 			// 300 offchain bridged in + 300 onchain = 600 total; 600 / 3 = 200 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 200);
@@ -765,10 +762,7 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(1i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(201u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 
 			// All authorities get the same truncated share — no winner receives the remainder
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 67);
@@ -791,10 +785,7 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(-100i128);
 			<Flip as FeePayment>::burn_or_reserve_offchain(300u128);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 
 			// Only onchain: 100 each
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -817,10 +808,7 @@ mod test_flip_reward_distribution {
 			Flip::add_to_offchain_flip_to_be_distributed(300i128);
 			// Reserve not set → defaults to 0
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 
 			// 100 offchain each, 0 onchain
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
@@ -850,10 +838,7 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), 0);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				0,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(0, vec![ALICE, BOB, CHARLIE]);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 0);
 
@@ -871,10 +856,7 @@ mod test_flip_reward_distribution {
 			assert_eq!(OffchainFunds::<Test>::get(), offchain_before - AMOUNT);
 			assert_eq!(Reserve::<Test>::get(ONCHAIN_FLIP_TO_DISTRIBUTE_RESERVE_ID), AMOUNT);
 
-			let bridged = Flip::trigger_flip_reward_distribution(
-				1,
-				BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-			);
+			let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 			assert_eq!(bridged, 0);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&ALICE), 100);
 			assert_eq!(MockRewardsDistribution::<Test>::get_assigned_rewards(&BOB), 100);
@@ -922,10 +904,7 @@ mod test_flip_reward_distribution {
 
 				let total_funds_before = total_funds();
 
-				let bridged = Flip::trigger_flip_reward_distribution(
-					1,
-					BTreeSet::from_iter([ALICE, BOB, CHARLIE]),
-				);
+				let bridged = Flip::trigger_flip_reward_distribution(1, vec![ALICE, BOB, CHARLIE]);
 
 				// Distribution only moves funds between the reserve, validator balances, and the
 				// FlipToDistribute offchain-accounting offset - no funds are created or destroyed.

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -370,34 +370,47 @@ where
 		total_amount: Self::Balance,
 		mut settle: impl FnMut(&T::AccountId, T::Amount),
 	) {
-		let beneficiaries = HistoricalAuthorities::<T>::get(epoch_index);
-		if beneficiaries.is_empty() {
+		let mut authorities_to_reward: BTreeSet<T::AccountId> =
+			HistoricalAuthorities::<T>::get(epoch_index)
+				.into_iter()
+				.map(Into::into)
+				.collect();
+		if authorities_to_reward.is_empty() {
 			return;
 		}
-		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
+		let per_authority_amount = total_amount / (authorities_to_reward.len() as u32).into();
+		let bond = HistoricalBonds::<T>::get(epoch_index);
 
-		// `snapshot.validators` is exactly this operator's set of `epoch_index` authorities
-		// (it's the source `ValidatorToOperator` is populated from at registration), so the
-		// snapshot alone tells us both which operators have authorities this epoch and how
-		// many - no per-authority `ValidatorToOperator` lookup needed.
-		let mut rewarded: BTreeSet<T::AccountId> = BTreeSet::new();
-		for (_operator, snapshot) in DelegationSnapshots::<T>::iter_prefix(epoch_index) {
-			let count = snapshot.validators.len() as u32;
-			if count == 0 {
+		// Snapshots are registered for *all* operators at auction resolution, including those
+		// whose pooled stake didn't clear the bond: their last remaining validator is never
+		// demoted to delegator, so `snapshot.validators` can contain a non-authority. Only
+		// authority validators earn a share of the rewards. `remove` doubles as the membership
+		// check, draining `authorities` so that only independent (operator-less) authorities
+		// remain for the loop below.
+		for (operator, snapshot) in DelegationSnapshots::<T>::iter_prefix(epoch_index) {
+			let authority_count =
+				snapshot.validators.keys().filter(|v| authorities_to_reward.remove(*v)).count()
+					as u32;
+			if authority_count == 0 {
 				continue;
 			}
-			rewarded.extend(snapshot.validators.keys().cloned());
-			let total = per_beneficiary_amount.saturating_mul(count.into());
+			if (authority_count as usize) < snapshot.validators.len() {
+				// The auction fixed point guarantees a snapshot's validators are all-in or
+				// all-out of the authority set; a mixed snapshot means that invariant broke.
+				cf_runtime_utilities::log_or_panic!(
+					"Delegation snapshot of operator {:?} for epoch {} contains non-authority validators.",
+					operator,
+					epoch_index
+				);
+			}
+			let total = per_authority_amount.saturating_mul(authority_count.into());
 			snapshot
-				.distribute(total, HistoricalBonds::<T>::get(epoch_index))
+				.distribute(total, bond)
 				.for_each(|(account, amount)| settle(account, amount));
 		}
 
-		for beneficiary in &beneficiaries {
-			let beneficiary = beneficiary.into_ref();
-			if !rewarded.contains(beneficiary) {
-				settle(beneficiary, per_beneficiary_amount);
-			}
+		for authority in &authorities_to_reward {
+			settle(authority, per_authority_amount);
 		}
 	}
 }

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-	AuctionOutcome, Config, DelegationSnapshots, HistoricalBonds, Pallet, ValidatorToOperator,
+	AuctionOutcome, Config, DelegationSnapshots, HistoricalAuthorities, HistoricalBonds, Pallet,
+	ValidatorToOperator,
 };
 use cf_primitives::EpochIndex;
 use cf_traits::{EpochInfo, RewardsDistribution, Slashing};
@@ -364,14 +365,12 @@ where
 		distribute::<T>(epoch_index, beneficiary, reward_amount, settle);
 	}
 
-	/// `beneficiaries` must be exactly `epoch_index`'s full authority set. For a partial
-	/// set, call `distribute` directly per beneficiary instead.
 	fn distribute_all(
 		epoch_index: EpochIndex,
 		total_amount: Self::Balance,
-		beneficiaries: &[Self::AccountId],
 		mut settle: impl FnMut(&T::AccountId, T::Amount),
 	) {
+		let beneficiaries = HistoricalAuthorities::<T>::get(epoch_index);
 		if beneficiaries.is_empty() {
 			return;
 		}
@@ -394,7 +393,8 @@ where
 				.for_each(|(account, amount)| settle(account, amount));
 		}
 
-		for beneficiary in beneficiaries {
+		for beneficiary in &beneficiaries {
+			let beneficiary = beneficiary.into_ref();
 			if !rewarded.contains(beneficiary) {
 				settle(beneficiary, per_beneficiary_amount);
 			}
@@ -537,7 +537,7 @@ mod tests {
 			let delegators: BTreeMap<ValidatorId, u128> = delegator_amounts.iter().enumerate()
 				.map(|(i, amount)| (i as u64 + 1000, *amount * FLIPPERINOS_PER_FLIP))
 				.collect();
-			// Every validator in the snapshot is a beneficiary this epoch - the precondition
+			// Every validator in the snapshot is an authority this epoch - the invariant
 			// `distribute_all` relies on to derive authority counts from the snapshot alone.
 			let beneficiaries: Vec<ValidatorId> = validators.keys().cloned().collect();
 			// Constructed as an exact multiple of beneficiaries.len() so the internal division
@@ -546,6 +546,7 @@ mod tests {
 
 			new_test_ext().execute_with(|| {
 				crate::HistoricalBonds::<Test>::insert(EPOCH, bond);
+				crate::HistoricalAuthorities::<Test>::insert(EPOCH, &beneficiaries);
 
 				DelegationSnapshot::<ValidatorId, u128> {
 					operator: operator_account,
@@ -558,7 +559,6 @@ mod tests {
 				DelegatedRewardsDistribution::<Test>::distribute_all(
 					EPOCH,
 					total_amount,
-					&beneficiaries,
 					|account, amount| {
 						settled.entry(*account).and_modify(|a| *a += amount).or_insert(amount);
 					},

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -13,19 +13,25 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::{AuctionOutcome, Config, DelegationSnapshots, Pallet, ValidatorToOperator};
+use crate::{
+	AuctionOutcome, Config, DelegationSnapshots, HistoricalBonds, Pallet, ValidatorToOperator,
+};
 use cf_primitives::EpochIndex;
 use cf_traits::{EpochInfo, RewardsDistribution, Slashing};
 use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;
 use frame_support::{
-	sp_runtime::{traits::AtLeast32BitUnsigned, Perquintill},
+	sp_runtime::{traits::AtLeast32BitUnsigned, Perquintill, Saturating},
 	traits::IsType,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData, prelude::*};
+use sp_std::{
+	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
+	marker::PhantomData,
+	prelude::*,
+};
 
 pub const DEFAULT_MIN_OPERATOR_FEE: u32 = 1_500;
 pub const MAX_OPERATOR_FEE: u32 = 10_000;
@@ -357,6 +363,43 @@ where
 	) {
 		distribute::<T>(epoch_index, beneficiary, reward_amount, settle);
 	}
+
+	/// `beneficiaries` must be exactly `epoch_index`'s full authority set. For a partial
+	/// set, call `distribute` directly per beneficiary instead.
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		beneficiaries: &[Self::AccountId],
+		mut settle: impl FnMut(&T::AccountId, T::Amount),
+	) {
+		if beneficiaries.is_empty() {
+			return;
+		}
+		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
+
+		// `snapshot.validators` is exactly this operator's set of `epoch_index` authorities
+		// (it's the source `ValidatorToOperator` is populated from at registration), so the
+		// snapshot alone tells us both which operators have authorities this epoch and how
+		// many - no per-authority `ValidatorToOperator` lookup needed.
+		let mut rewarded: BTreeSet<T::AccountId> = BTreeSet::new();
+		for (_operator, snapshot) in DelegationSnapshots::<T>::iter_prefix(epoch_index) {
+			let count = snapshot.validators.len() as u32;
+			if count == 0 {
+				continue;
+			}
+			rewarded.extend(snapshot.validators.keys().cloned());
+			let total = per_beneficiary_amount.saturating_mul(count.into());
+			snapshot
+				.distribute(total, HistoricalBonds::<T>::get(epoch_index))
+				.for_each(|(account, amount)| settle(account, amount));
+		}
+
+		for beneficiary in beneficiaries {
+			if !rewarded.contains(beneficiary) {
+				settle(beneficiary, per_beneficiary_amount);
+			}
+		}
+	}
 }
 
 pub struct DelegationSlasher<T, S>(PhantomData<(T, S)>);
@@ -404,11 +447,9 @@ pub fn distribute<T: Config>(
 
 	if let Some(operator) = ValidatorToOperator::<T>::get(epoch_index, validator) {
 		if let Some(snapshot) = DelegationSnapshots::<T>::get(epoch_index, &operator) {
-			snapshot.distribute(total, Pallet::<T>::bond()).for_each(|(account, amount)| {
-				if amount > Zero::zero() {
-					settle(account, amount);
-				}
-			});
+			snapshot
+				.distribute(total, HistoricalBonds::<T>::get(epoch_index))
+				.for_each(|(account, amount)| settle(account, amount));
 		} else {
 			settle(validator, total);
 			cf_runtime_utilities::log_or_panic!(
@@ -469,6 +510,67 @@ mod tests {
 					sum, total_to_distribute,
 					"Sum of distributions ({}) does not equal total ({})",
 					sum, total_to_distribute
+				);
+
+				Ok(())
+			});
+		}
+	}
+
+	proptest! {
+		#[test]
+		fn distribute_all_sums_to_total(
+			validator_amounts in prop::collection::vec(1u128..1_000_000u128, 1..10),
+			delegator_amounts in prop::collection::vec(1u128..1_000_000u128, 0..50),
+			per_beneficiary_amount in 1u128..10_000u128,
+			delegation_fee_bps in 2_000u32..10_000u32,
+			bond in 100_000u128..10_000_000u128,
+		) {
+			const EPOCH: EpochIndex = 1;
+			let operator_account = 1u64;
+			let per_beneficiary_amount = per_beneficiary_amount * FLIPPERINOS_PER_FLIP;
+			let bond = bond * FLIPPERINOS_PER_FLIP;
+
+			let validators: BTreeMap<ValidatorId, u128> = validator_amounts.iter().enumerate()
+				.map(|(i, amount)| (i as u64 + 100, *amount * FLIPPERINOS_PER_FLIP))
+				.collect();
+			let delegators: BTreeMap<ValidatorId, u128> = delegator_amounts.iter().enumerate()
+				.map(|(i, amount)| (i as u64 + 1000, *amount * FLIPPERINOS_PER_FLIP))
+				.collect();
+			// Every validator in the snapshot is a beneficiary this epoch - the precondition
+			// `distribute_all` relies on to derive authority counts from the snapshot alone.
+			let beneficiaries: Vec<ValidatorId> = validators.keys().cloned().collect();
+			// Constructed as an exact multiple of beneficiaries.len() so the internal division
+			// in `distribute_all` recovers `per_beneficiary_amount` exactly (no remainder).
+			let total_amount = per_beneficiary_amount * beneficiaries.len() as u128;
+
+			new_test_ext().execute_with(|| {
+				crate::HistoricalBonds::<Test>::insert(EPOCH, bond);
+
+				DelegationSnapshot::<ValidatorId, u128> {
+					operator: operator_account,
+					validators,
+					delegators,
+					delegation_fee_bps,
+				}.register_for_epoch::<Test>(EPOCH);
+
+				let mut settled: BTreeMap<ValidatorId, u128> = BTreeMap::new();
+				DelegatedRewardsDistribution::<Test>::distribute_all(
+					EPOCH,
+					total_amount,
+					&beneficiaries,
+					|account, amount| {
+						settled.entry(*account).and_modify(|a| *a += amount).or_insert(amount);
+					},
+				);
+
+				// Property: the sum of all settled amounts equals total_amount, exactly like
+				// beneficiaries.len() separate `distribute` calls would sum to.
+				let sum: u128 = settled.values().sum();
+				prop_assert_eq!(
+					sum, total_amount,
+					"Sum of settled amounts ({}) does not equal expected total ({})",
+					sum, total_amount
 				);
 
 				Ok(())

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3395,7 +3395,7 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		const REWARD_AMOUNT: u128 = 100_000u128;
 
 		crate::CurrentEpoch::<Test>::put(EPOCH);
-		crate::Bond::<Test>::put(BOND);
+		crate::HistoricalBonds::<Test>::insert(EPOCH, BOND);
 
 		DelegationSnapshot::<u64, u128> {
 			operator: OPERATOR,
@@ -3434,6 +3434,81 @@ fn test_delegated_rewards_distribution_correctly_distributes_to_snapshot() {
 		// Verify total
 		let total_minted: u128 = minted.values().sum();
 		assert_eq!(total_minted, REWARD_AMOUNT);
+	});
+}
+
+#[test]
+fn distribute_all_matches_looped_distribute() {
+	use crate::delegation::DelegatedRewardsDistribution;
+	use cf_traits::RewardsDistribution;
+
+	new_test_ext().execute_with(|| {
+		const VALIDATOR_A: u64 = 100;
+		const VALIDATOR_B: u64 = 101;
+		const OPERATOR: u64 = 200;
+		const DELEGATOR1: u64 = 300;
+		const DELEGATOR2: u64 = 400;
+		const SOLO_VALIDATOR: u64 = 500;
+
+		const EPOCH: u32 = 10;
+		const BOND: u128 = 1_000_000u128;
+		const PER_BENEFICIARY_AMOUNT: u128 = 100_000u128;
+
+		crate::CurrentEpoch::<Test>::put(EPOCH);
+		crate::HistoricalBonds::<Test>::insert(EPOCH, BOND);
+
+		DelegationSnapshot::<u64, u128> {
+			operator: OPERATOR,
+			validators: [(VALIDATOR_A, 200_000u128), (VALIDATOR_B, 300_000u128)]
+				.into_iter()
+				.collect(),
+			delegators: [(DELEGATOR1, 500_000u128), (DELEGATOR2, 1_500_000u128)]
+				.into_iter()
+				.collect(),
+			delegation_fee_bps: 2000, // 20% fee
+		}
+		.register_for_epoch::<Test>(EPOCH);
+
+		let beneficiaries = [VALIDATOR_A, VALIDATOR_B, SOLO_VALIDATOR];
+
+		// Ground truth: loop `distribute` once per beneficiary (the trait's default
+		// `distribute_all` behaviour), accumulating into a single map.
+		let mut looped = BTreeMap::new();
+		for beneficiary in &beneficiaries {
+			DelegatedRewardsDistribution::<Test>::distribute(
+				EPOCH,
+				PER_BENEFICIARY_AMOUNT,
+				beneficiary,
+				|account, amount| {
+					looped
+						.entry(*account)
+						.and_modify(|a: &mut u128| *a += amount)
+						.or_insert(amount);
+				},
+			);
+		}
+
+		let mut batched = BTreeMap::new();
+		DelegatedRewardsDistribution::<Test>::distribute_all(
+			EPOCH,
+			PER_BENEFICIARY_AMOUNT * beneficiaries.len() as u128,
+			&beneficiaries,
+			|account, amount| {
+				batched
+					.entry(*account)
+					.and_modify(|a: &mut u128| *a += amount)
+					.or_insert(amount);
+			},
+		);
+
+		assert_eq!(batched, looped);
+
+		// The solo authority (no operator) is settled with its full share directly.
+		assert_eq!(batched.get(&SOLO_VALIDATOR), Some(&PER_BENEFICIARY_AMOUNT));
+
+		// Total settled equals beneficiaries.len() * per_beneficiary_amount.
+		let total: u128 = batched.values().sum();
+		assert_eq!(total, PER_BENEFICIARY_AMOUNT * beneficiaries.len() as u128);
 	});
 }
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3449,6 +3449,9 @@ fn distribute_all_matches_looped_distribute() {
 		const DELEGATOR1: u64 = 300;
 		const DELEGATOR2: u64 = 400;
 		const SOLO_VALIDATOR: u64 = 500;
+		const LOSING_OPERATOR: u64 = 600;
+		const LOSING_VALIDATOR: u64 = 601;
+		const LOSING_DELEGATOR: u64 = 602;
 
 		const EPOCH: u32 = 10;
 		const BOND: u128 = 1_000_000u128;
@@ -3470,6 +3473,16 @@ fn distribute_all_matches_looped_distribute() {
 				.into_iter()
 				.collect(),
 			delegation_fee_bps: 2000, // 20% fee
+		}
+		.register_for_epoch::<Test>(EPOCH);
+
+		// An operator whose pooled stake didn't clear the bond: its snapshot is registered for
+		// the epoch, but its sole validator is not an authority and must not earn anything.
+		DelegationSnapshot::<u64, u128> {
+			operator: LOSING_OPERATOR,
+			validators: [(LOSING_VALIDATOR, 100_000u128)].into_iter().collect(),
+			delegators: [(LOSING_DELEGATOR, 400_000u128)].into_iter().collect(),
+			delegation_fee_bps: 2000,
 		}
 		.register_for_epoch::<Test>(EPOCH);
 
@@ -3508,6 +3521,11 @@ fn distribute_all_matches_looped_distribute() {
 
 		// The solo authority (no operator) is settled with its full share directly.
 		assert_eq!(batched.get(&SOLO_VALIDATOR), Some(&PER_BENEFICIARY_AMOUNT));
+
+		// The losing operator's snapshot earns nothing.
+		assert_eq!(batched.get(&LOSING_OPERATOR), None);
+		assert_eq!(batched.get(&LOSING_VALIDATOR), None);
+		assert_eq!(batched.get(&LOSING_DELEGATOR), None);
 
 		// Total settled equals beneficiaries.len() * per_beneficiary_amount.
 		let total: u128 = batched.values().sum();

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3456,6 +3456,10 @@ fn distribute_all_matches_looped_distribute() {
 
 		crate::CurrentEpoch::<Test>::put(EPOCH);
 		crate::HistoricalBonds::<Test>::insert(EPOCH, BOND);
+		crate::HistoricalAuthorities::<Test>::insert(
+			EPOCH,
+			vec![VALIDATOR_A, VALIDATOR_B, SOLO_VALIDATOR],
+		);
 
 		DelegationSnapshot::<u64, u128> {
 			operator: OPERATOR,
@@ -3471,8 +3475,8 @@ fn distribute_all_matches_looped_distribute() {
 
 		let beneficiaries = [VALIDATOR_A, VALIDATOR_B, SOLO_VALIDATOR];
 
-		// Ground truth: loop `distribute` once per beneficiary (the trait's default
-		// `distribute_all` behaviour), accumulating into a single map.
+		// Ground truth: loop `distribute` once per authority with an even share, accumulating
+		// into a single map.
 		let mut looped = BTreeMap::new();
 		for beneficiary in &beneficiaries {
 			DelegatedRewardsDistribution::<Test>::distribute(
@@ -3492,7 +3496,6 @@ fn distribute_all_matches_looped_distribute() {
 		DelegatedRewardsDistribution::<Test>::distribute_all(
 			EPOCH,
 			PER_BENEFICIARY_AMOUNT * beneficiaries.len() as u128,
-			&beneficiaries,
 			|account, amount| {
 				batched
 					.entry(*account)

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -34,12 +34,7 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 				true,
 			);
 		} else if new > activation_epoch {
-			let flip_distributed = Flip::trigger_flip_reward_distribution(
-				new - 1,
-				pallet_cf_validator::HistoricalAuthorities::<crate::Runtime>::get(new - 1)
-					.into_iter()
-					.collect(),
-			);
+			let flip_distributed = Flip::trigger_flip_reward_distribution(new - 1);
 			let egress_fee_consumed = Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -935,19 +935,24 @@ impl_runtime_apis! {
 
 					let mut reward_pool: Vec<AccountReward<FlipBalance>> = Vec::new();
 
-					// Authorities covered by some operator's `snapshot.validators` (mirrors
-					// `DelegatedRewardsDistribution::distribute_all`); anyone left over is
-					// independent and gets their full share directly, added after the loop below.
-					let mut rewarded: BTreeSet<AccountId> = BTreeSet::new();
+					// Mirrors `DelegatedRewardsDistribution::distribute_all`: snapshot validators
+					// are drained out of `authority_set` as we go, leaving only independent
+					// authorities, which get their full share directly after the loop below.
+					let mut authorities_to_reward: BTreeSet<&AccountId> = authorities.iter().collect();
 
 					for (operator, snapshot) in
 						pallet_cf_validator::DelegationSnapshots::<Runtime>::iter_prefix(epoch_index)
 					{
-						let num_authority_nodes = snapshot.validators.len() as u32;
+						// Snapshots of operators whose pooled stake didn't clear the bond are
+						// still registered but hold a non-authority validator - they earn nothing.
+						let num_authority_nodes = snapshot
+							.validators
+							.keys()
+							.filter(|v| authorities_to_reward.remove(*v))
+							.count() as u32;
 						if num_authority_nodes == 0 {
 							continue;
 						}
-						rewarded.extend(snapshot.validators.keys().cloned());
 
 						let total = per_authority_share.saturating_mul(num_authority_nodes as FlipBalance);
 						let rewards: BTreeMap<AccountId, FlipBalance> = snapshot
@@ -996,18 +1001,16 @@ impl_runtime_apis! {
 						}
 					}
 
-					for authority in &authorities {
-						if !rewarded.contains(authority) {
-							reward_pool.push(AccountReward {
-								account: authority.clone(),
-								bid: Flip::balance(authority),
-								bond: Flip::bond(authority),
-								reward: per_authority_share,
-								role: AccountRole::Validator,
-								managed_by: None,
-								delegated_to: None,
-							});
-						}
+					for authority in authorities_to_reward {
+						reward_pool.push(AccountReward {
+							account: authority.clone(),
+							bid: Flip::balance(authority),
+							bond: Flip::bond(authority),
+							reward: per_authority_share,
+							role: AccountRole::Validator,
+							managed_by: None,
+							delegated_to: None,
+						});
 					}
 
 					(total_rewards, per_authority_share, reward_pool)

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -51,7 +51,7 @@ use cf_primitives::{
 };
 use cf_traits::{
 	AdjustedFeeEstimationApi, AssetConverter, BalanceApi, ChainflipWithTargetChain, EpochKey,
-	GetBlockHeight, KeyProvider, RewardsDistribution, SwapLimits, SwapParameterValidation,
+	GetBlockHeight, KeyProvider, SwapLimits, SwapParameterValidation,
 };
 use codec::{Decode, Encode};
 use core::ops::Range;
@@ -77,9 +77,7 @@ use pallet_cf_pools::{
 };
 use pallet_cf_reputation::HeartbeatQualification;
 use pallet_cf_swapping::{AffiliateDetails, BrokerPrivateBtcChannels, SwapLegInfo};
-use pallet_cf_validator::{
-	AssociationToOperator, DelegatedRewardsDistribution, DelegationAcceptance,
-};
+use pallet_cf_validator::{AssociationToOperator, DelegationAcceptance};
 use scale_info::prelude::string::String;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
@@ -934,77 +932,40 @@ impl_runtime_apis! {
 						pallet_cf_account_roles::AccountRoles::<Runtime>::get(account)
 							.unwrap_or_default()
 					};
-					let managed_by = |account: &AccountId| {
-						pallet_cf_validator::ValidatorToOperator::<Runtime>::get(epoch_index, account)
-					};
 
-					// `distribute` looks up each authority's managing operator (if any) and
-					// settles its cut across that operator's validators/delegators, or pays the
-					// authority directly if it's independent - mirroring
-					// `Flip::trigger_flip_reward_distribution`'s per-authority settlement, without
-					// mutating any storage.
-					let mut operators_with_authorities: BTreeSet<AccountId> = BTreeSet::new();
-					let mut rewards: BTreeMap<AccountId, FlipBalance> = BTreeMap::new();
-					let mut reward_pool = Vec::new();
+					let mut reward_pool: Vec<AccountReward<FlipBalance>> = Vec::new();
 
-					for validator in &authorities {
-						match managed_by(validator) {
-							Some(operator) => {
-								operators_with_authorities.insert(operator);
-							},
-							None => {
-								reward_pool.push(AccountReward {
-									account: validator.clone(),
-									bid: Flip::balance(validator),
-									bond: Flip::bond(validator),
-									reward: per_authority_share,
-									role: AccountRole::Validator,
-									managed_by: None,
-									delegated_to: None,
-								});
-							},
+					// Authorities covered by some operator's `snapshot.validators` (mirrors
+					// `DelegatedRewardsDistribution::distribute_all`); anyone left over is
+					// independent and gets their full share directly, added after the loop below.
+					let mut rewarded: BTreeSet<AccountId> = BTreeSet::new();
+
+					for (operator, snapshot) in
+						pallet_cf_validator::DelegationSnapshots::<Runtime>::iter_prefix(epoch_index)
+					{
+						let num_authority_nodes = snapshot.validators.len() as u32;
+						if num_authority_nodes == 0 {
+							continue;
 						}
+						rewarded.extend(snapshot.validators.keys().cloned());
 
-						<DelegatedRewardsDistribution<Runtime> as RewardsDistribution>::distribute(
-							epoch_index,
-							per_authority_share,
-							validator,
-							|account, amount| {
-								rewards
-									.entry(account.clone())
-									.and_modify(|r: &mut FlipBalance| *r = r.saturating_add(amount))
-									.or_insert(amount);
-							},
-						);
-					}
-
-					let reward_of =
-						|account: &AccountId| rewards.get(account).copied().unwrap_or_default();
-
-					for operator in operators_with_authorities {
+						let total = per_authority_share.saturating_mul(num_authority_nodes as FlipBalance);
+						let rewards: BTreeMap<AccountId, FlipBalance> = snapshot
+							.distribute(total, bond)
+							.map(|(account, amount)| (account.clone(), amount))
+							.collect();
+						let reward_of =
+							|account: &AccountId| rewards.get(account).copied().unwrap_or_default();
 
 						reward_pool.push(AccountReward {
 							account: operator.clone(),
-							bid: Zero::zero(),
-							bond: Flip::bond(&operator),
+							bid: 0,
+							bond: 0,
 							reward: reward_of(&operator),
 							role: AccountRole::Operator,
 							managed_by: None,
 							delegated_to: None,
 						});
-
-						let Some(snapshot) = pallet_cf_validator::DelegationSnapshots::<Runtime>::get(
-							epoch_index,
-							&operator,
-						) else {
-							log::warn!(
-									"Operator {:?} has authority slot(s) in epoch {} but no delegation snapshot found.",
-									operator,
-									epoch_index
-								);
-							continue;
-						};
-
 
 						for (account, bid) in &snapshot.validators {
 							reward_pool.push(AccountReward {
@@ -1019,14 +980,32 @@ impl_runtime_apis! {
 						}
 
 						for (account, bid) in &snapshot.delegators {
+							let role = role_of(account);
 							reward_pool.push(AccountReward {
 								account: account.clone(),
 								bid: *bid,
 								bond: Flip::bond(account),
 								reward: reward_of(account),
-								role: role_of(account),
-								managed_by: managed_by(account),
+								role,
+								// `Validator`-role accounts can't hold a `DelegationChoice`
+								// (`delegate` rejects Validator/Operator callers), so a Validator
+								// here can only be demoted from this same operator's own set.
+								managed_by: (role == AccountRole::Validator).then(|| operator.clone()),
 								delegated_to: Some(operator.clone()),
+							});
+						}
+					}
+
+					for authority in &authorities {
+						if !rewarded.contains(authority) {
+							reward_pool.push(AccountReward {
+								account: authority.clone(),
+								bid: Flip::balance(authority),
+								bond: Flip::bond(authority),
+								reward: per_authority_share,
+								role: AccountRole::Validator,
+								managed_by: None,
+								delegated_to: None,
 							});
 						}
 					}

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -81,7 +81,6 @@ use pallet_cf_validator::{AssociationToOperator, DelegationAcceptance};
 use scale_info::prelude::string::String;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
-use sp_runtime::traits::Zero;
 use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	vec::Vec,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -396,28 +396,15 @@ pub trait RewardsDistribution {
 		settle: impl FnMut(&Self::AccountId, Self::Balance),
 	);
 
-	/// Splits `total_amount` evenly across `beneficiaries` for `epoch_index`.
-	///
-	/// `beneficiaries` must be exactly `epoch_index`'s complete set of reward recipients (e.g.
-	/// all current authorities) - implementations may batch/optimize on that assumption (e.g.
-	/// when beneficiaries share distribution state, such as the same managing operator's
-	/// snapshot). The default just divides evenly and calls `distribute` once per beneficiary.
+	/// Splits `total_amount` evenly across `epoch_index`'s complete set of reward recipients
+	/// (e.g. that epoch's full authority set), as determined by the implementation.
+	/// To settle a partial
+	/// set, call [Self::distribute] per beneficiary instead.
 	fn distribute_all(
 		epoch_index: EpochIndex,
 		total_amount: Self::Balance,
-		beneficiaries: &[Self::AccountId],
-		mut settle: impl FnMut(&Self::AccountId, Self::Balance),
-	) where
-		Self::Balance: Copy + core::ops::Div<Output = Self::Balance> + From<u32>,
-	{
-		if beneficiaries.is_empty() {
-			return;
-		}
-		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
-		for beneficiary in beneficiaries {
-			Self::distribute(epoch_index, per_beneficiary_amount, beneficiary, &mut settle);
-		}
-	}
+		settle: impl FnMut(&Self::AccountId, Self::Balance),
+	);
 }
 
 /// A representation of the current network state for this heartbeat interval.

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -395,6 +395,29 @@ pub trait RewardsDistribution {
 		beneficiary: &Self::AccountId,
 		settle: impl FnMut(&Self::AccountId, Self::Balance),
 	);
+
+	/// Splits `total_amount` evenly across `beneficiaries` for `epoch_index`.
+	///
+	/// `beneficiaries` must be exactly `epoch_index`'s complete set of reward recipients (e.g.
+	/// all current authorities) - implementations may batch/optimize on that assumption (e.g.
+	/// when beneficiaries share distribution state, such as the same managing operator's
+	/// snapshot). The default just divides evenly and calls `distribute` once per beneficiary.
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		beneficiaries: &[Self::AccountId],
+		mut settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) where
+		Self::Balance: Copy + core::ops::Div<Output = Self::Balance> + From<u32>,
+	{
+		if beneficiaries.is_empty() {
+			return;
+		}
+		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
+		for beneficiary in beneficiaries {
+			Self::distribute(epoch_index, per_beneficiary_amount, beneficiary, &mut settle);
+		}
+	}
 }
 
 /// A representation of the current network state for this heartbeat interval.

--- a/state-chain/traits/src/mocks/rewards_distribution.rs
+++ b/state-chain/traits/src/mocks/rewards_distribution.rs
@@ -44,6 +44,23 @@ impl<T: Chainflip> RewardsDistribution for MockRewardsDistribution<T> {
 		);
 		settle(beneficiary, amount);
 	}
+
+	fn distribute_all(
+		epoch_index: EpochIndex,
+		total_amount: Self::Balance,
+		mut settle: impl FnMut(&Self::AccountId, Self::Balance),
+	) {
+		let beneficiaries: sp_std::vec::Vec<Self::AccountId> =
+			<Self as MockPalletStorage>::get_storage(b"BENEFICIARIES", epoch_index)
+				.unwrap_or_default();
+		if beneficiaries.is_empty() {
+			return;
+		}
+		let per_beneficiary_amount = total_amount / (beneficiaries.len() as u32).into();
+		for beneficiary in &beneficiaries {
+			Self::distribute(epoch_index, per_beneficiary_amount, beneficiary, &mut settle);
+		}
+	}
 }
 
 impl<T: Chainflip> MockRewardsDistribution<T> {
@@ -51,5 +68,12 @@ impl<T: Chainflip> MockRewardsDistribution<T> {
 		beneficiary: &<Self as RewardsDistribution>::AccountId,
 	) -> <Self as RewardsDistribution>::Balance {
 		<Self as MockPalletStorage>::get_storage(b"REWARDS", beneficiary).unwrap_or_default()
+	}
+
+	pub fn set_beneficiaries(
+		epoch_index: EpochIndex,
+		beneficiaries: sp_std::vec::Vec<<Self as RewardsDistribution>::AccountId>,
+	) {
+		<Self as MockPalletStorage>::put_storage(b"BENEFICIARIES", epoch_index, beneficiaries);
 	}
 }


### PR DESCRIPTION
# Pull Request

This adds a distribute_all method to make reward distribution more efficient. (as mentioned on the base PR). 

I also updated the RPC to use a similar pattern, it now iterates over the snapshots instead of building a list of operators first. 

This also fixes a bug in the calculation where we were using `CurrentBond()` instead of `HistoricalBond(epoch)`.
