### PR TITLE
fix: save generated keys before displaying them (PRO-2955)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,6 +2120,7 @@ dependencies = [
  "serde",
  "serde_json",
  "substrate-build-script-utils",
+ "tempfile",
  "tokio",
  "utilities",
 ]

--- a/api/bin/chainflip-cli/Cargo.toml
+++ b/api/bin/chainflip-cli/Cargo.toml
@@ -30,5 +30,8 @@ cf-chains = { workspace = true, default-features = true }
 cf-utilities = { workspace = true, default-features = true }
 custom-rpc = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [build-dependencies]
 substrate-build-script-utils = { workspace = true }

--- a/api/bin/chainflip-cli/src/main.rs
+++ b/api/bin/chainflip-cli/src/main.rs
@@ -36,7 +36,12 @@ use chainflip_api::{
 use clap::Parser;
 use futures::FutureExt;
 use serde::Serialize;
-use std::{io::Write, path::PathBuf, str::FromStr, sync::Arc};
+use std::{
+	io::Write,
+	path::{Path, PathBuf},
+	str::FromStr,
+	sync::Arc,
+};
 
 mod settings;
 
@@ -577,6 +582,21 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 
 	let keys = Keys::new(seed_phrase)?;
 
+	// Save the keys before displaying them: if we can't write them, the user is better off never
+	// seeing them at all, rather than mistaking them for the keys their node will actually use.
+	let key_dir = path
+		.map(|path| {
+			write_secret_keys(
+				&path,
+				&[
+					("node_key", &keys.node_key.secret_key),
+					("signing_key", &keys.signing_key.secret_key),
+					("ethereum_key", &keys.ethereum_key.secret_key),
+				],
+			)
+		})
+		.transpose()?;
+
 	if json {
 		println!("{}", serde_json::to_string_pretty(&keys)?);
 	} else {
@@ -587,30 +607,7 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 		eprintln!("{}", DISCLAIMER);
 	}
 
-	if let Some(path) = path {
-		if !path.try_exists().context("Could not determine if the directory path exists.")? {
-			std::fs::create_dir_all(&path).context("Unable to create keys directory.")?;
-		}
-		let path = path.canonicalize().context("Unable to resolve path to keys directory.")?;
-
-		for (name, key) in [
-			("node_key", hex::encode(keys.node_key.secret_key)),
-			("signing_key", hex::encode(keys.signing_key.secret_key)),
-			("ethereum_key", hex::encode(keys.ethereum_key.secret_key)),
-		] {
-			let filename = [name, "_file"].concat();
-			write!(
-				std::fs::OpenOptions::new()
-					.write(true)
-					.create_new(true)
-					.open(path.join(&filename))
-					.context(format!("Could not open file {filename}."))?,
-				"{}",
-				key
-			)
-			.context("Error while writing to file.")?;
-		}
-
+	if let Some(path) = key_dir {
 		eprintln!();
 		eprintln!(" 💾 Saved all secret keys to '{}'.", path.display());
 	} else {
@@ -622,6 +619,85 @@ fn generate_keys(json: bool, path: Option<PathBuf>, seed_phrase: Option<String>)
 	}
 
 	Ok(())
+}
+
+/// Writes each secret key to `<dir>/<name>_file` as hex, creating `dir` if it doesn't exist yet.
+/// Returns the canonical path to `dir`.
+///
+/// Either all keys are written or none are: any file created before an error occurs is removed
+/// again, so that a failed invocation neither leaves behind keys the user never got to see nor
+/// blocks a subsequent retry.
+fn write_secret_keys(dir: &Path, keys: &[(&str, &[u8])]) -> Result<PathBuf> {
+	if !dir.try_exists().context("Could not determine if the directory path exists.")? {
+		std::fs::create_dir_all(dir).context("Unable to create keys directory.")?;
+	}
+	let dir = dir.canonicalize().context("Unable to resolve path to keys directory.")?;
+
+	let mut written = Vec::with_capacity(keys.len());
+	let result = keys.iter().try_for_each(|&(name, secret_key)| {
+		let filename = [name, "_file"].concat();
+		let file_path = dir.join(&filename);
+		write!(
+			std::fs::OpenOptions::new()
+				.write(true)
+				.create_new(true)
+				.open(&file_path)
+				.context(format!("Could not open file {filename}."))?,
+			"{}",
+			hex::encode(secret_key)
+		)
+		.context("Error while writing to file.")?;
+		written.push(file_path);
+		Ok(())
+	});
+
+	if let Err(e) = result {
+		for file_path in written {
+			let _ = std::fs::remove_file(file_path);
+		}
+		return Err(e)
+	}
+
+	Ok(dir)
+}
+
+#[cfg(test)]
+const TEST_KEYS: [(&str, &[u8]); 3] =
+	[("node_key", &[0x01, 0x23]), ("signing_key", &[0x45, 0x67]), ("ethereum_key", &[0x89, 0xab])];
+
+#[test]
+fn test_write_secret_keys() {
+	let temp_dir = tempfile::tempdir().unwrap();
+	// The keys directory doesn't have to exist yet.
+	let keys_dir = temp_dir.path().join("keys");
+
+	let written_dir = write_secret_keys(&keys_dir, &TEST_KEYS).unwrap();
+
+	assert_eq!(written_dir, keys_dir.canonicalize().unwrap());
+	for (name, expected) in
+		[("node_key", "0123"), ("signing_key", "4567"), ("ethereum_key", "89ab")]
+	{
+		assert_eq!(
+			std::fs::read_to_string(written_dir.join([name, "_file"].concat())).unwrap(),
+			expected
+		);
+	}
+}
+
+#[test]
+fn test_write_secret_keys_removes_partially_written_keys() {
+	let temp_dir = tempfile::tempdir().unwrap();
+	let keys_dir = temp_dir.path();
+
+	// A pre-existing key file makes the write fail part-way through: `node_key_file` has already
+	// been written at that point.
+	std::fs::write(keys_dir.join("signing_key_file"), "pre-existing").unwrap();
+
+	assert!(write_secret_keys(keys_dir, &TEST_KEYS).is_err());
+
+	assert!(!keys_dir.join("node_key_file").exists());
+	assert!(!keys_dir.join("ethereum_key_file").exists());
+	assert_eq!(std::fs::read_to_string(keys_dir.join("signing_key_file")).unwrap(), "pre-existing");
 }
 
 #[test]


### PR DESCRIPTION
# Pull Request

Closes: [PRO-2955](https://linear.app/chainflip/issue/PRO-2955/chainflip-cli-generate-keys-prints-keys-even-if-it-cant-save-them)

## Summary

`chainflip-cli generate-keys --path <dir>` displayed the generated keys and seed phrase *before* writing them to disk. If the write then failed — most commonly because key files already existed in the target directory, but permissions etc. would do the same — the user was left looking at a set of keys that their node would never actually load, with only an easy-to-miss error line to tell them otherwise. As the issue notes, that can lead to funding an account whose node isn't the one running.

The fix is to save first and display second:

- The file-writing logic moves out of `generate_keys` into a `write_secret_keys` helper, which is called before anything is printed. If it fails, the command bails out and no keys are shown.
- Because keys are now written before the user has seen the seed phrase, a partially-successful write would leave behind secrets that were never displayed, and `create_new(true)` would make every retry fail. So `write_secret_keys` removes any file it created if a later write fails — either all keys land or none do.
- The `💾 Saved all secret keys to ...` / `💡 You can save the private key files ...` messages still print last, so the user-visible output ordering is unchanged on the success path.

Judgement calls:

- The all-or-nothing cleanup is slightly beyond the letter of the issue, but without it the reorder makes the partial-failure case worse rather than better.
- `tempfile` is added as a dev-dependency of `chainflip-cli` (it is already a pinned workspace dependency) so the new behaviour can be unit tested.

## API Changes

None. This is a CLI-only change; the set of files written and their contents are identical, only the ordering of writing vs. printing changed.

### RPCS

No changes.

### Extrinsics & Events

No changes.

## Verification

Commands run and observed to pass:

- `cargo check -p chainflip-cli --all-targets` — passed, no warnings for `chainflip-cli`.
- `cargo clippy -p chainflip-cli --all-targets` — passed, no clippy warnings for `chainflip-cli` (verified by touching `main.rs` to force a re-lint; the only warnings in the run are pre-existing `deprecated` warnings in `custom-rpc`).
- `cargo test -p chainflip-cli` — `5 passed; 0 failed; 2 ignored`, including the two new tests `test_write_secret_keys` and `test_write_secret_keys_removes_partially_written_keys`.
- `cargo fmt --all --check` — clean.

Manual smoke test with the built binary:

- `chainflip-cli generate-keys --path <new dir>` → keys displayed, all three key files written, `💾 Saved all secret keys to ...`.
- Re-running the same command against the now-populated directory → the only output is `Error: Could not open file node_key_file.: File exists (os error 17)`, exit code 1, no keys or seed phrase printed, and the existing key files are untouched.

## Not verified

- Full-workspace `cargo build` / `cargo test` (not feasible in this environment; only the `chainflip-cli` crate and its dependency graph were built).
- Bouncer / integration tests, localnet, and runtime benchmarks — not run; this change touches no runtime code.
- Failure modes other than a pre-existing file (e.g. read-only directory, disk full) were not reproduced manually; the cleanup path for a mid-sequence failure is covered by unit test rather than by a live run.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants. — n/a
    * [ ] Integration tests for runtime-wide behaviours. — n/a, no runtime code touched
    * [ ] Bouncer tests for E2E features involving external chains. — n/a
  * [x] Benchmarks: no placeholders, no weights affected.
  * [x] Migrations: none needed.
  * [x] Bouncer typegen: no runtime types changed.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits — there are none.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.

Opened autonomously by a scheduled Claude Code routine. Needs human review before marking ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdWprPq5mH3bKodbPUZMJZ)_