### PR TITLE
feat: extrinsic for moving funds from vault to native balance

### DIFF
--- a/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
@@ -1491,6 +1491,21 @@ export interface ChainErrors extends GenericChainErrors {
     InternalSwapsDisabled: GenericPalletError;
 
     /**
+     * Transfers to the on-chain balance are disabled due to safe mode.
+     **/
+    FlipTransferToOnChainBalanceDisabled: GenericPalletError;
+
+    /**
+     * Transfers to the on-chain balance are only available once Flip 2.1 is active.
+     **/
+    FlipTransferToOnChainBalanceUnavailable: GenericPalletError;
+
+    /**
+     * The transferred amount is below the minimum funding amount.
+     **/
+    BelowMinimumFunding: GenericPalletError;
+
+    /**
      * Generic pallet error
      **/
     [error: string]: GenericPalletError;

--- a/bouncer/generated/chaintypes/chainflip-node/events.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/events.d.ts
@@ -2816,6 +2816,11 @@ export interface ChainEvents extends GenericChainEvents {
         error: DispatchError;
       }
     >;
+    FlipTransferredToOnChainBalance: GenericPalletEvent<
+      'LiquidityProvider',
+      'FlipTransferredToOnChainBalance',
+      { accountId: AccountId32; amount: bigint }
+    >;
 
     /**
      * Generic pallet event

--- a/bouncer/generated/chaintypes/chainflip-node/tx.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/tx.d.ts
@@ -4369,6 +4369,28 @@ export interface ChainTx<
     >;
 
     /**
+     * Move Flip from the caller's free balance to their on-chain balance, where it can be
+     * used to pay transaction fees or to delegate.
+     *
+     * The transfer is one-way: on-chain funds can only be recovered by redeeming them to an
+     * external address.
+     *
+     * @param {bigint} amount
+     **/
+    transferFlipToOnChainBalance: GenericTxCall<
+      (amount: bigint) => ChainSubmittableExtrinsic<
+        {
+          pallet: 'LiquidityProvider';
+          palletCall: {
+            name: 'TransferFlipToOnChainBalance';
+            params: { amount: bigint };
+          };
+        },
+        ChainKnownTypes
+      >
+    >;
+
+    /**
      * Generic pallet tx call
      **/
     [callName: string]: GenericTxCall<TxCall<ChainKnownTypes>>;

--- a/bouncer/generated/chaintypes/chainflip-node/types.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/types.d.ts
@@ -636,6 +636,7 @@ export type PalletCfLpPalletSafeMode = {
   depositEnabled: boolean;
   withdrawalEnabled: boolean;
   internalSwapsEnabled: boolean;
+  flipToOnChainBalanceEnabled: boolean;
 };
 
 export type PalletCfValidatorPalletSafeMode = {
@@ -3935,7 +3936,15 @@ export type PalletCfLpCall =
   | {
       name: 'PurgeBalances';
       params: { accounts: Array<[AccountId32, CfPrimitivesChainsAssetsAnyAsset, bigint]> };
-    };
+    }
+  /**
+   * Move Flip from the caller's free balance to their on-chain balance, where it can be
+   * used to pay transaction fees or to delegate.
+   *
+   * The transfer is one-way: on-chain funds can only be recovered by redeeming them to an
+   * external address.
+   **/
+  | { name: 'TransferFlipToOnChainBalance'; params: { amount: bigint } };
 
 export type PalletCfLpCallLike =
   /**
@@ -3999,7 +4008,15 @@ export type PalletCfLpCallLike =
   | {
       name: 'PurgeBalances';
       params: { accounts: Array<[AccountId32Like, CfPrimitivesChainsAssetsAnyAsset, bigint]> };
-    };
+    }
+  /**
+   * Move Flip from the caller's free balance to their on-chain balance, where it can be
+   * used to pay transaction fees or to delegate.
+   *
+   * The transfer is one-way: on-chain funds can only be recovered by redeeming them to an
+   * external address.
+   **/
+  | { name: 'TransferFlipToOnChainBalance'; params: { amount: bigint } };
 
 export type CfAmmMathPriceLimits = {
   minPrice: CfAmmMathPrice;
@@ -13385,7 +13402,8 @@ export type CfTraitsFundingSource =
   | {
       type: 'InitialFunding';
       value: { channelId?: bigint | undefined; asset: CfPrimitivesChainsAssetsAnyAsset };
-    };
+    }
+  | { type: 'FreeBalance' };
 
 export type CfPrimitivesSwapRequestId = bigint;
 
@@ -14976,7 +14994,8 @@ export type PalletCfLpEvent =
         amount: bigint;
         error: DispatchError;
       };
-    };
+    }
+  | { name: 'FlipTransferredToOnChainBalance'; data: { accountId: AccountId32; amount: bigint } };
 
 /**
  * The `Event` enum of this pallet
@@ -19104,7 +19123,19 @@ export type PalletCfLpError =
   /**
    * Internal swaps disabled due to safe mode.
    **/
