### PR TITLE
feat: trigger rewards distribution before transitioning to the new epoch

### DIFF
--- a/bouncer/tests/flip_reward_activation.ts
+++ b/bouncer/tests/flip_reward_activation.ts
@@ -107,8 +107,9 @@ export async function testFlipRewardActivation(testContext: TestContext) {
   const epochAfterActivation = await cf.stepUntilEvent(validatorNewEpochEvent);
   assert.strictEqual(epochAfterActivation, activationEpoch + 1);
 
-  // The epoch following activation distributes accrued fee rewards to authorities. With real
-  // swap volume behind it, a non-zero amount should actually have been distributed.
+  // The fee rewards accrued during the activation epoch are distributed at its end, in the same
+  // block as the transition to the next epoch. With real swap volume behind it, a non-zero
+  // amount should actually have been distributed.
   const distributed = await cf.expectEvent(flipFlipDistributedEvent);
   const totalDistributed = distributed.amounts.reduce((sum, [, amount]) => sum + amount, 0n);
   assert.ok(

--- a/state-chain/pallets/cf-emissions/src/lib.rs
+++ b/state-chain/pallets/cf-emissions/src/lib.rs
@@ -239,7 +239,7 @@ impl<T: Config> Pallet<T> {
 	/// Burns the network fee and broadcasts an updated total supply to the gateway.
 	/// No-ops if safe mode has disabled emissions sync.
 	pub fn burn_and_broadcast_supply_update(current_block: BlockNumberFor<T>, force: bool) {
-		if T::SafeMode::get().emissions_sync_enabled {
+		if force || T::SafeMode::get().emissions_sync_enabled {
 			Self::burn_flip_network_fee(force);
 			Self::broadcast_update_total_supply(T::Issuance::total_issuance(), current_block);
 			Self::deposit_event(Event::SupplyUpdateBroadcastRequested(current_block));

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1662,7 +1662,8 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Among other things, updates the authority, historical and backup sets.
 	///
-	/// Also triggers [T::EpochTransitionHandler::on_new_epoch] which may call into other pallets.
+	/// Also triggers [T::EpochTransitionHandler::on_epoch_ending] and
+	/// [T::EpochTransitionHandler::on_new_epoch] which may call into other pallets.
 	///
 	/// Note this function is not benchmarked - it is only ever triggered via the session pallet,
 	/// which at the time of writing uses `T::BlockWeights::get().max_block` ie. it implicitly fills
@@ -1673,11 +1674,12 @@ impl<T: Config> Pallet<T> {
 	) {
 		log::debug!(target: "cf-validator", "Starting new epoch");
 
+		let old_epoch = CurrentEpoch::<T>::get();
+		T::EpochTransitionHandler::on_epoch_ending(old_epoch);
+
 		// Update epoch numbers.
-		let (old_epoch, new_epoch) = CurrentEpoch::<T>::mutate(|epoch| {
-			*epoch = epoch.saturating_add(One::one());
-			(*epoch - 1, *epoch)
-		});
+		let new_epoch = old_epoch.saturating_add(One::one());
+		CurrentEpoch::<T>::put(new_epoch);
 
 		// Set the expiry block number for the old epoch.
 		EpochExpiries::<T>::insert(

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -119,7 +119,45 @@ pub const EXPECTED_BOND: Amount = WINNING_BIDS[WINNING_BIDS.len() - 1].amount;
 
 pub struct TestEpochTransitionHandler;
 
-impl EpochTransitionHandler for TestEpochTransitionHandler {}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EpochTransitionHook {
+	EpochEnding,
+	NewEpoch,
+}
+
+thread_local! {
+	pub static EPOCH_TRANSITION_HOOK_CALLS: RefCell<Vec<(EpochTransitionHook, EpochIndex, EpochIndex)>> =
+		RefCell::new(Default::default());
+}
+
+impl TestEpochTransitionHandler {
+	/// Drains the recorded `(hook, passed_epoch, CurrentEpoch at call time)` tuples.
+	pub fn take_hook_calls() -> Vec<(EpochTransitionHook, EpochIndex, EpochIndex)> {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| calls.take())
+	}
+}
+
+impl EpochTransitionHandler for TestEpochTransitionHandler {
+	fn on_epoch_ending(ending: EpochIndex) {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| {
+			calls.borrow_mut().push((
+				EpochTransitionHook::EpochEnding,
+				ending,
+				CurrentEpoch::<Test>::get(),
+			))
+		});
+	}
+
+	fn on_new_epoch(new: EpochIndex) {
+		EPOCH_TRANSITION_HOOK_CALLS.with(|calls| {
+			calls.borrow_mut().push((
+				EpochTransitionHook::NewEpoch,
+				new,
+				CurrentEpoch::<Test>::get(),
+			))
+		});
+	}
+}
 
 thread_local! {
 	pub static MISSED_SLOTS: RefCell<(u64, u64)> = RefCell::new(Default::default());

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -682,6 +682,26 @@ fn test_reputation_is_reset_on_expired_epoch() {
 		assert!(MockReputationResetter::<Test>::reputation_was_reset());
 	});
 }
+#[test]
+fn epoch_transition_hooks_straddle_the_epoch_increment() {
+	new_test_ext().execute_with(|| {
+		let old_epoch = ValidatorPallet::current_epoch();
+		let _ = TestEpochTransitionHandler::take_hook_calls();
+
+		ValidatorPallet::transition_to_next_epoch(vec![1, 2], 100);
+
+		// `on_epoch_ending` must observe the ending epoch as current (reward distribution
+		// relies on this), `on_new_epoch` the new one.
+		assert_eq!(
+			TestEpochTransitionHandler::take_hook_calls(),
+			vec![
+				(EpochTransitionHook::EpochEnding, old_epoch, old_epoch),
+				(EpochTransitionHook::NewEpoch, old_epoch + 1, old_epoch + 1),
+			]
+		);
+	});
+}
+
 #[cfg(test)]
 mod bond_expiry {
 	use super::*;

--- a/state-chain/runtime/src/chainflip/epoch_transition.rs
+++ b/state-chain/runtime/src/chainflip/epoch_transition.rs
@@ -24,23 +24,28 @@ impl EpochTransitionHandler for ChainflipEpochTransitions {
 	fn on_expired_epoch(expired: EpochIndex) {
 		<Witnesser as EpochTransitionHandler>::on_expired_epoch(expired);
 	}
-	fn on_new_epoch(new: EpochIndex) {
-		AssetBalances::trigger_reconciliation();
-
-		let activation_epoch = pallet_cf_flip::FeeRewardsActivationEpoch::<crate::Runtime>::get();
-		if new == activation_epoch {
-			Emissions::burn_and_broadcast_supply_update(
-				frame_system::Pallet::<crate::Runtime>::block_number(),
-				true,
-			);
-		} else if new > activation_epoch {
-			let flip_distributed = Flip::trigger_flip_reward_distribution(new - 1);
+	fn on_epoch_ending(ending: EpochIndex) {
+		if Flip::is_flip_2_1_activated() {
+			let flip_distributed = Flip::trigger_flip_reward_distribution(ending);
 			let egress_fee_consumed = Swapping::maybe_trigger_flip_to_gateway_egress(
 				Environment::state_chain_gateway_address(),
 				flip_distributed,
 			);
 			Flip::add_to_offchain_flip_to_be_distributed(
 				i128::try_from(egress_fee_consumed).unwrap_or(i128::MAX).saturating_neg(),
+			);
+		}
+	}
+
+	fn on_new_epoch(new: EpochIndex) {
+		AssetBalances::trigger_reconciliation();
+
+		// One-off supply sync on activation: settles the outstanding burn so that fee
+		// accumulation starts from a clean slate.
+		if new == pallet_cf_flip::FeeRewardsActivationEpoch::<crate::Runtime>::get() {
+			Emissions::burn_and_broadcast_supply_update(
+				frame_system::Pallet::<crate::Runtime>::block_number(),
+				true,
 			);
 		}
 	}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -284,6 +284,10 @@ pub enum StartKeyActivationResult {
 pub trait EpochTransitionHandler {
 	/// When an epoch has been expired.
 	fn on_expired_epoch(_expired: EpochIndex) {}
+	/// When an epoch is ending. Called in the same block as [Self::on_new_epoch], but *before*
+	/// the epoch index is incremented, so `EpochInfo::epoch_index()` still returns the ending
+	/// epoch.
+	fn on_epoch_ending(_ending: EpochIndex) {}
 	/// When a new epoch has started.
 	fn on_new_epoch(_new: EpochIndex) {}
 }


### PR DESCRIPTION
Distribute rewards before the epoch ends, still while transitioning to the new epoch but before calling:
- `initialise_new_epoch()`
- `on_new_epoch()`