### PR TITLE
fix: bouncer resubmit assethub txs that fail to be included

### DIFF
--- a/bouncer/commands/setup_vaults.ts
+++ b/bouncer/commands/setup_vaults.ts
@@ -91,6 +91,7 @@ async function rotateAndFund(api: DisposableApiPromise, vault: AddressOrPair, ke
 export async function createAssetHubVault(logger: Logger): Promise<AddressOrPair> {
   // Step a
   logger.info('Requesting Assethub Vault creation');
+  // The timeout must accommodate submitHubExtrinsic's full retry ladder
   const { vaultAddress: hubVaultAddress } = await runWithTimeout(
     submitHubExtrinsic(
       logger,
@@ -101,7 +102,7 @@ export async function createAssetHubVault(logger: Logger): Promise<AddressOrPair
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vaultAddress: (result.eventData! as any)[0] as AddressOrPair,
     })),
-    90,
+    240,
     logger,
     'Creating Assethub vault',
   );

--- a/bouncer/shared/send_hubasset.ts
+++ b/bouncer/shared/send_hubasset.ts
@@ -26,6 +26,11 @@ async function allocateAliceNonce(): Promise<number> {
 }
 
 const MAX_ATTEMPTS = 5;
+// The fork-aware tx pool can strand a watched transaction indefinitely on a healthy, authoring
+// chain (observed in CI: a tx sat outside any block for 90s, then went Invalid, while its tip-bumped
+// resubmission was included within a second). So don't watch a submission forever: if it hasn't
+// reached a block by this deadline, give up on it and resubmit.
+const INCLUSION_TIMEOUT_MS = 30_000;
 // Each retry re-signs the same transfer with a higher tip. sr25519 signatures are
 // non-deterministic, so a resubmission is a *replacement* of the (possibly still pooled) previous
 // attempt and needs strictly higher priority to be accepted; without the tip bump a retry against
