### PR TITLE
feat: Include Chain in FailedToBroadcastTransaction

### DIFF
--- a/bouncer/generated/chaintypes/chainflip-node/types.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/types.d.ts
@@ -2029,7 +2029,7 @@ export type PalletCfReputationCallLike =
 export type StateChainRuntimeChainflipOffencesOffence =
   | { type: 'ParticipateSigningFailed' }
   | { type: 'ParticipateKeygenFailed' }
-  | { type: 'FailedToBroadcastTransaction' }
+  | { type: 'FailedToBroadcastTransaction'; value: CfPrimitivesChainsForeignChain }
   | { type: 'MissedAuthorshipSlot' }
   | { type: 'MissedHeartbeat' }
   | { type: 'GrandpaEquivocation' }

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -552,7 +552,10 @@ export const palletCfTokenholderGovernanceProposal = z.discriminatedUnion('__kin
 export const stateChainRuntimeChainflipOffencesOffence = z.discriminatedUnion('__kind', [
   z.object({ __kind: z.literal('ParticipateSigningFailed') }),
   z.object({ __kind: z.literal('ParticipateKeygenFailed') }),
-  z.object({ __kind: z.literal('FailedToBroadcastTransaction') }),
+  z.object({
+    __kind: z.literal('FailedToBroadcastTransaction'),
+    value: cfPrimitivesChainsForeignChain,
+  }),
   z.object({ __kind: z.literal('MissedAuthorshipSlot') }),
   z.object({ __kind: z.literal('MissedHeartbeat') }),
   z.object({ __kind: z.literal('GrandpaEquivocation') }),

--- a/state-chain/cf-integration-tests/src/mock_runtime.rs
+++ b/state-chain/cf-integration-tests/src/mock_runtime.rs
@@ -76,7 +76,14 @@ pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
 	(Offence::MissedHeartbeat, (15, HEARTBEAT_BLOCK_INTERVAL)),
 	// We exclude them from the nomination pool of the next attempt,
 	// so there is no need to suspend them further.
-	(Offence::FailedToBroadcastTransaction, (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Ethereum), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Polkadot), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Bitcoin), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Arbitrum), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Solana), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Assethub), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Tron), (10, 0)),
+	(Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Bsc), (10, 0)),
 	(Offence::GrandpaEquivocation, (50, HEARTBEAT_BLOCK_INTERVAL * 5)),
 	(Offence::FailedLivenessCheck(cf_chains::ForeignChain::Solana), (4, 0)),
 ];

--- a/state-chain/cf-integration-tests/src/signer_nomination.rs
+++ b/state-chain/cf-integration-tests/src/signer_nomination.rs
@@ -14,14 +14,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use cf_traits::{offence_reporting::OffenceReporter, EpochInfo, ThresholdSignerNomination};
+use cf_primitives::ForeignChain;
+use cf_traits::{
+	offence_reporting::OffenceReporter, BroadcastNomination, EpochInfo, ThresholdSignerNomination,
+};
 use pallet_cf_threshold_signature::PalletOffence;
 use pallet_cf_validator::{CurrentAuthorities, CurrentEpoch, HistoricalAuthorities};
 use sp_runtime::AccountId32;
-use state_chain_runtime::{EvmInstance, Reputation, Runtime, Validator};
+use state_chain_runtime::{
+	chainflip::Offence, BitcoinInstance, EthereumInstance, EvmInstance, Reputation, Runtime,
+	Validator,
+};
 
 type RuntimeThresholdSignerNomination =
 	<Runtime as pallet_cf_threshold_signature::Config<EvmInstance>>::ThresholdSignerNomination;
+type EthereumBroadcastSignerNomination =
+	<Runtime as pallet_cf_broadcast::Config<EthereumInstance>>::BroadcastSignerNomination;
+type BitcoinBroadcastSignerNomination =
+	<Runtime as pallet_cf_broadcast::Config<BitcoinInstance>>::BroadcastSignerNomination;
 
 #[test]
 fn threshold_signer_nomination_respects_epoch() {
@@ -94,5 +104,28 @@ fn nodes_who_failed_to_sign_excluded_from_threshold_nomination() {
 		test_not_nominated_for_offence(|node_id| {
 			Reputation::report(PalletOffence::ParticipateSigningFailed, node_id)
 		});
+	});
+}
+
+#[test]
+fn failed_broadcasters_are_only_excluded_on_the_failed_chain() {
+	super::genesis::with_test_defaults().build().execute_with(|| {
+		let mut authorities = Validator::current_authorities();
+		let failed_broadcaster = authorities.pop().expect("the test has authorities");
+
+		Reputation::suspend_all(
+			[failed_broadcaster.clone()],
+			&Offence::FailedToBroadcastTransaction(ForeignChain::Ethereum),
+			10,
+		);
+
+		assert_eq!(
+			EthereumBroadcastSignerNomination::nominate_broadcaster((), authorities.clone()),
+			None,
+		);
+		assert_eq!(
+			BitcoinBroadcastSignerNomination::nominate_broadcaster((), authorities),
+			Some(failed_broadcaster),
+		);
 	});
 }

--- a/state-chain/cf-integration-tests/src/signer_nomination.rs
+++ b/state-chain/cf-integration-tests/src/signer_nomination.rs
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use cf_chains::{Bitcoin, Ethereum};
 use cf_primitives::ForeignChain;
 use cf_traits::{
 	offence_reporting::OffenceReporter, BroadcastNomination, EpochInfo, ThresholdSignerNomination,
@@ -120,11 +121,14 @@ fn failed_broadcasters_are_only_excluded_on_the_failed_chain() {
 		);
 
 		assert_eq!(
-			EthereumBroadcastSignerNomination::nominate_broadcaster((), authorities.clone()),
+			EthereumBroadcastSignerNomination::nominate_broadcaster::<Ethereum, _>(
+				(),
+				authorities.clone(),
+			),
 			None,
 		);
 		assert_eq!(
-			BitcoinBroadcastSignerNomination::nominate_broadcaster((), authorities),
+			BitcoinBroadcastSignerNomination::nominate_broadcaster::<Bitcoin, _>((), authorities),
 			Some(failed_broadcaster),
 		);
 	});

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -97,15 +97,16 @@ use state_chain_runtime::{
 		custom_api::CustomRuntimeApi,
 		elections_api::ElectoralRuntimeApi,
 		types::{
-			AuctionState, BoostPoolDepth, BrokerInfo, CcmData, ChainAccounts, DelegationSnapshot,
-			DispatchErrorWithMessage, EncodedNonNativeCall, EncodedNonNativeCallGeneric,
-			EncodingType, EvmCallDetails, FailingWitnessValidators, FeeTypes, IngressEvents,
-			LendingPosition, LiquidityProviderBoostPoolInfo, LiquidityProviderInfo, NetworkFees,
-			NonceOrAccount, OpenedDepositChannels, OperatorInfo, RewardDistributionEstimate,
-			RpcAccountInfoCommonItems, RpcLendingConfig, RpcLendingPool, RuntimeApiAccountInfo,
-			RuntimeApiPenalty, ShouldSweep, SimulateSwapAdditionalOrder, SimulatedSwapInformation,
-			TradingStrategyInfo, TradingStrategyLimits, TransactionScreeningEvents, ValidatorInfo,
-			VaultAddresses, VaultSwapDetails,
+			before_version_21, AuctionState, BoostPoolDepth, BrokerInfo, CcmData, ChainAccounts,
+			DelegationSnapshot, DispatchErrorWithMessage, EncodedNonNativeCall,
+			EncodedNonNativeCallGeneric, EncodingType, EvmCallDetails, FailingWitnessValidators,
+			FeeTypes, IngressEvents, LendingPosition, LiquidityProviderBoostPoolInfo,
+			LiquidityProviderInfo, NetworkFees, NonceOrAccount, OpenedDepositChannels,
+			OperatorInfo, RewardDistributionEstimate, RpcAccountInfoCommonItems, RpcLendingConfig,
+			RpcLendingPool, RuntimeApiAccountInfo, RuntimeApiPenalty, ShouldSweep,
+			SimulateSwapAdditionalOrder, SimulatedSwapInformation, TradingStrategyInfo,
+			TradingStrategyLimits, TransactionScreeningEvents, ValidatorInfo, VaultAddresses,
+			VaultSwapDetails,
 		},
 	},
 	safe_mode::RuntimeSafeMode,
