### PR TITLE
fix: increase timeout for `CheckAvailabilityAllSolanaNonces` test.

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -269,6 +269,8 @@ jobs:
           # Ethereum cbBTC are the unreleased assets now, so retarget the filter to exclude
           # them instead.
           sed -i "s/a.chain !== 'Tron'/a.chain !== 'Bsc' \&\& !(a.chain === 'Ethereum' \&\& a.asset === 'CBBTC')/" bouncer/tests/rpc_tests.ts
+          # Apply the current Solana nonce timeout to the pre-upgrade bouncer checkout.
+          sed -i "/'CheckAvailabilityAllSolanaNonces'/,/^  );$/ s/5 \* ciTimeoutFactor/30 * ciTimeoutFactor/" bouncer/tests/fast_bouncer.test.ts
           cd bouncer
           pnpm install --frozen-lockfile
           ./test_commands/all_cuncurrent_tests.sh

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -85,7 +85,7 @@ describe('ConcurrentTests', () => {
   serialTest(
     'CheckAvailabilityAllSolanaNonces',
     checkAvailabilityAllSolanaNonces,
-    5 * ciTimeoutFactor,
+    30 * ciTimeoutFactor,
   );
   serialTest('CheckNoWitnessingTaskRestarts', checkNoWitnessingTaskRestarts, 5 * ciTimeoutFactor);
   serialTest('CheckNoTransferFallbacks', checkNoTransferFallbacks, 10 * ciTimeoutFactor);


### PR DESCRIPTION
# Pull Request

## Summary

For some reason the `CheckAvailabilityAllSolanaNonces` test seems to start timing out in the upgrade test (I've seen it in two or three failed merge queue runs). It currently has a timeout of ~8s, but internally it retries up to 1 minute.

This PR raises the outer timeout to ~1 minute. This should either give it enough time, or point us to something else as the cause.

This also updates the upgrade test workflow to edit the pre-upgrade timeout.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Anything non-obvious is documented in the `Summary` section above.
