### PR TITLE
chore: increase local tron node maxtime ratio

### DIFF
--- a/engine/src/tron/retry_rpc.rs
+++ b/engine/src/tron/retry_rpc.rs
@@ -402,10 +402,13 @@ impl<Rpc: TronSigningRpcApi> TronRetrySigningRpcApi for TronRetryRpcClient<Rpc> 
 								}
 							},
 							_ => {
+								// Tron returns the message as hex-encoded UTF-8 bytes.
 								return Err(anyhow::anyhow!(
 									"Failed to estimate energy (code: {:?}, message: {:?})",
 									energy_estimate.result.code,
-									energy_estimate.result.message,
+									energy_estimate.result.message
+									.and_then(|m| hex::decode(m).ok())
+									.and_then(|bytes| String::from_utf8(bytes).ok()),
 								));
 							},
 						}.try_into()?;

--- a/engine/src/tron/retry_rpc.rs
+++ b/engine/src/tron/retry_rpc.rs
@@ -36,6 +36,16 @@ use super::{
 	rpc_client_api::{BlockBalance, BlockNumber, Transaction, TransactionInfo, TronAddress},
 };
 
+// Tron returns error messages as hex-encoded UTF-8 bytes; fall back to the raw string if it
+// isn't hex/UTF-8 encoded.
+fn decode_tron_error_message(message: Option<String>) -> Option<String> {
+	message
+		.clone()
+		.and_then(|m| hex::decode(m).ok())
+		.and_then(|bytes| String::from_utf8(bytes).ok())
+		.or(message)
+}
+
 #[derive(Clone)]
 pub struct TronRetryRpcClient<Rpc: TronRpcApi> {
 	rpc_retry_client: RetrierClient<Rpc>,
@@ -402,13 +412,10 @@ impl<Rpc: TronSigningRpcApi> TronRetrySigningRpcApi for TronRetryRpcClient<Rpc> 
 								}
 							},
 							_ => {
-								// Tron returns the message as hex-encoded UTF-8 bytes.
 								return Err(anyhow::anyhow!(
 									"Failed to estimate energy (code: {:?}, message: {:?})",
 									energy_estimate.result.code,
-									energy_estimate.result.message
-									.and_then(|m| hex::decode(m).ok())
-									.and_then(|bytes| String::from_utf8(bytes).ok()),
+									decode_tron_error_message(energy_estimate.result.message),
 								));
 							},
 						}.try_into()?;

--- a/localnet/init/tron/config-peer.conf
+++ b/localnet/init/tron/config-peer.conf
@@ -52,7 +52,7 @@ vm = {
   # Increase the maxTimeRatio (default 5.0 assumes near-dedicated CPU); to not get OUT_OF_TIME errors.
   # Raise it per TRON's guidance for virtualized/shared hardware. See developers.tron.network FAQ.
   minTimeRatio = 0.0
-  maxTimeRatio = 20.0
+  maxTimeRatio = 50.0
 }
 
 genesis.block = {
@@ -116,7 +116,7 @@ committee = {
   allowNewReward = 1
   memoFee = 1000000
   allowDelegateOptimization = 1
-  allowDynamicEnergy = 1
+  allowDynamicEnergy = 0
   dynamicEnergyThreshold = 5000000000
   dynamicEnergyIncreaseFactor = 2000
   dynamicEnergyMaxFactor = 34000

--- a/localnet/init/tron/config.conf
+++ b/localnet/init/tron/config.conf
@@ -52,7 +52,7 @@ vm = {
   # Increase the maxTimeRatio (default 5.0 assumes near-dedicated CPU); to not get OUT_OF_TIME errors.
   # Raise it per TRON's guidance for virtualized/shared hardware. See developers.tron.network FAQ.
   minTimeRatio = 0.0
-  maxTimeRatio = 20.0
+  maxTimeRatio = 50.0
 }
 
 genesis.block = {
@@ -127,7 +127,7 @@ committee = {
   allowNewReward = 1
   memoFee = 1000000
   allowDelegateOptimization = 1
-  allowDynamicEnergy = 1
+  allowDynamicEnergy = 0
   dynamicEnergyThreshold = 5000000000
   dynamicEnergyIncreaseFactor = 2000
   dynamicEnergyMaxFactor = 34000


### PR DESCRIPTION
# Pull Request

## Summary

This PR improves localnet tron:
* Limits often CPU timeout errors caused by congested tron node by increasing MaxTimeRatio config
* Fixes decoding error response from estimate_gas rpc which returns a hex-encoded string

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Unrelated changes are isolated in dedicated commits.

