### PR TITLE
chore: update storage analysis script:

### DIFF
--- a/state-chain/runtime-tests/.gitignore
+++ b/state-chain/runtime-tests/.gitignore
@@ -1,1 +1,2 @@
 snapshots/
+storage-report-*.md

--- a/state-chain/runtime-tests/Cargo.lock
+++ b/state-chain/runtime-tests/Cargo.lock
@@ -7226,6 +7226,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cf-primitives",
+ "dirs",
  "frame-remote-externalities",
  "frame-support",
  "hex",

--- a/state-chain/runtime-tests/Cargo.lock
+++ b/state-chain/runtime-tests/Cargo.lock
@@ -746,7 +746,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "hash-db",
  "log",
@@ -1108,6 +1108,9 @@ dependencies = [
 name = "cf-primitives"
 version = "0.1.0"
 dependencies = [
+ "cf-proc-macros",
+ "derive-where",
+ "duplicate",
  "frame-support",
  "hex",
  "n-functor",
@@ -1120,6 +1123,15 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "utilities",
+]
+
+[[package]]
+name = "cf-proc-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2630,8 +2642,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "43.0.1"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2655,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "43.0.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2685,7 +2697,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.11.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -2701,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.54.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "futures",
  "indicatif",
@@ -2722,8 +2734,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "43.0.2"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2764,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "35.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2784,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -2796,7 +2808,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2806,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "43.0.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2825,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2839,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2849,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.49.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5504,7 +5516,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aura"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5520,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5533,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "44.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5809,6 +5821,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-core",
  "sp-std",
 ]
 
@@ -5878,8 +5891,10 @@ dependencies = [
  "cf-amm",
  "cf-chains",
  "cf-primitives",
+ "cf-proc-macros",
  "cf-runtime-utilities",
  "cf-traits",
+ "derive-where",
  "frame-support",
  "frame-system",
  "log",
@@ -5890,6 +5905,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-runtime",
  "sp-std",
+ "utilities",
 ]
 
 [[package]]
