### PR TITLE
chore: update to latest DM with new arb witnessing [release/2.2]

### DIFF
--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -46,6 +46,27 @@ export async function setupElections<A = []>(cf: ChainflipIO<A>): Promise<void> 
     cf.info('Ignoring bitcoin elections setup as bitcoinElections pallet is not available.');
   }
 
+  if (chainflip.query.arbitrumElections) {
+    const ingressSafetyMargin = 3;
+
+    const response = JSON.parse(
+      (await chainflip.query.arbitrumElections.electoralUnsynchronisedSettings()) as any,
+    );
+
+    // set higher safety margin for ingresses so that we don't miss txs
+    response[1].safetyMargin = ingressSafetyMargin;
+    response[2].safetyMargin = ingressSafetyMargin;
+
+    // update election settings
+    await submitGovernanceExtrinsic((api) =>
+      api.tx.arbitrumElections.updateSettings(response, null, 'Heed'),
+    );
+
+    cf.info(`Ingress safety margin for arbitrum elections set to ${ingressSafetyMargin}.`);
+  } else {
+    cf.info('Ignoring arbitrum elections setup as arbitrumElections pallet is not available.');
+  }
+
   if (chainflip.query.genericElections) {
     const upToDateTimeout = 86400;
 
@@ -74,15 +95,6 @@ export async function setupElections<A = []>(cf: ChainflipIO<A>): Promise<void> 
   } else {
     cf.info('Ignoring Oracle elections setup as genericElections pallet is not available.');
   }
