### PR TITLE
feat: inventory strategy support for different decimal assets

### DIFF
--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -919,8 +919,10 @@ mod test {
 			);
 		}
 
-		// The ratio between assets with a 12 decimal difference, as used to price stablecoin pairs.
-		// Truncating lands 10 ticks (~1 bps) below the true price.
+		// For the price of assets with a 12 decimal difference (Usdc and BscUsdt), the true tick is
+		// fractional, and flooring lands almost a full tick (~1 bps) below it.
+		// Price = floor(10^6 * 2^128 / 10^18)
+		// tick  = ln(Price / 2^128) / ln(1.0001) = -276324.0264396...
 		let price =
 			Price::from_amounts(U256::from(10u128.pow(6)), U256::from(10u128.pow(18))).unwrap();
 		assert_eq!(price.into_tick(), Some(-276325));

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -534,6 +534,28 @@ impl Price {
 		self.try_into_sqrt_price().map(SqrtPrice::to_tick)
 	}
 
+	/// Converts a `price` to the closest valid tick, instead of the greatest tick at or below the
+	/// price. Use this where truncating would bias a result in one direction, since ticks are a
+	/// coarse (1 bps) grid. Will return `None` if the price is too high or low to be represented by
+	/// a valid tick i.e. one inside MIN_TICK..=MAX_TICK.
+	///
+	/// This function never panics.
+	pub fn into_nearest_tick(self) -> Option<Tick> {
+		let tick_below = self.into_tick()?;
+		let tick_above = tick_below + 1;
+		let Some(price_above) = Price::from_tick(tick_above) else {
+			return Some(tick_below);
+		};
+		// `into_tick` rounds down, so `price_below <= self < price_above`, but compare with
+		// `abs_diff` regardless to stay panic-free if that ever fails to hold exactly.
+		let price_below = Price::from_tick(tick_below)?;
+		Some(if self.0.abs_diff(price_below.0) <= self.0.abs_diff(price_above.0) {
+			tick_below
+		} else {
+			tick_above
+		})
+	}
+
 	pub fn try_into_sqrt_price(self) -> Option<SqrtPrice> {
 		SqrtPrice::try_from(self).ok()
 	}
@@ -871,5 +893,47 @@ mod test {
 		assert_eq!(*price_2.hundredth_bps_difference_from(&ref_price).unwrap(), 500 * 100);
 		assert!(*price_2_1.hundredth_bps_difference_from(&ref_price).unwrap() > 500 * 100);
 		assert_eq!(ref_price.hundredth_bps_difference_from(&Price::from_raw(U256::zero())), None);
+	}
+
+	#[test]
+	fn test_into_nearest_tick() {
+		// Very low ticks are excluded: down there `Price`'s fixed point representation is too
+		// coarse to even distinguish adjacent ticks.
+		for tick in [-276324, -100, 0, 1, 100, 500000, MAX_TICK - 1] {
+			let price = Price::from_tick(tick).unwrap();
+			assert_eq!(price.into_nearest_tick(), Some(tick), "{tick}");
+
+			// A price a quarter of the way into the tick rounds back down to it, one three quarters
+			// of the way in rounds up to the next.
+			let next_price = Price::from_tick(tick + 1).unwrap();
+			let tick_width = next_price.as_raw() - price.as_raw();
+			assert_eq!(
+				Price::from_raw(price.as_raw() + tick_width / 4).into_nearest_tick(),
+				Some(tick),
+				"{tick}"
+			);
+			assert_eq!(
+				Price::from_raw(next_price.as_raw() - tick_width / 4).into_nearest_tick(),
+				Some(tick + 1),
+				"{tick}"
+			);
+		}
+
+		// The ratio between assets with a 12 decimal difference, as used to price stablecoin pairs.
+		// Truncating lands 10 ticks (~1 bps) below the true price.
+		let price =
+			Price::from_amounts(U256::from(10u128.pow(6)), U256::from(10u128.pow(18))).unwrap();
+		assert_eq!(price.into_tick(), Some(-276325));
+		assert_eq!(price.into_nearest_tick(), Some(-276324));
+
+		// Equal decimals price exactly at tick zero, so rounding is a no-op.
+		let one =
+			Price::from_amounts(U256::from(10u128.pow(6)), U256::from(10u128.pow(6))).unwrap();
+		assert_eq!(one.into_tick(), Some(0));
+		assert_eq!(one.into_nearest_tick(), Some(0));
+
+		// Out of bounds price will return none
+		assert_eq!(Price::from_raw(U256::MAX).into_nearest_tick(), None);
+		assert_eq!(Price::from_raw(U256::zero()).into_nearest_tick(), None);
 	}
 }