@@ -5935,6 +5951,7 @@ dependencies = [
 name = "pallet-cf-trading-strategy"
 version = "0.1.0"
 dependencies = [
+ "cf-amm",
  "cf-amm-math",
  "cf-primitives",
  "cf-runtime-utilities",
@@ -5961,11 +5978,15 @@ dependencies = [
  "frame-system",
  "log",
  "nanorand",
+ "pallet-cf-funding",
+ "pallet-cf-reputation",
+ "pallet-grandpa",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-application-crypto",
+ "sp-consensus-grandpa",
  "sp-core",
  "sp-std",
  "utilities",
@@ -6014,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6036,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6058,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6076,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6091,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7412,7 +7433,7 @@ checksum = "3fc4972f129a0ea378b69fa7c186d63255606e362ad00795f00b869dea5265eb"
 [[package]]
 name = "sc-allocator"
 version = "34.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "log",
  "sp-core",
@@ -7423,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "46.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "array-bytes",
  "docify",
@@ -7449,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -7460,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "fnv",
  "futures",
@@ -7486,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.45.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -7509,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.41.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -7522,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.38.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "log",
  "polkavm",
@@ -7533,7 +7554,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.41.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "anyhow",
  "log",
@@ -7549,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.23.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -7576,8 +7597,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.53.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "0.53.1"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -7627,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.51.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -7637,7 +7658,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.19.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "bs58",
  "bytes",
@@ -7658,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.52.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7678,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "chrono",
  "futures",
@@ -7697,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "futures",
@@ -7714,7 +7735,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-channel",
  "futures",
@@ -8331,7 +8352,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "docify",
  "hash-db",
@@ -8353,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "25.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -8367,7 +8388,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8379,7 +8400,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -8393,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -8403,7 +8424,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8422,7 +8443,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.45.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "futures",
@@ -8436,7 +8457,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.45.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8452,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "26.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8469,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.45.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8480,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "38.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -8527,7 +8548,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -8540,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -8550,7 +8571,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -8559,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8569,7 +8590,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8579,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.20.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8591,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8604,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "43.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "bytes",
  "docify",
@@ -8630,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.44.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -8641,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -8649,8 +8670,8 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.12.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "0.12.2"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -8660,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8671,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8681,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "backtrace",
  "regex",
@@ -8690,7 +8711,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "36.0.1"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -8700,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "44.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -8729,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "32.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -8747,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "Inflector",
  "expander",
@@ -8760,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "41.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8774,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "41.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8787,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.48.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "hash-db",
  "log",
@@ -8807,12 +8828,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8824,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8836,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -8848,7 +8869,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -8856,8 +8877,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "41.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "41.1.1"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -8882,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "42.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -8899,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -8911,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -8923,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.1.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -8990,12 +9011,13 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-chain-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bitvec",
  "cf-amm",
  "cf-chains",
  "cf-primitives",
+ "cf-proc-macros",
  "cf-runtime-utilities",
  "cf-session-benchmarking",
  "cf-test-utilities",
@@ -9128,7 +9150,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "hmac",
  "pbkdf2",
@@ -9140,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -9154,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.52.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -9166,8 +9188,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "29.0.0"
-source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509#1a65a2d9c0ac21b1d557fd7137907905c15b414f"
+version = "29.0.1"
+source = "git+https://github.com/chainflip-io/polkadot-sdk.git?tag=chainflip-substrate-stable2509-2.2.7#536fcf510e291c19c2e08ad3499b6b6aaa6f72cf"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -9955,7 +9977,9 @@ dependencies = [
  "async-broadcast",
  "async-channel",
  "bs58",
+ "cf-proc-macros",
  "clap",
+ "duplicate",
  "futures",
  "futures-util",
  "hex",
@@ -9974,7 +9998,9 @@ dependencies = [
  "scale-json",
  "scopeguard",
  "serde",
+ "sp-arithmetic",
  "sp-core",
+ "sp-std",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/state-chain/runtime-tests/Cargo.toml
+++ b/state-chain/runtime-tests/Cargo.toml
@@ -3,6 +3,10 @@ name = "runtime-tests"
 version = "0.1.0"
 edition = "2021"
 
+# This crate is in the workspace `exclude` list, to keep its heavy dependency tree out of the
+# workspace build. That also means it cannot use `workspace = true`: the git tags below must be
+# kept in sync with the workspace root by hand, or the crate stops compiling.
+
 [dependencies]
 # Local dependencies
 state-chain-runtime = { path = "../runtime", features = ["std"] }
@@ -11,13 +15,13 @@ pallet-cf-validator = { path = "../pallets/cf-validator", features = ["std"] }
 pallet-cf-witnesser = { path = "../pallets/cf-witnesser", features = ["std"] }
 
 # Polkadot SDK dependencies
-frame-remote-externalities = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-sp-state-machine = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-sc-executor = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
-sc-executor-common = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-3" }
+frame-remote-externalities = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+frame-support = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+sp-state-machine = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+sp-runtime = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+sp-io = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+sc-executor = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
+sc-executor-common = { git = "https://github.com/chainflip-io/polkadot-sdk.git", tag = "chainflip-substrate-stable2509-2.2.7" }
 codec = { version = "3.7.4", package = "parity-scale-codec", features = [
     "std",
 ] }

--- a/state-chain/runtime-tests/Cargo.toml
+++ b/state-chain/runtime-tests/Cargo.toml
@@ -28,6 +28,7 @@ codec = { version = "3.7.4", package = "parity-scale-codec", features = [
 
 tokio = { version = "1.38.0", features = ["full"] }
 anyhow = "1.0.86"
+dirs = "5.0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 log = "0.4.21"
 hex = "0.4.3"

--- a/state-chain/runtime-tests/src/main.rs
+++ b/state-chain/runtime-tests/src/main.rs
@@ -26,7 +26,15 @@ mod tests;
 
 type StateChainBlock = state_chain_runtime::Block;
 
-const HELP: &str = "\
+fn help() -> String {
+	// Resolved rather than created: printing the help shouldn't leave a directory behind.
+	let snapshot_dir = snapshot_dir().map_or_else(
+		|_| format!("<none: no cache directory found, set {SNAPSHOT_DIR_VAR}>"),
+		|dir| dir.display().to_string(),
+	);
+
+	format!(
+		"\
 Runs the state chain runtime tests against real chain state, either fetched from a network
 or loaded from a local snapshot.
 
@@ -54,13 +62,13 @@ TARGET (one or more):
     <path>.snap                 a snapshot file at an explicit path, always read offline
 
     Fetched state is cached by block hash, so a block that has been run before is re-used
-    offline instead of being fetched again. The cache lives outside the repository (it
-    survives `git clean` and is shared between checkouts); its location is logged on
-    startup.
+    offline instead of being fetched again. The cache lives outside the repository, so it
+    survives `git clean` and is shared between checkouts:
+
+        {snapshot_dir}
 
 ENVIRONMENT:
-    CF_RUNTIME_TESTS_SNAPSHOT_DIR   where to cache snapshots
-                                    (default: <user cache dir>/chainflip/runtime-tests)
+    CF_RUNTIME_TESTS_SNAPSHOT_DIR   where to cache snapshots (see above)
     STORAGE_ANALYSIS_ONLY=1     run the storage analysis only, skipping the tests
     RUST_LOG=debug              log level (default: info)
 
@@ -71,7 +79,9 @@ EXAMPLES:
 
 A storage report is written to `state-chain/runtime-tests/storage-report-<hash>.md` for
 every block that is processed.\
-";
+"
+	)
+}
 
 #[derive(Debug, Clone)]
 pub enum Network {
@@ -154,12 +164,12 @@ impl FromStr for Target {
 /// Overrides where snapshots are cached.
 const SNAPSHOT_DIR_VAR: &str = "CF_RUNTIME_TESTS_SNAPSHOT_DIR";
 
-/// Where fetched chain state is cached, created on demand.
+/// Where fetched chain state is cached.
 ///
 /// Deliberately outside the repository: snapshots are large, are keyed by an immutable block
 /// hash, and so are worth sharing between checkouts rather than losing to a `git clean`.
 fn snapshot_dir() -> anyhow::Result<PathBuf> {
-	let dir = match std::env::var_os(SNAPSHOT_DIR_VAR) {
+	Ok(match std::env::var_os(SNAPSHOT_DIR_VAR) {
 		Some(dir) => PathBuf::from(dir),
 		None => dirs::cache_dir()
 			.ok_or_else(|| {
@@ -167,7 +177,12 @@ fn snapshot_dir() -> anyhow::Result<PathBuf> {
 			})?
 			.join("chainflip")
 			.join("runtime-tests"),
-	};
+	})
+}
+
+/// [`snapshot_dir`], created if it doesn't exist yet.
+fn create_snapshot_dir() -> anyhow::Result<PathBuf> {
+	let dir = snapshot_dir()?;
 
 	std::fs::create_dir_all(&dir)
 		.map_err(|e| anyhow!("Unable to create snapshot directory {}: {e}", dir.display()))?;
@@ -180,12 +195,12 @@ async fn main() -> anyhow::Result<()> {
 	let args: Vec<String> = std::env::args().skip(1).collect();
 
 	if args.iter().any(|arg| matches!(arg.as_str(), "help" | "--help" | "-h")) {
-		println!("{HELP}");
+		println!("{}", help());
 		return Ok(())
 	}
 
 	let Some((first, rest)) = args.split_first() else {
-		eprintln!("{HELP}");
+		eprintln!("{}", help());
 		anyhow::bail!("No arguments provided.");
 	};
 
@@ -211,7 +226,7 @@ async fn main() -> anyhow::Result<()> {
 		.collect::<anyhow::Result<Vec<_>>>()?;
 
 	if targets.is_empty() {
-		eprintln!("{HELP}");
+		eprintln!("{}", help());
 		anyhow::bail!("No targets provided. Provide one or more snapshots, hashes or `latest`.");
 	}
 
@@ -230,7 +245,7 @@ async fn main() -> anyhow::Result<()> {
 	}
 
 	let network = network.map(Network::url);
-	let snapshot_dir = snapshot_dir()?;
+	let snapshot_dir = create_snapshot_dir()?;
 	log::info!("Caching snapshots in {}", snapshot_dir.display());
 
 	let modes: Vec<_> = targets

--- a/state-chain/runtime-tests/src/main.rs
+++ b/state-chain/runtime-tests/src/main.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::str::FromStr;
+use std::{
+	path::{Path, PathBuf},
+	str::FromStr,
+};
 
 use anyhow::anyhow;
 use frame_remote_externalities::{Mode, OfflineConfig, OnlineConfig, SnapshotConfig, Transport};
@@ -47,13 +50,17 @@ NETWORK (optional):
 
 TARGET (one or more):
     latest                      the network's latest finalised block (needs a NETWORK)
-    0x<hash>                    a specific block hash
-    snapshots/0x<hash>.snap     a previously downloaded snapshot
+    0x<hash>                    a specific block, from the snapshot cache or the network
+    <path>.snap                 a snapshot file at an explicit path, always read offline
 
-    Fetched state is cached under `snapshots/`, so a block that has been run before is
-    re-used offline instead of being fetched again.
+    Fetched state is cached by block hash, so a block that has been run before is re-used
+    offline instead of being fetched again. The cache lives outside the repository (it
+    survives `git clean` and is shared between checkouts); its location is logged on
+    startup.
 
 ENVIRONMENT:
+    CF_RUNTIME_TESTS_SNAPSHOT_DIR   where to cache snapshots
+                                    (default: <user cache dir>/chainflip/runtime-tests)
     STORAGE_ANALYSIS_ONLY=1     run the storage analysis only, skipping the tests
     RUST_LOG=debug              log level (default: info)
 
@@ -62,8 +69,8 @@ EXAMPLES:
     cargo run -- b 0xabc123... 0xdef456...   # fetch and test two specific blocks
     cargo run -- 0xabc123...                 # re-run against an existing snapshot
 
-A storage report is written to `storage-report-<hash>.md` in this directory for every
-block that is processed.\
+A storage report is written to `state-chain/runtime-tests/storage-report-<hash>.md` for
+every block that is processed.\
 ";
 
 #[derive(Debug, Clone)]
@@ -113,8 +120,10 @@ impl FromStr for Network {
 pub enum Target {
 	/// The network's latest finalised block.
 	Latest,
-	/// A specific block, given either as a hash or as the snapshot it was cached in.
+	/// A specific block, cached in [`snapshot_dir`] under its hash.
 	Block(state_chain_runtime::Hash),
+	/// A snapshot file at an explicit path, read as given.
+	Snapshot(PathBuf),
 }
 
 impl FromStr for Target {
@@ -125,19 +134,45 @@ impl FromStr for Target {
 			return Ok(Self::Latest)
 		}
 
-		// Snapshots are named after the block hash they hold.
-		// TODO: If a snapshot file is specified at some other path, try to use it.
-		s.trim_start_matches("snapshots/")
-			.trim_end_matches(".snap")
-			.parse()
-			.map(Self::Block)
-			.map_err(|_| {
-				anyhow!(
-					"Invalid argument `{s}`: expected a network name or url, `latest`, a block \
-					 hash, or a snapshot. Run with `help` for details."
-				)
-			})
+		// A bare hash is looked up in (and cached to) the snapshot directory; anything that
+		// names a file is used verbatim, so that snapshots kept elsewhere can be replayed.
+		if let Ok(hash) = s.parse() {
+			return Ok(Self::Block(hash))
+		}
+
+		if s.ends_with(".snap") {
+			return Ok(Self::Snapshot(PathBuf::from(s)))
+		}
+
+		Err(anyhow!(
+			"Invalid argument `{s}`: expected a network name or url, `latest`, a block hash, or \
+			 a path to a `.snap` file. Run with `help` for details."
+		))
 	}
+}
+
+/// Overrides where snapshots are cached.
+const SNAPSHOT_DIR_VAR: &str = "CF_RUNTIME_TESTS_SNAPSHOT_DIR";
+
+/// Where fetched chain state is cached, created on demand.
+///
+/// Deliberately outside the repository: snapshots are large, are keyed by an immutable block
+/// hash, and so are worth sharing between checkouts rather than losing to a `git clean`.
+fn snapshot_dir() -> anyhow::Result<PathBuf> {
+	let dir = match std::env::var_os(SNAPSHOT_DIR_VAR) {
+		Some(dir) => PathBuf::from(dir),
+		None => dirs::cache_dir()
+			.ok_or_else(|| {
+				anyhow!("Unable to locate a cache directory. Set {SNAPSHOT_DIR_VAR} to choose one.")
+			})?
+			.join("chainflip")
+			.join("runtime-tests"),
+	};
+
+	std::fs::create_dir_all(&dir)
+		.map_err(|e| anyhow!("Unable to create snapshot directory {}: {e}", dir.display()))?;
+
+	Ok(dir)
 }
 
 #[tokio::main]
@@ -186,40 +221,47 @@ async fn main() -> anyhow::Result<()> {
 		anyhow::bail!("`latest` requires a network, e.g. `berghain latest`.");
 	}
 
+	for target in &targets {
+		if let Target::Snapshot(path) = target {
+			if !path.is_file() {
+				anyhow::bail!("Snapshot not found: {}", path.display());
+			}
+		}
+	}
+
 	let network = network.map(Network::url);
+	let snapshot_dir = snapshot_dir()?;
+	log::info!("Caching snapshots in {}", snapshot_dir.display());
 
-	let hashes = targets
+	let modes: Vec<_> = targets
 		.into_iter()
-		.map(|target| match target {
-			Target::Latest => None,
-			Target::Block(hash) => Some(hash),
-		})
-		.collect::<Vec<_>>();
+		.map(|target| {
+			// An explicitly-pathed snapshot is read as given: there is no hash to fetch it by.
+			let hash = match target {
+				Target::Block(hash) => Some(hash),
+				Target::Latest => None,
+				Target::Snapshot(path) =>
+					return Mode::Offline(OfflineConfig {
+						state_snapshot: SnapshotConfig::new(path),
+					}),
+			};
 
-	let modes: Vec<_> = match (network, hashes) {
-		(None, hashes) => hashes
-			.into_iter()
-			.map(|hash| {
-				Mode::<state_chain_runtime::Hash>::Offline(OfflineConfig {
-					state_snapshot: snapshot_file_for_hash(hash),
-				})
-			})
-			.collect(),
-		(Some(network), hashes) => hashes
-			.into_iter()
-			.map(|hash| {
-				Mode::OfflineOrElseOnline(
-					OfflineConfig { state_snapshot: snapshot_file_for_hash(hash) },
+			let state_snapshot = snapshot_file_for_hash(&snapshot_dir, hash);
+
+			match &network {
+				None => Mode::Offline(OfflineConfig { state_snapshot }),
+				Some(network) => Mode::OfflineOrElseOnline(
+					OfflineConfig { state_snapshot: state_snapshot.clone() },
 					OnlineConfig {
 						at: hash,
-						state_snapshot: Some(snapshot_file_for_hash(hash)),
+						state_snapshot: Some(state_snapshot),
 						transport: Transport::Uri(network.clone()),
 						..Default::default()
 					},
-				)
-			})
-			.collect(),
-	};
+				),
+			}
+		})
+		.collect();
 
 	for mode in modes {
 		let snapshot_config = match &mode {
@@ -238,10 +280,11 @@ async fn main() -> anyhow::Result<()> {
 
 		// If the snapshot was for "latest", rename it to the actual hash.
 		if let Some(snapshot) = snapshot_config {
-			if snapshot.path == snapshot_file_for_hash(None).path {
+			if snapshot.path == snapshot_file_for_hash(&snapshot_dir, None).path {
 				std::fs::rename(
 					snapshot.path,
-					snapshot_file_for_hash(Some(remote_externalities.header.hash())).path,
+					snapshot_file_for_hash(&snapshot_dir, Some(remote_externalities.header.hash()))
+						.path,
 				)?;
 			}
 		}
@@ -252,11 +295,9 @@ async fn main() -> anyhow::Result<()> {
 	Ok(())
 }
 
-fn snapshot_file_for_hash(hash: Option<state_chain_runtime::Hash>) -> SnapshotConfig {
-	if let Some(hash) = hash {
-		format!("snapshots/{:?}.snap", hash)
-	} else {
-		"snapshots/latest.snap".to_string()
-	}
-	.into()
+fn snapshot_file_for_hash(dir: &Path, hash: Option<state_chain_runtime::Hash>) -> SnapshotConfig {
+	SnapshotConfig::new(dir.join(match hash {
+		Some(hash) => format!("{hash:?}.snap"),
+		None => "latest.snap".to_string(),
+	}))
 }

--- a/state-chain/runtime-tests/src/main.rs
+++ b/state-chain/runtime-tests/src/main.rs
@@ -23,6 +23,49 @@ mod tests;
 
 type StateChainBlock = state_chain_runtime::Block;
 
+const HELP: &str = "\
+Runs the state chain runtime tests against real chain state, either fetched from a network
+or loaded from a local snapshot.
+
+USAGE:
+    cargo run -- [NETWORK] <TARGET>...
+    cargo run -- help
+
+    This crate is excluded from the workspace, so cargo must be run from within
+    `state-chain/runtime-tests`.
+
+NETWORK (optional):
+    local                       http://localhost:9944
+    sisyphos | s                https://archive.sisyphos.chainflip.io:443
+    perseverance | p            https://archive.perseverance.chainflip.io:443
+    berghain | mainnet | b | m  https://mainnet-archive.chainflip.io:443
+    <url>                       any other archive node RPC endpoint, with an explicit
+                                scheme (http://, https://, ws:// or wss://)
+
+    The leading argument is taken as the network only if it matches one of the above.
+    With no network, state is loaded from local snapshots and nothing is fetched.
+
+TARGET (one or more):
+    latest                      the network's latest finalised block (needs a NETWORK)
+    0x<hash>                    a specific block hash
+    snapshots/0x<hash>.snap     a previously downloaded snapshot
+
+    Fetched state is cached under `snapshots/`, so a block that has been run before is
+    re-used offline instead of being fetched again.
+
+ENVIRONMENT:
+    STORAGE_ANALYSIS_ONLY=1     run the storage analysis only, skipping the tests
+    RUST_LOG=debug              log level (default: info)
+
+EXAMPLES:
+    cargo run -- berghain latest             # fetch and test mainnet's latest block
+    cargo run -- b 0xabc123... 0xdef456...   # fetch and test two specific blocks
+    cargo run -- 0xabc123...                 # re-run against an existing snapshot
+
+A storage report is written to `storage-report-<hash>.md` in this directory for every
+block that is processed.\
+";
+
 #[derive(Debug, Clone)]
 pub enum Network {
 	Local,
@@ -32,24 +75,84 @@ pub enum Network {
 	Custom(String),
 }
 
+impl Network {
+	fn url(self) -> String {
+		match self {
+			Self::Local => "http://localhost:9944".to_string(),
+			Self::Sisyphos => "https://archive.sisyphos.chainflip.io:443".to_string(),
+			Self::Perseverance => "https://archive.perseverance.chainflip.io:443".to_string(),
+			Self::Berghain => "https://mainnet-archive.chainflip.io:443".to_string(),
+			Self::Custom(url) => url,
+		}
+	}
+}
+
 impl FromStr for Network {
+	/// `Err` means "not a network", not "malformed": the argument is then tried as a target.
 	type Err = ();
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		const SCHEMES: [&str; 4] = ["http://", "https://", "ws://", "wss://"];
+
 		match s {
 			"local" => Ok(Self::Local),
 			"sisyphos" | "s" => Ok(Self::Sisyphos),
 			"perseverance" | "p" => Ok(Self::Perseverance),
 			"berghain" | "mainnet" | "b" | "m" => Ok(Self::Berghain),
-			s if !s.starts_with("0x") => Ok(Self::Custom(s.to_string())),
+			// A custom endpoint must carry an explicit scheme. Accepting bare strings would
+			// swallow any mistyped target as a URL, and fail much later at connection time.
+			s if SCHEMES.iter().any(|scheme| s.starts_with(scheme)) =>
+				Ok(Self::Custom(s.to_string())),
 			_ => Err(()),
 		}
 	}
 }
 
+/// A block to run the tests against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Target {
+	/// The network's latest finalised block.
+	Latest,
+	/// A specific block, given either as a hash or as the snapshot it was cached in.
+	Block(state_chain_runtime::Hash),
+}
+
+impl FromStr for Target {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		if s == "latest" {
+			return Ok(Self::Latest)
+		}
+
+		// Snapshots are named after the block hash they hold.
+		// TODO: If a snapshot file is specified at some other path, try to use it.
+		s.trim_start_matches("snapshots/")
+			.trim_end_matches(".snap")
+			.parse()
+			.map(Self::Block)
+			.map_err(|_| {
+				anyhow!(
+					"Invalid argument `{s}`: expected a network name or url, `latest`, a block \
+					 hash, or a snapshot. Run with `help` for details."
+				)
+			})
+	}
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-	let args: Vec<String> = std::env::args().collect();
+	let args: Vec<String> = std::env::args().skip(1).collect();
+
+	if args.iter().any(|arg| matches!(arg.as_str(), "help" | "--help" | "-h")) {
+		println!("{HELP}");
+		return Ok(())
+	}
+
+	let Some((first, rest)) = args.split_first() else {
+		eprintln!("{HELP}");
+		anyhow::bail!("No arguments provided.");
+	};
 
 	tracing_subscriber::FmtSubscriber::builder()
 		.with_env_filter(
@@ -60,38 +163,38 @@ async fn main() -> anyhow::Result<()> {
 		.try_init()
 		.expect("setting default subscriber failed");
 
-	let network = Network::from_str(&args[1]).ok().map(|network| match network {
-		Network::Local => "http://localhost:9944".to_string(),
-		Network::Sisyphos => "https://archive.sisyphos.chainflip.io:443".to_string(),
-		Network::Perseverance => "https://archive.perseverance.chainflip.io:443".to_string(),
-		Network::Berghain => "https://mainnet-archive.chainflip.io:443".to_string(),
-		Network::Custom(url) => url,
-	});
+	// The leading argument is the network if it names one; otherwise every argument is a
+	// target and the run is offline.
+	let (network, target_args) = match first.parse::<Network>() {
+		Ok(network) => (Some(network), rest),
+		Err(()) => (None, args.as_slice()),
+	};
 
-	let hashes = args
-		.into_iter()
-		.skip(if network.is_some() { 2 } else { 1 })
-		.map(|s| {
-			if s == "latest" {
-				Ok(None)
-			} else {
-				s.parse()
-					.or_else(|_| {
-						// Assume snapshot file relative to the current path.
-						// TODO:
-						// If a snapshot file is specified at some other path, try to use it.
-						s.trim_start_matches("snapshots/").trim_end_matches(".snap").parse()
-					})
-					.map(Some)
-			}
-		})
-		.collect::<Result<Vec<_>, _>>()?;
+	let targets = target_args
+		.iter()
+		.map(|arg| arg.parse::<Target>())
+		.collect::<anyhow::Result<Vec<_>>>()?;
 
-	if hashes.is_empty() {
-		anyhow::bail!(
-			"No hashes provided. Either provide a list of snapshots, hashes or 'latest'."
-		);
+	if targets.is_empty() {
+		eprintln!("{HELP}");
+		anyhow::bail!("No targets provided. Provide one or more snapshots, hashes or `latest`.");
 	}
+
+	// Resolving `latest` requires querying the network, and the snapshot it would otherwise be
+	// read from is renamed to its block hash as soon as it has been fetched.
+	if network.is_none() && targets.contains(&Target::Latest) {
+		anyhow::bail!("`latest` requires a network, e.g. `berghain latest`.");
+	}
+
+	let network = network.map(Network::url);
+
+	let hashes = targets
+		.into_iter()
+		.map(|target| match target {
+			Target::Latest => None,
+			Target::Block(hash) => Some(hash),
+		})
+		.collect::<Vec<_>>();
 
 	let modes: Vec<_> = match (network, hashes) {
 		(None, hashes) => hashes

--- a/state-chain/runtime-tests/src/tests.rs
+++ b/state-chain/runtime-tests/src/tests.rs
@@ -13,11 +13,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::BTreeMap;
-
 use crate::StateChainBlock;
 use frame_remote_externalities::RemoteExternalities;
-use frame_support::StorageHasher;
 
 pub type Ext = sp_state_machine::TestExternalities<sp_runtime::traits::BlakeTwo256>;
 
@@ -32,63 +29,48 @@ pub trait RuntimeTest: Default {
 pub mod auction_resolution;
 pub mod rotation_breakdown;
 pub mod rotation_on_initialize;
+pub mod storage_analysis;
 pub mod swap_rate;
 pub mod witnesser_cull;
 
-pub fn run_all(ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<()> {
+/// Set to skip the runtime tests and only produce the storage report.
+fn storage_analysis_only() -> bool {
+	std::env::var("STORAGE_ANALYSIS_ONLY").is_ok_and(|v| v != "0")
+}
+
+pub fn run_all(mut ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<()> {
 	let block_hash = ext.header.hash();
 	let state_version = ext.state_version;
+
+	// The flat key/value state. Note this is not the same as the raw snapshot below, which is
+	// the trie node database (path prefix + node hash), and so cannot be attributed to storage
+	// items directly.
+	let pairs = ext.inner_ext.execute_with(|| {
+		let mut pairs = Vec::new();
+		let mut key = Vec::new();
+		while let Some(next) = sp_io::storage::next_key(&key) {
+			if let Some(value) = sp_io::storage::get(&next) {
+				pairs.push((next.clone(), value.to_vec()));
+			}
+			key = next;
+		}
+		pairs
+	});
+
 	let (raw_storage, storage_root) = ext.inner_ext.into_raw_snapshot();
 
-	let mut size_by_prefix = BTreeMap::<Vec<u8>, (usize, usize)>::new();
-	for (k, (v, _)) in raw_storage.iter() {
-		size_by_prefix
-			// 16 bytes for the prefix, 16 bytes for the key
-			.entry(k.iter().take(16 + 16).copied().collect::<Vec<_>>())
-			.and_modify(|(c, s)| {
-				*c += 1;
-				*s += v.len();
-			})
-			.or_insert((1, v.len()));
+	storage_analysis::run(block_hash, &pairs, &raw_storage)?;
+
+	if storage_analysis_only() {
+		return Ok(())
 	}
-	let mut size_by_prefix = size_by_prefix.into_iter().collect::<Vec<_>>();
-	size_by_prefix.sort_by_key(|(_, (_, size))| std::cmp::Reverse(*size));
-
-	let pallets_by_prefix =
-		<state_chain_runtime::AllPalletsWithSystem as frame_support::traits::PalletsInfoAccess>::infos()
-			.into_iter()
-			.map(|info| {
-				let prefix = frame_support::Twox128::hash(info.name.as_bytes());
-				(prefix, info.name)
-			})
-			.collect::<BTreeMap<_, _>>();
-
-	println!("=== Storage usage top 10:");
-	for (prefix, (count, size)) in size_by_prefix.into_iter().take(10) {
-		let decription = if let Some(name) = pallets_by_prefix.get(&prefix[..16]) {
-			format!("Pallet {}[{}]", name, hex::encode(&prefix[16..]),)
-		} else if hex::encode(&prefix[..5]) == "3a636f6465" {
-			format!("Runtime WASM")
-		} else {
-			format!("Prefix 0x{}", hex::encode(prefix),)
-		};
-
-		println!(
-			"{:<64}: num_items: {:>7} / total_size: ~{:>3}{}",
-			decription,
-			count,
-			if size < 1_000_000 { size / 1_000 } else { size / 1_000_000 },
-			if size < 1_000_000 { "Kb" } else { "Mb" },
-		);
-	}
-	println!("========================");
 
 	log::info!("Running tests for block hash: {:?}", block_hash);
 
 	let mk_ext = || {
 		sp_state_machine::TestExternalities::from_raw_snapshot(
 			raw_storage.clone(),
-			storage_root.clone(),
+			storage_root,
 			state_version,
 		)
 	};

--- a/state-chain/runtime-tests/src/tests.rs
+++ b/state-chain/runtime-tests/src/tests.rs
@@ -33,11 +33,6 @@ pub mod storage_analysis;
 pub mod swap_rate;
 pub mod witnesser_cull;
 
-/// Set to skip the runtime tests and only produce the storage report.
-fn storage_analysis_only() -> bool {
-	std::env::var("STORAGE_ANALYSIS_ONLY").is_ok_and(|v| v != "0")
-}
-
 pub fn run_all(mut ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<()> {
 	let block_hash = ext.header.hash();
 	let state_version = ext.state_version;
@@ -61,7 +56,9 @@ pub fn run_all(mut ext: RemoteExternalities<StateChainBlock>) -> anyhow::Result<
 
 	storage_analysis::run(block_hash, &pairs, &raw_storage)?;
 
-	if storage_analysis_only() {
+	// If the STORAGE_ANALYSIS_ONLY environment variable is set to a non-zero value, we skip running
+	// the tests.
+	if std::env::var("STORAGE_ANALYSIS_ONLY").is_ok_and(|v| v != "0") {
 		return Ok(())
 	}
 

--- a/state-chain/runtime-tests/src/tests/rotation_breakdown.rs
+++ b/state-chain/runtime-tests/src/tests/rotation_breakdown.rs
@@ -44,8 +44,17 @@ fn rotation_context() -> Option<u32> {
 	let duration = Validator::epoch_duration();
 	let trigger = started.saturating_add(duration);
 	let phase = Validator::current_rotation_phase();
-	println!("  epoch {} started at {}, duration {} -> trigger block {}", Validator::current_epoch(), started, duration, trigger);
-	println!("  rotation phase: {}", if matches!(phase, pallet_cf_validator::RotationPhase::Idle) { "Idle" } else { "NOT Idle" });
+	println!(
+		"  epoch {} started at {}, duration {} -> trigger block {}",
+		Validator::current_epoch(),
+		started,
+		duration,
+		trigger
+	);
+	println!(
+		"  rotation phase: {}",
+		if matches!(phase, pallet_cf_validator::RotationPhase::Idle) { "Idle" } else { "NOT Idle" }
+	);
 	if matches!(phase, pallet_cf_validator::RotationPhase::Idle) {
 		Some(trigger)
 	} else {

--- a/state-chain/runtime-tests/src/tests/rotation_on_initialize.rs
+++ b/state-chain/runtime-tests/src/tests/rotation_on_initialize.rs
@@ -81,7 +81,9 @@ impl RuntimeTest for Test {
 					);
 				},
 				Err(_) => {
-					println!("\n  Validator::on_initialize PANICKED against real state (see stderr).");
+					println!(
+						"\n  Validator::on_initialize PANICKED against real state (see stderr)."
+					);
 				},
 			}
 		});

--- a/state-chain/runtime-tests/src/tests/storage_analysis.rs
+++ b/state-chain/runtime-tests/src/tests/storage_analysis.rs
@@ -1,0 +1,711 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage footprint analysis of a live chain snapshot.
+//!
+//! Buckets every raw trie key by its 32-byte storage prefix, maps those prefixes back to
+//! `(pallet, storage item)` pairs via the runtime metadata, and reports:
+//! - which items dominate the state size (hotspots),
+//! - prefixes with no corresponding metadata entry (dead storage / leaked prefixes),
+//! - key-space statistics for the largest maps (to spot unbounded growth).
+
+use std::collections::BTreeMap;
+
+use codec::Decode;
+use frame_support::{
+	StorageHasher as _, Twox128,
+	__private::metadata::{
+		v14::{StorageEntryType, StorageHasher},
+		RuntimeMetadata,
+	},
+};
+
+/// Flat state: storage key -> storage value.
+type Pairs = [(Vec<u8>, Vec<u8>)];
+/// Trie node database: (path prefix ++ node hash) -> (encoded node, refcount).
+type TrieNodes = [(Vec<u8>, (Vec<u8>, i32))];
+
+/// How many of the biggest items get a detailed key-space breakdown.
+const DETAILED_ITEMS: usize = 40;
+/// How many sample keys to record per orphaned prefix.
+const ORPHAN_SAMPLES: usize = 3;
+/// Source trees swept for candidate storage item names, relative to the repository root.
+const CANDIDATE_SOURCE_DIRS: [&str; 3] = ["state-chain", "engine", "api"];
+/// Every FRAME pallet stores its storage version under this postfix. It is not a metadata
+/// entry, so it would otherwise be reported as an orphan for every single pallet.
+const STORAGE_VERSION_KEY_POSTFIX: &[u8] = b":__STORAGE_VERSION__:";
+
+#[derive(Default, Clone)]
+struct Stats {
+	count: usize,
+	value_bytes: usize,
+	key_bytes: usize,
+	empty_values: usize,
+	max_value: usize,
+	min_value: usize,
+	/// Suffixes (key bytes after the 32-byte prefix), only retained for the report's
+	/// detailed section. Kept unconditionally: the whole snapshot is in memory anyway.
+	suffixes: Vec<Vec<u8>>,
+	value_sizes: Vec<usize>,
+}
+
+impl Stats {
+	fn add(&mut self, key: &[u8], value: &[u8]) {
+		if self.count == 0 {
+			self.min_value = value.len();
+		}
+		self.count += 1;
+		self.value_bytes += value.len();
+		self.key_bytes += key.len();
+		if value.is_empty() {
+			self.empty_values += 1;
+		}
+		self.max_value = self.max_value.max(value.len());
+		self.min_value = self.min_value.min(value.len());
+		self.value_sizes.push(value.len());
+		if key.len() > 32 {
+			self.suffixes.push(key[32..].to_vec());
+		}
+	}
+
+	fn total_bytes(&self) -> usize {
+		self.value_bytes + self.key_bytes
+	}
+
+	/// Requires `value_sizes` to have been sorted first.
+	fn percentile(&self, p: f64) -> usize {
+		if self.value_sizes.is_empty() {
+			return 0
+		}
+		self.value_sizes[(((self.value_sizes.len() - 1) as f64) * p).round() as usize]
+	}
+}
+
+struct ItemInfo {
+	pallet: String,
+	item: String,
+	hashers: Vec<StorageHasher>,
+	key_type: String,
+	value_type: String,
+}
+
+impl ItemInfo {
+	fn full_name(&self) -> String {
+		format!("{}::{}", self.pallet, self.item)
+	}
+}
+
+/// Number of leading bytes a hasher contributes before the (optionally) concatenated raw key.
+/// `None` means the raw key is not recoverable from the trie key.
+fn hasher_prefix_len(h: &StorageHasher) -> Option<usize> {
+	match h {
+		StorageHasher::Blake2_128Concat => Some(16),
+		StorageHasher::Twox64Concat => Some(8),
+		StorageHasher::Identity => Some(0),
+		StorageHasher::Blake2_128 | StorageHasher::Twox128 => None,
+		StorageHasher::Blake2_256 | StorageHasher::Twox256 => None,
+	}
+}
+
+fn hasher_name(h: &StorageHasher) -> &'static str {
+	match h {
+		StorageHasher::Blake2_128 => "Blake2_128",
+		StorageHasher::Blake2_256 => "Blake2_256",
+		StorageHasher::Blake2_128Concat => "Blake2_128Concat",
+		StorageHasher::Twox128 => "Twox128",
+		StorageHasher::Twox256 => "Twox256",
+		StorageHasher::Twox64Concat => "Twox64Concat",
+		StorageHasher::Identity => "Identity",
+	}
+}
+
+/// Storage item names are Twox128 hashes, so a removed item can only be identified by hashing
+/// candidate names and looking for a match. A removed item no longer has a `pub type`
+/// declaration, but its name almost always survives somewhere — an error or event variant, a
+/// migration's `old` module, an RPC type — so this sweeps every type-shaped identifier in the
+/// source tree rather than only declarations. Junk candidates cost nothing: a 128-bit hash
+/// makes an accidental match impossible.
+fn candidate_names() -> BTreeMap<Vec<u8>, String> {
+	fn visit(dir: &std::path::Path, out: &mut BTreeMap<Vec<u8>, String>) {
+		let Ok(entries) = std::fs::read_dir(dir) else { return };
+		for entry in entries.flatten() {
+			let path = entry.path();
+			if path.is_dir() {
+				if path.file_name().is_some_and(|n| n != "target") {
+					visit(&path, out);
+				}
+			} else if path.extension().is_some_and(|e| e == "rs") {
+				let Ok(contents) = std::fs::read_to_string(&path) else { continue };
+				for token in contents.split(|c: char| !c.is_ascii_alphanumeric()) {
+					if looks_like_a_type_name(token) {
+						out.entry(Twox128::hash(token.as_bytes()).to_vec())
+							.or_insert_with(|| token.to_string());
+					}
+				}
+			}
+		}
+	}
+
+	// The repo root, resolved from this crate's location at build time.
+	let Some(repo_root) = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).ancestors().nth(2)
+	else {
+		return Default::default()
+	};
+	let mut out = BTreeMap::new();
+	for dir in CANDIDATE_SOURCE_DIRS {
+		visit(&repo_root.join(dir), &mut out);
+	}
+	add_names_from_git_history(repo_root, &mut out);
+	out
+}
+
+fn looks_like_a_type_name(token: &str) -> bool {
+	token.len() >= 3 &&
+		token.len() <= 64 &&
+		token.starts_with(|c: char| c.is_ascii_uppercase()) &&
+		token.chars().any(|c| c.is_ascii_lowercase()) &&
+		// Addresses and hashes from test fixtures are the bulk of the noise.
+		!(token.len() >= 8 && token.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// An item removed long enough ago leaves nothing in the working tree, but its `pub type`
+/// declaration survives in the diff history. Best-effort and additive: yields nothing outside
+/// a git checkout, and less on a shallow clone. Takes a few seconds; the diff is streamed
+/// rather than buffered because `git log -p` over a deep clone is arbitrarily large.
+fn add_names_from_git_history(repo_root: &std::path::Path, out: &mut BTreeMap<Vec<u8>, String>) {
+	use std::io::BufRead;
+
+	let Ok(mut child) = std::process::Command::new("git")
+		.args(["log", "--all", "-p", "-U0", "--", "*.rs"])
+		.current_dir(repo_root)
+		.stdout(std::process::Stdio::piped())
+		.stderr(std::process::Stdio::null())
+		.spawn()
+	else {
+		return
+	};
+	if let Some(stdout) = child.stdout.take() {
+		for line in std::io::BufReader::new(stdout).lines().map_while(Result::ok) {
+			// Added or removed declaration lines, i.e. `+pub type Foo<T> = ...`.
+			let Some(rest) = line.strip_prefix(['+', '-']) else { continue };
+			let Some(rest) = rest.trim_start().strip_prefix("pub type ") else { continue };
+			let name = rest
+				.chars()
+				.take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+				.collect::<String>();
+			if looks_like_a_type_name(&name) {
+				out.entry(Twox128::hash(name.as_bytes()).to_vec()).or_insert(name);
+			}
+		}
+	}
+	let _ = child.wait();
+}
+
+fn human(bytes: usize) -> String {
+	const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+	let mut v = bytes as f64;
+	let mut u = 0;
+	while v >= 1024.0 && u < UNITS.len() - 1 {
+		v /= 1024.0;
+		u += 1;
+	}
+	if u == 0 {
+		format!("{bytes} B")
+	} else {
+		format!("{v:.1} {}", UNITS[u])
+	}
+}
+
+/// Best-effort interpretation of the first key component of a map, used to spot
+/// stale ranges (e.g. block numbers or epochs that should have been cleaned up) and
+/// lopsided fan-out (one account/id owning a disproportionate share of a double map).
+fn summarise_first_key_component(suffixes: &[Vec<u8>], hashers: &[StorageHasher]) -> Vec<String> {
+	let mut out = Vec::new();
+	let Some(hash_len) = hashers.first().and_then(hasher_prefix_len) else { return out };
+
+	// A concat hasher emits `hash(key) ++ key`, so equal leading `hash_len` bytes means
+	// equal first key, whatever the key type is. Works for maps of any arity.
+	if hash_len > 0 {
+		let mut fan_out = BTreeMap::<&[u8], usize>::new();
+		for s in suffixes.iter().filter(|s| s.len() >= hash_len) {
+			*fan_out.entry(&s[..hash_len]).or_default() += 1;
+		}
+		if !fan_out.is_empty() && hashers.len() > 1 {
+			let max = fan_out.values().copied().max().unwrap_or(0);
+			out.push(format!(
+				"{} distinct first keys, avg fan-out {:.1}, max fan-out {}",
+				fan_out.len(),
+				suffixes.len() as f64 / fan_out.len() as f64,
+				max,
+			));
+			// Few enough groups to enumerate: the raw key follows the concat hash, so show
+			// it decoded as a u32 (epoch/block-number keys, the usual stale-data suspects).
+			if fan_out.len() <= 16 {
+				let mut groups = suffixes
+					.iter()
+					.filter(|s| s.len() >= hash_len + 4)
+					.fold(BTreeMap::<u32, usize>::new(), |mut acc, s| {
+						let mut buf = [0u8; 4];
+						buf.copy_from_slice(&s[hash_len..hash_len + 4]);
+						*acc.entry(u32::from_le_bytes(buf)).or_default() += 1;
+						acc
+					})
+					.into_iter()
+					.collect::<Vec<_>>();
+				groups.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+				out.push(format!(
+					"first key as u32 -> entries: {}",
+					groups.iter().map(|(k, c)| format!("{k}: {c}")).collect::<Vec<_>>().join(", ")
+				));
+			}
+		} else if !fan_out.is_empty() {
+			out.push(format!("{} distinct keys", fan_out.len()));
+		}
+	}
+
+	// Only single-key maps let us pin down the raw key bytes unambiguously.
+	if hashers.len() != 1 {
+		return out
+	}
+	let raws: Vec<&[u8]> =
+		suffixes.iter().filter(|s| s.len() > hash_len).map(|s| &s[hash_len..]).collect();
+	let Some(first) = raws.first() else { return out };
+	if !raws.iter().all(|r| r.len() == first.len()) {
+		out.push("variable-length raw key".to_string());
+		return out
+	}
+	let width = first.len();
+
+	match width {
+		1 | 2 | 4 | 8 | 16 => {
+			let mut values = raws
+				.iter()
+				.map(|r| {
+					let mut buf = [0u8; 16];
+					buf[..width].copy_from_slice(&r[..width]);
+					u128::from_le_bytes(buf)
+				})
+				.collect::<Vec<_>>();
+			values.sort_unstable();
+			out.push(format!(
+				"as u{}: min={} max={} span={}",
+				width * 8,
+				values[0],
+				values[values.len() - 1],
+				values[values.len() - 1].saturating_sub(values[0]),
+			));
+		},
+		32 => out.push("32-byte key (AccountId / hash)".to_string()),
+		n => out.push(format!("uniform raw key of {n} bytes")),
+	}
+	out
+}
+
+pub fn analyse(
+	block_hash: state_chain_runtime::Hash,
+	pairs: &Pairs,
+	trie_nodes: &TrieNodes,
+) -> String {
+	let metadata = state_chain_runtime::Runtime::metadata();
+	let RuntimeMetadata::V14(v14) = &metadata.1 else {
+		panic!("expected V14 metadata");
+	};
+
+	let type_name = |id: u32| -> String {
+		v14.types
+			.resolve(id)
+			.map(|t| {
+				if t.path.segments.is_empty() {
+					format!("{:?}", t.type_def).split_whitespace().next().unwrap_or("?").to_string()
+				} else {
+					t.path.segments.join("::")
+				}
+			})
+			.unwrap_or_else(|| "?".to_string())
+	};
+
+	// 32-byte storage prefix -> declared storage item.
+	let mut declared = BTreeMap::<Vec<u8>, ItemInfo>::new();
+	// 16-byte pallet prefix -> pallet name, so orphans can at least be attributed to a pallet.
+	let mut pallet_prefixes = BTreeMap::<Vec<u8>, String>::new();
+
+	for pallet in &v14.pallets {
+		let Some(storage) = &pallet.storage else { continue };
+		let pallet_prefix = Twox128::hash(storage.prefix.as_bytes()).to_vec();
+		pallet_prefixes.insert(pallet_prefix.clone(), storage.prefix.clone());
+		for entry in &storage.entries {
+			let mut key = pallet_prefix.clone();
+			key.extend_from_slice(&Twox128::hash(entry.name.as_bytes()));
+			let (hashers, key_type, value_type) = match &entry.ty {
+				StorageEntryType::Plain(v) => (vec![], "-".to_string(), type_name(v.id)),
+				StorageEntryType::Map { hashers, key, value } =>
+					(hashers.clone(), type_name(key.id), type_name(value.id)),
+			};
+			declared.insert(
+				key,
+				ItemInfo {
+					pallet: storage.prefix.clone(),
+					item: entry.name.clone(),
+					hashers,
+					key_type,
+					value_type,
+				},
+			);
+		}
+	}
+
+	// Pallets registered in the runtime but with no `Storage` section still own a prefix.
+	for info in <state_chain_runtime::AllPalletsWithSystem as frame_support::traits::PalletsInfoAccess>::infos() {
+		pallet_prefixes
+			.entry(Twox128::hash(info.name.as_bytes()).to_vec())
+			.or_insert_with(|| info.name.to_string());
+	}
+
+	// If the source tree isn't reachable this comes back empty, and orphans are still
+	// reported, just by hash rather than by name.
+	let candidates = candidate_names();
+	let name_item = |hash: &[u8]| -> String {
+		if hash == Twox128::hash(STORAGE_VERSION_KEY_POSTFIX) {
+			return ":__STORAGE_VERSION__: (FRAME pallet storage version, not a metadata entry)"
+				.to_string()
+		}
+		match candidates.get(hash) {
+			Some(name) => format!("{name} (matched by hash)"),
+			None => format!("0x{}", hex::encode(hash)),
+		}
+	};
+
+	let mut by_prefix = BTreeMap::<Vec<u8>, Stats>::new();
+	let mut well_known = BTreeMap::<Vec<u8>, Stats>::new();
+	let mut total_keys = 0usize;
+	let mut total_bytes = 0usize;
+
+	for (k, v) in pairs.iter() {
+		total_keys += 1;
+		total_bytes += k.len() + v.len();
+		if k.first() == Some(&b':') || k.len() < 32 {
+			well_known.entry(k.clone()).or_default().add(k, v);
+		} else {
+			by_prefix.entry(k[..32].to_vec()).or_default().add(k, v);
+		}
+	}
+
+	let mut report = String::new();
+	let mut w = |s: String| {
+		report.push_str(&s);
+		report.push('\n');
+	};
+
+	// The metadata we map against comes from the *local* runtime. If the snapshot predates it,
+	// items removed since then show up as orphans, so surface both versions.
+	let onchain_spec_version = {
+		let mut key = Twox128::hash(b"System").to_vec();
+		key.extend_from_slice(&Twox128::hash(b"LastRuntimeUpgrade"));
+		pairs
+			.iter()
+			.find(|(k, _)| *k == key)
+			.and_then(|(_, v)| {
+				<(codec::Compact<u32>, String)>::decode(&mut &v[..]).ok().map(|(v, _)| v.0)
+			})
+			.map(|v| v.to_string())
+			.unwrap_or_else(|| "unknown".to_string())
+	};
+
+	w("# State storage analysis".to_string());
+	w(String::new());
+	w(format!("Block hash: `{block_hash:?}`"));
+	w(format!("On-chain spec version (snapshot): {onchain_spec_version}"));
+	w(format!(
+		"Local runtime spec version (source of metadata): {}",
+		state_chain_runtime::VERSION.spec_version
+	));
+	w(format!(
+		"Flat state: {total_keys} entries / {} of key+value bytes ({total_bytes} B)",
+		human(total_bytes)
+	));
+	w(format!(
+		"Trie node database: {} nodes / {} (what a node actually stores on disk)",
+		trie_nodes.len(),
+		human(trie_nodes.iter().map(|(k, (v, _))| k.len() + v.len()).sum::<usize>()),
+	));
+	w(format!("Distinct 32-byte storage prefixes present: {}", by_prefix.len()));
+	w(format!("Storage items declared in metadata: {}", declared.len()));
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Per-pallet rollup.
+	// ---------------------------------------------------------------------------------------
+	let mut per_pallet = BTreeMap::<String, (usize, usize, usize)>::new(); // (items, keys, bytes)
+	for (prefix, stats) in &by_prefix {
+		let name = declared
+			.get(prefix)
+			.map(|i| i.pallet.clone())
+			.or_else(|| pallet_prefixes.get(&prefix[..16]).cloned())
+			.unwrap_or_else(|| format!("<unknown pallet 0x{}>", hex::encode(&prefix[..16])));
+		let e = per_pallet.entry(name).or_default();
+		e.0 += 1;
+		e.1 += stats.count;
+		e.2 += stats.total_bytes();
+	}
+	let mut per_pallet = per_pallet.into_iter().collect::<Vec<_>>();
+	per_pallet.sort_by_key(|(_, (_, _, bytes))| std::cmp::Reverse(*bytes));
+
+	w("## Per-pallet totals".to_string());
+	w(String::new());
+	w("| Pallet | Items | Keys | Bytes | % of state |".to_string());
+	w("|---|---:|---:|---:|---:|".to_string());
+	for (name, (items, keys, bytes)) in &per_pallet {
+		w(format!(
+			"| {name} | {items} | {keys} | {} | {:.2}% |",
+			human(*bytes),
+			100.0 * *bytes as f64 / total_bytes as f64
+		));
+	}
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Well-known / non-prefixed keys (`:code`, `:heappages`, ...).
+	// ---------------------------------------------------------------------------------------
+	w("## Well-known keys".to_string());
+	w(String::new());
+	w("| Key | Bytes |".to_string());
+	w("|---|---:|".to_string());
+	let mut wk = well_known.into_iter().collect::<Vec<_>>();
+	wk.sort_by_key(|(_, s)| std::cmp::Reverse(s.total_bytes()));
+	for (k, s) in wk {
+		let name = String::from_utf8(k.clone())
+			.ok()
+			.filter(|s| s.chars().all(|c| c.is_ascii_graphic()))
+			.unwrap_or_else(|| format!("0x{}", hex::encode(&k)));
+		w(format!("| `{name}` | {} |", human(s.total_bytes())));
+	}
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Every present storage item, largest first.
+	// ---------------------------------------------------------------------------------------
+	for stats in by_prefix.values_mut() {
+		stats.value_sizes.sort_unstable();
+	}
+	let declared_prefixes = declared.keys().cloned().collect::<std::collections::BTreeSet<_>>();
+	let present_prefixes = by_prefix.keys().cloned().collect::<std::collections::BTreeSet<_>>();
+
+	let mut items = by_prefix.iter().collect::<Vec<_>>();
+	items.sort_by_key(|(_, s)| std::cmp::Reverse(s.total_bytes()));
+
+	w("## Storage items by total size".to_string());
+	w(String::new());
+	w("| # | Item | Keys | Total | Values | Keys(bytes) | avg val | p50 | p99 | max | empty |"
+		.to_string());
+	w("|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|".to_string());
+	for (i, (prefix, stats)) in items.iter().enumerate() {
+		let name = match declared.get(*prefix) {
+			Some(info) => info.full_name(),
+			None => format!(
+				"⚠️ ORPHAN {}::{}",
+				pallet_prefixes
+					.get(&prefix[..16])
+					.cloned()
+					.unwrap_or_else(|| format!("0x{}", hex::encode(&prefix[..16]))),
+				name_item(&prefix[16..])
+			),
+		};
+		w(format!(
+			"| {} | {name} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+			i + 1,
+			stats.count,
+			human(stats.total_bytes()),
+			human(stats.value_bytes),
+			human(stats.key_bytes),
+			stats.value_bytes / stats.count.max(1),
+			stats.percentile(0.5),
+			stats.percentile(0.99),
+			stats.max_value,
+			stats.empty_values,
+		));
+	}
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Orphaned prefixes: present in state but absent from the current metadata.
+	// ---------------------------------------------------------------------------------------
+	let storage_version_hash = Twox128::hash(STORAGE_VERSION_KEY_POSTFIX);
+	let (version_keys, orphans): (Vec<_>, Vec<_>) = items
+		.iter()
+		.filter(|(prefix, _)| !declared_prefixes.contains(*prefix))
+		.partition(|(prefix, _)| prefix[16..] == storage_version_hash);
+
+	w("## Orphaned prefixes (state with no matching metadata entry)".to_string());
+	w(String::new());
+	w(format!(
+		"Excluding {} pallet `:__STORAGE_VERSION__:` keys ({}), which are expected.",
+		version_keys.len(),
+		human(version_keys.iter().map(|(_, s)| s.total_bytes()).sum::<usize>()),
+	));
+	w(String::new());
+	if orphans.is_empty() {
+		w("_None. Every prefix in state maps to a declared storage item._".to_string());
+	} else {
+		w(format!(
+			"{} orphaned prefixes, {} keys, {} total.",
+			orphans.len(),
+			orphans.iter().map(|(_, s)| s.count).sum::<usize>(),
+			human(orphans.iter().map(|(_, s)| s.total_bytes()).sum::<usize>()),
+		));
+		w(String::new());
+		w("| Pallet | Item | Keys | Bytes | Sample key suffixes |".to_string());
+		w("|---|---|---:|---:|---|".to_string());
+		for (prefix, stats) in &orphans {
+			let owner = pallet_prefixes
+				.get(&prefix[..16])
+				.cloned()
+				.unwrap_or_else(|| format!("<removed pallet 0x{}>", hex::encode(&prefix[..16])));
+			let samples = stats
+				.suffixes
+				.iter()
+				.take(ORPHAN_SAMPLES)
+				.map(|s| format!("0x{}", hex::encode(s)))
+				.collect::<Vec<_>>()
+				.join(", ");
+			w(format!(
+				"| {owner} | {} | {} | {} | {} |",
+				name_item(&prefix[16..]),
+				stats.count,
+				human(stats.total_bytes()),
+				if samples.is_empty() { "(plain value)".to_string() } else { samples },
+			));
+		}
+	}
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Physical footprint. Trie node keys are `path prefix ++ node hash`, so a node can only be
+	// attributed to a storage item once the path is deep enough to cover the 32-byte prefix.
+	// Shallow nodes (near the root) are unattributable, hence the residual bucket.
+	// ---------------------------------------------------------------------------------------
+	let mut trie_by_pallet = BTreeMap::<String, (usize, usize)>::new();
+	let mut unattributed = (0usize, 0usize);
+	for (k, (v, _)) in trie_nodes.iter() {
+		let size = k.len() + v.len();
+		let name = (k.len() >= 32)
+			.then(|| declared.get(&k[..32]).map(|i| i.pallet.clone()))
+			.flatten();
+		match name {
+			Some(pallet) => {
+				let e = trie_by_pallet.entry(pallet).or_default();
+				e.0 += 1;
+				e.1 += size;
+			},
+			None => {
+				unattributed.0 += 1;
+				unattributed.1 += size;
+			},
+		}
+	}
+	let trie_total = trie_nodes.iter().map(|(k, (v, _))| k.len() + v.len()).sum::<usize>();
+	let mut trie_by_pallet = trie_by_pallet.into_iter().collect::<Vec<_>>();
+	trie_by_pallet.sort_by_key(|(_, (_, bytes))| std::cmp::Reverse(*bytes));
+
+	w("## Physical trie footprint by pallet".to_string());
+	w(String::new());
+	w("| Pallet | Nodes | Bytes | % of trie |".to_string());
+	w("|---|---:|---:|---:|".to_string());
+	for (name, (nodes, bytes)) in trie_by_pallet.iter().take(20) {
+		w(format!(
+			"| {name} | {nodes} | {} | {:.2}% |",
+			human(*bytes),
+			100.0 * *bytes as f64 / trie_total as f64
+		));
+	}
+	w(format!(
+		"| _unattributed (shallow nodes)_ | {} | {} | {:.2}% |",
+		unattributed.0,
+		human(unattributed.1),
+		100.0 * unattributed.1 as f64 / trie_total as f64
+	));
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Declared but empty: candidates for removal, and a sanity check on the mapping.
+	// ---------------------------------------------------------------------------------------
+	let unused = declared
+		.iter()
+		.filter(|(prefix, _)| !present_prefixes.contains(*prefix))
+		.map(|(_, info)| info.full_name())
+		.collect::<Vec<_>>();
+	w(format!("## Declared but absent from state ({} items)", unused.len()));
+	w(String::new());
+	w(unused.join(", "));
+	w(String::new());
+
+	// ---------------------------------------------------------------------------------------
+	// Key-space detail for the biggest items: growth shape and stale-range detection.
+	// ---------------------------------------------------------------------------------------
+	w(format!("## Key-space detail for the {DETAILED_ITEMS} largest items"));
+	w(String::new());
+	for (prefix, stats) in items.iter().take(DETAILED_ITEMS) {
+		let Some(info) = declared.get(*prefix) else { continue };
+		let shape = if info.hashers.is_empty() {
+			"Plain value".to_string()
+		} else {
+			format!(
+				"Map<{}> keyed by {}",
+				info.hashers.iter().map(hasher_name).collect::<Vec<_>>().join(" + "),
+				info.key_type
+			)
+		};
+		w(format!("### {}", info.full_name()));
+		w(String::new());
+		w(format!("- {shape}"));
+		w(format!("- Value type: `{}`", info.value_type));
+		w(format!(
+			"- {} keys, {} total ({} values / {} key overhead)",
+			stats.count,
+			human(stats.total_bytes()),
+			human(stats.value_bytes),
+			human(stats.key_bytes)
+		));
+		if !info.hashers.is_empty() {
+			let summary = summarise_first_key_component(&stats.suffixes, &info.hashers);
+			if summary.is_empty() {
+				w("- First key component: not recoverable from trie key".to_string());
+			}
+			for line in summary {
+				w(format!("- First key component: {line}"));
+			}
+		}
+		w(String::new());
+	}
+
+	report
+}
+
+/// Print a short summary and write the full report next to the snapshots.
+pub fn run(
+	block_hash: state_chain_runtime::Hash,
+	pairs: &Pairs,
+	trie_nodes: &TrieNodes,
+) -> anyhow::Result<()> {
+	let report = analyse(block_hash, pairs, trie_nodes);
+	let path = format!("storage-report-{block_hash:?}.md");
+	std::fs::write(&path, &report)?;
+	println!("Storage report written to {path}");
+	// Echo the header + per-pallet table so the terminal is useful on its own.
+	for line in report.lines().take_while(|l| !l.starts_with("## Well-known")) {
+		println!("{line}");
+	}
+	Ok(())
+}

--- a/state-chain/runtime-tests/src/tests/storage_analysis.rs
+++ b/state-chain/runtime-tests/src/tests/storage_analysis.rs
@@ -600,16 +600,12 @@ pub fn analyse(
 	let mut unattributed = (0usize, 0usize);
 	for (k, (v, _)) in trie_nodes.iter() {
 		let size = k.len() + v.len();
-let hash_len = std::mem::size_of::<state_chain_runtime::Hash>();
+		let hash_len = std::mem::size_of::<state_chain_runtime::Hash>();
 		let path_len = k.len().saturating_sub(hash_len);
 		let name = (path_len >= 32)
 			.then(|| declared.get(&k[..32]).map(|i| i.pallet.clone()))
 			.flatten()
-			.or_else(|| {
-				(path_len >= 16)
-					.then(|| pallet_prefixes.get(&k[..16]).cloned())
-					.flatten()
-			});
+			.or_else(|| (path_len >= 16).then(|| pallet_prefixes.get(&k[..16]).cloned()).flatten());
 		match name {
 			Some(pallet) => {
 				let e = trie_by_pallet.entry(pallet).or_default();

--- a/state-chain/runtime-tests/src/tests/storage_analysis.rs
+++ b/state-chain/runtime-tests/src/tests/storage_analysis.rs
@@ -693,16 +693,17 @@ pub fn analyse(
 	report
 }
 
-/// Print a short summary and write the full report next to the snapshots.
+/// Print a short summary and write the full report in this crate's directory.
 pub fn run(
 	block_hash: state_chain_runtime::Hash,
 	pairs: &Pairs,
 	trie_nodes: &TrieNodes,
 ) -> anyhow::Result<()> {
 	let report = analyse(block_hash, pairs, trie_nodes);
-	let path = format!("storage-report-{block_hash:?}.md");
+	let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(format!("storage-report-{block_hash:?}.md"));
 	std::fs::write(&path, &report)?;
-	println!("Storage report written to {path}");
+	println!("Storage report written to {}", path.display());
 	// Echo the header + per-pallet table so the terminal is useful on its own.
 	for line in report.lines().take_while(|l| !l.starts_with("## Well-known")) {
 		println!("{line}");

--- a/state-chain/runtime-tests/src/tests/storage_analysis.rs
+++ b/state-chain/runtime-tests/src/tests/storage_analysis.rs
@@ -600,9 +600,16 @@ pub fn analyse(
 	let mut unattributed = (0usize, 0usize);
 	for (k, (v, _)) in trie_nodes.iter() {
 		let size = k.len() + v.len();
-		let name = (k.len() >= 32)
+let hash_len = std::mem::size_of::<state_chain_runtime::Hash>();
+		let path_len = k.len().saturating_sub(hash_len);
+		let name = (path_len >= 32)
 			.then(|| declared.get(&k[..32]).map(|i| i.pallet.clone()))
-			.flatten();
+			.flatten()
+			.or_else(|| {
+				(path_len >= 16)
+					.then(|| pallet_prefixes.get(&k[..16]).cloned())
+					.flatten()
+			});
 		match name {
 			Some(pallet) => {
 				let e = trie_by_pallet.entry(pallet).or_default();

--- a/state-chain/runtime-tests/src/tests/swap_rate.rs
+++ b/state-chain/runtime-tests/src/tests/swap_rate.rs
@@ -44,9 +44,8 @@ impl RuntimeTest for Test {
 		println!("Native result: {:?}", native_result);
 
 		// --- WASM execution (uses the on-chain :code blob) ---
-		let wasm_code = ext.execute_with(|| {
-			sp_io::storage::get(b":code").expect(":code not found in state")
-		});
+		let wasm_code =
+			ext.execute_with(|| sp_io::storage::get(b":code").expect(":code not found in state"));
 		println!("WASM blob size: {} bytes", wasm_code.len());
 
 		let runtime_blob =

--- a/state-chain/runtime-tests/src/tests/witnesser_cull.rs
+++ b/state-chain/runtime-tests/src/tests/witnesser_cull.rs
@@ -44,10 +44,11 @@ impl RuntimeTest for Test {
 			println!("\n=== Witnesser cull probe @ {:?} ===", block_hash);
 			println!("  current_epoch:  {}", current);
 			println!("  EpochsToCull:   {:?}", to_cull);
+			println!("\n  per-epoch entry counts (the next epoch to cull is EpochsToCull.last()):");
 			println!(
-				"\n  per-epoch entry counts (the next epoch to cull is EpochsToCull.last()):"
+				"  {:<8} {:>10} {:>16} {:>12}",
+				"epoch", "votes", "call_hash_exec", "extra_data"
 			);
-			println!("  {:<8} {:>10} {:>16} {:>12}", "epoch", "votes", "call_hash_exec", "extra_data");
 
 			// Count entries per recent epoch. iter_prefix walks only that epoch's sub-map.
 			for epoch in current.saturating_sub(12)..=current {
@@ -58,7 +59,12 @@ impl RuntimeTest for Test {
 				let mark = if to_cull.contains(&epoch) { " <- queued to cull" } else { "" };
 				println!(
 					"  {:<8} {:>10} {:>16} {:>12}   ({:?}){}",
-					epoch, votes, call_hash, extra, t.elapsed(), mark,
+					epoch,
+					votes,
+					call_hash,
+					extra,
+					t.elapsed(),
+					mark,
 				);
 			}
 		});
@@ -90,9 +96,9 @@ impl RuntimeTest for CullCost {
 			EpochsToCull::<Runtime>::put(vec![epoch]);
 
 			// on_idle is handed a full block's ref-time (2s) as leftover budget — the worst case.
-			// With the per-block cull cap in place, a single on_idle should now clear only a bounded
-			// slice and leave the epoch queued (contrast: without the cap it cleared the whole
-			// ~230k-item epoch in this one call, a ~295ms spike).
+			// With the per-block cull cap in place, a single on_idle should now clear only a
+			// bounded slice and leave the epoch queued (contrast: without the cap it cleared the
+			// whole ~230k-item epoch in this one call, a ~295ms spike).
 			let budget = Weight::from_parts(2_000_000_000_000, u64::MAX);
 
 			let t = Instant::now();
@@ -102,8 +108,15 @@ impl RuntimeTest for CullCost {
 
 			println!("  single on_idle with the per-block cull cap:");
 			println!("    wall clock (cold):     {:?}", elapsed);
-			println!("    weight self-charged:   {:.1} ms-equiv ref-time", used.ref_time() as f64 / 1e9);
-			println!("    votes deleted:         {} of {}", votes_before - votes_after, votes_before);
+			println!(
+				"    weight self-charged:   {:.1} ms-equiv ref-time",
+				used.ref_time() as f64 / 1e9
+			);
+			println!(
+				"    votes deleted:         {} of {}",
+				votes_before - votes_after,
+				votes_before
+			);
 			println!("    epoch fully culled:    {}", EpochsToCull::<Runtime>::get().is_empty());
 			println!(
 				"    -> bounded per block; the epoch stays queued and drains over ~{} blocks.",


### PR DESCRIPTION
# Pull Request

- Update dependency versions
- Better analytics for storage size
- Cargo fmt/clippy

The script now generates a storage-report file (gitignored) containing information about storage patterns and usage, as well potential orphaned storage that can be removed.

Orphan storage is identified by building a list of removed `pub type X` declarations from a history of git diffs and matching against those hashes.

I decided to keep this crate separate from the workspace to avoid building and running it with every CI run. The cost is that we won't auto-detect when dependencies go out of date. We can revisit later if this becomes an issue.