-
-  // The DM uses the ingress_events rpc for Arbitrum, so an ingress delay is required for BLS to work.
-  const arbitrumIngressDelay = 2;
-  await submitGovernanceExtrinsic((api) =>
-    api.tx.arbitrumIngressEgress.updatePalletConfig([
-      { SetIngressDelayArbitrum: { delayBlocks: arbitrumIngressDelay } },
-    ]),
-  );
-  cf.info(`Ingress delay for Arbitrum set to ${arbitrumIngressDelay} `);
 }
 
 export async function setupWitnessing<A>(cf: ChainflipIO<A>) {

--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -47,7 +47,7 @@ export async function setupElections<A = []>(cf: ChainflipIO<A>): Promise<void> 
   }
 
   if (chainflip.query.arbitrumIngressEgress) {
-    const ingressSafetyMargin = 3;
+    const ingressSafetyMargin = 2;
 
     // The runtime propagates this value to the Arbitrum ingress-related election settings.
     await submitGovernanceExtrinsic((api) =>

--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -46,25 +46,19 @@ export async function setupElections<A = []>(cf: ChainflipIO<A>): Promise<void> 
     cf.info('Ignoring bitcoin elections setup as bitcoinElections pallet is not available.');
   }
 
-  if (chainflip.query.arbitrumElections) {
+  if (chainflip.query.arbitrumIngressEgress) {
     const ingressSafetyMargin = 3;
 
-    const response = JSON.parse(
-      (await chainflip.query.arbitrumElections.electoralUnsynchronisedSettings()) as any,
-    );
-
-    // set higher safety margin for ingresses so that we don't miss txs
-    response[1].safetyMargin = ingressSafetyMargin;
-    response[2].safetyMargin = ingressSafetyMargin;
-
-    // update election settings
+    // The runtime propagates this value to the Arbitrum ingress-related election settings.
     await submitGovernanceExtrinsic((api) =>
-      api.tx.arbitrumElections.updateSettings(response, null, 'Heed'),
+      api.tx.arbitrumIngressEgress.updatePalletConfig([
+        { SetWitnessSafetyMarginArbitrum: { margin: ingressSafetyMargin } },
+      ]),
     );
 
-    cf.info(`Ingress safety margin for arbitrum elections set to ${ingressSafetyMargin}.`);
+    cf.info(`Ingress safety margin for Arbitrum set to ${ingressSafetyMargin}.`);
   } else {
-    cf.info('Ignoring arbitrum elections setup as arbitrumElections pallet is not available.');
+    cf.info('Ignoring Arbitrum ingress setup as arbitrumIngressEgress pallet is not available.');
   }
 
   if (chainflip.query.genericElections) {

--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -74,6 +74,15 @@ export async function setupElections<A = []>(cf: ChainflipIO<A>): Promise<void> 
   } else {
     cf.info('Ignoring Oracle elections setup as genericElections pallet is not available.');
   }
+
+  // The DM uses the ingress_events rpc for Arbitrum, so an ingress delay is required for BLS to work.
+  const arbitrumIngressDelay = 2;
+  await submitGovernanceExtrinsic((api) =>
+    api.tx.arbitrumIngressEgress.updatePalletConfig([
+      { SetIngressDelayArbitrum: { delayBlocks: arbitrumIngressDelay } },
+    ]),
+  );
+  cf.info(`Ingress delay for Arbitrum set to ${arbitrumIngressDelay} `);
 }
 
 export async function setupWitnessing<A>(cf: ChainflipIO<A>) {

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -134,13 +134,6 @@ export async function doTestSwapDeposits<A = []>(
   // NOTE: We currently don't test the following assets:
   // - Flip: we don't test Flip rejections because they are currently disabled in the
   //         deposit monitor, since Elliptic doesn't provide Flip analysis.
-  // - ArbEth: we don't test ArbEth rejections since on localnet the safety margin for ArbEth
-  //           is too short for the DM, the rejections fail more often than not due
-  //           to being too late.
-  //           Most of the functionality is covered by testing `Eth` and `ArbUsdc`.
-  //           An alternative would be to increase the ArbEth safety margin on localnet.
-  // - ArbUsdc: we also don't test ArbUsdc rejections, they have caused tests to become flaky
-  //            as well (PRO-2488).
   // - Btc VaultSwaps: For bitcoin, due to ancestor screening, we have to make sure to use
   //                   a dedicated "tainted" wallet. Since it's somewhat difficult to inject
   //                   a different wallet into the `sendVaultSwap` flow, we disable the test for now.

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -156,6 +156,9 @@ export async function doTestSwapDeposits<A = []>(
     (subcf) => testEvm(subcf, 'Usdt', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvm(subcf, 'Usdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvm(subcf, 'Wbtc', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) =>
       testBitcoin(subcf.withChildLogger('BrokerLevelScreening_testBitcoin'), false, async (txId) =>
         setTxRiskScore(txId, 9.0),
@@ -182,6 +185,9 @@ export async function doTestLpDeposits<A = []>(parentCf: ChainflipIO<A>) {
     (subcf) => testEvmLiquidityDeposit(subcf, 'Usdt', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmLiquidityDeposit(subcf, 'Usdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmLiquidityDeposit(subcf, 'Wbtc', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
   ]);
 }
 
@@ -189,6 +195,9 @@ export async function doTestVaultSwaps<A = []>(cf: ChainflipIO<A>) {
   await cf.with({ account: fullAccountFromUri('//BROKER_1', 'Broker') }).all([
     // --- vault swaps ---
     (subcf) => testBitcoinVaultSwap(subcf, async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Eth', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Usdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Usdt', async (txId) => setTxRiskScore(txId, 9.0)),

--- a/bouncer/tests/broker_level_screening/evm.ts
+++ b/bouncer/tests/broker_level_screening/evm.ts
@@ -32,13 +32,17 @@ import { arbitrumIngressEgressTransactionRejectedByBrokerEvent } from 'generated
 /**
  * Wait for the Deposit contract to be deployed.
  */
-async function waitForDepositContractDeployment(chain: Chain, depositAddress: string) {
+async function waitForDepositContractDeployment<A = []>(
+  cf: ChainflipIO<A>,
+  chain: Chain,
+  depositAddress: string,
+) {
   switch (chain) {
     case 'Arbitrum':
     case 'Ethereum':
       break;
     default:
-      throw new Error(`Unssuported evm chain ${chain}`);
+      throw new Error(`Unsupported evm chain ${chain}`);
   }
 
   const MAX_RETRIES = 100;
@@ -55,6 +59,11 @@ async function waitForDepositContractDeployment(chain: Chain, depositAddress: st
   if (!contractDeployed) {
     throw new Error(`${chain} contract not deployed at address ${depositAddress} within timeout!`);
   }
+  cf.debug(`Found deployed contract at ${depositAddress}!`);
+
+  // wait two SC blocks to make sure that the contract deployment + fetch has been witnessed and processed on the SC
+  // TODO: use events/SC-state for this
+  await sleep(12000);
 }
 
 async function waitForEvmTransactionRejection<A = []>(
@@ -104,6 +113,12 @@ export async function testEvm<A = []>(
 
   const chain = chainFromAsset(sourceAsset);
 
+  if (chain !== 'Arbitrum' && chain !== 'Ethereum') {
+    throw new Error(
+      `testEvm in BLS test only usable for Ethereum and Arbitrum! Found chain: ${chain}`,
+    );
+  }
+
   const destinationAddressForBtc = await newAssetAddress('Btc');
 
   cf.debug(`BTC destination address: ${destinationAddressForBtc}`);
@@ -144,13 +159,24 @@ export async function testEvm<A = []>(
     await send(cf.logger, sourceAsset, swapParams.depositAddress);
     cf.debug(`Sent initial ${sourceAsset} tx...`);
 
-    await cf.stepUntilEvent(
-      ethereumIngressEgressDepositFinalisedEvent.refine(
-        (event) =>
-          event.depositAddress === swapParams.depositAddress &&
-          event.channelId === BigInt(swapParams.channelId),
-      ),
-    );
+    if (chain === 'Ethereum') {
+      await cf.stepUntilEvent(
+        ethereumIngressEgressDepositFinalisedEvent.refine(
+          (event) =>
+            event.depositAddress === swapParams.depositAddress &&
+            event.channelId === BigInt(swapParams.channelId),
+        ),
+      );
+    } else if (chain === 'Arbitrum') {
+      await cf.stepUntilEvent(
+        arbitrumIngressEgressDepositFinalisedEvent.refine(
+          (event) =>
+            event.depositAddress === swapParams.depositAddress &&
+            event.channelId === BigInt(swapParams.channelId),
+        ),
+      );
+    }
+
     await cf.stepOneBlock();
 
     cf.debug(`Initial deposit ${sourceAsset} received...`);

--- a/bouncer/tests/broker_level_screening/evm.ts
+++ b/bouncer/tests/broker_level_screening/evm.ts
@@ -183,7 +183,7 @@ export async function testEvm<A = []>(
     // The first tx will cannot be rejected because we can't determine the txId for deposits to undeployed Deposit
     // contracts. We will reject the second transaction instead. We must wait until the fetch has been broadcasted
     // successfully to make sure the Deposit contract is deployed.
-    await waitForDepositContractDeployment(chain, swapParams.depositAddress);
+    await waitForDepositContractDeployment(cf, chain, swapParams.depositAddress);
   }
 
   cf.debug(`Sending ${sourceAsset} tx to reject...`);
@@ -360,7 +360,7 @@ export async function testEvmLiquidityDeposit<A extends WithLpAccount>(
       ),
     );
     cf.debug(`Account credited for ${observeAccountCreditedEvent.asset}...`);
-    await waitForDepositContractDeployment(chain, depositAddress);
+    await waitForDepositContractDeployment(cf, chain, depositAddress);
   }
 
   cf.debug(`Sending ${sourceAsset} tx to reject...`);

--- a/bouncer/tests/broker_level_screening/evm.ts
+++ b/bouncer/tests/broker_level_screening/evm.ts
@@ -140,7 +140,7 @@ export async function testEvm<A = []>(
       )
     : Promise.resolve();
 
-  if (sourceAsset === chainGasAsset('Ethereum')) {
+  if (sourceAsset === chainGasAsset(chain)) {
     await send(cf.logger, sourceAsset, swapParams.depositAddress);
     cf.debug(`Sent initial ${sourceAsset} tx...`);
 
@@ -296,7 +296,7 @@ export async function testEvmLiquidityDeposit<A extends WithLpAccount>(
 
   cf.debug(`Got deposit address: ${depositAddress}`);
 
-  if (sourceAsset === chainGasAsset('Ethereum') || sourceAsset === chainGasAsset('Arbitrum')) {
+  if (sourceAsset === chainGasAsset(chain)) {
     // The first tx cannot be rejected because we can't determine the txId for deposits to undeployed Deposit
     // contracts. We will reject the second transaction instead. We must wait until the fetch has been broadcasted
     // succesfully to make sure the Deposit contract is deployed.

--- a/bouncer/tests/broker_level_screening/evm.ts
+++ b/bouncer/tests/broker_level_screening/evm.ts
@@ -62,7 +62,7 @@ async function waitForDepositContractDeployment<A = []>(
   cf.debug(`Found deployed contract at ${depositAddress}!`);
 
   // wait two SC blocks to make sure that the contract deployment + fetch has been witnessed and processed on the SC
-  // TODO: use events/SC-state for this
+  // TODO: we should instead use events or SC-state for this
   await sleep(12000);
 }
 

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -297,7 +297,7 @@ services:
     command: -c /tron/config/config-peer.conf -d /tron/output-directory
 
   deposit-monitor:
-    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-e26dba53efa1cdd2db2c3c2c403ea7538abde49f}
+    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-6f4ceae52b07159ed63e36ba3d7285fe4ac9d05a}
     platform: linux/amd64
     container_name: deposit-monitor
     restart: unless-stopped

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -297,7 +297,7 @@ services:
     command: -c /tron/config/config-peer.conf -d /tron/output-directory
 
   deposit-monitor:
-    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-d565d33b98fad1c0c60018e59ea171e757dacbe5}
+    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-e26dba53efa1cdd2db2c3c2c403ea7538abde49f}
     platform: linux/amd64
     container_name: deposit-monitor
     restart: unless-stopped

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -297,7 +297,7 @@ services:
     command: -c /tron/config/config-peer.conf -d /tron/output-directory
 
   deposit-monitor:
-    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-6f4ceae52b07159ed63e36ba3d7285fe4ac9d05a}
+    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-7a628a24c5de496d344984b2153d760bca202d3e}
     platform: linux/amd64
     container_name: deposit-monitor
     restart: unless-stopped


### PR DESCRIPTION
# Pull Request

## Summary

This updates the DM to the latest version which includes the new arbitrum witnessing, and also:
 - Adds Arbitrum BLS tests to make sure that the DM works correctly (related: PRO-2487).
 - Increases the Arbitrum WitnessSafetyMargin from 1 to 2 blocks. This is required for the DM to have enough time.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Bouncer tests for E2E features involving external chains.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
