### PR TITLE
ci(bouncer): use ephemeral CPX52 runner in Hetzner

### DIFF
--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -71,11 +71,21 @@ jobs:
 
   bouncer:
     needs: [provision-bouncer-runner]
-    runs-on:
-      [self-hosted, linux, x64, "${{ needs.provision-bouncer-runner.outputs.runner-label }}"]
+    # Run even when provisioning fails, so that this job always reports under the name
+    # required by branch protection. A skipped job counts as a passing required check,
+    # which would hide provisioning failures.
+    if: ${{ !cancelled() }}
+    # The ephemeral runner label is unique per run, so it identifies the runner on its own.
+    # Fall back to a hosted runner when there is none to target, otherwise the job waits
+    # on a label that matches nothing until it times out.
+    runs-on: ${{ needs.provision-bouncer-runner.result == 'success' && needs.provision-bouncer-runner.outputs.runner-label || 'namespace-profile-default-light' }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     continue-on-error: ${{ inputs.continue-on-bouncer-error }}
     steps:
+      - name: Fail if runner provisioning failed 🚨
+        if: ${{ needs.provision-bouncer-runner.result != 'success' }}
+        run: exit 1
+
       - name: Setup ngrok ✨
         if: inputs.ngrok
         run: |

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -50,8 +50,10 @@ jobs:
     runs-on: namespace-profile-default-light
     timeout-minutes: 15
     outputs:
+      firewall-id: ${{ steps.provision.outputs.firewall-id }}
       runner-label: ${{ steps.provision.outputs.runner-label }}
       runner-name: ${{ steps.provision.outputs.runner-name }}
+      server-id: ${{ steps.provision.outputs.server-id }}
     steps:
       - name: Checkout chainflip-backend 🛒
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -344,8 +346,12 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+          FIREWALL_ID: ${{ needs.provision-bouncer-runner.outputs.firewall-id }}
           RUNNER_NAME: ${{ needs.provision-bouncer-runner.outputs.runner-name }}
-        run: ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy "$RUNNER_NAME"
+          SERVER_ID: ${{ needs.provision-bouncer-runner.outputs.server-id }}
+        run: |
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
+            "$RUNNER_NAME" "$SERVER_ID" "$FIREWALL_ID"
 
   chainspec-compatibility:
     runs-on: namespace-profile-default

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -46,8 +46,32 @@ permissions:
   contents: read
 
 jobs:
+  provision-bouncer-runner:
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 15
+    outputs:
+      runner-label: ${{ steps.provision.outputs.runner-label }}
+      runner-name: ${{ steps.provision.outputs.runner-name }}
+    steps:
+      - name: Checkout chainflip-backend 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Provision ephemeral Hetzner runner ☁️
+        id: provision
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+          LOG_POSTFIX: ${{ inputs.log-postfix }}
+        run: |
+          suffix=$(tr --complement --delete '[:alnum:]-' <<<"$LOG_POSTFIX")
+          runner_name="bouncer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}${suffix}"
+          runner_label="${runner_name}-cpx52"
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh create "$runner_name" "$runner_label"
+
   bouncer:
-    runs-on: hetzner
+    needs: [provision-bouncer-runner]
+    runs-on:
+      [self-hosted, linux, x64, "${{ needs.provision-bouncer-runner.outputs.runner-label }}"]
     timeout-minutes: ${{ inputs.timeout-minutes }}
     continue-on-error: ${{ inputs.continue-on-bouncer-error }}
     steps:
@@ -244,6 +268,14 @@ jobs:
           path: |
             /tmp/chainflip/bouncer.log
 
+      - name: Upload runner diagnostics 💾
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        with:
+          name: runner-diagnostics${{ inputs.log-postfix }}
+          path: /opt/actions-runner/_diag/
+
       - name: Dump indexer database
         if: always()
         continue-on-error: true
@@ -298,6 +330,22 @@ jobs:
         continue-on-error: true
         run: |
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
+
+  destroy-bouncer-runner:
+    if: ${{ always() && needs.provision-bouncer-runner.outputs.runner-name != '' }}
+    needs: [provision-bouncer-runner, bouncer]
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 10
+    steps:
+      - name: Checkout chainflip-backend 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Destroy ephemeral Hetzner runner 🧹
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+          RUNNER_NAME: ${{ needs.provision-bouncer-runner.outputs.runner-name }}
+        run: ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy "$RUNNER_NAME"
 
   chainspec-compatibility:
     runs-on: namespace-profile-default

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -50,7 +50,6 @@ jobs:
     runs-on: namespace-profile-default-light
     timeout-minutes: 15
     outputs:
-      firewall-id: ${{ steps.provision.outputs.firewall-id }}
       runner-label: ${{ steps.provision.outputs.runner-label }}
       runner-name: ${{ steps.provision.outputs.runner-name }}
       server-id: ${{ steps.provision.outputs.server-id }}
@@ -346,12 +345,11 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-          FIREWALL_ID: ${{ needs.provision-bouncer-runner.outputs.firewall-id }}
           RUNNER_NAME: ${{ needs.provision-bouncer-runner.outputs.runner-name }}
           SERVER_ID: ${{ needs.provision-bouncer-runner.outputs.server-id }}
         run: |
           ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
-            "$RUNNER_NAME" "$SERVER_ID" "$FIREWALL_ID"
+            "$RUNNER_NAME" "$SERVER_ID"
 
   chainspec-compatibility:
     runs-on: namespace-profile-default

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -345,11 +345,11 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-          RUNNER_NAME: ${{ needs.provision-bouncer-runner.outputs.runner-name }}
-          SERVER_ID: ${{ needs.provision-bouncer-runner.outputs.server-id }}
+          CF_BOUNCER_RUNNER_NAME: ${{ needs.provision-bouncer-runner.outputs.runner-name }}
+          CF_BOUNCER_SERVER_ID: ${{ needs.provision-bouncer-runner.outputs.server-id }}
         run: |
           ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
-            "$RUNNER_NAME" "$SERVER_ID"
+            "$CF_BOUNCER_RUNNER_NAME" "$CF_BOUNCER_SERVER_ID"
 
   chainspec-compatibility:
     runs-on: namespace-profile-default

--- a/.github/workflows/_41_test_benchmarks.yml
+++ b/.github/workflows/_41_test_benchmarks.yml
@@ -1,12 +1,40 @@
 on:
   workflow_call:
+    secrets:
+      CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN:
+        required: true
+      CF_HETZNER_API_TOKEN:
+        required: true
 
 env:
   FORCE_COLOR: 1
 
 jobs:
+  provision-benchmarks-runner:
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 15
+    outputs:
+      runner-label: ${{ steps.provision.outputs.runner-label }}
+      runner-name: ${{ steps.provision.outputs.runner-name }}
+      server-id: ${{ steps.provision.outputs.server-id }}
+    steps:
+      - name: Checkout 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Provision ephemeral Hetzner runner ☁️
+        id: provision
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+        run: |
+          runner_name="bouncer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-benchmarks"
+          runner_label="${runner_name}-cpx52"
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh create "$runner_name" "$runner_label"
+
   test-benchmarks:
-    runs-on: hetzner
+    needs: [provision-benchmarks-runner]
+    runs-on:
+      [self-hosted, linux, x64, "${{ needs.provision-benchmarks-runner.outputs.runner-label }}"]
     timeout-minutes: 60
     steps:
       - name: Checkout 🛒
@@ -24,3 +52,22 @@ jobs:
           --binary ./chainflip-node
           --steps 2
           --repetitions 1
+
+  destroy-benchmarks-runner:
+    if: ${{ always() && needs.provision-benchmarks-runner.outputs.runner-name != '' }}
+    needs: [provision-benchmarks-runner, test-benchmarks]
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 10
+    steps:
+      - name: Checkout 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Destroy ephemeral Hetzner runner 🧹
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+          RUNNER_NAME: ${{ needs.provision-benchmarks-runner.outputs.runner-name }}
+          SERVER_ID: ${{ needs.provision-benchmarks-runner.outputs.server-id }}
+        run: |
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
+            "$RUNNER_NAME" "$SERVER_ID"

--- a/.github/workflows/_41_test_benchmarks.yml
+++ b/.github/workflows/_41_test_benchmarks.yml
@@ -33,10 +33,20 @@ jobs:
 
   test-benchmarks:
     needs: [provision-benchmarks-runner]
-    runs-on:
-      [self-hosted, linux, x64, "${{ needs.provision-benchmarks-runner.outputs.runner-label }}"]
+    # Run even when provisioning fails, so that a provisioning failure is reported by
+    # this job rather than hidden behind a skip. A skipped job counts as a passing
+    # required check, which would hide provisioning failures.
+    if: ${{ !cancelled() }}
+    # The ephemeral runner label is unique per run, so it identifies the runner on its own.
+    # Fall back to a hosted runner when there is none to target, otherwise the job waits
+    # on a label that matches nothing until it times out.
+    runs-on: ${{ needs.provision-benchmarks-runner.result == 'success' && needs.provision-benchmarks-runner.outputs.runner-label || 'namespace-profile-default-light' }}
     timeout-minutes: 60
     steps:
+      - name: Fail if runner provisioning failed 🚨
+        if: ${{ needs.provision-benchmarks-runner.result != 'success' }}
+        run: exit 1
+
       - name: Checkout 🛒
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 

--- a/.github/workflows/_41_test_benchmarks.yml
+++ b/.github/workflows/_41_test_benchmarks.yml
@@ -66,8 +66,8 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-          RUNNER_NAME: ${{ needs.provision-benchmarks-runner.outputs.runner-name }}
-          SERVER_ID: ${{ needs.provision-benchmarks-runner.outputs.server-id }}
+          CF_BOUNCER_RUNNER_NAME: ${{ needs.provision-benchmarks-runner.outputs.runner-name }}
+          CF_BOUNCER_SERVER_ID: ${{ needs.provision-benchmarks-runner.outputs.server-id }}
         run: |
           ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
-            "$RUNNER_NAME" "$SERVER_ID"
+            "$CF_BOUNCER_RUNNER_NAME" "$CF_BOUNCER_SERVER_ID"

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -95,6 +95,9 @@ jobs:
   test-benchmarks:
     needs: [build-benchmarks]
     uses: ./.github/workflows/_41_test_benchmarks.yml
+    secrets:
+      CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+      CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
   upgrade-check:
     needs: [build-try-runtime]
     uses: ./.github/workflows/upgrade-test.yml

--- a/.github/workflows/ci-main-merge-queue.yml
+++ b/.github/workflows/ci-main-merge-queue.yml
@@ -30,6 +30,9 @@ jobs:
   test-benchmarks:
     needs: [build-benchmarks]
     uses: ./.github/workflows/_41_test_benchmarks.yml
+    secrets:
+      CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+      CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
   # Used to test upgrades to this version from the latest release
   build-try-runtime:
     uses: ./.github/workflows/_20_build.yml

--- a/.github/workflows/cleanup-hetzner-bouncer-runners.yml
+++ b/.github/workflows/cleanup-hetzner-bouncer-runners.yml
@@ -1,0 +1,23 @@
+name: Cleanup stale Hetzner bouncer runners
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 10
+    steps:
+      - name: Checkout chainflip-backend 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Delete stale runners 🧹
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+        run: ./ci/scripts/manage_hetzner_bouncer_runner.sh cleanup-stale 14400

--- a/.github/workflows/release-sisyphos.yml
+++ b/.github/workflows/release-sisyphos.yml
@@ -96,6 +96,9 @@ jobs:
   test-benchmarks:
     needs: [build-benchmarks]
     uses: ./.github/workflows/_41_test_benchmarks.yml
+    secrets:
+      CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+      CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
   upgrade-check:
     needs: [build-try-runtime]
     uses: ./.github/workflows/upgrade-test.yml

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -36,8 +36,33 @@ permissions:
   contents: read
 
 jobs:
+  provision-upgrade-runner:
+    if: inputs.run-job
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 15
+    outputs:
+      runner-label: ${{ steps.provision.outputs.runner-label }}
+      runner-name: ${{ steps.provision.outputs.runner-name }}
+      server-id: ${{ steps.provision.outputs.server-id }}
+    steps:
+      - name: Checkout chainflip-backend 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Provision ephemeral Hetzner runner ☁️
+        id: provision
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+        run: |
+          runner_name="bouncer-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-upgrade-test"
+          runner_label="${runner_name}-cpx52"
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh create "$runner_name" "$runner_label"
+
   upgrade_test:
-    runs-on: hetzner
+    if: inputs.run-job
+    needs: [provision-upgrade-runner]
+    runs-on:
+      [self-hosted, linux, x64, "${{ needs.provision-upgrade-runner.outputs.runner-label }}"]
     # conservatively 1.5 hours. 2 bouncer runs need to occur.
     timeout-minutes: 120
     steps:
@@ -442,3 +467,22 @@ jobs:
           ls -alR /tmp/chainflip
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" logs
           docker compose -f localnet/docker-compose.yml -p "chainflip-localnet" down --volumes --remove-orphans
+
+  destroy-upgrade-runner:
+    if: ${{ always() && needs.provision-upgrade-runner.outputs.runner-name != '' }}
+    needs: [provision-upgrade-runner, upgrade_test]
+    runs-on: namespace-profile-default-light
+    timeout-minutes: 10
+    steps:
+      - name: Checkout chainflip-backend 🛒
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Destroy ephemeral Hetzner runner 🧹
+        env:
+          CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+          CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+          RUNNER_NAME: ${{ needs.provision-upgrade-runner.outputs.runner-name }}
+          SERVER_ID: ${{ needs.provision-upgrade-runner.outputs.server-id }}
+        run: |
+          ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
+            "$RUNNER_NAME" "$SERVER_ID"

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,7 +37,6 @@ permissions:
 
 jobs:
   provision-upgrade-runner:
-    if: inputs.run-job
     runs-on: namespace-profile-default-light
     timeout-minutes: 15
     outputs:
@@ -59,7 +58,6 @@ jobs:
           ./ci/scripts/manage_hetzner_bouncer_runner.sh create "$runner_name" "$runner_label"
 
   upgrade_test:
-    if: inputs.run-job
     needs: [provision-upgrade-runner]
     runs-on:
       [self-hosted, linux, x64, "${{ needs.provision-upgrade-runner.outputs.runner-label }}"]
@@ -481,8 +479,8 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-          RUNNER_NAME: ${{ needs.provision-upgrade-runner.outputs.runner-name }}
-          SERVER_ID: ${{ needs.provision-upgrade-runner.outputs.server-id }}
+          CF_BOUNCER_RUNNER_NAME: ${{ needs.provision-upgrade-runner.outputs.runner-name }}
+          CF_BOUNCER_SERVER_ID: ${{ needs.provision-upgrade-runner.outputs.server-id }}
         run: |
           ./ci/scripts/manage_hetzner_bouncer_runner.sh destroy \
-            "$RUNNER_NAME" "$SERVER_ID"
+            "$CF_BOUNCER_RUNNER_NAME" "$CF_BOUNCER_SERVER_ID"

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,6 +37,7 @@ permissions:
 
 jobs:
   provision-upgrade-runner:
+    if: inputs.run-job
     runs-on: namespace-profile-default-light
     timeout-minutes: 15
     outputs:
@@ -59,11 +60,21 @@ jobs:
 
   upgrade_test:
     needs: [provision-upgrade-runner]
-    runs-on:
-      [self-hosted, linux, x64, "${{ needs.provision-upgrade-runner.outputs.runner-label }}"]
+    # Run even when provisioning is skipped (run-job: false) or fails, so that this
+    # job always reports under the name required by branch protection. A skipped job
+    # counts as a passing required check, which would hide provisioning failures.
+    if: ${{ !cancelled() }}
+    # The ephemeral runner label is unique per run, so it identifies the runner on its own.
+    # Fall back to a hosted runner when there is none to target, otherwise the job waits
+    # on a label that matches nothing until it times out.
+    runs-on: ${{ needs.provision-upgrade-runner.result == 'success' && needs.provision-upgrade-runner.outputs.runner-label || 'namespace-profile-default-light' }}
     # conservatively 1.5 hours. 2 bouncer runs need to occur.
     timeout-minutes: 120
     steps:
+      - name: Fail if runner provisioning failed 🚨
+        if: ${{ inputs.run-job && needs.provision-upgrade-runner.result != 'success' }}
+        run: exit 1
+
       - name: Checkout chainflip-backend 🛒
         if: inputs.run-job
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -425,7 +436,7 @@ jobs:
           path: |
             /tmp/chainflip/snapshots/*.snap
       - name: Dump indexer database
-        if: always()
+        if: ${{ always() && inputs.run-job }}
         continue-on-error: true
         env:
           PGPASSWORD: postgres
@@ -433,7 +444,7 @@ jobs:
           pg_dump -h 127.0.0.1 -p 5432 -U postgres squid_archive > /tmp/chainflip/indexer-pgsql-dump
 
       - name: Upload indexer database
-        if: always()
+        if: ${{ always() && inputs.run-job }}
         continue-on-error: true
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
         with:

--- a/ci/scripts/manage_hetzner_bouncer_runner.sh
+++ b/ci/scripts/manage_hetzner_bouncer_runner.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 readonly HCLOUD_API_URL=https://api.hetzner.cloud/v1
 readonly GITHUB_API_URL=https://api.github.com
+readonly HETZNER_BOUNCER_FIREWALL_ID=2374657
 readonly MANAGED_LABEL_SELECTOR='managed-by%3Dgithub-actions%2Cpurpose%3Dbouncer'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
@@ -32,16 +33,36 @@ github_api() {
 delete_hcloud_resource() {
   local resource=$1
   local resource_id=$2
+  local max_attempts=${3:-1}
+  local attempt
+  local error
+  local response
   local status
 
-  status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
-    --request DELETE \
-    --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
-    "$HCLOUD_API_URL/$resource/$resource_id")
-  if [[ ! "$status" =~ ^2[0-9][0-9]$ && "$status" != 404 ]]; then
-    echo "Failed to delete Hetzner $resource/$resource_id (HTTP $status)" >&2
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if ! response=$(curl --silent --show-error --write-out $'\n%{http_code}' \
+      --request DELETE \
+      --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
+      "$HCLOUD_API_URL/$resource/$resource_id"); then
+      echo "Failed to request deletion of Hetzner $resource/$resource_id" >&2
+      return 1
+    fi
+    status=${response##*$'\n'}
+
+    if [[ "$status" =~ ^2[0-9][0-9]$ || "$status" == 404 ]]; then
+      return 0
+    fi
+    if ((attempt < max_attempts)) && [[ "$status" =~ ^(409|422|423)$ ]]; then
+      sleep 1
+      continue
+    fi
+
+    error=$(jq --raw-output \
+      'if .error then "\(.error.code): \(.error.message)" else empty end' \
+      <<<"${response%$'\n'*}" 2>/dev/null || true)
+    echo "Failed to delete Hetzner $resource/$resource_id (HTTP $status${error:+; $error})" >&2
     return 1
-  fi
+  done
 }
 
 delete_github_runner() {
@@ -51,12 +72,12 @@ delete_github_runner() {
   local runner_is_busy
   local status
 
-  # The teardown job can start before an ephemeral runner has finished reporting the
-  # previous job. Wait for automatic deregistration, or delete it once it is idle.
-  for _ in {1..30}; do
+  # Hetzner cleanup runs first, so only allow a short window for GitHub to notice
+  # the disconnect before reporting the remaining runner record.
+  for _ in {1..10}; do
     if ! runners=$(github_api \
       "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners?name=$runner_name&per_page=100"); then
-      sleep 2
+      sleep 1
       continue
     fi
 
@@ -67,7 +88,7 @@ delete_github_runner() {
     runner_is_busy=$(jq --raw-output --arg name "$runner_name" \
       '[.runners[] | select(.name == $name)][0].busy // false' <<<"$runners")
     if [[ "$runner_is_busy" == true ]]; then
-      sleep 2
+      sleep 1
       continue
     fi
 
@@ -80,7 +101,7 @@ delete_github_runner() {
     case "$status" in
       204 | 404) return 0 ;;
       422)
-        sleep 2
+        sleep 1
         ;;
       *)
         echo "Failed to delete GitHub runner $runner_name (HTTP $status)" >&2
@@ -113,11 +134,8 @@ wait_for_server_deletion() {
 destroy_runner() {
   local runner_name=$1
   local server_id=${2:-}
-  local firewall_id=${3:-}
   local response
   local cleanup_status=0
-
-  delete_github_runner "$runner_name" || cleanup_status=1
 
   if [[ -n "$server_id" ]]; then
     if delete_hcloud_resource servers "$server_id"; then
@@ -140,18 +158,7 @@ destroy_runner() {
     cleanup_status=1
   fi
 
-  if [[ -n "$firewall_id" ]]; then
-    delete_hcloud_resource firewalls "$firewall_id" || cleanup_status=1
-  elif response=$(hcloud_api "$HCLOUD_API_URL/firewalls?name=$runner_name"); then
-    while read -r firewall_id; do
-      [[ -n "$firewall_id" ]] || continue
-      delete_hcloud_resource firewalls "$firewall_id" || cleanup_status=1
-    done < <(jq --raw-output --arg name "$runner_name" \
-      '.firewalls[] | select(.name == $name) | .id' <<<"$response")
-  else
-    echo "Failed to look up Hetzner firewall $runner_name" >&2
-    cleanup_status=1
-  fi
+  delete_github_runner "$runner_name" || cleanup_status=1
 
   return "$cleanup_status"
 }
@@ -159,7 +166,6 @@ destroy_runner() {
 create_runner() {
   local runner_name=$1
   local runner_label=$2
-  local firewall_id=''
   local server_id=''
   local response
 
@@ -169,7 +175,6 @@ create_runner() {
       delete_hcloud_resource servers "$server_id" || true
       wait_for_server_deletion "$server_id" || true
     fi
-    [[ -z "$firewall_id" ]] || delete_hcloud_resource firewalls "$firewall_id" || true
     exit "$exit_code"
   }
   trap cleanup_failed_creation ERR
@@ -198,16 +203,6 @@ create_runner() {
   resource_labels=$(jq --null-input \
     --arg run_id "${GITHUB_RUN_ID:-unknown}" \
     '{"managed-by":"github-actions",purpose:"bouncer","github-run-id":$run_id}')
-
-  response=$(jq --null-input \
-    --arg name "$runner_name" \
-    --argjson labels "$resource_labels" \
-    '{name:$name,labels:$labels,rules:[]}' \
-    | hcloud_api --request POST --data-binary @- "$HCLOUD_API_URL/firewalls")
-  firewall_id=$(jq --exit-status --raw-output '.firewall.id' <<<"$response")
-  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "firewall-id=$firewall_id" >>"$GITHUB_OUTPUT"
-  fi
 
   local startup_script
   local runner_environment
@@ -250,7 +245,7 @@ EOF
     --arg name "$runner_name" \
     --arg server_type "${HETZNER_SERVER_TYPE:-cpx52}" \
     --arg user_data "$user_data" \
-    --argjson firewall_id "$firewall_id" \
+    --argjson firewall_id "$HETZNER_BOUNCER_FIREWALL_ID" \
     --argjson labels "$resource_labels" \
     '{
       name:$name,
@@ -308,8 +303,9 @@ cleanup_stale_runners() {
     "$HCLOUD_API_URL/firewalls?label_selector=$MANAGED_LABEL_SELECTOR&per_page=50")
   while IFS=$'\t' read -r firewall_id created_at; do
     [[ -n "$firewall_id" ]] || continue
+    [[ "$firewall_id" == "$HETZNER_BOUNCER_FIREWALL_ID" ]] && continue
     if ((now - $(date --date="$created_at" +%s) > max_age_seconds)); then
-      delete_hcloud_resource firewalls "$firewall_id" || true
+      delete_hcloud_resource firewalls "$firewall_id" 10 || true
     fi
   done < <(jq --raw-output '.firewalls[] | [.id, .created] | @tsv' <<<"$response")
 }
@@ -323,18 +319,18 @@ main() {
       create_runner "$2" "$3"
       ;;
     destroy)
-      [[ $# -ge 2 && $# -le 4 ]] || {
-        echo "Usage: $0 destroy RUNNER_NAME [SERVER_ID] [FIREWALL_ID]" >&2
+      [[ $# -ge 2 && $# -le 3 ]] || {
+        echo "Usage: $0 destroy RUNNER_NAME [SERVER_ID]" >&2
         return 2
       }
-      destroy_runner "$2" "${3:-}" "${4:-}"
+      destroy_runner "$2" "${3:-}"
       ;;
     cleanup-stale)
       [[ $# -le 2 ]] || { echo "Usage: $0 cleanup-stale [MAX_AGE_SECONDS]" >&2; return 2; }
       cleanup_stale_runners "${2:-14400}"
       ;;
     *)
-      echo "Usage: $0 {create RUNNER_NAME RUNNER_LABEL|destroy RUNNER_NAME [SERVER_ID] [FIREWALL_ID]|cleanup-stale [MAX_AGE_SECONDS]}" >&2
+      echo "Usage: $0 {create RUNNER_NAME RUNNER_LABEL|destroy RUNNER_NAME [SERVER_ID]|cleanup-stale [MAX_AGE_SECONDS]}" >&2
       return 2
       ;;
   esac

--- a/ci/scripts/manage_hetzner_bouncer_runner.sh
+++ b/ci/scripts/manage_hetzner_bouncer_runner.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly HCLOUD_API_URL=https://api.hetzner.cloud/v1
+readonly GITHUB_API_URL=https://api.github.com
+readonly MANAGED_LABEL_SELECTOR='managed-by%3Dgithub-actions%2Cpurpose%3Dbouncer'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+require_environment() {
+  : "${CF_HETZNER_API_TOKEN:?CF_HETZNER_API_TOKEN is required}"
+  : "${CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN:?CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN is required}"
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+}
+
+hcloud_api() {
+  curl --fail-with-body --silent --show-error \
+    --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
+    --header "Content-Type: application/json" \
+    "$@"
+}
+
+github_api() {
+  curl --fail-with-body --silent --show-error \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer $CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    "$@"
+}
+
+delete_hcloud_resource() {
+  local resource=$1
+  local resource_id=$2
+  local status
+
+  status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+    --request DELETE \
+    --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
+    "$HCLOUD_API_URL/$resource/$resource_id")
+  if [[ "$status" != 204 && "$status" != 404 ]]; then
+    echo "Failed to delete Hetzner $resource/$resource_id (HTTP $status)" >&2
+    return 1
+  fi
+}
+
+delete_github_runner() {
+  local runner_name=$1
+  local runners
+
+  runners=$(github_api \
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners?name=$runner_name&per_page=100")
+
+  while read -r runner_id; do
+    [[ -n "$runner_id" ]] || continue
+    github_api --request DELETE \
+      "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners/$runner_id" >/dev/null
+  done < <(jq --raw-output --arg name "$runner_name" \
+    '.runners[] | select(.name == $name) | .id' <<<"$runners")
+}
+
+wait_for_server_deletion() {
+  local server_id=$1
+  local status
+
+  for _ in {1..30}; do
+    status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+      --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
+      "$HCLOUD_API_URL/servers/$server_id")
+    [[ "$status" == 404 ]] && return 0
+    [[ "$status" == 200 ]] || return 1
+    sleep 2
+  done
+
+  echo "Timed out waiting for Hetzner server $server_id to be deleted" >&2
+  return 1
+}
+
+destroy_runner() {
+  local runner_name=$1
+  local response
+
+  response=$(hcloud_api "$HCLOUD_API_URL/servers?name=$runner_name")
+  while read -r server_id; do
+    [[ -n "$server_id" ]] || continue
+    delete_hcloud_resource servers "$server_id"
+    wait_for_server_deletion "$server_id"
+  done < <(jq --raw-output --arg name "$runner_name" \
+    '.servers[] | select(.name == $name) | .id' <<<"$response")
+
+  response=$(hcloud_api "$HCLOUD_API_URL/firewalls?name=$runner_name")
+  while read -r firewall_id; do
+    [[ -n "$firewall_id" ]] || continue
+    delete_hcloud_resource firewalls "$firewall_id"
+  done < <(jq --raw-output --arg name "$runner_name" \
+    '.firewalls[] | select(.name == $name) | .id' <<<"$response")
+
+  delete_github_runner "$runner_name"
+}
+
+create_runner() {
+  local runner_name=$1
+  local runner_label=$2
+  local firewall_id=''
+  local server_id=''
+  local response
+
+  cleanup_failed_creation() {
+    local exit_code=$?
+    if [[ -n "$server_id" ]]; then
+      delete_hcloud_resource servers "$server_id" || true
+      wait_for_server_deletion "$server_id" || true
+    fi
+    [[ -z "$firewall_id" ]] || delete_hcloud_resource firewalls "$firewall_id" || true
+    exit "$exit_code"
+  }
+  trap cleanup_failed_creation ERR
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "runner-label=$runner_label"
+      echo "runner-name=$runner_name"
+    } >>"$GITHUB_OUTPUT"
+  fi
+
+  response=$(github_api --request POST \
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners/registration-token")
+  local registration_token
+  registration_token=$(jq --exit-status --raw-output '.token' <<<"$response")
+  echo "::add-mask::$registration_token"
+
+  response=$(github_api \
+    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners/downloads")
+  local runner_download_url
+  runner_download_url=$(jq --exit-status --raw-output \
+    '[.[] | select(.os == "linux" and .architecture == "x64")][0].download_url' \
+    <<<"$response")
+
+  local resource_labels
+  resource_labels=$(jq --null-input \
+    --arg run_id "${GITHUB_RUN_ID:-unknown}" \
+    '{"managed-by":"github-actions",purpose:"bouncer","github-run-id":$run_id}')
+
+  response=$(jq --null-input \
+    --arg name "$runner_name" \
+    --argjson labels "$resource_labels" \
+    '{name:$name,labels:$labels,rules:[]}' \
+    | hcloud_api --request POST --data-binary @- "$HCLOUD_API_URL/firewalls")
+  firewall_id=$(jq --exit-status --raw-output '.firewall.id' <<<"$response")
+
+  local startup_script
+  local runner_environment
+  local runner_service
+  startup_script=$(base64 <"$SCRIPT_DIR/start_ephemeral_github_runner.sh" | tr -d '\n')
+  runner_environment=$(printf '%s\n' \
+    "GITHUB_RUNNER_URL=https://github.com/$GITHUB_REPOSITORY" \
+    "RUNNER_DOWNLOAD_URL=$runner_download_url" \
+    "RUNNER_LABEL=$runner_label" \
+    "RUNNER_NAME=$runner_name" \
+    "RUNNER_REGISTRATION_TOKEN=$registration_token" \
+    | base64 | tr -d '\n')
+  runner_service=$(base64 <<'EOF' | tr -d '\n'
+[Unit]
+Description=Ephemeral GitHub Actions runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/actions-runner.env
+ExecStart=/usr/local/sbin/start-ephemeral-github-runner
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  )
+
+  local user_data
+  user_data=$(jq --null-input --raw-output \
+    --arg environment "$runner_environment" \
+    --arg script "$startup_script" \
+    --arg service "$runner_service" \
+    '"#cloud-config\nwrite_files:\n  - path: /usr/local/sbin/start-ephemeral-github-runner\n    encoding: b64\n    permissions: '\''0755'\''\n    content: \($script)\n  - path: /etc/actions-runner.env\n    encoding: b64\n    permissions: '\''0600'\''\n    content: \($environment)\n  - path: /etc/systemd/system/actions-runner.service\n    encoding: b64\n    permissions: '\''0644'\''\n    content: \($service)\nruncmd:\n  - [systemctl, daemon-reload]\n  - [systemctl, enable, --now, actions-runner.service]\n"')
+
+  response=$(jq --null-input \
+    --arg image "${HETZNER_IMAGE:-ubuntu-24.04}" \
+    --arg location "${HETZNER_LOCATION:-fsn1}" \
+    --arg name "$runner_name" \
+    --arg server_type "${HETZNER_SERVER_TYPE:-cpx52}" \
+    --arg user_data "$user_data" \
+    --argjson firewall_id "$firewall_id" \
+    --argjson labels "$resource_labels" \
+    '{
+      name:$name,
+      server_type:$server_type,
+      image:$image,
+      location:$location,
+      user_data:$user_data,
+      labels:$labels,
+      firewalls:[{firewall:$firewall_id}],
+      public_net:{enable_ipv4:true,enable_ipv6:false},
+      start_after_create:true
+    }' \
+    | hcloud_api --request POST --data-binary @- "$HCLOUD_API_URL/servers")
+  server_id=$(jq --exit-status --raw-output '.server.id' <<<"$response")
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "server-id=$server_id" >>"$GITHUB_OUTPUT"
+  fi
+
+  echo "Waiting for ephemeral runner $runner_name to register"
+  for _ in {1..60}; do
+    if response=$(github_api \
+      "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners?name=$runner_name&per_page=100"); then
+      if jq --exit-status --arg name "$runner_name" \
+        'any(.runners[]; .name == $name and .status == "online")' <<<"$response" >/dev/null; then
+        trap - ERR
+        echo "Ephemeral runner $runner_name is online"
+        return 0
+      fi
+    fi
+    sleep 10
+  done
+
+  echo "Timed out waiting for ephemeral runner $runner_name" >&2
+  return 1
+}
+
+cleanup_stale_runners() {
+  local max_age_seconds=${1:-14400}
+  local now
+  local response
+  now=$(date +%s)
+
+  response=$(hcloud_api \
+    "$HCLOUD_API_URL/servers?label_selector=$MANAGED_LABEL_SELECTOR&per_page=50")
+  while IFS=$'\t' read -r runner_name created_at; do
+    [[ -n "$runner_name" ]] || continue
+    if ((now - $(date --date="$created_at" +%s) > max_age_seconds)); then
+      echo "Deleting stale bouncer runner $runner_name"
+      destroy_runner "$runner_name"
+    fi
+  done < <(jq --raw-output '.servers[] | [.name, .created] | @tsv' <<<"$response")
+
+  response=$(hcloud_api \
+    "$HCLOUD_API_URL/firewalls?label_selector=$MANAGED_LABEL_SELECTOR&per_page=50")
+  while IFS=$'\t' read -r firewall_id created_at; do
+    [[ -n "$firewall_id" ]] || continue
+    if ((now - $(date --date="$created_at" +%s) > max_age_seconds)); then
+      delete_hcloud_resource firewalls "$firewall_id" || true
+    fi
+  done < <(jq --raw-output '.firewalls[] | [.id, .created] | @tsv' <<<"$response")
+}
+
+main() {
+  require_environment
+
+  case "${1:-}" in
+    create)
+      [[ $# == 3 ]] || { echo "Usage: $0 create RUNNER_NAME RUNNER_LABEL" >&2; return 2; }
+      create_runner "$2" "$3"
+      ;;
+    destroy)
+      [[ $# == 2 ]] || { echo "Usage: $0 destroy RUNNER_NAME" >&2; return 2; }
+      destroy_runner "$2"
+      ;;
+    cleanup-stale)
+      [[ $# -le 2 ]] || { echo "Usage: $0 cleanup-stale [MAX_AGE_SECONDS]" >&2; return 2; }
+      cleanup_stale_runners "${2:-14400}"
+      ;;
+    *)
+      echo "Usage: $0 {create RUNNER_NAME RUNNER_LABEL|destroy RUNNER_NAME|cleanup-stale [MAX_AGE_SECONDS]}" >&2
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/ci/scripts/manage_hetzner_bouncer_runner.sh
+++ b/ci/scripts/manage_hetzner_bouncer_runner.sh
@@ -38,7 +38,7 @@ delete_hcloud_resource() {
     --request DELETE \
     --header "Authorization: Bearer $CF_HETZNER_API_TOKEN" \
     "$HCLOUD_API_URL/$resource/$resource_id")
-  if [[ "$status" != 204 && "$status" != 404 ]]; then
+  if [[ ! "$status" =~ ^2[0-9][0-9]$ && "$status" != 404 ]]; then
     echo "Failed to delete Hetzner $resource/$resource_id (HTTP $status)" >&2
     return 1
   fi
@@ -47,16 +47,50 @@ delete_hcloud_resource() {
 delete_github_runner() {
   local runner_name=$1
   local runners
+  local runner_id
+  local runner_is_busy
+  local status
 
-  runners=$(github_api \
-    "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners?name=$runner_name&per_page=100")
+  # The teardown job can start before an ephemeral runner has finished reporting the
+  # previous job. Wait for automatic deregistration, or delete it once it is idle.
+  for _ in {1..30}; do
+    if ! runners=$(github_api \
+      "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners?name=$runner_name&per_page=100"); then
+      sleep 2
+      continue
+    fi
 
-  while read -r runner_id; do
-    [[ -n "$runner_id" ]] || continue
-    github_api --request DELETE \
-      "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners/$runner_id" >/dev/null
-  done < <(jq --raw-output --arg name "$runner_name" \
-    '.runners[] | select(.name == $name) | .id' <<<"$runners")
+    runner_id=$(jq --raw-output --arg name "$runner_name" \
+      '[.runners[] | select(.name == $name)][0].id // empty' <<<"$runners")
+    [[ -n "$runner_id" ]] || return 0
+
+    runner_is_busy=$(jq --raw-output --arg name "$runner_name" \
+      '[.runners[] | select(.name == $name)][0].busy // false' <<<"$runners")
+    if [[ "$runner_is_busy" == true ]]; then
+      sleep 2
+      continue
+    fi
+
+    status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+      --request DELETE \
+      --header "Accept: application/vnd.github+json" \
+      --header "Authorization: Bearer $CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN" \
+      --header "X-GitHub-Api-Version: 2022-11-28" \
+      "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runners/$runner_id")
+    case "$status" in
+      204 | 404) return 0 ;;
+      422)
+        sleep 2
+        ;;
+      *)
+        echo "Failed to delete GitHub runner $runner_name (HTTP $status)" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  echo "Timed out waiting for GitHub runner $runner_name to become idle" >&2
+  return 1
 }
 
 wait_for_server_deletion() {
@@ -78,24 +112,48 @@ wait_for_server_deletion() {
 
 destroy_runner() {
   local runner_name=$1
+  local server_id=${2:-}
+  local firewall_id=${3:-}
   local response
+  local cleanup_status=0
 
-  response=$(hcloud_api "$HCLOUD_API_URL/servers?name=$runner_name")
-  while read -r server_id; do
-    [[ -n "$server_id" ]] || continue
-    delete_hcloud_resource servers "$server_id"
-    wait_for_server_deletion "$server_id"
-  done < <(jq --raw-output --arg name "$runner_name" \
-    '.servers[] | select(.name == $name) | .id' <<<"$response")
+  delete_github_runner "$runner_name" || cleanup_status=1
 
-  response=$(hcloud_api "$HCLOUD_API_URL/firewalls?name=$runner_name")
-  while read -r firewall_id; do
-    [[ -n "$firewall_id" ]] || continue
-    delete_hcloud_resource firewalls "$firewall_id"
-  done < <(jq --raw-output --arg name "$runner_name" \
-    '.firewalls[] | select(.name == $name) | .id' <<<"$response")
+  if [[ -n "$server_id" ]]; then
+    if delete_hcloud_resource servers "$server_id"; then
+      wait_for_server_deletion "$server_id" || cleanup_status=1
+    else
+      cleanup_status=1
+    fi
+  elif response=$(hcloud_api "$HCLOUD_API_URL/servers?name=$runner_name"); then
+    while read -r server_id; do
+      [[ -n "$server_id" ]] || continue
+      if delete_hcloud_resource servers "$server_id"; then
+        wait_for_server_deletion "$server_id" || cleanup_status=1
+      else
+        cleanup_status=1
+      fi
+    done < <(jq --raw-output --arg name "$runner_name" \
+      '.servers[] | select(.name == $name) | .id' <<<"$response")
+  else
+    echo "Failed to look up Hetzner server $runner_name" >&2
+    cleanup_status=1
+  fi
 
-  delete_github_runner "$runner_name"
+  if [[ -n "$firewall_id" ]]; then
+    delete_hcloud_resource firewalls "$firewall_id" || cleanup_status=1
+  elif response=$(hcloud_api "$HCLOUD_API_URL/firewalls?name=$runner_name"); then
+    while read -r firewall_id; do
+      [[ -n "$firewall_id" ]] || continue
+      delete_hcloud_resource firewalls "$firewall_id" || cleanup_status=1
+    done < <(jq --raw-output --arg name "$runner_name" \
+      '.firewalls[] | select(.name == $name) | .id' <<<"$response")
+  else
+    echo "Failed to look up Hetzner firewall $runner_name" >&2
+    cleanup_status=1
+  fi
+
+  return "$cleanup_status"
 }
 
 create_runner() {
@@ -147,6 +205,9 @@ create_runner() {
     '{name:$name,labels:$labels,rules:[]}' \
     | hcloud_api --request POST --data-binary @- "$HCLOUD_API_URL/firewalls")
   firewall_id=$(jq --exit-status --raw-output '.firewall.id' <<<"$response")
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "firewall-id=$firewall_id" >>"$GITHUB_OUTPUT"
+  fi
 
   local startup_script
   local runner_environment
@@ -262,15 +323,18 @@ main() {
       create_runner "$2" "$3"
       ;;
     destroy)
-      [[ $# == 2 ]] || { echo "Usage: $0 destroy RUNNER_NAME" >&2; return 2; }
-      destroy_runner "$2"
+      [[ $# -ge 2 && $# -le 4 ]] || {
+        echo "Usage: $0 destroy RUNNER_NAME [SERVER_ID] [FIREWALL_ID]" >&2
+        return 2
+      }
+      destroy_runner "$2" "${3:-}" "${4:-}"
       ;;
     cleanup-stale)
       [[ $# -le 2 ]] || { echo "Usage: $0 cleanup-stale [MAX_AGE_SECONDS]" >&2; return 2; }
       cleanup_stale_runners "${2:-14400}"
       ;;
     *)
-      echo "Usage: $0 {create RUNNER_NAME RUNNER_LABEL|destroy RUNNER_NAME|cleanup-stale [MAX_AGE_SECONDS]}" >&2
+      echo "Usage: $0 {create RUNNER_NAME RUNNER_LABEL|destroy RUNNER_NAME [SERVER_ID] [FIREWALL_ID]|cleanup-stale [MAX_AGE_SECONDS]}" >&2
       return 2
       ;;
   esac

--- a/ci/scripts/start_ephemeral_github_runner.sh
+++ b/ci/scripts/start_ephemeral_github_runner.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_RUNNER_URL:?GITHUB_RUNNER_URL is required}"
+: "${RUNNER_DOWNLOAD_URL:?RUNNER_DOWNLOAD_URL is required}"
+: "${RUNNER_LABEL:?RUNNER_LABEL is required}"
+: "${RUNNER_NAME:?RUNNER_NAME is required}"
+: "${RUNNER_REGISTRATION_TOKEN:?RUNNER_REGISTRATION_TOKEN is required}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install --yes \
+  build-essential \
+  ca-certificates \
+  curl \
+  docker-compose-v2 \
+  docker.io \
+  git \
+  jq \
+  npm \
+  python3 \
+  sudo \
+  tar \
+  unzip \
+  xz-utils
+
+systemctl enable --now docker
+
+if ! id runner >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash runner
+fi
+usermod --append --groups docker,sudo runner
+echo "runner ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/actions-runner
+chmod 0440 /etc/sudoers.d/actions-runner
+
+npm install --global pnpm@10
+
+runner_root=/opt/actions-runner
+install --directory --owner runner --group runner "$runner_root"
+curl --fail --location --silent --show-error "$RUNNER_DOWNLOAD_URL" \
+  --output "$runner_root/actions-runner.tar.gz"
+tar --extract --gzip --file "$runner_root/actions-runner.tar.gz" --directory "$runner_root"
+rm "$runner_root/actions-runner.tar.gz"
+
+"$runner_root/bin/installdependencies.sh"
+chown --recursive runner:runner "$runner_root"
+
+cd "$runner_root"
+runuser --user runner -- ./config.sh \
+  --ephemeral \
+  --labels "$RUNNER_LABEL" \
+  --name "$RUNNER_NAME" \
+  --token "$RUNNER_REGISTRATION_TOKEN" \
+  --unattended \
+  --url "$GITHUB_RUNNER_URL" \
+  --work _work
+
+rm -f \
+  /etc/actions-runner.env \
+  /var/lib/cloud/instance/user-data.txt \
+  /var/lib/cloud/instance/user-data.txt.i
+unset RUNNER_REGISTRATION_TOKEN
+
+exec runuser --user runner -- ./run.sh


### PR DESCRIPTION
# Pull Request


## Summary

Replace the always-running Hetzner bouncer runner with an ephemeral CPX52 created for each CI bouncer job and deleted afterward.

  - Provision a uniquely labelled, repository-scoped GitHub runner.
  - Register it as ephemeral so it accepts one job only.
  - Apply a Hetzner firewall.
  - Destroy the server, and runner registration after the job.
  - Add hourly cleanup for resources older than four hours.
  - Upload runner diagnostics before teardown.

