### PR TITLE
ci(bouncer): reduce stale cleanup frequency

### DIFF
--- a/.github/workflows/cleanup-hetzner-bouncer-runners.yml
+++ b/.github/workflows/cleanup-hetzner-bouncer-runners.yml
@@ -2,7 +2,7 @@ name: Cleanup stale Hetzner bouncer runners
 
 on:
   schedule:
-    - cron: "17 * * * *"
+    - cron: "17 */6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -20,4 +20,4 @@ jobs:
         env:
           CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
           CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-        run: ./ci/scripts/manage_hetzner_bouncer_runner.sh cleanup-stale 14400
+        run: ./ci/scripts/manage_hetzner_bouncer_runner.sh cleanup-stale 10800


### PR DESCRIPTION
# Pull Request

## Summary

* Changed the Hetzner bouncer runner cleanup workflow schedule from hourly (17 * * * *) to every 6 hours (17 */6 * * *)
* Adjusted the stale-runner threshold from 4h (14400) to 3h (10800) so it stays below the run interval — guaranteeing any stale runner is removed at the next scheduled cleanup (worst case ~6h)