### PR TITLE
fix: cargo audit RUSTSEC-2026-0258

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -85,6 +85,7 @@ tree --no-default-features --depth 1 --edges=features,normal
 # - RUSTSEC-2026-0186: Unsound pointer arithmetic in memmap2. Transitive dependency of parity-db - out of our control.
 # - RUSTSEC-2026-0222: Wasmtime type-index mixup between multiple engines. Low severity embedder-API-misuse issue; we only execute the trusted runtime wasm and don't control the wasmtime version (pinned by polkadot-sdk). Dependency of substrate.
 # - RUSTSEC-2026-0253: Unsoundness in `lru::LruCache::pop()` when the key's `Drop` panics. Our own dependency is on the patched 0.18.2; the remaining 0.12.5 is pinned by libp2p, where `libp2p-identify` doesn't use `lru` at all and `libp2p-swarm`'s only `pop()` is keyed by `Multiaddr`, which has no `Drop` impl.
+# - RUSTSEC-2026-0258: h2 unbounded empty DATA frames. Low severity DoS. Patched where possible, but still some transitive dependencies are unpatched.
 
 #
 cf-audit = '''
@@ -137,6 +138,7 @@ audit -D unmaintained -D unsound
 	--ignore RUSTSEC-2026-0186
 	--ignore RUSTSEC-2026-0222
 	--ignore RUSTSEC-2026-0253
+	--ignore RUSTSEC-2026-0258
 '''
 
 [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
  "cfg_aliases 0.2.1",
- "hashbrown 0.15.5",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1714,7 +1714,7 @@ dependencies = [
  "parity-scale-codec",
  "proptest",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "scale-decode",
  "scale-info",
  "scale-json",
@@ -2171,7 +2171,7 @@ dependencies = [
  "parity-scale-codec",
  "pin-project",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "rlp 0.5.2",
  "rocksdb",
  "sc-rpc-api",
@@ -3414,7 +3414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3932,7 +3932,7 @@ dependencies = [
  "engine-proc-macros",
  "engine-upgrade-utils",
  "predicates",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "tempfile",
 ]
 
@@ -4112,7 +4112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5587,9 +5587,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5711,41 +5711,17 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core 0.2.0",
- "http 0.2.12",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "headers-core 0.3.0",
+ "headers-core",
  "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http 0.2.12",
 ]
 
 [[package]]
@@ -6058,7 +6034,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -6101,6 +6077,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -6114,19 +6091,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -6163,9 +6127,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -6569,7 +6535,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7489,7 +7455,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -8059,24 +8025,6 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid 1.21.0",
-]
-
-[[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin 0.9.8",
- "version_check",
 ]
 
 [[package]]
@@ -10821,7 +10769,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -11011,7 +10959,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11339,12 +11287,10 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -11356,14 +11302,13 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -11375,18 +11320,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-tls 0.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -11394,6 +11347,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
@@ -11401,6 +11355,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -11617,7 +11572,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15578,7 +15533,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15868,19 +15823,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
- "webpki-roots",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -16010,7 +15953,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -16275,25 +16218,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
@@ -16525,7 +16449,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "scale-info",
  "scale-json",
  "scopeguard",
@@ -16686,20 +16610,19 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+checksum = "c0a808122a8a77eecdabaefd88ddb1913c4be5ea1465399f63ba64c7aa705fea"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
- "headers 0.3.9",
- "http 0.2.12",
- "hyper 0.14.32",
+ "headers",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "log",
  "mime",
  "mime_guess",
- "multer",
  "percent-encoding",
  "pin-project",
  "scoped-tls",
@@ -16707,7 +16630,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -17284,7 +17206,7 @@ dependencies = [
  "ethereum-types 0.14.1",
  "futures",
  "futures-timer",
- "headers 0.4.1",
+ "headers",
  "hex",
  "idna",
  "jsonrpc-core",
@@ -17343,6 +17265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17380,7 +17311,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17509,6 +17440,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16620,6 +16620,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "log",
  "mime",
  "mime_guess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15843,6 +15843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16234,6 +16246,22 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -16632,6 +16660,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "=0.3.19" }
 typenum = { version = "1.15" }
 url = { version = "2.4" }
-warp = { version = "0.4.3", features = ["server"] }
+warp = { version = "0.4.3", features = ["server", "websocket"] }
 # TODO replace this crate. It's not very well maintained.
 web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "3b01caf7fb7a151fc7ec69a2f42a35252912b3c8" }
 x25519-dalek = { version = "2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ rand = { version = "0.8.5", default-features = false }
 rayon = { version = "1.7.0" }
 redis = { version = "0.27.5" }
 regex = { version = "1.10.2" }
-reqwest = { version = "0.11.4" }
+reqwest = { version = "0.12.28" }
 rlp = { version = "0.5.2", default-features = false }
 rocksdb = { version = "0.21.0" }
 scale-decode = { version = "0.16" }
@@ -187,7 +187,7 @@ tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "=0.3.19" }
 typenum = { version = "1.15" }
 url = { version = "2.4" }
-warp = { version = "0.3.6" }
+warp = { version = "0.4.3" }
 # TODO replace this crate. It's not very well maintained.
 web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "3b01caf7fb7a151fc7ec69a2f42a35252912b3c8" }
 x25519-dalek = { version = "2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "=0.3.19" }
 typenum = { version = "1.15" }
 url = { version = "2.4" }
-warp = { version = "0.4.3" }
+warp = { version = "0.4.3", features = ["server"] }
 # TODO replace this crate. It's not very well maintained.
 web3 = { git = "https://github.com/tomusdrw/rust-web3", rev = "3b01caf7fb7a151fc7ec69a2f42a35252912b3c8" }
 x25519-dalek = { version = "2.0" }

--- a/api/bin/chainflip-elections-tracker/src/bin/log_votes_summary.rs
+++ b/api/bin/chainflip-elections-tracker/src/bin/log_votes_summary.rs
@@ -159,15 +159,24 @@ async fn run_dashboard(
 	tx: broadcast::Sender<String>,
 	block_query_tx: BlockQuerySender,
 ) {
-	let index = warp::path::end().and(warp::get()).map(|| warp::reply::html(DASHBOARD_HTML));
+	let index = warp::path::end()
+		.and(warp::get())
+		.map(|| warp::reply::html(DASHBOARD_HTML.to_string()));
 
-	let ws_route = warp::path("ws").and(warp::ws()).map(move |ws: warp::ws::Ws| {
+	// Path segments are owned `String`s (and `warp::path!` is expanded by hand) because
+	// `&'static str` segments trip higher-ranked lifetime inference in the spawned task
+	// ("implementation of `AsRef` is not general enough").
+	let ws_route = warp::path("ws".to_string()).and(warp::ws()).map(move |ws: warp::ws::Ws| {
 		let rx = tx.subscribe();
 		ws.on_upgrade(move |websocket| handle_ws_client(websocket, rx))
 	});
 
-	let block_query =
-		warp::path!("api" / "block" / u32).and(warp::get()).then(move |number: u32| {
+	let block_query = warp::path("api".to_string())
+		.and(warp::path("block".to_string()))
+		.and(warp::path::param::<u32>())
+		.and(warp::path::end())
+		.and(warp::get())
+		.then(move |number: u32| {
 			let tx = block_query_tx.clone();
 			async move {
 				let (reply_tx, reply_rx) = oneshot::channel();

--- a/utilities/src/with_std/health.rs
+++ b/utilities/src/with_std/health.rs
@@ -86,21 +86,24 @@ pub async fn start<'a, 'env>(
 
 	const PATH: &str = "health";
 
-	let future =
-		warp::serve(warp::any().and(warp::path(PATH)).and(warp::path::end()).map(move || {
-			warp::reply::with_status(
-				if has_completed_initialising.load(std::sync::atomic::Ordering::Relaxed) {
-					RUNNING
-				} else {
-					INITIALISING
-				},
-				warp::http::StatusCode::OK,
-			)
-		}))
-		.bind((health_check_settings.hostname.parse::<IpAddr>()?, health_check_settings.port));
+	let server =
+		warp::serve(warp::any().and(warp::path(PATH.to_string())).and(warp::path::end()).map(
+			move || {
+				warp::reply::with_status(
+					if has_completed_initialising.load(std::sync::atomic::Ordering::Relaxed) {
+						RUNNING.to_string()
+					} else {
+						INITIALISING.to_string()
+					},
+					warp::http::StatusCode::OK,
+				)
+			},
+		))
+		.bind((health_check_settings.hostname.parse::<IpAddr>()?, health_check_settings.port))
+		.await;
 
 	scope.spawn_weak(async move {
-		future.await;
+		server.run().await;
 		Ok(())
 	});
 

--- a/utilities/src/with_std/logging.rs
+++ b/utilities/src/with_std/logging.rs
@@ -128,7 +128,7 @@ pub async fn init_json_logger(settings: LoggingSettings) -> DefaultGuard {
 		const MAX_CONTENT_LENGTH: u64 = 2 * 1024;
 
 		let change_filter = warp::post()
-			.and(warp::path(PATH))
+			.and(warp::path(PATH.to_string()))
 			.and(warp::path::end())
 			.and(warp::body::content_length_limit(MAX_CONTENT_LENGTH))
 			.and(warp::body::json())
@@ -158,18 +158,24 @@ pub async fn init_json_logger(settings: LoggingSettings) -> DefaultGuard {
 				}
 			});
 
-		let get_filter = warp::get().and(warp::path(PATH)).and(warp::path::end()).then(move || {
-			futures::future::ready({
-				let (status, message) =
-					match reload_handle.with_current(|env_filter| env_filter.to_string()) {
-						Ok(reply) => (warp::http::StatusCode::OK, reply),
-						Err(error) =>
-							(warp::http::StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
-					};
+		let get_filter =
+			warp::get()
+				.and(warp::path(PATH.to_string()))
+				.and(warp::path::end())
+				.then(move || {
+					futures::future::ready({
+						let (status, message) = match reload_handle
+							.with_current(|env_filter| env_filter.to_string())
+						{
+							Ok(reply) => (warp::http::StatusCode::OK, reply),
+							Err(error) =>
+								(warp::http::StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+						};
 
-				warp::reply::with_status(warp::reply::json(&message), status).into_response()
-			})
-		});
+						warp::reply::with_status(warp::reply::json(&message), status)
+							.into_response()
+					})
+				});
 
 		warp::serve(change_filter.or(get_filter))
 			.run((std::net::Ipv4Addr::LOCALHOST, settings.command_server_port))

--- a/utilities/src/with_std/metrics.rs
+++ b/utilities/src/with_std/metrics.rs
@@ -571,13 +571,19 @@ pub async fn start<'a, 'env>(
 
 	const PATH: &str = "metrics";
 
-	let future = {
-		warp::serve(warp::any().and(warp::path(PATH)).and(warp::path::end()).map(metrics_handler))
-			.bind((prometheus_settings.hostname.parse::<IpAddr>()?, prometheus_settings.port))
+	let server = {
+		warp::serve(
+			warp::any()
+				.and(warp::path(PATH.to_string()))
+				.and(warp::path::end())
+				.map(metrics_handler),
+		)
+		.bind((prometheus_settings.hostname.parse::<IpAddr>()?, prometheus_settings.port))
+		.await
 	};
 
 	scope.spawn_weak(async move {
-		future.await;
+		server.run().await;
 		Ok(())
 	});
 


### PR DESCRIPTION
# Pull Request

Addresses RUSTSEC-2026-0258 by bumping the dependencies where possible, ignoring the rest. 

it's a low-severity dos issue in a transitive dependency of hyper. 