### PR TITLE
feat: circuit breaker for fee price estimates

### DIFF
--- a/bouncer/commands/go_bananas.ts
+++ b/bouncer/commands/go_bananas.ts
@@ -264,13 +264,16 @@ async function playSwapper<A = []>(cf: ChainflipIO<A>) {
   }
 }
 
+// Keep in sync with `price` in shared/setup_swaps.ts: prices for assets without an oracle feed
+// have to stay within the runtime's `MAX_PRICE_ESTIMATE_DEVIATION_FACTOR` of
+// `hard_coded_price_for_asset`, or fee estimation falls back to the hard-coded price.
 const price = new Map<Asset, number>([
   ['Eth', 1000],
-  ['Btc', 10000],
+  ['Btc', 40000],
   ['Usdc', 1],
   ['Usdt', 1],
-  ['Wbtc', 10000],
-  ['Flip', 10],
+  ['Wbtc', 40000],
+  ['Flip', 1],
   ['ArbEth', 1000],
   ['ArbUsdc', 1],
   ['ArbUsdt', 1],

--- a/bouncer/shared/setup_swaps.ts
+++ b/bouncer/shared/setup_swaps.ts
@@ -9,14 +9,14 @@ export const deposits = new Map<Asset, number>([
   ['Eth', 1000],
   ['ArbEth', 1000],
   ['Bnb', 1000],
-  ['Btc', 100],
+  ['Btc', 25],
   ['Usdc', 15000000],
   ['ArbUsdc', 1000000],
   ['ArbUsdt', 1000000],
   ['BscUsdt', 1000000],
   ['Usdt', 1000000],
-  ['Wbtc', 100],
-  ['Cbbtc', 100],
+  ['Wbtc', 25],
+  ['Cbbtc', 25],
   ['Flip', 100000],
   ['Sol', 1000],
   ['SolUsdc', 100000],
@@ -28,25 +28,35 @@ export const deposits = new Map<Asset, number>([
   ['HubUsdt', 250000],
 ]);
 
+// Also pushed to the mock Chainlink feeds by `updateDefaultPriceFeeds`, so the oracle and the
+// pools always agree.
+//
+// Two constraints when changing these:
+//  - For assets with no oracle feed (see `get_chainlink_assetpair`), fees are estimated by
+//    probing the pool, and the runtime discards a probe that deviates from
+//    `hard_coded_price_for_asset` by more than `MAX_PRICE_ESTIMATE_DEVIATION_FACTOR`. A price
+//    outside that band makes every fee denominated in that asset wrong by the full ratio.
+//  - Each full-range order consumes roughly `deposits * price` of the Usdc deposit, so the sum
+//    over all pools has to stay under `deposits.get('Usdc')`.
 export const price = new Map<Asset, number>([
   ['Eth', 1000],
   ['ArbEth', 1000],
   ['Bnb', 600],
-  ['Btc', 10000],
+  ['Btc', 40000],
   ['Usdc', 1],
   ['Usdt', 1],
-  ['Wbtc', 10000],
-  ['Cbbtc', 10000],
+  ['Wbtc', 40000],
+  ['Cbbtc', 40000],
   ['ArbUsdc', 1],
   ['ArbUsdt', 1],
   ['BscUsdt', 1],
-  ['Flip', 10],
+  ['Flip', 1],
   ['Sol', 100],
   ['SolUsdc', 1],
   ['SolUsdt', 1],
   ['Trx', 1],
   ['TrxUsdt', 1],
-  ['HubDot', 10],
+  ['HubDot', 2],
   ['HubUsdc', 1],
   ['HubUsdt', 1],
 ]);

--- a/state-chain/amm-math/src/lib.rs
+++ b/state-chain/amm-math/src/lib.rs
@@ -592,6 +592,15 @@ impl Price {
 			if increase { ONE_AS_BASIS_POINTS + bps } else { ONE_AS_BASIS_POINTS - bps };
 		Self(mul_div_floor_checked(self.0, U256::from(adjusted_bps), ONE_AS_BASIS_POINTS).unwrap())
 	}
+	/// Returns true if this price is within `factor` of `other` in either direction, i.e. if
+	/// `other / factor <= self <= other * factor`.
+	///
+	/// Multiplication saturates, so a `factor` large enough to overflow simply widens the band.
+	pub fn is_within_factor_of(&self, other: &Price, factor: u32) -> bool {
+		let scale = |price: U256| price.saturating_mul(U256::from(factor));
+		self.0 <= scale(other.0) && scale(self.0) >= other.0
+	}
+
 	/// Calculates the basis points difference from some other price to this one, assuming they
 	/// are both prices of the same base/quote pair.
 	///
@@ -868,6 +877,31 @@ mod test {
 				asset
 			);
 		}
+	}
+
+	#[test]
+	fn is_within_factor_of_is_inclusive_at_the_boundary() {
+		let reference = Price::from_raw(U256::from(1_000_000u64));
+
+		// Exactly `factor` times the reference, in both directions.
+		assert!(Price::from_raw(U256::from(4_000_000u64)).is_within_factor_of(&reference, 4));
+		assert!(Price::from_raw(U256::from(250_000u64)).is_within_factor_of(&reference, 4));
+	}
+
+	#[test]
+	fn is_within_factor_of_rejects_one_unit_beyond_the_boundary() {
+		let reference = Price::from_raw(U256::from(1_000_000u64));
+
+		assert!(!Price::from_raw(U256::from(4_000_001u64)).is_within_factor_of(&reference, 4));
+		assert!(!Price::from_raw(U256::from(249_999u64)).is_within_factor_of(&reference, 4));
+	}
+
+	#[test]
+	fn is_within_factor_of_saturates_instead_of_overflowing() {
+		// Scaling either side would overflow U256; saturating widens the band rather than
+		// wrapping around to a spurious rejection.
+		assert!(Price::from_raw(U256::MAX).is_within_factor_of(&Price::from_raw(U256::MAX), 4));
+		assert!(Price::from_raw(U256::MAX).is_within_factor_of(&Price::from_raw(U256::MAX / 2), 4));
 	}
 
 	#[test]

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -3712,12 +3712,12 @@ pub mod utilities {
 			Asset::TrxUsdt |
 			Asset::BscUsdt => 100, // $1
 			Asset::Flip => 40,                                    // ~$0.40
-			Asset::Eth | Asset::ArbEth => 280_000,                // ~$2,800
-			Asset::Dot | Asset::HubDot => 200,                    // ~$2
-			Asset::Btc | Asset::Wbtc | Asset::Cbbtc => 8_650_000, // ~$86,500
-			Asset::Sol => 12_700,                                 // ~$127
-			Asset::Trx => 30,                                     // ~$0.3
-			Asset::Bnb => 60_000,                                 // ~$600
+			Asset::Eth | Asset::ArbEth => 250_000,                // ~$2,500
+			Asset::Dot | Asset::HubDot => 100,                    // ~$1
+			Asset::Btc | Asset::Wbtc | Asset::Cbbtc => 8_000_000, // ~$80,000
+			Asset::Sol => 10_000,                                 // ~$100
+			Asset::Trx => 30,                                     // ~$0.30
+			Asset::Bnb => 70_000,                                 // ~$700
 		};
 
 		Price::from_usd_cents(asset, price_usd_cents)

--- a/state-chain/pallets/cf-swapping/src/lib.rs
+++ b/state-chain/pallets/cf-swapping/src/lib.rs
@@ -2939,7 +2939,10 @@ pub mod pallet {
 			side: Side,
 		) -> Price {
 			const ESTIMATION_AMOUNT_USDC: u128 = 20_000_000; // 20 USDC
-			match side {
+
+			let fallback_price = utilities::hard_coded_price_for_asset(asset);
+
+			let simulated_price = match side {
 				// Buy means we buy Asset and sell USDC
 				Side::Buy => {
 					// Estimated Asset amount
@@ -2956,11 +2959,10 @@ pub mod pallet {
 					.and_then(|estimation_output| {
 						Price::from_amounts(ESTIMATION_AMOUNT_USDC.into(), estimation_output.into())
 					})
-					.unwrap_or_else(|| utilities::hard_coded_price_for_asset(asset))
 				},
 				// Sell means we sell Asset and buy USDC
 				Side::Sell => {
-					let estimated_input = utilities::hard_coded_price_for_asset(asset) // USD / Asset
+					let estimated_input = fallback_price // USD / Asset
 						// How much input is required for the output?
 						.input_amount_floor(ESTIMATION_AMOUNT_USDC)
 						.unwrap_or_default() // Asset
@@ -2978,8 +2980,24 @@ pub mod pallet {
 					.and_then(|estimation_output| {
 						Price::from_amounts(estimation_output.into(), estimated_input.into())
 					})
-					.unwrap_or_else(|| utilities::hard_coded_price_for_asset(asset))
 				},
+			};
+
+			match simulated_price {
+				Some(price)
+					if price.is_within_factor_of(
+						&fallback_price,
+						utilities::MAX_PRICE_ESTIMATE_DEVIATION_FACTOR,
+					) =>
+					price,
+				Some(implausible_price) => {
+					log::debug!(
+						"Simulated {side:?} price for {asset:?} deviates from the hard-coded price by more than {}x, falling back to the hard-coded price. Simulated: {implausible_price:?}, hard-coded: {fallback_price:?}",
+						utilities::MAX_PRICE_ESTIMATE_DEVIATION_FACTOR,
+					);
+					fallback_price
+				},
+				None => fallback_price,
 			}
 		}
 
@@ -3695,6 +3713,15 @@ impl<T: Config> AffiliateRegistry for Pallet<T> {
 
 pub mod utilities {
 	use super::*;
+
+	/// A pool-derived price estimate is discarded if it deviates from the hard-coded price by
+	/// more than this factor in either direction, since that implies a manipulated or illiquid
+	/// pool rather than a real move.
+	///
+	/// Note this bounds estimates against a manually maintained constant: if a real price moves
+	/// by more than this factor before [`hard_coded_price_for_asset`] is refreshed, sound
+	/// estimates will be rejected in favour of a stale one.
+	pub const MAX_PRICE_ESTIMATE_DEVIATION_FACTOR: u32 = 4;
 
 	/// Provides a static price that can be used as a fallback when estimating fees/gas.
 	/// These prices are rough approximations of real market prices and should be updated

--- a/state-chain/pallets/cf-swapping/src/mock.rs
+++ b/state-chain/pallets/cf-swapping/src/mock.rs
@@ -77,6 +77,13 @@ pub enum SwapFailureMode {
 
 thread_local! {
 	pub static SWAP_FAILURE_MODE: RefCell<SwapFailureMode> = RefCell::new(SwapFailureMode::None);
+	/// Per-asset simulated prices in USD cents, overriding [`SwapRate`] for swaps between the
+	/// asset and the stable asset. Needed because the global rate is a single multiplier applied
+	/// to every pair, which cannot represent plausible prices for more than one asset at a time.
+	///
+	/// Cents rather than a float rate so the arithmetic is exact and identical on every platform.
+	pub static ASSET_PRICES_USD_CENTS: RefCell<sp_std::collections::btree_map::BTreeMap<Asset, u128>> =
+		RefCell::new(Default::default());
 }
 
 pub struct MockSwappingApi;
@@ -84,6 +91,40 @@ pub struct MockSwappingApi;
 impl MockSwappingApi {
 	pub fn set_swaps_should_fail(mode: SwapFailureMode) {
 		SWAP_FAILURE_MODE.with(|cell| *cell.borrow_mut() = mode);
+	}
+
+	/// Set the simulated price of `asset` in USD cents, overriding the global [`SwapRate`] for
+	/// swaps between `asset` and the stable asset. Unlike the global rate this is direction-aware,
+	/// so the buy and sell sides of the same asset agree.
+	pub fn set_asset_price_usd_cents(asset: Asset, cents: u128) {
+		ASSET_PRICES_USD_CENTS.with(|prices| {
+			prices.borrow_mut().insert(asset, cents);
+		});
+	}
+
+	/// One whole unit of `asset` expressed in Usdc-fine hundredths, i.e. the divisor that turns a
+	/// cents price into a fine-amount ratio. Mirrors `Price::from_usd_cents`.
+	fn cents_scale(asset: Asset) -> u128 {
+		100u128.saturating_mul(10u128.pow(asset.decimals() - Asset::Usdc.decimals()))
+	}
+
+	fn swap_at_asset_price(
+		from: Asset,
+		to: Asset,
+		input_amount: AssetAmount,
+	) -> Option<AssetAmount> {
+		ASSET_PRICES_USD_CENTS.with(|prices| {
+			let prices = prices.borrow();
+			// Single-leg swaps always involve the stable asset, so the price is keyed on the
+			// other leg.
+			if to == STABLE_ASSET {
+				let cents = *prices.get(&from)?;
+				input_amount.checked_mul(cents).map(|v| v / Self::cents_scale(from))
+			} else {
+				let cents = *prices.get(&to)?;
+				input_amount.checked_mul(Self::cents_scale(to)).map(|v| v / cents)
+			}
+		})
 	}
 
 	fn swap_should_fail(from: Asset, to: Asset) -> bool {
@@ -127,7 +168,8 @@ impl SwappingApi for MockSwappingApi {
 		swaps.push((from, to, input_amount));
 		Swaps::set(swaps);
 
-		let output_amount = (input_amount as f64 * SwapRate::get()) as AssetAmount;
+		let output_amount = Self::swap_at_asset_price(from, to, input_amount)
+			.unwrap_or_else(|| (input_amount as f64 * SwapRate::get()) as AssetAmount);
 
 		let mut liquidity = Liquidity::get();
 

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -18,6 +18,31 @@ use cf_traits::mocks::price_feed_api::MockPriceFeedApi;
 
 use super::*;
 
+/// The hard-coded fallback prices that estimates are sanity-checked against. Mirrored here as
+/// exact literals (rather than derived from `Price`, which would round-trip through f64) so tests
+/// can express simulated prices relative to them. Kept honest by
+/// [`hard_coded_price_constants_mirror_production`].
+const FLIP_PRICE_CENTS: u128 = 40;
+const DOT_PRICE_CENTS: u128 = 100;
+const TRX_PRICE_CENTS: u128 = 30;
+const ETH_PRICE_CENTS: u128 = 250_000;
+
+#[test]
+fn hard_coded_price_constants_mirror_production() {
+	for (asset, cents) in [
+		(Asset::Flip, FLIP_PRICE_CENTS),
+		(Asset::Dot, DOT_PRICE_CENTS),
+		(Asset::Trx, TRX_PRICE_CENTS),
+		(Asset::Eth, ETH_PRICE_CENTS),
+	] {
+		assert_eq!(
+			utilities::hard_coded_price_for_asset(asset),
+			Price::from_usd_cents(asset, cents as u32),
+			"test constant for {asset:?} no longer matches the hard-coded price",
+		);
+	}
+}
+
 #[test]
 fn swap_output_amounts_correctly_account_for_fees() {
 	for (from, to) in
@@ -492,8 +517,12 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 	new_test_ext().execute_with(|| {
 		NetworkFee::<Test>::set(FeeRateAndMinimum { rate: Permill::from_percent(1), minimum: 0 });
 
-		// The swap simulation will use the swap rate in tests to estimate prices.
-		SwapRate::set(2_f64);
+		// The swap simulation uses these prices to estimate. They must be within the circuit
+		// breaker's deviation limit of the hard-coded prices, but differ from them so that the
+		// assertions below distinguish a simulated price from the fallback.
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Flip, FLIP_PRICE_CENTS * 2);
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Dot, DOT_PRICE_CENTS * 3);
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Trx, TRX_PRICE_CENTS * 2);
 
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
@@ -503,7 +532,8 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				false,
 				false
 			),
-			500 // 1 leg swap, so 1/2 of input
+			1_250_000_000_000_001 /* 1000 Usdc-fine of Flip at 2x $0.40, plus a small rounding
+			                       * error */
 		);
 
 		assert_eq!(
@@ -514,7 +544,7 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				true,
 				false
 			),
-			505 // 1 leg swap + 1% network fee
+			1_262_626_262_500_001 // Same as above + 1% network fee
 		);
 
 		assert_eq!(
@@ -525,7 +555,8 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				false,
 				false
 			),
-			250 // 2 leg swap, so 1/4th of input
+			// 2 leg swap: 1000 Dot-fine at 3x $1, paid in Flip at 2x $0.40, plus a rounding error
+			375_000_000_004
 		);
 
 		assert_eq!(
@@ -536,7 +567,7 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				false,
 				false
 			),
-			500 // 1 leg swap, so 1/2 of input
+			1667 // 1000 Usdc-fine of Trx at 2x $0.30
 		);
 
 		assert_eq!(
@@ -547,12 +578,11 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				true,
 				false
 			),
-			505 // 1 leg swap + 1% network fee
+			1683 // Same as above + 1% network fee
 		);
 
 		// Using a combination of swap simulation (flip) and hard coded price (Eth).
 		MockSwappingApi::set_swaps_should_fail(SwapFailureMode::Assets(vec![Asset::Eth]));
-		SwapRate::set(0.000000000002_f64); // Flip will be worth $2 via swap simulation
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
 				Asset::Flip,
@@ -561,8 +591,9 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				false,
 				false
 			),
-			// So the result is half the Eth price, plus a small rounding error
-			1250 * 10_u128.pow(18) + 1
+			// The hard-coded Eth price divided by the simulated Flip price (2x $0.40), plus a
+			// small rounding error
+			3125 * 10_u128.pow(18) + 1
 		);
 	});
 }