-  | 'InternalSwapsDisabled';
+  | 'InternalSwapsDisabled'
+  /**
+   * Transfers to the on-chain balance are disabled due to safe mode.
+   **/
+  | 'FlipTransferToOnChainBalanceDisabled'
+  /**
+   * Transfers to the on-chain balance are only available once Flip 2.1 is active.
+   **/
+  | 'FlipTransferToOnChainBalanceUnavailable'
+  /**
+   * The transferred amount is below the minimum funding amount.
+   **/
+  | 'BelowMinimumFunding';
 
 export type PalletCfIngressEgressDepositChannelDetailsEthereum = {
   owner: AccountId32;

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -121,6 +121,7 @@ export const palletCfLpPalletSafeMode = z.object({
   depositEnabled: z.boolean(),
   withdrawalEnabled: z.boolean(),
   internalSwapsEnabled: z.boolean(),
+  flipToOnChainBalanceEnabled: z.boolean(),
 });
 
 export const palletCfValidatorPalletSafeMode = z.object({
@@ -409,6 +410,7 @@ export const cfTraitsFundingSource = z.discriminatedUnion('__kind', [
     channelId: numberOrHex.nullish(),
     asset: cfPrimitivesChainsAssetsAnyAsset,
   }),
+  z.object({ __kind: z.literal('FreeBalance') }),
 ]);
 
 export const palletCfValidatorDelegationDelegationAmount = z.discriminatedUnion('__kind', [

--- a/bouncer/generated/events/liquidityProvider/flipTransferredToOnChainBalance.ts
+++ b/bouncer/generated/events/liquidityProvider/flipTransferredToOnChainBalance.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { accountId, numberOrHex } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
+
+export const liquidityProviderFlipTransferredToOnChainBalance = z.object({
+  accountId,
+  amount: numberOrHex,
+});
+
+export const liquidityProviderFlipTransferredToOnChainBalanceEvent = defineEvent(
+  'LiquidityProvider.FlipTransferredToOnChainBalance',
+  liquidityProviderFlipTransferredToOnChainBalance,
+);

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__runtime_safe_mode_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__runtime_safe_mode_serialization.snap
@@ -18,7 +18,8 @@ expression: val
   "liquidity_provider": {
     "deposit_enabled": true,
     "withdrawal_enabled": true,
-    "internal_swaps_enabled": true
+    "internal_swaps_enabled": true,
+    "flip_to_on_chain_balance_enabled": true
   },
   "validator": {
     "authority_rotation_enabled": true,

--- a/state-chain/pallets/cf-flip/src/lib.rs
+++ b/state-chain/pallets/cf-flip/src/lib.rs
@@ -656,6 +656,11 @@ impl<T: Config> FeePayment for Pallet<T> {
 		Pallet::<T>::settle(account_id, Pallet::<T>::mint(amount).into());
 	}
 
+	#[cfg(feature = "runtime-benchmarks")]
+	fn activate_flip_2_1() {
+		FeeRewardsActivationEpoch::<T>::set(T::EpochInfo::epoch_index());
+	}
+
 	fn try_take_fee(
 		account_id: &Self::AccountId,
 		amount: Self::Amount,

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -37,7 +37,8 @@ use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
 use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
-	FundAccount, Funding, FundingSource, GetMinimumFunding, RedemptionCheck, SpawnAccount,
+	FundAccount, Funding, FundingSource, GetMinimumFunding, MoveFlipToGateway, RedemptionCheck,
+	SpawnAccount,
 };
 use cf_utilities::derive_common_traits;
 use codec::{Decode, DecodeWithMemTracking, Encode};
@@ -418,6 +419,9 @@ pub mod pallet {
 
 		/// Safe Mode access.
 		type SafeMode: Get<PalletSafeMode>;
+
+		/// Earmarks Flip held in the Vault for transfer to the State Chain Gateway.
+		type MoveFlipToGateway: MoveFlipToGateway;
 
 		/// Benchmark stuff
 		type WeightInfo: WeightInfo;
@@ -1193,12 +1197,20 @@ impl<T: Config> FundAccount for Pallet<T> {
 
 	fn fund_account(account_id: Self::AccountId, amount: Self::Amount, source: FundingSource) {
 		let total_balance = Self::add_funds_to_account(&account_id, amount);
-		if let FundingSource::EthTransaction { funder, .. } = source {
-			if RestrictedAddresses::<T>::contains_key(funder) {
-				RestrictedBalances::<T>::mutate(account_id.clone(), |map| {
-					map.entry(funder).and_modify(|balance| *balance += amount).or_insert(amount);
-				});
-			}
+		match source {
+			FundingSource::EthTransaction { funder, .. } =>
+				if RestrictedAddresses::<T>::contains_key(funder) {
+					RestrictedBalances::<T>::mutate(account_id.clone(), |map| {
+						map.entry(funder)
+							.and_modify(|balance| *balance += amount)
+							.or_insert(amount);
+					});
+				},
+			// These funds are backed by Flip in the Vault rather than in the Gateway, so an
+			// equivalent amount must be moved across to keep the Gateway fully backed.
+			FundingSource::FreeBalance =>
+				T::MoveFlipToGateway::add_flip_to_be_sent_to_gateway(amount.into()),
+			FundingSource::Swap { .. } | FundingSource::InitialFunding { .. } => {},
 		}
 
 		Self::deposit_event(Event::Funded {

--- a/state-chain/pallets/cf-funding/src/mock.rs
+++ b/state-chain/pallets/cf-funding/src/mock.rs
@@ -21,8 +21,8 @@ use cf_primitives::FlipBalance;
 use cf_traits::{
 	impl_mock_chainflip, impl_mock_runtime_safe_mode,
 	mocks::{
-		broadcaster::MockBroadcaster, rewards_distribution::MockRewardsDistribution, time_source,
-		waived_fees::WaivedFeesMock,
+		broadcaster::MockBroadcaster, flip_burn_info::MockFlipBurnOrMoveInfo,
+		rewards_distribution::MockRewardsDistribution, time_source, waived_fees::WaivedFeesMock,
 	},
 	AccountRoleRegistry, RedemptionCheck,
 };
@@ -225,6 +225,7 @@ impl pallet_cf_funding::Config for Test {
 	type EthereumSCApi = EmptyCall;
 	type SafeMode = MockRuntimeSafeMode;
 	type RegisterRedemption = MockRegisterRedemption;
+	type MoveFlipToGateway = MockFlipBurnOrMoveInfo;
 }
 
 pub const REDEMPTION_TTL_SECS: u64 = 10;

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -21,8 +21,10 @@ use crate::{
 use cf_primitives::FlipBalance;
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{
-	mocks::account_role_registry::MockAccountRoleRegistry, AccountInfo, AccountRoleRegistry,
-	Bonding, Chainflip, FundAccount, SetSafeMode, Slashing,
+	mocks::{
+		account_role_registry::MockAccountRoleRegistry, flip_burn_info::MockFlipBurnOrMoveInfo,
+	},
+	AccountInfo, AccountRoleRegistry, Bonding, Chainflip, FundAccount, SetSafeMode, Slashing,
 };
 use sp_core::H160;
 
@@ -2701,4 +2703,27 @@ pub mod sub_accounts {
 			assert!(frame_system::Pallet::<Test>::account_exists(&sub_account_id));
 		});
 	}
+}
+
+#[test]
+fn funding_from_free_balance_earmarks_a_transfer_to_the_gateway() {
+	new_test_ext().execute_with(|| {
+		const AMOUNT: u128 = 1_000;
+
+		// Funds arriving via the Gateway are already backed, so nothing is earmarked.
+		Funding::fund_account(
+			ALICE,
+			AMOUNT,
+			FundingSource::EthTransaction { tx_hash: TX_HASH, funder: ETH_DUMMY_ADDR },
+		);
+		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), 0);
+
+		// Funds moved from a free balance are backed by Flip in the Vault, so the same amount
+		// must be earmarked for transfer to the Gateway.
+		Funding::fund_account(ALICE, AMOUNT, FundingSource::FreeBalance);
+		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), AMOUNT);
+
+		Funding::fund_account(BOB, AMOUNT * 2, FundingSource::FreeBalance);
+		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), AMOUNT * 3);
+	});
 }

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -117,6 +117,7 @@ pub struct BoostConfiguration {
 	PartialEq,
 	Eq,
 	RuntimeDebug,
+	Default,
 )]
 pub struct PalletSafeMode {
 	pub add_boost_funds_enabled: bool,

--- a/state-chain/pallets/cf-lp/src/benchmarking.rs
+++ b/state-chain/pallets/cf-lp/src/benchmarking.rs
@@ -19,7 +19,7 @@
 use super::*;
 use cf_chains::{address::EncodedAddress, benchmarking_value::BenchmarkValue};
 use cf_primitives::{AccountRole, Asset, FLIPPERINOS_PER_FLIP};
-use cf_traits::{AccountRoleRegistry, FeePayment, RefundAddressRegistry};
+use cf_traits::{AccountRoleRegistry, FeePayment, GetMinimumFunding, RefundAddressRegistry};
 use frame_benchmarking::v2::*;
 use frame_support::{assert_ok, traits::OnNewAccount};
 use frame_system::RawOrigin;
@@ -140,6 +140,24 @@ mod benchmarks {
 			Default::default(),
 			None,
 		);
+	}
+
+	#[benchmark]
+	fn transfer_flip_to_on_chain_balance() {
+		let caller = <T as Chainflip>::AccountRoleRegistry::whitelisted_caller_with_role(
+			AccountRole::LiquidityProvider,
+		)
+		.unwrap();
+
+		T::FeePayment::activate_flip_2_1();
+
+		let amount = T::MinimumFunding::get_min_funding_amount();
+		T::BalanceApi::credit_account(&caller, Asset::Flip, amount);
+
+		#[extrinsic_call]
+		transfer_flip_to_on_chain_balance(RawOrigin::Signed(caller.clone()), amount);
+
+		assert_eq!(T::BalanceApi::get_balance(&caller, Asset::Flip), 0);
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -23,7 +23,8 @@ use cf_primitives::{
 };
 use cf_traits::{
 	impl_pallet_safe_mode, AccountRoleRegistry, BalanceApi, Chainflip, DepositApi, EgressApi,
-	LpStatsApi, PoolApi, RefundAddressRegistry, ScheduledEgressDetails, SwapRequestHandler,
+	FeePayment, FundAccount, FundingSource, GetMinimumFunding, LpStatsApi, PoolApi,
+	RefundAddressRegistry, ScheduledEgressDetails, SwapRequestHandler,
 	WithdrawalAddressRestriction,
 };
 use frame_support::{
@@ -52,7 +53,7 @@ use cf_chains::address::EncodedAddress;
 pub const STORAGE_VERSION_U16: u16 = 4;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
 
-impl_pallet_safe_mode!(PalletSafeMode; deposit_enabled, withdrawal_enabled, internal_swaps_enabled);
+impl_pallet_safe_mode!(PalletSafeMode; deposit_enabled, withdrawal_enabled, internal_swaps_enabled, flip_to_on_chain_balance_enabled);
 
 pub const STATS_UPDATE_INTERVAL_IN_BLOCKS: u64 = 24 * 3600 / SECONDS_PER_BLOCK; // 24 hours
 
@@ -244,7 +245,6 @@ pub mod pallet {
 		/// Benchmark weights
 		type WeightInfo: WeightInfo;
 
-		#[cfg(feature = "runtime-benchmarks")]
 		type FeePayment: cf_traits::FeePayment<
 			Amount = <Self as Chainflip>::Amount,
 			AccountId = <Self as frame_system::Config>::AccountId,
@@ -252,6 +252,15 @@ pub mod pallet {
 
 		/// The interface to access the minimum deposit amount for each asset
 		type MinimumDeposit: MinimumDeposit;
+
+		/// Credits Flip to an account's on-chain balance.
+		type FundAccount: FundAccount<
+			AccountId = <Self as frame_system::Config>::AccountId,
+			Amount = <Self as Chainflip>::Amount,
+		>;
+
+		/// The minimum amount of Flip that may be credited to an on-chain balance.
+		type MinimumFunding: GetMinimumFunding;
 	}
 
 	#[pallet::error]
@@ -287,6 +296,12 @@ pub mod pallet {
 		InternalSwapBelowMinimumDepositAmount,
 		/// Internal swaps disabled due to safe mode.
 		InternalSwapsDisabled,
+		/// Transfers to the on-chain balance are disabled due to safe mode.
+		FlipTransferToOnChainBalanceDisabled,
+		/// Transfers to the on-chain balance are only available once Flip 2.1 is active.
+		FlipTransferToOnChainBalanceUnavailable,
+		/// The transferred amount is below the minimum funding amount.
+		BelowMinimumFunding,
 	}
 
 	#[pallet::event]
@@ -576,6 +591,45 @@ pub mod pallet {
 					});
 				}
 			}
+
+			Ok(())
+		}
+
+		/// Move Flip from the caller's free balance to their on-chain balance, where it can be
+		/// used to pay transaction fees or to delegate.
+		///
+		/// The transfer is one-way: on-chain funds can only be recovered by redeeming them to an
+		/// external address.
+		#[pallet::call_index(9)]
+		#[pallet::weight(T::WeightInfo::transfer_flip_to_on_chain_balance())]
+		pub fn transfer_flip_to_on_chain_balance(
+			origin: OriginFor<T>,
+			amount: AssetAmount,
+		) -> DispatchResult {
+			ensure!(
+				T::SafeMode::get().flip_to_on_chain_balance_enabled,
+				Error::<T>::FlipTransferToOnChainBalanceDisabled
+			);
+
+			// The on-chain balance is backed by Flip in the State Chain Gateway, whereas the free
+			// balance is backed by Flip in the Vault. Earmarked Flip is only egressed from the
+			// Vault to the Gateway at the end of an epoch, and only while Flip 2.1 is active.
+			ensure!(
+				T::FeePayment::is_flip_2_1_activated(),
+				Error::<T>::FlipTransferToOnChainBalanceUnavailable
+			);
+
+			ensure!(
+				amount >= T::MinimumFunding::get_min_funding_amount(),
+				Error::<T>::BelowMinimumFunding
+			);
+
+			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
+
+			T::BalanceApi::try_debit_account(&account_id, Asset::Flip, amount)
+				.map_err(|_| Error::<T>::InsufficientBalance)?;
+
+			T::FundAccount::fund_account(account_id, amount.into(), FundingSource::FreeBalance);
 
 			Ok(())
 		}

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -349,6 +349,10 @@ pub mod pallet {
 			amount: AssetAmount,
 			error: DispatchError,
 		},
