### PR TITLE
test: PRO-1534 use non-default key in broadcast tests

### DIFF
--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -20,10 +20,10 @@ use core::cmp::max;
 
 use crate::{
 	mock::*, AbortedBroadcasts, AggKey, AwaitingBroadcast, BroadcastBarriers, BroadcastId,
-	BroadcastIdToTransactionOutIds, ChainBlockNumberFor, DelayedBroadcastRetryQueue, Error,
-	Event as BroadcastEvent, Event, FailedBroadcasters, Instance1, PalletConfigUpdate,
-	PalletOffence, PendingApiCalls, PendingBroadcasts, Timeouts, TransactionMetadata,
-	TransactionOutIdToBroadcastId,
+	BroadcastIdToTransactionOutIds, ChainBlockNumberFor, CurrentOnChainKey,
+	DelayedBroadcastRetryQueue, Error, Event as BroadcastEvent, Event, FailedBroadcasters,
+	IncomingKeyAndBroadcastId, Instance1, PalletConfigUpdate, PalletOffence, PendingApiCalls,
+	PendingBroadcasts, Timeouts, TransactionMetadata, TransactionOutIdToBroadcastId,
 };
 use cf_chains::{
 	mocks::{
@@ -88,6 +88,10 @@ const SIG3: <MockEthereumChainCrypto as ChainCrypto>::ThresholdSignature =
 
 const SIG4: <MockEthereumChainCrypto as ChainCrypto>::ThresholdSignature =
 	MockThresholdSignature { signing_key: MockAggKey([0xdd; 4]), signed_payload: [0xdd; 4] };
+
+/// Key handed over by a rotation broadcast. Deliberately not `Default::default()`: the key
+/// storage would otherwise decode to the same value whether or not the pallet wrote to it.
+const NEW_AGG_KEY: AggKey<Test, Instance1> = MockAggKey(*b"newk");
 
 struct MockCfe;
 
@@ -708,7 +712,7 @@ fn broadcast_barrier_for_polkadot() {
 			let broadcast_id_2 = initiate_and_sign_broadcast(
 				&mock_api_call(),
 				SIG2,
-				TxType::Rotation { new_key: Default::default() },
+				TxType::Rotation { new_key: NEW_AGG_KEY },
 			);
 			// tx2 emits broadcast request and also pauses any further new broadcast requests
 			assert_transaction_broadcast_request_event(broadcast_id_2, SIG2);
@@ -766,7 +770,7 @@ fn broadcast_barrier_for_bitcoin() {
 		let broadcast_id_2 = initiate_and_sign_broadcast(
 			&mock_api_call(),
 			SIG2,
-			TxType::Rotation { new_key: Default::default() },
+			TxType::Rotation { new_key: NEW_AGG_KEY },
 		);
 		// tx2 emits broadcast request and does not pause future broadcasts in bitcoin
 		assert_transaction_broadcast_request_event(broadcast_id_2, SIG2);
@@ -802,7 +806,7 @@ fn broadcast_barrier_for_ethereum() {
 			let broadcast_id_3 = initiate_and_sign_broadcast(
 				&mock_api_call(),
 				SIG3,
-				TxType::Rotation { new_key: Default::default() },
+				TxType::Rotation { new_key: NEW_AGG_KEY },
 			);
 
 			// tx3 is ready for broadcast but since there is a broadcast pause, broadcast request is
@@ -1489,7 +1493,7 @@ fn should_release_barriers_correctly_in_case_of_rotation_tx_succeeding_first() {
 		let broadcast_id_2 = initiate_and_sign_broadcast(
 			&mock_api_call(),
 			SIG2,
-			TxType::Rotation { new_key: Default::default() },
+			TxType::Rotation { new_key: NEW_AGG_KEY },
 		);
 
 		// the rotation tx should create barriers on both txs
@@ -1520,6 +1524,36 @@ fn should_release_barriers_correctly_in_case_of_rotation_tx_succeeding_first() {
 		));
 
 		assert_eq!(BroadcastBarriers::<Test, Instance1>::get(), BTreeSet::new());
+	});
+}
+
+#[test]
+fn incoming_key_is_activated_by_its_own_rotation_broadcast() {
+	new_test_ext().execute_with(|| {
+		// No barriers, so the broadcasts can be witnessed in any order.
+		MockBroadcastBarriers::set(&ChainChoice::Bitcoin);
+
+		let rotation_broadcast_id = initiate_and_sign_broadcast(
+			&mock_api_call(),
+			SIG1,
+			TxType::Rotation { new_key: NEW_AGG_KEY },
+		);
+		let other_broadcast_id = initiate_and_sign_broadcast(&mock_api_call(), SIG2, TxType::Normal);
+
+		assert_eq!(
+			IncomingKeyAndBroadcastId::<Test, Instance1>::get(),
+			Some((NEW_AGG_KEY, rotation_broadcast_id))
+		);
+		assert_ne!(rotation_broadcast_id, other_broadcast_id);
+		assert_eq!(CurrentOnChainKey::<Test, Instance1>::get(), None);
+
+		// Any other broadcast succeeding must not activate the incoming key.
+		witness_broadcast(SIG2);
+		assert_eq!(CurrentOnChainKey::<Test, Instance1>::get(), None);
+
+		witness_broadcast(SIG1);
+		assert_eq!(CurrentOnChainKey::<Test, Instance1>::get(), Some(NEW_AGG_KEY));
+		assert!(!IncomingKeyAndBroadcastId::<Test, Instance1>::exists());
 	});
 }
 

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -1538,7 +1538,8 @@ fn incoming_key_is_activated_by_its_own_rotation_broadcast() {
 			SIG1,
 			TxType::Rotation { new_key: NEW_AGG_KEY },
 		);
-		let other_broadcast_id = initiate_and_sign_broadcast(&mock_api_call(), SIG2, TxType::Normal);
+		let other_broadcast_id =
+			initiate_and_sign_broadcast(&mock_api_call(), SIG2, TxType::Normal);
 
 		assert_eq!(
 			IncomingKeyAndBroadcastId::<Test, Instance1>::get(),


### PR DESCRIPTION
# Pull Request

Closes: [PRO-1534](https://linear.app/chainflip/issue/PRO-1534/use-non-default-key-in-broadcast-tests)

## Summary

The broadcast pallet tests passed `Default::default()` as the new aggregate key whenever they initiated a rotation broadcast (`TxType::Rotation { new_key: Default::default() }`). As PRO-1534 notes, using default values as test inputs invites false positives — here the key is written to `IncomingKeyAndBroadcastId` and later promoted to `CurrentOnChainKey`, and neither storage item was asserted on anywhere in the pallet's tests.

Changes:

* Introduce a named, non-default key constant `NEW_AGG_KEY` and use it in the four rotation broadcasts in `tests.rs`.
* Add `incoming_key_is_activated_by_its_own_rotation_broadcast`, which covers the key hand-over that the default key was masking: the incoming key is stored against the rotation broadcast id, is *not* activated when some other broadcast succeeds first, and becomes `CurrentOnChainKey` (clearing `IncomingKeyAndBroadcastId`) once its own broadcast is witnessed.

Judgement calls:

* Scope is kept to the broadcast pallet, matching the issue title. The issue also observes that `Default::default()` is used as a test value in other places; those are left alone.
* Other `Default::default()` arguments in these tests (transaction payloads, signer ids, block numbers) are not keys and are untouched.
* No production code is changed, so there are no API, RPC, extrinsic or event changes.

## API Changes

None — test-only change.

### RPCS

None.

### Extrinsics & Events

None.

## Verification

Run locally on this branch:

* `cargo fmt --all` — clean; the only reformatting was inside the file this PR touches.
* `cargo check -p pallet-cf-broadcast --tests` — passed (`CHECK_EXIT=0`).
* `cargo clippy -p pallet-cf-broadcast --tests` — passed with no warnings for this crate (`CLIPPY_EXIT=0`).
* `cargo test -p pallet-cf-broadcast` — passed: `43 passed; 0 failed; 0 ignored`, including the new test. (`cargo-nextest` is not installed in this environment, so `cargo test` was used instead of `cargo nextest run`.)

I also sanity-checked that the new test is not vacuous: temporarily relaxing the `rotation_broadcast_id == broadcast_id` guard in `transaction_succeeded` (so any successful broadcast activates the incoming key) makes `incoming_key_is_activated_by_its_own_rotation_broadcast` fail, and the change was reverted afterwards.

## Not verified

* Full-workspace `cargo build` / `cargo test` — not run (cold build does not fit this environment).
* Runtime integration tests (`cf-integration-tests`) — not run.
* Bouncer / E2E tests — not run.
* Runtime benchmarks — not run (no benchmark or weight changes in this PR).
* CI as a whole — relying on the PR's own CI run.

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants. — n/a
    * [ ] Integration tests for runtime-wide behaviours. — n/a
    * [ ] Bouncer tests for E2E features involving external chains. — n/a
* [x] Benchmarks: no placeholders; no benchmark changes.
* [x] Migrations: none.
* [x] Bouncer typegen: no runtime type changes.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits (the `cargo fmt` result is its own commit).
  * [x] Anything non-obvious is documented in the `Summary` section above.

Opened autonomously by a scheduled Claude Code routine. Needs human review before marking ready.


---
_Generated by [Claude Code](https://claude.ai/code/session_019g8hNxZ1hNYTuX2ySpGiWN)_