@@ -1770,19 +1771,6 @@ where
 				})
 				.collect()
 		}],
-		cf_penalties() -> Vec<(Offence, RpcPenalty)> [map: |penalties| {
-			penalties
-				.into_iter()
-				.map(|(offence, RuntimeApiPenalty {reputation_points,suspension_duration_blocks})| (
-					offence,
-					RpcPenalty {
-						reputation_points,
-						suspension_duration_blocks,
-					})
-				)
-				.collect()
-		}],
-		cf_suspensions() -> RpcSuspensions,
 		cf_generate_gov_key_call_hash(call: Vec<u8>) -> GovCallHash,
 		cf_failed_call_ethereum(broadcast_id: BroadcastId) -> Option<<cf_chains::Ethereum as Chain>::Transaction>,
 		cf_failed_call_arbitrum(broadcast_id: BroadcastId) -> Option<<cf_chains::Arbitrum as Chain>::Transaction>,
@@ -1793,6 +1781,47 @@ where
 		cf_affiliate_details(broker: state_chain_runtime::AccountId, affiliate: Option<state_chain_runtime::AccountId>) -> Vec<(state_chain_runtime::AccountId, AffiliateDetails)>,
 		cf_all_open_deposit_channels() -> Vec<OpenedDepositChannels>,
 		cf_auction_state() -> RpcAuctionState [map: Into::into],