+		FlipTransferredToOnChainBalance {
+			account_id: T::AccountId,
+			amount: AssetAmount,
+		},
 	}
 
 	#[pallet::pallet]
@@ -610,6 +614,7 @@ pub mod pallet {
 				T::SafeMode::get().flip_to_on_chain_balance_enabled,
 				Error::<T>::FlipTransferToOnChainBalanceDisabled
 			);
+			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
 
 			// The on-chain balance is backed by Flip in the State Chain Gateway, whereas the free
 			// balance is backed by Flip in the Vault. Earmarked Flip is only egressed from the
@@ -624,12 +629,16 @@ pub mod pallet {
 				Error::<T>::BelowMinimumFunding
 			);
 
-			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(origin)?;
-
 			T::BalanceApi::try_debit_account(&account_id, Asset::Flip, amount)
 				.map_err(|_| Error::<T>::InsufficientBalance)?;
 
-			T::FundAccount::fund_account(account_id, amount.into(), FundingSource::FreeBalance);
+			T::FundAccount::fund_account(
+				account_id.clone(),
+				amount.into(),
+				FundingSource::FreeBalance,
+			);
+
+			Self::deposit_event(Event::<T>::FlipTransferredToOnChainBalance { account_id, amount });
 
 			Ok(())
 		}

