### PR TITLE
chore: remove lp-api and broker-api docker and deb images

### DIFF
--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -78,8 +78,6 @@ jobs:
           - chainflip-node
           - chainflip-engine
           - chainflip-cli
-          - chainflip-broker-api
-          - chainflip-lp-api
           - generate-genesis-keys
           - chainflip-engine-databases
         docker-repo:
@@ -162,8 +160,6 @@ jobs:
           - chainflip-node
           - chainflip-engine
           - chainflip-cli
-          - chainflip-broker-api
-          - chainflip-lp-api
         docker-repo:
           - chainfliplabs
     runs-on: namespace-profile-default

--- a/.github/workflows/_25_package.yml
+++ b/.github/workflows/_25_package.yml
@@ -53,8 +53,6 @@ jobs:
           cargo deb -v --no-build --no-strip -p chainflip-node --deb-revision "${{ steps.get-date.outputs.date }}" --variant=${{ inputs.network }}
           cargo deb -v --no-build --no-strip -p engine-runner --deb-revision "${{ steps.get-date.outputs.date }}" --variant=${{ inputs.network }}
           cargo deb -v --no-build --no-strip -p chainflip-cli --deb-revision "${{ steps.get-date.outputs.date }}"
-          cargo deb -v --no-build --no-strip -p chainflip-broker-api --deb-revision "${{ steps.get-date.outputs.date }}"
-          cargo deb -v --no-build --no-strip -p chainflip-lp-api --deb-revision "${{ steps.get-date.outputs.date }}"
 
       - name: Upload packages 📤
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874

--- a/.github/workflows/_30_publish.yml
+++ b/.github/workflows/_30_publish.yml
@@ -126,7 +126,6 @@ jobs:
           echo "apt-get install chainflip-cli" >> $GITHUB_STEP_SUMMARY
           echo "apt-get install chainflip-node" >> $GITHUB_STEP_SUMMARY
           echo "apt-get install chainflip-engine" >> $GITHUB_STEP_SUMMARY
-          echo "apt-get install chainflip-broker-api" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Testnet tools summary 📝


### PR DESCRIPTION
# Pull Request

Closes: PRO-2999

## Summary

* This PR the `chainflip-broker-api` and `chainflip-lp-api` binaries are no longer packaged or published
* Removed publishing both docker and debian images
* The binaries are still built since localnet starts them directly. Dockerfiles, lint jobs and release version checks are untouched.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
