### PR TITLE
fix: handle BSC in `cf_ingress_egress_events` rpc.

### DIFF
--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -2331,6 +2331,7 @@ mod witnessed_events {
 			ForeignChain::Ethereum => extract_ethereum_witnessed_events(),
 			ForeignChain::Arbitrum => extract_arbitrum_witnessed_events(),
 			ForeignChain::Tron => extract_tron_witnessed_events(),
+			ForeignChain::Bsc => extract_bsc_witnessed_events(),
 			_ => Err(DispatchErrorWithMessage::RawMessage(
 				b"Chain not supported for witnessed events".to_vec(),
 			)),
@@ -2433,6 +2434,24 @@ mod witnessed_events {
 		);
 
 		Ok(RawWitnessedEvents::Tron { deposits, vault_deposits, broadcasts })
+	}
+
+	fn extract_bsc_witnessed_events() -> Result<RawWitnessedEvents, DispatchErrorWithMessage> {
+		let state =
+			ElectoralUnsynchronisedState::<Runtime, BscInstance>::get().ok_or_else(|| {
+				DispatchErrorWithMessage::RawMessage(
+					b"Bsc electoral state not initialized".to_vec(),
+				)
+			})?;
+
+		let (deposits, vault_deposits, broadcasts) = extract_witnessed_events_for_state!(
+			deposits: &state.1,
+			vault_deposits: &state.2,
+			broadcasts: &state.3,
+			height: |h: &cf_chains::witness_period::BlockWitnessRange<Bsc>| *h.root(),
+		);
+
+		Ok(RawWitnessedEvents::Bsc { deposits, vault_deposits, broadcasts })
 	}
 
 	fn convert_deposit_witness<C: Chain>(


### PR DESCRIPTION
# Pull Request

## Summary

This adds BSC handling to the `cf_ingress_egress_events` rpc. It was already handled by the `cf_ingress_events` rpc, but that is a separate code path.

## API Changes

### RPCS

Previously, calling `cf_ingress_egress_events` returned `DispatchError: Chain not supported for witnessed events`. Now it properly returns the events.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
