### PR TITLE
chore: bump lru to 0.18.2 and ignore RUSTSEC-2026-0253

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -84,6 +84,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0173: proc-macro-error2 unmaintained. Build-time proc-macro helper, transitive dependency of `subxt-macro`. Not a runtime security concern.
 # - RUSTSEC-2026-0186: Unsound pointer arithmetic in memmap2. Transitive dependency of parity-db - out of our control.
 # - RUSTSEC-2026-0222: Wasmtime type-index mixup between multiple engines. Low severity embedder-API-misuse issue; we only execute the trusted runtime wasm and don't control the wasmtime version (pinned by polkadot-sdk). Dependency of substrate.
+# - RUSTSEC-2026-0253: Unsoundness in `lru::LruCache::pop()` when the key's `Drop` panics. Our own dependency is on the patched 0.18.2; the remaining 0.12.5 is pinned by libp2p, where `libp2p-identify` doesn't use `lru` at all and `libp2p-swarm`'s only `pop()` is keyed by `Multiaddr`, which has no `Drop` impl.
 
 #
 cf-audit = '''
@@ -135,6 +136,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0173
 	--ignore RUSTSEC-2026-0186
 	--ignore RUSTSEC-2026-0222
+	--ignore RUSTSEC-2026-0253
 '''
 
 [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases 0.2.1",
- "hashbrown 0.12.3",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3354,7 +3354,7 @@ dependencies = [
  "itertools 0.13.0",
  "jsonrpsee",
  "log",
- "lru 0.16.3",
+ "lru 0.18.2",
  "pallet-cf-broadcast",
  "pallet-cf-elections",
  "pallet-cf-environment",
@@ -3561,7 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4272,7 +4272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5866,6 +5866,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -6355,7 +6361,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -6774,7 +6780,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7936,11 +7942,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -9926,7 +9932,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -11140,7 +11146,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11301,7 +11307,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11338,9 +11344,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11972,7 +11978,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12051,7 +12057,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16451,7 +16457,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18458,7 +18464,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ lazy_static = { version = "1.4" }
 libp2p-identity = { version = "0.2.3" }
 libsecp256k1 = { version = "0.7", default-features = false }
 log = { version = "0.4.16" }
-lru = { version = "0.16.3", default-features = false }
+lru = { version = "0.18.2", default-features = false }
 mockall = { version = "0.13.0" }
 nanorand = { version = "0.7.0", default-features = false }
 num-bigint = { version = "0.4.3" }


### PR DESCRIPTION
`cargo cf-audit` is failing on `RUSTSEC-2026-0253` (unsoundness in `lru::LruCache::pop()` when the key's `Drop` panics).

- Bumps our own `lru` dependency to the patched `0.18.2`. Drop-in — no code changes needed.
- Ignores the advisory for the remaining `lru` 0.12.5, which is pinned by libp2p. It isn't reachable there: `libp2p-identify` declares `lru` but never uses it, and `libp2p-swarm`'s only `pop()` is keyed by `Multiaddr`, which has no `Drop` impl.

`cargo cf-audit` passes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)