@@ -623,6 +654,67 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 			6_313_131 // Same as above + 1% network fee
 		);
 	});
+}
+
+/// A pool-derived price estimate is only trusted if it is within a bounded factor of the
+/// hard-coded price. A wildly different estimate implies a manipulated or illiquid pool.
+mod price_estimate_circuit_breaker {
+	use super::*;
+
+	fn estimate_flip_price(simulated_price_cents: u128, side: Side) -> Price {
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Flip, simulated_price_cents);
+		Swapping::estimate_usdc_price_using_simulated_swap_or_fallback(Asset::Flip, side)
+	}
+
+	#[test]
+	fn simulated_sell_price_far_above_hard_coded_price_is_rejected() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				estimate_flip_price(FLIP_PRICE_CENTS * 5, Side::Sell),
+				utilities::hard_coded_price_for_asset(Asset::Flip)
+			);
+		});
+	}
+
+	#[test]
+	fn simulated_sell_price_far_below_hard_coded_price_is_rejected() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				estimate_flip_price(FLIP_PRICE_CENTS / 5, Side::Sell),
+				utilities::hard_coded_price_for_asset(Asset::Flip)
+			);
+		});
+	}
+
+	#[test]
+	fn simulated_buy_price_far_above_hard_coded_price_is_rejected() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				estimate_flip_price(FLIP_PRICE_CENTS * 5, Side::Buy),
+				utilities::hard_coded_price_for_asset(Asset::Flip)
+			);
+		});
+	}
+
+	#[test]
+	fn simulated_price_well_below_the_deviation_limit_is_used() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				estimate_flip_price(FLIP_PRICE_CENTS / 2, Side::Sell),
+				Price::from_usd_cents(Asset::Flip, 20)
+			);
+		});
+	}
+
+	#[test]
+	fn simulated_price_within_the_deviation_limit_is_used() {
+		new_test_ext().execute_with(|| {
+			assert_eq!(
+				estimate_flip_price(FLIP_PRICE_CENTS * 2, Side::Sell),
+				Price::from_usd_cents(Asset::Flip, 80)
+			);
+		});
+	}
 }
 
 /// Test the use of the price oracle in calculating fees/gas.