--- a/state-chain/pallets/cf-lp/src/mock.rs
+++ b/state-chain/pallets/cf-lp/src/mock.rs
@@ -23,6 +23,7 @@ use cf_traits::{
 	mocks::{
 		address_converter::MockAddressConverter, balance_api::MockRefundAddressRegistry,
 		deposit_handler::MockDepositHandler, egress_handler::MockEgressHandler,
+		fee_payment::MockFeePayment, minimum_funding::MockMinimumFundingProvider,
 		pool_api::MockPoolApi, swap_request_api::MockSwapRequestHandler,
 		withdrawal_address_restriction::MockWithdrawalAddressRestriction,
 	},
@@ -148,10 +149,11 @@ impl crate::Config for Test {
 	type WithdrawalRestriction =
 		MockWithdrawalAddressRestriction<<Self as frame_system::Config>::AccountId>;
 	type RefundAddressRegistry = MockRefundAddressRegistry;
-	#[cfg(feature = "runtime-benchmarks")]
-	type FeePayment = cf_traits::mocks::fee_payment::MockFeePayment<Self>;
+	type FeePayment = MockFeePayment<Self>;
 	type SwapRequestHandler = MockSwapRequestHandler<(Ethereum, MockEgressHandler<Ethereum>)>;
 	type MinimumDeposit = MockMinimumDepositProvider;
+	type FundAccount = MockFundingInfo<Self>;
+	type MinimumFunding = MockMinimumFundingProvider;
 }
 
 pub const LP_ACCOUNT: AccountId = 1;

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -1131,20 +1131,6 @@ mod transfer_flip_to_on_chain_balance {
 	}
 
 	#[test]
-	fn transfers_accumulate() {
-		new_test_ext().execute_with(|| {
-			let amount = min_funding();
-			setup(amount * 3);
-
-			assert_ok!(transfer(amount));
-			assert_ok!(transfer(amount * 2));
-
-			assert_eq!(MockBalanceApi::get_balance(&LP_ACCOUNT, Asset::Flip), Some(0));
-			assert_eq!(MockFundingInfo::<Test>::total_balance_of(&LP_ACCOUNT), amount * 3);
-		});
-	}
-
-	#[test]
 	fn cannot_transfer_more_than_the_free_balance() {
 		new_test_ext().execute_with(|| {
 			setup(min_funding());

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -36,7 +36,10 @@ use cf_traits::{
 	LpStatsApi, PriceLimitsAndExpiry, RefundAddressRegistry, SafeMode, SetSafeMode,
 	SwapOutputAction, SwapRequestType,
 };
-use frame_support::{assert_err, assert_noop, assert_ok, error::BadOrigin, traits::OriginTrait};
+use frame_support::{
+	assert_err, assert_noop, assert_ok, error::BadOrigin, sp_runtime::DispatchResult,
+	traits::OriginTrait,
+};
 use sp_runtime::FixedU128;
 
 #[test]
@@ -1074,6 +1077,137 @@ mod withdrawal_restriction {
 				Asset::Eth,
 				LP_ACCOUNT_2,
 			));
+		});
+	}
+}
+
+mod transfer_flip_to_on_chain_balance {
+	use super::*;
+	use cf_traits::{
+		mocks::{
+			fee_payment::MockFeePayment, funding_info::MockFundingInfo,
+			minimum_funding::MockMinimumFundingProvider,
+		},
+		FundingInfo, FundingSource, GetMinimumFunding,
+	};
+
+	fn min_funding() -> AssetAmount {
+		MockMinimumFundingProvider::get_min_funding_amount()
+	}
+
+	fn transfer(amount: AssetAmount) -> DispatchResult {
+		LiquidityProvider::transfer_flip_to_on_chain_balance(
+			RuntimeOrigin::signed(LP_ACCOUNT),
+			amount,
+		)
+	}
+
+	fn setup(free_balance: AssetAmount) {
+		MockFeePayment::<Test>::set_flip_2_1_activated(true);
+		MockBalanceApi::insert_balance(LP_ACCOUNT, Asset::Flip, free_balance);
+	}
+
+	#[test]
+	fn moves_free_balance_to_on_chain_balance() {
+		new_test_ext().execute_with(|| {
+			const AMOUNT: AssetAmount = 1_000;
+			setup(AMOUNT * 2);
+
+			assert_ok!(transfer(AMOUNT));
+
+			assert_eq!(MockBalanceApi::get_balance(&LP_ACCOUNT, Asset::Flip), Some(AMOUNT));
+			assert_eq!(MockFundingInfo::<Test>::total_balance_of(&LP_ACCOUNT), AMOUNT);
+			// The funding source is what earmarks the equivalent amount for transfer to the
+			// gateway, so that the on-chain balance remains fully backed. See the funding pallet.
+			assert_eq!(
+				MockFundingInfo::<Test>::last_funding_source(),
+				Some(FundingSource::FreeBalance)
+			);
+		});
+	}
+
+	#[test]
+	fn transfers_accumulate() {
+		new_test_ext().execute_with(|| {
+			let amount = min_funding();
+			setup(amount * 3);
+
+			assert_ok!(transfer(amount));
+			assert_ok!(transfer(amount * 2));
+
+			assert_eq!(MockBalanceApi::get_balance(&LP_ACCOUNT, Asset::Flip), Some(0));
+			assert_eq!(MockFundingInfo::<Test>::total_balance_of(&LP_ACCOUNT), amount * 3);
+		});
+	}
+
+	#[test]
+	fn cannot_transfer_more_than_the_free_balance() {
+		new_test_ext().execute_with(|| {
+			setup(min_funding());
+
+			assert_noop!(transfer(min_funding() + 1), Error::<Test>::InsufficientBalance);
+		});
+	}
+
+	#[test]
+	fn cannot_transfer_below_the_minimum_funding_amount() {
+		new_test_ext().execute_with(|| {
+			setup(min_funding());
+
+			assert_noop!(transfer(min_funding() - 1), Error::<Test>::BelowMinimumFunding);
+			assert_ok!(transfer(min_funding()));
+		});
+	}
+
+	#[test]
+	fn cannot_transfer_before_flip_2_1_is_activated() {
+		new_test_ext().execute_with(|| {
+			setup(min_funding());
+			MockFeePayment::<Test>::set_flip_2_1_activated(false);
+
+			assert_noop!(
+				transfer(min_funding()),
+				Error::<Test>::FlipTransferToOnChainBalanceUnavailable
+			);
+		});
+	}
+
+	#[test]
+	fn safe_mode_prevents_transfers() {
+		new_test_ext().execute_with(|| {
+			setup(min_funding());
+
+			MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
+				liquidity_provider: PalletSafeMode {
+					flip_to_on_chain_balance_enabled: false,
+					..PalletSafeMode::code_green()
+				},
+			});
+			assert_err!(
+				transfer(min_funding()),
+				Error::<Test>::FlipTransferToOnChainBalanceDisabled
+			);
+
+			MockRuntimeSafeMode::set_safe_mode(MockRuntimeSafeMode {
+				liquidity_provider: PalletSafeMode::code_green(),
+			});
+			assert_ok!(transfer(min_funding()));
+		});
+	}
+
+	#[test]
+	fn only_liquidity_providers_can_transfer() {
+		new_test_ext().execute_with(|| {
+			MockFeePayment::<Test>::set_flip_2_1_activated(true);
+			MockBalanceApi::insert_balance(NON_LP_ACCOUNT, Asset::Flip, min_funding());
+
+			assert_noop!(
+				LiquidityProvider::transfer_flip_to_on_chain_balance(
+					RuntimeOrigin::signed(NON_LP_ACCOUNT),
+					min_funding(),
+				),
+				BadOrigin
+			);
 		});
 	}
 }

