### PR TITLE
fix: clear next epoch snapshots when rotation starts

### DIFF
--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -1933,6 +1933,7 @@ impl<T: Config> Pallet<T> {
 
 				// Register the delegation snapshots for the next epoch.
 				let next_epoch_index = CurrentEpoch::<T>::get() + 1;
+				DelegationSnapshot::clear_epoch_registrations::<T>(next_epoch_index);
 				for snapshot in delegation_snapshots.into_values() {
 					snapshot.register_for_epoch::<T>(next_epoch_index);
 				}

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3565,6 +3565,46 @@ mod keygen_failure_with_delegation {
 	}
 
 	#[test]
+	fn fresh_rotation_clears_pending_delegation_registrations() {
+		const STALE_OPERATOR: u64 = 2000;
+		const STALE_VALIDATOR: u64 = 201;
+		const STALE_MAPPING_VALIDATOR: u64 = 202;
+
+		new_test_ext().execute_with(|| {
+			setup_operator_with_validators();
+			let next_epoch = CurrentEpoch::<Test>::get() + 1;
+
+			// Model state left by an aborted attempt: one operator will be overwritten by the
+			// fresh auction, while the other will not be present in its result.
+			DelegationSnapshot::<u64, u128> {
+				operator: OPERATOR,
+				validators: [(STALE_MAPPING_VALIDATOR, 100)].into_iter().collect(),
+				delegators: Default::default(),
+				delegation_fee_bps: DEFAULT_MIN_OPERATOR_FEE,
+			}
+			.register_for_epoch::<Test>(next_epoch);
+			DelegationSnapshot::<u64, u128> {
+				operator: STALE_OPERATOR,
+				validators: [(STALE_VALIDATOR, 100)].into_iter().collect(),
+				delegators: Default::default(),
+				delegation_fee_bps: DEFAULT_MIN_OPERATOR_FEE,
+			}
+			.register_for_epoch::<Test>(next_epoch);
+
+			ValidatorPallet::start_authority_rotation();
+
+			let snapshot = DelegationSnapshots::<Test>::get(next_epoch, OPERATOR).unwrap();
+			assert!(snapshot.validators.contains_key(&VALIDATOR_1));
+			assert_eq!(ValidatorToOperator::<Test>::get(next_epoch, VALIDATOR_1), Some(OPERATOR));
+
+			assert!(!snapshot.validators.contains_key(&STALE_MAPPING_VALIDATOR));
+			assert_eq!(ValidatorToOperator::<Test>::get(next_epoch, STALE_MAPPING_VALIDATOR), None);
+			assert!(!DelegationSnapshots::<Test>::contains_key(next_epoch, STALE_OPERATOR));
+			assert_eq!(ValidatorToOperator::<Test>::get(next_epoch, STALE_VALIDATOR), None);
+		});
+	}
+
+	#[test]
 	fn keygen_failure_updates_delegation_snapshot() {
 		new_test_ext().execute_with(|| {
 			setup_operator_with_validators();


### PR DESCRIPTION
# Pull Request

## Summary

Clear snapshots for the next epoch when a rotation starts, this prevents a weird edge case where if the rotation aborts we keep the old snapshots saved. 
Since we index by epoch and operator, an operator present in the outdated snapshot but not present in the official one (when rotation succeed), could cause some miscalculation when distributing the rewards. The total amount distributed would still be correct, but the way it is distributed is not. 
This is not easily gameable, if at all, it requires sophisticated set up and for a validator to register with another operator while being in the outdated snapshot. Since operator and validators are usually managed by the same entity this limits the impact still it is good practice to have a proper set of snapshots which are "clean" and not mixed up with old/outdated data. 

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * x ] Unit tests for isolated local conditions.