### PR TITLE
fix: call outer witness function instead of inner for vault swaps

### DIFF
--- a/state-chain/runtime/src/chainflip/witnessing/pallet_hooks.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/pallet_hooks.rs
@@ -69,7 +69,7 @@ hook_impls! {
 				);
 			},
 			Witness(deposit) => {
-				pallet_cf_ingress_egress::Pallet::<T, I>::process_vault_swap_request_full_witness_inner(
+				pallet_cf_ingress_egress::Pallet::<T, I>::process_vault_swap_request_full_witness(
 					block_height,
 					deposit.clone(),
 				);


### PR DESCRIPTION
# Pull Request

## Summary

This ensures that we properly call the wrapper which is something we might want to rely on in the future.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.

