### PR TITLE
fix: Ensure Flip is credited to account when opening channel with FLIP

### DIFF
--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -34,7 +34,7 @@ pub use weights::WeightInfo;
 mod tests;
 
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
-use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
+use cf_primitives::{chains::assets::eth::Asset as EthAsset, Asset, AssetAmount};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
 	FundAccount, Funding, FundingSource, GetMinimumFunding, MoveFlipToGateway, RedemptionCheck,
@@ -1205,7 +1205,13 @@ impl<T: Config> FundAccount for Pallet<T> {
 				},
 			// These funds are backed by Flip in the Vault rather than in the Gateway, so an
 			// equivalent amount must be moved across to keep the Gateway fully backed.
-			FundingSource::FreeBalance =>
+			//
+			// The same applies to a Flip deposit at account creation, which is credited straight
+			// from the Vault. Account creation with any other asset instead reaches the account
+			// via a swap, and the swap output action earmarks the full output itself - so
+			// earmarking here as well would double-count it.
+			FundingSource::FreeBalance |
+			FundingSource::InitialFunding { asset: Asset::Flip, .. } =>
 				T::MoveFlipToGateway::add_flip_to_be_sent_to_gateway(amount.into()),
 			FundingSource::Swap { .. } | FundingSource::InitialFunding { .. } => {},
 		}

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -34,7 +34,7 @@ pub use weights::WeightInfo;
 mod tests;
 
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
-use cf_primitives::{chains::assets::eth::Asset as EthAsset, Asset, AssetAmount};
+use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
 	FundAccount, Funding, FundingSource, GetMinimumFunding, MoveFlipToGateway, RedemptionCheck,
@@ -1195,6 +1195,7 @@ impl<T: Config> FundAccount for Pallet<T> {
 	fn fund_account(account_id: Self::AccountId, amount: Self::Amount, source: FundingSource) {
 		let total_balance = Self::add_funds_to_account(&account_id, amount);
 		match source {
+			// Deposited directly into the Gateway, so these funds are already backed.
 			FundingSource::EthTransaction { funder, .. } =>
 				if RestrictedAddresses::<T>::contains_key(funder) {
 					RestrictedBalances::<T>::mutate(account_id.clone(), |map| {
@@ -1203,17 +1204,12 @@ impl<T: Config> FundAccount for Pallet<T> {
 							.or_insert(amount);
 					});
 				},
-			// These funds are backed by Flip in the Vault rather than in the Gateway, so an
-			// equivalent amount must be moved across to keep the Gateway fully backed.
-			//
-			// The same applies to a Flip deposit at account creation, which is credited straight
-			// from the Vault. Account creation with any other asset instead reaches the account
-			// via a swap, and the swap output action earmarks the full output itself - so
-			// earmarking here as well would double-count it.
+			// Every other source credits Flip that is held in the Vault, so an equivalent amount
+			// must be moved across to keep the Gateway fully backed.
 			FundingSource::FreeBalance |
-			FundingSource::InitialFunding { asset: Asset::Flip, .. } =>
+			FundingSource::Swap { .. } |
+			FundingSource::InitialFunding { .. } =>
 				T::MoveFlipToGateway::add_flip_to_be_sent_to_gateway(amount.into()),
-			FundingSource::Swap { .. } | FundingSource::InitialFunding { .. } => {},
 		}
 
 		Self::deposit_event(Event::Funded {

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 	PendingRedemptions, Redemption, RedemptionAmount, RedemptionTax, RestrictedAddresses,
 	RestrictedBalances,
 };
-use cf_primitives::{Asset, FlipBalance};
+use cf_primitives::{Asset, FlipBalance, SwapRequestId};
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{
 	mocks::{
@@ -2831,27 +2831,28 @@ fn funding_from_free_balance_earmarks_a_transfer_to_the_gateway() {
 	});
 }
 
+/// Only a deposit into the Gateway arrives already backed. Every other source credits Flip that
+/// is sitting in the Vault, so it must be earmarked for transfer to keep the Gateway whole.
 #[test]
-fn only_flip_account_creation_deposits_are_earmarked() {
+fn every_source_but_a_gateway_deposit_is_earmarked() {
 	new_test_ext().execute_with(|| {
 		const AMOUNT: u128 = 1_000;
 
-		// Account creation with a non-Flip deposit funds the account up front and reaches it via
-		// a swap, which earmarks the full swap output itself. Earmarking here too would
-		// double-count.
-		Funding::fund_account(
-			ALICE,
-			AMOUNT,
+		for (i, source) in [
 			FundingSource::InitialFunding { channel_id: Some(1), asset: Asset::Eth },
-		);
-		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), 0);
-
-		// A Flip deposit is credited straight from the Vault, so it must be earmarked.
-		Funding::fund_account(
-			BOB,
-			AMOUNT,
 			FundingSource::InitialFunding { channel_id: Some(2), asset: Asset::Flip },
-		);
-		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), AMOUNT);
+			FundingSource::Swap { swap_request_id: SwapRequestId(1) },
+			FundingSource::FreeBalance,
+		]
+		.into_iter()
+		.enumerate()
+		{
+			Funding::fund_account(ALICE, AMOUNT, source.clone());
+			assert_eq!(
+				MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(),
+				AMOUNT * (i as u128 + 1),
+				"expected {source:?} to be earmarked"
+			);
+		}
 	});
 }

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 	PendingRedemptions, Redemption, RedemptionAmount, RedemptionTax, RestrictedAddresses,
 	RestrictedBalances,
 };
