### PR TITLE
chore: ci job to benchmark exec time of mainnet blocks

### DIFF
--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -17,12 +17,6 @@ name: "Run Block Execution Benchmark"
 # persist/re-share the synced chain-data directory across runs.
 
 on:
-  # TEMPORARY: lets us test-run this workflow via a plain push, since
-  # workflow_dispatch is only invokable once this file exists on the default
-  # branch. Remove this `push` trigger before merging to main.
-  push:
-    branches:
-      - feat/benchmark-exec-time-mainnet-blocks
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -68,7 +62,7 @@ jobs:
     uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
     with:
       command: apply
-      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
     secrets: inherit
 
   run_block_benchmark:
@@ -77,7 +71,7 @@ jobs:
         self-hosted,
         linux,
         x64,
-        "${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}",
+        "${{ github.event.inputs.benchmark_machine_spec }}",
       ]
     needs: [deploy_benchmarks_runner]
     continue-on-error: true
@@ -97,22 +91,22 @@ jobs:
             FULL_SHA=$(git rev-parse "${{ inputs.commit_sha }}")
           else
             FULL_SHA=$(curl -sH "Authorization: token $GH_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml/runs?status=success&per_page=1" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci-benchmarks-${{ inputs.binary_artefact_source }}.yml/runs?status=success&per_page=1" \
               | jq -r '.workflow_runs[0].head_sha // empty')
             if [ -z "$FULL_SHA" ]; then
-              echo "Could not find a successful ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml run to source a binary from" >&2
+              echo "Could not find a successful ci-benchmarks-${{ inputs.binary_artefact_source }}.yml run to source a binary from" >&2
               exit 1
             fi
           fi
           echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
           echo "Using commit $FULL_SHA"
 
-      - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml
+      - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
         uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
         with:
-          workflow: ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml
+          workflow: ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
           workflow_conclusion: completed
-          name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile || 'production' }}
+          name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile }}
           commit: ${{ steps.resolve-sha.outputs.full_sha }}
           github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           search_artifacts: true
@@ -137,8 +131,8 @@ jobs:
             > "$BASE_PATH/sync.log" 2>&1 &
           echo "sync_pid=$!" >> "$GITHUB_ENV"
 
-          echo "Syncing for ${{ inputs.sync_duration_minutes || '3' }} minutes..."
-          sleep $(( ${{ inputs.sync_duration_minutes || '3' }} * 60 ))
+          echo "Syncing for ${{ inputs.sync_duration_minutes }} minutes..."
+          sleep $(( ${{ inputs.sync_duration_minutes }} * 60 ))
 
       - name: Stop sync and determine imported block range 🛑
         id: block-range
@@ -211,5 +205,5 @@ jobs:
     uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
     with:
       command: destroy
-      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
     secrets: inherit

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -20,8 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: "Which commit SHA should we get the chainflip-node binary from?"
-        required: true
+        description: "Commit SHA to benchmark. Leave empty to use the latest successful benchmarks build."
+        required: false
         type: string
       sync_duration_minutes:
         description: "How many minutes to warp-sync against Berghain before stopping and benchmarking?"
@@ -82,13 +82,26 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Resolve full commit SHA
+      - name: Resolve commit SHA
         id: resolve-sha
+        env:
+          GH_TOKEN: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
         run: |
-          FULL_SHA=$(git rev-parse "${{ inputs.commit_sha }}")
+          if [ -n "${{ inputs.commit_sha }}" ]; then
+            FULL_SHA=$(git rev-parse "${{ inputs.commit_sha }}")
+          else
+            FULL_SHA=$(curl -sH "Authorization: token $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci-benchmarks-${{ inputs.binary_artefact_source }}.yml/runs?status=success&per_page=1" \
+              | jq -r '.workflow_runs[0].head_sha // empty')
+            if [ -z "$FULL_SHA" ]; then
+              echo "Could not find a successful ci-benchmarks-${{ inputs.binary_artefact_source }}.yml run to source a binary from" >&2
+              exit 1
+            fi
+          fi
           echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "Using commit $FULL_SHA"
 
