### PR TITLE
feat: bouncer seedable ccm

### DIFF
--- a/bouncer/shared/new_sol_address.ts
+++ b/bouncer/shared/new_sol_address.ts
@@ -4,3 +4,13 @@ import { sha256 } from 'shared/utils';
 export function newSolAddress(seed: string): string {
   return Keypair.fromSeed(sha256(seed)).publicKey.toBase58();
 }
+
+// A Solana keypair derived deterministically from `rng`, so generated account addresses are
+// reproducible from the seed rather than cryptographically random.
+export function seededSolanaKeypair(rng: () => number): Keypair {
+  const seed = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    seed[i] = Math.floor(rng() * 256);
+  }
+  return Keypair.fromSeed(seed);
+}

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -1,7 +1,8 @@
-import { Keypair, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { u8aToHex } from '@polkadot/util';
-import { randomAsHex } from 'polkadot/util-crypto';
 import { performSwap, performVaultSwap } from 'shared/perform_swap';
+import { seededHexBytes } from 'shared/utils/seeded_rng';
+import { seededSolanaKeypair } from 'shared/new_sol_address';
 import {
   chainFromAsset,
   getContractAddress,
@@ -42,7 +43,15 @@ const MAX_CCM_BYTES_USDT = 632;
 const SOLANA_BYTES_PER_ACCOUNT = 33;
 const BYTES_PER_ALT = 34; // 32 + 1 + 1 (for vector lengths)
 
-function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number = Math.random) {
+// Options for the public CCM metadata builders. `rng` (defaulting to `Math.random`) seeds the
+// otherwise-random message/metadata generation so a run can be reproduced from a fixed seed.
+export type CcmMetadataOptions = {
+  message?: string;
+  additionalData?: string;
+  rng?: () => number;
+};
+
+function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number) {
   // Test all combinations
   const useLegacy = maxBytes < BYTES_PER_ALT || rng() < 0.5;
   const useAlt = !useLegacy && rng() < 0.5;
@@ -50,7 +59,7 @@ function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number = Math.r
 
   const additionalAccounts = [];
   const cfReceiverAddress = getContractAddress('Solana', 'CFTESTER');
-  const fallbackAddress = Keypair.generate().publicKey.toBytes();
+  const fallbackAddress = seededSolanaKeypair(rng).publicKey.toBytes();
 
   if (useAlt) {
     // We will only use one ALT
@@ -65,7 +74,7 @@ function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number = Math.r
 
   for (let i = 0; i < numAdditionalAccounts; i++) {
     additionalAccounts.push({
-      pubkey: Keypair.generate().publicKey.toBytes(),
+      pubkey: seededSolanaKeypair(rng).publicKey.toBytes(),
       is_writable: rng() < 0.5,
     });
   }
@@ -107,8 +116,9 @@ function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number = Math.r
 
 // Generate random bytes. Setting a minimum length of 10 because very short messages can end up
 // with the SC returning an ASCII character in SwapDepositAddressReady.
-function newCcmArbitraryBytes(maxLength: number, rng: () => number = Math.random): string {
-  return randomAsHex(Math.floor(rng() * Math.max(0, maxLength - 10)) + 10);
+function newCcmArbitraryBytes(maxLength: number, rng: () => number): string {
+  const numBytes = Math.floor(rng() * Math.max(0, maxLength - 10)) + 10;
+  return seededHexBytes(numBytes, rng);
 }
 
 // For Solana the maximum number of extra accounts that can be passed is limited by the tx size
@@ -116,8 +126,8 @@ function newCcmArbitraryBytes(maxLength: number, rng: () => number = Math.random
 function newCcmAdditionalData(
   destAsset: Asset,
   message: string,
+  rng: () => number,
   maxLength?: number,
-  rng: () => number = Math.random,
 ): string {
   const destChain = chainFromAsset(destAsset);
 
@@ -154,11 +164,7 @@ function newCcmAdditionalData(
   }
 }
 
-function newCcmMessage(
-  destAsset: Asset,
-  maxLength?: number,
-  rng: () => number = Math.random,
-): string {
+function newCcmMessage(destAsset: Asset, rng: () => number, maxLength?: number): string {
   const destChain = chainFromAsset(destAsset);
   let length: number;
 
@@ -198,13 +204,11 @@ const OVERHEAD_ENERGY = 20000;
 
 export async function newCcmMetadata(
   destAsset: Asset,
-  ccmMessage?: string,
-  ccmAdditionalDataArray?: string,
-  rng: () => number = Math.random,
+  options: CcmMetadataOptions = {},
 ): Promise<CcmDepositMetadata> {
-  const message = ccmMessage ?? newCcmMessage(destAsset, undefined, rng);
-  const ccmAdditionalData =
-    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, undefined, rng);
+  const rng = options.rng ?? Math.random;
+  const message = options.message ?? newCcmMessage(destAsset, rng);
+  const ccmAdditionalData = options.additionalData ?? newCcmAdditionalData(destAsset, message, rng);
   const destChain = chainFromAsset(destAsset);
 
   let userLogicGasBudget;
@@ -235,10 +239,10 @@ export async function newCcmMetadata(
 export async function newVaultSwapCcmMetadata(
   sourceAsset: Asset,
   destAsset: Asset,
-  ccmMessage?: string,
-  ccmAdditionalDataArray?: string,
-  rng: () => number = Math.random,
+  options: CcmMetadataOptions = {},
 ): Promise<CcmDepositMetadata> {
+  const rng = options.rng ?? Math.random;
+  const { message: ccmMessage, additionalData: ccmAdditionalDataArray } = options;
   const sourceChain = chainFromAsset(sourceAsset);
   let messageMaxLength;
   let metadataMaxLength;
@@ -266,11 +270,11 @@ export async function newVaultSwapCcmMetadata(
     }
   }
 
-  const message = ccmMessage ?? newCcmMessage(destAsset, messageMaxLength, rng);
+  const message = ccmMessage ?? newCcmMessage(destAsset, rng, messageMaxLength);
   // For now we only enforce empty ccmAdditionalData for Vault swaps, not deposit channels.
   const ccmAdditionalData =
-    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, metadataMaxLength, rng);
-  return newCcmMetadata(destAsset, message, ccmAdditionalData);
+    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, rng, metadataMaxLength);
+  return newCcmMetadata(destAsset, { message, additionalData: ccmAdditionalData });
 }
 
 export async function prepareSwap(

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -42,10 +42,10 @@ const MAX_CCM_BYTES_USDT = 632;
 const SOLANA_BYTES_PER_ACCOUNT = 33;
 const BYTES_PER_ALT = 34; // 32 + 1 + 1 (for vector lengths)
 
-function newSolanaCcmAdditionalData(maxBytes: number) {
+function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number = Math.random) {
   // Test all combinations
-  const useLegacy = maxBytes < BYTES_PER_ALT || Math.random() < 0.5;
-  const useAlt = !useLegacy && Math.random() < 0.5;
+  const useLegacy = maxBytes < BYTES_PER_ALT || rng() < 0.5;
+  const useAlt = !useLegacy && rng() < 0.5;
   let bytesAvailable = maxBytes;
 
   const additionalAccounts = [];
@@ -61,12 +61,12 @@ function newSolanaCcmAdditionalData(maxBytes: number) {
   }
 
   const maxAccounts = Math.floor(bytesAvailable / SOLANA_BYTES_PER_ACCOUNT);
-  const numAdditionalAccounts = Math.floor(Math.random() * maxAccounts);
+  const numAdditionalAccounts = Math.floor(rng() * maxAccounts);
 
   for (let i = 0; i < numAdditionalAccounts; i++) {
     additionalAccounts.push({
       pubkey: Keypair.generate().publicKey.toBytes(),
-      is_writable: Math.random() < 0.5,
+      is_writable: rng() < 0.5,
     });
   }
 
@@ -107,13 +107,18 @@ function newSolanaCcmAdditionalData(maxBytes: number) {
 
 // Generate random bytes. Setting a minimum length of 10 because very short messages can end up
 // with the SC returning an ASCII character in SwapDepositAddressReady.
-function newCcmArbitraryBytes(maxLength: number): string {
-  return randomAsHex(Math.floor(Math.random() * Math.max(0, maxLength - 10)) + 10);
+function newCcmArbitraryBytes(maxLength: number, rng: () => number = Math.random): string {
+  return randomAsHex(Math.floor(rng() * Math.max(0, maxLength - 10)) + 10);
 }
 
 // For Solana the maximum number of extra accounts that can be passed is limited by the tx size
 // and therefore also depends on the message length.
-function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: number): string {
+function newCcmAdditionalData(
+  destAsset: Asset,
+  message: string,
+  maxLength?: number,
+  rng: () => number = Math.random,
+): string {
   const destChain = chainFromAsset(destAsset);
 
   switch (destChain) {
@@ -138,7 +143,7 @@ function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: num
       if (maxLength !== undefined) {
         bytesAvailable = Math.min(bytesAvailable, maxLength);
       }
-      const ccmAdditionalData = newSolanaCcmAdditionalData(bytesAvailable);
+      const ccmAdditionalData = newSolanaCcmAdditionalData(bytesAvailable, rng);
       if (ccmAdditionalData.slice(2).length / 2 > MAX_CCM_ADDITIONAL_DATA_LENGTH) {
         throw new Error(`CCM additional data length exceeds limit: ${ccmAdditionalData.length}`);
       }
@@ -149,7 +154,11 @@ function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: num
   }
 }
 
-function newCcmMessage(destAsset: Asset, maxLength?: number): string {
+function newCcmMessage(
+  destAsset: Asset,
+  maxLength?: number,
+  rng: () => number = Math.random,
+): string {
   const destChain = chainFromAsset(destAsset);
   let length: number;
 
@@ -181,7 +190,7 @@ function newCcmMessage(destAsset: Asset, maxLength?: number): string {
     length = Math.min(length, maxLength);
   }
 
-  return newCcmArbitraryBytes(length);
+  return newCcmArbitraryBytes(length, rng);
 }
 // Minimum overhead to ensure simple CCM transactions succeed
 const OVERHEAD_COMPUTE_UNITS = 30000;
@@ -191,9 +200,11 @@ export async function newCcmMetadata(
   destAsset: Asset,
   ccmMessage?: string,
   ccmAdditionalDataArray?: string,
+  rng: () => number = Math.random,
 ): Promise<CcmDepositMetadata> {
-  const message = ccmMessage ?? newCcmMessage(destAsset);
-  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
+  const message = ccmMessage ?? newCcmMessage(destAsset, undefined, rng);
+  const ccmAdditionalData =
+    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, undefined, rng);
   const destChain = chainFromAsset(destAsset);
 
   let userLogicGasBudget;
@@ -226,6 +237,7 @@ export async function newVaultSwapCcmMetadata(
   destAsset: Asset,
   ccmMessage?: string,
   ccmAdditionalDataArray?: string,
+  rng: () => number = Math.random,
 ): Promise<CcmDepositMetadata> {
   const sourceChain = chainFromAsset(sourceAsset);
   let messageMaxLength;
@@ -254,10 +266,10 @@ export async function newVaultSwapCcmMetadata(
     }
   }
 
-  const message = ccmMessage ?? newCcmMessage(destAsset, messageMaxLength);
+  const message = ccmMessage ?? newCcmMessage(destAsset, messageMaxLength, rng);
   // For now we only enforce empty ccmAdditionalData for Vault swaps, not deposit channels.
   const ccmAdditionalData =
-    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, metadataMaxLength);
+    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, metadataMaxLength, rng);
   return newCcmMetadata(destAsset, message, ccmAdditionalData);
 }
 

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -349,7 +349,7 @@ export function defaultAssetAmounts(asset: Asset): string {
     case 'Bnb':
       return '5';
     case 'HubDot':
-      return '50';
+      return '200';
     case 'Usdc':
     case 'Usdt':
     case 'ArbUsdc':

--- a/bouncer/shared/utils/seeded_rng.ts
+++ b/bouncer/shared/utils/seeded_rng.ts
@@ -16,3 +16,15 @@ export function seededRng(seed: number): () => number {
   };
 }
 /* eslint-enable no-bitwise, operator-assignment */
+
+/** Deterministic `0x`-prefixed random bytes of the given length, driven by `rng` so the content — */
+/** not just the length — is reproducible from the seed. */
+export function seededHexBytes(numBytes: number, rng: () => number): `0x${string}` {
+  let hex = '0x';
+  for (let i = 0; i < numBytes; i++) {
+    hex += Math.floor(rng() * 256)
+      .toString(16)
+      .padStart(2, '0');
+  }
+  return hex as `0x${string}`;
+}

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -48,8 +48,8 @@ export async function initiateSwap(
   if (ccmSwap) {
     ccmSwapMetadata =
       functionCall === testSwap
-        ? await newCcmMetadata(destAsset, undefined, undefined, rng)
-        : await newVaultSwapCcmMetadata(sourceAsset, destAsset, undefined, undefined, rng);
+        ? await newCcmMetadata(destAsset, { rng })
+        : await newVaultSwapCcmMetadata(sourceAsset, destAsset, { rng });
   }
 
   if (destAsset === 'Btc') {

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -42,13 +42,14 @@ export async function initiateSwap(
   destAsset: Asset,
   functionCall: typeof testSwap | typeof testVaultSwap,
   ccmSwap: boolean = false,
+  rng: () => number = Math.random,
 ): Promise<SwapParams | VaultSwapParams> {
   let ccmSwapMetadata;
   if (ccmSwap) {
     ccmSwapMetadata =
       functionCall === testSwap
-        ? await newCcmMetadata(destAsset)
-        : await newVaultSwapCcmMetadata(sourceAsset, destAsset);
+        ? await newCcmMetadata(destAsset, undefined, undefined, rng)
+        : await newVaultSwapCcmMetadata(sourceAsset, destAsset, undefined, undefined, rng);
   }
 
   if (destAsset === 'Btc') {
@@ -57,7 +58,7 @@ export async function initiateSwap(
       cf,
       sourceAsset,
       destAsset,
-      btcAddressTypesArray[Math.floor(Math.random() * btcAddressTypesArray.length)],
+      btcAddressTypesArray[Math.floor(rng() * btcAddressTypesArray.length)],
       ccmSwapMetadata,
       testContext.swapContext,
     );
@@ -249,12 +250,22 @@ export function testAllSwaps(timeoutPerSwap: number, thoroughlyTestedAssets: Ass
     ccmSwap: boolean = false,
   ) {
     allSwapsCount++;
+    const swapNumber = allSwapsCount;
     const swapType = functionCall === testSwap ? 'Swap' : 'VaultSwap';
     allSwaps.push({
-      name: `Swap ${allSwapsCount}: ${sourceAsset} to ${destAsset} (${ccmSwap ? 'CCM ' : ''}${swapType})`,
+      name: `Swap ${swapNumber}: ${sourceAsset} to ${destAsset} (${ccmSwap ? 'CCM ' : ''}${swapType})`,
       test: async (context) => {
         const cf = await newChainflipIO(context.logger, [] as []);
-        await initiateSwap(cf, context, sourceAsset, destAsset, functionCall, ccmSwap);
+        // Deterministic per-swap seed derived from the AllSwaps seed, so CCM generation is reproducible
+        await initiateSwap(
+          cf,
+          context,
+          sourceAsset,
+          destAsset,
+          functionCall,
+          ccmSwap,
+          seededRng(GENERATE_SWAPS_SEED + swapNumber),
+        );
       },
     });
   }

--- a/bouncer/tests/delegate_flip.ts
+++ b/bouncer/tests/delegate_flip.ts
@@ -200,7 +200,7 @@ export async function testCcmSwapFundAccount(testContext: TestContext) {
   }
 
   const ccmMessage = web3.eth.abi.encodeParameters(['address', 'bytes'], [scUtilsAddress, pubkey]);
-  const ccmMetadata = await newCcmMetadata('Flip', ccmMessage);
+  const ccmMetadata = await newCcmMetadata('Flip', { message: ccmMessage });
   // Override gas budget for this particular use case
   ccmMetadata.gasBudget = '1000000';
 

--- a/bouncer/tests/gaslimit_ccm.test.ts
+++ b/bouncer/tests/gaslimit_ccm.test.ts
@@ -236,10 +236,9 @@ async function testGasLimitSwapToEvm<A = []>(
 
   const gasConsumption = getRandomGasConsumption(chainFromAsset(destAsset));
 
-  const ccmMetadata = await newCcmMetadata(
-    destAsset,
-    web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
-  );
+  const ccmMetadata = await newCcmMetadata(destAsset, {
+    message: web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
+  });
 
   // Estimating gas separately. We can't rely on the default gas estimation in `newCcmMetadata()`
   // because the CF tester gas consumption depends on the gas limit, making this a circular calculation.
@@ -378,10 +377,9 @@ async function testTronInsufficientGas<A = []>(
 
   // No need to override the gasBudget since the numberOfStores will make sure the energy
   // consumption is higher than the budget.
-  const ccmMetadata = await newCcmMetadata(
-    destAsset,
-    tronWeb.utils.abi.encodeParams(['string', 'uint256'], ['GasTest', numberOfStores]),
-  );
+  const ccmMetadata = await newCcmMetadata(destAsset, {
+    message: tronWeb.utils.abi.encodeParams(['string', 'uint256'], ['GasTest', numberOfStores]),
+  });
 
   const { tag, destAddress, broadcastId, gasLimitBudget } = await executeAndTrackCcmSwap(
     cf,


### PR DESCRIPTION
Makes CCM metadata generation reproducible and fixes a flaky AllSwaps failure.

- Thread a seeded `rng` through the CCM message/metadata builders (defaults to `Math.random` for other callers); each AllSwaps swap gets a deterministic per-swap seed derived from the AllSwaps seed, so a failing run reproduces from the logged seed.
- Raise the default HubDot swap amount `50 → 200`. HubDot is low-value (~2 USDC), so a 50-DOT swap could egress below a CCM egress's dust limit once the (message-driven) gas budget is deducted, ignoring the egress.
