### PR TITLE
fix: validate lending interest payment interval (PRO-2966)

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
@@ -473,15 +473,25 @@ mod tests {
 			Perquintill::from_percent(5)
 		);
 
-		// Intervals outside of the range enforced by the setter are caught rather than
-		// dividing by zero (`log_or_panic!` panics in tests, logs in production):
-		cf_utilities::assert_panics!(CONFIG.interest_per_year_to_per_payment_interval(
-			interest_per_year,
-			MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS + 1
-		));
-		cf_utilities::assert_panics!(
-			CONFIG.interest_per_year_to_per_payment_interval(interest_per_year, 0)
-		);
+		// Intervals outside of the range enforced by the setter are caught rather than dividing
+		// by zero. `log_or_panic!` panics under debug assertions and only logs without them, so
+		// which of the two we observe depends on the profile the tests are built with.
+		for invalid_interval in [0, MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS + 1] {
+			if cfg!(debug_assertions) {
+				cf_utilities::assert_panics!(CONFIG.interest_per_year_to_per_payment_interval(
+					interest_per_year,
+					invalid_interval
+				));
+			} else {
+				assert_eq!(
+					CONFIG.interest_per_year_to_per_payment_interval(
+						interest_per_year,
+						invalid_interval
+					),
+					Perquintill::zero()
+				);
+			}
+		}
 	}
 
 	#[test]

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/config.rs
@@ -15,6 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+use cf_primitives::BLOCKS_IN_YEAR;
+
+/// Longer intervals would make the number of payment intervals per year round down to zero,
+/// which we can't derive a per-interval interest rate from.
+pub const MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS: u32 = BLOCKS_IN_YEAR;
+
 /// Interest "curve" is defined as two linear segments. One is in effect from 0% to
 /// `junction_utilisation`, and the second is in effect from `junction_utilisation` to 100%.
 #[derive(
@@ -231,12 +237,19 @@ impl LendingConfiguration {
 		interest_per_year: Permill,
 		interval_blocks: u32,
 	) -> Perquintill {
-		use cf_primitives::BLOCKS_IN_YEAR;
+		// Guaranteed to be non-zero by the validation performed when the interval is set, but
+		// this is reached from `on_initialize`, so we don't risk dividing by zero here.
+		let Some(intervals_per_year) =
+			BLOCKS_IN_YEAR.checked_div(interval_blocks).filter(|intervals| *intervals > 0)
+		else {
+			log_or_panic!("Invalid interest payment interval: {interval_blocks} blocks");
+			return Perquintill::zero();
+		};
 
 		Perquintill::from_parts(
 			(interest_per_year.deconstruct() as u64 *
 				(Perquintill::ACCURACY / Permill::ACCURACY as u64)) /
-				(BLOCKS_IN_YEAR / interval_blocks) as u64,
+				intervals_per_year as u64,
 		)
 	}
 