--- a/state-chain/pallets/cf-lp/src/tests.rs
+++ b/state-chain/pallets/cf-lp/src/tests.rs
@@ -1123,6 +1123,10 @@ mod transfer_flip_to_on_chain_balance {
 				MockFundingInfo::<Test>::last_funding_source(),
 				Some(FundingSource::FreeBalance)
 			);
+
+			System::assert_last_event(RuntimeEvent::LiquidityProvider(
+				Event::FlipTransferredToOnChainBalance { account_id: LP_ACCOUNT, amount: AMOUNT },
+			));
 		});
 	}
 

--- a/state-chain/pallets/cf-lp/src/weights.rs
+++ b/state-chain/pallets/cf-lp/src/weights.rs
@@ -54,6 +54,7 @@ pub trait WeightInfo {
 	fn deregister_lp_account() -> Weight;
 	fn register_liquidity_refund_address() -> Weight;
 	fn schedule_swap() -> Weight;
+	fn transfer_flip_to_on_chain_balance() -> Weight;
 	fn update_agg_stats_item() -> Weight;
 	fn on_idle_nothing_to_do() -> Weight;
 	fn purge_balances(n: u32, ) -> Weight;
@@ -207,6 +208,33 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 		//  Estimated: `0`
 		// Minimum execution time: 81_602_000 picoseconds.
 		Weight::from_parts(82_797_000, 0)
+	}
+	/// Storage: `Environment::RuntimeSafeMode` (r:1 w:0)
+	/// Proof: `Environment::RuntimeSafeMode` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::FeeRewardsActivationEpoch` (r:1 w:0)
+	/// Proof: `Flip::FeeRewardsActivationEpoch` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Funding::MinimumFunding` (r:1 w:0)
+	/// Proof: `Funding::MinimumFunding` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
+	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityPools::Pools` (r:1 w:0)
+	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `AssetBalances::FreeBalances` (r:1 w:1)
+	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::Account` (r:1 w:1)
+	/// Proof: `Flip::Account` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::OffchainFunds` (r:1 w:1)
+	/// Proof: `Flip::OffchainFunds` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Swapping::FlipToBeSentToGateway` (r:1 w:1)
+	/// Proof: `Swapping::FlipToBeSentToGateway` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn transfer_flip_to_on_chain_balance() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1824`
+		//  Estimated: `5289`
+		// Minimum execution time: 61_957_000 picoseconds.
+		Weight::from_parts(62_863_000, 5289)
+			.saturating_add(T::DbWeight::get().reads(9_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `LiquidityProvider::LpDeltaStats` (r:1 w:1)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -397,6 +425,33 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 81_602_000 picoseconds.
 		Weight::from_parts(82_797_000, 0)
+	}
+	/// Storage: `Environment::RuntimeSafeMode` (r:1 w:0)
+	/// Proof: `Environment::RuntimeSafeMode` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::FeeRewardsActivationEpoch` (r:1 w:0)
+	/// Proof: `Flip::FeeRewardsActivationEpoch` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Funding::MinimumFunding` (r:1 w:0)
+	/// Proof: `Funding::MinimumFunding` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
+	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `LiquidityPools::Pools` (r:1 w:0)
+	/// Proof: `LiquidityPools::Pools` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `AssetBalances::FreeBalances` (r:1 w:1)
+	/// Proof: `AssetBalances::FreeBalances` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::Account` (r:1 w:1)
+	/// Proof: `Flip::Account` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Flip::OffchainFunds` (r:1 w:1)
+	/// Proof: `Flip::OffchainFunds` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Swapping::FlipToBeSentToGateway` (r:1 w:1)
+	/// Proof: `Swapping::FlipToBeSentToGateway` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn transfer_flip_to_on_chain_balance() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1824`
+		//  Estimated: `5289`
+		// Minimum execution time: 61_957_000 picoseconds.
+		Weight::from_parts(62_863_000, 5289)
+			.saturating_add(ParityDbWeight::get().reads(9_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `LiquidityProvider::LpDeltaStats` (r:1 w:1)
 	/// Proof: `LiquidityProvider::LpDeltaStats` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -3583,6 +3583,14 @@ impl<T: Config> cf_traits::FlipBurnOrMoveInfo for Pallet<T> {
 	}
 }
 
+impl<T: Config> cf_traits::MoveFlipToGateway for Pallet<T> {
+	fn add_flip_to_be_sent_to_gateway(amount: AssetAmount) {
+		FlipToBeSentToGateway::<T>::mutate(|total| {
+			total.saturating_accrue(amount);
+		});
+	}
+}
+
 impl<T: Config> cf_traits::NetworkFeeApi for Pallet<T> {
 	fn get_network_fee_rate(
 		input_asset: Asset,

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -600,9 +600,10 @@ impl pallet_cf_lp::Config for Runtime {
 	type RefundAddressRegistry = AssetBalances;
 	type SwapRequestHandler = Swapping;
 	type WeightInfo = pallet_cf_lp::weights::PalletWeight<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
 	type FeePayment = Flip;
 	type MinimumDeposit = MinimumDepositProvider;
+	type FundAccount = Funding;
+	type MinimumFunding = Funding;
 }
 
 impl pallet_cf_account_roles::Config for Runtime {
@@ -779,6 +780,7 @@ impl pallet_cf_funding::Config for Runtime {
 	type RedemptionChecker = Validator;
 	type EthereumSCApi = crate::chainflip::ethereum_sc_calls::EthereumSCApi<FlipBalance>;
 	type SafeMode = RuntimeSafeMode;
+	type MoveFlipToGateway = Swapping;
 	type WeightInfo = pallet_cf_funding::weights::PalletWeight<Runtime>;
 }
 

--- a/state-chain/runtime/src/migrations/safe_mode.rs
+++ b/state-chain/runtime/src/migrations/safe_mode.rs
@@ -44,3 +44,59 @@ impl OnRuntimeUpgrade for SafeModeMigration {
 		Weight::zero()
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::runtime_apis::custom_api::types::before_version_19::LiquidityProviderSafeMode as OldLiquidityProviderSafeMode;
+	use cf_traits::SafeMode;
+	use codec::Encode;
+
+	#[test]
+	fn translates_pre_upgrade_storage() {
+		sp_io::TestExternalities::default().execute_with(|| {
+			unhashed::put_raw(
+				&pallet_cf_environment::RuntimeSafeMode::<Runtime>::hashed_key(),
+				&OldRuntimeSafeMode {
+					// Deliberately neither code green nor code red: the storage item is
+					// `ValueQuery`, so a migration that silently wiped it would read back as code
+					// green and a uniform fixture couldn't tell the two apart.
+					liquidity_provider: OldLiquidityProviderSafeMode {
+						deposit_enabled: false,
+						withdrawal_enabled: true,
+						internal_swaps_enabled: false,
+					},
+					funding: pallet_cf_funding::PalletSafeMode::code_red(),
+					..Default::default()
+				}
+				.encode(),
+			);
+
+			SafeModeMigration::on_runtime_upgrade();
+
+			let migrated = pallet_cf_environment::RuntimeSafeMode::<Runtime>::get();
+			assert_eq!(
+				migrated.liquidity_provider,
+				pallet_cf_lp::PalletSafeMode {
+					deposit_enabled: false,
+					withdrawal_enabled: true,
+					internal_swaps_enabled: false,
+					flip_to_on_chain_balance_enabled: true,
+				}
+			);
+			assert_eq!(migrated.funding, pallet_cf_funding::PalletSafeMode::code_red());
+		});
+	}
+
+	#[test]
+	fn leaves_current_format_untouched() {
+		sp_io::TestExternalities::default().execute_with(|| {
+			let already_migrated = RuntimeSafeMode::code_red();
+			pallet_cf_environment::RuntimeSafeMode::<Runtime>::put(already_migrated.clone());
+
+			SafeModeMigration::on_runtime_upgrade();
+
+			assert_eq!(pallet_cf_environment::RuntimeSafeMode::<Runtime>::get(), already_migrated);
+		});
+	}
+}

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -454,6 +454,27 @@ impl From<LendingPoolsSafeMode> for pallet_cf_lending_pools::PalletSafeMode {
 	}
 }
 
+// The liquidity provider safe mode before `flip_to_on_chain_balance_enabled` was added.
+#[derive(
+	Encode, Decode, TypeInfo, Clone, PartialEq, Eq, frame_support::pallet_prelude::RuntimeDebug,
+)]
+pub struct LiquidityProviderSafeMode {
+	pub deposit_enabled: bool,
+	pub withdrawal_enabled: bool,
+	pub internal_swaps_enabled: bool,
+}
+
+impl From<LiquidityProviderSafeMode> for pallet_cf_lp::PalletSafeMode {
+	fn from(old: LiquidityProviderSafeMode) -> Self {
+		Self {
+			deposit_enabled: old.deposit_enabled,
+			withdrawal_enabled: old.withdrawal_enabled,
+			internal_swaps_enabled: old.internal_swaps_enabled,
+			flip_to_on_chain_balance_enabled: true,
+		}
+	}
+}
+
 // The v16 RuntimeSafeMode: no broadcast_tron, ingress_egress_tron, or tron_elections fields,
 // and with the old LendingPoolsSafeMode and WitnesserCallPermission.
 #[derive(
@@ -463,7 +484,7 @@ pub struct RuntimeSafeMode {
 	pub emissions: pallet_cf_emissions::PalletSafeMode,
 	pub funding: pallet_cf_funding::PalletSafeMode,
 	pub swapping: pallet_cf_swapping::PalletSafeMode,
-	pub liquidity_provider: pallet_cf_lp::PalletSafeMode,
+	pub liquidity_provider: LiquidityProviderSafeMode,
 	pub validator: pallet_cf_validator::PalletSafeMode,
 	pub pools: pallet_cf_pools::PalletSafeMode,
 	pub trading_strategies: pallet_cf_trading_strategy::PalletSafeMode,
@@ -513,7 +534,7 @@ impl From<RuntimeSafeMode> for crate::safe_mode::RuntimeSafeMode {
 			emissions: old.emissions,
 			funding: old.funding,
 			swapping: old.swapping,
-			liquidity_provider: old.liquidity_provider,
+			liquidity_provider: old.liquidity_provider.into(),
 			validator: old.validator,
 			pools: old.pools,
 			trading_strategies: old.trading_strategies,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -454,27 +454,6 @@ impl From<LendingPoolsSafeMode> for pallet_cf_lending_pools::PalletSafeMode {
 	}
 }
 
-// The liquidity provider safe mode before `flip_to_on_chain_balance_enabled` was added.
-#[derive(
-	Encode, Decode, TypeInfo, Clone, PartialEq, Eq, frame_support::pallet_prelude::RuntimeDebug,
-)]
-pub struct LiquidityProviderSafeMode {
-	pub deposit_enabled: bool,
-	pub withdrawal_enabled: bool,
-	pub internal_swaps_enabled: bool,
-}
-
-impl From<LiquidityProviderSafeMode> for pallet_cf_lp::PalletSafeMode {
-	fn from(old: LiquidityProviderSafeMode) -> Self {
-		Self {
-			deposit_enabled: old.deposit_enabled,
-			withdrawal_enabled: old.withdrawal_enabled,
-			internal_swaps_enabled: old.internal_swaps_enabled,
-			flip_to_on_chain_balance_enabled: true,
-		}
-	}
-}
-
 // The v16 RuntimeSafeMode: no broadcast_tron, ingress_egress_tron, or tron_elections fields,
 // and with the old LendingPoolsSafeMode and WitnesserCallPermission.
 #[derive(