-      - name: Fetch chainflip-node from ${{ inputs.commit_sha }}
+      - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
         uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
         with:
           workflow: ci-benchmarks-${{ inputs.binary_artefact_source }}.yml

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -1,0 +1,187 @@
+name: "Run Block Execution Benchmark"
+
+# Manually triggered from the Actions UI. Warp-syncs a chainflip-node against
+# real Berghain (mainnet) for a fixed window, discovers whichever block range
+# got imported, stops the sync, then replays that exact range with
+# `chainflip-node benchmark block` to compare declared (weight) vs actual
+# measured execution time per block.
+#
+# Runs on the same self-hosted benchmark runner / binary artifact used by
+# `_100_run_benchmarks.yml` (pallet weight calculation), so results are
+# comparable to the hardware the on-chain weights were benchmarked against.
+#
+# Caveat: each run does a fresh warp sync against live mainnet, so two
+# separate runs are not guaranteed to import the exact same block range.
+# For an apples-to-apples before/after comparison, compare execution-time
+# deltas relative to weight within a single run, or extend this workflow to
+# persist/re-share the synced chain-data directory across runs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Which commit SHA should we get the chainflip-node binary from?"
+        required: true
+        type: string
+      sync_duration_minutes:
+        description: "How many minutes to warp-sync against Berghain before stopping and benchmarking?"
+        required: false
+        type: string
+        default: "15"
+      benchmark_machine_spec:
+        description: "What machine spec should the benchmark run on?"
+        required: true
+        default: 4vCPU-8GB
+        type: choice
+        options:
+          - 4vCPU-8GB
+          - 4vCPU-16GB
+      profile:
+        description: "Which profile should we use?"
+        required: false
+        type: choice
+        default: production
+        options:
+          - production
+          - release
+      binary_artefact_source:
+        description: "Which source should we use for the binary artefact?"
+        required: false
+        type: choice
+        options:
+          - main
+          - release
+        default: release
+
+env:
+  FORCE_COLOR: 1
+  BASE_PATH: /tmp/chainflip-berghain-benchmark
+
+jobs:
+  deploy_benchmarks_runner:
+    uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
+    with:
+      command: apply
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
+    secrets: inherit
+
+  run_block_benchmark:
+    runs-on:
+      [
+        self-hosted,
+        linux,
+        x64,
+        "${{ github.event.inputs.benchmark_machine_spec }}",
+      ]
+    needs: [deploy_benchmarks_runner]
+    continue-on-error: true
+    timeout-minutes: 40
+    steps:
+      - name: Checkout 🛒
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Resolve full commit SHA
+        id: resolve-sha
+        run: |
+          FULL_SHA=$(git rev-parse "${{ inputs.commit_sha }}")
+          echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch chainflip-node from ${{ inputs.commit_sha }}
+        uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
+        with:
+          workflow: ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
+          workflow_conclusion: completed
+          name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile }}
+          commit: ${{ steps.resolve-sha.outputs.full_sha }}
+          github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
+          search_artifacts: true
+          check_artifacts: true
+
+      - name: Update permissions on chainflip-node 🚓
+        run: chmod +x ./chainflip-node
+
+      - name: Warp-sync against Berghain 🔄
+        run: |
+          rm -rf "$BASE_PATH"
+          mkdir -p "$BASE_PATH"
+
+          ./chainflip-node \
+            --chain=state-chain/node/chainspecs/berghain.chainspec.raw.json \
+            --base-path="$BASE_PATH" \
+            --sync=warp \
+            --state-pruning=128 \
+            --blocks-pruning=128 \
+            --no-telemetry \
+            --name=ci-block-benchmark \
+            > "$BASE_PATH/sync.log" 2>&1 &
+          echo "sync_pid=$!" >> "$GITHUB_ENV"
+
+          echo "Syncing for ${{ inputs.sync_duration_minutes }} minutes..."
+          sleep $(( ${{ inputs.sync_duration_minutes }} * 60 ))
+
+      - name: Stop sync and determine imported block range 🛑
+        id: block-range
+        run: |
+          kill "$sync_pid" || true
+          # Give it a moment to release the DB lock cleanly.
+          for i in $(seq 1 30); do
+            kill -0 "$sync_pid" 2>/dev/null || break
+            sleep 1
+          done
+
+          BLOCKS=$(grep -oE 'Imported #[0-9]+' "$BASE_PATH/sync.log" | grep -oE '[0-9]+' | sort -n)
+          if [ -z "$BLOCKS" ]; then
+            echo "No blocks were imported during the sync window - see sync.log" >&2
+            tail -n 100 "$BASE_PATH/sync.log" >&2
+            exit 1
+          fi
+
+          FROM=$(echo "$BLOCKS" | head -n1)
+          TO=$(echo "$BLOCKS" | tail -n1)
+          echo "Imported blocks $FROM..$TO"
+          echo "from=$FROM" >> "$GITHUB_OUTPUT"
+          echo "to=$TO" >> "$GITHUB_OUTPUT"
+
+      - name: Run block execution benchmark 📏
+        run: |
+          ./chainflip-node benchmark block \
+            --chain=state-chain/node/chainspecs/berghain.chainspec.raw.json \
+            --base-path="$BASE_PATH" \
+            --from=${{ steps.block-range.outputs.from }} \
+            --to=${{ steps.block-range.outputs.to }} \
+            | tee benchmark-block-output.txt
+
+      - name: Upload benchmark output 📦
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        with:
+          name: benchmark-block-output-${{ steps.resolve-sha.outputs.full_sha }}
+          path: benchmark-block-output.txt
+
+      - name: Write job summary 📝
+        run: |
+          {
+            echo "### Block execution benchmark"
+            echo "Commit: \`${{ steps.resolve-sha.outputs.full_sha }}\`"
+            echo "Blocks: ${{ steps.block-range.outputs.from }}..${{ steps.block-range.outputs.to }}"
+            echo '```'
+            cat benchmark-block-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup 🧹
+        if: always()
+        run: |
+          kill "$sync_pid" 2>/dev/null || true
+          rm -rf "$BASE_PATH"
+          rm -f ./chainflip-node
+
+  destroy_benchmarks_runner:
+    needs: [run_block_benchmark]
+    if: always()
+    uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
+    with:
+      command: destroy
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
+    secrets: inherit

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -170,7 +170,7 @@ jobs:
             --base-path="$BASE_PATH" \
             --from=${{ steps.block-range.outputs.from }} \
             --to=${{ steps.block-range.outputs.to }} \
-            | tee benchmark-block-output.txt
+            2>&1 | tee benchmark-block-output.txt
 
       - name: Upload benchmark output 📦
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
@@ -188,6 +188,15 @@ jobs:
             cat benchmark-block-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Zip chain database 🗄️
+        run: (cd "$BASE_PATH" && zip -rq "$GITHUB_WORKSPACE/berghain-chaindata.zip" .)
+
+      - name: Upload chain database 📦
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        with:
+          name: berghain-chaindata-${{ steps.block-range.outputs.from }}-${{ steps.block-range.outputs.to }}
+          path: berghain-chaindata.zip
 
       - name: Cleanup 🧹
         if: always()

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -189,14 +189,14 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Zip chain database 🗄️
-        run: (cd "$BASE_PATH" && zip -rq "$GITHUB_WORKSPACE/berghain-chaindata.zip" .)
+      - name: Archive chain database 🗄️
+        run: tar -czf "$GITHUB_WORKSPACE/berghain-chaindata.tar.gz" -C "$BASE_PATH" .
 
       - name: Upload chain database 📦
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
         with:
           name: berghain-chaindata-${{ steps.block-range.outputs.from }}-${{ steps.block-range.outputs.to }}
-          path: berghain-chaindata.zip
+          path: berghain-chaindata.tar.gz
 
       - name: Cleanup 🧹
         if: always()

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -33,7 +33,7 @@ on:
         description: "How many minutes to warp-sync against Berghain before stopping and benchmarking?"
         required: false
         type: string
-        default: "15"
+        default: "3"
       benchmark_machine_spec:
         description: "What machine spec should the benchmark run on?"
         required: true
@@ -137,8 +137,8 @@ jobs:
             > "$BASE_PATH/sync.log" 2>&1 &
           echo "sync_pid=$!" >> "$GITHUB_ENV"
 
-          echo "Syncing for ${{ inputs.sync_duration_minutes || '15' }} minutes..."
-          sleep $(( ${{ inputs.sync_duration_minutes || '15' }} * 60 ))
+          echo "Syncing for ${{ inputs.sync_duration_minutes || '3' }} minutes..."
+          sleep $(( ${{ inputs.sync_duration_minutes || '3' }} * 60 ))
 
       - name: Stop sync and determine imported block range 🛑
         id: block-range

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -17,6 +17,12 @@ name: "Run Block Execution Benchmark"
 # persist/re-share the synced chain-data directory across runs.
 
 on:
+  # TEMPORARY: lets us test-run this workflow via a plain push, since
+  # workflow_dispatch is only invokable once this file exists on the default
+  # branch. Remove this `push` trigger before merging to main.
+  push:
+    branches:
+      - feat/benchmark-exec-time-mainnet-blocks
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -62,7 +68,7 @@ jobs:
     uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
     with:
       command: apply
-      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}
     secrets: inherit
 
   run_block_benchmark:
