### PR TITLE
feat: ensure broadcasts are retried a minimum number of times

### DIFF
--- a/bouncer/generated/chaintypes/chainflip-node/query.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/query.d.ts
@@ -2613,6 +2613,16 @@ export interface ChainStorage extends GenericChainStorage {
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
 
     /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
+
+    /**
      * Live transaction broadcast requests.
      *
      * @param {number} arg
@@ -2756,6 +2766,16 @@ export interface ChainStorage extends GenericChainStorage {
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
 
     /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
+
+    /**
      * Live transaction broadcast requests.
      *
      * @param {number} arg
@@ -2896,6 +2916,16 @@ export interface ChainStorage extends GenericChainStorage {
      * @param {Callback<Array<AccountId32>> =} callback
      **/
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
+
+    /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
 
     /**
      * Live transaction broadcast requests.
@@ -4393,6 +4423,16 @@ export interface ChainStorage extends GenericChainStorage {
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
 
     /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
+
+    /**
      * Live transaction broadcast requests.
      *
      * @param {number} arg
@@ -5047,6 +5087,16 @@ export interface ChainStorage extends GenericChainStorage {
      * @param {Callback<Array<AccountId32>> =} callback
      **/
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
+
+    /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
 
     /**
      * Live transaction broadcast requests.
@@ -5946,6 +5996,16 @@ export interface ChainStorage extends GenericChainStorage {
      * @param {Callback<Array<AccountId32>> =} callback
      **/
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
+
+    /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
 
     /**
      * Live transaction broadcast requests.
@@ -7602,6 +7662,16 @@ export interface ChainStorage extends GenericChainStorage {
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
 
     /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
+
+    /**
      * Live transaction broadcast requests.
      *
      * @param {number} arg
@@ -8340,6 +8410,16 @@ export interface ChainStorage extends GenericChainStorage {
      * @param {Callback<Array<AccountId32>> =} callback
      **/
     failedBroadcasters: GenericStorageQuery<(arg: number) => Array<AccountId32>, number>;
+
+    /**
+     * The number of failed attempts for each broadcast. This is *not* the same as the size of
+     * `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+     * all become eligible for nomination again.
+     *
+     * @param {number} arg
+     * @param {Callback<number> =} callback
+     **/
+    broadcastAttemptCount: GenericStorageQuery<(arg: number) => number, number>;
 
     /**
      * Live transaction broadcast requests.

--- a/bouncer/tests/gaslimit_ccm.test.ts
+++ b/bouncer/tests/gaslimit_ccm.test.ts
@@ -29,10 +29,10 @@ import { chainTrackingChainStateUpdatedEvent } from 'generated/events/generic/ch
 import { ingressEgressCcmBroadcastRequestedEvent } from 'generated/events/generic/ingressEgress/ccmBroadcastRequested';
 import { broadcasterTransactionBroadcastRequestEvent } from 'generated/events/generic/broadcaster/transactionBroadcastRequest';
 import { broadcasterTransactionFeeDeficitRecordedEvent } from 'generated/events/generic/broadcaster/transactionFeeDeficitRecorded';
-import { broadcasterBroadcastAbortedEvent } from 'generated/events/generic/broadcaster/broadcastAborted';
+import { broadcasterBroadcastRetryScheduledEvent } from 'generated/events/generic/broadcaster/broadcastRetryScheduled';
 
 // Minimum and maximum gas consumption values to be in a useful range for testing. Not using very low numbers
-// to avoid flakiness in the tests expecting a broadcast abort due to not having enough gas.
+// to avoid flakiness in the tests expecting a broadcast failure due to not having enough gas.
 const RANGE_TEST_GAS_CONSUMPTION: Record<string, { min: number; max: number }> = {
   Ethereum: { min: 150000, max: 1000000 },
   Arbitrum: { min: 3000000, max: 5000000 },
@@ -214,7 +214,7 @@ async function testGasLimitSwapToEvm<A = []>(
   cf: ChainflipIO<A>,
   sourceAsset: Asset,
   destAsset: Asset,
-  abortTest: boolean = false,
+  insufficientGas: boolean = false,
 ) {
   function getRandomGasConsumption(chain: string): number {
     const { min, max } = RANGE_TEST_GAS_CONSUMPTION[chain];
@@ -247,7 +247,7 @@ async function testGasLimitSwapToEvm<A = []>(
   const baseCfTesterGas = await estimateCcmCfTesterGas(destChain, '0x');
 
   // Adding buffers on both ends to avoid flakiness.
-  if (abortTest) {
+  if (insufficientGas) {
     // Chainflip overestimates the overhead for safety so we use a 25% buffer to ensure that
     // the gas budget is too low.We also apply a 50% on the baseCfTesterGas since it's highly unreliable.
     ccmMetadata.gasBudget = Math.round(gasConsumption * 0.75 + baseCfTesterGas * 0.5).toString();
@@ -256,18 +256,18 @@ async function testGasLimitSwapToEvm<A = []>(
     ccmMetadata.gasBudget = (baseCfTesterGas + Math.round(gasConsumption * 1.1)).toString();
   }
 
-  const testTag = abortTest ? `InsufficientGas` : '';
+  const testTag = insufficientGas ? `InsufficientGas` : '';
 
   const { tag, destAddress, broadcastId, maxFeePerGas, gasLimitBudget } =
     await executeAndTrackCcmSwap(cf, sourceAsset, destAsset, ccmMetadata, testTag);
   cf.debug(`${tag} Finished tracking events`);
 
   cf.debug(
-    `Expecting broadcast ${abortTest ? 'abort' : 'success'}. Broadcast gas budget: ${gasLimitBudget}, user gasBudget ${ccmMetadata.gasBudget} cfTester gasConsumption ${gasConsumption}`,
+    `Expecting broadcast ${insufficientGas ? 'failure' : 'success'}. Broadcast gas budget: ${gasLimitBudget}, user gasBudget ${ccmMetadata.gasBudget} cfTester gasConsumption ${gasConsumption}`,
   );
 
-  if (abortTest) {
-    // Expect Broadcast Aborted
+  if (insufficientGas) {
+    // Expect the broadcast to fail
     let stopObservingCcmReceived = false;
 
     // We run this because we want to ensure that we *don't* get a CCM event.
@@ -285,13 +285,15 @@ async function testGasLimitSwapToEvm<A = []>(
         throw new Error(`$CCM event emitted. Transaction should not have been broadcasted!`);
       }
     });
+    // A retry is scheduled on the first failed attempt. We assert on that rather than on
+    // BroadcastAborted so that the test doesn't depend on the broadcast pallet's retry policy.
     await cf.stepUntilEvent(
-      broadcasterBroadcastAbortedEvent[destChain].refine(
+      broadcasterBroadcastRetryScheduledEvent[destChain].refine(
         (event) => event.broadcastId === broadcastId,
       ),
     );
     stopObservingCcmReceived = true;
-    cf.debug(`Broadcast Aborted found! broadcastId: ${broadcastId}`);
+    cf.debug(`Broadcast failed as expected! broadcastId: ${broadcastId}`);
   } else {
     // Check that broadcast is not aborted.
     // TODO: add ChainflipIO version of observeBadEvent.
@@ -391,7 +393,7 @@ async function testTronInsufficientGas<A = []>(
 
   cf.debug(`${tag} Finished tracking events`);
   cf.debug(
-    `Expecting broadcast abort . Broadcast gas budget: ${gasLimitBudget}, user gasBudget ${ccmMetadata.gasBudget}}`,
+    `Expecting broadcast failure. Broadcast gas budget: ${gasLimitBudget}, user gasBudget ${ccmMetadata.gasBudget}`,
   );
   let stopObservingCcmReceived = false;
 
@@ -407,13 +409,14 @@ async function testTronInsufficientGas<A = []>(
       throw new Error(`$CCM event emitted. Transaction should not have been broadcasted!`);
     }
   });
+  // See the equivalent EVM assertion for why we don't wait for the broadcast to be aborted.
   await cf.stepUntilEvent(
-    broadcasterBroadcastAbortedEvent[destChain].refine(
+    broadcasterBroadcastRetryScheduledEvent[destChain].refine(
       (data) => Number(data.broadcastId) === Number(broadcastId),
     ),
   );
   stopObservingCcmReceived = true;
-  cf.debug(`Broadcast Aborted found! broadcastId: ${broadcastId}`);
+  cf.debug(`Broadcast failed as expected! broadcastId: ${broadcastId}`);
 }
 
 function spamEvmChain<A = []>(cf: ChainflipIO<A>, chain: Chain): () => void {

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -311,6 +311,13 @@ pub mod pallet {
 	pub type FailedBroadcasters<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Twox64Concat, BroadcastId, BTreeSet<T::ValidatorId>, ValueQuery>;
 
+	/// The number of failed attempts for each broadcast. This is *not* the same as the size of
+	/// `FailedBroadcasters`, which is cleared each time all authorities have failed, so that they
+	/// all become eligible for nomination again.
+	#[pallet::storage]
+	pub type BroadcastAttemptCount<T, I = ()> =
+		StorageMap<_, Twox64Concat, BroadcastId, AttemptCount, ValueQuery>;
+
 	/// Live transaction broadcast requests.
 	#[pallet::storage]
 	pub type AwaitingBroadcast<T: Config<I>, I: 'static = ()> =
@@ -893,6 +900,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	pub fn clean_up_broadcast_storage(broadcast_id: BroadcastId) -> Option<ApiCallFor<T, I>> {
 		AwaitingBroadcast::<T, I>::remove(broadcast_id);
+		BroadcastAttemptCount::<T, I>::remove(broadcast_id);
 		TransactionMetadata::<T, I>::remove(broadcast_id);
 		for transaction_out_id in BroadcastIdToTransactionOutIds::<T, I>::take(broadcast_id) {
 			TransactionOutIdToBroadcastId::<T, I>::remove(transaction_out_id);
@@ -1073,16 +1081,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Handles a broadcast failure. The reporter is added to a list of FailedBroadcasters to be
 	/// slashed later. If no reporter is given, the Nominated broadcast is used instead.
 	/// The broadcast will then be retried.
+	///
+	/// Retry behaviour:
+	/// We retry until all validators have failed to broadcast, and if at that point we have *not*
+	/// reached at least `MIN_RETRY_ATTEMPTS` attempts, we clear the list of failed broadcasters
+	/// and repeat. So with a minimum of 10 and 8 validators, we would retry 16 times before
+	/// aborting. Note that clearing the list also discards the offences accrued so far: only the
+	/// failures of the final round are reported if the broadcast eventually succeeds.
 	fn handle_broadcast_failure(
 		broadcast_id: BroadcastId,
 		failed_broadcaster: T::ValidatorId,
 	) -> DispatchResult {
+		const MIN_RETRY_ATTEMPTS: AttemptCount = 10;
 		ensure!(
 			PendingBroadcasts::<T, I>::get().contains(&broadcast_id),
 			Error::<T, I>::InvalidBroadcastId
 		);
 
-		if let Ok(attempt_count) =
+		if let Ok(failure_count) =
 			FailedBroadcasters::<T, I>::try_mutate(broadcast_id, |failed_broadcasters| {
 				if failed_broadcasters.insert(failed_broadcaster.clone()) {
 					Ok(failed_broadcasters.len())
@@ -1090,10 +1106,23 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					Err(())
 				}
 			}) {
-			// Abort the broadcast if all validators reported failure, Retry otherwise.
-			if attempt_count >= T::EpochInfo::current_authority_count() as usize {
+			let attempt_count = BroadcastAttemptCount::<T, I>::mutate(broadcast_id, |count| {
+				*count = count.saturating_add(1);
+				*count
+			});
+			let all_validators_failed =
+				failure_count >= T::EpochInfo::current_authority_count() as usize;
+
+			// Abort the broadcast if all validators reported failure and we have tried
+			// at least MIN_RETRY_ATTEMPTS times. Retry otherwise.
+			if all_validators_failed && attempt_count >= MIN_RETRY_ATTEMPTS {
 				Self::abort_broadcast(broadcast_id);
 			} else {
+				if all_validators_failed {
+					// All validators have tried and failed, but we haven't reached the minimum
+					// retry attempts yet. Clear the list to give everyone a clean slate.
+					FailedBroadcasters::<T, I>::remove(broadcast_id);
+				}
 				Self::schedule_for_retry::<T::BroadcastFailureRetryPolicy>(broadcast_id);
 			}
 		} else {
@@ -1117,9 +1146,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			broadcast_id
 		);
 
-		// We want to keep the broadcast details, but we don't need the list of failed
-		// broadcasters any more.
+		// We want to keep the broadcast details, but we don't need the failed broadcasters or the
+		// attempt count any more.
 		FailedBroadcasters::<T, I>::remove(broadcast_id);
+		BroadcastAttemptCount::<T, I>::remove(broadcast_id);
 
 		T::BroadcastOutcomeHandler::on_broadcast_aborted(broadcast_id);
 
@@ -1129,9 +1159,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	pub fn attempt_count(broadcast_id: BroadcastId) -> AttemptCount {
-		// NOTE: decode_non_dedup_len is correct here only as long as we *don't* use `append` to
-		// insert items.
-		FailedBroadcasters::<T, I>::decode_non_dedup_len(broadcast_id).unwrap_or_default() as u32
+		BroadcastAttemptCount::<T, I>::get(broadcast_id)
 	}
 
 	/// Returns the ApiCall from a `transaction_out_id`.

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -19,11 +19,12 @@
 use core::cmp::max;
 
 use crate::{
-	mock::*, AbortedBroadcasts, AggKey, AwaitingBroadcast, BroadcastBarriers, BroadcastId,
-	BroadcastIdToTransactionOutIds, ChainBlockNumberFor, CurrentOnChainKey,
-	DelayedBroadcastRetryQueue, Error, Event as BroadcastEvent, Event, FailedBroadcasters,
-	IncomingKeyAndBroadcastId, Instance1, PalletConfigUpdate, PalletOffence, PendingApiCalls,
-	PendingBroadcasts, Timeouts, TransactionMetadata, TransactionOutIdToBroadcastId,
+	mock::*, AbortedBroadcasts, AggKey, AwaitingBroadcast, BroadcastAttemptCount,
+	BroadcastBarriers, BroadcastId, BroadcastIdToTransactionOutIds, ChainBlockNumberFor,
+	CurrentOnChainKey, DelayedBroadcastRetryQueue, Error, Event as BroadcastEvent, Event,
+	FailedBroadcasters, IncomingKeyAndBroadcastId, Instance1, PalletConfigUpdate, PalletOffence,
+	PendingApiCalls, PendingBroadcasts, Timeouts, TransactionMetadata,
+	TransactionOutIdToBroadcastId,
 };
 use cf_chains::{
 	mocks::{
@@ -253,6 +254,8 @@ fn test_abort_after_number_of_attempts_is_equal_to_the_number_of_authorities() {
 	new_test_ext().execute_with(|| {
 		let broadcast_id = initiate_and_sign_broadcast(&mock_api_call(), SIG1, TxType::Normal);
 		let next_block = System::block_number() + 1;
+		// The authority count exceeds the pallet's minimum number of retry attempts, so the
+		// broadcast is aborted as soon as every authority has failed once.
 		for i in 0..MockEpochInfo::current_authority_count() {
 			// Nominated signer responds that they can't sign the transaction.
 			// retry should kick off at end of block if sufficient block space is free.
@@ -270,6 +273,53 @@ fn test_abort_after_number_of_attempts_is_equal_to_the_number_of_authorities() {
 			RuntimeEvent::Broadcaster(Event::BroadcastAborted { broadcast_id })
 		);
 	});
+}
+
+#[test]
+fn test_abort_only_after_minimum_number_of_attempts() {
+	// Small enough that a single round of attempts is below the pallet's minimum of 10.
+	const AUTHORITY_COUNT: u32 = 8;
+	// Attempts are made in rounds of `AUTHORITY_COUNT`, so it takes two rounds to reach the
+	// minimum.
+	const EXPECTED_ATTEMPTS: u32 = 2 * AUTHORITY_COUNT;
+
+	new_test_ext()
+		.execute_with(|| {
+			MockEpochInfo::set_authorities((0..AUTHORITY_COUNT as u64).collect());
+			MockNominator::use_current_authorities_as_nominees::<MockEpochInfo>();
+
+			(initiate_and_sign_broadcast(&mock_api_call(), SIG1, TxType::Normal), 0u32)
+		})
+		// Each block retries the broadcast with a freshly nominated broadcaster.
+		.then_process_blocks_with(EXPECTED_ATTEMPTS, |(broadcast_id, attempt)| {
+			let attempt = attempt + 1;
+			assert!(
+				PendingBroadcasts::<Test, Instance1>::get().contains(&broadcast_id),
+				"Broadcast was aborted at attempt {attempt}, expected {EXPECTED_ATTEMPTS} attempts."
+			);
+
+			// The nominated broadcaster reports failure.
+			MockCfe::respond(Scenario::BroadcastFailure);
+
+			if attempt < EXPECTED_ATTEMPTS {
+				assert_eq!(Broadcaster::attempt_count(broadcast_id), attempt);
+				if attempt % AUTHORITY_COUNT == 0 {
+					// All authorities have failed, but the minimum number of attempts has not
+					// been reached: everyone is given a clean slate so that they can be
+					// re-nominated.
+					assert!(FailedBroadcasters::<Test, Instance1>::get(broadcast_id).is_empty());
+				}
+			}
+
+			(broadcast_id, attempt)
+		})
+		.then_execute_with(|(broadcast_id, _)| {
+			assert_eq!(
+				System::events().pop().expect("an event").event,
+				RuntimeEvent::Broadcaster(Event::BroadcastAborted { broadcast_id })
+			);
+			assert!(AbortedBroadcasts::<Test, Instance1>::get().contains(&broadcast_id));
+		});
 }
 
 #[test]
@@ -309,6 +359,7 @@ fn ready_to_abort_broadcast(broadcast_id: BroadcastId) -> u64 {
 
 	// The nominee should be the last one *not* in the `FailedBroadcasters` list
 	validators.remove(&nominee);
+	BroadcastAttemptCount::<Test, Instance1>::insert(broadcast_id, validators.len() as u32);
 	FailedBroadcasters::<Test, Instance1>::insert(broadcast_id, validators);
 	nominee
 }
@@ -964,6 +1015,7 @@ fn broadcast_can_be_aborted_due_to_timeout() {
 			assert!(
 				FailedBroadcasters::<Test, Instance1>::decode_non_dedup_len(broadcast_id).is_none()
 			);
+			assert_eq!(Broadcaster::attempt_count(broadcast_id), 0);
 		});
 }
 

--- a/state-chain/traits/src/mocks/signer_nomination.rs
+++ b/state-chain/traits/src/mocks/signer_nomination.rs
@@ -21,7 +21,7 @@ use crate::{BroadcastNomination, EpochIndex, EpochInfo, ThresholdSignerNominatio
 
 parameter_types! {
 	pub storage ThresholdNominees: Option<BTreeSet<u64>> = None;
-	pub storage LastNominatedIndex: Option<u32> = None;
+	pub storage LastNominee: Option<u64> = None;
 }
 
 pub struct MockNominator;
@@ -29,18 +29,21 @@ pub struct MockNominator;
 impl BroadcastNomination for MockNominator {
 	type BroadcasterId = u64;
 
+	/// Nominates the lowest-numbered nominee that is not excluded, or `None` if they are all
+	/// excluded.
 	fn nominate_broadcaster<S>(
 		_seed: S,
-		_exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
+		exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
 	) -> Option<Self::BroadcasterId> {
-		let next_nomination_index = LastNominatedIndex::get().map(|n| n + 1).unwrap_or_default();
-		LastNominatedIndex::set(&Some(next_nomination_index));
-
-		Self::get_nominees()
+		let excluded = BTreeSet::from_iter(exclude_ids);
+		let nominee = Self::get_nominees()
 			.unwrap()
-			.iter()
-			.nth(next_nomination_index as usize)
-			.copied()
+			.into_iter()
+			.find(|nominee| !excluded.contains(nominee));
+
+		LastNominee::set(&nominee);
+
+		nominee
 	}
 }
 
@@ -69,20 +72,12 @@ impl MockNominator {
 		ThresholdNominees::get()
 	}
 
-	pub fn reset_last_nominee() {
-		LastNominatedIndex::set(&None);
-	}
-
 	pub fn set_nominees(nominees: Option<BTreeSet<u64>>) {
 		ThresholdNominees::set(&nominees);
 	}
 
 	pub fn get_last_nominee() -> Option<u64> {
-		Self::get_nominees()
-			.unwrap()
-			.iter()
-			.nth(LastNominatedIndex::get().expect("No one nominated yet") as usize)
-			.copied()
+		LastNominee::get()
 	}
 
 	pub fn use_current_authorities_as_nominees<


### PR DESCRIPTION
# Pull Request

Related to: PRO-3071

## Summary

Adds `const MIN_RETRY_ATTEMPTS = 10` to the broadcast pallet and changes the retry behaviour thus:

We retry using all validators, and if we haven't reached the minimum number of attempts, we clear the failed validators list and retry with all validators. 

This required introducing a new storage item to track the total attempt count, and updating the signer nomination mock. 