--- a/state-chain/cf-integration-tests/src/trading_strategy.rs
+++ b/state-chain/cf-integration-tests/src/trading_strategy.rs
@@ -354,7 +354,7 @@ fn oracle_strategy_basic_usage() {
 				Runtime,
 				RuntimeEvent::LiquidityPools(pallet_cf_pools::Event::LimitOrderUpdated {
 					sell_amount_change: Some(cf_traits::IncreaseOrDecrease::Decrease(ORDER_AMOUNT)),
-					tick: -199,
+					tick: -198,
 					..
 				})
 			);
@@ -362,7 +362,7 @@ fn oracle_strategy_basic_usage() {
 				Runtime,
 				RuntimeEvent::LiquidityPools(pallet_cf_pools::Event::LimitOrderUpdated {
 					sell_amount_change: Some(cf_traits::IncreaseOrDecrease::Decrease(ORDER_AMOUNT)),
-					tick: -195,
+					tick: -194,
 					..
 				})
 			);

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -19,14 +19,12 @@ use core::cell::RefCell;
 use crate::{self as pallet_cf_swapping, PalletSafeMode, WeightInfo};
 use cf_chains::AnyChain;
 use cf_primitives::{Asset, AssetAmount, ChainflipNetwork, ChannelId, STABLE_ASSET};
-#[cfg(feature = "runtime-benchmarks")]
-use cf_traits::mocks::fee_payment::MockFeePayment;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
 		address_converter::MockAddressConverter, balance_api::MockBalance, bonding::MockBonderFor,
 		deposit_handler::MockDepositHandler, egress_handler::MockEgressHandler,
-		ingress_egress_fee_handler::MockIngressEgressFeeHandler,
+		fee_payment::MockFeePayment, ingress_egress_fee_handler::MockIngressEgressFeeHandler,
 		lending_pools::MockLendingSystemApi, minimum_funding::MockMinimumFundingProvider,
 		pool_price_api::MockPoolPriceApi, price_feed_api::MockPriceFeedApi,
 		withdrawal_address_restriction::MockWithdrawalAddressRestriction,

--- a/state-chain/pallets/cf-trading-strategy/src/lib.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/lib.rs
@@ -31,7 +31,7 @@ mod tests;
 extern crate proptest;
 
 use cf_amm::common::AssetPair;
-use cf_amm_math::Price;
+use cf_amm_math::{Amount, Price};
 use cf_primitives::{Asset, AssetAmount, OrderId, StablecoinDefaults, Tick, STABLE_ASSET};
 use cf_runtime_utilities::log_or_panic;
 use cf_traits::{
@@ -216,11 +216,20 @@ impl TradingStrategy {
 					*max_sell_tick,
 				)?;
 				ensure!(*base_asset != STABLE_ASSET, Error::<T>::InvalidAssetsForStrategy);
-				// The strategy treats the base and quote assets as equivalent (1:1), which is only
-				// valid if they share the same number of decimals.
+				// The strategy values one unit of each asset equally, so it only makes sense for
+				// stablecoin pairs. A difference in decimals is absorbed into a fixed tick offset.
+				ensure!(base_asset.is_usd_stablecoin(), Error::<T>::InvalidAssetsForStrategy);
+				let pricing = PricingMode::equivalent(*base_asset, STABLE_ASSET)
+					.ok_or(Error::<T>::InvalidAssetsForStrategy)?;
+				// The configured ticks are shifted by that offset, so the shifted range must still
+				// be within the valid tick range.
 				ensure!(
-					base_asset.decimals() == STABLE_ASSET.decimals(),
-					Error::<T>::InvalidAssetsForStrategy
+					[*min_buy_tick, *max_buy_tick, *min_sell_tick, *max_sell_tick].into_iter().all(
+						|tick| cf_amm_math::is_tick_valid(
+							tick.saturating_add(pricing.relative_tick)
+						)
+					),
+					Error::<T>::InvalidTick
 				);
 			},
 			TradingStrategy::OracleTracking {
@@ -682,54 +691,69 @@ pub mod pallet {
 	}
 }
 
+/// How the base asset is valued in terms of the quote asset when pricing and sizing orders.
 #[derive(Clone, Copy)]