@@ -71,7 +77,7 @@ jobs:
         self-hosted,
         linux,
         x64,
-        "${{ github.event.inputs.benchmark_machine_spec }}",
+        "${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}",
       ]
     needs: [deploy_benchmarks_runner]
     continue-on-error: true
@@ -91,22 +97,22 @@ jobs:
             FULL_SHA=$(git rev-parse "${{ inputs.commit_sha }}")
           else
             FULL_SHA=$(curl -sH "Authorization: token $GH_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci-benchmarks-${{ inputs.binary_artefact_source }}.yml/runs?status=success&per_page=1" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml/runs?status=success&per_page=1" \
               | jq -r '.workflow_runs[0].head_sha // empty')
             if [ -z "$FULL_SHA" ]; then
-              echo "Could not find a successful ci-benchmarks-${{ inputs.binary_artefact_source }}.yml run to source a binary from" >&2
+              echo "Could not find a successful ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml run to source a binary from" >&2
               exit 1
             fi
           fi
           echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
           echo "Using commit $FULL_SHA"
 
-      - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
+      - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml
         uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
         with:
-          workflow: ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
+          workflow: ci-benchmarks-${{ inputs.binary_artefact_source || 'release' }}.yml
           workflow_conclusion: completed
-          name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile }}
+          name: chainflip-node-ubuntu-benchmarks-${{ inputs.profile || 'production' }}
           commit: ${{ steps.resolve-sha.outputs.full_sha }}
           github_token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           search_artifacts: true