+	}
+
+	fn cf_penalties(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<Vec<(Offence, RpcPenalty)>> {
+		self.rpc_backend
+			.with_versioned_runtime_api(at, |api, hash, api_version| {
+				if api_version < 21 {
+					#[expect(deprecated)]
+					api.cf_penalties_before_version_21(hash)
+						.map(before_version_21::into_current_offences)
+				} else {
+					api.cf_penalties(hash)
+				}
+			})
+			.map(|penalties| {
+				penalties
+					.into_iter()
+					.map(
+						|(
+							offence,
+							RuntimeApiPenalty { reputation_points, suspension_duration_blocks },
+						)| {
+							(offence, RpcPenalty { reputation_points, suspension_duration_blocks })
+						},
+					)
+					.collect()
+			})
+	}
+
+	fn cf_suspensions(&self, at: Option<state_chain_runtime::Hash>) -> RpcResult<RpcSuspensions> {
+		self.rpc_backend.with_versioned_runtime_api(at, |api, hash, api_version| {
+			if api_version < 21 {
+				#[expect(deprecated)]
+				api.cf_suspensions_before_version_21(hash)
+					.map(before_version_21::into_current_offences)
+			} else {
+				api.cf_suspensions(hash)
+			}
+		})
 	}
 
 	pass_through_and_flatten! {

--- a/state-chain/custom-rpc/src/monitoring.rs
+++ b/state-chain/custom-rpc/src/monitoring.rs
@@ -28,7 +28,7 @@ use state_chain_runtime::{
 	runtime_apis::{
 		monitoring_api::MonitoringRuntimeApi,
 		types::{
-			ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, EpochState,
+			before_version_21, ActivateKeysBroadcastIds, AuthoritiesInfo, BtcUtxos, EpochState,
 			ExternalChainsBlockHeight, FeeImbalance, FlipSupply, LastRuntimeUpgradeInfo,
 			MonitoringDataV2, OpenDepositChannels, PendingBroadcasts, PendingTssCeremonies,
 			RedemptionsInfo, SolanaNonces,
@@ -234,7 +234,6 @@ where
 		cf_external_chains_block_height() -> ExternalChainsBlockHeight,
 		cf_btc_utxos() -> BtcUtxos,
 		cf_dot_aggkey() -> PolkadotAccountId,
-		cf_suspended_validators() -> Vec<(Offence, u32)>,
 		cf_epoch_state() -> RpcEpochState [map: Into::into],
 		cf_redemptions() -> RedemptionsInfo,
 		cf_pending_broadcasts_count() -> PendingBroadcasts,
@@ -246,7 +245,40 @@ where
 		cf_sol_nonces() -> SolanaNonces,
 		cf_sol_aggkey() -> SolAddress,
 		cf_sol_onchain_key() -> SolAddress,
-		cf_monitoring_data() -> RpcMonitoringData [map: Into::into],
+	}
+
+	fn cf_suspended_validators(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<Vec<(Offence, u32)>> {
+		self.rpc_backend.with_versioned_runtime_api(at, |api, hash, api_version| {
+			if api_version < 5 {
+				#[expect(deprecated)]
+				api.cf_suspended_validators_before_version_5(hash)
+					.map(before_version_21::into_current_offences)
+			} else {
+				api.cf_suspended_validators(hash)
+			}
+		})
+	}
+
+	fn cf_monitoring_data(
+		&self,
+		at: Option<state_chain_runtime::Hash>,
+	) -> RpcResult<RpcMonitoringData> {
+		self.rpc_backend
+			.with_versioned_runtime_api(at, |api, hash, api_version| {
+				if api_version < 3 {
+					#[expect(deprecated)]
+					api.cf_monitoring_data_before_version_3(hash).map(MonitoringDataV2::from)
+				} else if api_version < 5 {
+					#[expect(deprecated)]
+					api.cf_monitoring_data_before_version_5(hash).map(MonitoringDataV2::from)
+				} else {
+					api.cf_monitoring_data(hash)
+				}
+			})
+			.map(Into::into)
 	}
 
 	fn cf_fee_imbalance(

--- a/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__suspensions_serialization.snap
+++ b/state-chain/custom-rpc/src/snapshots/custom_rpc__tests__suspensions_serialization.snap
@@ -4,7 +4,9 @@ expression: val
 ---
 [
   [
-    "FailedToBroadcastTransaction",
+    {
+      "FailedToBroadcastTransaction": "Ethereum"
+    },
     [
       [
         1,

--- a/state-chain/custom-rpc/src/tests.rs
+++ b/state-chain/custom-rpc/src/tests.rs
@@ -594,7 +594,10 @@ fn asset_map_serialization() {
 #[test]
 fn suspensions_serialization() {
 	let val = vec![
-		(Offence::FailedToBroadcastTransaction, vec![(1u32, ID_1), (2u32, ID_2)]),
+		(
+			Offence::FailedToBroadcastTransaction(ForeignChain::Ethereum),
+			vec![(1u32, ID_1), (2u32, ID_2)],
+		),
 		(Offence::ParticipateKeyHandoverFailed, vec![(3u32, ID_1)]),
 		(Offence::ParticipateSigningFailed, vec![(4u32, ID_2)]),
 	];

--- a/state-chain/node/src/chain_spec/common.rs
+++ b/state-chain/node/src/chain_spec/common.rs
@@ -78,7 +78,38 @@ pub const PENALTIES: &[(Offence, (i32, BlockNumber))] = &[
 	(Offence::ParticipateKeygenFailed, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
 	(Offence::ParticipateSigningFailed, (REPUTATION_PENALTY_MEDIUM, MINUTES / 2)),
 	(Offence::MissedAuthorshipSlot, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL)),
-	(Offence::FailedToBroadcastTransaction, (REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL)),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Ethereum),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Polkadot),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Bitcoin),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Arbitrum),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Solana),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Assethub),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Tron),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
+	(
+		Offence::FailedToBroadcastTransaction(cf_chains::ForeignChain::Bsc),
+		(REPUTATION_PENALTY_MEDIUM, HEARTBEAT_BLOCK_INTERVAL),
+	),
 	(Offence::GrandpaEquivocation, (REPUTATION_PENALTY_LARGE, HEARTBEAT_BLOCK_INTERVAL * 5)),
 	(
 		Offence::FailedLivenessCheck(cf_chains::ForeignChain::Solana),

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -29,7 +29,7 @@ use cf_chains::{
 	address::IntoForeignChainAddress, ApiCall, Chain, ChainCrypto, FeeRefundCalculator,
 	RequiresSignatureRefresh, RetryPolicy, TransactionBuilder, TransactionMetadata as _,
 };
-use cf_primitives::{BroadcastId, ThresholdSignatureRequestId};
+use cf_primitives::{BroadcastId, ForeignChain, ThresholdSignatureRequestId};
 use cf_traits::{
 	impl_pallet_safe_mode, offence_reporting::OffenceReporter, BroadcastNomination,
 	BroadcastOutcomeHandler, Broadcaster, CfeBroadcastRequest, Chainflip, ChainflipWithTargetChain,
@@ -78,7 +78,7 @@ pub type AttemptCount = u32;
 	MaxEncodedLen,
 )]
 pub enum PalletOffence {
-	FailedToBroadcastTransaction,
+	FailedToBroadcastTransaction(ForeignChain),
 }
 
 #[derive(
@@ -883,7 +883,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let failed_broadcasters = FailedBroadcasters::<T, I>::take(broadcast_id);
 		if !failed_broadcasters.is_empty() {
 			T::OffenceReporter::report_many(
-				PalletOffence::FailedToBroadcastTransaction,
+				PalletOffence::FailedToBroadcastTransaction(T::TargetChain::get()),
 				failed_broadcasters,
 			);
 		}

--- a/state-chain/pallets/cf-broadcast/src/lib.rs
+++ b/state-chain/pallets/cf-broadcast/src/lib.rs
@@ -1019,10 +1019,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		);
 
 		// Pass in the current block number as part of the seed to achieve pseudo-randomness.
-		if let Some(nominated_signer) = T::BroadcastSignerNomination::nominate_broadcaster(
-			(broadcast_id, frame_system::Pallet::<T>::block_number()),
-			FailedBroadcasters::<T, I>::get(broadcast_id),
-		) {
+		if let Some(nominated_signer) =
+			T::BroadcastSignerNomination::nominate_broadcaster::<T::TargetChain, _>(
+				(broadcast_id, frame_system::Pallet::<T>::block_number()),
+				FailedBroadcasters::<T, I>::get(broadcast_id),
+			) {
 			// Overwrite the old entry with updated broadcast data.
 			broadcast_data.nominee = Some(nominated_signer.clone());
 			AwaitingBroadcast::<T, I>::insert(broadcast_id, broadcast_data.clone());

--- a/state-chain/pallets/cf-broadcast/src/tests.rs
+++ b/state-chain/pallets/cf-broadcast/src/tests.rs
@@ -461,7 +461,7 @@ fn transaction_succeeded_after_timeout_reports_failed_nodes() {
 		witness_broadcast(SIG1);
 
 		MockOffenceReporter::assert_reported(
-			PalletOffence::FailedToBroadcastTransaction,
+			PalletOffence::FailedToBroadcastTransaction(ForeignChain::Ethereum),
 			failed_authorities,
 		);
 	});

--- a/state-chain/pallets/cf-reputation/src/lib.rs
+++ b/state-chain/pallets/cf-reputation/src/lib.rs
@@ -21,7 +21,7 @@
 use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::traits::{BlockNumberProvider, Saturating, Zero},
-	traits::{Get, OnKilledAccount},
+	traits::{Get, OnKilledAccount, StorageVersion},
 };
 use frame_system::pallet_prelude::*;
 use sp_std::{
@@ -109,6 +109,9 @@ pub enum PalletOffence {
 	MissedHeartbeat,
 }
 
+pub const STORAGE_VERSION_U16: u16 = 1;
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
+
 #[frame_support::pallet]
 pub mod pallet {
 
@@ -119,6 +122,7 @@ pub mod pallet {
 	use super::*;
 
 	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 

--- a/state-chain/pallets/cf-reputation/src/tests.rs
+++ b/state-chain/pallets/cf-reputation/src/tests.rs
@@ -14,7 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
+use frame_support::{
+	assert_noop, assert_ok,
+	traits::{GetStorageVersion, OnInitialize},
+};
 
 use cf_traits::{
 	mocks::{account_role_registry::MockAccountRoleRegistry, flip_slasher::MockFlipSlasher},
@@ -26,6 +29,13 @@ use crate::{mock::*, *};
 
 fn reputation_points(who: &<Test as frame_system::Config>::AccountId) -> ReputationPoints {
 	ReputationPallet::reputation(who).reputation_points
+}
+
+#[test]
+fn genesis_sets_current_storage_version() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(ReputationPallet::on_chain_storage_version(), STORAGE_VERSION);
+	});
 }
 
 pub fn advance_by_heartbeat_intervals(n: u64) {

--- a/state-chain/runtime/src/chainflip/offences.rs
+++ b/state-chain/runtime/src/chainflip/offences.rs
@@ -46,7 +46,7 @@ pub enum Offence {
 	/// There was a failure in participation during a key generation ceremony.
 	ParticipateKeygenFailed,
 	/// An authority did not broadcast a transaction.
-	FailedToBroadcastTransaction,
+	FailedToBroadcastTransaction(ForeignChain),
 	/// An authority missed their authorship slot.
 	MissedAuthorshipSlot,
 	/// A node has missed a heartbeat submission.
@@ -74,8 +74,8 @@ impl OffenceList<Runtime> for KeygenExclusionOffences {
 impl From<pallet_cf_broadcast::PalletOffence> for Offence {
 	fn from(offences: pallet_cf_broadcast::PalletOffence) -> Self {
 		match offences {
-			pallet_cf_broadcast::PalletOffence::FailedToBroadcastTransaction =>
-				Self::FailedToBroadcastTransaction,
+			pallet_cf_broadcast::PalletOffence::FailedToBroadcastTransaction(chain) =>
+				Self::FailedToBroadcastTransaction(chain),
 		}
 	}
 }

--- a/state-chain/runtime/src/chainflip/signer_nomination.rs
+++ b/state-chain/runtime/src/chainflip/signer_nomination.rs
@@ -15,12 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Reputation, Runtime, Validator};
-use cf_primitives::EpochIndex;
+use cf_primitives::{EpochIndex, ForeignChain};
 use cf_traits::{Chainflip, EpochInfo};
-use frame_support::Hashable;
+use frame_support::{traits::Get, Hashable};
 use nanorand::{Rng, WyRand};
 use pallet_cf_validator::HistoricalAuthorities;
-use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+use sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, vec::Vec};
 
 use super::Offence;
 
@@ -84,9 +84,9 @@ fn eligible_authorities(
 ///
 /// Signers serving a suspension for any of the offences in ExclusionOffences are
 /// excluded from being nominated.
-pub struct RandomSignerNomination;
+pub struct RandomSignerNomination<C = ()>(PhantomData<C>);
 
-impl cf_traits::BroadcastNomination for RandomSignerNomination {
+impl<C: Get<ForeignChain>> cf_traits::BroadcastNomination for RandomSignerNomination<C> {
 	type BroadcasterId = <Runtime as Chainflip>::ValidatorId;
 
 	fn nominate_broadcaster<H: Hashable>(
@@ -94,7 +94,7 @@ impl cf_traits::BroadcastNomination for RandomSignerNomination {
 		exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
 	) -> Option<Self::BroadcasterId> {
 		let mut all_excludes = Reputation::validators_suspended_for(&[
-			Offence::FailedToBroadcastTransaction,
+			Offence::FailedToBroadcastTransaction(C::get()),
 			Offence::MissedHeartbeat,
 		]);
 		all_excludes.extend(exclude_ids);

--- a/state-chain/runtime/src/chainflip/signer_nomination.rs
+++ b/state-chain/runtime/src/chainflip/signer_nomination.rs
@@ -20,7 +20,7 @@ use cf_traits::{Chainflip, EpochInfo};
 use frame_support::{traits::Get, Hashable};
 use nanorand::{Rng, WyRand};
 use pallet_cf_validator::HistoricalAuthorities;
-use sp_std::{collections::btree_set::BTreeSet, marker::PhantomData, vec::Vec};
+use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
 use super::Offence;
 
@@ -84,12 +84,12 @@ fn eligible_authorities(
 ///
 /// Signers serving a suspension for any of the offences in ExclusionOffences are
 /// excluded from being nominated.
-pub struct RandomSignerNomination<C = ()>(PhantomData<C>);
+pub struct RandomSignerNomination;
 
-impl<C: Get<ForeignChain>> cf_traits::BroadcastNomination for RandomSignerNomination<C> {
+impl cf_traits::BroadcastNomination for RandomSignerNomination {
 	type BroadcasterId = <Runtime as Chainflip>::ValidatorId;
 
-	fn nominate_broadcaster<H: Hashable>(
+	fn nominate_broadcaster<C: Get<ForeignChain>, H: Hashable>(
 		seed: H,
 		exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
 	) -> Option<Self::BroadcasterId> {

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -920,7 +920,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Runtime {
 	type ApiCall = eth::api::EthereumApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::EthTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Ethereum>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -945,7 +945,7 @@ impl pallet_cf_broadcast::Config<Instance2> for Runtime {
 	type ApiCall = dot::api::PolkadotApi<DotEnvironment>;
 	type ThresholdSigner = PolkadotThresholdSigner;
 	type TransactionBuilder = chainflip::DotTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Polkadot>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, PolkadotCryptoInstance>;
@@ -970,7 +970,7 @@ impl pallet_cf_broadcast::Config<Instance3> for Runtime {
 	type ApiCall = cf_chains::btc::api::BitcoinApi<BtcEnvironment>;
 	type ThresholdSigner = BitcoinThresholdSigner;
 	type TransactionBuilder = chainflip::BtcTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Bitcoin>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, BitcoinInstance>;
@@ -995,7 +995,7 @@ impl pallet_cf_broadcast::Config<Instance4> for Runtime {
 	type ApiCall = cf_chains::arb::api::ArbitrumApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::ArbTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Arbitrum>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -1020,7 +1020,7 @@ impl pallet_cf_broadcast::Config<Instance5> for Runtime {
 	type ApiCall = cf_chains::sol::api::SolanaApi<SolEnvironment>;
 	type ThresholdSigner = SolanaThresholdSigner;
 	type TransactionBuilder = chainflip::SolanaTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Solana>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, SolanaInstance>;
@@ -1045,7 +1045,7 @@ impl pallet_cf_broadcast::Config<Instance6> for Runtime {
 	type ApiCall = hub::api::AssethubApi<HubEnvironment>;
 	type ThresholdSigner = PolkadotThresholdSigner;
 	type TransactionBuilder = chainflip::DotTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Assethub>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, PolkadotCryptoInstance>;
@@ -1070,7 +1070,7 @@ impl pallet_cf_broadcast::Config<Instance7> for Runtime {
 	type ApiCall = cf_chains::tron::api::TronApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::TronTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Tron>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -1095,7 +1095,7 @@ impl pallet_cf_broadcast::Config<Instance8> for Runtime {
 	type ApiCall = BscApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::BscTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Bsc>;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -920,7 +920,7 @@ impl pallet_cf_broadcast::Config<Instance1> for Runtime {
 	type ApiCall = eth::api::EthereumApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::EthTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Ethereum>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -945,7 +945,7 @@ impl pallet_cf_broadcast::Config<Instance2> for Runtime {
 	type ApiCall = dot::api::PolkadotApi<DotEnvironment>;
 	type ThresholdSigner = PolkadotThresholdSigner;
 	type TransactionBuilder = chainflip::DotTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Polkadot>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, PolkadotCryptoInstance>;
@@ -970,7 +970,7 @@ impl pallet_cf_broadcast::Config<Instance3> for Runtime {
 	type ApiCall = cf_chains::btc::api::BitcoinApi<BtcEnvironment>;
 	type ThresholdSigner = BitcoinThresholdSigner;
 	type TransactionBuilder = chainflip::BtcTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Bitcoin>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, BitcoinInstance>;
@@ -995,7 +995,7 @@ impl pallet_cf_broadcast::Config<Instance4> for Runtime {
 	type ApiCall = cf_chains::arb::api::ArbitrumApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::ArbTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Arbitrum>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -1020,7 +1020,7 @@ impl pallet_cf_broadcast::Config<Instance5> for Runtime {
 	type ApiCall = cf_chains::sol::api::SolanaApi<SolEnvironment>;
 	type ThresholdSigner = SolanaThresholdSigner;
 	type TransactionBuilder = chainflip::SolanaTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Solana>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, SolanaInstance>;
@@ -1045,7 +1045,7 @@ impl pallet_cf_broadcast::Config<Instance6> for Runtime {
 	type ApiCall = hub::api::AssethubApi<HubEnvironment>;
 	type ThresholdSigner = PolkadotThresholdSigner;
 	type TransactionBuilder = chainflip::DotTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Assethub>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, PolkadotCryptoInstance>;
@@ -1070,7 +1070,7 @@ impl pallet_cf_broadcast::Config<Instance7> for Runtime {
 	type ApiCall = cf_chains::tron::api::TronApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::TronTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Tron>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;
@@ -1095,7 +1095,7 @@ impl pallet_cf_broadcast::Config<Instance8> for Runtime {
 	type ApiCall = BscApi<EvmEnvironment>;
 	type ThresholdSigner = EvmThresholdSigner;
 	type TransactionBuilder = chainflip::BscTransactionBuilder;
-	type BroadcastSignerNomination = chainflip::RandomSignerNomination;
+	type BroadcastSignerNomination = chainflip::RandomSignerNomination<Bsc>;
 	type OffenceReporter = Reputation;
 	type EnsureThresholdSigned =
 		pallet_cf_threshold_signature::EnsureThresholdSigned<Self, EvmInstance>;

--- a/state-chain/runtime/src/lib.rs
+++ b/state-chain/runtime/src/lib.rs
@@ -541,6 +541,7 @@ macro_rules! instanced_migrations {
 
 // Add version-specific migrations here.
 pub type MigrationsForV2_3 = (
+	migrations::failed_broadcast_chain::Migration,
 	migrations::safe_mode::SafeModeMigration,
 	migrations::assethub_deposit_details::Migration,
 	migrations::assethub_elections::AssethubElectionsInit,

--- a/state-chain/runtime/src/migrations.rs
+++ b/state-chain/runtime/src/migrations.rs
@@ -20,6 +20,7 @@ pub mod assethub_deposit_details;
 pub mod assethub_elections;
 pub mod broker_withdrawal_addresses_to_asset_balances;
 pub mod bsc_integration;
+pub mod failed_broadcast_chain;
 pub mod housekeeping;
 pub mod refund_addresses_to_asset_balances;
 pub mod safe_mode;

--- a/state-chain/runtime/src/migrations/failed_broadcast_chain.rs
+++ b/state-chain/runtime/src/migrations/failed_broadcast_chain.rs
@@ -1,0 +1,175 @@
+// Copyright 2026 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Migrates the legacy global failed-broadcast penalty and removes its suspensions.
+
+use crate::{runtime_apis::types::before_version_21, DbWeight, Runtime};
+use cf_primitives::ForeignChain;
+use frame_support::{
+	migrations::VersionedMigration, traits::UncheckedOnRuntimeUpgrade, weights::Weight,
+};
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+mod old {
+	use super::*;
+	use frame_support::{pallet_prelude::OptionQuery, storage_alias, Twox64Concat};
+
+	#[storage_alias]
+	pub type Penalties = StorageMap<
+		Reputation,
+		Twox64Concat,
+		before_version_21::Offence,
+		pallet_cf_reputation::Penalty<Runtime>,
+		OptionQuery,
+	>;
+
+	#[storage_alias]
+	pub type Suspensions = StorageMap<
+		Reputation,
+		Twox64Concat,
+		before_version_21::Offence,
+		sp_std::collections::vec_deque::VecDeque<(crate::BlockNumber, crate::AccountId)>,
+		OptionQuery,
+	>;
+}
+
+const OLD_STORAGE_VERSION: u16 = 0;
+
+pub type Migration = VersionedMigration<
+	OLD_STORAGE_VERSION,
+	{ pallet_cf_reputation::STORAGE_VERSION_U16 },
+	Migrate,
+	pallet_cf_reputation::Pallet<Runtime>,
+	DbWeight,
+>;
+
+pub struct Migrate;
+
+impl UncheckedOnRuntimeUpgrade for Migrate {
+	fn on_runtime_upgrade() -> Weight {
+		let legacy_offence = before_version_21::Offence::FailedToBroadcastTransaction;
+		let mut writes = 2u64;
+
+		if let Some(penalty) = old::Penalties::take(legacy_offence) {
+			// Genesis configuration is not reapplied to live state during an upgrade.
+			for chain in ForeignChain::iter() {
+				pallet_cf_reputation::Penalties::<Runtime>::insert(
+					crate::chainflip::Offence::FailedToBroadcastTransaction(chain),
+					penalty.clone(),
+				);
+				writes = writes.saturating_add(1);
+			}
+		}
+
+		old::Suspensions::remove(legacy_offence);
+
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		Ok(old::Penalties::get(before_version_21::Offence::FailedToBroadcastTransaction).encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+		let legacy_penalty: Option<pallet_cf_reputation::Penalty<Runtime>> =
+			Decode::decode(&mut &state[..]).map_err(|_| {
+				TryRuntimeError::Other("failed to decode failed-broadcast migration state")
+			})?;
+
+		frame_support::ensure!(
+			old::Penalties::get(before_version_21::Offence::FailedToBroadcastTransaction).is_none(),
+			"legacy failed-broadcast penalty was not removed",
+		);
+		frame_support::ensure!(
+			old::Suspensions::get(before_version_21::Offence::FailedToBroadcastTransaction)
+				.is_none(),
+			"legacy failed-broadcast suspensions were not removed",
+		);
+
+		for chain in ForeignChain::iter() {
+			let offence = crate::chainflip::Offence::FailedToBroadcastTransaction(chain);
+			if let Some(ref penalty) = legacy_penalty {
+				frame_support::ensure!(
+					pallet_cf_reputation::Penalties::<Runtime>::get(offence) == *penalty,
+					"failed-broadcast penalty was not migrated",
+				);
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::traits::{GetStorageVersion, OnRuntimeUpgrade, StorageVersion};
+	use pallet_cf_reputation::Penalty;
+	use sp_runtime::AccountId32;
+	use sp_std::collections::vec_deque::VecDeque;
+
+	#[test]
+	fn migrates_legacy_penalty_and_discards_suspensions() {
+		sp_io::TestExternalities::new_empty().execute_with(|| {
+			assert_eq!(
+				pallet_cf_reputation::Pallet::<Runtime>::in_code_storage_version(),
+				StorageVersion::new(pallet_cf_reputation::STORAGE_VERSION_U16),
+			);
+			assert_eq!(
+				pallet_cf_reputation::Pallet::<Runtime>::on_chain_storage_version(),
+				StorageVersion::new(OLD_STORAGE_VERSION),
+			);
+
+			let legacy_offence = before_version_21::Offence::FailedToBroadcastTransaction;
+			let penalty = Penalty::<Runtime> { reputation: 10, suspension: 20 };
+			old::Penalties::insert(legacy_offence, penalty.clone());
+			old::Suspensions::insert(
+				legacy_offence,
+				VecDeque::from([(30, AccountId32::new([1; 32]))]),
+			);
+
+			Migration::on_runtime_upgrade();
+			assert_eq!(
+				pallet_cf_reputation::Pallet::<Runtime>::on_chain_storage_version(),
+				StorageVersion::new(pallet_cf_reputation::STORAGE_VERSION_U16),
+			);
+
+			assert!(old::Penalties::get(legacy_offence).is_none());
+			assert!(old::Suspensions::get(legacy_offence).is_none());
+			for chain in ForeignChain::iter() {
+				let offence = crate::chainflip::Offence::FailedToBroadcastTransaction(chain);
+				assert_eq!(pallet_cf_reputation::Penalties::<Runtime>::get(offence), penalty,);
+				assert!(!pallet_cf_reputation::Suspensions::<Runtime>::contains_key(offence));
+			}
+
+			// The version guard makes subsequent executions a no-op.
+			Migration::on_runtime_upgrade();
+			for chain in ForeignChain::iter() {
+				let offence = crate::chainflip::Offence::FailedToBroadcastTransaction(chain);
+				assert_eq!(pallet_cf_reputation::Penalties::<Runtime>::get(offence), penalty,);
+				assert!(!pallet_cf_reputation::Suspensions::<Runtime>::contains_key(offence));
+			}
+		});
+	}
+}

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -79,7 +79,7 @@ use sp_api::decl_runtime_apis;
 // `#[renamed($OLD_NAME, $VERSION)]` attribute which will handle renaming
 // of apis automatically.
 decl_runtime_apis!(
-	#[api_version(20)]
+	#[api_version(21)]
 	pub trait CustomRuntimeApi {
 		/// Returns true if the current phase is the auction phase.
 		fn cf_is_auction_phase() -> bool;
@@ -112,7 +112,11 @@ decl_runtime_apis!(
 		#[changed_in(7)]
 		fn cf_operator_info();
 		fn cf_operator_info(account_id: &AccountId32) -> OperatorInfo<FlipBalance>;
+		#[changed_in(21)]
+		fn cf_penalties() -> Vec<(before_version_21::Offence, RuntimeApiPenalty)>;
 		fn cf_penalties() -> Vec<(Offence, RuntimeApiPenalty)>;
+		#[changed_in(21)]
+		fn cf_suspensions() -> Vec<(before_version_21::Offence, Vec<(u32, AccountId32)>)>;
 		fn cf_suspensions() -> Vec<(Offence, Vec<(u32, AccountId32)>)>;
 		fn cf_generate_gov_key_call_hash(call: Vec<u8>) -> GovCallHash;
 		#[changed_in(5)]

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -462,6 +462,7 @@ pub mod before_version_15;
 pub mod before_version_16;
 pub mod before_version_17;
 pub mod before_version_19;
+pub mod before_version_21;
 pub mod before_version_3;
 pub mod before_version_9;
 

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
@@ -1,0 +1,95 @@
+// Copyright 2026 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+/// The runtime offence shape before failed broadcasts became chain-specific.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Serialize, Deserialize)]
+pub enum Offence {
+	ParticipateSigningFailed,
+	ParticipateKeygenFailed,
+	FailedToBroadcastTransaction,
+	MissedAuthorshipSlot,
+	MissedHeartbeat,
+	GrandpaEquivocation,
+	ParticipateKeyHandoverFailed,
+	FailedToWitnessInTime,
+	FailedLivenessCheck(ForeignChain),
+}
+
+impl From<super::Offence> for Offence {
+	fn from(offence: super::Offence) -> Self {
+		match offence {
+			super::Offence::ParticipateSigningFailed => Self::ParticipateSigningFailed,
+			super::Offence::ParticipateKeygenFailed => Self::ParticipateKeygenFailed,
+			super::Offence::FailedToBroadcastTransaction(_) => Self::FailedToBroadcastTransaction,
+			super::Offence::MissedAuthorshipSlot => Self::MissedAuthorshipSlot,
+			super::Offence::MissedHeartbeat => Self::MissedHeartbeat,
+			super::Offence::GrandpaEquivocation => Self::GrandpaEquivocation,
+			super::Offence::ParticipateKeyHandoverFailed => Self::ParticipateKeyHandoverFailed,
+			super::Offence::FailedToWitnessInTime => Self::FailedToWitnessInTime,
+			super::Offence::FailedLivenessCheck(chain) => Self::FailedLivenessCheck(chain),
+		}
+	}
+}
+
+impl Offence {
+	fn into_current(self) -> super::Offence {
+		match self {
+			Self::ParticipateSigningFailed => super::Offence::ParticipateSigningFailed,
+			Self::ParticipateKeygenFailed => super::Offence::ParticipateKeygenFailed,
+			// The legacy offence did not identify its chain. Ethereum is only a placeholder when
+			// presenting historical data through the current RPC type.
+			Self::FailedToBroadcastTransaction =>
+				super::Offence::FailedToBroadcastTransaction(ForeignChain::Ethereum),
+			Self::MissedAuthorshipSlot => super::Offence::MissedAuthorshipSlot,
+			Self::MissedHeartbeat => super::Offence::MissedHeartbeat,
+			Self::GrandpaEquivocation => super::Offence::GrandpaEquivocation,
+			Self::ParticipateKeyHandoverFailed => super::Offence::ParticipateKeyHandoverFailed,
+			Self::FailedToWitnessInTime => super::Offence::FailedToWitnessInTime,
+			Self::FailedLivenessCheck(chain) => super::Offence::FailedLivenessCheck(chain),
+		}
+	}
+}
+
+pub fn into_current_offences<T>(entries: Vec<(Offence, T)>) -> Vec<(super::Offence, T)> {
+	entries
+		.into_iter()
+		.map(|(offence, value)| (offence.into_current(), value))
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn legacy_offences_map_one_to_one_with_ethereum_as_placeholder() {
+		assert_eq!(
+			into_current_offences(sp_std::vec![
+				(Offence::FailedToBroadcastTransaction, 1),
+				(Offence::MissedHeartbeat, 2),
+			]),
+			sp_std::vec![
+				(
+					crate::chainflip::Offence::FailedToBroadcastTransaction(ForeignChain::Ethereum),
+					1,
+				),
+				(crate::chainflip::Offence::MissedHeartbeat, 2),
+			],
+		);
+	}
+}

--- a/state-chain/runtime/src/runtime_apis/monitoring_api.rs
+++ b/state-chain/runtime/src/runtime_apis/monitoring_api.rs
@@ -22,7 +22,7 @@ use sp_api::decl_runtime_apis;
 use types::*;
 
 decl_runtime_apis!(
-	#[api_version(4)]
+	#[api_version(5)]
 	pub trait MonitoringRuntimeApi {
 		fn cf_authorities() -> AuthoritiesInfo;
 		#[changed_in(3)]
@@ -31,6 +31,9 @@ decl_runtime_apis!(
 		fn cf_external_chains_block_height() -> ExternalChainsBlockHeight;
 		fn cf_btc_utxos() -> BtcUtxos;
 		fn cf_dot_aggkey() -> PolkadotAccountId;
+		#[changed_in(5)]
+		fn cf_suspended_validators(
+		) -> Vec<(super::custom_api::types::before_version_21::Offence, u32)>;
 		fn cf_suspended_validators() -> Vec<(Offence, u32)>;
 		fn cf_epoch_state() -> EpochState;
 		fn cf_redemptions() -> RedemptionsInfo;
@@ -54,6 +57,8 @@ decl_runtime_apis!(
 		fn cf_sol_onchain_key() -> SolAddress;
 		#[changed_in(3)]
 		fn cf_monitoring_data() -> types::before_monitoring_v3::MonitoringDataV2;
+		#[changed_in(5)]
+		fn cf_monitoring_data() -> types::before_monitoring_v5::MonitoringDataV2;
 		fn cf_monitoring_data() -> MonitoringDataV2;
 		#[changed_in(4)]
 		fn cf_accounts_info(

--- a/state-chain/runtime/src/runtime_apis/monitoring_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/monitoring_api/types.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chainflip::Offence;
+use crate::{chainflip::Offence, runtime_apis::custom_api::types::before_version_21};
 use cf_chains::{
 	dot::PolkadotAccountId,
 	sol::{api::DurableNonceAndAccount, SolAddress, SolSignature},
@@ -158,7 +158,7 @@ pub mod before_monitoring_v3 {
 		pub fee_imbalance: FeeImbalance<AssetAmount>,
 		pub authorities: super::AuthoritiesInfo,
 		pub build_version: super::LastRuntimeUpgradeInfo,
-		pub suspended_validators: Vec<(Offence, u32)>,
+		pub suspended_validators: Vec<(before_version_21::Offence, u32)>,
 		pub pending_swaps: u32,
 		pub dot_aggkey: PolkadotAccountId,
 		pub flip_supply: super::FlipSupply,
@@ -181,7 +181,11 @@ pub mod before_monitoring_v3 {
 				fee_imbalance: new.fee_imbalance.into(),
 				authorities: new.authorities,
 				build_version: new.build_version,
-				suspended_validators: new.suspended_validators,
+				suspended_validators: new
+					.suspended_validators
+					.into_iter()
+					.map(|(offence, count)| (offence.into(), count))
+					.collect(),
 				pending_swaps: new.pending_swaps,
 				dot_aggkey: new.dot_aggkey,
 				flip_supply: new.flip_supply,
@@ -189,6 +193,190 @@ pub mod before_monitoring_v3 {
 				sol_onchain_key: new.sol_onchain_key,
 				sol_nonces: new.sol_nonces,
 				activating_key_broadcast_ids: new.activating_key_broadcast_ids.into(),
+			}
+		}
+	}
+
+	impl From<ExternalChainsBlockHeight> for super::ExternalChainsBlockHeight {
+		fn from(old: ExternalChainsBlockHeight) -> Self {
+			Self {
+				bitcoin: old.bitcoin,
+				ethereum: old.ethereum,
+				polkadot: old.polkadot,
+				solana: old.solana,
+				arbitrum: old.arbitrum,
+				assethub: old.assethub,
+				tron: 0,
+				bsc: 0,
+			}
+		}
+	}
+
+	impl From<PendingBroadcasts> for super::PendingBroadcasts {
+		fn from(old: PendingBroadcasts) -> Self {
+			Self {
+				ethereum: old.ethereum,
+				bitcoin: old.bitcoin,
+				polkadot: old.polkadot,
+				arbitrum: old.arbitrum,
+				solana: old.solana,
+				assethub: old.assethub,
+				tron: 0,
+				bsc: 0,
+			}
+		}
+	}
+
+	impl From<OpenDepositChannels> for super::OpenDepositChannels {
+		fn from(old: OpenDepositChannels) -> Self {
+			Self {
+				ethereum: old.ethereum,
+				bitcoin: old.bitcoin,
+				polkadot: old.polkadot,
+				arbitrum: old.arbitrum,
+				solana: old.solana,
+				assethub: old.assethub,
+				tron: 0,
+				bsc: 0,
+			}
+		}
+	}
+
+	impl<A: Default> From<FeeImbalance<A>> for super::FeeImbalance<A> {
+		fn from(old: FeeImbalance<A>) -> Self {
+			Self {
+				ethereum: old.ethereum,
+				polkadot: old.polkadot,
+				arbitrum: old.arbitrum,
+				bitcoin: old.bitcoin,
+				solana: old.solana,
+				assethub: old.assethub,
+				tron: VaultImbalance::Surplus(Default::default()),
+				bsc: VaultImbalance::Surplus(Default::default()),
+			}
+		}
+	}
+
+	impl From<ActivateKeysBroadcastIds> for super::ActivateKeysBroadcastIds {
+		fn from(old: ActivateKeysBroadcastIds) -> Self {
+			Self {
+				ethereum: old.ethereum,
+				bitcoin: old.bitcoin,
+				polkadot: old.polkadot,
+				arbitrum: old.arbitrum,
+				solana: old.solana,
+				assethub: old.assethub,
+				tron: None,
+				bsc: None,
+			}
+		}
+	}
+
+	impl From<MonitoringDataV2> for super::MonitoringDataV2 {
+		fn from(old: MonitoringDataV2) -> Self {
+			Self {
+				external_chains_height: old.external_chains_height.into(),
+				btc_utxos: old.btc_utxos,
+				epoch: old.epoch,
+				pending_redemptions: old.pending_redemptions,
+				pending_broadcasts: old.pending_broadcasts.into(),
+				pending_tss: old.pending_tss,
+				open_deposit_channels: old.open_deposit_channels.into(),
+				fee_imbalance: old.fee_imbalance.into(),
+				authorities: old.authorities,
+				build_version: old.build_version,
+				suspended_validators: before_version_21::into_current_offences(
+					old.suspended_validators,
+				),
+				pending_swaps: old.pending_swaps,
+				dot_aggkey: old.dot_aggkey,
+				flip_supply: old.flip_supply,
+				sol_aggkey: old.sol_aggkey,
+				sol_onchain_key: old.sol_onchain_key,
+				sol_nonces: old.sol_nonces,
+				activating_key_broadcast_ids: old.activating_key_broadcast_ids.into(),
+			}
+		}
+	}
+}
+
+pub mod before_monitoring_v5 {
+	use super::*;
+
+	#[derive(Serialize, Deserialize, Encode, Decode, Eq, PartialEq, TypeInfo, Debug, Clone)]
+	pub struct MonitoringDataV2 {
+		pub external_chains_height: super::ExternalChainsBlockHeight,
+		pub btc_utxos: super::BtcUtxos,
+		pub epoch: super::EpochState,
+		pub pending_redemptions: super::RedemptionsInfo,
+		pub pending_broadcasts: super::PendingBroadcasts,
+		pub pending_tss: super::PendingTssCeremonies,
+		pub open_deposit_channels: super::OpenDepositChannels,
+		pub fee_imbalance: super::FeeImbalance<AssetAmount>,
+		pub authorities: super::AuthoritiesInfo,
+		pub build_version: super::LastRuntimeUpgradeInfo,
+		pub suspended_validators: Vec<(before_version_21::Offence, u32)>,
+		pub pending_swaps: u32,
+		pub dot_aggkey: PolkadotAccountId,
+		pub flip_supply: super::FlipSupply,
+		pub sol_aggkey: SolAddress,
+		pub sol_onchain_key: SolAddress,
+		pub sol_nonces: super::SolanaNonces,
+		pub activating_key_broadcast_ids: super::ActivateKeysBroadcastIds,
+	}
+
+	impl From<super::MonitoringDataV2> for MonitoringDataV2 {
+		fn from(new: super::MonitoringDataV2) -> Self {
+			Self {
+				external_chains_height: new.external_chains_height,
+				btc_utxos: new.btc_utxos,
+				epoch: new.epoch,
+				pending_redemptions: new.pending_redemptions,
+				pending_broadcasts: new.pending_broadcasts,
+				pending_tss: new.pending_tss,
+				open_deposit_channels: new.open_deposit_channels,
+				fee_imbalance: new.fee_imbalance,
+				authorities: new.authorities,
+				build_version: new.build_version,
+				suspended_validators: new
+					.suspended_validators
+					.into_iter()
+					.map(|(offence, count)| (offence.into(), count))
+					.collect(),
+				pending_swaps: new.pending_swaps,
+				dot_aggkey: new.dot_aggkey,
+				flip_supply: new.flip_supply,
+				sol_aggkey: new.sol_aggkey,
+				sol_onchain_key: new.sol_onchain_key,
+				sol_nonces: new.sol_nonces,
+				activating_key_broadcast_ids: new.activating_key_broadcast_ids,
+			}
+		}
+	}
+
+	impl From<MonitoringDataV2> for super::MonitoringDataV2 {
+		fn from(old: MonitoringDataV2) -> Self {
+			Self {
+				external_chains_height: old.external_chains_height,
+				btc_utxos: old.btc_utxos,
+				epoch: old.epoch,
+				pending_redemptions: old.pending_redemptions,
+				pending_broadcasts: old.pending_broadcasts,
+				pending_tss: old.pending_tss,
+				open_deposit_channels: old.open_deposit_channels,
+				fee_imbalance: old.fee_imbalance,
+				authorities: old.authorities,
+				build_version: old.build_version,
+				suspended_validators: before_version_21::into_current_offences(
+					old.suspended_validators,
+				),
+				pending_swaps: old.pending_swaps,
+				dot_aggkey: old.dot_aggkey,
+				flip_supply: old.flip_supply,
+				sol_aggkey: old.sol_aggkey,
+				sol_onchain_key: old.sol_onchain_key,
+				sol_nonces: old.sol_nonces,
+				activating_key_broadcast_ids: old.activating_key_broadcast_ids,
 			}
 		}
 	}

--- a/state-chain/traits/src/lib.rs
+++ b/state-chain/traits/src/lib.rs
@@ -468,7 +468,7 @@ pub trait BroadcastNomination {
 
 	/// Returns a random broadcaster id, excluding particular provided ids. The seed value is used
 	/// as a source of randomness. Returns None if no signers are live.
-	fn nominate_broadcaster<H: Hashable>(
+	fn nominate_broadcaster<C: Get<ForeignChain>, H: Hashable>(
 		seed: H,
 		exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
 	) -> Option<Self::BroadcasterId>;

--- a/state-chain/traits/src/mocks/signer_nomination.rs
+++ b/state-chain/traits/src/mocks/signer_nomination.rs
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use frame_support::parameter_types;
+use cf_primitives::ForeignChain;
+use frame_support::{parameter_types, traits::Get};
 use sp_std::collections::btree_set::BTreeSet;
 
 use crate::{BroadcastNomination, EpochIndex, EpochInfo, ThresholdSignerNomination};
@@ -31,7 +32,7 @@ impl BroadcastNomination for MockNominator {
 
 	/// Nominates the lowest-numbered nominee that is not excluded, or `None` if they are all
 	/// excluded.
-	fn nominate_broadcaster<S>(
+	fn nominate_broadcaster<C: Get<ForeignChain>, S>(
 		_seed: S,
 		exclude_ids: impl IntoIterator<Item = Self::BroadcasterId>,
 	) -> Option<Self::BroadcasterId> {


### PR DESCRIPTION
# Pull Request

Closes: PRO-2700

## Summary

Include `ForeignChain` in `FailedToBroadcastTransaction` penalty.
This is a quality of life improvement to help node operators easily detect which chain their validators are having problem to submit transaction to, and also it simplifies debugging this problem from our side.

Also added backwards compatibility for monitoring RPCs which was missing.

### RPCS

Rpcs returning the offence have been updated to be backwards compatible, since the previous penalty was general for every chain I opted for defaulting every `FailedToBroadcastTransaction` to `FailedToBroadcastTransaction(Ethereum)` in case an RPC is querying for historical values.
I don't think these RPCs will ever be used for historical queries but if that can be a problem maybe it can be changed (not sure how tho).


---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [x] Integration tests for runtime-wide behaviours.
  * [x] Migrations: if you wrote one, did you test it using try-runtime?
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.