### PR TITLE
fix: update Solana localnet connection to use 127.0.0.1

### DIFF
--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -895,9 +895,9 @@ export function getWeb3(chain: Chain): Web3 {
 }
 
 export function getSolConnection(): Connection {
-  return new Connection(process.env.SOL_HTTP_ENDPOINT ?? 'http://0.0.0.0:8899', {
+  return new Connection(process.env.SOL_HTTP_ENDPOINT ?? 'http://127.0.0.1:8899', {
     commitment: 'confirmed',
-    wsEndpoint: `${process.env.SOL_WS_ENDPOINT ?? 'ws://0.0.0.0:8900'}`,
+    wsEndpoint: process.env.SOL_WS_ENDPOINT ?? 'ws://127.0.0.1:8900',
   });
 }
 


### PR DESCRIPTION
# Pull Request

This was causing issues on my local machine. 

`0.0.0.0` is a bind address, not a target. Linux is lenient and treats it as localhost. Mac OS refuses it (on my machine). 

Changed it to the more correct 127.0.0.1