### PR TITLE
chore: single line rust toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,13 +1,5 @@
 [toolchain]
 channel = "nightly-2026-01-06"
-components = [
-	"cargo",
-	"clippy",
-	"rust-analyzer",
-	"rust-src",
-	"rust-std",
-	"rustc",
-	"rustfmt",
-]
+components = ["cargo", "clippy", "rust-analyzer", "rust-src", "rust-std", "rustc", "rustfmt"]
 targets = ["wasm32v1-none"]
 profile = "minimal"


### PR DESCRIPTION
# Pull Request

## Summary

Collapses the `components` array in `rust-toolchain.toml` onto a single line. No functional change — rustup installs exactly the same components.

The reason it matters is a quirk in the rust-analyzer VS Code extension. It prefers the toolchain's own `rust-analyzer` binary over its bundled one, but only if it can find the component declared in `rust-toolchain.toml`, which it detects with this regex:

```js
/components\s*=\s*\[.*"rust-analyzer".*\]/g
```

No `s` flag, so `.` never matches a newline. With the array spread over multiple lines the check silently fails and the extension falls back to its bundled server. That server (currently built ~2026-07-28) then rejects our pinned `nightly-2026-01-06` as too old and pops up this on every startup:

> Your workspace uses a rust-toolchain file with a toolchain too old for the extension shipped rust-analyzer to work properly. Consider adding the rust-analyzer component to the toolchain file to use a compatible rust-analyzer version. Add the following to your rust-toolchain file's `[toolchain]` section:
> `components = ["rust-analyzer"]`

Which is misleading, since the component was already there — just not on one line.

Verified against the extension's own regex: the previous file matched 0 times, this one matches once. Anyone who reformats this array across multiple lines will bring the warning back.

## API Changes

None.

### RPCS

None.

### Extrinsics & Events

None.