@@ -435,6 +448,39 @@ mod tests {
 		assert_eq!(
 			CONFIG.derive_interest_rate_per_year(asset, Permill::from_percent(100)),
 			Permill::from_percent(50)
+		);
+	}
+
+	#[test]
+	fn interest_per_payment_interval() {
+		let interest_per_year = Permill::from_percent(10);
+
+		// With a payment interval of exactly one year, the per-interval rate is the annual rate:
+		assert_eq!(
+			CONFIG.interest_per_year_to_per_payment_interval(
+				interest_per_year,
+				MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS
+			),
+			Perquintill::from_percent(10)
+		);
+
+		// Halving the interval halves the per-interval rate:
+		assert_eq!(
+			CONFIG.interest_per_year_to_per_payment_interval(
+				interest_per_year,
+				MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS / 2
+			),
+			Perquintill::from_percent(5)
+		);
+
+		// Intervals outside of the range enforced by the setter are caught rather than
+		// dividing by zero (`log_or_panic!` panics in tests, logs in production):
+		cf_utilities::assert_panics!(CONFIG.interest_per_year_to_per_payment_interval(
+			interest_per_year,
+			MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS + 1
+		));
+		cf_utilities::assert_panics!(
+			CONFIG.interest_per_year_to_per_payment_interval(interest_per_year, 0)
 		);
 	}
 

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -37,7 +37,7 @@ pub use general_lending::{
 
 pub use general_lending::config::{
 	InterestRateConfiguration, LendingConfiguration, LendingPoolConfiguration, LtvThresholds,
-	NetworkFeeContributions,
+	NetworkFeeContributions, MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS,
 };
 
 use boost::BoostPool;
@@ -666,7 +666,10 @@ pub mod pallet {
 							config.fee_swap_interval_blocks = *interval;
 						},
 						PalletConfigUpdate::SetInterestPaymentIntervalBlocks(interval) => {
-							ensure!(*interval > 0, Error::<T>::InvalidConfigurationParameters);
+							ensure!(
+								*interval > 0 && *interval <= MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS,
+								Error::<T>::InvalidConfigurationParameters
+							);
 							config.interest_payment_interval_blocks = *interval;
 						},
 						PalletConfigUpdate::SetFeeSwapThresholdUsd(amount_threshold) => {

--- a/state-chain/pallets/cf-lending-pools/src/tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/tests.rs
@@ -441,6 +441,37 @@ fn can_update_config_for_specific_asset() {
 }
 
 #[test]
+fn cannot_set_out_of_range_interest_payment_interval() {
+	new_test_ext().execute_with(|| {
+		let original_interval = LendingConfig::<Test>::get().interest_payment_interval_blocks;
+
+		for invalid_interval in [0, MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS + 1] {
+			assert_noop!(
+				LendingPools::update_pallet_config(
+					RuntimeOrigin::root(),
+					bounded_vec![PalletConfigUpdate::SetInterestPaymentIntervalBlocks(
+						invalid_interval
+					)]
+				),
+				crate::Error::<Test>::InvalidConfigurationParameters
+			);
+		}
+
+		assert_eq!(
+			LendingConfig::<Test>::get().interest_payment_interval_blocks,
+			original_interval
+		);
+
+		assert_ok!(LendingPools::update_pallet_config(
+			RuntimeOrigin::root(),
+			bounded_vec![PalletConfigUpdate::SetInterestPaymentIntervalBlocks(
+				MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS
+			)]
+		));
+	});
+}
+
+#[test]
 fn test_add_funds_to_legacy_boost_pool() {
 	new_test_ext().execute_with(|| {
 		const BOOST_FUNDS: AssetAmount = 500_000_000;


### PR DESCRIPTION
# Pull Request

Closes: [PRO-2966](https://linear.app/chainflip/issue/PRO-2966/validate-lending-interest-payment-interval-divide-by-zero-panic-risk)

## Summary

From the Cecuro audit (2026-06-24). Governance-gated and low risk, but cheap to fix.

`LendingConfiguration::interest_per_year_to_per_payment_interval` divides by
`BLOCKS_IN_YEAR / interval_blocks`. The `SetInterestPaymentIntervalBlocks` setter only rejected
zero, so an interval greater than `BLOCKS_IN_YEAR` (5,259,600 blocks, ~1 year) made that inner
division round down to `0`, and the outer division then panicked. Because the conversion is reached
from `lending_upkeep` in `on_initialize`, that panic would halt the chain.

Two changes, matching the fix described on the issue:

- **Bound the interval in the setter.** `SetInterestPaymentIntervalBlocks` now rejects anything
  above `MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS` (`= BLOCKS_IN_YEAR`) in addition to zero, returning
  the existing `InvalidConfigurationParameters` error.
- **Divide defensively in the conversion.** `checked_div` plus an explicit non-zero check, falling
  back to `log_or_panic!` and `Perquintill::zero()` rather than dividing by zero. This is
  unreachable given the setter, but the function runs in a runtime hook so it shouldn't rely on
  that.

### Judgement calls

- **No behaviour change for valid configs.** For any interval in `1..=BLOCKS_IN_YEAR` the divisor
  is at least 1 and the computed rate is bit-for-bit identical to before. The genesis default (10
  blocks) and the value used in tests (712) are both well inside the new bound.
- **Left the rounding issue alone.** The issue also notes that intervals which don't evenly divide
  `BLOCKS_IN_YEAR` inflate the effective rate. That's real — the integer `BLOCKS_IN_YEAR /
  interval_blocks` rounds the number of intervals per year down — but fixing it means restructuring
  the arithmetic (multiply before dividing), which changes the interest actually charged under the
  current mainnet config. That's an economic change, not a panic fix, so it's deliberately out of
  scope here and may warrant its own issue.
- **Constant lives next to the arithmetic** in `general_lending/config.rs` and is re-exported from
  the pallet root, so the setter and the conversion can't drift apart.
- **The unit test branches on `cfg!(debug_assertions)`.** `log_or_panic!` panics under debug
  assertions and only logs without them, and the CI test job runs `--release`, so the observable
  behaviour of the defensive branch differs by profile. The test asserts a panic in one and a
  `Perquintill::zero()` return in the other. See the second commit — the first version of the test
  only handled the debug case and went red in CI.

## API Changes

### RPCS

None. No runtime API signature or wire shape is affected — `LendingConfiguration`'s fields are
unchanged, so no runtime API versioning is required.

### Extrinsics & Events

No encoding changes. `PalletConfigUpdate::SetInterestPaymentIntervalBlocks` is unchanged; it just
rejects a range of values it previously accepted. No storage layout change, so no migration.

## Verification

Run locally on this branch, on a 4-core box (full-workspace builds were out of reach, so everything
below is scoped to the touched crate):

| Command | Result |
| --- | --- |
| `cargo fmt --all` then `cargo fmt --all --check` | clean |
| `cargo check -p pallet-cf-lending-pools --tests` | passed (exit 0) |
| `cargo clippy -p pallet-cf-lending-pools --tests` | passed (exit 0), no warnings on the changed code |
| `cargo test -p pallet-cf-lending-pools` (dev profile) | **140 passed, 0 failed** |
| `cargo test --release -p pallet-cf-lending-pools --features runtime-benchmarks,try-runtime` | **161 passed, 0 failed** |

The release run mirrors the profile and feature set the CI `cf-test-ci-nextest` job uses, and was
added specifically to confirm the profile-dependent assertion described above.

The two new tests are in those runs:

- `general_lending::config::tests::interest_per_payment_interval` — asserts a one-year interval
  yields the annual rate and a half-year interval yields half of it, and that out-of-range intervals
  (`0` and `BLOCKS_IN_YEAR + 1`) hit the defensive branch instead of dividing by zero.
- `tests::cannot_set_out_of_range_interest_payment_interval` — asserts the setter rejects `0` and
  `MAX_INTEREST_PAYMENT_INTERVAL_BLOCKS + 1`, leaves the stored value untouched, and still accepts
  the boundary value.

The pre-existing `tests::can_update_all_config_items` also still passes, which covers the setter's
happy path.

## Not verified

- Full-workspace `cargo build` / `cargo test` — not attempted locally; a cold build of this
  workspace does not fit in the run. CI covers this.
- `cargo cf-clippy` (the workspace-wide alias with `runtime-benchmarks,try-runtime,...` features and
  `-D warnings`) — only the crate-scoped plain clippy was run locally.
- Runtime integration tests (`cf-integration-tests`) and bouncer/E2E tests.
- Runtime benchmarks and weights — unchanged, but not regenerated or run.
- Downstream crates that consume the pallet (`custom-rpc`, `state-chain-runtime`) were not compiled
  locally. The only public surface change is an added `pub const`, which is additive, but this is
  unconfirmed by a local compiler.

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours — not needed; the change is local to the pallet's config setter.
    * [ ] Bouncer tests for E2E features involving external chains — n/a.
  * [x] Benchmarks: no dangling placeholders; weights unaffected.
  * [x] Migrations: none needed, storage layout is unchanged.
  * [x] Bouncer typegen: no runtime types changed.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and covered by tests.
  * [x] Unrelated changes are isolated — the diff touches only the setter, the conversion, and their tests.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.

---

Opened autonomously by a scheduled Claude Code routine. Needs human review before marking ready.