### PR TITLE
chore(btc): correct comment on MAX_NULLDATA_LENGTH

### DIFF
--- a/state-chain/chains/src/btc/vault_swap_encoding.rs
+++ b/state-chain/chains/src/btc/vault_swap_encoding.rs
@@ -22,7 +22,10 @@ use sp_core::ConstU32;
 use sp_runtime::BoundedVec;
 use sp_std::vec::Vec;
 
-// The maximum length of data that can be encoded in a nulldata utxo
+// Historically Bitcoin Core's default OP_RETURN relay limit (`-datacarriersize`
+// defaulted to 83 bytes, ~80 usable). Since v30.0 (Oct 2025) the default is
+// 100,000 bytes, so this is no longer network-enforced — just a conservative
+// capacity hint that comfortably fits the payload below.
 const MAX_NULLDATA_LENGTH: usize = 80;
 
 #[repr(u8)]


### PR DESCRIPTION
Noticed this comment while browsing your repo:

```rust
// The maximum length of data that can be encoded in a nulldata utxo
const MAX_NULLDATA_LENGTH: usize = 80;
```

As of Bitcoin Core v30.0 this limit is now de-facto 100,000 bytes, see release notes here: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-30.0.md