### PR TITLE
feat: set bsc min fee per gas

### DIFF
--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - "/tmp/chainflip/data/config:/config"
 
   bsc:
-    image: ghcr.io/chainflip-io/chainflip-eth-contracts/bsc:test-bsc-node-15-${NODE_COUNT}
+    image: ghcr.io/chainflip-io/chainflip-eth-contracts/bsc:v1.5.1-rc1-${NODE_COUNT}
     container_name: bsc-node
     platform: linux/amd64
     ports:

--- a/state-chain/chains/src/bsc.rs
+++ b/state-chain/chains/src/bsc.rs
@@ -104,8 +104,12 @@ impl Default for BscTrackedData {
 	}
 }
 
-/// Minimum gas price (wei) BSC validators will accept; below this, txs are likely dropped.
-const MIN_FEE_PER_GAS: <Bsc as Chain>::ChainAmount = 1_000_000_000; // 1 Gwei
+/// Minimum fee per gas price (wei) that BSC validators will accept; transactions below this are
+/// likely to be dropped. Set to 0.1 Gwei — the BSC Testnet minimum — which also covers the lower
+/// BSC Mainnet minimum of 0.05 Gwei, avoiding the need for per-network storage.
+/// For localnet, this must match the BSC docker image config: `[Eth.Miner] GasPrice` and
+/// `[Eth.TxPool] PriceLimit`.
+const MIN_FEE_PER_GAS: <Bsc as Chain>::ChainAmount = 100_000_000;
 
 impl BscTrackedData {
 	pub fn max_fee_per_gas(


### PR DESCRIPTION
# Pull Request

## Summary

* This PR updates the state chain `MIN_FEE_PER_GAS` to be 0.1 Gwei — the BSC Testnet minimum — which also covers the lower BSC Mainnet minimum of 0.05 Gwei, avoiding the need for per-network storage.
* For localnet, this must match the BSC docker image config: `[Eth.Miner] GasPrice` and `[Eth.TxPool] PriceLimit`, hence requiring a new tagged bsc-node in docker-compose.yml

## API Changes

*Document the impact on any external APIs, whether breaking or non-breaking.*

### RPCS

*Any changes to the RPC interfaces, or internal behaviour?*

### Extrinsics & Events

*Any changes to extrinsic or event encodings?*

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
