### PR TITLE
chore: resolve cargo cf-audit advisories

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -83,6 +83,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0119: DoS vector in hickory-proto which is used by libp2p. Dependency of substrate, related to DNS resolution. Low risk.
 # - RUSTSEC-2026-0173: proc-macro-error2 unmaintained. Build-time proc-macro helper, transitive dependency of `subxt-macro`. Not a runtime security concern.
 # - RUSTSEC-2026-0186: Unsound pointer arithmetic in memmap2. Transitive dependency of parity-db - out of our control.
+# - RUSTSEC-2026-0222: Wasmtime type-index mixup between multiple engines. Low severity embedder-API-misuse issue; we only execute the trusted runtime wasm and don't control the wasmtime version (pinned by polkadot-sdk). Dependency of substrate.
 
 #
 cf-audit = '''
@@ -133,6 +134,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0119
 	--ignore RUSTSEC-2026-0173
 	--ignore RUSTSEC-2026-0186
+	--ignore RUSTSEC-2026-0222
 '''
 
 [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -760,7 +760,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -4662,11 +4662,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -4677,7 +4676,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -14100,7 +14099,7 @@ dependencies = [
  "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "fnv",
  "futures-lite",
  "futures-util",
@@ -14154,7 +14153,7 @@ dependencies = [
  "derive_more 2.1.1",
  "ed25519-zebra",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "fnv",
  "futures-lite",
  "futures-util",
@@ -14203,7 +14202,7 @@ dependencies = [
  "bs58",
  "derive_more 0.99.20",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "fnv",
  "futures-channel",
  "futures-lite",
@@ -14239,7 +14238,7 @@ dependencies = [
  "bs58",
  "derive_more 2.1.1",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "fnv",
  "futures-channel",
  "futures-lite",


### PR DESCRIPTION
Resolves the two new advisories flagged by `cargo cf-audit`:

- **RUSTSEC-2026-0221** (`event-listener`): bumped 5.4.1 → 5.4.2 — a real fix (patch bump). The unsound `!Send`-tag path isn't reachable via our transitive users anyway.
- **RUSTSEC-2026-0222** (`wasmtime`): added to the ignore list. Substrate-pinned (can't bump), low-severity embedder-API-misuse affecting multi-engine untrusted wasm — we only execute the trusted runtime wasm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)