### PR TITLE
feat: auto deregister lp when redeem all

### DIFF
--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -318,3 +318,77 @@ fn min_auction_bid_qualification() {
 		);
 	});
 }
+
+#[test]
+fn full_redemption_deregisters_liquidity_provider() {
+	use cf_chains::address::EncodedAddress;
+	use cf_primitives::{AccountRole, Asset, AssetAmount};
+	use cf_traits::{FundAccount, FundingSource};
+	use state_chain_runtime::LiquidityProvider;
+
+	const LP: AccountId = AccountId::new([0xe1; 32]);
+	const LP_BALANCE: FlipBalance = 100 * FLIPPERINOS_PER_FLIP;
+	const FREE_BALANCE: AssetAmount = 1_000_000_000_000_000_000;
+
+	super::genesis::with_test_defaults().build().execute_with(|| {
+		network::new_account(&LP, AccountRole::LiquidityProvider);
+		network::register_refund_addresses(&LP);
+		Funding::fund_account(
+			LP.clone(),
+			LP_BALANCE - Flip::balance(&LP),
+			FundingSource::EthTransaction {
+				tx_hash: Default::default(),
+				funder: Default::default(),
+			},
+		);
+
+		// An LP that still holds funds in the protocol can't be deregistered, and the
+		// deregistration hook says exactly why.
+		crate::swapping::credit_account(&LP, Asset::Eth, FREE_BALANCE);
+		assert_noop!(
+			Funding::redeem(
+				RuntimeOrigin::signed(LP.clone()),
+				RedemptionAmount::Max,
+				ETH_DUMMY_ADDR,
+				None,
+			),
+			pallet_cf_asset_balances::Error::<Runtime>::FundsRemaining
+		);
+
+		// A partial redemption is unaffected: it doesn't empty the account.
+		assert_ok!(Funding::redeem(
+			RuntimeOrigin::signed(LP.clone()),
+			RedemptionAmount::Exact(LP_BALANCE / 2),
+			ETH_DUMMY_ADDR,
+			None,
+		));
+		assert_eq!(
+			pallet_cf_account_roles::AccountRoles::<Runtime>::get(&LP),
+			Some(AccountRole::LiquidityProvider)
+		);
+		assert_ok!(Funding::redeemed(LP.clone(), LP_BALANCE / 2, Default::default()));
+
+		// Once the LP has no state left in the protocol, redeeming the remaining balance
+		// deregisters the account - no separate deregistration extrinsic needed.
+		assert_ok!(LiquidityProvider::withdraw_asset(
+			RuntimeOrigin::signed(LP.clone()),
+			FREE_BALANCE,
+			Asset::Eth,
+			EncodedAddress::Eth(Default::default()),
+		));
+		assert_ok!(Funding::redeem(
+			RuntimeOrigin::signed(LP.clone()),
+			RedemptionAmount::Max,
+			ETH_DUMMY_ADDR,
+			None,
+		));
+		assert_eq!(
+			pallet_cf_account_roles::AccountRoles::<Runtime>::get(&LP),
+			Some(AccountRole::Unregistered)
+		);
+		// The deregistration hook cleans up the LP's refund addresses.
+		assert!(pallet_cf_asset_balances::RefundAddresses::<Runtime>::iter_prefix(&LP)
+			.next()
+			.is_none());
+	});
+}

--- a/state-chain/pallets/cf-funding/src/lib.rs
+++ b/state-chain/pallets/cf-funding/src/lib.rs
@@ -34,7 +34,7 @@ pub use weights::WeightInfo;
 mod tests;
 
 use cf_chains::{evm::Address as EthereumAddress, RegisterRedemption};