@@ -484,7 +463,7 @@ pub struct RuntimeSafeMode {
 	pub emissions: pallet_cf_emissions::PalletSafeMode,
 	pub funding: pallet_cf_funding::PalletSafeMode,
 	pub swapping: pallet_cf_swapping::PalletSafeMode,
-	pub liquidity_provider: LiquidityProviderSafeMode,
+	pub liquidity_provider: before_version_19::LiquidityProviderSafeMode,
 	pub validator: pallet_cf_validator::PalletSafeMode,
 	pub pools: pallet_cf_pools::PalletSafeMode,
 	pub trading_strategies: pallet_cf_trading_strategy::PalletSafeMode,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
@@ -422,6 +422,27 @@ impl From<WitnesserCallPermission> for crate::safe_mode::WitnesserCallPermission
 	}
 }
 
+// The liquidity provider safe mode before `flip_to_on_chain_balance_enabled` was added.
+#[derive(
+	Encode, Decode, TypeInfo, Clone, PartialEq, Eq, frame_support::pallet_prelude::RuntimeDebug,
+)]
+pub struct LiquidityProviderSafeMode {
+	pub deposit_enabled: bool,
+	pub withdrawal_enabled: bool,
+	pub internal_swaps_enabled: bool,
+}
+
+impl From<LiquidityProviderSafeMode> for pallet_cf_lp::PalletSafeMode {
+	fn from(old: LiquidityProviderSafeMode) -> Self {
+		Self {
+			deposit_enabled: old.deposit_enabled,
+			withdrawal_enabled: old.withdrawal_enabled,
+			internal_swaps_enabled: old.internal_swaps_enabled,
+			flip_to_on_chain_balance_enabled: true,
+		}
+	}
+}
+
 #[derive(
 	Encode, Decode, TypeInfo, Clone, PartialEq, Eq, frame_support::pallet_prelude::RuntimeDebug,
 )]