@@ -697,7 +789,7 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 		);
 
 		// Using both Swap Simulation (Flip) and an oracle price (Btc)
-		SwapRate::set(0.000000000002_f64); // Flip will be worth $2 via swap simulation
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Flip, FLIP_PRICE_CENTS * 2);
 		assert_eq!(
 			Swapping::calculate_input_for_desired_output_or_default_to_zero(
 				Asset::Flip,
@@ -706,8 +798,8 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				false,
 				false
 			),
-			// ~=15k + 40bps + rounding error
-			(15_000 + 60) * 10u128.pow(Asset::Flip.decimals()) + 1
+			// $30k of Btc at the simulated Flip price (2x $0.40), + 40bps + rounding error
+			(37_500 + 150) * 10u128.pow(Asset::Flip.decimals()) + 1
 		);
 
 		// Check that the network fee is still applied when using the same asset as the input and
@@ -1227,9 +1319,16 @@ fn test_refund_fee_calculation() {
 		assert_eq!(take_refund_fee(5, Asset::Usdc, false), (0, 5));
 		assert_eq!(take_refund_fee(u128::MAX, Asset::Usdc, false), (u128::MAX - 10, 10));
 
-		// Conversion needed, no oracle price set, so the refund fee is 10 / DEFAULT_SWAP_RATE = 5
-		assert_eq!(take_refund_fee(1000, Asset::Flip, false), (995, 5));
+		// Conversion needed. At 2x the hard-coded Flip price, the 10 Usdc-fine minimum is
+		// 1.25e13 Flip-fine.
+		MockSwappingApi::set_asset_price_usd_cents(Asset::Flip, FLIP_PRICE_CENTS * 2);
+		const ONE_FLIP: AssetAmount = 10u128.pow(18);
+		assert_eq!(
+			take_refund_fee(ONE_FLIP, Asset::Flip, false),
+			(ONE_FLIP - 12_500_000_000_001, 12_500_000_000_001)
+		);
 		assert_eq!(take_refund_fee(0, Asset::Flip, false), (0, 0));
+		// Less than the fee, so the whole amount is taken.
 		assert_eq!(take_refund_fee(3, Asset::Flip, false), (0, 3));
 
 		// Internal swaps use a different network fee (and therefore refund fee)
@@ -1238,7 +1337,10 @@ fn test_refund_fee_calculation() {
 			minimum: 30,
 		});
 		assert_eq!(take_refund_fee(1000, Asset::Usdc, true), (970, 30));