-use cf_primitives::{chains::assets::eth::Asset as EthAsset, AssetAmount};
+use cf_primitives::{chains::assets::eth::Asset as EthAsset, AccountRole, AssetAmount};
 use cf_traits::{
 	impl_pallet_safe_mode, AccountInfo, AccountRoleRegistry, Broadcaster, Chainflip, FeePayment,
 	FundAccount, Funding, FundingSource, GetMinimumFunding, MoveFlipToGateway, RedemptionCheck,
@@ -92,6 +92,9 @@ pub struct Redemption<T: Config> {
 	pub account_id: T::AccountId,
 	/// The Ethereum address to take into account for any redemption restrictions.
 	pub redemption_address: Option<EthereumAddress>,
+	/// Whether this redemption would leave the account with a zero balance, in which case the
+	/// account's role needs to be deregistered before the funds can leave it.
+	pub empties_account: bool,
 }
 
 impl<T: Config> Redemption<T> {
@@ -108,7 +111,6 @@ impl<T: Config> Redemption<T> {
 			&RestrictedBalances::<T>::get(account_id),
 			Some(redemption_address),
 			MinimumFunding::<T>::get(),
-			true,
 		)
 	}
 	pub fn for_rebalance(
@@ -124,7 +126,6 @@ impl<T: Config> Redemption<T> {
 			&RestrictedBalances::<T>::get(source_account_id),
 			redemption_address.as_ref(),
 			MinimumFunding::<T>::get(),
-			true,
 		)
 	}
 	pub fn for_rpc(account_id: &T::AccountId) -> Result<Self, Error<T>> {
@@ -136,7 +137,6 @@ impl<T: Config> Redemption<T> {
 			&RestrictedBalances::<T>::get(account_id),
 			None,
 			MinimumFunding::<T>::get(),
-			false,
 		)
 	}
 
@@ -149,7 +149,6 @@ impl<T: Config> Redemption<T> {
 		restricted_balances: &BTreeMap<EthereumAddress, FlipBalance<T>>,
 		bound_redeem_address: Option<&EthereumAddress>,
 		minimum_funding: FlipBalance<T>,
-		require_deregistration: bool,
 	) -> Result<Self, Error<T>> {
 		if let Some(address) = redemption_address {
 			if let Some(bound_address) = bound_redeem_address {
@@ -234,16 +233,6 @@ impl<T: Config> Redemption<T> {
 			remaining_balance == Zero::zero() || remaining_balance >= minimum_funding,
 			Error::<T>::BelowMinimumFunding
 		);
-		if require_deregistration && account_balance == debit_amount {
-			ensure!(
-				T::AccountRoleRegistry::is_unregistered(account_id),
-				Error::<T>::AccountMustBeUnregistered
-			);
-			ensure!(
-				frame_system::Pallet::<T>::can_dec_provider(account_id),
-				Error::<T>::AccountHasRemainingConsumers
-			);
-		}
 
 		Ok(Redemption {
 			redeem_amount,
@@ -251,7 +240,30 @@ impl<T: Config> Redemption<T> {
 			restricted_redeem_amount: restricted_debit_amount.saturating_sub(applied_fee),
 			account_id: account_id.clone(),
 			redemption_address: redemption_address.cloned(),
+			empties_account: remaining_balance.is_zero(),
 		})
+	}
+
+	/// Deregisters the account's role if this redemption would empty it, so that the account can be
+	/// reaped once the redemption settles.
+	pub fn deregister_account_if_emptied(&self) -> DispatchResult {
+		if !self.empties_account {
+			return Ok(())
+		}
+
+		match T::AccountRoleRegistry::account_role(&self.account_id) {
+			AccountRole::Unregistered => {},
+			AccountRole::LiquidityProvider =>
+				T::AccountRoleRegistry::deregister_as_liquidity_provider(&self.account_id)?,
+			_ => return Err(Error::<T>::AccountMustBeUnregistered.into()),
+		}
+
+		ensure!(
+			frame_system::Pallet::<T>::can_dec_provider(&self.account_id),
+			Error::<T>::AccountHasRemainingConsumers
+		);
+
+		Ok(())
 	}
 
 	/// Returns the total debit amount, which is the sum of the redeem amount and the redemption
@@ -696,6 +708,8 @@ pub mod pallet {
 				redemption.total_debit_amount(),
 			)?;
 
+			redemption.deregister_account_if_emptied()?;
+
 			redemption.take_fee()?;
 			redemption.update_restricted_balances(None)?;
 
@@ -730,6 +744,8 @@ pub mod pallet {
 					expiry_time: contract_expiry,
 				});
 			} else {
+				// The fee may have emptied the account, in which case it needs reaping here
+				Self::kill_account_if_zero_balance(&account_id);
 				Self::deposit_event(Event::RedemptionAmountZero { account_id })
 			}
 
@@ -883,6 +899,7 @@ pub mod pallet {
 
 			let redemption =
 				Redemption::<T>::for_rebalance(&source_account_id, amount, redemption_address)?;
+			redemption.deregister_account_if_emptied()?;
 			redemption.take_fee()?;
 			redemption.update_restricted_balances(Some(&recipient_account_id))?;
 

--- a/state-chain/pallets/cf-funding/src/tests.rs
+++ b/state-chain/pallets/cf-funding/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 	PendingRedemptions, Redemption, RedemptionAmount, RedemptionTax, RestrictedAddresses,
 	RestrictedBalances,
 };
-use cf_primitives::{Asset, FlipBalance, SwapRequestId};
+use cf_primitives::{AccountRole, Asset, FlipBalance, SwapRequestId};
 use cf_test_utilities::assert_event_sequence;
 use cf_traits::{
 	mocks::{
@@ -1872,6 +1872,90 @@ fn account_references_must_be_zero_for_full_redeem() {
 }
 
 #[test]
+fn full_redemption_deregisters_liquidity_provider() {
+	const FUNDING_AMOUNT: FlipBalance = 100;
+	const PARTIAL_AMOUNT: FlipBalance = 50;
+	new_test_ext().execute_with(|| {
+		Funding::fund_account(
+			ALICE,
+			FUNDING_AMOUNT,
+			FundingSource::EthTransaction { tx_hash: TX_HASH, funder: ETH_ZERO_ADDRESS },
+		);
+		assert_ok!(
+			<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_as_liquidity_provider(
+				&ALICE
+			)
+		);
+
+		// A partial redemption leaves the account intact.
+		assert_ok!(Funding::redeem(
+			OriginTrait::signed(ALICE),
+			PARTIAL_AMOUNT.into(),
+			ETH_DUMMY_ADDR,
+			Default::default()
+		));
+		assert_ok!(Funding::redeemed(ALICE, PARTIAL_AMOUNT, TX_HASH));
+		assert!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::has_account_role(
+			&ALICE,
+			AccountRole::LiquidityProvider
+		));
+
+		// Redeeming the remaining balance deregisters the account, no prior deregistration
+		// required.
+		assert_ok!(Funding::redeem(
+			OriginTrait::signed(ALICE),
+			RedemptionAmount::Max,
+			ETH_DUMMY_ADDR,
+			Default::default()
+		));
+		assert!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::is_unregistered(&ALICE));
+
+		assert_ok!(Funding::redeemed(
+			ALICE,
+			FUNDING_AMOUNT - PARTIAL_AMOUNT - REDEMPTION_TAX,
+			TX_HASH
+		));
+		assert_eq!(
+			frame_system::Pallet::<Test>::providers(&ALICE),
+			0,
+			"Account should have been reaped on final redemption."
+		);
+	});
+}
+
+#[test]
+fn full_redemption_requires_explicit_deregistration_of_other_roles() {
+	const FUNDING_AMOUNT: FlipBalance = 100;
+	new_test_ext().execute_with(|| {
+		for (account_id, role) in [(ALICE, AccountRole::Broker), (BOB, AccountRole::Operator)] {
+			Funding::fund_account(
+				account_id.clone(),
+				FUNDING_AMOUNT,
+				FundingSource::EthTransaction { tx_hash: TX_HASH, funder: ETH_ZERO_ADDRESS },
+			);
+			assert_ok!(
+				<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::register_account_role(
+					&account_id,
+					role,
+				)
+			);
+
+			// Roles whose deregistration cleans up state outside of the deregistration hooks
+			// have to be deregistered explicitly.
+			assert_noop!(
+				Funding::redeem(
+					OriginTrait::signed(account_id),
+					RedemptionAmount::Max,
+					ETH_DUMMY_ADDR,
+					Default::default()
+				),
+				Error::<Test>::AccountMustBeUnregistered,
+			);
+		}
+	});
+}
+
+#[test]
 fn only_governance_can_update_settings() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
@@ -2170,6 +2254,37 @@ pub mod rebalancing {
 				AMOUNT + MIN_FUNDING,
 				"Total balance to be correct."
 			);
+		});
+	}
+
+	#[test]
+	fn rebalancing_all_funds_deregisters_liquidity_provider() {
+		new_test_ext().execute_with(|| {
+			const AMOUNT: u128 = 100;
+
+			assert_ok!(setup_test(
+				vec![
+					AccountSetup::new(ALICE)
+						.with_balance(AMOUNT, None)
+						.with_role(AccountRole::LiquidityProvider),
+					AccountSetup::new(BOB),
+				],
+				vec![]
+			));
+
+			// Moving the entire balance away empties the account, so its role is deregistered.
+			assert_ok!(Funding::rebalance(
+				OriginTrait::signed(ALICE),
+				BOB,
+				None,
+				RedemptionAmount::Max
+			));
+
+			assert!(<MockAccountRoleRegistry as AccountRoleRegistry<Test>>::is_unregistered(
+				&ALICE
+			));
+			assert!(!frame_system::Pallet::<Test>::account_exists(&ALICE));
+			assert_eq!(Flip::total_balance_of(&BOB), AMOUNT + MIN_FUNDING);
 		});
 	}
 