@@ -131,8 +137,8 @@ jobs:
             > "$BASE_PATH/sync.log" 2>&1 &
           echo "sync_pid=$!" >> "$GITHUB_ENV"
 
-          echo "Syncing for ${{ inputs.sync_duration_minutes }} minutes..."
-          sleep $(( ${{ inputs.sync_duration_minutes }} * 60 ))
+          echo "Syncing for ${{ inputs.sync_duration_minutes || '15' }} minutes..."
+          sleep $(( ${{ inputs.sync_duration_minutes || '15' }} * 60 ))
 
       - name: Stop sync and determine imported block range 🛑
         id: block-range
@@ -196,5 +202,5 @@ jobs:
     uses: ./.github/workflows/_110_deploy_benchmarks_runner.yml
     with:
       command: destroy
-      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec }}
+      benchmark_machine_spec: ${{ inputs.benchmark_machine_spec || '4vCPU-8GB' }}
     secrets: inherit


### PR DESCRIPTION
# Pull Request

Closes: PRO-2690

## Summary

* This PR adds a job that becnhmarks block execution of mainnet blocks
* It syncs against mainnet by running for a specified number of minutes and downloading the resulting block data into a local databse.
* This block database is then used by the `chainflip-node benchmark block` tool to re-run the blocks and determine whether the benchmarking estimates were correct or over weight.
* `chainflip-node benchmark block` is run on a similar machine where the benchmarks were generated
* The block databse and a summary of resutls are uploaded as artifacts.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
