### PR TITLE
perf: skip unused vote-component storage reads and writes

### DIFF
--- a/state-chain/pallets/cf-elections/src/benchmarking.rs
+++ b/state-chain/pallets/cf-elections/src/benchmarking.rs
@@ -17,7 +17,7 @@
 use crate::{
 	bitmap_components::ElectionBitmapComponents,
 	electoral_system::{AuthorityVoteOf, IndividualComponentOf, VotePropertiesOf},
-	vote_storage::VoteStorage,
+	vote_storage::{ComponentStorageKind, VoteStorage},
 	*,
 };
 use cf_chains::benchmarking_value::BenchmarkValue;
@@ -523,6 +523,7 @@ mod benchmarks {
 			ElectionBitmapComponents::<T, I>::with(
 				epoch,
 				UniqueMonotonicIdentifier::from(i as u64),
+				ComponentStorageKind::Both,
 				|_a| Ok(i),
 			)
 			.unwrap();

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -190,7 +190,7 @@ pub mod pallet {
 		fmt::Debug,
 		vec::Vec,
 	};
-	use vote_storage::{AuthorityVote, VoteComponents, VoteStorage};
+	use vote_storage::{AuthorityVote, ComponentStorageKind, VoteComponents, VoteStorage};
 
 	pub const MAXIMUM_VOTES_PER_EXTRINSIC: u32 = 16;
 	const BLOCKS_BETWEEN_CLEANUP: u64 = 128;
@@ -860,6 +860,7 @@ pub mod pallet {
 						let bitmap_components = ElectionBitmapComponents::<T, I>::with(
 							epoch_index,
 							*unique_monotonic_identifier,
+							ComponentStorageKind::Both,
 							|election_bitmap_components| {
 								election_bitmap_components.get_all(&current_authorities)
 							},
@@ -1041,7 +1042,7 @@ pub mod pallet {
 		};
 		use crate::{
 			electoral_system::{BitmapComponentOf, ElectoralSystemTypes},
-			vote_storage::VoteStorage,
+			vote_storage::{ComponentStorageKind, VoteStorage},
 		};
 		use bitvec::prelude::*;
 		use cf_primitives::{AuthorityCount, EpochIndex};
@@ -1072,8 +1073,30 @@ pub mod pallet {
 			>(
 				current_epoch: EpochIndex,
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
+				component_storage_kind: ComponentStorageKind,
 				f: F,
 			) -> Result<R, CorruptStorageError> {
+				// An election whose vote storage has no bitmap component never populates
+				// `BitmapComponents`, so there is nothing to load and nothing to store. Skipping
+				// both saves a read and - since `ALWAYS_STORE_AFTER_CLOSURE` would otherwise
+				// `kill` a key that was never set - a write, for every vote on such an
+				// election.
+				if !component_storage_kind.has_bitmap() {
+					let mut this = Self {
+						epoch: current_epoch,
+						bitmaps: Default::default(),
+						_phantom: Default::default(),
+					};
+					let r = f(&mut this)?;
+					// Callers promised there would be no bitmap component. Dropping one silently
+					// would lose a vote, so treat the inconsistency as corrupt storage.
+					return if this.bitmaps.is_empty() {
+						Ok(r)
+					} else {
+						Err(CorruptStorageError::new())
+					};
+				}
+
 				let (updated, mut this) =
 					if let Some(mut this) =
 						BitmapComponents::<T, I>::get(unique_monotonic_identifier)
@@ -1192,11 +1215,13 @@ pub mod pallet {
 			pub(crate) fn with<R, F: for<'a> FnOnce(&'a Self) -> Result<R, CorruptStorageError>>(
 				current_epoch: EpochIndex,
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
+				component_storage_kind: ComponentStorageKind,
 				f: F,
 			) -> Result<R, CorruptStorageError> {
 				Self::inner_with::<false, _, _>(
 					current_epoch,
 					unique_monotonic_identifier,
+					component_storage_kind,
 					|this| f(&*this),
 				)
 			}
@@ -1207,9 +1232,15 @@ pub mod pallet {
 			>(
 				current_epoch: EpochIndex,
 				unique_monotonic_identifier: UniqueMonotonicIdentifier,
+				component_storage_kind: ComponentStorageKind,
 				f: F,
 			) -> Result<R, CorruptStorageError> {
-				Self::inner_with::<true, _, _>(current_epoch, unique_monotonic_identifier, f)
+				Self::inner_with::<true, _, _>(
+					current_epoch,
+					unique_monotonic_identifier,
+					component_storage_kind,
+					f,
+				)
 			}
 
 			pub(super) fn add(
@@ -1389,12 +1420,18 @@ pub mod pallet {
 					continue;
 				}
 
+				let component_storage_kind =
+					VoteStorageOf::<T::ElectoralSystemRunner>::component_storage_kind(
+						&partial_vote,
+					);
+
 				Self::handle_corrupt_storage(Self::take_vote_and_then(
 					epoch_index,
 					unique_monotonic_identifier,
 					&authority,
 					authority_index,
 					true, // Ensured before the loop.
+					component_storage_kind,
 					|option_existing_vote, election_bitmap_components| {
 						let components = <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::partial_vote_into_components(
 							<T::ElectoralSystemRunner as ElectoralSystemRunner>::generate_vote_properties(
@@ -1404,6 +1441,9 @@ pub mod pallet {
 							)?,
 							partial_vote
 						)?;
+
+						// The reads above were skipped on the strength of this value.
+						component_storage_kind.ensure_matches(&components)?;
 
 						if let Some(bitmap_component) = components.bitmap_component {
 							// Store bitmap component and update shared data reference counts
@@ -1505,6 +1545,7 @@ pub mod pallet {
 				&authority,
 				authority_index,
 				ContributingAuthorities::<T, I>::contains_key(&authority),
+				ComponentStorageKind::Both, // Make no assumptions about what is stored.
 				|_, _| Ok(()),
 			))?;
 			Ok(())
@@ -2075,14 +2116,21 @@ pub mod pallet {
 			authority: &T::ValidatorId,
 			authority_index: AuthorityCount,
 			is_contributing_authority: bool,
+			component_storage_kind: ComponentStorageKind,
 			f: F,
 		) -> Result<R, CorruptStorageError> {
 			ElectionBitmapComponents::<T, I>::with_mut(
 				epoch_index,
 				unique_monotonic_identifier,
+				component_storage_kind,
 				|election_bitmap_components| {
-					let individual_component =
-						IndividualComponents::<T, I>::take(unique_monotonic_identifier, authority);
+					// An election's vote storage is fixed for its lifetime, so when it has no
+					// individual component there is nothing stored here to take.
+					let individual_component = if component_storage_kind.has_individual() {
+						IndividualComponents::<T, I>::take(unique_monotonic_identifier, authority)
+					} else {
+						None
+					};
 
 					let r = f(
 						<<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::components_into_authority_vote(
@@ -2136,6 +2184,7 @@ pub mod pallet {
 					bitmap_component: ElectionBitmapComponents::<T, I>::with(
 						epoch_index,
 						unique_monotonic_identifier,
+						ComponentStorageKind::Both,
 						|election_bitmap_components| {
 							election_bitmap_components.get(authority_index)
 						},

--- a/state-chain/pallets/cf-elections/src/vote_storage.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage.rs
@@ -38,6 +38,48 @@ pub struct VoteComponents<VS: VoteStorage> {
 	pub bitmap_component: Option<<VS as VoteStorage>::BitmapComponent>,
 }
 
+/// Which of the two vote-component storages a vote can occupy.
+///
+/// This lets the pallet skip reading and writing a component storage that a vote can never
+/// occupy. It cannot be derived from `partial_vote_into_components`, whose `Properties` argument
+/// is only available after those reads have happened.
+///
+/// May over-report, must never under-report: reporting a component as unusable while
+/// `partial_vote_into_components` can still produce it drops votes and leaks shared data
+/// references, so the pallet treats that inconsistency as corrupt storage.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ComponentStorageKind {
+	BitmapOnly,
+	IndividualOnly,
+	Both,
+}
+
+impl ComponentStorageKind {
+	pub fn has_bitmap(&self) -> bool {
+		matches!(self, Self::BitmapOnly | Self::Both)
+	}
+
+	pub fn has_individual(&self) -> bool {
+		matches!(self, Self::IndividualOnly | Self::Both)
+	}
+
+	/// Errors if `components` populates a storage that this kind excludes, i.e. if the
+	/// `VoteStorage` under-reported. The pallet skips reads on the strength of this value, so
+	/// continuing would leak the shared data references held by the vote being replaced.
+	pub fn ensure_matches<VS: VoteStorage>(
+		&self,
+		components: &VoteComponents<VS>,
+	) -> Result<(), CorruptStorageError> {
+		if (components.bitmap_component.is_some() && !self.has_bitmap()) ||
+			(components.individual_component.is_some() && !self.has_individual())
+		{
+			Err(CorruptStorageError::new())
+		} else {
+			Ok(())
+		}
+	}
+}
+
 /// Describes a method of storing vote information.
 ///
 /// Implementations of this trait should *NEVER* directly access the storage of the election pallet,
@@ -78,6 +120,10 @@ pub trait VoteStorage: private::Sealed + Sized {
 		partial_vote: Self::PartialVote,
 	) -> Result<VoteComponents<Self>, CorruptStorageError>;
 
+	/// Which components `partial_vote_into_components` can populate for this partial vote. See
+	/// [`ComponentStorageKind`] for the over/under-reporting contract.
+	fn component_storage_kind(partial_vote: &Self::PartialVote) -> ComponentStorageKind;
+
 	/// Note: If all components are `None` this *MUST* always return `None`.
 	#[expect(clippy::type_complexity)]
 	fn components_into_authority_vote<
@@ -107,4 +153,150 @@ pub trait VoteStorage: private::Sealed + Sized {
 mod private {
 	/// Ensures `VoteStorage` can only be implemented here.
 	pub trait Sealed {}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{
+		bitmap::Bitmap,
+		bitmap_numerical::BitmapNoHash,
+		change::{MonotonicChange, MonotonicChangeVote},
+		composite::tuple_5_impls::{CompositePartialVote, CompositeVoteProperties},
+		individual::{identity::Identity, Individual},
+		ComponentStorageKind, VoteComponents, VoteStorage,
+	};
+	use crate::SharedDataHash;
+	use cf_utilities::{assert_err, assert_ok};
+
+	/// `component_storage_kind` is what allows the pallet to skip reading and writing a component
+	/// storage, so it must never report a component as unusable while
+	/// `partial_vote_into_components` still produces one. Over-reporting is merely slower, and so
+	/// is allowed - but each impl below is exact today, and the equality assertions pin that down.
+	fn assert_component_storage_kind<VS: VoteStorage>(
+		expected: ComponentStorageKind,
+		properties: VS::Properties,
+		partial_vote: VS::PartialVote,
+	) {
+		let declared = VS::component_storage_kind(&partial_vote);
+		assert_eq!(declared, expected);
+
+		let produced = VS::partial_vote_into_components(properties, partial_vote).unwrap();
+		assert_eq!(produced.bitmap_component.is_some(), declared.has_bitmap());
+		assert_eq!(produced.individual_component.is_some(), declared.has_individual());
+	}
+
+	#[test]
+	fn component_storage_kind_agrees_with_produced_components() {
+		assert_component_storage_kind::<Bitmap<u64>>(
+			ComponentStorageKind::BitmapOnly,
+			(),
+			SharedDataHash::of(&7u64),
+		);
+		assert_component_storage_kind::<BitmapNoHash<u64>>(
+			ComponentStorageKind::BitmapOnly,
+			(),
+			7u64,
+		);
+		assert_component_storage_kind::<Individual<(), Identity<u64>>>(
+			ComponentStorageKind::IndividualOnly,
+			(),
+			7u64,
+		);
+		assert_component_storage_kind::<MonotonicChange<u64, u32>>(
+			ComponentStorageKind::Both,
+			(),
+			MonotonicChangeVote { value: SharedDataHash::of(&7u64), block: 1u32 },
+		);
+	}
+
+	#[test]
+	fn composite_component_storage_kind_follows_the_voted_variant() {
+		type Composite = (
+			Bitmap<u64>,
+			BitmapNoHash<u64>,
+			Individual<(), Identity<u64>>,
+			MonotonicChange<u64, u32>,
+			Bitmap<u32>,
+		);
+
+		// Each variant must report its own electoral system's components, not the first one's.
+		assert_component_storage_kind::<Composite>(
+			ComponentStorageKind::BitmapOnly,
+			CompositeVoteProperties::A(()),
+			CompositePartialVote::A(SharedDataHash::of(&7u64)),
+		);
+		assert_component_storage_kind::<Composite>(
+			ComponentStorageKind::BitmapOnly,
+			CompositeVoteProperties::B(()),
+			CompositePartialVote::B(7u64),
+		);
+		assert_component_storage_kind::<Composite>(
+			ComponentStorageKind::IndividualOnly,
+			CompositeVoteProperties::C(()),
+			CompositePartialVote::C(7u64),
+		);
+		assert_component_storage_kind::<Composite>(
+			ComponentStorageKind::Both,
+			CompositeVoteProperties::D(()),
+			CompositePartialVote::D(MonotonicChangeVote {
+				value: SharedDataHash::of(&7u64),
+				block: 1u32,
+			}),
+		);
+	}
+
+	/// A `VoteStorage` that under-reports would have the pallet skip a read it needed to perform,
+	/// silently leaking the previous vote's shared data references. `ensure_matches` is the guard
+	/// that turns that into a `CorruptStorageError` instead, so exercise it in both directions.
+	///
+	/// The components are built by hand rather than by a deliberately-broken `VoteStorage`: the
+	/// trait is sealed, and every real impl is consistent, so an under-reporting pairing is not
+	/// otherwise reachable.
+	#[test]
+	fn under_reported_components_are_rejected() {
+		// `Bitmap`'s `IndividualComponent` and `Properties` are both `()`.
+		let individual_present = VoteComponents::<Bitmap<u64>> {
+			individual_component: Some(((), ())),
+			bitmap_component: None,
+		};
+		assert_err!(ComponentStorageKind::BitmapOnly.ensure_matches(&individual_present));
+
+		let bitmap_present = VoteComponents::<Bitmap<u64>> {
+			individual_component: None,
+			bitmap_component: Some(SharedDataHash::of(&7u64)),
+		};
+		assert_err!(ComponentStorageKind::IndividualOnly.ensure_matches(&bitmap_present));
+
+		// Both components present is under-reporting for either single-component kind.
+		let both_present = VoteComponents::<Bitmap<u64>> {
+			individual_component: Some(((), ())),
+			bitmap_component: Some(SharedDataHash::of(&7u64)),
+		};
+		assert_err!(ComponentStorageKind::BitmapOnly.ensure_matches(&both_present));
+		assert_err!(ComponentStorageKind::IndividualOnly.ensure_matches(&both_present));
+	}
+
+	#[test]
+	fn matching_and_over_reported_components_are_accepted() {
+		let bitmap_present = VoteComponents::<Bitmap<u64>> {
+			individual_component: None,
+			bitmap_component: Some(SharedDataHash::of(&7u64)),
+		};
+		let individual_present = VoteComponents::<Bitmap<u64>> {
+			individual_component: Some(((), ())),
+			bitmap_component: None,
+		};
+		let neither_present =
+			VoteComponents::<Bitmap<u64>> { individual_component: None, bitmap_component: None };
+
+		assert_ok!(ComponentStorageKind::BitmapOnly.ensure_matches(&bitmap_present));
+		assert_ok!(ComponentStorageKind::IndividualOnly.ensure_matches(&individual_present));
+
+		// Over-reporting is permitted: `Both` accepts whatever is produced, and a kind that
+		// claims a component the vote did not produce is merely slower, not unsound.
+		assert_ok!(ComponentStorageKind::Both.ensure_matches(&bitmap_present));
+		assert_ok!(ComponentStorageKind::Both.ensure_matches(&individual_present));
+		assert_ok!(ComponentStorageKind::BitmapOnly.ensure_matches(&neither_present));
+		assert_ok!(ComponentStorageKind::IndividualOnly.ensure_matches(&neither_present));
+	}
 }

--- a/state-chain/pallets/cf-elections/src/vote_storage/bitmap.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/bitmap.rs
@@ -19,7 +19,7 @@ mod tests;
 
 use frame_support::{pallet_prelude::Member, Parameter};
 
-use super::{AuthorityVote, VoteComponents, VoteStorage};
+use super::{AuthorityVote, ComponentStorageKind, VoteComponents, VoteStorage};
 
 use crate::{CorruptStorageError, SharedDataHash};
 
@@ -47,6 +47,9 @@ impl<T: Parameter + Member> VoteStorage for Bitmap<T> {
 		partial_vote: Self::PartialVote,
 	) -> Result<VoteComponents<Self>, CorruptStorageError> {
 		Ok(VoteComponents { bitmap_component: Some(partial_vote), individual_component: None })
+	}
+	fn component_storage_kind(_partial_vote: &Self::PartialVote) -> ComponentStorageKind {
+		ComponentStorageKind::BitmapOnly
 	}
 	fn components_into_authority_vote<
 		GetSharedData: FnMut(SharedDataHash) -> Result<Option<Self::SharedData>, CorruptStorageError>,

--- a/state-chain/pallets/cf-elections/src/vote_storage/bitmap_numerical.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/bitmap_numerical.rs
@@ -16,7 +16,7 @@
 
 use frame_support::{pallet_prelude::Member, Parameter};
 
-use super::{AuthorityVote, VoteComponents, VoteStorage};
+use super::{AuthorityVote, ComponentStorageKind, VoteComponents, VoteStorage};
 
 use crate::{CorruptStorageError, SharedDataHash};
 
@@ -47,6 +47,9 @@ impl<T: Parameter + Member> VoteStorage for BitmapNoHash<T> {
 		partial_vote: Self::PartialVote,
 	) -> Result<VoteComponents<Self>, CorruptStorageError> {
 		Ok(VoteComponents { bitmap_component: Some(partial_vote), individual_component: None })
+	}
+	fn component_storage_kind(_partial_vote: &Self::PartialVote) -> ComponentStorageKind {
+		ComponentStorageKind::BitmapOnly
 	}
 	fn components_into_authority_vote<
 		GetSharedData: FnMut(SharedDataHash) -> Result<Option<Self::SharedData>, CorruptStorageError>,

--- a/state-chain/pallets/cf-elections/src/vote_storage/change.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/change.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	Parameter,
 };
 
-use super::{AuthorityVote, VoteComponents, VoteStorage};
+use super::{AuthorityVote, ComponentStorageKind, VoteComponents, VoteStorage};
 
 use crate::{CorruptStorageError, SharedDataHash};
 
@@ -56,6 +56,9 @@ impl<T: Parameter + Member, S: Parameter + Member> VoteStorage for MonotonicChan
 			bitmap_component: Some(partial_vote.value),
 			individual_component: Some(((), partial_vote.block)),
 		})
+	}
+	fn component_storage_kind(_partial_vote: &Self::PartialVote) -> ComponentStorageKind {
+		ComponentStorageKind::Both
 	}
 	fn components_into_authority_vote<
 		GetSharedData: FnMut(SharedDataHash) -> Result<Option<Self::SharedData>, CorruptStorageError>,

--- a/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/composite.rs
@@ -27,7 +27,7 @@ macro_rules! generate_vote_storage_tuple_impls {
             #[allow(unused_imports)]
             use crate::{CorruptStorageError, SharedDataHash};
 
-            use super::super::{private, VoteStorage, AuthorityVote, VoteComponents};
+            use super::super::{private, VoteStorage, AuthorityVote, ComponentStorageKind, VoteComponents};
 
             use codec::{Encode, Decode, DecodeWithMemTracking};
             use scale_info::TypeInfo;
@@ -107,6 +107,14 @@ macro_rules! generate_vote_storage_tuple_impls {
                         // For when we have a composite of 1
                         #[allow(unreachable_patterns)]
                         _ => Err(CorruptStorageError::new()),
+                    }
+                }
+
+                fn component_storage_kind(partial_vote: &Self::PartialVote) -> ComponentStorageKind {
+                    match partial_vote {
+                        $(
+                            CompositePartialVote::$t(partial_vote) => <$t as VoteStorage>::component_storage_kind(partial_vote),
+                        )*
                     }
                 }
 

--- a/state-chain/pallets/cf-elections/src/vote_storage/individual.rs
+++ b/state-chain/pallets/cf-elections/src/vote_storage/individual.rs
@@ -23,7 +23,7 @@ mod tests;
 
 use frame_support::{pallet_prelude::Member, Parameter};
 
-use super::{AuthorityVote, VoteComponents, VoteStorage};
+use super::{AuthorityVote, ComponentStorageKind, VoteComponents, VoteStorage};
 
 use crate::{CorruptStorageError, SharedDataHash};
 
@@ -54,6 +54,9 @@ impl<P: Parameter + Member, T: IndividualVoteStorage> VoteStorage for Individual
 			bitmap_component: None,
 			individual_component: Some((properties, partial_vote)),
 		})
+	}
+	fn component_storage_kind(_partial_vote: &Self::PartialVote) -> ComponentStorageKind {
+		ComponentStorageKind::IndividualOnly
 	}
 	fn components_into_authority_vote<
 		GetSharedData: FnMut(SharedDataHash) -> Result<Option<Self::SharedData>, CorruptStorageError>,


### PR DESCRIPTION
# Pull Request

Closes: PRO-3035

## Summary

* This PR is a followup for a set of performance improvements #6756 .
* Self contained to be separately reviewed and modified

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
