### PR TITLE
chore: disable BscUsdt oracle prices

### DIFF
--- a/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/generic_elections.rs
@@ -81,7 +81,7 @@ pub(crate) fn get_chainlink_assetpair(asset: any::Asset) -> Option<ChainlinkAsse
 		any::Asset::Trx => None,
 		any::Asset::TrxUsdt => Some(UsdtUsd),
 		any::Asset::Bnb => None,
-		any::Asset::BscUsdt => Some(UsdtUsd),
+		any::Asset::BscUsdt => None,
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

We can't rely on USDT/USD prices for BnbUsdt because this is "Binance Wrapped Usdt" and not directly provided by Tether. So this PR disables oracle prices for BnbUsdt (internally called `BscUsdt`).

We did the same in [this PR](https://github.com/chainflip-io/chainflip-backend/pull/6590) for WBTC because its real world price didn't exactly match oracle BTC/USD price.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Anything non-obvious is documented in the `Summary` section above.
