### PR TITLE
chore: update to latest DM with new arb witnessing [main]

### DIFF
--- a/bouncer/shared/setup_elections.ts
+++ b/bouncer/shared/setup_elections.ts
@@ -3,15 +3,31 @@ import { ChainflipIO } from 'shared/utils/chainflip_io';
 import type { ChainflipClient } from 'shared/utils/dedot';
 
 export async function setupIngressEgressPallet<A>(cf: ChainflipIO<A>) {
-  await cf.submitGovernance({
-    extrinsic: (api) =>
-      api.tx.solanaIngressEgress.updatePalletConfig([
-        {
-          type: 'SetIngressDelaySolana',
-          value: { delayBlocks: 15 },
-        },
-      ]),
-  });
+  await cf.all([
+    // Solana ingress is very fast so an ingress delay is required for BLS to work.
+    (c) =>
+      c.submitGovernance({
+        extrinsic: (api) =>
+          api.tx.solanaIngressEgress.updatePalletConfig([
+            {
+              type: 'SetIngressDelaySolana',
+              value: { delayBlocks: 15 },
+            },
+          ]),
+      }),
+
+    // The DM uses the ingress_events rpc for Arbitrum, so an ingress delay is required for BLS to work.
+    (c) =>
+      c.submitGovernance({
+        extrinsic: (api) =>
+          api.tx.arbitrumIngressEgress.updatePalletConfig([
+            {
+              type: 'SetIngressDelayArbitrum',
+              value: { delayBlocks: 2 },
+            },
+          ]),
+      }),
+  ]);
 }
 
 // dedot's query proxy throws on an unknown pallet, so check the metadata before touching one (these

--- a/bouncer/tests/broker_level_screening.ts
+++ b/bouncer/tests/broker_level_screening.ts
@@ -164,6 +164,9 @@ export async function doTestSwapDeposits<A = []>(
     (subcf) => testEvm(subcf, 'Wbtc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvm(subcf, 'Bnb', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvm(subcf, 'BscUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvm(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) =>
       testBitcoin(subcf.withChildLogger('BrokerLevelScreening_testBitcoin'), false, async (txId) =>
         setTxRiskScore(txId, 9.0),
@@ -190,6 +193,9 @@ export async function doTestLpDeposits<A = []>(parentCf: ChainflipIO<A>) {
     (subcf) => testEvmLiquidityDeposit(subcf, 'Usdt', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmLiquidityDeposit(subcf, 'Usdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmLiquidityDeposit(subcf, 'Wbtc', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmLiquidityDeposit(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
   ]);
 }
 
@@ -197,6 +203,9 @@ export async function doTestVaultSwaps<A = []>(cf: ChainflipIO<A>) {
   await cf.with({ account: fullAccountFromUri('//BROKER_1', 'Broker') }).all([
     // --- vault swaps ---
     (subcf) => testBitcoinVaultSwap(subcf, async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbEth', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbUsdc', async (txId) => setTxRiskScore(txId, 9.0)),
+    (subcf) => testEvmVaultSwap(subcf, 'ArbUsdt', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Eth', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Usdc', async (txId) => setTxRiskScore(txId, 9.0)),
     (subcf) => testEvmVaultSwap(subcf, 'Usdt', async (txId) => setTxRiskScore(txId, 9.0)),

--- a/localnet/docker-compose.yml
+++ b/localnet/docker-compose.yml
@@ -276,7 +276,7 @@ services:
     command: -c /tron/config/config-peer.conf -d /tron/output-directory
 
   deposit-monitor:
-    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-ec2e4ba8c1a30c913cdfef8be12008f54f16be21}
+    image: ghcr.io/chainflip-io/chainflip-deposit-monitor/chainflip-deposit-monitor:${DEPOSIT_MONITOR_IMAGE_TAG:-development-e26dba53efa1cdd2db2c3c2c403ea7538abde49f}
     platform: linux/amd64
     container_name: deposit-monitor
     restart: unless-stopped


### PR DESCRIPTION
# Pull Request

## Summary

This updates the DM to the latest version which includes the new arbitrum witnessing, and also:
 - Adds Arbitrum BLS tests to make sure that the DM works correctly.
 - Increases the Arbitrum ingress delay from 0 to 2 blocks. This is required for the DM to have enough time.

Note: There's a [sibling PR](https://github.com/chainflip-io/chainflip-backend/pull/6721) into release/2.2 to ensure compatibility with current mainnet.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Bouncer tests for E2E features involving external chains.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.