-enum PricingMode {
-	/// Used by static strategies (`InventoryBased`): the two assets are treated as equivalent
-	/// (1:1). This relies on both assets having the same number of decimals, which is enforced at
-	/// deploy time by `validate_params`.
-	Equivalent,
-	/// Used by `OracleTracking`: `relative_price` is the oracle price of the base asset
-	/// denominated in the quote asset, with its matching `relative_tick`. Amounts are compared in
-	/// the quote denomination and orders are additionally refreshed whenever the oracle moves the
-	/// ticks.
-	Oracle { relative_tick: Tick, relative_price: Price },
+struct PricingMode {
+	/// Price of the base asset denominated in the quote asset, expressed in fine amounts, so it
+	/// also accounts for any difference in the two assets' decimals.
+	relative_price: Price,
+	/// The tick closest to `relative_price`, applied as an offset to the configured tick ranges.
+	/// Rounded to the nearest tick rather than truncated, so the whole order grid isn't
+	/// systematically shifted below the price it is meant to be centred on.
+	relative_tick: Tick,
+	/// Whether orders should also be refreshed when `relative_tick` moves. Only oracle prices
+	/// move; the fixed 1:1 price does not.
+	tracks_oracle: bool,
 }
 
 impl PricingMode {
-	/// The tick offset applied to the configured tick ranges (zero for static strategies).
-	fn tick_offset(self) -> Tick {
-		match self {
-			PricingMode::Equivalent => 0,
-			PricingMode::Oracle { relative_tick, .. } => relative_tick,
-		}
+	/// Values one unit of the base asset as one unit of the quote asset, scaled for any difference
+	/// in their decimals. Used by `InventoryBased`, which is restricted to stablecoin pairs.
+	fn equivalent(base_asset: Asset, quote_asset: Asset) -> Option<Self> {
+		let relative_price = equivalent_value_price(base_asset, quote_asset)?;
+		Some(Self {
+			relative_price,
+			relative_tick: relative_price.into_nearest_tick()?,
+			tracks_oracle: false,
+		})
 	}
 
-	/// Whether orders should also be refreshed when the (oracle-driven) ticks move.
-	fn tracks_oracle(self) -> bool {
-		matches!(self, PricingMode::Oracle { .. })
+	/// Values the base asset at the given oracle price of the base asset denominated in the quote
+	/// asset.
+	fn oracle(relative_price: Price) -> Option<Self> {
+		Some(Self {
+			relative_price,
+			relative_tick: relative_price.into_nearest_tick()?,
+			tracks_oracle: true,
+		})
 	}
 
-	/// Express an amount of the base asset in the quote denomination (identity for static
-	/// strategies). Rounds up to match the threshold/balance comparison semantics.
+	/// Express an amount of the base asset in the quote denomination. Rounds up to match the
+	/// threshold/balance comparison semantics.
 	fn base_to_quote(self, base_amount: AssetAmount) -> Option<AssetAmount> {
 		use frame_support::sp_runtime::SaturatedConversion;
-		match self {
-			PricingMode::Equivalent => Some(base_amount),
-			PricingMode::Oracle { relative_price, .. } =>
-				relative_price.output_amount_ceil(base_amount).map(|v| v.saturated_into()),
-		}
+		self.relative_price
+			.output_amount_ceil(base_amount)
+			.map(|amount| amount.saturated_into())
 	}
 
-	/// Convert an amount expressed in the quote denomination back to the base asset (identity for
-	/// static strategies). Rounds down so we never place orders exceeding the available balance.
+	/// Convert an amount expressed in the quote denomination back to the base asset. Rounds down so
+	/// we never place orders exceeding the available balance.
 	fn quote_to_base(self, quote_amount: AssetAmount) -> Option<AssetAmount> {
 		use frame_support::sp_runtime::SaturatedConversion;
-		match self {
-			PricingMode::Equivalent => Some(quote_amount),
-			PricingMode::Oracle { relative_price, .. } =>
-				relative_price.input_amount_floor(quote_amount).map(|v| v.saturated_into()),
-		}
+		self.relative_price
+			.input_amount_floor(quote_amount)
+			.map(|amount| amount.saturated_into())
 	}
+}
+
+/// The price of `base_asset` in terms of `quote_asset` assuming one unit of each is worth the same,
+/// i.e. purely the ratio of their fine-amount scales (exactly one when the decimals match).
+fn equivalent_value_price(base_asset: Asset, quote_asset: Asset) -> Option<Price> {
+	Price::from_amounts(
+		Amount::from(10u128).pow(quote_asset.decimals().into()),
+		Amount::from(10u128).pow(base_asset.decimals().into()),
+	)
 }
 
 impl<T: Config> Pallet<T> {
@@ -886,7 +910,8 @@ impl<T: Config> Pallet<T> {
 
 	/// Execute the InventoryBased strategy.
 	///
-	/// Uses fixed ticks (no oracle offset) and native asset amounts (no USD conversion).
+	/// Values the base and quote assets 1:1, so the only price adjustment is the fixed offset that
+	/// accounts for a difference in the two assets' decimals.
 	fn execute_inventory_based(
 		base_asset: Asset,
 		min_buy_tick: Tick,
@@ -897,6 +922,15 @@ impl<T: Config> Pallet<T> {
 		existing_orders: &[&StrategyLimitOrder<T::AccountId>],
 		thresholds: &BTreeMap<Asset, AssetAmount>,
 	) {
+		let Some(pricing) = PricingMode::equivalent(base_asset, STABLE_ASSET) else {
+			log_or_panic!(
+				"Failed to derive the 1:1 price for asset {:?}, skipping strategy {:?}",
+				base_asset,
+				strategy_id
+			);
+			return;
+		};
+
 		Self::execute_with_inventory_logic(
 			base_asset,
 			STABLE_ASSET,
@@ -904,7 +938,7 @@ impl<T: Config> Pallet<T> {
 			max_buy_tick,
 			min_sell_tick,
 			max_sell_tick,
-			PricingMode::Equivalent,
+			pricing,
 			strategy_id,
 			existing_orders,
 			thresholds,
@@ -937,10 +971,7 @@ impl<T: Config> Pallet<T> {
 				None
 			},
 			Some(oracle) if oracle.stale => None,
-			Some(oracle) => oracle.price.into_tick().map(|relative_tick| PricingMode::Oracle {
-				relative_tick,
-				relative_price: oracle.price,
-			}),
+			Some(oracle) => PricingMode::oracle(oracle.price),
 		};
 
 		let pricing = match pricing {
@@ -972,8 +1003,8 @@ impl<T: Config> Pallet<T> {
 	/// for oracle strategies, because the oracle has moved the ticks), cancels existing orders, and
 	/// places new ones according to the inventory-based logic.
 	///
-	/// Amounts are valued in the quote denomination using `pricing` (the identity for static
-	/// strategies), so no price lookups happen here.
+	/// Amounts are valued in the quote denomination using `pricing`, so no price lookups happen
+	/// here.
 	fn execute_with_inventory_logic(
 		base_asset: Asset,
 		quote_asset: Asset,
@@ -1020,7 +1051,7 @@ impl<T: Config> Pallet<T> {
 			pricing.base_to_quote(base_threshold).unwrap_or(u128::MAX).min(quote_threshold);
 
 		// Use the balance of assets to calculate the desired limit orders
-		let tick_offset = pricing.tick_offset();
+		let tick_offset = pricing.relative_tick;
 		let total = total_quote.saturating_add(total_base);
 		let new_orders: Vec<_> = inventory_based_strategy_logic(
 			total_quote,
@@ -1046,7 +1077,7 @@ impl<T: Config> Pallet<T> {
 		.collect();
 
 		// Check if the ticks changed to justify updating the orders.
-		let ticks_need_update = pricing.tracks_oracle() && {
+		let ticks_need_update = pricing.tracks_oracle && {
 			existing_orders
 				.iter()
 				.map(|order| (order.tick, order.side))

--- a/state-chain/pallets/cf-trading-strategy/src/tests.rs
+++ b/state-chain/pallets/cf-trading-strategy/src/tests.rs
@@ -781,8 +781,8 @@ fn strategy_deployment_validation() {
 				Error::<Test>::InvalidAssetsForStrategy
 			);
 
-			// InventoryBased treats the two assets as 1:1, so the base asset must have the same
-			// number of decimals as the stable (quote) asset.
+			// InventoryBased values one unit of each asset equally, so the base asset must be a
+			// stablecoin.
 			assert_err!(
 				TradingStrategyPallet::deploy_strategy(
 					RuntimeOrigin::signed(LP),
@@ -1479,6 +1479,144 @@ mod inventory_based_strategy {
 				);
 			});
 	}
+
+	#[test]
+	fn base_asset_with_different_decimals() {
+		const BSC_USDT: Asset = Asset::BscUsdt; // Has 18 decimals, compared to USDC's 6 decimals.
+		const MIN_BUY_TICK: Tick = -10;
+		const MAX_BUY_TICK: Tick = 0;
+		const MIN_SELL_TICK: Tick = 0;
+		const MAX_SELL_TICK: Tick = 10;
+		const AVERAGE_BUY_TICK: Tick = -5;
+		const AVERAGE_SELL_TICK: Tick = 5;
+
+		const ONE_BSC_USDT: AssetAmount = 10u128.pow(18);
+		const ONE_USDC: AssetAmount = 10u128.pow(6);
+
+		// 100 units of each asset, i.e. equal value at the assumed 1:1 rate.
+		const BSC_USDT_AMOUNT: AssetAmount = 100 * ONE_BSC_USDT;
+		const USDC_AMOUNT: AssetAmount = 100 * ONE_USDC;
+
+		// Every configured tick is shifted by the tick at which the two starting balances are
+		// worth the same, i.e. the price at which the assets trade 1:1.
+		let decimals_tick =
+			cf_amm_math::Price::from_amounts(USDC_AMOUNT.into(), BSC_USDT_AMOUNT.into())
+				.unwrap()
+				.into_nearest_tick()
+				.unwrap();
+		assert_eq!(
+			equivalent_value_price(BSC_USDT, QUOTE_ASSET)
+				.unwrap()
+				.into_nearest_tick()
+				.unwrap(),
+			decimals_tick
+		);
+
+		new_test_ext()
+			.then_execute_at_next_block(|_| {
+				let thresholds = BTreeMap::from_iter([(BSC_USDT, 0), (QUOTE_ASSET, 0)]);
+				MinimumDeploymentAmountForStrategy::<Test>::set(thresholds.clone());
+				MinimumAddedFundsToStrategy::<Test>::set(thresholds.clone());
+				LimitOrderUpdateThresholds::<Test>::set(thresholds);
+
+				let initial_amounts: BTreeMap<_, _> =
+					[(BSC_USDT, BSC_USDT_AMOUNT), (QUOTE_ASSET, USDC_AMOUNT)].into();
+				for (asset, amount) in initial_amounts.clone() {
+					MockRefundAddressRegistry::register_refund_address(LP, asset.into());
+					MockBalance::credit_account(&LP, asset, amount);
+				}
+
+				assert_ok!(TradingStrategyPallet::deploy_strategy(
+					RuntimeOrigin::signed(LP),
+					TradingStrategy::InventoryBased {
+						base_asset: BSC_USDT,
+						min_buy_tick: MIN_BUY_TICK,
+						max_buy_tick: MAX_BUY_TICK,
+						min_sell_tick: MIN_SELL_TICK,
+						max_sell_tick: MAX_SELL_TICK,
+					},
+					initial_amounts,
+				));
+
+				let (_, strategy_id, _) = Strategies::<Test>::iter().next().unwrap();
+				strategy_id
+			})
+			.then_execute_at_next_block(|strategy_id| {
+				// The two sides hold equal value, so each gets a single order at the average tick
+				// of its range, shifted by the decimals offset, holding that side's full balance.
+				assert_eq!(
+					MockPoolApi::get_limit_orders(),
+					vec![
+						MockLimitOrder {
+							base_asset: BSC_USDT,
+							quote_asset: QUOTE_ASSET,
+							account_id: strategy_id,
+							side: Side::Buy,
+							order_id: STRATEGY_ORDER_ID_1,
+							tick: decimals_tick + AVERAGE_BUY_TICK,
+							amount: USDC_AMOUNT,
+						},
+						MockLimitOrder {
+							base_asset: BSC_USDT,
+							quote_asset: QUOTE_ASSET,
+							account_id: strategy_id,
+							side: Side::Sell,
+							order_id: STRATEGY_ORDER_ID_1,
+							tick: decimals_tick + AVERAGE_SELL_TICK,
+							amount: BSC_USDT_AMOUNT,
+						},
+					]
+				);
+
+				// Double the BscUsdt balance, unbalancing the inventory 2:1 in its favour.
+				MockBalance::credit_account(&strategy_id, BSC_USDT, BSC_USDT_AMOUNT);
+
+				strategy_id
+			})
+			.then_execute_at_next_block(|strategy_id| {
+				// Valued in Usdc: 100 on the buy side, 200 on the sell side, so half of the 300
+				// total is 150. The sell side keeps 150 at its average tick and pushes the
+				// remaining 50 to a tick 2/3 of the way across its range (its share of the total);
+				// the buy side, being the smaller one, moves its whole balance to a single tick 1/3
+				// of the way across its own range.
+				assert_eq!(
+					MockPoolApi::get_limit_orders(),
+					vec![
+						MockLimitOrder {
+							base_asset: BSC_USDT,
+							quote_asset: QUOTE_ASSET,
+							account_id: strategy_id,
+							side: Side::Buy,
+							order_id: STRATEGY_ORDER_ID_0,
+							tick: decimals_tick + MIN_BUY_TICK + 3,
+							amount: USDC_AMOUNT,
+						},
+						MockLimitOrder {
+							base_asset: BSC_USDT,
+							quote_asset: QUOTE_ASSET,
+							account_id: strategy_id,
+							side: Side::Sell,
+							order_id: STRATEGY_ORDER_ID_0,
+							tick: decimals_tick + MAX_SELL_TICK - 7,
+							// Orders are sized in Usdc and converted back to BscUsdt at the same
+							// 10^12 scale, so 50 Usdc of value is exactly 50 BscUsdt.
+							amount: 50 * ONE_BSC_USDT,
+						},
+						MockLimitOrder {
+							base_asset: BSC_USDT,
+							quote_asset: QUOTE_ASSET,
+							account_id: strategy_id,
+							side: Side::Sell,
+							order_id: STRATEGY_ORDER_ID_1,
+							tick: decimals_tick + AVERAGE_SELL_TICK,
+							// The last order on the side absorbs the remainder, so the two sell
+							// orders together deploy the full balance with no dust left over.
+							amount: 2 * BSC_USDT_AMOUNT - 50 * ONE_BSC_USDT,
+						},
+					]
+				);
+			});
+	}
 }
 
 mod oracle_strategy {
@@ -1499,7 +1637,8 @@ mod oracle_strategy {
 		const AVERAGE_SELL_OFFSET_TICK: Tick = 8;
 
 		let new_oracle_price = Price::from_usd_cents(BASE_ASSET, 101);
-		const NEW_ORACLE_TICK: Tick = 99;
+		// A 1% price increase sits at tick 99.51, which rounds to 100.
+		const NEW_ORACLE_TICK: Tick = 100;
 		const EXPECTED_NEW_BUY_TICK: Tick = AVERAGE_BUY_OFFSET_TICK + NEW_ORACLE_TICK;
 		const EXPECTED_NEW_SELL_TICK: Tick = AVERAGE_SELL_OFFSET_TICK + NEW_ORACLE_TICK;
 
@@ -1778,14 +1917,15 @@ mod oracle_strategy {
 		// $20/BTC and $2/USDC => relative price of 0.1 (BTC in terms of USDC)
 		let btc_price = Price::from_usd(BTC, 20);
 		let usdc_price = Price::from_usd(USDC, 2);
-		let oracle_tick = btc_price.divide_by(usdc_price).unwrap().into_tick().unwrap();
+		let oracle_tick = btc_price.divide_by(usdc_price).unwrap().into_nearest_tick().unwrap();
 
 		const BTC_AMOUNT: AssetAmount = 1_000_000_000; // 10 BTC with 8 decimals
 		const USDC_AMOUNT: AssetAmount = 100_000_000; // 100 USDC with 6 decimals
 
 		// $20.20/BTC: 1% price increase
 		let new_btc_price = Price::from_usd_cents(BTC, 20_20);
-		let new_oracle_tick = new_btc_price.divide_by(usdc_price).unwrap().into_tick().unwrap();
+		let new_oracle_tick =
+			new_btc_price.divide_by(usdc_price).unwrap().into_nearest_tick().unwrap();
 
 		new_test_ext()
 			.then_execute_at_next_block(|_| {


### PR DESCRIPTION
# Pull Request

## Summary

BcsUsdt has 18 decimals (all other stable coins have 6) and does not have an oracle (oracle supports any decimal assets already), so it was unable to be used for any strategy. This PR changes how the Inventory based strategy works so it can support different asset decimals. Same behaviour, just using a different relative tick. No external/UI change needed.

Added a `into_nearest_tick` function because the 12 decimal difference price lands on a tick of 0.9, making the relative price almost 1 tick off without the new rounding. This will affect the oracle strategy as well, but it's for the better and will not be noticable.
Note: BcsUsdt will still need to be enable using governance on mainnet. Or we can add a migration to this PR to enable it if we like. @dandanlen 

---
* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
