### PR TITLE
test: PRO-1272 pretty-print JSON in custom-rpc insta snapshots

### DIFF
--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__environment_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__environment_serialization.snap
@@ -1,5 +1,982 @@
 ---
 source: state-chain/custom-rpc/src/tests.rs
-expression: "serde_json::to_value(env).unwrap()"
+expression: to_pretty_json(&env)
 ---
-{"funding":{"minimum_funding_amount":0,"redemption_tax":0},"ingress_egress":{"boost_delays":{"Arbitrum":0,"Assethub":2,"Bitcoin":0,"Ethereum":5,"Polkadot":0,"Solana":456,"Tron":5},"boost_minimum_add_funds_amounts":{"Arbitrum":{"ETH":"0x0","USDC":"0x0","USDT":"0x0"},"Assethub":{"DOT":"0x0","USDC":"0x0","USDT":"0x0"},"Bitcoin":{"BTC":"0x2710"},"Bsc":{"BNB":"0x0","USDT":"0x0"},"Ethereum":{"CBBTC":"0x0","ETH":"0x0","FLIP":"0x0","USDC":"0x0","USDT":"0x0","WBTC":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0","USDT":"0x0"},"Tron":{"TRX":"0x0","USDT":"0x0"}},"channel_opening_fees":{"Arbitrum":1000,"Assethub":1000,"Bitcoin":0,"Ethereum":1000,"Polkadot":1000,"Solana":1000,"Tron":1000},"egress_dust_limits":{"Arbitrum":{"ETH":0,"USDC":"0xffffffffffffffff","USDT":0},"Assethub":{"DOT":0,"USDC":0,"USDT":0},"Bitcoin":{"BTC":0},"Bsc":{"BNB":10,"USDT":40},"Ethereum":{"CBBTC":0,"ETH":0,"FLIP":"0xffffffffffffffffffffffffffffffff","USDC":"0x7ffffffffffffffe","USDT":0,"WBTC":0},"Polkadot":{"DOT":0},"Solana":{"SOL":0,"USDC":0,"USDT":0},"Tron":{"TRX":0,"USDT":0}},"egress_fees":{"Arbitrum":{"ETH":0,"USDC":null,"USDT":null},"Assethub":{"DOT":"0x7ffffffffffffffe","USDC":null,"USDT":null},"Bitcoin":{"BTC":0},"Bsc":{"BNB":10,"USDT":null},"Ethereum":{"CBBTC":0,"ETH":0,"FLIP":"0xffffffffffffffffffffffffffffffff","USDC":null,"USDT":null,"WBTC":0},"Polkadot":{"DOT":"0x7ffffffffffffffe"},"Solana":{"SOL":1,"USDC":null,"USDT":null},"Tron":{"TRX":0,"USDT":null}},"ingress_delays":{"Arbitrum":5,"Assethub":2,"Bitcoin":0,"Ethereum":5,"Polkadot":2,"Solana":123,"Tron":5},"ingress_fees":{"Arbitrum":{"ETH":0,"USDC":null,"USDT":null},"Assethub":{"DOT":"0x7ffffffffffffffe","USDC":null,"USDT":null},"Bitcoin":{"BTC":0},"Bsc":{"BNB":10,"USDT":null},"Ethereum":{"CBBTC":null,"ETH":0,"FLIP":"0xffffffffffffffffffffffffffffffff","USDC":null,"USDT":null,"WBTC":null},"Polkadot":{"DOT":"0x7ffffffffffffffe"},"Solana":{"SOL":0,"USDC":null,"USDT":null},"Tron":{"TRX":0,"USDT":null}},"minimum_deposit_amounts":{"Arbitrum":{"ETH":0,"USDC":"0xffffffffffffffff","USDT":0},"Assethub":{"DOT":0,"USDC":0,"USDT":0},"Bitcoin":{"BTC":0},"Bsc":{"BNB":"0xa","USDT":"0x28"},"Ethereum":{"CBBTC":0,"ETH":0,"FLIP":"0xffffffffffffffff","USDC":"0x7ffffffffffffffe","USDT":0,"WBTC":0},"Polkadot":{"DOT":0},"Solana":{"SOL":0,"USDC":0,"USDT":0},"Tron":{"TRX":0,"USDT":0}},"witness_safety_margins":{"Arbitrum":null,"Assethub":null,"Bitcoin":3,"Ethereum":3,"Polkadot":null,"Solana":null,"Tron":null}},"pools":{"fees":{"Arbitrum":{"ETH":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Assethub":{"DOT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Bitcoin":{"BTC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Bsc":{"BNB":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Ethereum":{"CBBTC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"ETH":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"FLIP":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"WBTC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Polkadot":{"DOT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Solana":{"SOL":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDC":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}},"Tron":{"TRX":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}},"USDT":{"limit_order_fee_hundredth_pips":0,"limit_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"limit_total_swap_inputs":{"base":"0x0","quote":"0x0"},"quote_asset":{"asset":"USDC","chain":"Ethereum"},"range_order_fee_hundredth_pips":100,"range_order_total_fees_earned":{"base":"0x0","quote":"0x0"},"range_total_swap_inputs":{"base":"0x0","quote":"0x0"}}}}},"swapping":{"default_oracle_price_protection":{"Arbitrum":{"ETH":55,"USDC":25,"USDT":25},"Assethub":{"DOT":null,"USDC":25,"USDT":25},"Bitcoin":{"BTC":55},"Bsc":{"BNB":55,"USDT":25},"Ethereum":{"CBBTC":55,"ETH":55,"FLIP":null,"USDC":null,"USDT":25,"WBTC":55},"Polkadot":{"DOT":null},"Solana":{"SOL":55,"USDC":25,"USDT":25},"Tron":{"TRX":null,"USDT":25}},"max_swap_request_duration_blocks":14400,"max_swap_retry_duration_blocks":600,"maximum_swap_amounts":{"Arbitrum":{"ETH":null,"USDC":0,"USDT":0},"Assethub":{"DOT":null,"USDC":null,"USDT":null},"Bitcoin":{"BTC":0},"Bsc":{"BNB":null,"USDT":null},"Ethereum":{"CBBTC":0,"ETH":0,"FLIP":null,"USDC":"0x7ffffffffffffffe","USDT":null,"WBTC":0},"Polkadot":{"DOT":null},"Solana":{"SOL":null,"USDC":null,"USDT":null},"Tron":{"TRX":0,"USDT":null}},"minimum_chunk_size":{"Arbitrum":{"ETH":0,"USDC":101112,"USDT":0},"Assethub":{"DOT":0,"USDC":0,"USDT":0},"Bitcoin":{"BTC":789},"Bsc":{"BNB":"0xa","USDT":"0x28"},"Ethereum":{"CBBTC":789,"ETH":123,"FLIP":0,"USDC":456,"USDT":0,"WBTC":789},"Polkadot":{"DOT":0},"Solana":{"SOL":0,"USDC":0,"USDT":0},"Tron":{"TRX":0,"USDT":0}},"network_fee_hundredth_pips":1000000,"network_fees":{"internal_swap_network_fee":{"rates":{"Arbitrum":{"ETH":20000,"USDC":123000,"USDT":324000},"Assethub":{"DOT":20000,"USDC":789000,"USDT":101000},"Bitcoin":{"BTC":20000},"Bsc":{"BNB":30000,"USDT":40000},"Ethereum":{"CBBTC":20000,"ETH":20000,"FLIP":20000,"USDC":420000,"USDT":249000,"WBTC":20000},"Polkadot":{"DOT":20000},"Solana":{"SOL":20000,"USDC":456000,"USDT":561000},"Tron":{"TRX":20000,"USDT":123000}},"standard_rate_and_minimum":{"minimum":200,"rate":20000}},"regular_network_fee":{"rates":{"Arbitrum":{"ETH":1000,"USDC":1000,"USDT":1000},"Assethub":{"DOT":1000,"USDC":1000,"USDT":1000},"Bitcoin":{"BTC":40000},"Bsc":{"BNB":5000,"USDT":6000},"Ethereum":{"CBBTC":40000,"ETH":20000,"FLIP":10000,"USDC":1000,"USDT":1000,"WBTC":40000},"Polkadot":{"DOT":50000},"Solana":{"SOL":1000,"USDC":1000,"USDT":1000},"Tron":{"TRX":1000,"USDT":1000}},"standard_rate_and_minimum":{"minimum":100,"rate":1000}}},"swap_retry_delay_blocks":5}}
+{
+  "funding": {
+    "minimum_funding_amount": 0,
+    "redemption_tax": 0
+  },
+  "ingress_egress": {
+    "boost_delays": {
+      "Arbitrum": 0,
+      "Assethub": 2,
+      "Bitcoin": 0,
+      "Ethereum": 5,
+      "Polkadot": 0,
+      "Solana": 456,
+      "Tron": 5
+    },
+    "boost_minimum_add_funds_amounts": {
+      "Arbitrum": {
+        "ETH": "0x0",
+        "USDC": "0x0",
+        "USDT": "0x0"
+      },
+      "Assethub": {
+        "DOT": "0x0",
+        "USDC": "0x0",
+        "USDT": "0x0"
+      },
+      "Bitcoin": {
+        "BTC": "0x2710"
+      },
+      "Bsc": {
+        "BNB": "0x0",
+        "USDT": "0x0"
+      },
+      "Ethereum": {
+        "CBBTC": "0x0",
+        "ETH": "0x0",
+        "FLIP": "0x0",
+        "USDC": "0x0",
+        "USDT": "0x0",
+        "WBTC": "0x0"
+      },
+      "Polkadot": {
+        "DOT": "0x0"
+      },
+      "Solana": {
+        "SOL": "0x0",
+        "USDC": "0x0",
+        "USDT": "0x0"
+      },
+      "Tron": {
+        "TRX": "0x0",
+        "USDT": "0x0"
+      }
+    },
+    "channel_opening_fees": {
+      "Arbitrum": 1000,
+      "Assethub": 1000,
+      "Bitcoin": 0,
+      "Ethereum": 1000,
+      "Polkadot": 1000,
+      "Solana": 1000,
+      "Tron": 1000
+    },
+    "egress_dust_limits": {
+      "Arbitrum": {
+        "ETH": 0,
+        "USDC": "0xffffffffffffffff",
+        "USDT": 0
+      },
+      "Assethub": {
+        "DOT": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Bitcoin": {
+        "BTC": 0
+      },
+      "Bsc": {
+        "BNB": 10,
+        "USDT": 40
+      },
+      "Ethereum": {
+        "CBBTC": 0,
+        "ETH": 0,
+        "FLIP": "0xffffffffffffffffffffffffffffffff",
+        "USDC": "0x7ffffffffffffffe",
+        "USDT": 0,
+        "WBTC": 0
+      },
+      "Polkadot": {
+        "DOT": 0
+      },
+      "Solana": {
+        "SOL": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": 0
+      }
+    },
+    "egress_fees": {
+      "Arbitrum": {
+        "ETH": 0,
+        "USDC": null,
+        "USDT": null
+      },
+      "Assethub": {
+        "DOT": "0x7ffffffffffffffe",
+        "USDC": null,
+        "USDT": null
+      },
+      "Bitcoin": {
+        "BTC": 0
+      },
+      "Bsc": {
+        "BNB": 10,
+        "USDT": null
+      },
+      "Ethereum": {
+        "CBBTC": 0,
+        "ETH": 0,
+        "FLIP": "0xffffffffffffffffffffffffffffffff",
+        "USDC": null,
+        "USDT": null,
+        "WBTC": 0
+      },
+      "Polkadot": {
+        "DOT": "0x7ffffffffffffffe"
+      },
+      "Solana": {
+        "SOL": 1,
+        "USDC": null,
+        "USDT": null
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": null
+      }
+    },
+    "ingress_delays": {
+      "Arbitrum": 5,
+      "Assethub": 2,
+      "Bitcoin": 0,
+      "Ethereum": 5,
+      "Polkadot": 2,
+      "Solana": 123,
+      "Tron": 5
+    },
+    "ingress_fees": {
+      "Arbitrum": {
+        "ETH": 0,
+        "USDC": null,
+        "USDT": null
+      },
+      "Assethub": {
+        "DOT": "0x7ffffffffffffffe",
+        "USDC": null,
+        "USDT": null
+      },
+      "Bitcoin": {
+        "BTC": 0
+      },
+      "Bsc": {
+        "BNB": 10,
+        "USDT": null
+      },
+      "Ethereum": {
+        "CBBTC": null,
+        "ETH": 0,
+        "FLIP": "0xffffffffffffffffffffffffffffffff",
+        "USDC": null,
+        "USDT": null,
+        "WBTC": null
+      },
+      "Polkadot": {
+        "DOT": "0x7ffffffffffffffe"
+      },
+      "Solana": {
+        "SOL": 0,
+        "USDC": null,
+        "USDT": null
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": null
+      }
+    },
+    "minimum_deposit_amounts": {
+      "Arbitrum": {
+        "ETH": 0,
+        "USDC": "0xffffffffffffffff",
+        "USDT": 0
+      },
+      "Assethub": {
+        "DOT": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Bitcoin": {
+        "BTC": 0
+      },
+      "Bsc": {
+        "BNB": "0xa",
+        "USDT": "0x28"
+      },
+      "Ethereum": {
+        "CBBTC": 0,
+        "ETH": 0,
+        "FLIP": "0xffffffffffffffff",
+        "USDC": "0x7ffffffffffffffe",
+        "USDT": 0,
+        "WBTC": 0
+      },
+      "Polkadot": {
+        "DOT": 0
+      },
+      "Solana": {
+        "SOL": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": 0
+      }
+    },
+    "witness_safety_margins": {
+      "Arbitrum": null,
+      "Assethub": null,
+      "Bitcoin": 3,
+      "Ethereum": 3,
+      "Polkadot": null,
+      "Solana": null,
+      "Tron": null
+    }
+  },
+  "pools": {
+    "fees": {
+      "Arbitrum": {
+        "ETH": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Assethub": {
+        "DOT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Bitcoin": {
+        "BTC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Bsc": {
+        "BNB": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Ethereum": {
+        "CBBTC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "ETH": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "FLIP": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "WBTC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Polkadot": {
+        "DOT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Solana": {
+        "SOL": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDC": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      },
+      "Tron": {
+        "TRX": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        },
+        "USDT": {
+          "limit_order_fee_hundredth_pips": 0,
+          "limit_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "limit_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "quote_asset": {
+            "asset": "USDC",
+            "chain": "Ethereum"
+          },
+          "range_order_fee_hundredth_pips": 100,
+          "range_order_total_fees_earned": {
+            "base": "0x0",
+            "quote": "0x0"
+          },
+          "range_total_swap_inputs": {
+            "base": "0x0",
+            "quote": "0x0"
+          }
+        }
+      }
+    }
+  },
+  "swapping": {
+    "default_oracle_price_protection": {
+      "Arbitrum": {
+        "ETH": 55,
+        "USDC": 25,
+        "USDT": 25
+      },
+      "Assethub": {
+        "DOT": null,
+        "USDC": 25,
+        "USDT": 25
+      },
+      "Bitcoin": {
+        "BTC": 55
+      },
+      "Bsc": {
+        "BNB": 55,
+        "USDT": 25
+      },
+      "Ethereum": {
+        "CBBTC": 55,
+        "ETH": 55,
+        "FLIP": null,
+        "USDC": null,
+        "USDT": 25,
+        "WBTC": 55
+      },
+      "Polkadot": {
+        "DOT": null
+      },
+      "Solana": {
+        "SOL": 55,
+        "USDC": 25,
+        "USDT": 25
+      },
+      "Tron": {
+        "TRX": null,
+        "USDT": 25
+      }
+    },
+    "max_swap_request_duration_blocks": 14400,
+    "max_swap_retry_duration_blocks": 600,
+    "maximum_swap_amounts": {
+      "Arbitrum": {
+        "ETH": null,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Assethub": {
+        "DOT": null,
+        "USDC": null,
+        "USDT": null
+      },
+      "Bitcoin": {
+        "BTC": 0
+      },
+      "Bsc": {
+        "BNB": null,
+        "USDT": null
+      },
+      "Ethereum": {
+        "CBBTC": 0,
+        "ETH": 0,
+        "FLIP": null,
+        "USDC": "0x7ffffffffffffffe",
+        "USDT": null,
+        "WBTC": 0
+      },
+      "Polkadot": {
+        "DOT": null
+      },
+      "Solana": {
+        "SOL": null,
+        "USDC": null,
+        "USDT": null
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": null
+      }
+    },
+    "minimum_chunk_size": {
+      "Arbitrum": {
+        "ETH": 0,
+        "USDC": 101112,
+        "USDT": 0
+      },
+      "Assethub": {
+        "DOT": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Bitcoin": {
+        "BTC": 789
+      },
+      "Bsc": {
+        "BNB": "0xa",
+        "USDT": "0x28"
+      },
+      "Ethereum": {
+        "CBBTC": 789,
+        "ETH": 123,
+        "FLIP": 0,
+        "USDC": 456,
+        "USDT": 0,
+        "WBTC": 789
+      },
+      "Polkadot": {
+        "DOT": 0
+      },
+      "Solana": {
+        "SOL": 0,
+        "USDC": 0,
+        "USDT": 0
+      },
+      "Tron": {
+        "TRX": 0,
+        "USDT": 0
+      }
+    },
+    "network_fee_hundredth_pips": 1000000,
+    "network_fees": {
+      "internal_swap_network_fee": {
+        "rates": {
+          "Arbitrum": {
+            "ETH": 20000,
+            "USDC": 123000,
+            "USDT": 324000
+          },
+          "Assethub": {
+            "DOT": 20000,
+            "USDC": 789000,
+            "USDT": 101000
+          },
+          "Bitcoin": {
+            "BTC": 20000
+          },
+          "Bsc": {
+            "BNB": 30000,
+            "USDT": 40000
+          },
+          "Ethereum": {
+            "CBBTC": 20000,
+            "ETH": 20000,
+            "FLIP": 20000,
+            "USDC": 420000,
+            "USDT": 249000,
+            "WBTC": 20000
+          },
+          "Polkadot": {
+            "DOT": 20000
+          },
+          "Solana": {
+            "SOL": 20000,
+            "USDC": 456000,
+            "USDT": 561000
+          },
+          "Tron": {
+            "TRX": 20000,
+            "USDT": 123000
+          }
+        },
+        "standard_rate_and_minimum": {
+          "minimum": 200,
+          "rate": 20000
+        }
+      },
+      "regular_network_fee": {
+        "rates": {
+          "Arbitrum": {
+            "ETH": 1000,
+            "USDC": 1000,
+            "USDT": 1000
+          },
+          "Assethub": {
+            "DOT": 1000,
+            "USDC": 1000,
+            "USDT": 1000
+          },
+          "Bitcoin": {
+            "BTC": 40000
+          },
+          "Bsc": {
+            "BNB": 5000,
+            "USDT": 6000
+          },
+          "Ethereum": {
+            "CBBTC": 40000,
+            "ETH": 20000,
+            "FLIP": 10000,
+            "USDC": 1000,
+            "USDT": 1000,
+            "WBTC": 40000
+          },
+          "Polkadot": {
+            "DOT": 50000
+          },
+          "Solana": {
+            "SOL": 1000,
+            "USDC": 1000,
+            "USDT": 1000
+          },
+          "Tron": {
+            "TRX": 1000,
+            "USDT": 1000
+          }
+        },
+        "standard_rate_and_minimum": {
+          "minimum": 100,
+          "rate": 1000
+        }
+      }
+    },
+    "swap_retry_delay_blocks": 5
+  }
+}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__swap_output_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__swap_output_serialization.snap
@@ -1,5 +1,28 @@
 ---
 source: state-chain/custom-rpc/src/tests.rs
-expression: "serde_json::to_value(RpcSwapOutputV2\n{\n    output: 1_000_000_000_000_000_000u128.into(), intermediary:\n    Some(1_000_000u128.into()), network_fee: RpcFee\n    { asset: Asset::Usdc, amount: 1_000u128.into() }, ingress_fee: RpcFee\n    { asset: Asset::Flip, amount: 500u128.into() }, egress_fee: RpcFee\n    { asset: Asset::Eth, amount: 1_000_000u128.into() }, broker_commission:\n    RpcFee { asset: Asset::Usdc, amount: 100u128.into() },\n}).unwrap()"
+expression: "to_pretty_json(&RpcSwapOutputV2\n{\n    output: 1_000_000_000_000_000_000u128.into(), intermediary:\n    Some(1_000_000u128.into()), network_fee: RpcFee\n    { asset: Asset::Usdc, amount: 1_000u128.into() }, ingress_fee: RpcFee\n    { asset: Asset::Flip, amount: 500u128.into() }, egress_fee: RpcFee\n    { asset: Asset::Eth, amount: 1_000_000u128.into() }, broker_commission:\n    RpcFee { asset: Asset::Usdc, amount: 100u128.into() },\n})"
 ---
-{"broker_commission":{"amount":"0x64","asset":"USDC","chain":"Ethereum"},"egress_fee":{"amount":"0xf4240","asset":"ETH","chain":"Ethereum"},"ingress_fee":{"amount":"0x1f4","asset":"FLIP","chain":"Ethereum"},"intermediary":"0xf4240","network_fee":{"amount":"0x3e8","asset":"USDC","chain":"Ethereum"},"output":"0xde0b6b3a7640000"}
+{
+  "broker_commission": {
+    "amount": "0x64",
+    "asset": "USDC",
+    "chain": "Ethereum"
+  },
+  "egress_fee": {
+    "amount": "0xf4240",
+    "asset": "ETH",
+    "chain": "Ethereum"
+  },
+  "ingress_fee": {
+    "amount": "0x1f4",
+    "asset": "FLIP",
+    "chain": "Ethereum"
+  },
+  "intermediary": "0xf4240",
+  "network_fee": {
+    "amount": "0x3e8",
+    "asset": "USDC",
+    "chain": "Ethereum"
+  },
+  "output": "0xde0b6b3a7640000"
+}

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__swap_output_v2_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__swap_output_v2_serialization.snap
@@ -1,5 +1,28 @@
 ---
 source: state-chain/custom-rpc/src/tests.rs
-expression: "serde_json::to_value(RpcSwapOutputV2\n{\n    output: 1_000_000_000_000_000_000u128.into(), intermediary:\n    Some(1_000_000u128.into()), network_fee: RpcFee\n    { asset: Asset::Usdc, amount: 1_000u128.into() }, ingress_fee: RpcFee\n    { asset: Asset::Flip, amount: 500u128.into() }, egress_fee: RpcFee\n    { asset: Asset::Eth, amount: 1_000_000u128.into() }, broker_commission:\n    RpcFee { asset: Asset::Usdc, amount: 100u128.into() },\n}).unwrap()"
+expression: "to_pretty_json(&RpcSwapOutputV2\n{\n    output: 1_000_000_000_000_000_000u128.into(), intermediary:\n    Some(1_000_000u128.into()), network_fee: RpcFee\n    { asset: Asset::Usdc, amount: 1_000u128.into() }, ingress_fee: RpcFee\n    { asset: Asset::Flip, amount: 500u128.into() }, egress_fee: RpcFee\n    { asset: Asset::Eth, amount: 1_000_000u128.into() }, broker_commission:\n    RpcFee { asset: Asset::Usdc, amount: 100u128.into() },\n})"
 ---
-{"broker_commission":{"amount":"0x64","asset":"USDC","chain":"Ethereum"},"egress_fee":{"amount":"0xf4240","asset":"ETH","chain":"Ethereum"},"ingress_fee":{"amount":"0x1f4","asset":"FLIP","chain":"Ethereum"},"intermediary":"0xf4240","network_fee":{"amount":"0x3e8","asset":"USDC","chain":"Ethereum"},"output":"0xde0b6b3a7640000"}
+{
+  "broker_commission": {
+    "amount": "0x64",
+    "asset": "USDC",
+    "chain": "Ethereum"
+  },
+  "egress_fee": {
+    "amount": "0xf4240",
+    "asset": "ETH",
+    "chain": "Ethereum"
+  },
+  "ingress_fee": {
+    "amount": "0x1f4",
+    "asset": "FLIP",
+    "chain": "Ethereum"
+  },
+  "intermediary": "0xf4240",
+  "network_fee": {
+    "amount": "0x3e8",
+    "asset": "USDC",
+    "chain": "Ethereum"
+  },
+  "output": "0xde0b6b3a7640000"
+}

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -86,6 +86,17 @@ use sp_runtime::{AccountId32, FixedU64};
 const ID_1: AccountId32 = AccountId32::new([1; 32]);
 const ID_2: AccountId32 = AccountId32::new([2; 32]);
 
+/// Pretty-print a value as JSON, for snapshots that would otherwise be squashed onto a single
+/// line.
+///
+/// Goes via [`serde_json::Value`] rather than serializing directly: some of our types are backed
+/// by hash maps, so serializing them directly yields a non-deterministic key order, whereas
+/// `Value`'s map is sorted. Note also that `insta::assert_json_snapshot!` is not equivalent - it
+/// uses insta's own serializer instead of serde_json.
+pub fn to_pretty_json<T: Serialize>(value: &T) -> String {
+	serde_json::to_string_pretty(&serde_json::to_value(value).unwrap()).unwrap()
+}
+
 fn asset_map<T: Clone>(v: T) -> any::AssetMap<T> {
 	any::AssetMap {
 		eth: eth::AssetMap {
@@ -434,7 +445,7 @@ fn test_environment_serialization() {
 		},
 	};
 
-	insta::assert_snapshot!(serde_json::to_value(env).unwrap());
+	insta::assert_snapshot!(to_pretty_json(&env));
 }
 
 #[test]
@@ -508,15 +519,14 @@ fn test_boost_fees_serialization() {
 
 #[test]
 fn test_swap_output_serialization() {
-	insta::assert_snapshot!(serde_json::to_value(RpcSwapOutputV2 {
+	insta::assert_snapshot!(to_pretty_json(&RpcSwapOutputV2 {
 		output: 1_000_000_000_000_000_000u128.into(),
 		intermediary: Some(1_000_000u128.into()),
 		network_fee: RpcFee { asset: Asset::Usdc, amount: 1_000u128.into() },
 		ingress_fee: RpcFee { asset: Asset::Flip, amount: 500u128.into() },
 		egress_fee: RpcFee { asset: Asset::Eth, amount: 1_000_000u128.into() },
 		broker_commission: RpcFee { asset: Asset::Usdc, amount: 100u128.into() },
-	})
-	.unwrap());
+	}));
 }
 
 #[test]
@@ -543,15 +553,14 @@ fn test_vault_addresses_custom_rpc() {
 
 #[test]
 fn swap_output_v2_serialization() {
-	insta::assert_snapshot!(serde_json::to_value(RpcSwapOutputV2 {
+	insta::assert_snapshot!(to_pretty_json(&RpcSwapOutputV2 {
 		output: 1_000_000_000_000_000_000u128.into(),
 		intermediary: Some(1_000_000u128.into()),
 		network_fee: RpcFee { asset: Asset::Usdc, amount: 1_000u128.into() },
 		ingress_fee: RpcFee { asset: Asset::Flip, amount: 500u128.into() },
 		egress_fee: RpcFee { asset: Asset::Eth, amount: 1_000_000u128.into() },
 		broker_commission: RpcFee { asset: Asset::Usdc, amount: 100u128.into() },
-	})
-	.unwrap());
+	}));
 }
 
 #[test]

--- a/state-chain/custom-rpc/src/tests/before_v7/account_info.rs
+++ b/state-chain/custom-rpc/src/tests/before_v7/account_info.rs
@@ -20,11 +20,10 @@ use state_chain_runtime::runtime_apis::types::{
 
 #[test]
 fn test_no_account_serialization() {
-	insta::assert_snapshot!(serde_json::to_value(RpcAccountInfoBeforeV7::unregistered(
+	insta::assert_snapshot!(to_pretty_json(&RpcAccountInfoBeforeV7::unregistered(
 		0,
 		any::AssetMap::default()
-	))
-	.unwrap());
+	)));
 }
 
 #[test]
@@ -121,7 +120,7 @@ fn test_lp_serialization() {
 		0,
 	);
 
-	insta::assert_snapshot!(serde_json::to_value(lp).unwrap());
+	insta::assert_snapshot!(to_pretty_json(&lp));
 }
 
 #[test]
@@ -143,5 +142,5 @@ fn test_validator_serialization() {
 		estimated_redeemable_balance: 0,
 	});
 
-	insta::assert_snapshot!(serde_json::to_value(validator).unwrap());
+	insta::assert_snapshot!(to_pretty_json(&validator));
 }

--- a/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__lp_serialization.snap
+++ b/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__lp_serialization.snap
@@ -1,5 +1,140 @@
 ---
 source: state-chain/custom-rpc/src/tests/before_v7/account_info.rs
-expression: "serde_json::to_value(lp).unwrap()"
+expression: to_pretty_json(&lp)
 ---
-{"balances":{"Arbitrum":{"ETH":"0x1","USDC":"0x2","USDT":"0x0"},"Assethub":{"DOT":"0x0","USDC":"0x0","USDT":"0x0"},"Bitcoin":{"BTC":"0x0"},"Bsc":{"BNB":"0x0","USDT":"0x0"},"Ethereum":{"CBBTC":"0x0","ETH":"0xffffffffffffffffffffffffffffffff","FLIP":"0x7fffffffffffffffffffffffffffffff","USDC":"0x0","USDT":"0x0","WBTC":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x3","USDC":"0x4","USDT":"0x0"},"Tron":{"TRX":"0x0","USDT":"0x0"}},"boost_balances":{"Arbitrum":{"ETH":[],"USDC":[],"USDT":[]},"Assethub":{"DOT":[],"USDC":[],"USDT":[]},"Bitcoin":{"BTC":[{"available_balance":"0x2faf080","fee_tier":5,"in_use_balance":"0x2faf080","is_withdrawing":false,"total_balance":"0x5f5e100"}]},"Bsc":{"BNB":[],"USDT":[]},"Ethereum":{"CBBTC":[],"ETH":[],"FLIP":[],"USDC":[],"USDT":[],"WBTC":[]},"Polkadot":{"DOT":[]},"Solana":{"SOL":[],"USDC":[],"USDT":[]},"Tron":{"TRX":[],"USDT":[]}},"earned_fees":{"Arbitrum":{"ETH":"0x1","USDC":"0x2","USDT":"0x3"},"Assethub":{"DOT":"0x0","USDC":"0x0","USDT":"0x0"},"Bitcoin":{"BTC":"0x0"},"Bsc":{"BNB":"0xa","USDT":"0x28"},"Ethereum":{"CBBTC":"0x0","ETH":"0x0","FLIP":"0xffffffffffffffff","USDC":"0x7ffffffffffffffe","USDT":"0x0","WBTC":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x2","USDC":"0x4","USDT":"0x6"},"Tron":{"TRX":"0x0","USDT":"0x0"}},"flip_balance":"0x0","refund_addresses":{"Arbitrum":"0x0202020202020202020202020202020202020202","Bitcoin":null,"Ethereum":"0x0101010101010101010101010101010101010101","Polkadot":"111111111111111111111111111111111HC1","Solana":null},"role":"liquidity_provider"}
+{
+  "balances": {
+    "Arbitrum": {
+      "ETH": "0x1",
+      "USDC": "0x2",
+      "USDT": "0x0"
+    },
+    "Assethub": {
+      "DOT": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Bitcoin": {
+      "BTC": "0x0"
+    },
+    "Bsc": {
+      "BNB": "0x0",
+      "USDT": "0x0"
+    },
+    "Ethereum": {
+      "CBBTC": "0x0",
+      "ETH": "0xffffffffffffffffffffffffffffffff",
+      "FLIP": "0x7fffffffffffffffffffffffffffffff",
+      "USDC": "0x0",
+      "USDT": "0x0",
+      "WBTC": "0x0"
+    },
+    "Polkadot": {
+      "DOT": "0x0"
+    },
+    "Solana": {
+      "SOL": "0x3",
+      "USDC": "0x4",
+      "USDT": "0x0"
+    },
+    "Tron": {
+      "TRX": "0x0",
+      "USDT": "0x0"
+    }
+  },
+  "boost_balances": {
+    "Arbitrum": {
+      "ETH": [],
+      "USDC": [],
+      "USDT": []
+    },
+    "Assethub": {
+      "DOT": [],
+      "USDC": [],
+      "USDT": []
+    },
+    "Bitcoin": {
+      "BTC": [
+        {
+          "available_balance": "0x2faf080",
+          "fee_tier": 5,
+          "in_use_balance": "0x2faf080",
+          "is_withdrawing": false,
+          "total_balance": "0x5f5e100"
+        }
+      ]
+    },
+    "Bsc": {
+      "BNB": [],
+      "USDT": []
+    },
+    "Ethereum": {
+      "CBBTC": [],
+      "ETH": [],
+      "FLIP": [],
+      "USDC": [],
+      "USDT": [],
+      "WBTC": []
+    },
+    "Polkadot": {
+      "DOT": []
+    },
+    "Solana": {
+      "SOL": [],
+      "USDC": [],
+      "USDT": []
+    },
+    "Tron": {
+      "TRX": [],
+      "USDT": []
+    }
+  },
+  "earned_fees": {
+    "Arbitrum": {
+      "ETH": "0x1",
+      "USDC": "0x2",
+      "USDT": "0x3"
+    },
+    "Assethub": {
+      "DOT": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Bitcoin": {
+      "BTC": "0x0"
+    },
+    "Bsc": {
+      "BNB": "0xa",
+      "USDT": "0x28"
+    },
+    "Ethereum": {
+      "CBBTC": "0x0",
+      "ETH": "0x0",
+      "FLIP": "0xffffffffffffffff",
+      "USDC": "0x7ffffffffffffffe",
+      "USDT": "0x0",
+      "WBTC": "0x0"
+    },
+    "Polkadot": {
+      "DOT": "0x0"
+    },
+    "Solana": {
+      "SOL": "0x2",
+      "USDC": "0x4",
+      "USDT": "0x6"
+    },
+    "Tron": {
+      "TRX": "0x0",
+      "USDT": "0x0"
+    }
+  },
+  "flip_balance": "0x0",
+  "refund_addresses": {
+    "Arbitrum": "0x0202020202020202020202020202020202020202",
+    "Bitcoin": null,
+    "Ethereum": "0x0101010101010101010101010101010101010101",
+    "Polkadot": "111111111111111111111111111111111HC1",
+    "Solana": null
+  },
+  "role": "liquidity_provider"
+}

--- a/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__no_account_serialization.snap
+++ b/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__no_account_serialization.snap
@@ -1,5 +1,47 @@
 ---
 source: state-chain/custom-rpc/src/tests/before_v7/account_info.rs
-expression: "serde_json::to_value(RpcAccountInfoBeforeV7::unregistered(0,\nany::AssetMap::default())).unwrap()"
+expression: "to_pretty_json(&RpcAccountInfoBeforeV7::unregistered(0,\nany::AssetMap::default()))"
 ---
-{"asset_balances":{"Arbitrum":{"ETH":"0x0","USDC":"0x0","USDT":"0x0"},"Assethub":{"DOT":"0x0","USDC":"0x0","USDT":"0x0"},"Bitcoin":{"BTC":"0x0"},"Bsc":{"BNB":"0x0","USDT":"0x0"},"Ethereum":{"CBBTC":"0x0","ETH":"0x0","FLIP":"0x0","USDC":"0x0","USDT":"0x0","WBTC":"0x0"},"Polkadot":{"DOT":"0x0"},"Solana":{"SOL":"0x0","USDC":"0x0","USDT":"0x0"},"Tron":{"TRX":"0x0","USDT":"0x0"}},"flip_balance":"0x0","role":"unregistered"}
+{
+  "asset_balances": {
+    "Arbitrum": {
+      "ETH": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Assethub": {
+      "DOT": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Bitcoin": {
+      "BTC": "0x0"
+    },
+    "Bsc": {
+      "BNB": "0x0",
+      "USDT": "0x0"
+    },
+    "Ethereum": {
+      "CBBTC": "0x0",
+      "ETH": "0x0",
+      "FLIP": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0",
+      "WBTC": "0x0"
+    },
+    "Polkadot": {
+      "DOT": "0x0"
+    },
+    "Solana": {
+      "SOL": "0x0",
+      "USDC": "0x0",
+      "USDT": "0x0"
+    },
+    "Tron": {
+      "TRX": "0x0",
+      "USDT": "0x0"
+    }
+  },
+  "flip_balance": "0x0",
+  "role": "unregistered"
+}

--- a/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__validator_serialization.snap
+++ b/state-chain/custom-rpc/src/tests/before_v7/snapshots/custom_rpc__tests__before_v7__account_info__validator_serialization.snap
@@ -1,5 +1,25 @@
 ---
 source: state-chain/custom-rpc/src/tests/before_v7/account_info.rs
-expression: "serde_json::to_value(validator).unwrap()"
+expression: to_pretty_json(&validator)
 ---
-{"apy_bp":100,"bond":"0xde0b6b3a7640000","bound_redeem_address":"0x0101010101010101010101010101010101010101","estimated_redeemable_balance":"0x0","flip_balance":"0xde0b6b3a7640000","is_bidding":false,"is_current_authority":true,"is_current_backup":false,"is_online":true,"is_qualified":true,"keyholder_epochs":[123],"last_heartbeat":0,"reputation_points":0,"restricted_balances":{"0x0101010101010101010101010101010101010101":"0xde0b6b3a7640000"},"role":"validator"}
+{
+  "apy_bp": 100,
+  "bond": "0xde0b6b3a7640000",
+  "bound_redeem_address": "0x0101010101010101010101010101010101010101",
+  "estimated_redeemable_balance": "0x0",
+  "flip_balance": "0xde0b6b3a7640000",
+  "is_bidding": false,
+  "is_current_authority": true,
+  "is_current_backup": false,
+  "is_online": true,
+  "is_qualified": true,
+  "keyholder_epochs": [
+    123
+  ],
+  "last_heartbeat": 0,
+  "reputation_points": 0,
+  "restricted_balances": {
+    "0x0101010101010101010101010101010101010101": "0xde0b6b3a7640000"
+  },
+  "role": "validator"
+}


### PR DESCRIPTION
# Pull Request

Closes: [PRO-1272](https://linear.app/chainflip/issue/PRO-1272/cargo-insta-should-use-pretty-formatting)

## Summary

Six `insta::assert_snapshot!(serde_json::to_value(..))` call sites in `custom-rpc` squashed their entire JSON payload onto a single line, so any snapshot diff was unreadable. `custom_rpc__tests__environment_serialization.snap` was a single ~978-key line.

This adds a `to_pretty_json` test helper in `state-chain/custom-rpc/src/tests.rs` and switches those call sites to it. The regenerated snapshots are **pure reformatting** — keys, values and ordering are all unchanged (verified, see below).

### Judgement calls

**The helper goes via `serde_json::Value` rather than serializing directly.** My first attempt used `serde_json::to_string_pretty(&value)` — matching the `to_string_pretty` call sites already present in these files — but that turned out to make two of the tests **flaky**: `test_lp_serialization` and `test_environment_serialization` failed intermittently with keys in a different order. Some of these types are backed by hash maps, so serializing them directly yields a non-deterministic key order. `serde_json::Value`'s map is a sorted `BTreeMap`, which is what made the original `to_value` snapshots stable. Routing through `Value` keeps that determinism and matches the approach suggested on the Linear issue, as well as the existing `insta_assert_json_pretty!` macro in `utilities/scale-json/src/test.rs`.

**`insta::assert_json_snapshot!` is deliberately not used.** It relies on insta's own serializer rather than serde_json, so its output can differ from what the RPC actually emits. This is noted on the issue and is documented in the helper's doc comment.

**Pre-existing call sites left alone.** The existing `assert_json_snapshot!` and direct `to_string_pretty(&..)` call sites elsewhere in these files are untouched to keep the diff scoped. Worth flagging for a reviewer though: given the flakiness described above, the direct `to_string_pretty(&wrapper)` call sites in `src/tests/account_info.rs` are theoretically exposed to the same non-deterministic ordering if any of their types are ever backed by a hash map. They pass consistently today, so I have not changed them.

## API Changes

None. This is test-only — no runtime, RPC or type changes.

### RPCS

No changes. The snapshots' JSON content is byte-for-byte equivalent modulo whitespace, including the `before_v7` wire-compatibility snapshots.

### Extrinsics & Events

No changes.

## Verification

Exact commands run and their observed results:

| Command | Result |
| --- | --- |
| `cargo fmt --all` | Clean; touched only the two files edited here |
| `cargo test -p custom-rpc --no-run` | `Finished` — compiles, exit 0 |
| `cargo test -p custom-rpc` | `test result: ok. 61 passed; 0 failed; 0 ignored` |
| `cargo test -p custom-rpc` ×5 more | `ok. 61 passed; 0 failed` every run (determinism check) |
| `cargo clippy -p custom-rpc --all-targets -- -D warnings -A deprecated -W clippy::allow_attributes` | `Finished`, exit 0 |

Snapshots were regenerated with `INSTA_FORCE_UPDATE=1 cargo test -p custom-rpc`. That flag also strips stale `assertion_line:` metadata from three unrelated snapshots (`auction_state_serialization`, `vault_swap_details_serialization-2`/`-3`); those were reverted to keep the diff scoped.

To confirm the snapshot changes are purely presentational, each changed `.snap` payload was parsed as JSON and compared against its version at `HEAD`, both for deep equality and for key order (via `object_pairs_hook`). All six were identical on both counts.

Note: the build needed `apt-get install protobuf-compiler` in this environment — `litep2p`'s build script requires `protoc`. That is an environment gap, not something this PR changes.

## Not verified

- Full-workspace `cargo build` / `cargo test` — not attempted; only `custom-rpc` was built and tested.
- `cargo cf-clippy` across the workspace with the full feature set (`runtime-benchmarks,try-runtime,runtime-integration-tests,slow-tests`) — only `custom-rpc` was linted, with the same lint flags.
- Runtime integration tests, bouncer/E2E tests, benchmarks, try-runtime — none run, and none appear relevant to a test-only formatting change.
- No CI run observed at the time of opening.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions. *(this PR is test-only; existing snapshot tests all pass)*
    * [ ] Proptests for important invariants. *(n/a)*
    * [ ] Integration tests for runtime-wide behaviours. *(n/a)*
    * [ ] Bouncer tests for E2E features involving external chains. *(n/a)*
  * [x] Benchmarks: did you leave any dangling placeholders? *(none — no extrinsics touched)*
  * [x] Migrations: if you wrote one, did you test it using try-runtime? *(no migration)*
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this. *(no runtime types changed)*
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits. *(no unrelated changes)*
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.

Opened autonomously by a scheduled Claude Code routine. Needs human review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vex6AuZ5LhShpMHKrnwX9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vex6AuZ5LhShpMHKrnwX9b)_