### PR TITLE
chore: check dedot generated type definitions when merging

### DIFF
--- a/.github/workflows/_23_check_generated_bouncer_dependencies.yml
+++ b/.github/workflows/_23_check_generated_bouncer_dependencies.yml
@@ -1,4 +1,4 @@
-name: Ensure event schemas are up to date
+name: Ensure generated bouncer dependencies are up to date
 
 on:
   workflow_call:
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  check-event-schemas:
+  check-generated-bouncer-dependencies:
     runs-on: namespace-profile-default
     steps:
       - name: Checkout chainflip-backend 🛒
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run Test 🧪
         shell: bash
-        run: ./ci/scripts/check_event_schemas.sh
+        run: ./ci/scripts/check_generated_bouncer_dependencies.sh

--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -2,119 +2,119 @@
 name: Release Chainflip Development
 on: pull_request
 concurrency:
-  group: ${{ github.ref }}-release-development
-  cancel-in-progress: true
+    group: ${{ github.ref }}-release-development
+    cancel-in-progress: true
 
 jobs:
-  pre-check:
-    uses: ./.github/workflows/_01_pre_check.yml
-    secrets: inherit
-  force-version-bump:
-    uses: ./.github/workflows/_05_force_version_bump.yml
-    secrets: inherit
-    with:
-      network-to-check-against: "sisyphos"
-  test:
-    uses: ./.github/workflows/_10_test.yml
-    secrets: inherit
-  coverage:
-    uses: ./.github/workflows/_11_coverage.yml
-    with:
-      test_features: runtime-benchmarks
-    secrets: inherit
-  build:
-    uses: ./.github/workflows/_20_build.yml
-    secrets: inherit
-    with:
-      profile: "release"
-  build-turbo:
-    uses: ./.github/workflows/_20_build.yml
-    secrets: inherit
-    with:
-      profile: "release-turbo"
-      upload-name: "chainflip-backend-bin-turbo"
-  # Used to test upgrades to this version from the latest release
-  build-try-runtime:
-    uses: ./.github/workflows/_20_build.yml
-    secrets: inherit
-    with:
-      profile: "try-runtime"
-      upload-name: "chainflip-backend-bin-try-runtime"
-      binary-subdir: release
-  build-benchmarks:
-    uses: ./.github/workflows/_20_build.yml
-    secrets: inherit
-    with:
-      profile: "benchmarks"
-      upload-name: "chainflip-backend-bin-benchmarks"
-      binary-subdir: release
-  check-event-schemas:
-    needs: [build]
-    uses: ./.github/workflows/_23_check_event_schemas.yml
-    secrets: inherit
-  docker:
-    needs: [build]
-    uses: ./.github/workflows/_24_docker.yml
-    secrets: inherit
-    with:
-      network: "test"
-      environment: "development"
-  package:
-    needs: [build]
-    uses: ./.github/workflows/_25_package.yml
-    with:
-      network: "test"
-    secrets: inherit
-  post-check:
-    needs: [build]
-    uses: ./.github/workflows/_40_post_check.yml
-    secrets: inherit
-    with:
-      full-bouncer: false
-      ngrok: true
-  post-check-turbo:
-    needs: [build-turbo]
-    uses: ./.github/workflows/_40_post_check.yml
-    secrets: inherit
-    with:
-      full-bouncer: false
-      ngrok: true
-      chainflip-backend-bin-suffix: -turbo
-      log-postfix: "-turbo"
-      continue-on-bouncer-error: true
-  post-check-old-rpcs:
-    needs: [build]
-    uses: ./.github/workflows/_40_post_check.yml
-    secrets: inherit
-    with:
-      full-bouncer: false
-      ngrok: true
-      broker-endpoint: "http://127.0.0.1:10997"
-      lp-endpoint: "http://127.0.0.1:10589"
-      log-postfix: "-post-check-old-rpcs"
-  test-benchmarks:
-    needs: [build-benchmarks]
-    uses: ./.github/workflows/_41_test_benchmarks.yml
-    secrets:
-      CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
-      CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
-  upgrade-check:
-    needs: [build-try-runtime]
-    uses: ./.github/workflows/upgrade-test.yml
-    secrets: inherit
-    with:
-      run-job: false
-  publish:
-    needs: [package]
-    uses: ./.github/workflows/_30_publish.yml
-    with:
-      version: ci/${{ github.sha }}/
-      environment: "development"
-    secrets: inherit
-  upload-versioned-build-artifacts:
-    needs: [build]
-    uses: ./.github/workflows/_61_upload_versioned_build_artifacts.yml
-    secrets: inherit
-    with:
-      is_release: false
-      is_development: true
+    pre-check:
+        uses: ./.github/workflows/_01_pre_check.yml
+        secrets: inherit
+    force-version-bump:
+        uses: ./.github/workflows/_05_force_version_bump.yml
+        secrets: inherit
+        with:
+            network-to-check-against: "sisyphos"
+    test:
+        uses: ./.github/workflows/_10_test.yml
+        secrets: inherit
+    coverage:
+        uses: ./.github/workflows/_11_coverage.yml
+        with:
+            test_features: runtime-benchmarks
+        secrets: inherit
+    build:
+        uses: ./.github/workflows/_20_build.yml
+        secrets: inherit
+        with:
+            profile: "release"
+    build-turbo:
+        uses: ./.github/workflows/_20_build.yml
+        secrets: inherit
+        with:
+            profile: "release-turbo"
+            upload-name: "chainflip-backend-bin-turbo"
+    # Used to test upgrades to this version from the latest release
+    build-try-runtime:
+        uses: ./.github/workflows/_20_build.yml
+        secrets: inherit
+        with:
+            profile: "try-runtime"
+            upload-name: "chainflip-backend-bin-try-runtime"
+            binary-subdir: release
+    build-benchmarks:
+        uses: ./.github/workflows/_20_build.yml
+        secrets: inherit
+        with:
+            profile: "benchmarks"
+            upload-name: "chainflip-backend-bin-benchmarks"
+            binary-subdir: release
+    check-generated-bouncer-dependencies:
+        needs: [build]
+        uses: ./.github/workflows/_23_check_generated_bouncer_dependencies.yml
+        secrets: inherit
+    docker:
+        needs: [build]
+        uses: ./.github/workflows/_24_docker.yml
+        secrets: inherit
+        with:
+            network: "test"
+            environment: "development"
+    package:
+        needs: [build]
+        uses: ./.github/workflows/_25_package.yml
+        with:
+            network: "test"
+        secrets: inherit
+    post-check:
+        needs: [build]
+        uses: ./.github/workflows/_40_post_check.yml
+        secrets: inherit
+        with:
+            full-bouncer: false
+            ngrok: true
+    post-check-turbo:
+        needs: [build-turbo]
+        uses: ./.github/workflows/_40_post_check.yml
+        secrets: inherit
+        with:
+            full-bouncer: false
+            ngrok: true
+            chainflip-backend-bin-suffix: -turbo
+            log-postfix: "-turbo"
+            continue-on-bouncer-error: true
+    post-check-old-rpcs:
+        needs: [build]
+        uses: ./.github/workflows/_40_post_check.yml
+        secrets: inherit
+        with:
+            full-bouncer: false
+            ngrok: true
+            broker-endpoint: "http://127.0.0.1:10997"
+            lp-endpoint: "http://127.0.0.1:10589"
+            log-postfix: "-post-check-old-rpcs"
+    test-benchmarks:
+        needs: [build-benchmarks]
+        uses: ./.github/workflows/_41_test_benchmarks.yml
+        secrets:
+            CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN: ${{ secrets.CF_GITHUB_RUNNERS_MANAGEMENT_TOKEN }}
+            CF_HETZNER_API_TOKEN: ${{ secrets.CF_HETZNER_API_TOKEN }}
+    upgrade-check:
+        needs: [build-try-runtime]
+        uses: ./.github/workflows/upgrade-test.yml
+        secrets: inherit
+        with:
+            run-job: false
+    publish:
+        needs: [package]
+        uses: ./.github/workflows/_30_publish.yml
+        with:
+            version: ci/${{ github.sha }}/
+            environment: "development"
+        secrets: inherit
+    upload-versioned-build-artifacts:
+        needs: [build]
+        uses: ./.github/workflows/_61_upload_versioned_build_artifacts.yml
+        secrets: inherit
+        with:
+            is_release: false
+            is_development: true

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -39,9 +39,9 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/_22_check_blocktime.yml
     secrets: inherit