-use cf_primitives::FlipBalance;
+use cf_primitives::{Asset, FlipBalance};
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{
 	mocks::{
@@ -2828,5 +2828,30 @@ fn funding_from_free_balance_earmarks_a_transfer_to_the_gateway() {
 
 		Funding::fund_account(BOB, AMOUNT * 2, FundingSource::FreeBalance);
 		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), AMOUNT * 3);
+	});
+}
+
+#[test]
+fn only_flip_account_creation_deposits_are_earmarked() {
+	new_test_ext().execute_with(|| {
+		const AMOUNT: u128 = 1_000;
+
+		// Account creation with a non-Flip deposit funds the account up front and reaches it via
+		// a swap, which earmarks the full swap output itself. Earmarking here too would
+		// double-count.
+		Funding::fund_account(
+			ALICE,
+			AMOUNT,
+			FundingSource::InitialFunding { channel_id: Some(1), asset: Asset::Eth },
+		);
+		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), 0);
+
+		// A Flip deposit is credited straight from the Vault, so it must be earmarked.
+		Funding::fund_account(
+			BOB,
+			AMOUNT,
+			FundingSource::InitialFunding { channel_id: Some(2), asset: Asset::Flip },
+		);
+		assert_eq!(MockFlipBurnOrMoveInfo::peek_flip_to_be_sent_to_gateway(), AMOUNT);
 	});
 }

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -66,8 +66,9 @@ use cf_traits::{
 	AccountInfo, AccountRoleRegistry, AdditionalDepositAction, BalanceApi, BroadcastOutcomeHandler,
 	DepositApi, EgressApi, EpochInfo,
 	ExpiryBehaviour::RefundIfExpires,
-	FetchesTransfersLimitProvider, FundingInfo, GetBlockHeight, PriceLimitsAndExpiry, SafeMode,
-	ScheduledEgressDetails, SwapOutputAction, SwapRequestType, INITIAL_FLIP_FUNDING,
+	FetchesTransfersLimitProvider, FundingInfo, FundingSource, GetBlockHeight,
+	PriceLimitsAndExpiry, SafeMode, ScheduledEgressDetails, SwapOutputAction, SwapRequestType,
+	INITIAL_FLIP_FUNDING,
 };
 use std::collections::{BTreeMap, HashSet};
 
@@ -3247,6 +3248,68 @@ fn additional_action_correctly_prefund_and_create_account() {
 		));
 		assert_eq!(frame_system::Pallet::<Test>::account_nonce(NEW_ACCOUNT), 1);
 		assert_eq!(MockFundingInfo::<Test>::balance(&NEW_ACCOUNT), INITIAL_FLIP_FUNDING);