@@ -73,8 +78,14 @@ export async function submitHubExtrinsic(
   ) => {
     const tx = extrinsic(assethubApi);
     const txHash = tx.hash.toString();
+    let done = false;
+    let seenInBlock = false;
     const unsubscribe = await tx.signAndSend(alice, { nonce, tip }, (result) => {
+      if (result.status.isInBlock || result.status.isFinalized) {
+        seenInBlock = true;
+      }
       if (result.dispatchError !== undefined) {
+        done = true;
         if (result.dispatchError.isModule) {
           const decoded = assethubApi.registry.findMetaError(result.dispatchError.asModule);
           const { docs, name, section } = decoded;
@@ -86,6 +97,7 @@ export async function submitHubExtrinsic(
         }
       }
       if (result.status.isFinalized) {
+        done = true;
         unsubscribe();
 
         if (expectedEvent) {
@@ -101,16 +113,29 @@ export async function submitHubExtrinsic(
         }
       }
       if (result.status.isInvalid) {
+        done = true;
         unsubscribe();
         reject(new Error('Transaction is invalid'));
       }
       // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
       // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
       if (result.status.isDropped || result.status.isUsurped || result.status.isFinalityTimeout) {
+        done = true;
         unsubscribe();
         reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
       }
     });
+    setTimeout(() => {
+      if (!done && !seenInBlock) {
+        done = true;
+        unsubscribe();
+        reject(
+          new Error(
+            `Transaction not included within ${INCLUSION_TIMEOUT_MS / 1000}s of submission`,
+          ),
+        );
+      }
+    }, INCLUSION_TIMEOUT_MS);
   };
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/bouncer/shared/send_hubasset.ts
+++ b/bouncer/shared/send_hubasset.ts
@@ -79,13 +79,42 @@ export async function submitHubExtrinsic(
     const tx = extrinsic(assethubApi);
     const txHash = tx.hash.toString();
     let done = false;
-    let seenInBlock = false;
-    const unsubscribe = await tx.signAndSend(alice, { nonce, tip }, (result) => {
+    let inBlock = false;
+    let inclusionTimer: ReturnType<typeof setTimeout> | undefined;
+    // Assigned when signAndSend resolves; the deadline is only armed after that, and status
+    // callbacks only fire once the subscription exists.
+    let unsubscribe: () => void;
+
+    // The deadline is armed whenever the transaction is not in a block: on initial submission,
+    // and again if the block it made it into is retracted. It is disarmed while the transaction
+    // is in a block, so slow finalization doesn't trigger a false retry.
+    const armInclusionDeadline = () => {
+      clearTimeout(inclusionTimer);
+      inclusionTimer = setTimeout(() => {
+        if (!done && !inBlock) {
+          done = true;
+          unsubscribe();
+          reject(
+            new Error(
+              `Transaction not included within ${INCLUSION_TIMEOUT_MS / 1000}s of submission`,
+            ),
+          );
+        }
+      }, INCLUSION_TIMEOUT_MS);
+    };
+
+    unsubscribe = await tx.signAndSend(alice, { nonce, tip }, (result) => {
       if (result.status.isInBlock || result.status.isFinalized) {
-        seenInBlock = true;
+        inBlock = true;
+        clearTimeout(inclusionTimer);
+      }
+      if (result.status.isRetracted) {
+        inBlock = false;
+        armInclusionDeadline();
       }
       if (result.dispatchError !== undefined) {
         done = true;
+        clearTimeout(inclusionTimer);
         if (result.dispatchError.isModule) {
           const decoded = assethubApi.registry.findMetaError(result.dispatchError.asModule);
           const { docs, name, section } = decoded;
@@ -98,6 +127,7 @@ export async function submitHubExtrinsic(
       }
       if (result.status.isFinalized) {
         done = true;
+        clearTimeout(inclusionTimer);
         unsubscribe();
 
         if (expectedEvent) {
@@ -114,28 +144,25 @@ export async function submitHubExtrinsic(
       }
       if (result.status.isInvalid) {
         done = true;
+        clearTimeout(inclusionTimer);
         unsubscribe();
         reject(new Error('Transaction is invalid'));
       }
       // Only give up (and resubmit, with the pinned nonce) on terminal states where the tx
-      // definitely won't be applied. `isRetracted` is deliberately NOT terminal.
+      // definitely won't be applied. `isRetracted` is deliberately NOT terminal, but it re-arms
+      // the inclusion deadline above so a retracted tx gets a bounded window to re-enter a block.
       if (result.status.isDropped || result.status.isUsurped || result.status.isFinalityTimeout) {
         done = true;
+        clearTimeout(inclusionTimer);
         unsubscribe();
         reject(new Error(`Transaction was ${result.status.type.toLowerCase()}`));
       }
     });
-    setTimeout(() => {
-      if (!done && !seenInBlock) {
-        done = true;
-        unsubscribe();
-        reject(
-          new Error(
-            `Transaction not included within ${INCLUSION_TIMEOUT_MS / 1000}s of submission`,
-          ),
-        );
-      }
-    }, INCLUSION_TIMEOUT_MS);
+    // The callback can fire before signAndSend resolves, so only arm if the transaction isn't
+    // already in a block.
+    if (!done && !inBlock) {
+      armInclusionDeadline();
+    }
   };
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {


### PR DESCRIPTION
The fork-aware tx pool can strand a watched transaction indefinitely on a healthy chain. In [this CI run](https://github.com/chainflip-io/chainflip-backend/actions/runs/31666947669/job/94344994385) setup's `proxy.createPure` sat outside any block for ~90s (every block in the window contained only inherents) before the pool reported it Invalid — while the tip-bumped resubmission was included within one second, just after the 90s vault-creation timeout had already expired. Matches the known [stuck-transactions issue](https://github.com/paritytech/polkadot-sdk/issues/11034) in the fork-aware pool under relay-chain forks.

- `submitHubExtrinsic`: abandon and resubmit (pinned nonce, higher tip) any submission that hasn't reached a block within 30s.
- `setup_vaults`: raise the vault-creation timeout 90s → 240s so the full retry ladder fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)