### PR TITLE
feat: (cherry-pick) perf improvements (#6756)

### DIFF
--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/block_processor.rs
@@ -221,32 +221,34 @@ impl<T: BWProcessorTypes> BlockProcessor<T> {
 		safety_buffer: usize,
 	) {
 		//--------- calculate new events ---------
-		let new_events: Vec<_> = self
-			.blocks_data
-			.iter_mut()
-			.flat_map(|(block_height, block_info)| {
-				let new_next_age_to_process = ChainBlockNumberOf::<T::Chain>::steps_between(
-					block_height,
-					&seen_heights_below,
-				)
-				.0;
-				let age_range: Range<u32> =
-					(block_info.next_age_to_process)..new_next_age_to_process as u32;
+		let mut new_events = Vec::new();
+		for (block_height, block_info) in self.blocks_data.iter_mut() {
+			let new_next_age_to_process =
+				ChainBlockNumberOf::<T::Chain>::steps_between(block_height, &seen_heights_below).0;
+			let age_range: Range<u32> =
+				(block_info.next_age_to_process)..new_next_age_to_process as u32;
 
-				block_info.next_age_to_process = new_next_age_to_process as u32;
+			block_info.next_age_to_process = new_next_age_to_process as u32;
 
-				self.debug_events.run(BlockProcessorEvent::ProcessingBlockForAges {
-					height: *block_height,
-					ages: age_range.clone(),
-				});
+			// Nothing has aged, so the rules would produce nothing: skip before cloning the block
+			// data for them. Common, since this runs once per state machine step.
+			if age_range.is_empty() {
+				continue;
+			}
 
+			self.debug_events.run(BlockProcessorEvent::ProcessingBlockForAges {
+				height: *block_height,
+				ages: age_range.clone(),
+			});
+
+			new_events.extend(
 				self.rules
 					.run((age_range, block_info.block_data.clone(), block_info.safety_margin))
 					.into_iter()
 					.filter(|event| !self.processed_events.contains_key(event))
-					.map(|event| (*block_height, event))
-			})
-			.collect();
+					.map(|event| (*block_height, event)),
+			);
+		}
 
 		//--------- execute new events ---------
 		self.execute.run(new_events);

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/instance.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/instance.rs
@@ -68,8 +68,8 @@ pub trait BlockWitnesserInstance: CommonTraits + Validate + Member {
 
 	fn is_enabled() -> bool;
 	fn election_properties(
-		block_height: ChainBlockNumberOf<Self::Chain>,
-	) -> Self::ElectionProperties;
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties>;
 	fn processed_up_to(block_height: ChainBlockNumberOf<Self::Chain>);
 }
 
@@ -145,8 +145,8 @@ impls! {
 	}
 
 	Hook<HookTypeFor<Self, ElectionPropertiesHook>> {
-		fn run(&mut self, input: ChainBlockNumberOf<I::Chain>) -> I::ElectionProperties {
-			I::election_properties(input)
+		fn run(&mut self, input: Vec<ChainBlockNumberOf<I::Chain>>) -> Vec<I::ElectionProperties> {
+			I::election_properties(&input)
 		}
 	}
 

--- a/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/block_witnesser/state_machine.rs
@@ -29,6 +29,7 @@ use crate::{
 	generic_tools::*,
 };
 use cf_chains::witness_period::SaturatingStep;
+use cf_runtime_utilities::log_or_panic;
 use cf_traits::{Hook, HookType, Validate};
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use core::ops::Range;
@@ -92,10 +93,61 @@ impl<T: BWTypes> HookType for HookTypeFor<T, SafeModeEnabledHook> {
 
 pub struct ElectionPropertiesHook;
 impl<T: BWTypes> HookType for HookTypeFor<T, ElectionPropertiesHook> {
-	type Input = ChainBlockNumberOf<T::Chain>;
-	type Output = T::ElectionProperties;
+	type Input = Vec<ChainBlockNumberOf<T::Chain>>;
+	type Output = Vec<T::ElectionProperties>;
 }
 
+/// Nominally the function type is:
+/// ```ignore
+/// rules(age_range: Range<u32>, block_data: T::BlockData, safety_margin: u32)
+/// ```
+/// Computes the list of events that are caused by `block_data` aging from
+/// `age_range.start` to `age_range.end` (exclusive).
+///
+/// Requirements:
+///  - should only be called for consecutive age ranges. No ages should be skipped, and none should
+///    be overlapping.
+///  - safety_margin should be the same between calls.
+///
+/// Guarantees:
+///  - the concatenation of output events only depends on the total range covered.
+///  - in particular, if age_range is empty, the output MUST be an empty vector
+///
+/// ### Examples (Requirements):
+/// Let `d: T::BlockData`. Then the following sequence of calls is VALID:
+/// ```ignore
+/// rules(0..3, d, 4)
+/// rules(3..4, d, 4)
+/// rules(4..9, d, 4)
+/// ```
+///
+/// The following sequence is NOT VALID because the input ranges are overlapping
+/// ```ignore
+/// rules(0..3, d, 4)
+/// rules(2..5, d, 4) // overlap on age 2
+/// ```
+///
+/// The following sequence is NOT VALID because the safety margin changed
+/// ```ignore
+/// rules(0..3, d, 4)
+/// rules(3..5, d, 1) // calling with a different safety margin
+/// ```
+///
+/// ### Examples (Guarantees):
+/// The output should only depend on the union of all ages that `rules()` was called with,
+/// in particular the following examples hold:
+///
+/// Let `<>` denote the concatenation of vectors, then
+/// ```ignore
+/// rules(0..2, d, 4) <> rules(2..2, d, 4) <> rules(2..5, d, 4) == rules(0..5, d, 4)
+/// ```
+/// That is, since the 3 calls on the LHS cover 0..5, it's the same as calling rules once for the
+/// whole range.
+///
+/// This in particular also means that an empty range should always return an empty vector:
+/// ```ignore
+/// rules(2..2, d, 4) == []
+/// ```
 pub struct RulesHook;
 impl<T: BWProcessorTypes> HookType for HookTypeFor<T, RulesHook> {
 	type Input = (Range<u32>, T::BlockData, u32);
@@ -273,29 +325,42 @@ impl<T: BWTypes> Statemachine for BWStatemachine<T> {
 	type State = BlockWitnesserState<T>;
 
 	fn get_queries(state: &mut Self::State) -> Vec<Self::Query> {
-		state
-			.elections
-			.ongoing
-			.clone()
+		let ongoing = state.elections.ongoing.clone();
+
+		// One call for every ongoing height, rather than one per election: generating properties
+		// reads storage for some instances, so per-election would dominate this hook's cost.
+		let generated_properties =
+			state.generate_election_properties_hook.run(ongoing.keys().copied().collect());
+
+		if generated_properties.len() != ongoing.len() {
+			log_or_panic!(
+				"ElectionPropertiesHook returned {} properties for {} requested heights",
+				generated_properties.len(),
+				ongoing.len(),
+			);
+		}
+
+		ongoing
 			.into_iter()
-			.map(|(block_height, election_type)| match election_type {
+			.zip(generated_properties)
+			.map(|((block_height, election_type), generated_properties)| match election_type {
 				BWElectionType::Governance(properties) => BWElectionProperties {
 					properties,
 					election_type: EngineElectionType::BlockHeight { submit_hash: false },
 					block_height,
 				},
 				BWElectionType::Optimistic => BWElectionProperties {
-					properties: state.generate_election_properties_hook.run(block_height),
+					properties: generated_properties,
 					election_type: EngineElectionType::BlockHeight { submit_hash: true },
 					block_height,
 				},
 				BWElectionType::SafeBlockHeight => BWElectionProperties {
-					properties: state.generate_election_properties_hook.run(block_height),
+					properties: generated_properties,
 					election_type: EngineElectionType::BlockHeight { submit_hash: false },
 					block_height,
 				},
 				BWElectionType::ByHash(hash) => BWElectionProperties {
-					properties: state.generate_election_properties_hook.run(block_height),
+					properties: generated_properties,
 					election_type: EngineElectionType::ByHash(hash),
 					block_height,
 				},
@@ -593,7 +658,8 @@ pub mod tests {
 		for TypesFor<(N, H, Vec<D>)>
 	{
 		type ElectionProperties = ();
-		type ElectionPropertiesHook = MockHook<HookTypeFor<Self, ElectionPropertiesHook>>;
+		type ElectionPropertiesHook =
+			MockHook<HookTypeFor<Self, ElectionPropertiesHook>, "", ConstantBatchHook<()>>;
 		type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>>;
 		type ElectionTrackerDebugEventHook =
 			MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;

--- a/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine_es.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/state_machine/state_machine_es.rs
@@ -220,13 +220,16 @@ impl<ES: StatemachineElectoralSystemTypes> ElectoralSystem for StatemachineElect
 
 		// step for each election that reached consensus
 		log::debug!("ESSM: stepping for each election with consensus ({:?})", election_identifiers);
-		for election_identifier in &election_identifiers {
-			let election_access = ElectoralAccess::election_mut(*election_identifier);
+		let mut identifiers_and_properties = Vec::with_capacity(election_identifiers.len());
+		for election_identifier in election_identifiers {
+			let election_access = ElectoralAccess::election_mut(election_identifier);
+			let properties = election_access.properties()?;
 			log::debug!("ESSM: checking consensus for {election_identifier:?}");
 			if let Some(input) = election_access.check_consensus()?.has_consensus() {
 				log::debug!("ESSM: stepping with input {input:?}");
-				step(Either::Right((election_access.properties()?, input)))?;
+				step(Either::Right((properties.clone(), input)))?;
 			}
+			identifiers_and_properties.push((election_identifier, properties));
 		}
 
 		// gather the queries after all state transitions
@@ -238,9 +241,8 @@ impl<ES: StatemachineElectoralSystemTypes> ElectoralSystem for StatemachineElect
 		// (thus cannot be part of the loop above) since we first want to
 		// apply *all* state transitions to determine which elections should
 		// be kept open.
-		for election_identifier in election_identifiers {
+		for (election_identifier, properties) in identifiers_and_properties {
 			let election = ElectoralAccess::election_mut(election_identifier);
-			let properties: <ES::Statemachine as AbstractApi>::Query = election.properties()?;
 			if !queries.contains(&properties) {
 				election.delete();
 			} else {

--- a/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
+++ b/state-chain/pallets/cf-elections/src/electoral_systems/tests/block_witnesser.rs
@@ -55,7 +55,7 @@ use crate::{
 	vote_storage,
 };
 use cf_traits::{
-	hook_test_utils::{ConstantHook, MockHook},
+	hook_test_utils::{ConstantBatchHook, ConstantHook, MockHook},
 	Hook, HookType,
 };
 use cf_utilities::define_empty_struct;
@@ -107,8 +107,11 @@ impl BWProcessorTypes for Types {
 /// Associating BW types to the struct
 impl BWTypes for Types {
 	type ElectionProperties = ElectionProperties;
-	type ElectionPropertiesHook =
-		MockHook<HookTypeFor<Self, ElectionPropertiesHook>, "generate_election_properties">;
+	type ElectionPropertiesHook = MockHook<
+		HookTypeFor<Self, ElectionPropertiesHook>,
+		"generate_election_properties",
+		ConstantBatchHook<ElectionProperties>,
+	>;
 	type SafeModeEnabledHook = MockHook<HookTypeFor<Self, SafeModeEnabledHook>, "safe_mode">;
 	type ProcessedUpToHook = MockHook<HookTypeFor<Self, ProcessedUpToHook>, "processed_up_to">;
 	type ElectionTrackerDebugEventHook = MockHook<HookTypeFor<Self, ElectionTrackerDebugEventHook>>;
@@ -133,9 +136,13 @@ type SimpleBlockWitnesser = StatemachineElectoralSystem<Types>;
 register_checks! {
 	SimpleBlockWitnesser {
 		generate_election_properties_called_n_times(pre, post, n: u8) {
-			let pre_calls = pre.unsynchronised_state.generate_election_properties_hook.call_history.len();
-			let post_calls = post.unsynchronised_state.generate_election_properties_hook.call_history.len();
-			assert_eq!((post_calls - pre_calls) as u8, n, "generate_election_properties should have been called {} times in this `on_finalize`!", n);
+			// Properties are generated for every open election in a single batched call, so count
+			// the heights across the batches rather than the calls.
+			let generated_for = |state: &ElectoralSystemState<StatemachineElectoralSystem<Types>>| {
+				state.unsynchronised_state.generate_election_properties_hook.call_history.iter().map(Vec::len).sum::<usize>()
+			};
+			let generated = generated_for(post) - generated_for(pre);
+			assert_eq!(generated as u8, n, "generate_election_properties should have been called for {} heights in this `on_finalize`!", n);
 		},
 		number_of_open_elections_is(_pre, post, n: ElectionCount) {
 			assert_eq!(post.unsynchronised_state.elections.ongoing.len(), n as usize, "Number of open elections should be {}", n);

--- a/state-chain/pallets/cf-elections/src/lib.rs
+++ b/state-chain/pallets/cf-elections/src/lib.rs
@@ -868,6 +868,8 @@ pub mod pallet {
 							IndividualComponents::<T, I>::iter_prefix(unique_monotonic_identifier)
 								.collect::<BTreeMap<_, _>>();
 
+						let mut shared_data_cache = BTreeMap::new();
+
 						let votes = current_authorities
 							.into_iter()
 							.map(|validator_id| {
@@ -890,7 +892,10 @@ pub mod pallet {
 								 	// We don't bother to check if the reference has expired, as if we have the
 									// data we may as well use it, even if it was provided after the shared data
 									// reference expired (But before the reference was cleaned up `on_finalize`).
-									Ok(SharedData::<T, I>::get(shared_data_hash))
+									Ok(shared_data_cache
+										.entry(shared_data_hash)
+										.or_insert_with(|| SharedData::<T, I>::get(shared_data_hash))
+										.clone())
 								}) {
 									// Only a full vote can count towards consensus.
 									Ok(Some((properties, AuthorityVote::Vote(vote)))) => Ok(Some((properties, vote))),
@@ -1349,6 +1354,9 @@ pub mod pallet {
 				Error::<T, I>::NotContributing
 			);
 
+			// Constant for the whole extrinsic, so read it once rather than for every vote.
+			let block_number = frame_system::Pallet::<T>::current_block_number();
+
 			for (election_identifier, authority_vote) in *authority_votes {
 				// if an identifier refers to a non existent election, skip this vote,
 				// but continue processing others.
@@ -1386,6 +1394,7 @@ pub mod pallet {
 					unique_monotonic_identifier,
 					&authority,
 					authority_index,
+					true, // Ensured before the loop.
 					|option_existing_vote, election_bitmap_components| {
 						let components = <<T::ElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage as VoteStorage>::partial_vote_into_components(
 							<T::ElectoralSystemRunner as ElectoralSystemRunner>::generate_vote_properties(
@@ -1396,7 +1405,6 @@ pub mod pallet {
 							partial_vote
 						)?;
 
-						let block_number = frame_system::Pallet::<T>::current_block_number();
 						if let Some(bitmap_component) = components.bitmap_component {
 							// Store bitmap component and update shared data reference counts
 							election_bitmap_components.add(
@@ -1496,6 +1504,7 @@ pub mod pallet {
 				unique_monotonic_identifier,
 				&authority,
 				authority_index,
+				ContributingAuthorities::<T, I>::contains_key(&authority),
 				|_, _| Ok(()),
 			))?;
 			Ok(())
@@ -2065,6 +2074,7 @@ pub mod pallet {
 			unique_monotonic_identifier: UniqueMonotonicIdentifier,
 			authority: &T::ValidatorId,
 			authority_index: AuthorityCount,
+			is_contributing_authority: bool,
 			f: F,
 		) -> Result<R, CorruptStorageError> {
 			ElectionBitmapComponents::<T, I>::with_mut(
@@ -2094,7 +2104,9 @@ pub mod pallet {
 						);
 					}
 
-					if ContributingAuthorities::<T, I>::contains_key(authority) {
+					// Invalidate any cached consensus, since the votes have changed. Only a
+					// contributing authority's vote counts towards consensus.
+					if is_contributing_authority {
 						ElectionConsensusHistoryUpToDate::<T, I>::remove(
 							unique_monotonic_identifier,
 						);

--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -3721,19 +3721,32 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		);
 	}
 
-	// TODO: Write test
+	/// Every deposit channel currently in the lookup, active or not.
+	///
+	/// Pair this with `filter_active_deposit_channels` to get the active set at a height. They are
+	/// split so that the block witnessers, which need the active set at every open election's
+	/// height on every block, can pay for the storage iteration once per block rather than once
+	/// per election.
+	pub fn all_deposit_channels() -> Vec<DepositChannelDetails<T, I>> {
+		DepositChannelLookup::<T, I>::iter_values().collect()
+	}
 
-	// This should only be used if we're using ProcessedUpTo to track the block height.
-	pub fn active_deposit_channels_at(
+	/// The subset of `channels` that is active at the given height.
+	///
+	/// This should only be used if we're using ProcessedUpTo to track the block height.
+	pub fn filter_active_deposit_channels(
+		channels: &[DepositChannelDetails<T, I>],
 		opened_at_or_before: TargetChainBlockNumber<T, I>,
 		expires_after: TargetChainBlockNumber<T, I>,
 	) -> Vec<DepositChannelDetails<T, I>> {
 		debug_assert!(<T::TargetChain as Chain>::is_block_witness_root(opened_at_or_before));
 
-		DepositChannelLookup::<T, I>::iter_values()
+		channels
+			.iter()
 			.filter(|details| {
 				details.opened_at <= opened_at_or_before && details.expires_at >= expires_after
 			})
+			.cloned()
 			.collect()
 	}
 }

--- a/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/arbitrum_elections.rs
@@ -169,17 +169,25 @@ impl BlockWitnesserInstance for ArbitrumDepositChannelWitnessing {
 		.deposit_channel_witnessing_enabled
 	}
 
-	fn election_properties(height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
-		let height = height.root();
-		ArbitrumIngressEgress::active_deposit_channels_at(
-			// we advance by SAFETY_BUFFER before checking opened_at
-			height.saturating_forward(ARBITRUM_MAINNET_SAFETY_BUFFER as usize),
-			// we don't advance for expiry
-			*height,
-		)
-		.into_iter()
-		.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
-		.collect()
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// One pass over the deposit channels for the whole batch, rather than one per height.
+		let channels = ArbitrumIngressEgress::all_deposit_channels();
+		block_heights
+			.iter()
+			.map(|height| {
+				let height = height.root();
+				ArbitrumIngressEgress::filter_active_deposit_channels(
+					&channels,
+					height.saturating_forward(ARBITRUM_MAINNET_SAFETY_BUFFER as usize),
+					*height,
+				)
+				.into_iter()
+				.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
+				.collect()
+			})
+			.collect()
 	}
 
 	fn processed_up_to(up_to: ChainBlockNumberOf<Self::Chain>) {
@@ -216,9 +224,10 @@ impl BlockWitnesserInstance for ArbitrumVaultDepositWitnessing {
 	}
 
 	fn election_properties(
-		_block_height: pallet_cf_elections::electoral_systems::block_height_witnesser::ChainBlockNumberOf<Self::Chain>,
-	) {
+		block_heights: &[pallet_cf_elections::electoral_systems::block_height_witnesser::ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// Vault address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(
@@ -251,8 +260,11 @@ impl BlockWitnesserInstance for ArbitrumKeyManagerWitnessing {
 		.key_manager_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// KeyManager address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {

--- a/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/bitcoin_elections.rs
@@ -167,16 +167,24 @@ impl BlockWitnesserInstance for BitcoinDepositChannelWitnessing {
 		.deposit_channel_witnessing_enabled
 	}
 
-	fn election_properties(height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
-		BitcoinIngressEgress::active_deposit_channels_at(
-			// we advance by SAFETY_BUFFER before checking opened_at
-			height.saturating_forward(BITCOIN_MAINNET_SAFETY_BUFFER as usize),
-			// we don't advance for expiry
-			height,
-		)
-		.into_iter()
-		.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
-		.collect()
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// One pass over the deposit channels for the whole batch, rather than one per height.
+		let channels = BitcoinIngressEgress::all_deposit_channels();
+		block_heights
+			.iter()
+			.map(|height| {
+				BitcoinIngressEgress::filter_active_deposit_channels(
+					&channels,
+					height.saturating_forward(BITCOIN_MAINNET_SAFETY_BUFFER as usize),
+					*height,
+				)
+				.into_iter()
+				.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
+				.collect()
+			})
+			.collect()
 	}
 
 	fn processed_up_to(up_to: ChainBlockNumberOf<Self::Chain>) {
@@ -252,10 +260,15 @@ impl BlockWitnesserInstance for BitcoinVaultDepositWitnessing {
 	type ExecutionTarget = pallet_hooks::PalletHooks<Runtime, BitcoinInstance>;
 	type WitnessRules = PrewitnessImmediatelyAndWitnessAtSafetyMargin<Self::BlockEntry>;
 
-	fn election_properties(_height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// WARNING: If a private broker channel is closed by the broker while safe mode is
 		// activated, we will miss vault deposits to that channel that happened during safe mode.
-		pallet_cf_swapping::BrokerPrivateBtcChannels::<Runtime>::iter()
+		//
+		// The result doesn't depend on the height, so derive the addresses once for the whole
+		// batch rather than once per open election.
+		let properties = pallet_cf_swapping::BrokerPrivateBtcChannels::<Runtime>::iter()
 			.flat_map(|(broker_id, channel_id)| {
 				derive_current_and_previous_epoch_private_btc_vaults(channel_id)
 					.map_err(|err| {
@@ -266,7 +279,9 @@ impl BlockWitnesserInstance for BitcoinVaultDepositWitnessing {
 					.flatten()
 					.map(move |address| (address, broker_id.clone(), channel_id))
 			})
-			.collect::<Vec<_>>()
+			.collect::<Vec<_>>();
+
+		block_heights.iter().map(|_| properties.clone()).collect()
 	}
 
 	fn is_enabled() -> bool {
@@ -306,11 +321,15 @@ impl BlockWitnesserInstance for BitcoinEgressWitnessing {
 	}
 
 	fn election_properties(
-		_block_height: ChainBlockNumberOf<Self::Chain>,
-	) -> Self::ElectionProperties {
-		TransactionOutIdToBroadcastId::<Runtime, BitcoinInstance>::iter()
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// The result doesn't depend on the height, so iterate the broadcast lookup once for the
+		// whole batch rather than once per open election.
+		let properties = TransactionOutIdToBroadcastId::<Runtime, BitcoinInstance>::iter()
 			.map(|(tx_id, _)| tx_id)
-			.collect::<Vec<_>>()
+			.collect::<Vec<_>>();
+
+		block_heights.iter().map(|_| properties.clone()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {

--- a/state-chain/runtime/src/chainflip/witnessing/bsc_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/bsc_elections.rs
@@ -168,17 +168,25 @@ impl BlockWitnesserInstance for BscDepositChannelWitnessing {
 		.deposit_channel_witnessing_enabled
 	}
 
-	fn election_properties(height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
-		let height = height.root();
-		BscIngressEgress::active_deposit_channels_at(
-			// we advance by SAFETY_BUFFER before checking opened_at
-			height.saturating_forward(BSC_MAINNET_SAFETY_BUFFER as usize),
-			// we don't advance for expiry
-			*height,
-		)
-		.into_iter()
-		.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
-		.collect()
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// One pass over the deposit channels for the whole batch, rather than one per height.
+		let channels = BscIngressEgress::all_deposit_channels();
+		block_heights
+			.iter()
+			.map(|height| {
+				let height = height.root();
+				BscIngressEgress::filter_active_deposit_channels(
+					&channels,
+					height.saturating_forward(BSC_MAINNET_SAFETY_BUFFER as usize),
+					*height,
+				)
+				.into_iter()
+				.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
+				.collect()
+			})
+			.collect()
 	}
 
 	fn processed_up_to(up_to: ChainBlockNumberOf<Self::Chain>) {
@@ -215,9 +223,10 @@ impl BlockWitnesserInstance for BscVaultDepositWitnessing {
 	}
 
 	fn election_properties(
-		_block_height: pallet_cf_elections::electoral_systems::block_height_witnesser::ChainBlockNumberOf<Self::Chain>,
-	) {
+		block_heights: &[pallet_cf_elections::electoral_systems::block_height_witnesser::ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// Vault address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(
@@ -250,8 +259,11 @@ impl BlockWitnesserInstance for BscKeyManagerWitnessing {
 		.key_manager_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// KeyManager address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {

--- a/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/ethereum_elections.rs
@@ -166,16 +166,24 @@ impl BlockWitnesserInstance for EthereumDepositChannelWitnessing {
 		.deposit_channel_witnessing_enabled
 	}
 
-	fn election_properties(height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
-		EthereumIngressEgress::active_deposit_channels_at(
-			// we advance by SAFETY_BUFFER before checking opened_at
-			height.saturating_forward(ETHEREUM_MAINNET_SAFETY_BUFFER as usize),
-			// we don't advance for expiry
-			height,
-		)
-		.into_iter()
-		.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
-		.collect()
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// One pass over the deposit channels for the whole batch, rather than one per height.
+		let channels = EthereumIngressEgress::all_deposit_channels();
+		block_heights
+			.iter()
+			.map(|height| {
+				EthereumIngressEgress::filter_active_deposit_channels(
+					&channels,
+					height.saturating_forward(ETHEREUM_MAINNET_SAFETY_BUFFER as usize),
+					*height,
+				)
+				.into_iter()
+				.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
+				.collect()
+			})
+			.collect()
 	}
 
 	fn processed_up_to(up_to: ChainBlockNumberOf<Self::Chain>) {
@@ -214,8 +222,11 @@ impl BlockWitnesserInstance for EthereumVaultDepositWitnessing {
 		.vault_deposit_witnessing_enabled
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// Vault address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {
@@ -249,8 +260,11 @@ impl BlockWitnesserInstance for EthereumStateChainGatewayWitnessing {
 		.state_chain_gateway_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// StateChainGateway address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {
@@ -349,8 +363,11 @@ impl BlockWitnesserInstance for EthereumKeyManagerWitnessing {
 		.key_manager_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// KeyManager address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {
@@ -383,8 +400,11 @@ impl BlockWitnesserInstance for EthereumScUtilsWitnessing {
 		.sc_utils_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// ScUtils address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {

--- a/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
+++ b/state-chain/runtime/src/chainflip/witnessing/tron_elections.rs
@@ -158,14 +158,24 @@ impl BlockWitnesserInstance for TronDepositChannelWitnessing {
 		.deposit_channel_witnessing_enabled
 	}
 
-	fn election_properties(height: ChainBlockNumberOf<Self::Chain>) -> Self::ElectionProperties {
-		TronIngressEgress::active_deposit_channels_at(
-			height.saturating_forward(TRON_MAINNET_SAFETY_BUFFER as usize),
-			height,
-		)
-		.into_iter()
-		.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
-		.collect()
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
+		// One pass over the deposit channels for the whole batch, rather than one per height.
+		let channels = TronIngressEgress::all_deposit_channels();
+		block_heights
+			.iter()
+			.map(|height| {
+				TronIngressEgress::filter_active_deposit_channels(
+					&channels,
+					height.saturating_forward(TRON_MAINNET_SAFETY_BUFFER as usize),
+					*height,
+				)
+				.into_iter()
+				.map(|deposit_channel_details| deposit_channel_details.deposit_channel)
+				.collect()
+			})
+			.collect()
 	}
 
 	fn processed_up_to(up_to: ChainBlockNumberOf<Self::Chain>) {
@@ -198,8 +208,11 @@ impl BlockWitnesserInstance for TronVaultDepositWitnessing {
 		.vault_deposit_witnessing_enabled
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// Vault address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {
@@ -230,8 +243,11 @@ impl BlockWitnesserInstance for TronKeyManagerWitnessing {
 		.key_manager_witnessing
 	}
 
-	fn election_properties(_block_height: ChainBlockNumberOf<Self::Chain>) {
+	fn election_properties(
+		block_heights: &[ChainBlockNumberOf<Self::Chain>],
+	) -> Vec<Self::ElectionProperties> {
 		// KeyManager address doesn't change, it is read by the engine on startup
+		block_heights.iter().map(|_| ()).collect()
 	}
 
 	fn processed_up_to(_block_height: ChainBlockNumberOf<Self::Chain>) {

--- a/state-chain/traits/src/hook.rs
+++ b/state-chain/traits/src/hook.rs
@@ -187,6 +187,69 @@ pub mod hook_test_utils {
 		}
 	}
 
+	#[derive(
+		Clone,
+		PartialEq,
+		Eq,
+		PartialOrd,
+		Ord,
+		Debug,
+		Encode,
+		Decode,
+		DecodeWithMemTracking,
+		TypeInfo,
+		MaxEncodedLen,
+		Serialize,
+		Deserialize,
+	)]
+	#[cfg_attr(feature = "test", derive(Arbitrary))]
+	/// The batch counterpart to `ConstantHook`: returns the stored value once per input element.
+	///
+	/// `ConstantHook` returns a single value however many inputs it is given, which for a hook
+	/// whose output has to be parallel to its input would be a length mismatch. Use this for
+	/// those hooks instead.
+	///
+	/// Unlike `ConstantHook` this is parameterised by the item rather than the `HookType`, since
+	/// the value it stores is one element of the output rather than the whole of `T::Output`.
+	pub struct ConstantBatchHook<Item> {
+		pub state: Item,
+	}
+
+	impls! {
+		for ConstantBatchHook<Item> where
+		(
+			Item,
+		):
+
+		{
+			pub fn new(b: Item) -> Self {
+				Self { state: b }
+			}
+		}
+
+		Validate {
+			type Error = ();
+
+			fn is_valid(&self) -> Result<(), ()> {
+				Ok(())
+			}
+		}
+
+		Default where (Item: Default) {
+			fn default() -> Self {
+				Self::new(Default::default())
+			}
+		}
+	}
+
+	impl<In, Item: Clone, T: HookType<Input = Vec<In>, Output = Vec<Item>>> Hook<T>
+		for ConstantBatchHook<Item>
+	{
+		fn run(&mut self, input: Vec<In>) -> Vec<Item> {
+			input.iter().map(|_| self.state.clone()).collect()
+		}
+	}
+
 	/// Hook to use for when we want to not do anything, for example
 	/// useful for "disabling" debug hooks in production.
 	/// It is marked as `inline` so shouldn't have any runtime cost.


### PR DESCRIPTION
# Pull Request

Cherry pick of #6756 which was merged into `release/2.2`.

Original issue: PRO-3035

## Summary

Adds most of the non-controversial performance improvements to `vote()` and `on_finalize()` in the elections pallet.

Details:
- don't re-read ContributingAuthorities for every vote
- read the block number once per vote extrinsic
- cache SharedData lookups per election consensus check
- generate block witnesser election properties in one batch
- skip block processor work for blocks that haven't aged
- read each election's properties once per on_finalize

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