+
+		// The swap output action earmarks the full swap output, so these funds must not be
+		// earmarked again by the funding pallet. See
+		// `only_flip_account_creation_deposits_are_earmarked`.
+		assert_eq!(
+			MockFundingInfo::<Test>::last_funding_source(),
+			Some(FundingSource::InitialFunding { channel_id: Some(0), asset: Asset::Eth }),
+		);
+	});
+}
+
+#[test]
+fn additional_action_prefunds_from_a_flip_deposit_without_swapping() {
+	const DEPOSIT_AMOUNT: AssetAmount = FLIPPERINOS_PER_FLIP * 100;
+	const FLIP_TO_CREDIT: AssetAmount = FLIPPERINOS_PER_FLIP * 10;
+	const NEW_ACCOUNT: u64 = 0;
+
+	let full_witness = || {
+		EthereumIngressEgress::process_full_witness_deposit_inner(
+			None,
+			EthAsset::Flip,
+			DEPOSIT_AMOUNT,
+			Default::default(),
+			BoostStatus::NotBoosted,
+			0,
+			None,
+			ChannelAction::LiquidityProvision {
+				lp_account: NEW_ACCOUNT,
+				refund_address: ForeignChainAddress::Eth(Default::default()),
+				additional_action: Some(AdditionalDepositAction::FundFlip {
+					flip_amount_to_credit: FLIP_TO_CREDIT,
+				}),
+			},
+			0,
+			DepositOrigin::DepositChannel {
+				deposit_address: Default::default(),
+				channel_id: 0,
+				deposit_block_height: 0,
+				broker_id: BROKER,
+			},
+		)
+	};
+
+	new_test_ext().execute_with(|| {
+		assert!(full_witness().is_ok());
+
+		// The deposit is already Flip, so it is credited directly rather than swapped.
+		assert!(MockSwapRequestHandler::<Test>::get_swap_requests().is_empty());
+		assert_eq!(MockFundingInfo::<Test>::balance(&NEW_ACCOUNT), FLIP_TO_CREDIT);
+
+		// These funds come straight from the Vault, so the source must identify them as such -
+		// the funding pallet keys the Vault -> Gateway earmark off it.
+		assert_eq!(
+			MockFundingInfo::<Test>::last_funding_source(),
+			Some(FundingSource::InitialFunding { channel_id: Some(0), asset: Asset::Flip }),
+		);
+
+		// Whatever is left over lands in the free balance.
+		assert_eq!(
+			MockBalance::get_balance(&NEW_ACCOUNT, Asset::Flip),
+			DEPOSIT_AMOUNT - FLIP_TO_CREDIT
+		);
 	});
 }
 

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3249,9 +3249,9 @@ fn additional_action_correctly_prefund_and_create_account() {
 		assert_eq!(frame_system::Pallet::<Test>::account_nonce(NEW_ACCOUNT), 1);
 		assert_eq!(MockFundingInfo::<Test>::balance(&NEW_ACCOUNT), INITIAL_FLIP_FUNDING);
 
-		// The swap output action earmarks the full swap output, so these funds must not be
-		// earmarked again by the funding pallet. See
-		// `only_flip_account_creation_deposits_are_earmarked`.
+		// These funds come from the Vault, so the source must identify them as such - the funding
+		// pallet keys the Vault -> Gateway earmark off it. The rest of the swap output is
+		// earmarked separately when the swap completes and funds the account again.
 		assert_eq!(
 			MockFundingInfo::<Test>::last_funding_source(),
 			Some(FundingSource::InitialFunding { channel_id: Some(0), asset: Asset::Eth }),

--- a/state-chain/pallets/cf-lending-pools/src/lib.rs
+++ b/state-chain/pallets/cf-lending-pools/src/lib.rs
@@ -62,7 +62,8 @@ use cf_primitives::{
 use cf_traits::{
 	lending::{LendingApi, RepaymentAmount},
 	AccountRoleRegistry, BalanceApi, Chainflip, DeregistrationHooks, PoolApi, PriceFeedApi,
-	RefundAddressRegistry, SafeModeSet, SwapOutputAction, SwapRequestHandler, SwapRequestType,
+	RefundAddressRegistry, SafeMode, SafeModeSet, SwapOutputAction, SwapRequestHandler,
+	SwapRequestType,
 };
 use frame_support::{
 	fail,
@@ -117,7 +118,6 @@ pub struct BoostConfiguration {
 	PartialEq,
 	Eq,
 	RuntimeDebug,
-	Default,
 )]
 pub struct PalletSafeMode {
 	pub add_boost_funds_enabled: bool,
@@ -132,7 +132,13 @@ pub struct PalletSafeMode {
 	pub liquidations_enabled: bool,
 }
 
-impl cf_traits::SafeMode for PalletSafeMode {
+impl Default for PalletSafeMode {
+	fn default() -> Self {
+		Self::code_green()
+	}
+}
+
+impl SafeMode for PalletSafeMode {
 	fn code_red() -> Self {
 		Self {
 			add_boost_funds_enabled: false,

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2661,11 +2661,6 @@ pub mod pallet {
 													total.saturating_reduce(deficit);
 												});
 											}
-											FlipToBeSentToGateway::<T>::mutate(|total| {
-												total.saturating_accrue(
-													*flip_to_subtract_from_swap_output,
-												);
-											});
 										} else {
 											T::FundAccount::fund_account(
 												account_id.clone(),
@@ -2676,9 +2671,6 @@ pub mod pallet {
 													.into(),
 												FundingSource::Swap { swap_request_id },
 											);
-											FlipToBeSentToGateway::<T>::mutate(|total| {
-												total.saturating_accrue(output_amount);
-											});
 										}
 									} else {
 										log_or_panic!("Encountered transfer to gateway swap for asset that isn't Flip: {swap_request_id:?}");

--- a/state-chain/pallets/cf-swapping/src/tests.rs
+++ b/state-chain/pallets/cf-swapping/src/tests.rs
@@ -50,8 +50,8 @@ use cf_traits::{
 		pool_price_api::MockPoolPriceApi,
 		price_feed_api::MockPriceFeedApi,
 	},
-	AccountRoleRegistry, AssetConverter, Chainflip, SetSafeMode, SwapExecutionProgress,
-	INITIAL_FLIP_FUNDING,
+	AccountRoleRegistry, AssetConverter, Chainflip, FundingSource, SetSafeMode,
+	SwapExecutionProgress, INITIAL_FLIP_FUNDING,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -2206,7 +2206,12 @@ mod credit_flip_and_transfer {
 					MockFundingInfo::<Test>::balance(&LP_ACCOUNT),
 					EXPECTED_OUTPUT_AMOUNT.saturating_sub(INITIAL_FLIP_FUNDING)
 				);
-				assert_eq!(FlipToBeSentToGateway::<Test>::get(), EXPECTED_OUTPUT_AMOUNT);
+				// The earmark is keyed off the funding source by the funding pallet, which is
+				// mocked out here. See `every_source_but_a_gateway_deposit_is_earmarked`.
+				assert_eq!(
+					MockFundingInfo::<Test>::last_funding_source(),
+					Some(FundingSource::Swap { swap_request_id: SWAP_REQUEST_ID })
+				);
 			});
 	}
 
@@ -2280,7 +2285,9 @@ mod credit_flip_and_transfer {
 							.unwrap()
 					)
 				);
-				assert_eq!(FlipToBeSentToGateway::<Test>::get(), INITIAL_FLIP_FUNDING);
+				// The deficit path never funds the account, so no earmark originates here - the
+				// account's initial funding was already earmarked when the deposit was credited.
+				assert_eq!(FlipToBeSentToGateway::<Test>::get(), 0);
 			});
 	}
 }


### PR DESCRIPTION
## Summary

Fixes: PRO-3058

When opening a deposit channel with FLIP from the vault, we weren't scheduling a transfer of those funds to the gateway.

FWIW this is an accounting issue, not a vulnerability (eg. double spend). 