### PR TITLE
chore: Improve engine logs

### DIFF
--- a/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
+++ b/engine/sc-client/src/extrinsic_api/signed/submission_watcher.rs
@@ -351,7 +351,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 						tx_hash,
 						Some(transaction_status_stream),
 					);
-					info!(target: "state_chain_client", request_id = request.id, submission_id = submission_id, "Submission succeeded");
+					debug!(target: "state_chain_client", request_id = request.id, submission_id = submission_id, "Submission succeeded");
 					break Ok(Ok(tx_hash))
 				},
 				Err(rpc_err) => {
@@ -853,7 +853,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 								extrinsic_index as usize,
 								block_hash,
 							);
-							info!(target: "state_chain_client", request_id = matching_request.id, submission_id = submission.id, "Request found in finalized block with hash {block_hash:?}, tx_hash {tx_hash:?}, and extrinsic index {extrinsic_index}.");
+							debug!(target: "state_chain_client", request_id = matching_request.id, submission_id = submission.id, "Request found in finalized block with hash {block_hash:?}, tx_hash {tx_hash:?}, and extrinsic index {extrinsic_index}.");
 							if let Some(until_in_block_sender) =
 								matching_request.until_in_block_sender
 							{
@@ -885,7 +885,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 
 					if !alive {
 						any_submission_expired = true;
-						info!(target: "state_chain_client", request_id = submission.request_id, submission_id = submission.id, "Submission has timed out.");
+						warn!(target: "state_chain_client", request_id = submission.request_id, submission_id = submission.id, "Submission has timed out.");
 						if let Some(request) = requests.get_mut(&submission.request_id) {
 							request.pending_submissions.remove(&submission.id).unwrap();
 						}
@@ -909,7 +909,7 @@ impl<'a, 'env, BaseRpcClient: base_rpc_api::BaseRpcApi + Send + Sync + 'static>
 					(!request.resubmit_window.contains(&(block.header.number + 1)) ||
 						request.strictly_one_submission)
 			}) {
-				info!(target: "state_chain_client", request_id = request.id, "Request has timed out.");
+				warn!(target: "state_chain_client", request_id = request.id, "Request has timed out.");
 				if let Some(until_in_block_sender) = request.until_in_block_sender {
 					let _result = until_in_block_sender
 						.send(Err(ExtrinsicError::Other(InBlockError::NotInBlock)));

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -467,9 +467,9 @@ where
 
 							let error_message = format!("Retrier {name}: Error for request `{request_log}` with id `{request_id}` requested with `{primary_or_backup:?}`, attempt `{attempt}`: {e}. Delaying for {:?}", sleep_duration);
 							if attempt == 0 && !matches!(retry_limit, RetryLimit::Limit(1)) {
-								tracing::debug!(error_message);
+								tracing::debug!(retrier = name, "{error_message}");
 							} else {
-								tracing::warn!(error_message);
+								tracing::warn!(retrier = name, "{error_message}");
 							}
 
 							client_selector.request_failed(primary_or_backup);

--- a/utilities/src/with_std/task_scope.rs
+++ b/utilities/src/with_std/task_scope.rs
@@ -324,7 +324,7 @@ impl TaskProperties {
 	) {
 		match &result {
 			Ok(result) => match result {
-				Ok(_) => tracing::info!(
+				Ok(_) => tracing::debug!(
 					target: "task_scope",
 					"child task #{} ended: '{}'",
 					self.task_id,
@@ -653,7 +653,7 @@ impl<Error: Debug + Send + 'static> Stream for ScopeResultStream<Error> {
 				Pin::new(&mut self.as_mut().receiver.as_mut().unwrap()).poll_next(cx)
 			{
 				if let Some((properties, future)) = option {
-					tracing::info!(
+					tracing::debug!(
 						target: "task_scope",
 						"child task #{} started: '{}'",
 						properties.task_id,


### PR DESCRIPTION
# Pull Request

## Summary

I had Claude analyze some mainnet logs and see what can be improved (some of these I wanted to do for a long time). Here are some lower hanging fruit:

- taks_scope's start/end: 66% of all logs (~700k lines per day) are these task scope logs which are almost entirely useless for an operator; changed level from info to debug.
- Changed the level of successful extrincis submission (from info to debug), while at the same time changed unsuccessful sumission from info to warn. Success can be inferred from the absence of errors (time out is one of them), so these success lines are just noise. Removes ~200k lines per day.
- Retrier errors were printed with the message put under the `error_message` property, which is inconsistent with all other logs where `message` is expected instead. This was due to incorrect syntax and seemed unintentional. Fixed now.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [ ] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [ ] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [ ] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [ ] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
