### PR TITLE
fix: Continue accruing interest even if oracle prices aren't available

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -87,6 +87,14 @@ pub enum LiquidationStatus {
 	},
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LiquidationStatusChange {
+	NoChange,
+	HealthyToLiquidation { liquidation_type: LiquidationType },
+	ChangeLiquidationType { liquidation_type: LiquidationType },
+	AbortLiquidation { reason: LiquidationCompletionReason },
+}
+
 /// High precision interest amounts broken down by type
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, Default)]
 pub struct InterestBreakdown {
@@ -267,31 +275,15 @@ impl<T: Config> LoanAccount<T> {
 			.try_fold(0u128, |acc, x| Ok(acc.saturating_add(x?)))
 	}
 
-	#[transactional]
-	pub fn update_liquidation_status(
-		&mut self,
-		borrower_id: &T::AccountId,
+	fn determine_liquidation_status_change(
+		&self,
 		ltv: FixedU64,
-		price_cache: &OraclePriceCache<T>,
 		config: &LendingConfiguration,
-		weight_used: &mut Weight,
-	) -> DispatchResult {
+	) -> LiquidationStatusChange {
 		// This will saturate at 100%, but that's good enough (none of our thresholds exceed 100%):
 		let ltv: Permill = ltv.into_clamped_perthing();
 
-		#[derive(Debug)]
-		enum LiquidationStatusChange {
-			NoChange,
-			HealthyToLiquidation { liquidation_type: LiquidationType },
-			ChangeLiquidationType { liquidation_type: LiquidationType },
-			AbortLiquidation { reason: LiquidationCompletionReason },
-		}
-
-		// Every time we transition from a liquidating state we abort all liquidation swaps
-		// and repay any swapped into principal. If the next state is "NoLiquidation", the
-		// collateral is returned into the loan account; if it is "Liquidating", the collateral
-		// is used in the new liquidation swaps.
-		let new_status = match &mut self.liquidation_status {
+		match &self.liquidation_status {
 			LiquidationStatus::NoLiquidation => {
 				// If LTV requires us to initiate liquidation, we start a forced liquidation.
 				// Otherwise, if check if voluntary liquidation is requested and initiate it if so.
@@ -390,9 +382,23 @@ impl<T: Config> LoanAccount<T> {
 					LiquidationStatusChange::NoChange
 				}
 			},
-		};
+		}
+	}
 
-		match new_status {
+	#[transactional]
+	fn apply_liquidation_status_change(
+		&mut self,
+		borrower_id: &T::AccountId,
+		change: LiquidationStatusChange,
+		price_cache: &OraclePriceCache<T>,
+		config: &LendingConfiguration,
+		weight_used: &mut Weight,
+	) -> DispatchResult {
+		// Every time we transition from a liquidating state we abort all liquidation swaps
+		// and repay any swapped into principal. If the next state is "NoLiquidation", the
+		// collateral is returned into the loan account; if it is "Liquidating", the collateral
+		// is used in the new liquidation swaps.
+		match change {
 			LiquidationStatusChange::HealthyToLiquidation { liquidation_type } => {
 				ensure!(T::SafeMode::get().liquidations_enabled, Error::<T>::LiquidationsDisabled);
 				let collateral =
@@ -1375,30 +1381,31 @@ fn remove_loan_account_if_settled<T: Config>(maybe_account: &mut Option<LoanAcco
 	}
 }
 
-/// Run a single upkeep tick for one borrower. Wrapped in `#[transactional]` so any
-/// error rolls back the full set of storage writes for this account (interest
-/// collection touches pool and `PendingNetworkFees` storage outside of
-/// `LoanAccounts`, which `try_mutate_exists` does not roll back on its own).
-#[transactional]
+/// Run a single upkeep tick for one borrower.
 fn upkeep_for_borrower<T: Config>(
 	borrower_id: &T::AccountId,
 	price_cache: &OraclePriceCache<T>,
 	config: &LendingConfiguration,
 	weight_used: &mut Weight,
-) -> DispatchResult {
-	LoanAccounts::<T>::try_mutate_exists(borrower_id, |maybe_account| {
+) {
+	let change = LoanAccounts::<T>::mutate_exists(borrower_id, |maybe_account| {
 		let Some(loan_account) = maybe_account.as_mut() else {
 			log_or_panic!("Loan account missing for borrower {borrower_id:?} during upkeep");
-			return Ok(());
+			return None;
 		};
 
+		// Interest accrual does not need oracle prices and thus cannot fail. This simply records
+		// the owed amount; it remains pending until it can be collected (collection does require
+		// oracle prices).
 		loan_account.derive_and_charge_interest(config, weight_used);
 
-		// Some of these may fail due to oracle prices being unavailable, but that's
-		// OK and doesn't need any specific error handling (they will simply be re-tried
-		// at a later point).
 		weight_used.saturating_accrue(T::WeightInfo::derive_ltv());
-		let ltv = loan_account.derive_ltv(price_cache)?;
+
+		// No point proceeding further if we can't determine LTV (the risk of liquidation checks
+		// not running in case of oracle outages is accepted):
+		let Ok(ltv) = loan_account.derive_ltv(price_cache) else {
+			return None;
+		};
 
 		loan_account.check_low_ltv_penalty_and_collect_interest(
 			ltv,
@@ -1407,20 +1414,39 @@ fn upkeep_for_borrower<T: Config>(
 			weight_used,
 		);
 
-		loan_account.update_liquidation_status(
-			borrower_id,
-			ltv,
-			price_cache,
-			config,
-			weight_used,
-		)?;
+		Some(loan_account.determine_liquidation_status_change(ltv, config))
+	});
 
-		// If all loans are repaid manually while in liquidation, liquidation swaps will be
-		// aborted above and we need to delete the account:
-		remove_loan_account_if_settled(maybe_account);
+	// Updating liquidation status is done in a separate storage mutation so it can be rolled back
+	// if necessary without affecting interest accrual above. Importantly, liquidation status
+	// updates are rare, so this doesn't cost us extra storage access most of the time:
+	if let Some(change) = change.filter(|change| *change != LiquidationStatusChange::NoChange) {
+		weight_used.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+		// Swallowing the error is fine (most likely reason is liquidation being disabled via safe
+		// mode): this will be retried on the next block.
+		let _ = LoanAccounts::<T>::try_mutate_exists(borrower_id, |maybe_account| {
+			let Some(loan_account) = maybe_account.as_mut() else {
+				log_or_panic!(
+					"Loan account missing for borrower {borrower_id:?} during liquidation"
+				);
+				return Ok(());
+			};
 
-		Ok::<_, DispatchError>(())
-	})
+			loan_account.apply_liquidation_status_change(
+				borrower_id,
+				change,
+				price_cache,
+				config,
+				weight_used,
+			)?;
+
+			// If all loans are repaid manually while in liquidation, liquidation swaps will be
+			// aborted above and we need to delete the account:
+			remove_loan_account_if_settled(maybe_account);
+
+			Ok::<_, DispatchError>(())
+		});
+	}
 }
 
 /// Check collateralisation ratio (triggering/aborting liquidations if necessary) and
@@ -1437,9 +1463,7 @@ pub fn lending_upkeep<T: Config>(current_block: BlockNumberFor<T>) -> Weight {
 		.collect::<Vec<_>>()
 		.iter()
 	{
-		// Not being able to process a loan account is acceptable (expected when oracle
-		// prices are down or when liquidations are disabled).
-		let _ = upkeep_for_borrower::<T>(borrower_id, &price_cache, &config, &mut weight_used);
+		upkeep_for_borrower::<T>(borrower_id, &price_cache, &config, &mut weight_used);
 	}
 
 	// Swap fees in every asset every fee_swap_interval_blocks, but only if they exceed

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -4770,23 +4770,18 @@ mod safe_mode {
 			});
 	}
 
-	// Regression test for PRO-2860.
+	// Regression test for PRO-2973.
 	//
-	// When `update_liquidation_status` returns `Err(LiquidationsDisabled)` from inside
-	// `lending_upkeep`'s `try_mutate_exists` closure, the prior
-	// `check_low_ltv_penalty_and_collect_interest` call writes to external storage
-	// (lending pool totals, `PendingNetworkFees`). Those writes must roll back together
-	// with the borrower-side mutations (which `try_mutate_exists` discards on `Err`),
-	// otherwise the pool/network books reflect interest the borrower no longer owes.
+	// When liquidation is disabled, the failed liquidation transition must not roll back the
+	// borrower's interest accrual and the matching pool/network accounting.
 	#[test]
-	fn upkeep_does_not_commit_fees_when_liquidations_are_disabled() {
+	fn upkeep_commits_interest_when_liquidations_are_disabled() {
 		new_test_ext()
 			.with_funded_pool(INIT_POOL_AMOUNT)
 			.with_default_loan()
 			.then_execute_with(|_| {
-				// Snapshot pool / fee / loan state right after loan creation — once the
-				// origination fee has been taken. With the fix, this is exactly what we
-				// expect to see after upkeep runs while liquidations are disabled.
+				// Snapshot state right after loan creation, once the origination fee has been
+				// taken.
 				let pool_before = GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap();
 				let pending_network_fees_before = PendingNetworkFees::<Test>::get(LOAN_ASSET);
 				let loan_account_before = LoanAccounts::<Test>::get(BORROWER).unwrap();
@@ -4795,7 +4790,7 @@ mod safe_mode {
 				//  - liquidations disabled via safe mode,
 				//  - collection threshold low enough that any accrued interest gets collected,
 				//  - oracle price moved so that LTV exceeds the hard liquidation threshold (forces
-				//    `update_liquidation_status` down the `LiquidationsDisabled` path).
+				//    `apply_liquidation_status_change` down the `LiquidationsDisabled` path).
 				MockRuntimeSafeMode::set_safe_mode(PalletSafeMode {
 					liquidations_enabled: false,
 					..PalletSafeMode::code_green()
@@ -4810,10 +4805,8 @@ mod safe_mode {
 
 				(pool_before, pending_network_fees_before, loan_account_before)
 			})
-			// Process up to the first interest payment block so that upkeep runs
-			// `derive_and_charge_interest` followed by
-			// `check_low_ltv_penalty_and_collect_interest` followed by
-			// `update_liquidation_status` (which errors).
+			// Process up to the first interest payment block. The liquidation transition
+			// will fail, but the preceding interest accounting must commit.
 			.then_process_blocks_until_block(
 				INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
 			)
@@ -4828,23 +4821,57 @@ mod safe_mode {
 					RuntimeEvent::LendingPools(Event::<Test>::LiquidationInitiated { .. })
 				);
 
-				// The invariant: because the per-account closure returned `Err`, the
-				// upkeep tick for this borrower must be a no-op across all storage.
-				assert_eq!(
+				assert_ne!(
 					GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap(),
 					pool_before,
-					"pool accounting moved despite the loan-account mutations being rolled back",
+					"pool accounting did not receive the collected interest",
 				);
-				assert_eq!(
+				assert_ne!(
 					PendingNetworkFees::<Test>::get(LOAN_ASSET),
 					fees_before,
-					"network fees were collected without a matching borrower receivable",
+					"network fees did not receive the collected interest",
 				);
-				assert_eq!(
+				assert_ne!(
 					LoanAccounts::<Test>::get(BORROWER).unwrap(),
 					loan_account_before,
-					"loan account changed but upkeep was supposed to be a no-op",
+					"borrower debt did not reflect the collected interest",
 				);
+				assert_has_matching_event!(
+					Test,
+					RuntimeEvent::LendingPools(Event::<Test>::InterestTaken { .. })
+				);
+			});
+	}
+
+	#[test]
+	fn upkeep_accrues_interest_when_oracle_prices_are_stale() {
+		new_test_ext()
+			.with_funded_pool(INIT_POOL_AMOUNT)
+			.with_default_loan()
+			.then_execute_with(|_| {
+				let loan_account = LoanAccounts::<Test>::get(BORROWER).unwrap();
+
+				// No fees have been accrued:
+				assert_eq!(
+					loan_account.loans.get(&LOAN_ID).unwrap().pending_interest,
+					InterestBreakdown::default()
+				);
+
+				MockPriceFeedApi::set_stale(LOAN_ASSET, true);
+				System::reset_events();
+			})
+			.then_process_blocks_until_block(
+				INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
+			)
+			.then_execute_with(|_| {
+				let loan_account = LoanAccounts::<Test>::get(BORROWER).unwrap();
+
+				// Fees have been accrued (but not collected):
+				assert_ne!(
+					loan_account.loans.get(&LOAN_ID).unwrap().pending_interest,
+					InterestBreakdown::default()
+				);
+
 				assert_no_matching_event!(
 					Test,
 					RuntimeEvent::LendingPools(Event::<Test>::InterestTaken { .. })


### PR DESCRIPTION
# Pull Request

Closes: PRO-2973

## Summary

The change is simple: trivially split `update_liquidation_status` into 2 parts: `determine_liquidation_status_change` and `apply_liquidation_status_change`. `determine_liquidation_status_change` can't fail and runs in the same storage mutation as interest accrual. `apply_liquidation_status_change` is now in a separate storage mutation, so if it fails it won't roll back interest accrual. The second storage mutation is only performed when necessary (liquidation status change, so very rarely), so the code is still performant.

## API Changes

(no api changes)

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