-  check-event-schemas:
+  check-generated-bouncer-dependencies:
     needs: [build]
-    uses: ./.github/workflows/_23_check_event_schemas.yml
+    uses: ./.github/workflows/_23_check_generated_bouncer_dependencies.yml
     secrets: inherit
   docker:
     needs: [build]

--- a/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
@@ -1390,12 +1390,6 @@ export interface ChainErrors extends GenericChainErrors {
     BrokerAlreadyBound: GenericPalletError;
 
     /**
-     * The broker tried to withdraw to an address which is not the address the broker is bound
-     * to.
-     **/
-    BrokerBoundWithdrawalAddressRestrictionViolated: GenericPalletError;
-
-    /**
      * A zero default slippage protection will result in most swaps failing. Set to `None` to
      * reset to the permissive default (100bps).
      **/

--- a/bouncer/generated/chaintypes/chainflip-node/query.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/query.d.ts
@@ -3218,17 +3218,6 @@ export interface ChainStorage extends GenericChainStorage {
     vaultSwapMinimumBrokerFee: GenericStorageQuery<(arg: AccountId32Like) => number, AccountId32>;
 
     /**
-     * Map of bound addresses for accounts.
-     *
-     * @param {AccountId32Like} arg
-     * @param {Callback<H160 | undefined> =} callback
-     **/
-    boundBrokerWithdrawalAddress: GenericStorageQuery<
-      (arg: AccountId32Like) => H160 | undefined,
-      AccountId32
-    >;
-
-    /**
      *
      * @param {CfAmmCommonAssetPair} arg
      * @param {Callback<number> =} callback
@@ -5853,6 +5842,17 @@ export interface ChainStorage extends GenericChainStorage {
         arg: [AccountId32Like, CfPrimitivesChainsForeignChain],
       ) => CfChainsAddressForeignChainAddress | undefined,
       [AccountId32, CfPrimitivesChainsForeignChain]
+    >;
+
+    /**
+     * Ethereum withdrawal addresses permanently bound by brokers.
+     *
+     * @param {AccountId32Like} arg
+     * @param {Callback<H160 | undefined> =} callback
+     **/
+    boundBrokerWithdrawalAddress: GenericStorageQuery<
+      (arg: AccountId32Like) => H160 | undefined,
+      AccountId32
     >;
 
     /**

--- a/bouncer/generated/chaintypes/chainflip-node/types.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/types.d.ts
@@ -18494,11 +18494,6 @@ export type PalletCfSwappingError =
    **/
   | 'BrokerAlreadyBound'
   /**
-   * The broker tried to withdraw to an address which is not the address the broker is bound
-   * to.
-   **/
-  | 'BrokerBoundWithdrawalAddressRestrictionViolated'
-  /**
    * A zero default slippage protection will result in most swaps failing. Set to `None` to
    * reset to the permissive default (100bps).
    **/
@@ -21516,6 +21511,7 @@ export type StateChainRuntimeRuntimeApisCustomApiTypesValidatorInfo = {
   restrictedBalances: Array<[H160, bigint]>;
   estimatedRedeemableBalance: bigint;
   operator?: AccountId32 | undefined;
+  bid: bigint;
   maxBid?: bigint | undefined;
 };
 

--- a/ci/scripts/check_event_schemas.sh
+++ b/ci/scripts/check_event_schemas.sh
@@ -6,14 +6,17 @@ set -euo pipefail
 
 # Wait for node to start
 echo -e "🚀 Starting chainflip-node..."
-sleep 10
+sleep 30
+
+#################################################
+# Subsquid ingester event schemas
 
 # Call script to generate events
 echo -e "Generating event schemas..."
 cd bouncer && ./commands/generate_event_schemas.ts
 cd ..
 
-# Check whether a specific subdirectory is dirty
+# Check whether a event subdirectory is dirty
 EVENTS_DIR="bouncer/generated/events"
 
 if [[ -n "$(git status --porcelain -- "$EVENTS_DIR")" ]]; then
@@ -25,4 +28,27 @@ if [[ -n "$(git status --porcelain -- "$EVENTS_DIR")" ]]; then
   exit 1
 fi
 
-echo -e "Events are up to date!"
+#################################################
+# Dedot substrate api chaintypes
+
+# Call script to generate chaintypes (dedot)
+echo -e "Generating chaintypes (dedot)..."
+cd bouncer && ./commands/generate_chaintypes.ts
+cd ..
+
+# Check whether a event subdirectory is dirty
+CHAINTYPES_DIR="bouncer/generated/chaintypes"
+
+if [[ -n "$(git status --porcelain -- "$CHAINTYPES_DIR")" ]]; then
+  echo "ERROR: Event schemas in '$CHAINTYPES_DIR' are not up to date! Please run ./commands/generate_chaintypes.ts to regenerate dedot chaintypes and commit them."
+  echo ""
+  echo "The following chaintype changes have not been comitted:"
+  echo ""
+  git status -- "$CHAINTYPES_DIR"
+  exit 1
+fi
+
+#################################################
+# Success
+
+echo -e "Events and chaintypes are up to date!"

--- a/ci/scripts/check_generated_bouncer_dependencies.sh
+++ b/ci/scripts/check_generated_bouncer_dependencies.sh
@@ -2,7 +2,12 @@
 
 set -euo pipefail
 
-./chainflip-node --dev &
+mkdir -p /tmp/chainflip
+
+CHAIN=dev \
+KEYS_DIR=./localnet/init/keys \
+LOCALNET_INIT_DIR=localnet/init \
+./localnet/init/scripts/start-node.sh "$PWD" bashful 30333 9944 1-node
 
 # Wait for node to start
 echo -e "🚀 Starting chainflip-node..."

--- a/ci/scripts/check_generated_bouncer_dependencies.sh
+++ b/ci/scripts/check_generated_bouncer_dependencies.sh
@@ -16,13 +16,13 @@ echo -e "Generating event schemas..."
 cd bouncer && ./commands/generate_event_schemas.ts
 cd ..
 
-# Check whether a event subdirectory is dirty
+# Check whether the event subdirectory is dirty
 EVENTS_DIR="bouncer/generated/events"
 
 if [[ -n "$(git status --porcelain -- "$EVENTS_DIR")" ]]; then
   echo "ERROR: Event schemas in '$EVENTS_DIR' are not up to date! Please run ./commands/generate_event_schemas.ts to regenerate schemas and commit them."
   echo ""
-  echo "The following schema changes have not been comitted:"
+  echo "The following schema changes have not been committed:"
   echo ""
   git status -- "$EVENTS_DIR"
   exit 1
@@ -36,13 +36,13 @@ echo -e "Generating chaintypes (dedot)..."
 cd bouncer && ./commands/generate_chaintypes.ts
 cd ..
 
-# Check whether a event subdirectory is dirty
+# Check whether the chaintypes subdirectory is dirty
 CHAINTYPES_DIR="bouncer/generated/chaintypes"
 
 if [[ -n "$(git status --porcelain -- "$CHAINTYPES_DIR")" ]]; then
-  echo "ERROR: Event schemas in '$CHAINTYPES_DIR' are not up to date! Please run ./commands/generate_chaintypes.ts to regenerate dedot chaintypes and commit them."
+  echo "ERROR: Chaintypes in '$CHAINTYPES_DIR' are not up to date! Please run ./commands/generate_chaintypes.ts to regenerate dedot chaintypes and commit them."
   echo ""
-  echo "The following chaintype changes have not been comitted:"
+  echo "The following chaintype changes have not been committed:"
   echo ""
   git status -- "$CHAINTYPES_DIR"
   exit 1


### PR DESCRIPTION
# Pull Request

## Summary

We have a CI workflow which checks that the generated bouncer event schemas are up-to-date when merging. We didn't add a similar check for the new dedot chaintypes though. This PR adds it.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