-		assert_eq!(take_refund_fee(1000, Asset::Flip, true), (985, 15));
+		assert_eq!(
+			take_refund_fee(ONE_FLIP, Asset::Flip, true),
+			(ONE_FLIP - 37_500_000_000_001, 37_500_000_000_001)
+		);
 	});
 }
 

--- a/state-chain/pallets/cf-swapping/src/tests/fees.rs
+++ b/state-chain/pallets/cf-swapping/src/tests/fees.rs
@@ -562,7 +562,7 @@ fn test_calculate_input_for_desired_output_using_swap_simulation() {
 				false
 			),
 			// So the result is half the Eth price, plus a small rounding error
-			1400 * 10_u128.pow(18) + 1
+			1250 * 10_u128.pow(18) + 1
 		);
 	});
 }
@@ -584,7 +584,7 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				false,
 				false
 			),
-			14_000 * 10u128.pow(18) + 1 // 2 ETH ~= 14000 FLIP plus small rounding error
+			12_500 * 10u128.pow(18) + 1 // 2 ETH ~= 12500 FLIP plus small rounding error
 		);
 
 		assert_eq!(
@@ -608,7 +608,7 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				false,
 				false
 			),
-			6473989 // 2 ETH ~=  0.06473988439 BTC
+			6_250_000 // 2 ETH == 0.0625 BTC
 		);
 
 		// Make sure the network fee is also taken into account when using hard coded prices
@@ -620,7 +620,7 @@ fn test_calculate_input_for_desired_output_using_hard_coded_prices() {
 				true, // With network fee
 				false
 			),
-			6539382 // Same as above + 1% network fee
+			6_313_131 // Same as above + 1% network fee
 		);
 	});
 }
@@ -693,7 +693,7 @@ fn test_calculate_input_for_desired_output_using_oracle_prices() {
 				false,
 				false
 			),
-			236220472441 + 944_881_890 // ~236 SOL + 40bps
+			300_000_000_000 + 1_200_000_000 + 1 // 300 SOL + 40bps plus small rounding error
 		);
 
 		// Using both Swap Simulation (Flip) and an oracle price (Btc)


### PR DESCRIPTION
# Pull Request

Fixes: PRO-3094

Updates the fallback prices for all assets to current values (rounded). 

Adds a tolerance factor that is applied to the pool-based price estimate: if the estimate is more than 4x away from the fallback price, we use the fallback price. This prevents excessive drift and lessens the potential for manipulation.

Mitigates #6814 pending addition of new price oracles. 

