### PR TITLE
chore(CI): sleep longer before checking block time of chainflip-node

### DIFF
--- a/ci/scripts/check_blocktime.sh
+++ b/ci/scripts/check_blocktime.sh
@@ -4,7 +4,7 @@
 
 # Wait for node to start
 echo -e "🚀 Starting chainflip-node..."
-sleep 20
+sleep 40
 
 # call rpc to get blocktime
 # SLOT_DURATION="$(curl --silent -H "Content-Type: application/json" -d '{ "jsonrpc":"2.0", "id":"1", "method":"cf_slot_duration", "params":{} }' http://localhost:9944 | jq '.result')"


### PR DESCRIPTION
# Pull Request

## Summary

In 3 of the 9 latest CI runs on main the check happened too early and failed because the node wasn't up yet. For example in [this run](https://github.com/chainflip-io/chainflip-backend/actions/runs/31576751414/job/94052615142).
## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Anything non-obvious is documented in the `Summary` section above.