@@ -429,7 +450,7 @@ pub struct RuntimeSafeMode {
 	pub emissions: pallet_cf_emissions::PalletSafeMode,
 	pub funding: pallet_cf_funding::PalletSafeMode,
 	pub swapping: pallet_cf_swapping::PalletSafeMode,
-	pub liquidity_provider: pallet_cf_lp::PalletSafeMode,
+	pub liquidity_provider: LiquidityProviderSafeMode,
 	pub validator: pallet_cf_validator::PalletSafeMode,
 	pub pools: pallet_cf_pools::PalletSafeMode,
 	pub trading_strategies: pallet_cf_trading_strategy::PalletSafeMode,
@@ -482,7 +503,7 @@ impl From<RuntimeSafeMode> for crate::safe_mode::RuntimeSafeMode {
 			emissions: old.emissions,
 			funding: old.funding,
 			swapping: old.swapping,
-			liquidity_provider: old.liquidity_provider,
+			liquidity_provider: old.liquidity_provider.into(),
 			validator: old.validator,
 			pools: old.pools,
 			trading_strategies: old.trading_strategies,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
@@ -432,6 +432,13 @@ pub struct LiquidityProviderSafeMode {
 	pub internal_swaps_enabled: bool,
 }
 
+// Code green, to match the default of every other pallet safe mode.
+impl Default for LiquidityProviderSafeMode {
+	fn default() -> Self {
+		Self { deposit_enabled: true, withdrawal_enabled: true, internal_swaps_enabled: true }
+	}
+}
+
 impl From<LiquidityProviderSafeMode> for pallet_cf_lp::PalletSafeMode {
 	fn from(old: LiquidityProviderSafeMode) -> Self {
 		Self {
@@ -444,7 +451,14 @@ impl From<LiquidityProviderSafeMode> for pallet_cf_lp::PalletSafeMode {
 }
 
 #[derive(
-	Encode, Decode, TypeInfo, Clone, PartialEq, Eq, frame_support::pallet_prelude::RuntimeDebug,
+	Encode,
+	Decode,
+	TypeInfo,
+	Default,
+	Clone,
+	PartialEq,
+	Eq,
+	frame_support::pallet_prelude::RuntimeDebug,
 )]
 pub struct RuntimeSafeMode {
 	pub emissions: pallet_cf_emissions::PalletSafeMode,

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -773,6 +773,12 @@ pub trait FeePayment {
 		unimplemented!()
 	}
 
+	/// Helper function to activate FLIP 2.1 from the current epoch.
+	#[cfg(feature = "runtime-benchmarks")]
+	fn activate_flip_2_1() {
+		unimplemented!()
+	}
+
 	/// Burns an amount of tokens, if the account has enough. Otherwise fails.
 	fn try_take_fee(account_id: &Self::AccountId, amount: Self::Amount) -> DispatchResult;
 
@@ -1062,6 +1068,14 @@ pub trait FlipBurnOrMoveInfo {
 	fn take_flip_to_burn() -> i128;
 
 	fn take_flip_to_be_sent_to_gateway() -> AssetAmount;
+}
+
+/// Allows Flip held in the Vault to be earmarked for transfer to the State Chain Gateway.
+///
+/// Whenever Flip is credited to an on-chain balance without a corresponding Gateway deposit, the
+/// same amount must be earmarked here so that the Gateway remains fully backed.
+pub trait MoveFlipToGateway {
+	fn add_flip_to_be_sent_to_gateway(amount: AssetAmount);
 }
 
 /// The trait implementation is intentionally no-op by default
@@ -1486,6 +1500,7 @@ pub enum FundingSource {
 	EthTransaction { tx_hash: [u8; 32], funder: cf_chains::evm::Address },
 	Swap { swap_request_id: SwapRequestId },
 	InitialFunding { channel_id: Option<u64>, asset: Asset },
+	FreeBalance,
 }
 
 pub trait FundAccount {

--- a/state-chain/traits/src/mocks/fee_payment.rs
+++ b/state-chain/traits/src/mocks/fee_payment.rs
@@ -18,9 +18,21 @@ use frame_support::sp_runtime::{DispatchError, DispatchResult};
 
 use crate::{Chainflip, FeePayment};
 
-use super::funding_info::MockFundingInfo;
+use super::{funding_info::MockFundingInfo, MockPallet, MockPalletStorage};
 
 pub struct MockFeePayment<T>(sp_std::marker::PhantomData<T>);
+
+impl<T> MockPallet for MockFeePayment<T> {
+	const PREFIX: &'static [u8] = b"MockFeePayment";
+}
+
+const FLIP_2_1_ACTIVATED: &[u8] = b"FLIP_2_1_ACTIVATED";
+
+impl<T> MockFeePayment<T> {
+	pub fn set_flip_2_1_activated(activated: bool) {
+		Self::put_value(FLIP_2_1_ACTIVATED, activated);
+	}
+}
 
 pub const ERROR_INSUFFICIENT_LIQUIDITY: DispatchError =
 	DispatchError::Other("Insufficient liquidity");
@@ -40,11 +52,16 @@ impl<T: Chainflip<FundingInfo = MockFundingInfo<T>>> FeePayment for MockFeePayme
 	fn burn_or_reserve_offchain(_amount: Self::Amount) {}
 
 	fn is_flip_2_1_activated() -> bool {
-		false
+		Self::get_value(FLIP_2_1_ACTIVATED).unwrap_or(false)
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn mint_to_account(account_id: &Self::AccountId, amount: Self::Amount) {
 		MockFundingInfo::<T>::credit_funds(account_id, amount);
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn activate_flip_2_1() {
+		Self::set_flip_2_1_activated(true);
 	}
 }

--- a/state-chain/traits/src/mocks/flip_burn_info.rs
+++ b/state-chain/traits/src/mocks/flip_burn_info.rs
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{MockPallet, MockPalletStorage};
-use crate::FlipBurnOrMoveInfo;
+use crate::{FlipBurnOrMoveInfo, MoveFlipToGateway};
 use cf_primitives::AssetAmount;
 
 pub struct MockFlipBurnOrMoveInfo;
@@ -50,5 +50,11 @@ impl FlipBurnOrMoveInfo for MockFlipBurnOrMoveInfo {
 	}
 	fn take_flip_to_be_sent_to_gateway() -> AssetAmount {
 		Self::take_value(FLIP_TO_BE_SENT_TO_GATEWAY).unwrap_or_default()
+	}
+}
+
+impl MoveFlipToGateway for MockFlipBurnOrMoveInfo {
+	fn add_flip_to_be_sent_to_gateway(amount: AssetAmount) {
+		Self::set_flip_to_be_sent_to_gateway(Self::peek_flip_to_be_sent_to_gateway() + amount);
 	}
 }

--- a/state-chain/traits/src/mocks/funding_info.rs
+++ b/state-chain/traits/src/mocks/funding_info.rs
@@ -33,6 +33,7 @@ impl<T> MockPallet for MockFundingInfo<T> {
 }
 
 const BALANCES: &[u8] = b"BALANCES";
+const LAST_FUNDING_SOURCE: &[u8] = b"LAST_FUNDING_SOURCE";
 
 impl<T: Chainflip> MockFundingInfo<T> {
 	pub fn credit_funds(account_id: &T::AccountId, amount: T::Amount) {
@@ -122,7 +123,14 @@ impl<T: Chainflip> FundAccount for MockFundingInfo<T> {
 	type AccountId = T::AccountId;
 	type Amount = T::Amount;
 
-	fn fund_account(account_id: Self::AccountId, amount: Self::Amount, _source: FundingSource) {
+	fn fund_account(account_id: Self::AccountId, amount: Self::Amount, source: FundingSource) {
 		Self::credit_funds(&account_id, amount);
+		<Self as MockPalletStorage>::put_value(LAST_FUNDING_SOURCE, source);
+	}
+}
+
+impl<T: Chainflip> MockFundingInfo<T> {
+	pub fn last_funding_source() -> Option<FundingSource> {
+		<Self as MockPalletStorage>::get_value(LAST_FUNDING_SOURCE)
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-3033

## Summary

Add a new extrinsic to move funds from free balance to native balance. 

One I didn't add (for now) is a bouncer test. There are no new off-chain mechanisms, it uses existing infrastructure for this. We can add one at a later point if necessary. 

## API Changes

New LP-gated extrinsic `transfer_flip_to_on_chain_balance`

### RPCS

New addition to LP safe mode: `flip_to_on_chain_balance_enabled`


### Extrinsics & Events

Extrinsic as noted above. 
One new event `FlipTransferredToOnChainBalance`

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [x] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
