### PR TITLE
fix: retry assethub vault creation extrinsic on startup

### DIFF
--- a/bouncer/commands/setup_assethub_for_upgrade_test.ts
+++ b/bouncer/commands/setup_assethub_for_upgrade_test.ts
@@ -15,7 +15,7 @@ import {
   runWithTimeoutAndExit,
 } from 'shared/utils';
 import { aliceKeyringPair } from 'shared/polkadot_keyring';
-import { createPolkadotVault } from 'commands/setup_vaults';
+import { createAssetHubVault } from 'commands/setup_vaults';
 import { fullAccountFromUri, newChainflipIO } from 'shared/utils/chainflip_io';
 
 export async function rotateAndFund(
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
     'assethubVault:AwaitingGovernanceActivation',
   ).event;
   const hubKey = (await hubActivationRequest).data.newPublicKey;
-  const { vaultAddress: hubVaultAddress } = await createPolkadotVault(assethub);
+  const hubVaultAddress = await createAssetHubVault(cf.logger);
   const hubProxyAdded = observeEvent(cf.logger, 'proxy:ProxyAdded', { chain: 'assethub' }).event;
   const [, hubVaultEvent] = await Promise.all([
     rotateAndFund(assethub, hubVaultAddress, hubKey),

--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -45,34 +45,7 @@ import { validatorRotationPhaseUpdatedEvent } from 'generated/events/validator/r
 import { validatorRotationAbortedEvent } from 'generated/events/validator/rotationAborted';
 import { environmentBitcoinBlockNumberSetForVaultEvent } from 'generated/events/environment/bitcoinBlockNumberSetForVault';
 import { environmentSolanaInitializedEvent } from 'generated/events/environment/solanaInitialized';
-
-export async function createPolkadotVault(api: DisposableApiPromise) {
-  const { promise, resolve } = deferredPromise<{
-    vaultAddress: AddressOrPair;
-    vaultExtrinsicIndex: number;
-  }>();
-
-  const alice = await aliceKeyringPair();
-  const nonce = await api.rpc.system.accountNextIndex(alice.address);
-  const unsubscribe = await api.tx.proxy
-    .createPure(api.createType('ProxyType', 'Any'), 0, 0)
-    .signAndSend(alice, { nonce }, (result) => {
-      if (result.isError) {
-        handleSubstrateError(api)(result);
-      }
-      if (result.isFinalized) {
-        // TODO: figure out type inference so we don't have to coerce using `any`
-        const pureCreated = result.findRecord('proxy', 'PureCreated')!;
-        resolve({
-          vaultAddress: pureCreated.event.data[0] as AddressOrPair,
-          vaultExtrinsicIndex: result.txIndex!,
-        });
-        unsubscribe();
-      }
-    });
-
-  return promise;
-}
+import { submitHubExtrinsic } from 'shared/send_hubasset';
 
 async function rotateAndFund(api: DisposableApiPromise, vault: AddressOrPair, key: AddressOrPair) {
   const { promise, resolve } = deferredPromise<void>();
@@ -115,14 +88,19 @@ async function rotateAndFund(api: DisposableApiPromise, vault: AddressOrPair, ke
   await promise;
 }
 
-async function createAssetHubVault(
-  logger: Logger,
-  assethubApi: DisposableApiPromise,
-): Promise<AddressOrPair> {
+export async function createAssetHubVault(logger: Logger): Promise<AddressOrPair> {
   // Step a
   logger.info('Requesting Assethub Vault creation');
   const { vaultAddress: hubVaultAddress } = await runWithTimeout(
-    createPolkadotVault(assethubApi),
+    submitHubExtrinsic(
+      logger,
+      (api) => api.tx.proxy.createPure(api.createType('ProxyType', 'Any'), 0, 0),
+      'proxy.createPure',
+      { pallet: 'proxy', name: 'PureCreated' },
+    ).then((result) => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vaultAddress: (result.eventData! as any)[0] as AddressOrPair,
+    })),
     90,
     logger,
     'Creating Assethub vault',
@@ -170,7 +148,7 @@ async function main(): Promise<void> {
       `Initial setup_vaults forced rotation was ABORTED. Cannot continue with the test, please check the node logs for possible reasons.`,
     );
   }
-  const assetHubVaultCreateHandle = createAssetHubVault(cf.logger, assethub);
+  const assetHubVaultCreateHandle = createAssetHubVault(cf.logger);
 
   // Step 3
   cf.info('Waiting for new keys');

--- a/bouncer/shared/send_hubasset.ts
+++ b/bouncer/shared/send_hubasset.ts
@@ -71,51 +71,46 @@ export async function submitHubExtrinsic(
     resolve: (result: { txHash: string; eventData?: unknown }) => void,
     reject: (error: Error) => void,
   ) => {
-    const unsubscribe = await extrinsic(assethubApi).signAndSend(
-      alice,
-      { nonce, tip },
-      (result) => {
-        if (result.dispatchError !== undefined) {
-          if (result.dispatchError.isModule) {
-            const decoded = assethubApi.registry.findMetaError(result.dispatchError.asModule);
-            const { docs, name, section } = decoded;
-            unsubscribe();
-            reject(new Error(`${section}.${name}: ${docs.join(' ')}`));
-          } else {
-            unsubscribe();
-            reject(new Error('Error: ' + result.dispatchError.toString()));
-          }
-        }
-        if (result.status.isFinalized) {
+    const tx = extrinsic(assethubApi);
+    const txHash = tx.hash.toString();
+    const unsubscribe = await tx.signAndSend(alice, { nonce, tip }, (result) => {
+      if (result.dispatchError !== undefined) {
+        if (result.dispatchError.isModule) {
+          const decoded = assethubApi.registry.findMetaError(result.dispatchError.asModule);
+          const { docs, name, section } = decoded;
           unsubscribe();
+          reject(new Error(`${section}.${name}: ${docs.join(' ')}`));
+        } else {
+          unsubscribe();
+          reject(new Error('Error: ' + result.dispatchError.toString()));
+        }
+      }
+      if (result.status.isFinalized) {
+        unsubscribe();
 
-          if (expectedEvent) {
-            const eventData = result.findRecord(expectedEvent.pallet, expectedEvent.name);
-            if (eventData === undefined) {
-              reject(
-                new Error(
-                  `Error: extrinsic submitted succesfully, but expected event ${expectedEvent.pallet}.${expectedEvent.name} was not emitted.`,
-                ),
-              );
-              return;
-            }
-            resolve({ txHash: result.status.hash.toString(), eventData: eventData.event.data });
-          } else {
-            resolve({ txHash: result.status.hash.toString() });
+        if (expectedEvent) {
+          const eventData = result.findRecord(expectedEvent.pallet, expectedEvent.name);
+          if (eventData === undefined) {
+            logger.warn(
+              `Error: extrinsic ${extrinsicName} submitted successfully, but expected event ${expectedEvent.pallet}.${expectedEvent.name} was not emitted.`,
+            );
           }
+          resolve({ txHash, eventData: eventData?.event.data });
+        } else {
+          resolve({ txHash });
         }
-        if (result.status.isInvalid) {
-          unsubscribe();
-          reject(new Error('Transaction is invalid'));
-        }
-        // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
-        // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
-        if (result.status.isDropped || result.status.isUsurped) {
-          unsubscribe();
-          reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
-        }
-      },
-    );
+      }
+      if (result.status.isInvalid) {
+        unsubscribe();
+        reject(new Error('Transaction is invalid'));
+      }
+      // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
+      // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
+      if (result.status.isDropped || result.status.isUsurped || result.status.isFinalityTimeout) {
+        unsubscribe();
+        reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
+      }
+    });
   };
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/bouncer/shared/send_hubasset.ts
+++ b/bouncer/shared/send_hubasset.ts
@@ -7,8 +7,10 @@ import {
   Asset,
 } from 'shared/utils';
 import { aliceKeyringPair } from 'shared/polkadot_keyring';
-import { getAssethubApi } from 'shared/utils/substrate';
+import { DisposableApiPromise, getAssethubApi } from 'shared/utils/substrate';
 import { Logger } from 'shared/utils/logger';
+import { SubmittableExtrinsic } from '@polkadot/api/types';
+import { ISubmittableResult } from '@polkadot/types/types';
 
 let nextAliceNonce: number | undefined;
 
@@ -49,15 +51,15 @@ async function fillNonceGap(logger: Logger, nonce: number) {
   }
 }
 
-export async function sendHubAsset(
+// the signer is always `//Alice`
+export async function submitHubExtrinsic(
   logger: Logger,
-  asset: Asset,
-  address: string,
-  amount: string,
-): Promise<string> {
-  const planckAmount = amountToFineAmount(amount, assetDecimals(asset));
+  extrinsic: (api: DisposableApiPromise) => SubmittableExtrinsic<'promise', ISubmittableResult>,
+  extrinsicName: string,
+  expectedEvent?: { pallet: string; name: string },
+): Promise<{ txHash: string; eventData?: unknown }> {
   const alice = await aliceKeyringPair();
-  await using assethub = await getAssethubApi();
+  await using assethubApi = await getAssethubApi();
 
   // The nonce is pinned for the lifetime of this transfer and reused by every retry. Retrying
   // with a fresh nonce is what caused double-deposits in the past, when a retracted tx got
@@ -66,60 +68,65 @@ export async function sendHubAsset(
 
   const runSignAndSubmit = async (
     tip: number,
-    resolve: (txHash: string) => void,
+    resolve: (result: { txHash: string; eventData?: unknown }) => void,
     reject: (error: Error) => void,
   ) => {
-    let transferFunction;
-    if (asset === 'HubDot') {
-      transferFunction = assethub.tx.balances.transferKeepAlive(address, parseInt(planckAmount));
-    } else if (asset === 'HubUsdc' || asset === 'HubUsdt') {
-      transferFunction = assethub.tx.assets.transferKeepAlive(
-        getHubAssetId(asset),
-        address,
-        parseInt(planckAmount),
-      );
-    } else {
-      throw new Error(`Unsupported hub asset type: ${asset}`);
-    }
-
-    const unsubscribe = await transferFunction.signAndSend(alice, { nonce, tip }, (result) => {
-      if (result.dispatchError !== undefined) {
-        if (result.dispatchError.isModule) {
-          const decoded = assethub.registry.findMetaError(result.dispatchError.asModule);
-          const { docs, name, section } = decoded;
-          unsubscribe();
-          reject(new Error(`${section}.${name}: ${docs.join(' ')}`));
-        } else {
-          unsubscribe();
-          reject(new Error('Error: ' + result.dispatchError.toString()));
+    const unsubscribe = await extrinsic(assethubApi).signAndSend(
+      alice,
+      { nonce, tip },
+      (result) => {
+        if (result.dispatchError !== undefined) {
+          if (result.dispatchError.isModule) {
+            const decoded = assethubApi.registry.findMetaError(result.dispatchError.asModule);
+            const { docs, name, section } = decoded;
+            unsubscribe();
+            reject(new Error(`${section}.${name}: ${docs.join(' ')}`));
+          } else {
+            unsubscribe();
+            reject(new Error('Error: ' + result.dispatchError.toString()));
+          }
         }
-      }
-      if (result.status.isFinalized) {
-        unsubscribe();
-        resolve(result.status.hash.toString());
-      }
-      if (result.status.isInvalid) {
-        unsubscribe();
-        reject(new Error('Transaction is invalid'));
-      }
-      // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
-      // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
-      if (result.status.isDropped || result.status.isUsurped) {
-        unsubscribe();
-        reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
-      }
-    });
+        if (result.status.isFinalized) {
+          unsubscribe();
+
+          if (expectedEvent) {
+            const eventData = result.findRecord(expectedEvent.pallet, expectedEvent.name);
+            if (eventData === undefined) {
+              reject(
+                new Error(
+                  `Error: extrinsic submitted succesfully, but expected event ${expectedEvent.pallet}.${expectedEvent.name} was not emitted.`,
+                ),
+              );
+              return;
+            }
+            resolve({ txHash: result.status.hash.toString(), eventData: eventData.event.data });
+          } else {
+            resolve({ txHash: result.status.hash.toString() });
+          }
+        }
+        if (result.status.isInvalid) {
+          unsubscribe();
+          reject(new Error('Transaction is invalid'));
+        }
+        // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
+        // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
+        if (result.status.isDropped || result.status.isUsurped) {
+          unsubscribe();
+          reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
+        }
+      },
+    );
   };
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     try {
-      return await new Promise<string>((resolve, reject) => {
+      return await new Promise<{ txHash: string; eventData?: unknown }>((resolve, reject) => {
         assethubSigningMutex
           .runExclusive(() => runSignAndSubmit(attempt * TIP_STEP, resolve, reject))
           .catch(reject);
       });
     } catch (e) {
-      logger.warn(`Error sending asset ${asset} to ${address} (nonce ${nonce}): ${e}`);
+      logger.warn(`Error submitting extrinsic ${extrinsicName} (nonce ${nonce}): ${e}`);
       if (attempt >= MAX_ATTEMPTS - 1) {
         await fillNonceGap(logger, nonce);
         throw e;
@@ -128,5 +135,35 @@ export async function sendHubAsset(
     }
   }
 
-  return '';
+  // this case is impossible as we throw above
+  return {
+    txHash: '',
+  };
+}
+
+export async function sendHubAsset(
+  logger: Logger,
+  asset: Asset,
+  address: string,
+  amount: string,
+): Promise<string> {
+  const planckAmount = parseInt(amountToFineAmount(amount, assetDecimals(asset)));
+
+  let result;
+  if (asset === 'HubDot') {
+    result = await submitHubExtrinsic(
+      logger,
+      (api) => api.tx.balances.transferKeepAlive(address, planckAmount),
+      `balances.transferKeepAlive(${address}, ${planckAmount})`,
+    );
+  } else if (asset === 'HubUsdc' || asset === 'HubUsdt') {
+    result = await submitHubExtrinsic(
+      logger,
+      (api) => api.tx.assets.transferKeepAlive(getHubAssetId(asset), address, planckAmount),
+      `transferKeepAlive(${asset}, ${address}, ${planckAmount})`,
+    );
+  } else {
+    throw new Error(`Unsupported hub asset type: ${asset}`);
+  }
+  return result.txHash;
 }

--- a/bouncer/shared/send_hubasset.ts
+++ b/bouncer/shared/send_hubasset.ts
@@ -155,7 +155,7 @@ export async function sendHubAsset(
     result = await submitHubExtrinsic(
       logger,
       (api) => api.tx.assets.transferKeepAlive(getHubAssetId(asset), address, planckAmount),
-      `transferKeepAlive(${asset}, ${address}, ${planckAmount})`,
+      `assets.transferKeepAlive(${asset}, ${address}, ${planckAmount})`,
     );
   } else {
     throw new Error(`Unsupported hub asset type: ${asset}`);


### PR DESCRIPTION
# Pull Request

## Summary

Since the localnet assethub has been upgraded to 2.3.2 (3s block times) it seems that the failure mode of bouncer where assethub vault creation fails on startup has become much more frequent.

I think this is because of polkadot reorgs affecting inclusion of assethub blocks. Thus not all successfully submitted assethub extrinsics are finalised.

We don't currently have a retry mechanism for the vault creation extrinsic. This PR extracts the recently added retry mechanism from `sendHubAsset()` and makes it available for all extrinsic submissions.

To add a bit more detail:
 - the `createPolkadotVault(api)` method which existed to share code between assethub and polkadot setup is now removed and the content inlined into `createAssethubVault`, as we don't need polkadot setup anymore
 - the extracted extrinsic submission logic lives in a new function called `submitHubExtrinsic` and `sendHubAsset` calls into it. It follows a similar pattern as `ChainflipIO.submitExtrinsic` and allows to specify the expected event. It is a bit less sophisticated of course.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Anything non-obvious is documented in the `Summary` section above.