--- a/state-chain/pallets/cf-lp/src/lib.rs
+++ b/state-chain/pallets/cf-lp/src/lib.rs
@@ -506,13 +506,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::deregister_lp_account())]
 		pub fn deregister_lp_account(who: OriginFor<T>) -> DispatchResult {
 			let account_id = T::AccountRoleRegistry::ensure_liquidity_provider(who)?;
-
-			T::AccountRoleRegistry::deregister_as_liquidity_provider(&account_id)?;
-
-			T::RefundAddressRegistry::clear_refund_addresses(&account_id);
-			T::WithdrawalRestriction::clear_pending_withdrawal_changes(&account_id);
-
-			Ok(())
+			T::AccountRoleRegistry::deregister_as_liquidity_provider(&account_id)
 		}
 
 		/// Transfer some amount of an asset from the free balance to the free balance of another LP

--- a/state-chain/runtime/src/chainflip/deregistration_hooks.rs
+++ b/state-chain/runtime/src/chainflip/deregistration_hooks.rs
@@ -16,7 +16,9 @@
 
 use crate::{AccountId, AccountRoles, Runtime};
 use cf_primitives::AccountRole;
-use cf_traits::{AccountRoleRegistry, DeregistrationHooks, RefundAddressRegistry};
+use cf_traits::{
+	AccountRoleRegistry, DeregistrationHooks, RefundAddressRegistry, WithdrawalAddressRestriction,
+};
 use frame_support::sp_runtime::DispatchError;
 use pallet_cf_flip::Bonder;
 
@@ -67,6 +69,9 @@ impl DeregistrationHooks for RuntimeDeregistrationHooks {
 	fn on_deregistered(account_id: &Self::AccountId, account_role: AccountRole) {
 		if account_role == AccountRole::LiquidityProvider {
 			pallet_cf_asset_balances::Pallet::<Runtime>::clear_refund_addresses(account_id);
+			<pallet_cf_asset_balances::Pallet<Runtime> as WithdrawalAddressRestriction>::clear_pending_withdrawal_changes(
+				account_id,
+			);
 		}
 	}
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-3075

## Summary

* Redeeming an account's entire FLIP balance required the account to already be unregistered (AccountMustBeUnregistered), so LPs had to call deregister_lp_account first. This PR makes it easier by auto-deregistering
* Only implemented for LPs because it is the source of most reported issues
* This is a first PR in a series of account lifecycle improvements
*   Moved LP storage cleanup (refund addresses, pending withdrawal changes) out of deregister_lp_account and into the runtime's on_deregistered hook, so every deregistration path — explicit or automatic — clears the same state.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [ ] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [ ] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
