### PR TITLE
feat: multi operator delegation

### DIFF
--- a/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/errors.d.ts
@@ -567,6 +567,12 @@ export interface ChainErrors extends GenericChainErrors {
     StillDelegating: GenericPalletError;
 
     /**
+     * `delegate`/`undelegate` only support a delegator with at most one existing relation.
+     * Use `delegate_multi` and specify the full plan explicitly.
+     **/
+    MultiOperatorDelegator: GenericPalletError;
+
+    /**
      * Generic pallet error
      **/
     [error: string]: GenericPalletError;

--- a/bouncer/generated/chaintypes/chainflip-node/events.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/events.d.ts
@@ -36,6 +36,7 @@ import type {
   PalletCfValidatorPalletConfigUpdate,
   PalletCfValidatorDelegationOperatorSettings,
   PalletCfValidatorDelegationChange,
+  PalletCfValidatorDelegationDelegatorRelations,
   CfPrimitivesWitnessingTaskName,
   SpConsensusGrandpaAppPublic,
   PalletCfGovernanceGovernanceCouncil,
@@ -899,6 +900,17 @@ export interface ChainEvents extends GenericChainEvents {
       'Validator',
       'MaxBidUpdated',
       { delegator: AccountId32; change: PalletCfValidatorDelegationChange }
+    >;
+
+    /**
+     * A delegator submitted a new full delegation plan via `delegate_multi`. `plan` is the
+     * resulting set of relations that was actually stored (after dropping zero-amount
+     * entries and prorating down to fit the delegator's balance, if it was oversubscribed).
+     **/
+    DelegationPlanUpdated: GenericPalletEvent<
+      'Validator',
+      'DelegationPlanUpdated',
+      { delegator: AccountId32; plan: PalletCfValidatorDelegationDelegatorRelations }
     >;
 
     /**

--- a/bouncer/generated/chaintypes/chainflip-node/query.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/query.d.ts
@@ -47,6 +47,7 @@ import type {
   PalletCfValidatorRotationPhase,
   PalletCfValidatorAuctionResolverSetSizeParameters,
   PalletCfValidatorDelegationOperatorSettings,
+  PalletCfValidatorDelegationDelegatorRelations,
   PalletCfValidatorDelegationDelegationSnapshot,
   StateChainRuntimeOpaqueSessionKeys,
   SpStakingOffenceOffenceSeverity,
@@ -1427,16 +1428,15 @@ export interface ChainStorage extends GenericChainStorage {
     >;
 
     /**
-     * Maps an delegator to an associated operator account and max bid.
-     *
-     * The max bid determines how much of the delegator's balance can be used
-     * used by the operator when bidding for an authority slot.
+     * Maps a delegator to its live relations: the set of operators it delegates to and the max
+     * bid pledged to each. The sum of all of a delegator's max bids is capped at its funding
+     * balance. The key is always removed entirely once a delegator's relations become empty.
      *
      * @param {AccountId32Like} arg
-     * @param {Callback<[AccountId32, bigint] | undefined> =} callback
+     * @param {Callback<PalletCfValidatorDelegationDelegatorRelations | undefined> =} callback
      **/
-    delegationChoice: GenericStorageQuery<
-      (arg: AccountId32Like) => [AccountId32, bigint] | undefined,
+    delegationChoices: GenericStorageQuery<
+      (arg: AccountId32Like) => PalletCfValidatorDelegationDelegatorRelations | undefined,
       AccountId32
     >;
 

--- a/bouncer/generated/chaintypes/chainflip-node/tx.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/tx.d.ts
@@ -42,6 +42,7 @@ import type {
   CfPrimitivesSemVer,
   PalletCfValidatorDelegationOperatorSettings,
   PalletCfValidatorDelegationDelegationAmount,
+  PalletCfValidatorDelegationDelegatorRelations,
   CfPrimitivesWitnessingTaskName,
   SpConsensusGrandpaAppPublic,
   SpConsensusGrandpaAppSignature,
@@ -1672,6 +1673,13 @@ export interface ChainTx<
     >;
 
     /**
+     * Delegate to a single operator.
+     *
+     * This extrinsic pre-dates multi-operator delegation and keeps its original,
+     * implicit-switch behaviour: it is only valid for delegators with at most one existing
+     * relation. A delegator with relations to two or more operators (only reachable via
+     * [`Self::delegate_multi`]) must use `delegate_multi` instead, since "switch operator"
+     * is ambiguous once more than one relation exists.
      *
      * @param {AccountId32Like} operator
      * @param {PalletCfValidatorDelegationDelegationAmount} increase
@@ -1696,6 +1704,11 @@ export interface ChainTx<
     >;
 
     /**
+     * Undelegate from the sole operator a delegator currently delegates to.
+     *
+     * Only valid for delegators with at most one existing relation, mirroring `delegate`.
+     * A delegator with relations to two or more operators must use `delegate_multi` and
+     * submit a plan that omits the operator(s) to undelegate from.
      *
      * @param {PalletCfValidatorDelegationDelegationAmount} decrease
      **/
@@ -1706,6 +1719,36 @@ export interface ChainTx<
           palletCall: {
             name: 'Undelegate';
             params: { decrease: PalletCfValidatorDelegationDelegationAmount };
+          };
+        },
+        ChainKnownTypes
+      >
+    >;
+
+    /**
+     * Sets `delegator`'s complete delegation plan across one or more operators in a single
+     * call: `plan` becomes their entire new set of relations, replacing whatever existed
+     * before. Any operator the delegator was previously delegating to but that's absent
+     * from `plan` is fully undelegated; an empty `plan` undelegates everything. Unlike
+     * `delegate`, the caller declares exact target amounts rather than an
+     * increase/decrease delta -- entries with a zero amount are treated the same as an
+     * absent entry.
+     *
+     * If `plan`'s amounts sum to more than the delegator's funding balance, every entry is
+     * scaled down proportionally so the total exactly matches the balance -- the sum of a
+     * delegator's relations can never exceed what they actually hold. The (possibly
+     * scaled-down) total must be at least the minimum funding amount if `plan` is
+     * non-empty; individual entries may be smaller, only the total is checked.
+     *
+     * @param {PalletCfValidatorDelegationDelegatorRelations} plan
+     **/
+    delegateMulti: GenericTxCall<
+      (plan: PalletCfValidatorDelegationDelegatorRelations) => ChainSubmittableExtrinsic<
+        {
+          pallet: 'Validator';
+          palletCall: {
+            name: 'DelegateMulti';
+            params: { plan: PalletCfValidatorDelegationDelegatorRelations };
           };
         },
         ChainKnownTypes

--- a/bouncer/generated/chaintypes/chainflip-node/types.d.ts
+++ b/bouncer/generated/chaintypes/chainflip-node/types.d.ts
@@ -1400,11 +1400,43 @@ export type PalletCfValidatorCall =
    * Executed by an operator to deregister as an operator.
    **/
   | { name: 'DeregisterAsOperator' }
+  /**
+   * Delegate to a single operator.
+   *
+   * This extrinsic pre-dates multi-operator delegation and keeps its original,
+   * implicit-switch behaviour: it is only valid for delegators with at most one existing
+   * relation. A delegator with relations to two or more operators (only reachable via
+   * [`Self::delegate_multi`]) must use `delegate_multi` instead, since "switch operator"
+   * is ambiguous once more than one relation exists.
+   **/
   | {
       name: 'Delegate';
       params: { operator: AccountId32; increase: PalletCfValidatorDelegationDelegationAmount };
     }
+  /**
+   * Undelegate from the sole operator a delegator currently delegates to.
+   *
+   * Only valid for delegators with at most one existing relation, mirroring `delegate`.
+   * A delegator with relations to two or more operators must use `delegate_multi` and
+   * submit a plan that omits the operator(s) to undelegate from.
+   **/
   | { name: 'Undelegate'; params: { decrease: PalletCfValidatorDelegationDelegationAmount } }
+  /**
+   * Sets `delegator`'s complete delegation plan across one or more operators in a single
+   * call: `plan` becomes their entire new set of relations, replacing whatever existed
+   * before. Any operator the delegator was previously delegating to but that's absent
+   * from `plan` is fully undelegated; an empty `plan` undelegates everything. Unlike
+   * `delegate`, the caller declares exact target amounts rather than an
+   * increase/decrease delta -- entries with a zero amount are treated the same as an
+   * absent entry.
+   *
+   * If `plan`'s amounts sum to more than the delegator's funding balance, every entry is
+   * scaled down proportionally so the total exactly matches the balance -- the sum of a
+   * delegator's relations can never exceed what they actually hold. The (possibly
+   * scaled-down) total must be at least the minimum funding amount if `plan` is
+   * non-empty; individual entries may be smaller, only the total is checked.
+   **/
+  | { name: 'DelegateMulti'; params: { plan: PalletCfValidatorDelegationDelegatorRelations } }
   | { name: 'ReportWitnessingTaskRestart'; params: { task: CfPrimitivesWitnessingTaskName } }
   /**
    * Delegate this validator's GRANDPA vote to a delegate key.
@@ -1545,11 +1577,43 @@ export type PalletCfValidatorCallLike =
    * Executed by an operator to deregister as an operator.
    **/
   | { name: 'DeregisterAsOperator' }
+  /**
+   * Delegate to a single operator.
+   *
+   * This extrinsic pre-dates multi-operator delegation and keeps its original,
+   * implicit-switch behaviour: it is only valid for delegators with at most one existing
+   * relation. A delegator with relations to two or more operators (only reachable via
+   * [`Self::delegate_multi`]) must use `delegate_multi` instead, since "switch operator"
+   * is ambiguous once more than one relation exists.
+   **/
   | {
       name: 'Delegate';
       params: { operator: AccountId32Like; increase: PalletCfValidatorDelegationDelegationAmount };
     }
+  /**
+   * Undelegate from the sole operator a delegator currently delegates to.
+   *
+   * Only valid for delegators with at most one existing relation, mirroring `delegate`.
+   * A delegator with relations to two or more operators must use `delegate_multi` and
+   * submit a plan that omits the operator(s) to undelegate from.
+   **/
   | { name: 'Undelegate'; params: { decrease: PalletCfValidatorDelegationDelegationAmount } }
+  /**
+   * Sets `delegator`'s complete delegation plan across one or more operators in a single
+   * call: `plan` becomes their entire new set of relations, replacing whatever existed
+   * before. Any operator the delegator was previously delegating to but that's absent
+   * from `plan` is fully undelegated; an empty `plan` undelegates everything. Unlike
+   * `delegate`, the caller declares exact target amounts rather than an
+   * increase/decrease delta -- entries with a zero amount are treated the same as an
+   * absent entry.
+   *
+   * If `plan`'s amounts sum to more than the delegator's funding balance, every entry is
+   * scaled down proportionally so the total exactly matches the balance -- the sum of a
+   * delegator's relations can never exceed what they actually hold. The (possibly
+   * scaled-down) total must be at least the minimum funding amount if `plan` is
+   * non-empty; individual entries may be smaller, only the total is checked.
+   **/
+  | { name: 'DelegateMulti'; params: { plan: PalletCfValidatorDelegationDelegatorRelations } }
   | { name: 'ReportWitnessingTaskRestart'; params: { task: CfPrimitivesWitnessingTaskName } }
   /**
    * Delegate this validator's GRANDPA vote to a delegate key.
@@ -1608,6 +1672,10 @@ export type PalletCfValidatorDelegationDelegationAcceptance = 'Allow' | 'Deny';
 export type PalletCfValidatorDelegationDelegationAmount =
   | { type: 'Max' }
   | { type: 'Some'; value: bigint };
+
+export type PalletCfValidatorDelegationDelegatorRelations = {
+  operators: Array<[AccountId32, bigint]>;
+};
 
 export type CfPrimitivesWitnessingTaskName =
   | 'Ethereum'
@@ -13618,6 +13686,15 @@ export type PalletCfValidatorEvent =
       data: { delegator: AccountId32; change: PalletCfValidatorDelegationChange };
     }
   /**
+   * A delegator submitted a new full delegation plan via `delegate_multi`. `plan` is the
+   * resulting set of relations that was actually stored (after dropping zero-amount
+   * entries and prorating down to fit the delegator's balance, if it was oversubscribed).
+   **/
+  | {
+      name: 'DelegationPlanUpdated';
+      data: { delegator: AccountId32; plan: PalletCfValidatorDelegationDelegatorRelations };
+    }
+  /**
    * A validator reported that a witnessing task crashed and was restarted.
    **/
   | {
@@ -18174,7 +18251,12 @@ export type PalletCfValidatorError =
   /**
    * The account cannot deregister as a Liquidity Provider while actively delegating.
    **/
-  | 'StillDelegating';
+  | 'StillDelegating'
+  /**
+   * `delegate`/`undelegate` only support a delegator with at most one existing relation.
+   * Use `delegate_multi` and specify the full plan explicitly.
+   **/
+  | 'MultiOperatorDelegator';
 
 export type SpStakingOffenceOffenceSeverity = Perbill;
 
@@ -22860,13 +22942,8 @@ export type StateChainRuntimeRuntimeApisCustomApiTypesRpcAccountInfoCommonItems 
   estimatedRedeemableBalance: bigint;
   boundRedeemAddress?: H160 | undefined;
   restrictedBalances: Array<[H160, bigint]>;
-  currentDelegationStatus?: StateChainRuntimeRuntimeApisCustomApiTypesDelegationInfo | undefined;
-  upcomingDelegationStatus?: StateChainRuntimeRuntimeApisCustomApiTypesDelegationInfo | undefined;
-};
-
-export type StateChainRuntimeRuntimeApisCustomApiTypesDelegationInfo = {
-  operator: AccountId32;
-  bid: bigint;
+  currentDelegationStatus: Array<[AccountId32, bigint]>;
+  upcomingDelegationStatus: Array<[AccountId32, bigint]>;
 };
 
 export type StateChainRuntimeRuntimeApisCustomApiTypesRuntimeApiAccountInfoWrapper = {

--- a/bouncer/generated/events/common.ts
+++ b/bouncer/generated/events/common.ts
@@ -525,6 +525,10 @@ export const palletCfValidatorDelegationChange = z.discriminatedUnion('__kind', 
   z.object({ __kind: z.literal('Decrease'), value: numberOrHex }),
 ]);
 
+export const palletCfValidatorDelegationDelegatorRelations = z.object({
+  operators: z.array(z.tuple([accountId, numberOrHex])),
+});
+
 export const cfPrimitivesWitnessingTaskName = simpleEnum([
   'Ethereum',
   'Bitcoin',

--- a/bouncer/generated/events/validator/delegationPlanUpdated.ts
+++ b/bouncer/generated/events/validator/delegationPlanUpdated.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { accountId, palletCfValidatorDelegationDelegatorRelations } from '../common';
+import { defineEvent } from '@chainflip/processor/event';
+
+export const validatorDelegationPlanUpdated = z.object({
+  delegator: accountId,
+  plan: palletCfValidatorDelegationDelegatorRelations,
+});
+
+export const validatorDelegationPlanUpdatedEvent = defineEvent(
+  'Validator.DelegationPlanUpdated',
+  validatorDelegationPlanUpdated,
+);

--- a/bouncer/tests/fast_bouncer.test.ts
+++ b/bouncer/tests/fast_bouncer.test.ts
@@ -18,6 +18,7 @@ import { testBrokerLevelScreening } from 'tests/broker_level_screening';
 import { testFundRedeem } from 'tests/fund_redeem';
 import { concurrentTest, serialTest } from 'shared/utils/vitest';
 import { testCcmSwapFundAccount, testDelegate } from 'tests/delegate_flip';
+import { testMultiDelegate } from 'tests/multi_delegate_flip';
 import { testSpecialBitcoinSwaps } from 'tests/special_btc_swaps';
 import { testSignedRuntimeCall } from 'tests/signed_runtime_call';
 import { lendingTest } from 'tests/lending';
@@ -60,6 +61,7 @@ describe('ConcurrentTests', () => {
   concurrentTest('VaultSwaps', testVaultSwap, 340 * ciTimeoutFactor);
   concurrentTest('SpecialBitcoinSwaps', testSpecialBitcoinSwaps, 250 * ciTimeoutFactor);
   concurrentTest('DelegateFlip', testDelegate, 325 * ciTimeoutFactor);
+  concurrentTest('MultiDelegateFlip', testMultiDelegate, 200 * ciTimeoutFactor);
   concurrentTest('SwapAndFundAccountViaCCM', testCcmSwapFundAccount, 240 * ciTimeoutFactor);
   concurrentTest('SignedRuntimeCall', testSignedRuntimeCall, 280 * ciTimeoutFactor);
   concurrentTest('Lending', lendingTest, 360 * ciTimeoutFactor);

--- a/bouncer/tests/multi_delegate_flip.ts
+++ b/bouncer/tests/multi_delegate_flip.ts
@@ -1,19 +1,55 @@
-import type { AccountId32 } from 'dedot/codecs';
-import { amountToFineAmountBigInt, defaultAssetAmounts } from 'shared/utils';
-import { getIsoTime } from 'shared/utils/logger';
+import type { SubmittableResult } from '@polkadot/api';
+// eslint-disable-next-line no-restricted-imports
+import type { KeyringPair } from '@polkadot/keyring/types';
 import { fundFlip } from 'shared/fund_flip';
 import { AccountRole, setupAccount } from 'shared/setup_account';
 import { newChainflipIO, partialAccountFromUri } from 'shared/utils/chainflip_io';
+import { getChainflipPolkadotApi } from 'shared/utils/substrate';
+import { getIsoTime } from 'shared/utils/logger';
+import { amountToFineAmountBigInt, defaultAssetAmounts } from 'shared/utils';
 import { TestContext } from 'shared/utils/test_context';
-import { validatorDelegationPlanUpdatedEvent } from 'generated/events/validator/delegationPlanUpdated';
 
-// The generated `PalletCfValidatorDelegationDelegatorRelations` type is strict about
-// `AccountId32` (unlike top-level call params, which accept the more permissive
-// `AccountId32Like`), so SS58 addresses from a `KeyringPair` need this cast.
-const accountId = (address: string): AccountId32 => address as unknown as AccountId32;
+async function submitDelegateMulti(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  polkadotApi: any,
+  delegator: KeyringPair,
+  operators: Map<string, bigint>,
+) {
+  return new Promise<SubmittableResult['events']>((resolve, reject) => {
+    polkadotApi.tx.validator
+      .delegateMulti({ operators })
+      .signAndSend(delegator, (result: SubmittableResult) => {
+        if (result.dispatchError) {
+          reject(new Error(`delegateMulti: dispatch error ${result.dispatchError.toString()}`));
+        } else if (result.status.isInBlock || result.status.isFinalized) {
+          resolve(result.events);
+        }
+      })
+      .catch(reject);
+  });
+}
+
+function findEventData(events: SubmittableResult['events'], section: string, method: string) {
+  const found = events.find(({ event }) => event.section === section && event.method === method);
+  if (!found) {
+    throw new Error(`Event ${section}.${method} not found among: ${JSON.stringify(events)}`);
+  }
+  return found.event.data;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function operatorsOf(planUpdatedEventData: any): [string, bigint][] {
+  const operators = planUpdatedEventData.plan.operators;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return [...operators.entries()].map(([account, amount]: [any, any]) => [
+    account.toString(),
+    amount.toBigInt(),
+  ]);
+}
 
 export async function testMultiDelegate(testContext: TestContext) {
   const cf = await newChainflipIO(testContext.logger, []);
+  await using polkadotApi = await getChainflipPolkadotApi();
 
   // Account names have to be unique across bouncer runs, since if the test is run a second
   // time for accounts that are already registered/funded, expected events won't be re-emitted.
@@ -29,71 +65,75 @@ export async function testMultiDelegate(testContext: TestContext) {
   const delegatorCf = cf.with({ account: partialAccountFromUri(delegatorUri) });
   const delegator = delegatorCf.requirements.account.keypair;
 
-  const totalAmount = amountToFineAmountBigInt(defaultAssetAmounts('Flip'), 'Flip');
+  cf.info(`Funding delegator ${delegator.address} with Flip...`);
+  await fundFlip(delegatorCf, delegator.address, defaultAssetAmounts('Flip'));
+
+  const totalAmount = amountToFineAmountBigInt(defaultAssetAmounts('Flip'), 'Flip') / 2n;
   const amountToOperatorA = totalAmount / 2n;
   const amountToOperatorB = totalAmount - amountToOperatorA;
-
-  cf.info(`Funding delegator ${delegator.address} with Flip...`);
-  await fundFlip(cf, delegator.address, defaultAssetAmounts('Flip'));
 
   cf.info(
     `Delegating ${amountToOperatorA} to ${operatorA.address} and ${amountToOperatorB} to ${operatorB.address}...`,
   );
-  const plan = await delegatorCf.submitExtrinsic({
-    extrinsic: (api) =>
-      api.tx.validator.delegateMulti({
-        operators: [
-          [accountId(operatorA.address), amountToOperatorA],
-          [accountId(operatorB.address), amountToOperatorB],
-        ],
-      }),
-    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
-      (event) => event.delegator === delegator.address,
+  // we use chainflipPolkadotApi for submitting this extrinsic since dedot has a bug when there is a BTreeMap in the arguments of the extrinsic.
+  const planUpdated = findEventData(
+    await submitDelegateMulti(
+      polkadotApi,
+      delegator,
+      new Map([
+        [operatorA.address, amountToOperatorA],
+        [operatorB.address, amountToOperatorB],
+      ]),
     ),
-  });
+    'validator',
+    'DelegationPlanUpdated',
+  );
 
+  const operators = operatorsOf(planUpdated);
   if (
-    plan.plan.operators.length !== 2 ||
-    !plan.plan.operators.some(
+    operators.length !== 2 ||
+    !operators.some(
       ([operator, amount]) => operator === operatorA.address && amount === amountToOperatorA,
     ) ||
-    !plan.plan.operators.some(
+    !operators.some(
       ([operator, amount]) => operator === operatorB.address && amount === amountToOperatorB,
     )
   ) {
-    throw new Error(`Unexpected delegation plan after delegate_multi: ${JSON.stringify(plan)}`);
+    throw new Error(
+      `Unexpected delegation plan after delegate_multi: ${JSON.stringify(operators)}`,
+    );
   }
 
   cf.info(`Updating delegation plan to only delegate to ${operatorA.address}...`);
-  const updatedPlan = await delegatorCf.submitExtrinsic({
-    extrinsic: (api) =>
-      api.tx.validator.delegateMulti({ operators: [[accountId(operatorA.address), totalAmount]] }),
-    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
-      (event) => event.delegator === delegator.address,
-    ),
-  });
+  const updatedPlanUpdated = findEventData(
+    await submitDelegateMulti(polkadotApi, delegator, new Map([[operatorA.address, totalAmount]])),
+    'validator',
+    'DelegationPlanUpdated',
+  );
 
+  const updatedOperators = operatorsOf(updatedPlanUpdated);
   if (
-    updatedPlan.plan.operators.length !== 1 ||
-    !updatedPlan.plan.operators.some(
+    updatedOperators.length !== 1 ||
+    !updatedOperators.some(
       ([operator, amount]) => operator === operatorA.address && amount === totalAmount,
     )
   ) {
     throw new Error(
-      `Unexpected delegation plan after switching to a single operator: ${JSON.stringify(updatedPlan)}`,
+      `Unexpected delegation plan after switching to a single operator: ${JSON.stringify(updatedOperators)}`,
     );
   }
 
   cf.info('Undelegating from all operators via an empty plan...');
-  const emptyPlan = await delegatorCf.submitExtrinsic({
-    extrinsic: (api) => api.tx.validator.delegateMulti({ operators: [] }),
-    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
-      (event) => event.delegator === delegator.address,
-    ),
-  });
+  const emptyPlanUpdated = findEventData(
+    await submitDelegateMulti(polkadotApi, delegator, new Map()),
+    'validator',
+    'DelegationPlanUpdated',
+  );
 
-  if (emptyPlan.plan.operators.length !== 0) {
-    throw new Error(`Expected an empty delegation plan, got: ${JSON.stringify(emptyPlan)}`);
+  if (operatorsOf(emptyPlanUpdated).length !== 0) {
+    throw new Error(
+      `Expected an empty delegation plan, got: ${JSON.stringify(operatorsOf(emptyPlanUpdated))}`,
+    );
   }
 
   cf.info('Multi-operator delegation test completed successfully!');

--- a/bouncer/tests/multi_delegate_flip.ts
+++ b/bouncer/tests/multi_delegate_flip.ts
@@ -1,0 +1,100 @@
+import type { AccountId32 } from 'dedot/codecs';
+import { amountToFineAmountBigInt, defaultAssetAmounts } from 'shared/utils';
+import { getIsoTime } from 'shared/utils/logger';
+import { fundFlip } from 'shared/fund_flip';
+import { AccountRole, setupAccount } from 'shared/setup_account';
+import { newChainflipIO, partialAccountFromUri } from 'shared/utils/chainflip_io';
+import { TestContext } from 'shared/utils/test_context';
+import { validatorDelegationPlanUpdatedEvent } from 'generated/events/validator/delegationPlanUpdated';
+
+// The generated `PalletCfValidatorDelegationDelegatorRelations` type is strict about
+// `AccountId32` (unlike top-level call params, which accept the more permissive
+// `AccountId32Like`), so SS58 addresses from a `KeyringPair` need this cast.
+const accountId = (address: string): AccountId32 => address as unknown as AccountId32;
+
+export async function testMultiDelegate(testContext: TestContext) {
+  const cf = await newChainflipIO(testContext.logger, []);
+
+  // Account names have to be unique across bouncer runs, since if the test is run a second
+  // time for accounts that are already registered/funded, expected events won't be re-emitted.
+  const timestamp = getIsoTime();
+  const operatorAUri: `//${string}` = `//Operator_MultiA_${timestamp}`;
+  const operatorBUri: `//${string}` = `//Operator_MultiB_${timestamp}`;
+  const delegatorUri: `//${string}` = `//Delegator_Multi_${timestamp}`;
+
+  cf.info(`Registering operators ${operatorAUri} and ${operatorBUri}...`);
+  const operatorA = await setupAccount(cf, operatorAUri, AccountRole.Operator);
+  const operatorB = await setupAccount(cf, operatorBUri, AccountRole.Operator);
+
+  const delegatorCf = cf.with({ account: partialAccountFromUri(delegatorUri) });
+  const delegator = delegatorCf.requirements.account.keypair;
+
+  const totalAmount = amountToFineAmountBigInt(defaultAssetAmounts('Flip'), 'Flip');
+  const amountToOperatorA = totalAmount / 2n;
+  const amountToOperatorB = totalAmount - amountToOperatorA;
+
+  cf.info(`Funding delegator ${delegator.address} with Flip...`);
+  await fundFlip(cf, delegator.address, defaultAssetAmounts('Flip'));
+
+  cf.info(
+    `Delegating ${amountToOperatorA} to ${operatorA.address} and ${amountToOperatorB} to ${operatorB.address}...`,
+  );
+  const plan = await delegatorCf.submitExtrinsic({
+    extrinsic: (api) =>
+      api.tx.validator.delegateMulti({
+        operators: [
+          [accountId(operatorA.address), amountToOperatorA],
+          [accountId(operatorB.address), amountToOperatorB],
+        ],
+      }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
+      (event) => event.delegator === delegator.address,
+    ),
+  });
+
+  if (
+    plan.plan.operators.length !== 2 ||
+    !plan.plan.operators.some(
+      ([operator, amount]) => operator === operatorA.address && amount === amountToOperatorA,
+    ) ||
+    !plan.plan.operators.some(
+      ([operator, amount]) => operator === operatorB.address && amount === amountToOperatorB,
+    )
+  ) {
+    throw new Error(`Unexpected delegation plan after delegate_multi: ${JSON.stringify(plan)}`);
+  }
+
+  cf.info(`Updating delegation plan to only delegate to ${operatorA.address}...`);
+  const updatedPlan = await delegatorCf.submitExtrinsic({
+    extrinsic: (api) =>
+      api.tx.validator.delegateMulti({ operators: [[accountId(operatorA.address), totalAmount]] }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
+      (event) => event.delegator === delegator.address,
+    ),
+  });
+
+  if (
+    updatedPlan.plan.operators.length !== 1 ||
+    !updatedPlan.plan.operators.some(
+      ([operator, amount]) => operator === operatorA.address && amount === totalAmount,
+    )
+  ) {
+    throw new Error(
+      `Unexpected delegation plan after switching to a single operator: ${JSON.stringify(updatedPlan)}`,
+    );
+  }
+
+  cf.info('Undelegating from all operators via an empty plan...');
+  const emptyPlan = await delegatorCf.submitExtrinsic({
+    extrinsic: (api) => api.tx.validator.delegateMulti({ operators: [] }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent.refine(
+      (event) => event.delegator === delegator.address,
+    ),
+  });
+
+  if (emptyPlan.plan.operators.length !== 0) {
+    throw new Error(`Expected an empty delegation plan, got: ${JSON.stringify(emptyPlan)}`);
+  }
+
+  cf.info('Multi-operator delegation test completed successfully!');
+}

--- a/bouncer/tests/multi_delegate_flip.ts
+++ b/bouncer/tests/multi_delegate_flip.ts
@@ -1,55 +1,41 @@
-import type { SubmittableResult } from '@polkadot/api';
-// eslint-disable-next-line no-restricted-imports
-import type { KeyringPair } from '@polkadot/keyring/types';
 import { fundFlip } from 'shared/fund_flip';
 import { AccountRole, setupAccount } from 'shared/setup_account';
 import { newChainflipIO, partialAccountFromUri } from 'shared/utils/chainflip_io';
-import { getChainflipPolkadotApi } from 'shared/utils/substrate';
 import { getIsoTime } from 'shared/utils/logger';
 import { amountToFineAmountBigInt, defaultAssetAmounts } from 'shared/utils';
 import { TestContext } from 'shared/utils/test_context';
+import { validatorDelegationPlanUpdatedEvent } from 'generated/events/validator/delegationPlanUpdated';
+import type { PalletCfValidatorDelegationDelegatorRelations } from 'generated/chaintypes/chainflip-node/types';
 
-async function submitDelegateMulti(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  polkadotApi: any,
-  delegator: KeyringPair,
-  operators: Map<string, bigint>,
-) {
-  return new Promise<SubmittableResult['events']>((resolve, reject) => {
-    polkadotApi.tx.validator
-      .delegateMulti({ operators })
-      .signAndSend(delegator, (result: SubmittableResult) => {
-        if (result.dispatchError) {
-          reject(new Error(`delegateMulti: dispatch error ${result.dispatchError.toString()}`));
-        } else if (result.status.isInBlock || result.status.isFinalized) {
-          resolve(result.events);
-        }
-      })
-      .catch(reject);
-  });
-}
-
-function findEventData(events: SubmittableResult['events'], section: string, method: string) {
-  const found = events.find(({ event }) => event.section === section && event.method === method);
-  if (!found) {
-    throw new Error(`Event ${section}.${method} not found among: ${JSON.stringify(events)}`);
-  }
-  return found.event.data;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function operatorsOf(planUpdatedEventData: any): [string, bigint][] {
-  const operators = planUpdatedEventData.plan.operators;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return [...operators.entries()].map(([account, amount]: [any, any]) => [
-    account.toString(),
-    amount.toBigInt(),
-  ]);
+/**
+ * `BTreeMap<K, V>` has no distinct scale-info representation -- it derives `TypeInfo` as a
+ * `Sequence` of `(K, V)`, identical on the wire to `Vec<(K, V)>`. So dedot's registry builds the
+ * ordinary array/tuple codec for it, and a plain array of `[key, value]` pairs (exactly what the
+ * generated `Array<[AccountId32, bigint]>` type says) is the correct, and only, encodable shape --
+ * there's no dedicated `BTreeMap`/`Map` codec to route through.
+ *
+ * Passing a native `Map` instead (the intuitive JS analogue of a `BTreeMap`) doesn't hit a "BTreeMap
+ * bug" so much as a gap in that array codec: its `subAssert` correctly rejects a `Map` (`instanceof
+ * Array` fails, so `delegateMulti(...).sign()` throws a clear `ShapeAssertError`), but its `subEncode`
+ * -- used by the lower-level `tryEncode` that some codepaths call directly, bypassing that assert --
+ * reads `value.length`, which is `undefined` on a `Map` (only `.size` is defined). `undefined` is
+ * falsy, so the length-guarded entry loop is skipped entirely and a *valid, empty* operators list is
+ * encoded instead of throwing -- silently dropping every entry rather than failing loudly. That's the
+ * real dedot bug: a `Map` should be rejected at encode time, not silently coerced to `[]`.
+ *
+ * The cast below is only for the `AccountId32` vs `AccountId32Like` mismatch: dedot's codegen reuses
+ * the strict decode-side `AccountId32` class as this field's encode-side type too, even though the
+ * codec (like every other `AccountId32`-keyed field in these chaintypes) happily accepts a plain SS58
+ * address string at runtime.
+ */
+function toDelegatorOperators(
+  entries: [string, bigint][],
+): PalletCfValidatorDelegationDelegatorRelations['operators'] {
+  return entries as unknown as PalletCfValidatorDelegationDelegatorRelations['operators'];
 }
 
 export async function testMultiDelegate(testContext: TestContext) {
   const cf = await newChainflipIO(testContext.logger, []);
-  await using polkadotApi = await getChainflipPolkadotApi();
 
   // Account names have to be unique across bouncer runs, since if the test is run a second
   // time for accounts that are already registered/funded, expected events won't be re-emitted.
@@ -75,21 +61,18 @@ export async function testMultiDelegate(testContext: TestContext) {
   cf.info(
     `Delegating ${amountToOperatorA} to ${operatorA.address} and ${amountToOperatorB} to ${operatorB.address}...`,
   );
-  // we use chainflipPolkadotApi for submitting this extrinsic since dedot has a bug when there is a BTreeMap in the arguments of the extrinsic.
-  const planUpdated = findEventData(
-    await submitDelegateMulti(
-      polkadotApi,
-      delegator,
-      new Map([
-        [operatorA.address, amountToOperatorA],
-        [operatorB.address, amountToOperatorB],
-      ]),
-    ),
-    'validator',
-    'DelegationPlanUpdated',
-  );
+  const planUpdated = await delegatorCf.submitExtrinsic({
+    extrinsic: (client) =>
+      client.tx.validator.delegateMulti({
+        operators: toDelegatorOperators([
+          [operatorA.address, amountToOperatorA],
+          [operatorB.address, amountToOperatorB],
+        ]),
+      }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent,
+  });
 
-  const operators = operatorsOf(planUpdated);
+  const operators = planUpdated.plan.operators;
   if (
     operators.length !== 2 ||
     !operators.some(
@@ -100,18 +83,20 @@ export async function testMultiDelegate(testContext: TestContext) {
     )
   ) {
     throw new Error(
-      `Unexpected delegation plan after delegate_multi: ${JSON.stringify(operators)}`,
+      `Unexpected delegation plan after delegate_multi: ${JSON.stringify(operators, (_, v) => (typeof v === 'bigint' ? v.toString() : v))}`,
     );
   }
 
   cf.info(`Updating delegation plan to only delegate to ${operatorA.address}...`);
-  const updatedPlanUpdated = findEventData(
-    await submitDelegateMulti(polkadotApi, delegator, new Map([[operatorA.address, totalAmount]])),
-    'validator',
-    'DelegationPlanUpdated',
-  );
+  const updatedPlanUpdated = await delegatorCf.submitExtrinsic({
+    extrinsic: (client) =>
+      client.tx.validator.delegateMulti({
+        operators: toDelegatorOperators([[operatorA.address, totalAmount]]),
+      }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent,
+  });
 
-  const updatedOperators = operatorsOf(updatedPlanUpdated);
+  const updatedOperators = updatedPlanUpdated.plan.operators;
   if (
     updatedOperators.length !== 1 ||
     !updatedOperators.some(
@@ -119,20 +104,20 @@ export async function testMultiDelegate(testContext: TestContext) {
     )
   ) {
     throw new Error(
-      `Unexpected delegation plan after switching to a single operator: ${JSON.stringify(updatedOperators)}`,
+      `Unexpected delegation plan after switching to a single operator: ${JSON.stringify(updatedOperators, (_, v) => (typeof v === 'bigint' ? v.toString() : v))}`,
     );
   }
 
   cf.info('Undelegating from all operators via an empty plan...');
-  const emptyPlanUpdated = findEventData(
-    await submitDelegateMulti(polkadotApi, delegator, new Map()),
-    'validator',
-    'DelegationPlanUpdated',
-  );
+  const emptyPlanUpdated = await delegatorCf.submitExtrinsic({
+    extrinsic: (client) =>
+      client.tx.validator.delegateMulti({ operators: toDelegatorOperators([]) }),
+    expectedEvent: validatorDelegationPlanUpdatedEvent,
+  });
 
-  if (operatorsOf(emptyPlanUpdated).length !== 0) {
+  if (emptyPlanUpdated.plan.operators.length !== 0) {
     throw new Error(
-      `Expected an empty delegation plan, got: ${JSON.stringify(operatorsOf(emptyPlanUpdated))}`,
+      `Expected an empty delegation plan, got: ${JSON.stringify(emptyPlanUpdated.plan.operators, (_, v) => (typeof v === 'bigint' ? v.toString() : v))}`,
     );
   }
 

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -344,9 +344,6 @@ fn can_calculate_account_apy_for_validator_with_delegation() {
 		});
 }
 
-/// Unlike `setup_delegation`, drives `delegate_multi` so a single delegator can be tested
-/// against more than one operator at once -- `setup_delegation`'s legacy `delegate` call and its
-/// hard assertion that the delegator set is disjoint per-operator can't express that.
 #[test]
 fn delegator_can_split_stake_across_two_operators() {
 	const EPOCH_DURATION_BLOCKS: u32 = 200;

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -89,7 +89,7 @@ pub(crate) fn setup_delegation(
 	// Move to the next for delegation to take affect
 	testnet.move_to_the_next_epoch();
 
-	let actual_delegator_set = pallet_cf_validator::DelegationChoice::<Runtime>::iter()
+	let actual_delegator_set = pallet_cf_validator::DelegationChoices::<Runtime>::iter()
 		.map(|(d, _)| d)
 		.collect::<BTreeSet<_>>();
 	assert_eq!(actual_delegator_set, delegators.keys().cloned().collect());
@@ -341,5 +341,103 @@ fn can_calculate_account_apy_for_validator_with_delegation() {
 			};
 
 			assert_eq!(validator_apy, expected_apy_basis_point);
+		});
+}
+
+/// Unlike `setup_delegation`, drives `delegate_multi` so a single delegator can be tested
+/// against more than one operator at once -- `setup_delegation`'s legacy `delegate` call and its
+/// hard assertion that the delegator set is disjoint per-operator can't express that.
+#[test]
+fn delegator_can_split_stake_across_two_operators() {
+	const EPOCH_DURATION_BLOCKS: u32 = 200;
+	const MAX_AUTHORITIES: AuthorityCount = 3;
+	let managed_validator_a: AccountId = AccountId::from([0xcf; 32]);
+	let managed_validator_b: AccountId = AccountId::from([0xce; 32]);
+	super::genesis::with_test_defaults()
+		.epoch_duration(EPOCH_DURATION_BLOCKS)
+		.max_authorities(MAX_AUTHORITIES)
+		.with_additional_accounts(&[
+			(managed_validator_a.clone(), AccountRole::Validator, GENESIS_BALANCE / 5),
+			(managed_validator_b.clone(), AccountRole::Validator, GENESIS_BALANCE / 5),
+		])
+		.build()
+		.execute_with(|| {
+			let (mut testnet, _, _) = network::fund_authorities_and_join_auction(MAX_AUTHORITIES);
+			testnet.move_to_the_next_epoch();
+
+			let operator_a = AccountId::from([0xe1; 32]);
+			let operator_b = AccountId::from([0xe2; 32]);
+			let delegator = AccountId::from([0xa0; 32]);
+
+			for (operator, validator) in [
+				(operator_a.clone(), managed_validator_a.clone()),
+				(operator_b.clone(), managed_validator_b.clone()),
+			] {
+				new_account(&operator, AccountRole::Operator);
+				assert_ok!(Validator::claim_validator(
+					RuntimeOrigin::signed(operator.clone()),
+					validator.clone()
+				));
+				assert_ok!(Validator::accept_operator(
+					RuntimeOrigin::signed(validator),
+					operator.clone(),
+				));
+				assert_ok!(Validator::update_operator_settings(
+					RuntimeOrigin::signed(operator),
+					OperatorSettings {
+						fee_bps: 2000,
+						delegation_acceptance: DelegationAcceptance::Allow,
+					},
+				));
+			}
+
+			const BID_TO_A: Balance = 2 * GENESIS_BALANCE;
+			const BID_TO_B: Balance = 3 * GENESIS_BALANCE;
+			Funding::fund_account(
+				delegator.clone(),
+				BID_TO_A + BID_TO_B,
+				FundingSource::EthTransaction {
+					tx_hash: Default::default(),
+					funder: Default::default(),
+				},
+			);
+			assert_ok!(Validator::delegate_multi(
+				RuntimeOrigin::signed(delegator.clone()),
+				pallet_cf_validator::DelegatorRelations {
+					operators: BTreeMap::from_iter([
+						(operator_a.clone(), BID_TO_A),
+						(operator_b.clone(), BID_TO_B),
+					]),
+				}
+			));
+
+			testnet.move_to_the_next_epoch();
+
+			let epoch_index = pallet_cf_validator::Pallet::<Runtime>::epoch_index();
+			let snapshot_a =
+				pallet_cf_validator::DelegationSnapshots::<Runtime>::get(epoch_index, &operator_a)
+					.expect("operator_a snapshot should be registered on new epoch");
+			let snapshot_b =
+				pallet_cf_validator::DelegationSnapshots::<Runtime>::get(epoch_index, &operator_b)
+					.expect("operator_b snapshot should be registered on new epoch");
+
+			// The delegator's stake must be split exactly as pledged across both operators, not
+			// dropped or double-counted.
+			assert_eq!(snapshot_a.delegators.get(&delegator), Some(&BID_TO_A));
+			assert_eq!(snapshot_b.delegators.get(&delegator), Some(&BID_TO_B));
+
+			assert_eq!(
+				pallet_cf_flip::Account::<Runtime>::get(&delegator).bond(),
+				BID_TO_A + BID_TO_B,
+				"delegator's bond should reflect the sum of both relations"
+			);
+
+			// The delegator should be rewarded from both operators' pools.
+			let delegator_pre_balance = Flip::balance(&delegator);
+			testnet.move_forward_blocks(
+				pallet_cf_validator::CurrentAuthorities::<Runtime>::decode_len()
+					.expect("at least one authority") as u32,
+			);
+			assert!(Flip::balance(&delegator) > delegator_pre_balance);
 		});
 }

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -400,12 +400,11 @@ fn delegator_can_split_stake_across_two_operators() {
 			);
 			assert_ok!(Validator::delegate_multi(
 				RuntimeOrigin::signed(delegator.clone()),
-				pallet_cf_validator::DelegatorRelations {
-					operators: BTreeMap::from_iter([
-						(operator_a.clone(), BID_TO_A),
-						(operator_b.clone(), BID_TO_B),
-					]),
-				}
+				pallet_cf_validator::DelegationPlan::try_from_amounts(BTreeMap::from_iter([
+					(operator_a.clone(), BID_TO_A),
+					(operator_b.clone(), BID_TO_B),
+				]))
+				.unwrap()
 			));
 
 			testnet.move_to_the_next_epoch();

--- a/state-chain/cf-integration-tests/src/delegation.rs
+++ b/state-chain/cf-integration-tests/src/delegation.rs
@@ -400,9 +400,9 @@ fn delegator_can_split_stake_across_two_operators() {
 			);
 			assert_ok!(Validator::delegate_multi(
 				RuntimeOrigin::signed(delegator.clone()),
-				pallet_cf_validator::DelegationPlan::try_from_amounts(BTreeMap::from_iter([
-					(operator_a.clone(), BID_TO_A),
-					(operator_b.clone(), BID_TO_B),
+				pallet_cf_validator::DelegationPlan::try_from_map(BTreeMap::from_iter([
+					(operator_a.clone(), pallet_cf_validator::DelegationAmount::Some(BID_TO_A)),
+					(operator_b.clone(), pallet_cf_validator::DelegationAmount::Some(BID_TO_B)),
 				]))
 				.unwrap()
 			));

--- a/state-chain/cf-integration-tests/src/historical_compatibility.rs
+++ b/state-chain/cf-integration-tests/src/historical_compatibility.rs
@@ -26,7 +26,7 @@ use cf_utilities::{
 	for_each_runtime_version,
 	migrations::{
 		basics::{CanonicalPatchVersion, Version},
-		v20000, v20100, v20200, v20300,
+		v20000, v20100, v20200, v20300, v20400,
 	},
 };
 use frame_support::sp_runtime::AccountId32;

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -50,7 +50,7 @@ use cf_rpc_apis::{
 use cf_utilities::{
 	migrations::{
 		basics::{migrate_from_historical_type, try_migrate_from_historical_type},
-		v20000, v20100,
+		v20000, v20100, v20200, v20300,
 	},
 	rpc::NumberOrHex,
 };
@@ -2128,8 +2128,15 @@ where
 						#[expect(deprecated)]
 						api.cf_all_account_infos_before_version_19(hash, roles)?
 							.into_iter()
-							.map(Into::into)
-							.collect::<Vec<_>>()
+							.map(TryInto::try_into)
+							.collect::<Result<Vec<_>, _>>()
+							.map_err(|_err| {
+								CfApiError::ErrorObject(ErrorObject::owned(
+									ErrorCode::InternalError.code(),
+									"Error when migrating runtime api reply",
+									None::<()>,
+								))
+							})?
 					} else {
 						api.cf_all_account_infos(hash, roles)?
 					};
@@ -2370,20 +2377,38 @@ where
 					})?
 				} else if api_version < 19 {
 					#[expect(deprecated)]
-					api.cf_common_account_info_before_version_19(
-						hash,
-						&account_id,
-						ShouldSweep::Yes,
-					)?
-					.into()
+					try_migrate_from_historical_type(
+						v20200,
+						api.cf_common_account_info_before_version_19(
+							hash,
+							&account_id,
+							ShouldSweep::Yes,
+						)?,
+					)
+					.map_err(|_err| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InternalError.code(),
+							"Error when migrating runtime api reply",
+							None::<()>,
+						))
+					})?
 				} else if api_version < 21 {
 					#[expect(deprecated)]
-					api.cf_common_account_info_before_version_21(
-						hash,
-						&account_id,
-						ShouldSweep::Yes,
-					)?
-					.into()
+					try_migrate_from_historical_type(
+						v20300,
+						api.cf_common_account_info_before_version_21(
+							hash,
+							&account_id,
+							ShouldSweep::Yes,
+						)?,
+					)
+					.map_err(|_err| {
+						CfApiError::ErrorObject(ErrorObject::owned(
+							ErrorCode::InternalError.code(),
+							"Error when migrating runtime api reply",
+							None::<()>,
+						))
+					})?
 				} else {
 					api.cf_common_account_info(hash, &account_id, ShouldSweep::Yes)?
 				}

--- a/state-chain/custom-rpc/src/lib.rs
+++ b/state-chain/custom-rpc/src/lib.rs
@@ -2376,6 +2376,14 @@ where
 						ShouldSweep::Yes,
 					)?
 					.into()
+				} else if api_version < 21 {
+					#[expect(deprecated)]
+					api.cf_common_account_info_before_version_21(
+						hash,
+						&account_id,
+						ShouldSweep::Yes,
+					)?
+					.into()
 				} else {
 					api.cf_common_account_info(hash, &account_id, ShouldSweep::Yes)?
 				}

--- a/state-chain/custom-rpc/src/tests/account_info.rs
+++ b/state-chain/custom-rpc/src/tests/account_info.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use state_chain_runtime::runtime_apis::types::DelegationInfo;
-
 use super::*;
 
 #[test]
@@ -45,14 +43,14 @@ fn test_no_account_serialization() {
 			estimated_redeemable_balance: 0u32.into(),
 			bound_redeem_address: None,
 			restricted_balances: BTreeMap::new(),
-			current_delegation_status: Some(DelegationInfo {
-				operator: AccountId32::new([0x77; 32]),
-				bid: 1000000000000000000u128.into(), // 1 FLIP
-			}),
-			upcoming_delegation_status: Some(DelegationInfo {
-				operator: AccountId32::new([0x99; 32]),
-				bid: 500000000000000000u128.into(), // 0.5 FLIP
-			}),
+			current_delegation_status: BTreeMap::from([(
+				AccountId32::new([0x77; 32]),
+				1000000000000000000u128.into(), // 1 FLIP
+			)]),
+			upcoming_delegation_status: BTreeMap::from([(
+				AccountId32::new([0x99; 32]),
+				500000000000000000u128.into(), // 0.5 FLIP
+			)]),
 		},
 		role_specific: RpcAccountInfo::Unregistered {},
 	};
@@ -112,8 +110,8 @@ fn test_broker_serialization() {
 			restricted_balances: BTreeMap::from_iter(vec![
 				(H160::from([0xbb; 20]), 2000000000000000000u128.into()), // 2 FLIP restricted
 			]),
-			current_delegation_status: None,
-			upcoming_delegation_status: None,
+			current_delegation_status: BTreeMap::new(),
+			upcoming_delegation_status: BTreeMap::new(),
 		},
 		role_specific: RpcAccountInfo::Broker {
 			earned_fees,
@@ -252,8 +250,8 @@ fn test_lp_serialization() {
 			estimated_redeemable_balance: 1000000000000000000u128.into(), // 1 FLIP
 			bound_redeem_address: None,
 			restricted_balances: BTreeMap::new(),
-			current_delegation_status: None,
-			upcoming_delegation_status: None,
+			current_delegation_status: BTreeMap::new(),
+			upcoming_delegation_status: BTreeMap::new(),
 		},
 		role_specific: RpcAccountInfo::LiquidityProvider {
 			refund_addresses,
@@ -313,11 +311,11 @@ fn test_validator_serialization() {
 				(H160::from([0x55; 20]), (FLIPPERINOS_PER_FLIP * 10).into()), // 10 FLIP
 				(H160::from([0x66; 20]), (FLIPPERINOS_PER_FLIP * 5).into()),  // 5 FLIP
 			]),
-			current_delegation_status: Some(DelegationInfo {
-				operator: AccountId32::new([0x88; 32]),
-				bid: (FLIPPERINOS_PER_FLIP * 20).into(), // 20 FLIP
-			}),
-			upcoming_delegation_status: None,
+			current_delegation_status: BTreeMap::from([(
+				AccountId32::new([0x88; 32]),
+				(FLIPPERINOS_PER_FLIP * 20).into(), // 20 FLIP
+			)]),
+			upcoming_delegation_status: BTreeMap::new(),
 		},
 		role_specific: RpcAccountInfo::Validator {
 			last_heartbeat: 150000,
@@ -350,8 +348,8 @@ fn test_all_account_infos_serialization() {
 			estimated_redeemable_balance: (FLIPPERINOS_PER_FLIP * 25).into(),
 			bound_redeem_address: None,
 			restricted_balances: BTreeMap::new(),
-			current_delegation_status: None,
-			upcoming_delegation_status: None,
+			current_delegation_status: BTreeMap::new(),
+			upcoming_delegation_status: BTreeMap::new(),
 		},
 		role_specific: RpcAccountInfo::Validator {
 			last_heartbeat: 150_000,

--- a/state-chain/custom-rpc/src/tests/snapshots/custom_rpc__tests__account_info__no_account_serialization.snap
+++ b/state-chain/custom-rpc/src/tests/snapshots/custom_rpc__tests__account_info__no_account_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: state-chain/custom-rpc/src/tests/account_info.rs
+assertion_line: 57
 expression: "serde_json::to_string_pretty(&wrapper).unwrap()"
 ---
 {
@@ -47,12 +48,10 @@ expression: "serde_json::to_string_pretty(&wrapper).unwrap()"
   "bond": 0,
   "estimated_redeemable_balance": 0,
   "current_delegation_status": {
-    "operator": "5EmM3XnzKd5LJMr6oDAD6wEBP1Lgs7juQozaPpurTr3yVFbc",
-    "bid": "0xde0b6b3a7640000"
+    "5EmM3XnzKd5LJMr6oDAD6wEBP1Lgs7juQozaPpurTr3yVFbc": "0xde0b6b3a7640000"
   },
   "upcoming_delegation_status": {
-    "operator": "5FY6p4faNbTZeuEZat5QtPXhjUHvjopmqUCbQibdKpvyPbww",
-    "bid": "0x6f05b59d3b20000"
+    "5FY6p4faNbTZeuEZat5QtPXhjUHvjopmqUCbQibdKpvyPbww": "0x6f05b59d3b20000"
   },
   "role": "unregistered"
 }

--- a/state-chain/custom-rpc/src/tests/snapshots/custom_rpc__tests__account_info__validator_serialization.snap
+++ b/state-chain/custom-rpc/src/tests/snapshots/custom_rpc__tests__account_info__validator_serialization.snap
@@ -1,5 +1,6 @@
 ---
 source: state-chain/custom-rpc/src/tests/account_info.rs
+assertion_line: 336
 expression: "serde_json::to_string_pretty(&wrapper).unwrap()"
 ---
 {
@@ -52,8 +53,7 @@ expression: "serde_json::to_string_pretty(&wrapper).unwrap()"
     "0x6666666666666666666666666666666666666666": "0x4563918244f40000"
   },
   "current_delegation_status": {
-    "operator": "5F9ivoEHM7GSydYLC3cozfNwZEpJoTnLd96auGkjtqVUSM86",
-    "bid": "0x1158e460913d00000"
+    "5F9ivoEHM7GSydYLC3cozfNwZEpJoTnLd96auGkjtqVUSM86": "0x1158e460913d00000"
   },
   "role": "validator",
   "last_heartbeat": 150000,

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -37,9 +37,9 @@ use frame_support::{
 use frame_system::{pallet_prelude::OriginFor, Pallet as SystemPallet, RawOrigin};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_consensus_grandpa::AuthoritySignature;
-use sp_std::vec;
+use sp_std::{collections::btree_map::BTreeMap, vec};
 
-use delegation::{DelegationAcceptance, OperatorSettings};
+use delegation::{DelegationAcceptance, DelegatorRelations, OperatorSettings};
 
 mod p2p_crypto {
 	use sp_application_crypto::{app_crypto, ed25519, KeyTypeId};
@@ -597,7 +597,7 @@ mod benchmarks {
 		#[extrinsic_call]
 		delegate(RawOrigin::Signed(delegator.clone()), operator.clone(), DelegationAmount::Max);
 
-		assert!(DelegationChoice::<T>::get(delegator).is_some());
+		assert!(DelegationChoices::<T>::get(delegator).is_some());
 	}
 
 	#[benchmark]
@@ -624,7 +624,57 @@ mod benchmarks {
 		#[extrinsic_call]
 		undelegate(RawOrigin::Signed(delegator.clone()), DelegationAmount::Max);
 
-		assert!(DelegationChoice::<T>::get(&delegator).is_none());
+		assert!(DelegationChoices::<T>::get(&delegator).is_none());
+	}
+
+	#[benchmark]
+	fn delegate_multi() {
+		let accounts = <T as Chainflip>::AccountRoleRegistry::generate_whitelisted_callers(vec![
+			AccountRole::Operator,
+			AccountRole::Operator,
+			AccountRole::Unregistered,
+		])
+		.unwrap();
+		let (operator_a, operator_b, delegator) =
+			(accounts[0].clone(), accounts[1].clone(), accounts[2].clone());
+
+		fund_account::<T>(&delegator, 1000 * FLIPPERINOS_PER_FLIP);
+
+		for operator in [&operator_a, &operator_b] {
+			assert_ok!(Pallet::<T>::update_operator_settings(
+				RawOrigin::Signed(operator.clone()).into(),
+				OperatorSettings {
+					fee_bps: 2500,
+					delegation_acceptance: DelegationAcceptance::Allow
+				}
+			));
+		}
+
+		assert_ok!(Pallet::<T>::delegate_multi(
+			RawOrigin::Signed(delegator.clone()).into(),
+			DelegatorRelations {
+				operators: BTreeMap::from([(
+					operator_a.clone(),
+					(500 * FLIPPERINOS_PER_FLIP).into()
+				)])
+			},
+		));
+
+		#[extrinsic_call]
+		delegate_multi(
+			RawOrigin::Signed(delegator.clone()),
+			DelegatorRelations {
+				operators: BTreeMap::from([
+					(operator_a, (250 * FLIPPERINOS_PER_FLIP).into()),
+					(operator_b.clone(), (250 * FLIPPERINOS_PER_FLIP).into()),
+				]),
+			},
+		);
+
+		assert!(DelegationChoices::<T>::get(&delegator)
+			.unwrap()
+			.operators
+			.contains_key(&operator_b));
 	}
 
 	#[benchmark]

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -39,7 +39,7 @@ use sp_application_crypto::RuntimeAppPublic;
 use sp_consensus_grandpa::AuthoritySignature;
 use sp_std::{collections::btree_map::BTreeMap, vec};
 
-use delegation::{DelegationAcceptance, DelegatorRelations, OperatorSettings};
+use delegation::{DelegationAcceptance, DelegationPlan, OperatorSettings};
 
 mod p2p_crypto {
 	use sp_application_crypto::{app_crypto, ed25519, KeyTypeId};
@@ -652,28 +652,26 @@ mod benchmarks {
 
 		assert_ok!(Pallet::<T>::delegate_multi(
 			RawOrigin::Signed(delegator.clone()).into(),
-			DelegatorRelations {
-				operators: BTreeMap::from([(
-					operator_a.clone(),
-					(500 * FLIPPERINOS_PER_FLIP).into()
-				)])
-			},
+			DelegationPlan::try_from_amounts(BTreeMap::from([(
+				operator_a.clone(),
+				(500 * FLIPPERINOS_PER_FLIP).into()
+			)]))
+			.unwrap(),
 		));
 
 		#[extrinsic_call]
 		delegate_multi(
 			RawOrigin::Signed(delegator.clone()),
-			DelegatorRelations {
-				operators: BTreeMap::from([
-					(operator_a, (250 * FLIPPERINOS_PER_FLIP).into()),
-					(operator_b.clone(), (250 * FLIPPERINOS_PER_FLIP).into()),
-				]),
-			},
+			DelegationPlan::try_from_amounts(BTreeMap::from([
+				(operator_a, (250 * FLIPPERINOS_PER_FLIP).into()),
+				(operator_b.clone(), (250 * FLIPPERINOS_PER_FLIP).into()),
+			]))
+			.unwrap(),
 		);
 
 		assert!(DelegationChoices::<T>::get(&delegator)
 			.unwrap()
-			.operators
+			.into_map()
 			.contains_key(&operator_b));
 	}
 

--- a/state-chain/pallets/cf-validator/src/benchmarking.rs
+++ b/state-chain/pallets/cf-validator/src/benchmarking.rs
@@ -652,9 +652,9 @@ mod benchmarks {
 
 		assert_ok!(Pallet::<T>::delegate_multi(
 			RawOrigin::Signed(delegator.clone()).into(),
-			DelegationPlan::try_from_amounts(BTreeMap::from([(
+			DelegationPlan::try_from_map(BTreeMap::from([(
 				operator_a.clone(),
-				(500 * FLIPPERINOS_PER_FLIP).into()
+				DelegationAmount::Some((500 * FLIPPERINOS_PER_FLIP).into())
 			)]))
 			.unwrap(),
 		));
@@ -662,9 +662,9 @@ mod benchmarks {
 		#[extrinsic_call]
 		delegate_multi(
 			RawOrigin::Signed(delegator.clone()),
-			DelegationPlan::try_from_amounts(BTreeMap::from([
-				(operator_a, (250 * FLIPPERINOS_PER_FLIP).into()),
-				(operator_b.clone(), (250 * FLIPPERINOS_PER_FLIP).into()),
+			DelegationPlan::try_from_map(BTreeMap::from([
+				(operator_a, DelegationAmount::Some((250 * FLIPPERINOS_PER_FLIP).into())),
+				(operator_b.clone(), DelegationAmount::Some((250 * FLIPPERINOS_PER_FLIP).into())),
 			]))
 			.unwrap(),
 		);

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -139,6 +139,34 @@ pub struct OperatorSettings {
 	pub delegation_acceptance: DelegationAcceptance,
 }
 
+/// A delegator's live relations, keyed by operator, to their max bid pledged to that operator.
+///
+/// A delegator may hold relations to multiple operators simultaneously; the sum of all their
+/// max bids is capped at the delegator's funding balance (enforced by `delegate`/
+/// `delegate_multi`). Never stored with an empty `operators` map -- the storage key is removed
+/// entirely once a delegator's last relation is undelegated.
+#[derive(
+	Clone,
+	PartialEq,
+	Eq,
+	Debug,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	TypeInfo,
+	Serialize,
+	Deserialize,
+)]
+pub struct DelegatorRelations<Account: Ord, Amount> {
+	pub operators: BTreeMap<Account, Amount>,
+}
+
+impl<Account: Ord, Amount> Default for DelegatorRelations<Account, Amount> {
+	fn default() -> Self {
+		Self { operators: BTreeMap::new() }
+	}
+}
+
 /// A snapshot of delegations to an operator for a specific epoch, including all
 /// necessary information for reward distribution.
 #[derive(

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -23,7 +23,8 @@ use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
 use core::iter::Sum;
 use frame_support::{
 	sp_runtime::{traits::AtLeast32BitUnsigned, Perquintill, Saturating},
-	traits::IsType,
+	traits::{Get, IsType},
+	BoundedVec, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use scale_info::TypeInfo;
@@ -74,6 +75,10 @@ impl<T> DelegationAmount<T> {
 			DelegationAmount::Max => Ok(DelegationAmount::Max),
 			DelegationAmount::Some(amount) => Ok(DelegationAmount::Some(f(amount)?)),
 		}
+	}
+
+	pub fn is_max(&self) -> bool {
+		matches!(self, DelegationAmount::Max)
 	}
 }
 
@@ -139,17 +144,15 @@ pub struct OperatorSettings {
 	pub delegation_acceptance: DelegationAcceptance,
 }
 
-/// A delegator's live relations, keyed by operator, to their max bid pledged to that operator.
-///
-/// A delegator may hold relations to multiple operators simultaneously; the sum of all their
-/// max bids is capped at the delegator's funding balance (enforced by `delegate`/
-/// `delegate_multi`). Never stored with an empty `operators` map -- the storage key is removed
+/// A delegator's live delegation plan: the set of operators it delegates to and the max bid
+/// pledged to each. The sum of all a delegator's max bids is capped at its funding balance
+/// (enforced by `delegate`/`delegate_multi`). Never stored empty -- the storage key is removed
 /// entirely once a delegator's last relation is undelegated.
 #[derive(
-	Clone,
-	PartialEq,
-	Eq,
-	Debug,
+	CloneNoBound,
+	PartialEqNoBound,
+	EqNoBound,
+	DebugNoBound,
 	Encode,
 	Decode,
 	DecodeWithMemTracking,
@@ -157,13 +160,70 @@ pub struct OperatorSettings {
 	Serialize,
 	Deserialize,
 )]
-pub struct DelegatorRelations<Account: Ord, Amount> {
-	pub operators: BTreeMap<Account, Amount>,
+#[scale_info(skip_type_params(N))]
+#[serde(
+	bound = "Account: Serialize + for<'a> Deserialize<'a>, Amount: Serialize + for<'a> Deserialize<'a>"
+)]
+pub enum DelegationPlan<
+	Account: Clone + PartialEq + Eq + core::fmt::Debug,
+	Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+	N: Get<u32>,
+> {
+	/// Absolute caps per operator. Σ ≤ balance. At most one entry may be `Max`.
+	Fixed(BoundedVec<(Account, DelegationAmount<Amount>), N>),
+	// v2, appended later:
+	// /// Proportional split of the whole balance. Σ = 100%. Auto-compounds.
+	// Proportional(BoundedVec<(Account, Perbill), N>),
 }
 
-impl<Account: Ord, Amount> Default for DelegatorRelations<Account, Amount> {
+impl<
+		Account: Clone + PartialEq + Eq + core::fmt::Debug,
+		Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+		N: Get<u32>,
+	> Default for DelegationPlan<Account, Amount, N>
+{
 	fn default() -> Self {
-		Self { operators: BTreeMap::new() }
+		Self::Fixed(Default::default())
+	}
+}
+
+impl<
+		Account: Ord + Clone + PartialEq + Eq + core::fmt::Debug,
+		Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+		N: Get<u32>,
+	> DelegationPlan<Account, Amount, N>
+{
+	pub fn len(&self) -> usize {
+		match self {
+			Self::Fixed(entries) => entries.len(),
+		}
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.len() == 0
+	}
+
+	/// The raw `account -> requested amount` map backing this plan. Any `Max` entry is left
+	/// unresolved -- it's the caller's responsibility to resolve it against a balance before
+	/// treating the result as concrete amounts (see `try_from_amounts`, the counterpart used
+	/// once that resolution has happened).
+	pub fn into_map(self) -> BTreeMap<Account, DelegationAmount<Amount>> {
+		match self {
+			Self::Fixed(entries) => entries.into_iter().collect(),
+		}
+	}
+
+	/// Builds a `Fixed` plan from concrete per-operator amounts, i.e. once any `Max` entry has
+	/// already been resolved to a number. Fails if `entries` doesn't fit within the bound `N`.
+	pub fn try_from_amounts(entries: BTreeMap<Account, Amount>) -> Result<Self, ()> {
+		Ok(Self::Fixed(
+			entries
+				.into_iter()
+				.map(|(account, amount)| (account, DelegationAmount::Some(amount)))
+				.collect::<Vec<_>>()
+				.try_into()
+				.map_err(|_| ())?,
+		))
 	}
 }
 

--- a/state-chain/pallets/cf-validator/src/delegation.rs
+++ b/state-chain/pallets/cf-validator/src/delegation.rs
@@ -144,10 +144,14 @@ pub struct OperatorSettings {
 	pub delegation_acceptance: DelegationAcceptance,
 }
 
-/// A delegator's live delegation plan: the set of operators it delegates to and the max bid
-/// pledged to each. The sum of all a delegator's max bids is capped at its funding balance
-/// (enforced by `delegate`/`delegate_multi`). Never stored empty -- the storage key is removed
-/// entirely once a delegator's last relation is undelegated.
+/// A delegator's live delegation plan: the set of operators it delegates to and the value
+/// pledged to each. Generic over `Value` so the same shape serves two different points in a
+/// plan's life:
+/// - as `delegate_multi`'s input (`Value = DelegationAmount<Amount>`), where a cap may be given as
+///   `Max`, absorbing whatever of the balance isn't already claimed by the other, fixed entries --
+///   Σ of the `Some` entries ≤ balance, and at most one entry may be `Max`;
+/// - as the stored plan (`Value = Amount`), once any `Max` has already been resolved to a concrete
+///   number by `delegate_multi` and there's no more ambiguity left to represent.
 #[derive(
 	CloneNoBound,
 	PartialEqNoBound,
@@ -162,25 +166,23 @@ pub struct OperatorSettings {
 )]
 #[scale_info(skip_type_params(N))]
 #[serde(
-	bound = "Account: Serialize + for<'a> Deserialize<'a>, Amount: Serialize + for<'a> Deserialize<'a>"
+	bound = "Account: Serialize + for<'a> Deserialize<'a>, Value: Serialize + for<'a> Deserialize<'a>"
 )]
 pub enum DelegationPlan<
 	Account: Clone + PartialEq + Eq + core::fmt::Debug,
-	Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+	Value: Clone + PartialEq + Eq + core::fmt::Debug,
 	N: Get<u32>,
 > {
-	/// Absolute caps per operator. Σ ≤ balance. At most one entry may be `Max`.
-	Fixed(BoundedVec<(Account, DelegationAmount<Amount>), N>),
+	Fixed(BoundedVec<(Account, Value), N>),
 	// v2, appended later:
-	// /// Proportional split of the whole balance. Σ = 100%. Auto-compounds.
 	// Proportional(BoundedVec<(Account, Perbill), N>),
 }
 
 impl<
 		Account: Clone + PartialEq + Eq + core::fmt::Debug,
-		Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+		Value: Clone + PartialEq + Eq + core::fmt::Debug,
 		N: Get<u32>,
-	> Default for DelegationPlan<Account, Amount, N>
+	> Default for DelegationPlan<Account, Value, N>
 {
 	fn default() -> Self {
 		Self::Fixed(Default::default())
@@ -189,9 +191,9 @@ impl<
 
 impl<
 		Account: Ord + Clone + PartialEq + Eq + core::fmt::Debug,
-		Amount: Clone + PartialEq + Eq + core::fmt::Debug,
+		Value: Clone + PartialEq + Eq + core::fmt::Debug,
 		N: Get<u32>,
-	> DelegationPlan<Account, Amount, N>
+	> DelegationPlan<Account, Value, N>
 {
 	pub fn len(&self) -> usize {
 		match self {
@@ -203,27 +205,17 @@ impl<
 		self.len() == 0
 	}
 
-	/// The raw `account -> requested amount` map backing this plan. Any `Max` entry is left
-	/// unresolved -- it's the caller's responsibility to resolve it against a balance before
-	/// treating the result as concrete amounts (see `try_from_amounts`, the counterpart used
-	/// once that resolution has happened).
-	pub fn into_map(self) -> BTreeMap<Account, DelegationAmount<Amount>> {
+	/// The raw `account -> value` map backing this plan.
+	pub fn into_map(self) -> BTreeMap<Account, Value> {
 		match self {
 			Self::Fixed(entries) => entries.into_iter().collect(),
 		}
 	}
 
-	/// Builds a `Fixed` plan from concrete per-operator amounts, i.e. once any `Max` entry has
-	/// already been resolved to a number. Fails if `entries` doesn't fit within the bound `N`.
-	pub fn try_from_amounts(entries: BTreeMap<Account, Amount>) -> Result<Self, ()> {
-		Ok(Self::Fixed(
-			entries
-				.into_iter()
-				.map(|(account, amount)| (account, DelegationAmount::Some(amount)))
-				.collect::<Vec<_>>()
-				.try_into()
-				.map_err(|_| ())?,
-		))
+	/// Builds a `Fixed` plan directly from an `account -> value` map. Fails if `entries` doesn't
+	/// fit within the bound `N`.
+	pub fn try_from_map(entries: BTreeMap<Account, Value>) -> Result<Self, ()> {
+		Ok(Self::Fixed(entries.into_iter().collect::<Vec<_>>().try_into().map_err(|_| ())?))
 	}
 }
 

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -53,7 +53,7 @@ use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::{
 		traits::{BlockNumberProvider, One, Saturating, UniqueSaturatedInto, Zero},
-		Percent, Permill,
+		Percent, Permill, Perquintill,
 	},
 	traits::{EstimateNextSessionRotation, OnKilledAccount},
 };
@@ -115,7 +115,7 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
-pub const STORAGE_VERSION_U16: u16 = 11;
+pub const STORAGE_VERSION_U16: u16 = 12;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
 
 // Might be better to add the enum inside a struct rather than struct inside enum
@@ -401,13 +401,17 @@ pub mod pallet {
 	pub type OperatorSettingsLookup<T: Config> =
 		StorageMap<_, Identity, T::AccountId, OperatorSettings, OptionQuery>;
 
-	/// Maps an delegator to an associated operator account and max bid.
-	///
-	/// The max bid determines how much of the delegator's balance can be used
-	/// used by the operator when bidding for an authority slot.
+	/// Maps a delegator to its live relations: the set of operators it delegates to and the max
+	/// bid pledged to each. The sum of all of a delegator's max bids is capped at its funding
+	/// balance. The key is always removed entirely once a delegator's relations become empty.
 	#[pallet::storage]
-	pub type DelegationChoice<T: Config> =
-		StorageMap<_, Identity, T::AccountId, (T::AccountId, T::Amount), OptionQuery>;
+	pub type DelegationChoices<T: Config> = StorageMap<
+		_,
+		Identity,
+		T::AccountId,
+		DelegatorRelations<T::AccountId, T::Amount>,
+		OptionQuery,
+	>;
 
 	/// Maps a validator to the operator that manages it.
 	#[pallet::storage]
@@ -487,6 +491,13 @@ pub mod pallet {
 		/// The maximum bit of an delegator was updated. If the value is None it means that the
 		/// max_bid has been removed entirly.
 		MaxBidUpdated { delegator: T::AccountId, change: Change<T::Amount> },
+		/// A delegator submitted a new full delegation plan via `delegate_multi`. `plan` is the
+		/// resulting set of relations that was actually stored (after dropping zero-amount
+		/// entries and prorating down to fit the delegator's balance, if it was oversubscribed).
+		DelegationPlanUpdated {
+			delegator: T::AccountId,
+			plan: DelegatorRelations<T::AccountId, T::Amount>,
+		},
 		/// A validator reported that a witnessing task crashed and was restarted.
 		WitnessingTaskRestarted {
 			task: cf_primitives::WitnessingTaskName,
@@ -579,6 +590,9 @@ pub mod pallet {
 		NotLiquidityProvider,
 		/// The account cannot deregister as a Liquidity Provider while actively delegating.
 		StillDelegating,
+		/// `delegate`/`undelegate` only support a delegator with at most one existing relation.
+		/// Use `delegate_multi` and specify the full plan explicitly.
+		MultiOperatorDelegator,
 	}
 
 	/// Pallet implements [`Hooks`] trait
@@ -923,7 +937,7 @@ pub mod pallet {
 				T::FundingInfo::total_balance_of(&account_id) >= MinimumValidatorStake::<T>::get(),
 				Error::<T>::NotEnoughFunds
 			);
-			ensure!(!DelegationChoice::<T>::contains_key(&account_id), Error::<T>::NotAuthorized);
+			ensure!(!DelegationChoices::<T>::contains_key(&account_id), Error::<T>::NotAuthorized);
 			T::AccountRoleRegistry::register_as_validator(&account_id)
 		}
 
@@ -1124,12 +1138,14 @@ pub mod pallet {
 						Exceptions::<T>::mutate(&operator, |allowed| {
 							allowed.clear();
 							// Any existing delegators need be added to the allowed list.
-							for (delegator, (assigned_operator, _)) in DelegationChoice::<T>::iter()
-							{
-								if assigned_operator == operator {
-									allowed.insert(delegator.clone());
-								}
-							}
+							allowed.extend(
+								Self::get_all_associations_by_operator(
+									&operator,
+									AssociationToOperator::Delegator,
+									|_, _| (),
+								)
+								.into_keys(),
+							);
 						});
 					},
 					(DelegationAcceptance::Deny, DelegationAcceptance::Allow) => {
@@ -1160,19 +1176,20 @@ pub mod pallet {
 			let operator = T::AccountRoleRegistry::ensure_operator(origin)?;
 
 			// If the delegator is currently delegating to this operator, we need to
-			// undelegate them first.
-			let _ = DelegationChoice::<T>::try_mutate_exists(&delegator, |maybe_operator_choice| {
-				if let Some((assigned_operator, max_bid)) = maybe_operator_choice.take() {
-					if assigned_operator == operator {
+			// undelegate them from this operator (their other relations, if any, are untouched).
+			DelegationChoices::<T>::mutate_exists(&delegator, |maybe_relations| {
+				if let Some(relations) = maybe_relations {
+					if let Some(max_bid) = relations.operators.remove(&operator) {
 						Self::deposit_event(Event::Undelegated {
 							delegator: delegator.clone(),
 							operator: operator.clone(),
 							max_bid,
 						});
-						return Ok(());
+					}
+					if relations.operators.is_empty() {
+						*maybe_relations = None;
 					}
 				}
-				Err(())
 			});
 
 			match OperatorSettingsLookup::<T>::get(&operator)
@@ -1259,7 +1276,7 @@ pub mod pallet {
 				Error::<T>::OperatorFeeTooLow
 			);
 			ensure!(settings.fee_bps <= MAX_OPERATOR_FEE, Error::<T>::OperatorFeeTooHigh);
-			ensure!(!DelegationChoice::<T>::contains_key(&account_id), Error::<T>::NotAuthorized);
+			ensure!(!DelegationChoices::<T>::contains_key(&account_id), Error::<T>::NotAuthorized);
 
 			T::AccountRoleRegistry::register_as_operator(&account_id)?;
 			T::AccountRoleRegistry::set_vanity_name(&account_id, vanity_name)?;
@@ -1290,13 +1307,20 @@ pub mod pallet {
 				AssociationToOperator::Delegator,
 				|_, _| (),
 			) {
-				if let Some((_, max_bid)) = DelegationChoice::<T>::take(&delegator) {
-					Self::deposit_event(Event::Undelegated {
-						delegator,
-						operator: operator.clone(),
-						max_bid,
-					});
-				}
+				DelegationChoices::<T>::mutate_exists(&delegator, |maybe_relations| {
+					if let Some(relations) = maybe_relations {
+						if let Some(max_bid) = relations.operators.remove(&operator) {
+							Self::deposit_event(Event::Undelegated {
+								delegator: delegator.clone(),
+								operator: operator.clone(),
+								max_bid,
+							});
+						}
+						if relations.operators.is_empty() {
+							*maybe_relations = None;
+						}
+					}
+				});
 			}
 
 			ManagedValidators::<T>::remove(&operator);
@@ -1308,6 +1332,13 @@ pub mod pallet {
 			Ok(())
 		}
 
+		/// Delegate to a single operator.
+		///
+		/// This extrinsic pre-dates multi-operator delegation and keeps its original,
+		/// implicit-switch behaviour: it is only valid for delegators with at most one existing
+		/// relation. A delegator with relations to two or more operators (only reachable via
+		/// [`Self::delegate_multi`]) must use `delegate_multi` instead, since "switch operator"
+		/// is ambiguous once more than one relation exists.
 		#[pallet::call_index(18)]
 		#[pallet::weight(T::ValidatorWeightInfo::delegate())]
 		pub fn delegate(
@@ -1317,79 +1348,43 @@ pub mod pallet {
 		) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
-			// Delegation is only available to Liquidity Providers. Accounts that haven't yet
-			// registered a role (e.g. freshly-funded accounts delegating via the SC Utils EVM
-			// contract) are implicitly registered as Liquidity Providers on first delegation.
-			match T::AccountRoleRegistry::account_role(&delegator) {
-				AccountRole::Unregistered =>
-					T::AccountRoleRegistry::register_as_liquidity_provider(&delegator)?,
-				AccountRole::LiquidityProvider => {},
-				_ => return Err(Error::<T>::NotLiquidityProvider.into()),
-			}
-
-			ensure!(
-				T::AccountRoleRegistry::has_account_role(&operator, AccountRole::Operator),
-				Error::<T>::NotOperator
-			);
+			Self::ensure_delegator_role(&delegator)?;
+			Self::ensure_operator_accepts_delegator(&delegator, &operator)?;
 			ensure!(
 				CurrentRotationPhase::<T>::get() == RotationPhase::Idle,
 				Error::<T>::RotationInProgress
 			);
 
-			ensure!(
-				match OperatorSettingsLookup::<T>::get(&operator)
-					.expect(
-						"operator is forced to set valid preferences during account registration"
-					)
-					.delegation_acceptance
-				{
-					DelegationAcceptance::Allow =>
-						!Exceptions::<T>::get(&operator).contains(&delegator),
-					DelegationAcceptance::Deny =>
-						Exceptions::<T>::get(&operator).contains(&delegator),
-				},
-				Error::<T>::DelegatorBlocked
-			);
+			let mut operators =
+				DelegationChoices::<T>::get(&delegator).unwrap_or_default().operators;
+			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
+			let (old_max_bid, switch_from) = match operators.pop_first() {
+				None => (T::Amount::zero(), None),
+				Some((op, amt)) if op == operator => (amt, None),
+				Some((op, amt)) => (amt, Some(op)),
+			};
 
 			let balance = T::FundingInfo::balance(&delegator);
-			let (to_remove, to_add, old_max_bid) =
-				if let Some((current_operator, current_max_bid)) =
-					DelegationChoice::<T>::get(&delegator)
-				{
-					if current_operator != operator {
-						(Some(current_operator), Some(operator.clone()), current_max_bid)
-					} else {
-						(None, None, current_max_bid)
-					}
-				} else {
-					(None, Some(operator.clone()), T::Amount::zero())
-				};
-
 			let new_max_bid = match increase {
 				DelegationAmount::Max => balance,
 				DelegationAmount::Some(inc) =>
 					core::cmp::min(old_max_bid.saturating_add(inc), balance),
 			};
 
-			if let Some(change) = match old_max_bid.cmp(&new_max_bid) {
-				core::cmp::Ordering::Less => Some(Change::Increase(new_max_bid - old_max_bid)),
-				core::cmp::Ordering::Greater => Some(Change::Decrease(old_max_bid - new_max_bid)),
-				core::cmp::Ordering::Equal => None,
-			} {
-				Self::deposit_event(Event::MaxBidUpdated { delegator: delegator.clone(), change });
-			}
+			Self::deposit_max_bid_update(&delegator, old_max_bid, new_max_bid);
 
-			if let Some(old_operator) = to_remove {
+			let is_new_relation = switch_from.is_some() || old_max_bid.is_zero();
+			if let Some(old_operator) = &switch_from {
 				Self::deposit_event(Event::Undelegated {
 					delegator: delegator.clone(),
-					operator: old_operator,
+					operator: old_operator.clone(),
 					max_bid: old_max_bid,
 				});
 			}
-			if let Some(new_operator) = to_add {
+			if is_new_relation {
 				Self::deposit_event(Event::Delegated {
 					delegator: delegator.clone(),
-					operator: new_operator,
+					operator: operator.clone(),
 					max_bid: new_max_bid,
 				});
 			}
@@ -1399,11 +1394,22 @@ pub mod pallet {
 				Error::<T>::DelegationAmountBelowMinimum
 			);
 
-			DelegationChoice::<T>::insert(&delegator, (operator.clone(), new_max_bid));
+			DelegationChoices::<T>::mutate(&delegator, |maybe_relations| {
+				let relations = maybe_relations.get_or_insert_with(Default::default);
+				if let Some(old_operator) = &switch_from {
+					relations.operators.remove(old_operator);
+				}
+				relations.operators.insert(operator.clone(), new_max_bid);
+			});
 
 			Ok(())
 		}
 
+		/// Undelegate from the sole operator a delegator currently delegates to.
+		///
+		/// Only valid for delegators with at most one existing relation, mirroring `delegate`.
+		/// A delegator with relations to two or more operators must use `delegate_multi` and
+		/// submit a plan that omits the operator(s) to undelegate from.
 		#[pallet::call_index(19)]
 		#[pallet::weight(T::ValidatorWeightInfo::undelegate())]
 		pub fn undelegate(
@@ -1412,8 +1418,12 @@ pub mod pallet {
 		) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
+			let mut operators = DelegationChoices::<T>::get(&delegator)
+				.ok_or(Error::<T>::AccountIsNotDelegating)?
+				.operators;
+			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
 			let (current_operator, current_max_bid) =
-				DelegationChoice::<T>::get(&delegator).ok_or(Error::<T>::AccountIsNotDelegating)?;
+				operators.pop_first().ok_or(Error::<T>::AccountIsNotDelegating)?;
 
 			ensure!(
 				CurrentRotationPhase::<T>::get() == RotationPhase::Idle,
@@ -1434,17 +1444,10 @@ pub mod pallet {
 				DelegationAmount::Max => T::Amount::zero(),
 			};
 
-			if let Some(change) = match current_max_bid.cmp(&new_max_bid) {
-				core::cmp::Ordering::Less => Some(Change::Increase(new_max_bid - current_max_bid)),
-				core::cmp::Ordering::Greater =>
-					Some(Change::Decrease(current_max_bid - new_max_bid)),
-				core::cmp::Ordering::Equal => None,
-			} {
-				Self::deposit_event(Event::MaxBidUpdated { delegator: delegator.clone(), change });
-			}
+			Self::deposit_max_bid_update(&delegator, current_max_bid, new_max_bid);
 
 			if new_max_bid.is_zero() {
-				DelegationChoice::<T>::remove(&delegator);
+				DelegationChoices::<T>::remove(&delegator);
 				Self::deposit_event(Event::Undelegated {
 					delegator: delegator.clone(),
 					operator: current_operator,
@@ -1456,12 +1459,92 @@ pub mod pallet {
 				// check and simply remain registered as a Liquidity Provider.
 				let _ = T::AccountRoleRegistry::deregister_as_liquidity_provider(&delegator);
 			} else {
-				DelegationChoice::<T>::mutate(&delegator, |choice| {
-					if let Some((_, ref mut max_bid)) = choice {
-						*max_bid = new_max_bid;
+				DelegationChoices::<T>::mutate(&delegator, |maybe_relations| {
+					if let Some(relations) = maybe_relations {
+						relations.operators.insert(current_operator, new_max_bid);
 					}
 				});
 			}
+
+			Ok(())
+		}
+
+		/// Sets `delegator`'s complete delegation plan across one or more operators in a single
+		/// call: `plan` becomes their entire new set of relations, replacing whatever existed
+		/// before. Any operator the delegator was previously delegating to but that's absent
+		/// from `plan` is fully undelegated; an empty `plan` undelegates everything. Unlike
+		/// `delegate`, the caller declares exact target amounts rather than an
+		/// increase/decrease delta -- entries with a zero amount are treated the same as an
+		/// absent entry.
+		///
+		/// If `plan`'s amounts sum to more than the delegator's funding balance, every entry is
+		/// scaled down proportionally so the total exactly matches the balance -- the sum of a
+		/// delegator's relations can never exceed what they actually hold. The (possibly
+		/// scaled-down) total must be at least the minimum funding amount if `plan` is
+		/// non-empty; individual entries may be smaller, only the total is checked.
+		#[pallet::call_index(24)]
+		#[pallet::weight(T::ValidatorWeightInfo::delegate_multi())]
+		pub fn delegate_multi(
+			origin: OriginFor<T>,
+			plan: DelegatorRelations<T::AccountId, T::Amount>,
+		) -> DispatchResult {
+			let delegator = ensure_signed(origin)?;
+
+			ensure!(
+				CurrentRotationPhase::<T>::get() == RotationPhase::Idle,
+				Error::<T>::RotationInProgress
+			);
+
+			let new_relations: BTreeMap<T::AccountId, T::Amount> =
+				plan.operators.into_iter().filter(|(_, amount)| !amount.is_zero()).collect();
+
+			let new_relations = if new_relations.is_empty() {
+				DelegationChoices::<T>::remove(&delegator);
+				// Mirrors the auto-registration above. Best-effort: accounts that also hold
+				// other LP state (open orders, balances, etc.) fail the deregistration check
+				// and simply remain registered as a Liquidity Provider.
+				let _ = T::AccountRoleRegistry::deregister_as_liquidity_provider(&delegator);
+				Default::default()
+			} else {
+				Self::ensure_delegator_role(&delegator)?;
+
+				for operator in new_relations.keys() {
+					Self::ensure_operator_accepts_delegator(&delegator, operator)?;
+				}
+
+				// The sum of a delegator's relations can never exceed what they actually hold --
+				// scale every entry down proportionally to fit, rather than rejecting the plan
+				// outright.
+				let raw_total: T::Amount = new_relations.values().copied().sum();
+				let balance = T::FundingInfo::balance(&delegator);
+				let new_relations: BTreeMap<T::AccountId, T::Amount> = if raw_total > balance {
+					new_relations
+						.into_iter()
+						.map(|(operator, amount)| {
+							(operator, Perquintill::from_rational(amount, raw_total) * balance)
+						})
+						.filter(|(_, amount)| !amount.is_zero())
+						.collect()
+				} else {
+					new_relations
+				};
+
+				let new_total: T::Amount = new_relations.values().copied().sum();
+				ensure!(
+					new_total.into() >= T::MinimumFunding::get_min_funding_amount(),
+					Error::<T>::DelegationAmountBelowMinimum
+				);
+				DelegationChoices::<T>::insert(
+					&delegator,
+					DelegatorRelations { operators: new_relations.clone() },
+				);
+				new_relations
+			};
+
+			Self::deposit_event(Event::DelegationPlanUpdated {
+				delegator: delegator.clone(),
+				plan: DelegatorRelations { operators: new_relations.clone() },
+			});
 
 			Ok(())
 		}
@@ -1818,7 +1901,15 @@ impl<T: Config> Pallet<T> {
 		let mut managed_validator_bonds = BTreeMap::new();
 		for (_, snapshot) in DelegationSnapshots::<T>::iter_prefix(new_epoch) {
 			managed_validator_bonds.extend(snapshot.validator_bond_distribution(new_bond));
-			new_delegator_bids.extend(snapshot.delegators.clone());
+			// A delegator can appear in multiple operators' snapshots simultaneously, so their
+			// bids must be summed across snapshots, not overwritten -- their bond should reflect
+			// their total committed stake, not just whichever snapshot was iterated last.
+			for (delegator, bid) in &snapshot.delegators {
+				new_delegator_bids
+					.entry(delegator.clone())
+					.and_modify(|total: &mut T::Amount| *total = (*total).saturating_add(*bid))
+					.or_insert(*bid);
+			}
 		}
 		let mut outgoing_delegators = BTreeSet::new();
 		for (_, snapshot) in DelegationSnapshots::<T>::iter_prefix(new_epoch - 1) {
@@ -2233,21 +2324,78 @@ impl<T: Config> Pallet<T> {
 		match association {
 			AssociationToOperator::Validator =>
 				ManagedValidators::<T>::get(operator).into_iter().map(apply_f).collect(),
-			AssociationToOperator::Delegator => DelegationChoice::<T>::iter()
-				.filter_map(|(account_id, (managing_operator, max_bid))| {
-					if managing_operator == *operator {
-						Some((account_id.clone(), f(&account_id, Some(max_bid))))
-					} else {
-						None
-					}
+			AssociationToOperator::Delegator => DelegationChoices::<T>::iter()
+				.filter_map(|(account_id, relations)| {
+					relations
+						.operators
+						.get(operator)
+						.map(|max_bid| (account_id.clone(), f(&account_id, Some(*max_bid))))
 				})
 				.collect(),
 		}
 	}
 
-	/// Only accounts without Validator or Operator roles can be sourced from `DelegationChoice`.
+	/// Only accounts without Validator or Operator roles can be sourced from `DelegationChoices`.
 	pub(crate) fn is_delegation_eligible(account_id: &T::AccountId) -> bool {
 		T::AccountRoleRegistry::has_account_role(account_id, AccountRole::LiquidityProvider)
+	}
+
+	/// Sum of a delegator's max bids across all of its live operator relations.
+	pub(crate) fn total_delegated(delegator: &T::AccountId) -> T::Amount {
+		DelegationChoices::<T>::get(delegator)
+			.map(|relations| relations.operators.values().copied().sum())
+			.unwrap_or_else(T::Amount::zero)
+	}
+
+	/// Emits `MaxBidUpdated` if `old` and `new` differ. Shared by `delegate` and `undelegate`.
+	fn deposit_max_bid_update(delegator: &T::AccountId, old: T::Amount, new: T::Amount) {
+		if let Some(change) = match old.cmp(&new) {
+			core::cmp::Ordering::Less => Some(Change::Increase(new - old)),
+			core::cmp::Ordering::Greater => Some(Change::Decrease(old - new)),
+			core::cmp::Ordering::Equal => None,
+		} {
+			Self::deposit_event(Event::MaxBidUpdated { delegator: delegator.clone(), change });
+		}
+	}
+
+	/// Auto-registers `Unregistered` accounts as Liquidity Providers, erroring for any other
+	/// incompatible role. Shared by `delegate` and `delegate_multi`.
+	fn ensure_delegator_role(delegator: &T::AccountId) -> DispatchResult {
+		// Delegation is only available to Liquidity Providers. Accounts that haven't yet
+		// registered a role (e.g. freshly-funded accounts delegating via the SC Utils EVM
+		// contract) are implicitly registered as Liquidity Providers on first delegation.
+		match T::AccountRoleRegistry::account_role(delegator) {
+			AccountRole::Unregistered =>
+				T::AccountRoleRegistry::register_as_liquidity_provider(delegator)?,
+			AccountRole::LiquidityProvider => {},
+			_ => return Err(Error::<T>::NotLiquidityProvider.into()),
+		}
+		Ok(())
+	}
+
+	/// Checks that `operator` is a registered Operator and that its delegation acceptance
+	/// policy currently permits `delegator`. Shared by `delegate` and `delegate_multi`.
+	fn ensure_operator_accepts_delegator(
+		delegator: &T::AccountId,
+		operator: &T::AccountId,
+	) -> DispatchResult {
+		ensure!(
+			T::AccountRoleRegistry::has_account_role(operator, AccountRole::Operator),
+			Error::<T>::NotOperator
+		);
+
+		ensure!(
+			match OperatorSettingsLookup::<T>::get(operator)
+				.expect("operator is forced to set valid preferences during account registration")
+				.delegation_acceptance
+			{
+				DelegationAcceptance::Allow => !Exceptions::<T>::get(operator).contains(delegator),
+				DelegationAcceptance::Deny => Exceptions::<T>::get(operator).contains(delegator),
+			},
+			Error::<T>::DelegatorBlocked
+		);
+
+		Ok(())
 	}
 
 	/// Builds the delegation snapshots for the next epoch.
@@ -2294,20 +2442,54 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		for (delegator, (operator, max_bid)) in DelegationChoice::<T>::iter() {
+		for (delegator, relations) in DelegationChoices::<T>::iter() {
 			if !Self::is_delegation_eligible(&delegator) {
 				log::info!(
 					target: "cf-validator",
-					"ignoring ineligible DelegationChoice entry while building delegation snapshots: delegator={:?}, operator={:?}",
+					"ignoring ineligible DelegationChoices entry while building delegation snapshots: delegator={:?}",
 					delegator,
-					operator,
 				);
 				continue;
 			}
-			if let Some(snapshot) = snapshots.get_mut(&operator) {
-				let bid = core::cmp::min(max_bid, T::FundingInfo::balance(&delegator));
-				if bid > Zero::zero() {
-					snapshot.delegators.insert(delegator.clone(), bid);
+
+			// Only relations to operators actually bidding this epoch count towards the
+			// delegator's committed total -- an operator with no qualified validators has no
+			// snapshot and can't claim any of the delegator's balance.
+			let live_relations: Vec<(T::AccountId, T::Amount)> = relations
+				.operators
+				.into_iter()
+				.filter(|(operator, _)| snapshots.contains_key(operator))
+				.collect();
+			if live_relations.is_empty() {
+				continue;
+			}
+
+			let total_committed: T::Amount =
+				live_relations.iter().map(|(_, max_bid)| *max_bid).sum();
+			let balance = T::FundingInfo::balance(&delegator);
+
+			// A delegator's relations are each capped at `balance` individually when written
+			// (see `delegate`/`delegate_multi`), so the only way their sum can exceed `balance`
+			// here is a balance reduction after the fact (e.g. slashing) -- in that case,
+			// prorate each relation's share of the shrunk balance proportionally to what it was
+			// pledged. This reduces to exactly `min(bid, balance)` when there's only one
+			// relation, matching pre-multi-operator behaviour precisely.
+			if total_committed <= balance {
+				for (operator, bid) in live_relations {
+					if bid > Zero::zero() {
+						if let Some(snapshot) = snapshots.get_mut(&operator) {
+							snapshot.delegators.insert(delegator.clone(), bid);
+						}
+					}
+				}
+			} else {
+				for (operator, bid) in live_relations {
+					let scaled_bid = Perquintill::from_rational(bid, total_committed) * balance;
+					if scaled_bid > Zero::zero() {
+						if let Some(snapshot) = snapshots.get_mut(&operator) {
+							snapshot.delegators.insert(delegator.clone(), scaled_bid);
+						}
+					}
 				}
 			}
 		}
@@ -2545,12 +2727,13 @@ impl<T: Config> RedemptionCheck for Pallet<T> {
 	) -> DispatchResult {
 		Self::ensure_not_active_bidder_during_auction(validator_id)?;
 		// A delegator may redeem from the portion of their balance that is not
-		// reserved by their stored max_bid — the amount visible to the auction
-		// (capped at max_bid) cannot drop, but funds the user never pledged
-		// remain freely redeemable.
-		if let Some((_, max_bid)) = DelegationChoice::<T>::get(validator_id.into_ref()) {
+		// reserved by the sum of their stored max_bids (across all of their operator relations)
+		// — the amount visible to the auction (capped at that sum) cannot drop, but funds the
+		// user never pledged remain freely redeemable.
+		let total_max_bid = Self::total_delegated(validator_id.into_ref());
+		if total_max_bid > Zero::zero() {
 			let balance = T::FundingInfo::balance(validator_id.into_ref());
-			ensure!(balance.saturating_sub(amount) >= max_bid, Error::<T>::StillBidding);
+			ensure!(balance.saturating_sub(amount) >= total_max_bid, Error::<T>::StillBidding);
 		}
 		Ok(())
 	}
@@ -2561,7 +2744,7 @@ impl<T: Config> RedemptionCheck for Pallet<T> {
 		// definition of "restricted". Additional checks (like balance checks) are
 		// outside the scope of this implementation.
 		ensure!(
-			!DelegationChoice::<T>::contains_key(source.into_ref()),
+			!DelegationChoices::<T>::contains_key(source.into_ref()),
 			Error::<T>::DelegatorTransferRestricted
 		);
 
@@ -2608,7 +2791,7 @@ impl<T: Config> DeregistrationHooks for DelegatorDeregistrationCheck<T> {
 	type Error = Error<T>;
 
 	fn check(account_id: &Self::AccountId) -> Result<(), Self::Error> {
-		ensure!(!DelegationChoice::<T>::contains_key(account_id), Error::<T>::StillDelegating);
+		ensure!(!DelegationChoices::<T>::contains_key(account_id), Error::<T>::StillDelegating);
 
 		Ok(())
 	}
@@ -2618,12 +2801,14 @@ pub struct DelegatedAccountCleanup<T>(PhantomData<T>);
 
 impl<T: Config> OnKilledAccount<T::AccountId> for DelegatedAccountCleanup<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
-		if let Some((operator, max_bid)) = DelegationChoice::<T>::take(account_id) {
-			Pallet::<T>::deposit_event(Event::Undelegated {
-				delegator: account_id.clone(),
-				operator,
-				max_bid,
-			});
+		if let Some(relations) = DelegationChoices::<T>::take(account_id) {
+			for (operator, max_bid) in relations.operators {
+				Pallet::<T>::deposit_event(Event::Undelegated {
+					delegator: account_id.clone(),
+					operator,
+					max_bid,
+				});
+			}
 		}
 	}
 }

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -115,6 +115,12 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
+type DelegationPlanOf<T> = DelegationPlan<
+	<T as frame_system::Config>::AccountId,
+	<T as Chainflip>::Amount,
+	<T as pallet::Config>::MaxOperatorsPerDelegator,
+>;
+
 pub const STORAGE_VERSION_U16: u16 = 12;
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(STORAGE_VERSION_U16);
 
@@ -238,6 +244,11 @@ pub mod pallet {
 
 		/// GRANDPA vote delegation manager.
 		type GrandpaDelegation: GrandpaVoteDelegation;
+
+		/// The maximum number of operators a single delegator can have live relations with at
+		/// once.
+		#[pallet::constant]
+		type MaxOperatorsPerDelegator: Get<u32>;
 	}
 
 	/// Percentage of epoch we allow redemptions.
@@ -405,13 +416,8 @@ pub mod pallet {
 	/// bid pledged to each. The sum of all of a delegator's max bids is capped at its funding
 	/// balance. The key is always removed entirely once a delegator's relations become empty.
 	#[pallet::storage]
-	pub type DelegationChoices<T: Config> = StorageMap<
-		_,
-		Identity,
-		T::AccountId,
-		DelegatorRelations<T::AccountId, T::Amount>,
-		OptionQuery,
-	>;
+	pub type DelegationChoices<T: Config> =
+		StorageMap<_, Identity, T::AccountId, DelegationPlanOf<T>, OptionQuery>;
 
 	/// Maps a validator to the operator that manages it.
 	#[pallet::storage]
@@ -494,10 +500,7 @@ pub mod pallet {
 		/// A delegator submitted a new full delegation plan via `delegate_multi`. `plan` is the
 		/// resulting set of relations that was actually stored (after dropping zero-amount
 		/// entries and prorating down to fit the delegator's balance, if it was oversubscribed).
-		DelegationPlanUpdated {
-			delegator: T::AccountId,
-			plan: DelegatorRelations<T::AccountId, T::Amount>,
-		},
+		DelegationPlanUpdated { delegator: T::AccountId, plan: DelegationPlanOf<T> },
 		/// A validator reported that a witnessing task crashed and was restarted.
 		WitnessingTaskRestarted {
 			task: cf_primitives::WitnessingTaskName,
@@ -593,6 +596,8 @@ pub mod pallet {
 		/// `delegate`/`undelegate` only support a delegator with at most one existing relation.
 		/// Use `delegate_multi` and specify the full plan explicitly.
 		MultiOperatorDelegator,
+		/// At most one entry in a `delegate_multi` plan may be `DelegationAmount::Max`.
+		MultipleMaxDelegationEntries,
 	}
 
 	/// Pallet implements [`Hooks`] trait
@@ -1177,17 +1182,18 @@ pub mod pallet {
 
 			// If the delegator is currently delegating to this operator, we need to
 			// undelegate them from this operator (their other relations, if any, are untouched).
-			DelegationChoices::<T>::mutate_exists(&delegator, |maybe_relations| {
-				if let Some(relations) = maybe_relations {
-					if let Some(max_bid) = relations.operators.remove(&operator) {
+			DelegationChoices::<T>::mutate_exists(&delegator, |maybe_plan| {
+				if let Some(plan) = maybe_plan.take() {
+					let mut operators = Self::resolved_operators(plan);
+					if let Some(max_bid) = operators.remove(&operator) {
 						Self::deposit_event(Event::Undelegated {
 							delegator: delegator.clone(),
 							operator: operator.clone(),
 							max_bid,
 						});
 					}
-					if relations.operators.is_empty() {
-						*maybe_relations = None;
+					if !operators.is_empty() {
+						*maybe_plan = Some(Self::plan_from_amounts(operators));
 					}
 				}
 			});
@@ -1307,17 +1313,18 @@ pub mod pallet {
 				AssociationToOperator::Delegator,
 				|_, _| (),
 			) {
-				DelegationChoices::<T>::mutate_exists(&delegator, |maybe_relations| {
-					if let Some(relations) = maybe_relations {
-						if let Some(max_bid) = relations.operators.remove(&operator) {
+				DelegationChoices::<T>::mutate_exists(&delegator, |maybe_plan| {
+					if let Some(plan) = maybe_plan.take() {
+						let mut operators = Self::resolved_operators(plan);
+						if let Some(max_bid) = operators.remove(&operator) {
 							Self::deposit_event(Event::Undelegated {
 								delegator: delegator.clone(),
 								operator: operator.clone(),
 								max_bid,
 							});
 						}
-						if relations.operators.is_empty() {
-							*maybe_relations = None;
+						if !operators.is_empty() {
+							*maybe_plan = Some(Self::plan_from_amounts(operators));
 						}
 					}
 				});
@@ -1355,8 +1362,9 @@ pub mod pallet {
 				Error::<T>::RotationInProgress
 			);
 
-			let mut operators =
-				DelegationChoices::<T>::get(&delegator).unwrap_or_default().operators;
+			let mut operators = DelegationChoices::<T>::get(&delegator)
+				.map(Self::resolved_operators)
+				.unwrap_or_default();
 			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
 			let (old_max_bid, switch_from) = match operators.pop_first() {
 				None => (T::Amount::zero(), None),
@@ -1394,12 +1402,14 @@ pub mod pallet {
 				Error::<T>::DelegationAmountBelowMinimum
 			);
 
-			DelegationChoices::<T>::mutate(&delegator, |maybe_relations| {
-				let relations = maybe_relations.get_or_insert_with(Default::default);
+			DelegationChoices::<T>::mutate(&delegator, |maybe_plan| {
+				let mut operators =
+					maybe_plan.take().map(Self::resolved_operators).unwrap_or_default();
 				if let Some(old_operator) = &switch_from {
-					relations.operators.remove(old_operator);
+					operators.remove(old_operator);
 				}
-				relations.operators.insert(operator.clone(), new_max_bid);
+				operators.insert(operator.clone(), new_max_bid);
+				*maybe_plan = Some(Self::plan_from_amounts(operators));
 			});
 
 			Ok(())
@@ -1418,9 +1428,10 @@ pub mod pallet {
 		) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
-			let mut operators = DelegationChoices::<T>::get(&delegator)
-				.ok_or(Error::<T>::AccountIsNotDelegating)?
-				.operators;
+			let mut operators = Self::resolved_operators(
+				DelegationChoices::<T>::get(&delegator)
+					.ok_or(Error::<T>::AccountIsNotDelegating)?,
+			);
 			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
 			let (current_operator, current_max_bid) =
 				operators.pop_first().ok_or(Error::<T>::AccountIsNotDelegating)?;
@@ -1459,9 +1470,11 @@ pub mod pallet {
 				// check and simply remain registered as a Liquidity Provider.
 				let _ = T::AccountRoleRegistry::deregister_as_liquidity_provider(&delegator);
 			} else {
-				DelegationChoices::<T>::mutate(&delegator, |maybe_relations| {
-					if let Some(relations) = maybe_relations {
-						relations.operators.insert(current_operator, new_max_bid);
+				DelegationChoices::<T>::mutate(&delegator, |maybe_plan| {
+					if maybe_plan.is_some() {
+						let mut operators = BTreeMap::new();
+						operators.insert(current_operator, new_max_bid);
+						*maybe_plan = Some(Self::plan_from_amounts(operators));
 					}
 				});
 			}
@@ -1484,10 +1497,7 @@ pub mod pallet {
 		/// non-empty; individual entries may be smaller, only the total is checked.
 		#[pallet::call_index(24)]
 		#[pallet::weight(T::ValidatorWeightInfo::delegate_multi())]
-		pub fn delegate_multi(
-			origin: OriginFor<T>,
-			plan: DelegatorRelations<T::AccountId, T::Amount>,
-		) -> DispatchResult {
+		pub fn delegate_multi(origin: OriginFor<T>, plan: DelegationPlanOf<T>) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
 			ensure!(
@@ -1495,8 +1505,32 @@ pub mod pallet {
 				Error::<T>::RotationInProgress
 			);
 
-			let new_relations: BTreeMap<T::AccountId, T::Amount> =
-				plan.operators.into_iter().filter(|(_, amount)| !amount.is_zero()).collect();
+			let requested: BTreeMap<T::AccountId, DelegationAmount<T::Amount>> = plan.into_map();
+			ensure!(
+				requested.values().filter(|amount| amount.is_max()).count() <= 1,
+				Error::<T>::MultipleMaxDelegationEntries
+			);
+
+			let fixed_total: T::Amount = requested
+				.values()
+				.filter_map(|amount| match amount {
+					DelegationAmount::Some(amount) => Some(*amount),
+					DelegationAmount::Max => None,
+				})
+				.fold(T::Amount::zero(), |acc, amount| acc.saturating_add(amount));
+
+			let balance = T::FundingInfo::balance(&delegator);
+
+			// At most one entry may be `Max` (checked above); it absorbs whatever of the
+			// balance isn't already claimed by the other, fixed entries.
+			let new_relations: BTreeMap<T::AccountId, T::Amount> = requested
+				.into_iter()
+				.map(|(operator, amount)| match amount {
+					DelegationAmount::Some(amount) => (operator, amount),
+					DelegationAmount::Max => (operator, balance.saturating_sub(fixed_total)),
+				})
+				.filter(|(_, amount)| !amount.is_zero())
+				.collect();
 
 			let new_relations = if new_relations.is_empty() {
 				DelegationChoices::<T>::remove(&delegator);
@@ -1516,7 +1550,6 @@ pub mod pallet {
 				// scale every entry down proportionally to fit, rather than rejecting the plan
 				// outright.
 				let raw_total: T::Amount = new_relations.values().copied().sum();
-				let balance = T::FundingInfo::balance(&delegator);
 				let new_relations: BTreeMap<T::AccountId, T::Amount> = if raw_total > balance {
 					new_relations
 						.into_iter()
@@ -1536,14 +1569,14 @@ pub mod pallet {
 				);
 				DelegationChoices::<T>::insert(
 					&delegator,
-					DelegatorRelations { operators: new_relations.clone() },
+					Self::plan_from_amounts(new_relations.clone()),
 				);
 				new_relations
 			};
 
 			Self::deposit_event(Event::DelegationPlanUpdated {
 				delegator: delegator.clone(),
-				plan: DelegatorRelations { operators: new_relations.clone() },
+				plan: Self::plan_from_amounts(new_relations),
 			});
 
 			Ok(())
@@ -2325,9 +2358,8 @@ impl<T: Config> Pallet<T> {
 			AssociationToOperator::Validator =>
 				ManagedValidators::<T>::get(operator).into_iter().map(apply_f).collect(),
 			AssociationToOperator::Delegator => DelegationChoices::<T>::iter()
-				.filter_map(|(account_id, relations)| {
-					relations
-						.operators
+				.filter_map(|(account_id, plan)| {
+					Self::resolved_operators(plan)
 						.get(operator)
 						.map(|max_bid| (account_id.clone(), f(&account_id, Some(*max_bid))))
 				})
@@ -2343,8 +2375,48 @@ impl<T: Config> Pallet<T> {
 	/// Sum of a delegator's max bids across all of its live operator relations.
 	pub(crate) fn total_delegated(delegator: &T::AccountId) -> T::Amount {
 		DelegationChoices::<T>::get(delegator)
-			.map(|relations| relations.operators.values().copied().sum())
+			.map(|plan| Self::resolved_operators(plan).values().copied().sum())
 			.unwrap_or_else(T::Amount::zero)
+	}
+
+	/// The concrete `operator -> max_bid` map backing a stored plan. Every write path
+	/// (`delegate`/`undelegate`/`delegate_multi`) resolves any `Max` entry to a concrete number
+	/// before storing, so a stored plan should never actually contain one -- if it does, that's
+	/// a bug, not a valid state to silently propagate.
+	pub(crate) fn resolved_operators(
+		plan: DelegationPlanOf<T>,
+	) -> BTreeMap<T::AccountId, T::Amount> {
+		plan.into_map()
+			.into_iter()
+			.map(|(operator, amount)| {
+				let amount = match amount {
+					DelegationAmount::Some(amount) => amount,
+					DelegationAmount::Max => {
+						cf_runtime_utilities::log_or_panic!(
+							"DelegationChoices entry for {:?} contains an unresolved Max amount",
+							operator,
+						);
+						T::Amount::zero()
+					},
+				};
+				(operator, amount)
+			})
+			.collect()
+	}
+
+	/// Wraps concrete per-operator amounts into a `DelegationPlan`. Every call site either
+	/// removes entries from an already-bounded plan or replaces a single operator's entry in a
+	/// delegator known (via `MultiOperatorDelegator`) to have at most one relation, so the
+	/// result can never exceed `MaxOperatorsPerDelegator`.
+	pub(crate) fn plan_from_amounts(
+		operators: BTreeMap<T::AccountId, T::Amount>,
+	) -> DelegationPlanOf<T> {
+		DelegationPlanOf::<T>::try_from_amounts(operators).unwrap_or_else(|_| {
+			cf_runtime_utilities::log_or_panic!(
+				"delegator's operator relations exceeded MaxOperatorsPerDelegator"
+			);
+			Default::default()
+		})
 	}
 
 	/// Emits `MaxBidUpdated` if `old` and `new` differ. Shared by `delegate` and `undelegate`.
@@ -2442,7 +2514,7 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		for (delegator, relations) in DelegationChoices::<T>::iter() {
+		for (delegator, plan) in DelegationChoices::<T>::iter() {
 			if !Self::is_delegation_eligible(&delegator) {
 				log::info!(
 					target: "cf-validator",
@@ -2455,8 +2527,7 @@ impl<T: Config> Pallet<T> {
 			// Only relations to operators actually bidding this epoch count towards the
 			// delegator's committed total -- an operator with no qualified validators has no
 			// snapshot and can't claim any of the delegator's balance.
-			let live_relations: Vec<(T::AccountId, T::Amount)> = relations
-				.operators
+			let live_relations: Vec<(T::AccountId, T::Amount)> = Self::resolved_operators(plan)
 				.into_iter()
 				.filter(|(operator, _)| snapshots.contains_key(operator))
 				.collect();
@@ -2801,8 +2872,8 @@ pub struct DelegatedAccountCleanup<T>(PhantomData<T>);
 
 impl<T: Config> OnKilledAccount<T::AccountId> for DelegatedAccountCleanup<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
-		if let Some(relations) = DelegationChoices::<T>::take(account_id) {
-			for (operator, max_bid) in relations.operators {
+		if let Some(plan) = DelegationChoices::<T>::take(account_id) {
+			for (operator, max_bid) in Pallet::<T>::resolved_operators(plan) {
 				Pallet::<T>::deposit_event(Event::Undelegated {
 					delegator: account_id.clone(),
 					operator,

--- a/state-chain/pallets/cf-validator/src/lib.rs
+++ b/state-chain/pallets/cf-validator/src/lib.rs
@@ -115,9 +115,19 @@ pub enum PalletConfigUpdate {
 type RuntimeRotationState<T> =
 	RotationState<<T as Chainflip>::ValidatorId, <T as Chainflip>::Amount>;
 
-type DelegationPlanOf<T> = DelegationPlan<
+/// The stored/emitted form of a delegator's plan: every value has already been resolved to a
+/// concrete amount, so there's no `DelegationAmount::Max` left to represent.
+pub type DelegationPlanOf<T> = DelegationPlan<
 	<T as frame_system::Config>::AccountId,
 	<T as Chainflip>::Amount,
+	<T as pallet::Config>::MaxOperatorsPerDelegator,
+>;
+
+/// The form of a plan submitted to `delegate_multi`: values may still be `DelegationAmount::Max`,
+/// to be resolved against the delegator's balance before anything is stored.
+pub type RequestedDelegationPlanOf<T> = DelegationPlan<
+	<T as frame_system::Config>::AccountId,
+	DelegationAmount<<T as Chainflip>::Amount>,
 	<T as pallet::Config>::MaxOperatorsPerDelegator,
 >;
 
@@ -1184,7 +1194,7 @@ pub mod pallet {
 			// undelegate them from this operator (their other relations, if any, are untouched).
 			DelegationChoices::<T>::mutate_exists(&delegator, |maybe_plan| {
 				if let Some(plan) = maybe_plan.take() {
-					let mut operators = Self::resolved_operators(plan);
+					let mut operators = plan.into_map();
 					if let Some(max_bid) = operators.remove(&operator) {
 						Self::deposit_event(Event::Undelegated {
 							delegator: delegator.clone(),
@@ -1315,7 +1325,7 @@ pub mod pallet {
 			) {
 				DelegationChoices::<T>::mutate_exists(&delegator, |maybe_plan| {
 					if let Some(plan) = maybe_plan.take() {
-						let mut operators = Self::resolved_operators(plan);
+						let mut operators = plan.into_map();
 						if let Some(max_bid) = operators.remove(&operator) {
 							Self::deposit_event(Event::Undelegated {
 								delegator: delegator.clone(),
@@ -1363,7 +1373,7 @@ pub mod pallet {
 			);
 
 			let mut operators = DelegationChoices::<T>::get(&delegator)
-				.map(Self::resolved_operators)
+				.map(DelegationPlanOf::<T>::into_map)
 				.unwrap_or_default();
 			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
 			let (old_max_bid, switch_from) = match operators.pop_first() {
@@ -1404,7 +1414,7 @@ pub mod pallet {
 
 			DelegationChoices::<T>::mutate(&delegator, |maybe_plan| {
 				let mut operators =
-					maybe_plan.take().map(Self::resolved_operators).unwrap_or_default();
+					maybe_plan.take().map(DelegationPlanOf::<T>::into_map).unwrap_or_default();
 				if let Some(old_operator) = &switch_from {
 					operators.remove(old_operator);
 				}
@@ -1428,10 +1438,9 @@ pub mod pallet {
 		) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
-			let mut operators = Self::resolved_operators(
-				DelegationChoices::<T>::get(&delegator)
-					.ok_or(Error::<T>::AccountIsNotDelegating)?,
-			);
+			let mut operators = DelegationChoices::<T>::get(&delegator)
+				.ok_or(Error::<T>::AccountIsNotDelegating)?
+				.into_map();
 			ensure!(operators.len() <= 1, Error::<T>::MultiOperatorDelegator);
 			let (current_operator, current_max_bid) =
 				operators.pop_first().ok_or(Error::<T>::AccountIsNotDelegating)?;
@@ -1497,7 +1506,10 @@ pub mod pallet {
 		/// non-empty; individual entries may be smaller, only the total is checked.
 		#[pallet::call_index(24)]
 		#[pallet::weight(T::ValidatorWeightInfo::delegate_multi())]
-		pub fn delegate_multi(origin: OriginFor<T>, plan: DelegationPlanOf<T>) -> DispatchResult {
+		pub fn delegate_multi(
+			origin: OriginFor<T>,
+			plan: RequestedDelegationPlanOf<T>,
+		) -> DispatchResult {
 			let delegator = ensure_signed(origin)?;
 
 			ensure!(
@@ -2359,7 +2371,7 @@ impl<T: Config> Pallet<T> {
 				ManagedValidators::<T>::get(operator).into_iter().map(apply_f).collect(),
 			AssociationToOperator::Delegator => DelegationChoices::<T>::iter()
 				.filter_map(|(account_id, plan)| {
-					Self::resolved_operators(plan)
+					plan.into_map()
 						.get(operator)
 						.map(|max_bid| (account_id.clone(), f(&account_id, Some(*max_bid))))
 				})
@@ -2375,33 +2387,8 @@ impl<T: Config> Pallet<T> {
 	/// Sum of a delegator's max bids across all of its live operator relations.
 	pub(crate) fn total_delegated(delegator: &T::AccountId) -> T::Amount {
 		DelegationChoices::<T>::get(delegator)
-			.map(|plan| Self::resolved_operators(plan).values().copied().sum())
+			.map(|plan| plan.into_map().values().copied().sum())
 			.unwrap_or_else(T::Amount::zero)
-	}
-
-	/// The concrete `operator -> max_bid` map backing a stored plan. Every write path
-	/// (`delegate`/`undelegate`/`delegate_multi`) resolves any `Max` entry to a concrete number
-	/// before storing, so a stored plan should never actually contain one -- if it does, that's
-	/// a bug, not a valid state to silently propagate.
-	pub(crate) fn resolved_operators(
-		plan: DelegationPlanOf<T>,
-	) -> BTreeMap<T::AccountId, T::Amount> {
-		plan.into_map()
-			.into_iter()
-			.map(|(operator, amount)| {
-				let amount = match amount {
-					DelegationAmount::Some(amount) => amount,
-					DelegationAmount::Max => {
-						cf_runtime_utilities::log_or_panic!(
-							"DelegationChoices entry for {:?} contains an unresolved Max amount",
-							operator,
-						);
-						T::Amount::zero()
-					},
-				};
-				(operator, amount)
-			})
-			.collect()
 	}
 
 	/// Wraps concrete per-operator amounts into a `DelegationPlan`. Every call site either
@@ -2411,7 +2398,7 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn plan_from_amounts(
 		operators: BTreeMap<T::AccountId, T::Amount>,
 	) -> DelegationPlanOf<T> {
-		DelegationPlanOf::<T>::try_from_amounts(operators).unwrap_or_else(|_| {
+		DelegationPlanOf::<T>::try_from_map(operators).unwrap_or_else(|_| {
 			cf_runtime_utilities::log_or_panic!(
 				"delegator's operator relations exceeded MaxOperatorsPerDelegator"
 			);
@@ -2527,7 +2514,8 @@ impl<T: Config> Pallet<T> {
 			// Only relations to operators actually bidding this epoch count towards the
 			// delegator's committed total -- an operator with no qualified validators has no
 			// snapshot and can't claim any of the delegator's balance.
-			let live_relations: Vec<(T::AccountId, T::Amount)> = Self::resolved_operators(plan)
+			let live_relations: Vec<(T::AccountId, T::Amount)> = plan
+				.into_map()
 				.into_iter()
 				.filter(|(operator, _)| snapshots.contains_key(operator))
 				.collect();
@@ -2873,7 +2861,7 @@ pub struct DelegatedAccountCleanup<T>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for DelegatedAccountCleanup<T> {
 	fn on_killed_account(account_id: &T::AccountId) {
 		if let Some(plan) = DelegationChoices::<T>::take(account_id) {
-			for (operator, max_bid) in Pallet::<T>::resolved_operators(plan) {
+			for (operator, max_bid) in plan.into_map() {
 				Pallet::<T>::deposit_event(Event::Undelegated {
 					delegator: account_id.clone(),
 					operator,

--- a/state-chain/pallets/cf-validator/src/migrations.rs
+++ b/state-chain/pallets/cf-validator/src/migrations.rs
@@ -19,12 +19,20 @@ use cf_runtime_utilities::PlaceholderMigration;
 use frame_support::migrations::VersionedMigration;
 
 mod assign_lp_role_to_delegators;
+mod unify_delegation_choice;
 
 pub type PalletMigration<T> = (
 	VersionedMigration<
 		10,
 		11,
 		assign_lp_role_to_delegators::Migration<T>,
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>,
+	VersionedMigration<
+		11,
+		12,
+		unify_delegation_choice::Migration<T>,
 		Pallet<T>,
 		<T as frame_system::Config>::DbWeight,
 	>,

--- a/state-chain/pallets/cf-validator/src/migrations/assign_lp_role_to_delegators.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/assign_lp_role_to_delegators.rs
@@ -19,7 +19,7 @@
 //! Pre-existing delegators therefore need the role backfilled here so they satisfy the same
 //! invariant going forward.
 
-use crate::{Config, DelegationChoice};
+use crate::Config;
 use cf_primitives::AccountRole;
 use cf_traits::AccountRoleRegistry;
 use frame_support::{
@@ -36,6 +36,8 @@ use frame_support::pallet_prelude::DispatchError;
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
 
+use super::unify_delegation_choice::old;
+
 pub struct Migration<T>(PhantomData<T>);
 
 impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
@@ -43,7 +45,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 		let mut reads: u64 = 0;
 		let mut writes: u64 = 0;
 
-		for delegator in DelegationChoice::<T>::iter_keys() {
+		for delegator in old::DelegationChoice::<T>::iter_keys() {
 			reads.saturating_accrue(1);
 			match T::AccountRoleRegistry::account_role(&delegator) {
 				AccountRole::Unregistered => {
@@ -75,7 +77,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
-		let delegators_missing_lp_role: Vec<T::AccountId> = DelegationChoice::<T>::iter_keys()
+		let delegators_missing_lp_role: Vec<T::AccountId> = old::DelegationChoice::<T>::iter_keys()
 			.filter(|delegator| {
 				!T::AccountRoleRegistry::has_account_role(delegator, AccountRole::LiquidityProvider)
 			})
@@ -118,7 +120,7 @@ mod tests {
 	fn backfills_lp_role_for_unregistered_delegator() {
 		new_test_ext().execute_with(|| {
 			MockFlip::credit_funds(&ALICE, 1_000);
-			DelegationChoice::<Test>::insert(ALICE, (BOB, 1_000));
+			old::DelegationChoice::<Test>::insert(ALICE, (BOB, 1_000));
 
 			assert!(!is_liquidity_provider(&ALICE));
 

--- a/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 Chainflip Labs GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! `DelegationChoice: StorageMap<delegator, (operator, max_bid)>` only ever supported a single
+//! operator relation per delegator. To support multi-operator delegation, it's reshaped into
+//! `DelegationChoices: StorageMap<delegator, DelegatorRelations>`, where `DelegatorRelations`
+//! holds a full `operator -> max_bid` map instead of a single pair. This migration translates
+//! each pre-existing single-relation entry into the equivalent one-entry map, preserving all
+//! delegator/operator/max_bid data exactly.
+
+use crate::{Config, DelegationChoices, DelegatorRelations};
+use frame_support::{
+	pallet_prelude::Weight,
+	sp_runtime::Saturating,
+	traits::{Get, UncheckedOnRuntimeUpgrade},
+};
+use sp_std::{collections::btree_map::BTreeMap, marker::PhantomData};
+
+#[cfg(feature = "try-runtime")]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::pallet_prelude::DispatchError;
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+/// Shared with `assign_lp_role_to_delegators` -- both migrations read/write the same
+/// pre-version-11 `DelegationChoice` storage item.
+pub(super) mod old {
+	use super::*;
+	use frame_support::{pallet_prelude::OptionQuery, storage_alias, Identity};
+
+	#[storage_alias]
+	pub type DelegationChoice<T: Config> = StorageMap<
+		crate::Pallet<T>,
+		Identity,
+		<T as frame_system::Config>::AccountId,
+		(<T as frame_system::Config>::AccountId, <T as cf_traits::Chainflip>::Amount),
+		OptionQuery,
+	>;
+}
+
+pub struct Migration<T>(PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let mut entries_migrated: u64 = 0;
+
+		for (delegator, (operator, max_bid)) in old::DelegationChoice::<T>::drain() {
+			DelegationChoices::<T>::insert(
+				&delegator,
+				DelegatorRelations { operators: BTreeMap::from([(operator, max_bid)]) },
+			);
+			entries_migrated.saturating_accrue(1);
+		}
+
+		T::DbWeight::get()
+			.reads_writes(entries_migrated.saturating_add(1), entries_migrated.saturating_mul(2))
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, DispatchError> {
+		let entries: Vec<(T::AccountId, T::AccountId, T::Amount)> =
+			old::DelegationChoice::<T>::iter()
+				.map(|(delegator, (operator, max_bid))| (delegator, operator, max_bid))
+				.collect();
+		Ok(entries.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), DispatchError> {
+		let entries: Vec<(T::AccountId, T::AccountId, T::Amount)> =
+			Decode::decode(&mut &state[..]).map_err(|_| "failed to decode pre_upgrade state")?;
+
+		for (delegator, operator, max_bid) in entries {
+			let relations = DelegationChoices::<T>::get(&delegator)
+				.ok_or(DispatchError::Other("expected migrated DelegationChoices entry"))?;
+			frame_support::ensure!(
+				relations.operators.get(&operator) == Some(&max_bid),
+				DispatchError::Other("migrated max_bid did not match its pre-upgrade value")
+			);
+		}
+		frame_support::ensure!(
+			old::DelegationChoice::<T>::iter().next().is_none(),
+			DispatchError::Other("old DelegationChoice storage was not fully drained")
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{new_test_ext, MockFlip, Test, ALICE, BOB};
+
+	const OTHER_DELEGATOR: u64 = 102;
+
+	#[test]
+	fn migrates_single_relation_entries() {
+		new_test_ext().execute_with(|| {
+			MockFlip::credit_funds(&ALICE, 1_000);
+			MockFlip::credit_funds(&OTHER_DELEGATOR, 500);
+			old::DelegationChoice::<Test>::insert(ALICE, (BOB, 1_000));
+			old::DelegationChoice::<Test>::insert(OTHER_DELEGATOR, (BOB, 500));
+
+			#[cfg(feature = "try-runtime")]
+			let state = Migration::<Test>::pre_upgrade().unwrap();
+
+			Migration::<Test>::on_runtime_upgrade();
+
+			#[cfg(feature = "try-runtime")]
+			Migration::<Test>::post_upgrade(state).unwrap();
+
+			assert_eq!(
+				DelegationChoices::<Test>::get(ALICE).unwrap().operators,
+				BTreeMap::from([(BOB, 1_000)])
+			);
+			assert_eq!(
+				DelegationChoices::<Test>::get(OTHER_DELEGATOR).unwrap().operators,
+				BTreeMap::from([(BOB, 500)])
+			);
+			assert!(old::DelegationChoice::<Test>::iter().next().is_none());
+		});
+	}
+
+	#[test]
+	fn no_entries_is_a_noop() {
+		new_test_ext().execute_with(|| {
+			Migration::<Test>::on_runtime_upgrade();
+			assert!(DelegationChoices::<Test>::iter().next().is_none());
+		});
+	}
+}

--- a/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
@@ -61,13 +61,14 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 		for (delegator, (operator, max_bid)) in old::DelegationChoice::<T>::drain() {
 			DelegationChoices::<T>::insert(
 				&delegator,
-				DelegationPlan::try_from_amounts(BTreeMap::from([(operator, max_bid)]))
-					.unwrap_or_else(|_| {
+				DelegationPlan::try_from_map(BTreeMap::from([(operator, max_bid)])).unwrap_or_else(
+					|_| {
 						cf_runtime_utilities::log_or_panic!(
 							"migrated delegator relation exceeded MaxOperatorsPerDelegator"
 						);
 						Default::default()
-					}),
+					},
+				),
 			);
 			entries_migrated.saturating_accrue(1);
 		}
@@ -94,7 +95,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 			let plan = DelegationChoices::<T>::get(&delegator)
 				.ok_or(DispatchError::Other("expected migrated DelegationChoices entry"))?;
 			frame_support::ensure!(
-				plan.into_map().get(&operator) == Some(&crate::DelegationAmount::Some(max_bid)),
+				plan.into_map().get(&operator) == Some(&max_bid),
 				DispatchError::Other("migrated max_bid did not match its pre-upgrade value")
 			);
 		}
@@ -130,15 +131,11 @@ mod tests {
 			Migration::<Test>::post_upgrade(state).unwrap();
 
 			assert_eq!(
-				crate::Pallet::<Test>::resolved_operators(
-					DelegationChoices::<Test>::get(ALICE).unwrap()
-				),
+				DelegationChoices::<Test>::get(ALICE).unwrap().into_map(),
 				BTreeMap::from([(BOB, 1_000)])
 			);
 			assert_eq!(
-				crate::Pallet::<Test>::resolved_operators(
-					DelegationChoices::<Test>::get(OTHER_DELEGATOR).unwrap()
-				),
+				DelegationChoices::<Test>::get(OTHER_DELEGATOR).unwrap().into_map(),
 				BTreeMap::from([(BOB, 500)])
 			);
 			assert!(old::DelegationChoice::<Test>::iter().next().is_none());

--- a/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
+++ b/state-chain/pallets/cf-validator/src/migrations/unify_delegation_choice.rs
@@ -16,12 +16,12 @@
 
 //! `DelegationChoice: StorageMap<delegator, (operator, max_bid)>` only ever supported a single
 //! operator relation per delegator. To support multi-operator delegation, it's reshaped into
-//! `DelegationChoices: StorageMap<delegator, DelegatorRelations>`, where `DelegatorRelations`
-//! holds a full `operator -> max_bid` map instead of a single pair. This migration translates
-//! each pre-existing single-relation entry into the equivalent one-entry map, preserving all
+//! `DelegationChoices: StorageMap<delegator, DelegationPlan>`, where `DelegationPlan` holds a
+//! full `operator -> max_bid` set instead of a single pair. This migration translates each
+//! pre-existing single-relation entry into the equivalent one-entry plan, preserving all
 //! delegator/operator/max_bid data exactly.
 
-use crate::{Config, DelegationChoices, DelegatorRelations};
+use crate::{Config, DelegationChoices, DelegationPlan};
 use frame_support::{
 	pallet_prelude::Weight,
 	sp_runtime::Saturating,
@@ -61,7 +61,13 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 		for (delegator, (operator, max_bid)) in old::DelegationChoice::<T>::drain() {
 			DelegationChoices::<T>::insert(
 				&delegator,
-				DelegatorRelations { operators: BTreeMap::from([(operator, max_bid)]) },
+				DelegationPlan::try_from_amounts(BTreeMap::from([(operator, max_bid)]))
+					.unwrap_or_else(|_| {
+						cf_runtime_utilities::log_or_panic!(
+							"migrated delegator relation exceeded MaxOperatorsPerDelegator"
+						);
+						Default::default()
+					}),
 			);
 			entries_migrated.saturating_accrue(1);
 		}
@@ -85,10 +91,10 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for Migration<T> {
 			Decode::decode(&mut &state[..]).map_err(|_| "failed to decode pre_upgrade state")?;
 
 		for (delegator, operator, max_bid) in entries {
-			let relations = DelegationChoices::<T>::get(&delegator)
+			let plan = DelegationChoices::<T>::get(&delegator)
 				.ok_or(DispatchError::Other("expected migrated DelegationChoices entry"))?;
 			frame_support::ensure!(
-				relations.operators.get(&operator) == Some(&max_bid),
+				plan.into_map().get(&operator) == Some(&crate::DelegationAmount::Some(max_bid)),
 				DispatchError::Other("migrated max_bid did not match its pre-upgrade value")
 			);
 		}
@@ -124,11 +130,15 @@ mod tests {
 			Migration::<Test>::post_upgrade(state).unwrap();
 
 			assert_eq!(
-				DelegationChoices::<Test>::get(ALICE).unwrap().operators,
+				crate::Pallet::<Test>::resolved_operators(
+					DelegationChoices::<Test>::get(ALICE).unwrap()
+				),
 				BTreeMap::from([(BOB, 1_000)])
 			);
 			assert_eq!(
-				DelegationChoices::<Test>::get(OTHER_DELEGATOR).unwrap().operators,
+				crate::Pallet::<Test>::resolved_operators(
+					DelegationChoices::<Test>::get(OTHER_DELEGATOR).unwrap()
+				),
 				BTreeMap::from([(BOB, 500)])
 			);
 			assert!(old::DelegationChoice::<Test>::iter().next().is_none());

--- a/state-chain/pallets/cf-validator/src/mock.rs
+++ b/state-chain/pallets/cf-validator/src/mock.rs
@@ -236,6 +236,7 @@ impl Config for Test {
 	type MinimumFunding = MockMinimumFundingProvider;
 	type CfePeerRegistration = MockCfeInterface;
 	type GrandpaDelegation = MockGrandpaDelegation;
+	type MaxOperatorsPerDelegator = ConstU32<20>;
 }
 
 /// Session pallet requires a set of validators at genesis.

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -3484,9 +3484,7 @@ mod delegation {
 			assert_noop!(
 				ValidatorPallet::delegate_multi(
 					OriginTrait::signed(DELEGATOR),
-					DelegatorRelations {
-						operators: BTreeMap::from([(OPERATOR_A, half_of_min)])
-					}
+					DelegatorRelations { operators: BTreeMap::from([(OPERATOR_A, half_of_min)]) }
 				),
 				Error::<Test>::DelegationAmountBelowMinimum
 			);
@@ -3543,10 +3541,14 @@ mod delegation {
 				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
 				BTreeMap::from([(OPERATOR_B, BID_TO_B)])
 			);
-			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::DelegationPlanUpdated {
-				delegator: DELEGATOR,
-				plan: DelegatorRelations { operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]) },
-			}));
+			System::assert_last_event(RuntimeEvent::ValidatorPallet(
+				Event::DelegationPlanUpdated {
+					delegator: DELEGATOR,
+					plan: DelegatorRelations {
+						operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]),
+					},
+				},
+			));
 			assert!(<Roles as AccountRoleRegistry<Test>>::has_account_role(
 				&DELEGATOR,
 				AccountRole::LiquidityProvider

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1816,7 +1816,7 @@ fn redemption_amount_check_respects_delegation_reservation() {
 			ALICE,
 			DelegationAmount::Some(MAX_BID)
 		));
-		assert_eq!(DelegationChoice::<Test>::get(BOB), Some((ALICE, MAX_BID)));
+		assert_eq!(single_relation(BOB), Some((ALICE, MAX_BID)));
 
 		// Redeeming exactly the un-pledged portion is allowed.
 		assert_ok!(ValidatorPallet::ensure_can_redeem_amount(&BOB, BALANCE - MAX_BID));
@@ -1960,6 +1960,20 @@ fn should_expire_all_previous_epochs() {
 	});
 }
 
+/// Test helper mirroring the old single-valued `DelegationChoice::get` for delegators that have
+/// (at most) one relation -- most existing tests only ever exercise that case.
+#[cfg(test)]
+fn single_relation(delegator: u64) -> Option<(u64, u128)> {
+	DelegationChoices::<Test>::get(delegator).map(|relations| {
+		assert_eq!(
+			relations.operators.len(),
+			1,
+			"single_relation() test helper only supports a single-relation delegator"
+		);
+		relations.operators.into_iter().next().unwrap()
+	})
+}
+
 #[cfg(test)]
 mod operator {
 	use cf_test_utilities::assert_has_event;
@@ -1989,12 +2003,12 @@ mod operator {
 				ALICE,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(BOB), Some((ALICE, BID)));
+			assert_eq!(single_relation(BOB), Some((ALICE, BID)));
 
 			// Block BOB
 			assert_ok!(ValidatorPallet::block_delegator(OriginTrait::signed(ALICE), BOB));
 			assert!(Exceptions::<Test>::get(ALICE).contains(&BOB));
-			assert!(DelegationChoice::<Test>::get(BOB).is_none());
+			assert!(single_relation(BOB).is_none());
 
 			// Allow BOB again
 			assert_ok!(ValidatorPallet::allow_delegator(OriginTrait::signed(ALICE), BOB));
@@ -2052,7 +2066,7 @@ mod operator {
 				Error::<Test>::DelegatorBlocked
 			);
 			assert!(!Exceptions::<Test>::get(ALICE).contains(&BOB));
-			assert!(DelegationChoice::<Test>::get(BOB).is_none());
+			assert!(single_relation(BOB).is_none());
 
 			// Allow BOB (add to exceptions list to override deny default)
 			assert_ok!(ValidatorPallet::allow_delegator(OriginTrait::signed(ALICE), BOB));
@@ -2062,12 +2076,12 @@ mod operator {
 				ALICE,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(BOB), Some((ALICE, BID)));
+			assert_eq!(single_relation(BOB), Some((ALICE, BID)));
 
 			// Block BOB again (remove from exceptions list, back to deny default)
 			assert_ok!(ValidatorPallet::block_delegator(OriginTrait::signed(ALICE), BOB));
 			assert!(!Exceptions::<Test>::get(ALICE).contains(&BOB));
-			assert!(DelegationChoice::<Test>::get(BOB).is_none());
+			assert!(single_relation(BOB).is_none());
 
 			assert_event_sequence!(
 				Test,
@@ -2125,7 +2139,7 @@ mod operator {
 				ALICE,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(BOB), Some((ALICE, BID)));
+			assert_eq!(single_relation(BOB), Some((ALICE, BID)));
 			// Update operator settings to DENY delegation acceptance.
 			const NEW_OPERATOR_SETTINGS: OperatorSettings = OperatorSettings {
 				fee_bps: DEFAULT_MIN_OPERATOR_FEE,
@@ -2373,7 +2387,7 @@ mod delegation {
 				BOB,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(ALICE), Some((BOB, BID)));
+			assert_eq!(single_relation(ALICE), Some((BOB, BID)));
 			// Should emit MaxBidUpdated and Delegated events
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Delegated {
 				delegator: ALICE,
@@ -2437,8 +2451,14 @@ mod delegation {
 				INDEPENDENT_VALIDATOR
 			)));
 
-			DelegationChoice::<Test>::insert(ALICE, (BOB, BID));
-			DelegationChoice::<Test>::insert(INDEPENDENT_VALIDATOR, (BOB, BID));
+			DelegationChoices::<Test>::insert(
+				ALICE,
+				DelegatorRelations { operators: BTreeMap::from([(BOB, BID)]) },
+			);
+			DelegationChoices::<Test>::insert(
+				INDEPENDENT_VALIDATOR,
+				DelegatorRelations { operators: BTreeMap::from([(BOB, BID)]) },
+			);
 
 			let (snapshots, independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
 				<Test as crate::Config>::KeygenQualification,
@@ -2506,7 +2526,7 @@ mod delegation {
 				OriginTrait::signed(ALICE),
 				DelegationAmount::Max,
 			));
-			assert_eq!(DelegationChoice::<Test>::get(ALICE), None);
+			assert_eq!(single_relation(ALICE), None);
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
@@ -2618,7 +2638,7 @@ mod delegation {
 				DelegationAmount::Some(1),
 			));
 
-			assert!(DelegationChoice::<Test>::contains_key(ALICE));
+			assert!(DelegationChoices::<Test>::contains_key(ALICE));
 			assert!(<<Test as Chainflip>::AccountRoleRegistry as AccountRoleRegistry<Test>>::has_account_role(&ALICE, AccountRole::LiquidityProvider));
 		});
 	}
@@ -2860,7 +2880,7 @@ mod delegation {
 							DelegationAmount::Max
 						));
 						// Delegation choice should be removed after undelegation
-						assert!(DelegationChoice::<Test>::get(delegator).is_none());
+						assert!(single_relation(*delegator).is_none());
 					}
 				}
 			})
@@ -3021,7 +3041,7 @@ mod delegation {
 				DelegationAmount::Some(min_bid)
 			));
 
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, min_bid)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, min_bid)));
 
 			// If we are about to reduce out delegation so it is below the minimum,
 			// the amount will be "rounded down" to 0 and we won't end up with a dust
@@ -3031,7 +3051,7 @@ mod delegation {
 				DelegationAmount::Some(min_bid - 1)
 			));
 
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), None);
+			assert_eq!(single_relation(DELEGATOR), None);
 		});
 	}
 
@@ -3056,7 +3076,7 @@ mod delegation {
 				BOB,
 				DelegationAmount::Some(DELEGATION_AMOUNT)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, DELEGATION_AMOUNT)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, DELEGATION_AMOUNT)));
 			assert_event_sequence!(
 				Test,
 				RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
@@ -3096,10 +3116,7 @@ mod delegation {
 				ALICE,
 				DelegationAmount::Some(0)
 			));
-			assert_eq!(
-				DelegationChoice::<Test>::get(DELEGATOR),
-				Some((ALICE, DELEGATION_AMOUNT * 2))
-			);
+			assert_eq!(single_relation(DELEGATOR), Some((ALICE, DELEGATION_AMOUNT * 2)));
 
 			cf_test_utilities::assert_has_event::<Test>(RuntimeEvent::ValidatorPallet(
 				Event::Undelegated {
@@ -3146,7 +3163,7 @@ mod delegation {
 				OriginTrait::signed(DELEGATOR),
 				DelegationAmount::Some(300)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 700))); // Still delegated
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 700))); // Still delegated
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
 				delegator: DELEGATOR,
 				change: Change::Decrease(300),
@@ -3157,7 +3174,7 @@ mod delegation {
 				OriginTrait::signed(DELEGATOR),
 				DelegationAmount::Some(200)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 500))); // Still delegated
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 500))); // Still delegated
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
 				delegator: DELEGATOR,
 				change: Change::Decrease(200),
@@ -3170,9 +3187,9 @@ mod delegation {
 			));
 			// Verify delegation is removed after decrementing to zero
 			assert_eq!(
-				DelegationChoice::<Test>::get(DELEGATOR),
+				single_relation(DELEGATOR),
 				None,
-				"DelegationChoice should be None after decrementing to zero"
+				"delegation should be removed after decrementing to zero"
 			);
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
@@ -3210,7 +3227,7 @@ mod delegation {
 				OriginTrait::signed(DELEGATOR),
 				DelegationAmount::Some(BALANCE * 2)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), None);
+			assert_eq!(single_relation(DELEGATOR), None);
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
 				operator: BOB,
@@ -3248,7 +3265,7 @@ mod delegation {
 				OriginTrait::signed(DELEGATOR),
 				DelegationAmount::Some(300)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 700)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 700)));
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::MaxBidUpdated {
 				delegator: DELEGATOR,
 				change: Change::Decrease(300),
@@ -3284,7 +3301,7 @@ mod delegation {
 				BOB,
 				DelegationAmount::Some(200)
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 700)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 700)));
 
 			// Re-delegate with Max - should set to full balance
 			assert_ok!(ValidatorPallet::delegate(
@@ -3292,7 +3309,7 @@ mod delegation {
 				BOB,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 1000)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 1000)));
 		});
 	}
 
@@ -3314,7 +3331,7 @@ mod delegation {
 				BOB,
 				DelegationAmount::Max
 			));
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), Some((BOB, 500)));
+			assert_eq!(single_relation(DELEGATOR), Some((BOB, 500)));
 
 			// Clear events before account cleanup
 			System::reset_events();
@@ -3323,13 +3340,423 @@ mod delegation {
 			DelegatedAccountCleanup::<Test>::on_killed_account(&DELEGATOR);
 
 			// Check that delegation data is cleaned up
-			assert_eq!(DelegationChoice::<Test>::get(DELEGATOR), None);
+			assert_eq!(single_relation(DELEGATOR), None);
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::Undelegated {
 				delegator: DELEGATOR,
 				operator: BOB,
 				max_bid: 500,
 			}));
 		});
+	}
+
+	#[test]
+	fn can_delegate_to_multiple_operators_via_delegate_multi() {
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const DELEGATOR: u64 = 5000;
+		const BID_TO_A: u128 = 400;
+		const BID_TO_B: u128 = 600;
+
+		new_test_ext().execute_with(|| {
+			for operator in [OPERATOR_A, OPERATOR_B] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+			}
+			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
+
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+				}
+			));
+
+			assert_eq!(
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+			);
+
+			// Legacy `delegate`/`undelegate` no longer apply once there's more than one
+			// relation -- ambiguous which one they'd act on.
+			assert_noop!(
+				ValidatorPallet::delegate(
+					OriginTrait::signed(DELEGATOR),
+					OPERATOR_A,
+					DelegationAmount::Some(1)
+				),
+				Error::<Test>::MultiOperatorDelegator
+			);
+			assert_noop!(
+				ValidatorPallet::undelegate(OriginTrait::signed(DELEGATOR), DelegationAmount::Max),
+				Error::<Test>::MultiOperatorDelegator
+			);
+		});
+	}
+
+	#[test]
+	fn delegate_multi_prorates_plan_exceeding_balance() {
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const DELEGATOR: u64 = 5000;
+		const BALANCE: u128 = 1_000;
+		const REQUESTED_TO_A: u128 = 1_400;
+		const REQUESTED_TO_B: u128 = 600;
+
+		new_test_ext().execute_with(|| {
+			for operator in [OPERATOR_A, OPERATOR_B] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+			}
+			MockFlip::credit_funds(&DELEGATOR, BALANCE);
+
+			// The plan asks for more (2000) than the delegator's balance (1000) -- rather than
+			// rejecting it outright, every entry is scaled down proportionally so the sum
+			// exactly matches the balance. The two relations must never double-count the same
+			// stake.
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([
+						(OPERATOR_A, REQUESTED_TO_A),
+						(OPERATOR_B, REQUESTED_TO_B)
+					])
+				}
+			));
+
+			let requested_total = REQUESTED_TO_A + REQUESTED_TO_B;
+			let stored = DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators;
+			assert_eq!(stored.values().copied().sum::<u128>(), BALANCE);
+			// Proportional to the original 1400:600 (7:3) split.
+			assert_eq!(
+				stored,
+				BTreeMap::from([
+					(OPERATOR_A, BALANCE * REQUESTED_TO_A / requested_total),
+					(OPERATOR_B, BALANCE * REQUESTED_TO_B / requested_total)
+				])
+			);
+		});
+	}
+
+	#[test]
+	fn delegate_multi_checks_minimum_against_the_plan_total_not_each_entry() {
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const DELEGATOR: u64 = 5000;
+
+		new_test_ext().execute_with(|| {
+			for operator in [OPERATOR_A, OPERATOR_B] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+			}
+
+			let min_bid = MockMinimumFundingProvider::get_min_funding_amount();
+			let half_of_min: u128 = min_bid / 2;
+			assert!(half_of_min > 0 && half_of_min < min_bid, "test assumes min_bid is even");
+
+			MockFlip::credit_funds(&DELEGATOR, min_bid);
+
+			// Each individual entry is below the minimum, but the plan's total is not -- this
+			// must succeed, since only the aggregate is checked against the minimum.
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([
+						(OPERATOR_A, half_of_min),
+						(OPERATOR_B, min_bid - half_of_min)
+					])
+				}
+			));
+			assert_eq!(
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				BTreeMap::from([(OPERATOR_A, half_of_min), (OPERATOR_B, min_bid - half_of_min)])
+			);
+
+			// A plan whose total itself falls below the minimum is still rejected.
+			assert_noop!(
+				ValidatorPallet::delegate_multi(
+					OriginTrait::signed(DELEGATOR),
+					DelegatorRelations {
+						operators: BTreeMap::from([(OPERATOR_A, half_of_min)])
+					}
+				),
+				Error::<Test>::DelegationAmountBelowMinimum
+			);
+		});
+	}
+
+	#[test]
+	fn delegate_multi_plan_updates_and_removes_relations() {
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const DELEGATOR: u64 = 5000;
+		const BID_TO_A: u128 = 400;
+		const BID_TO_B: u128 = 600;
+
+		new_test_ext().execute_with(|| {
+			for operator in [OPERATOR_A, OPERATOR_B] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+			}
+			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+				}
+			));
+
+			// Submitting a new plan that still includes OPERATOR_B unchanged, but reduces
+			// OPERATOR_A, leaves OPERATOR_B untouched.
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([
+						(OPERATOR_A, BID_TO_A - 100),
+						(OPERATOR_B, BID_TO_B)
+					])
+				}
+			));
+			assert_eq!(
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				BTreeMap::from([(OPERATOR_A, BID_TO_A - 100), (OPERATOR_B, BID_TO_B)])
+			);
+
+			// Omitting OPERATOR_A from the next plan fully undelegates it; the delegator is
+			// still delegating (to OPERATOR_B) so the LP role must not be dropped.
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations { operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]) }
+			));
+			assert_eq!(
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				BTreeMap::from([(OPERATOR_B, BID_TO_B)])
+			);
+			System::assert_last_event(RuntimeEvent::ValidatorPallet(Event::DelegationPlanUpdated {
+				delegator: DELEGATOR,
+				plan: DelegatorRelations { operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]) },
+			}));
+			assert!(<Roles as AccountRoleRegistry<Test>>::has_account_role(
+				&DELEGATOR,
+				AccountRole::LiquidityProvider
+			));
+
+			// An empty plan fully undelegates everything and deregisters the LP role,
+			// mirroring `undelegate`'s behaviour.
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations { operators: Default::default() }
+			));
+			assert!(!DelegationChoices::<Test>::contains_key(DELEGATOR));
+			assert!(!<Roles as AccountRoleRegistry<Test>>::has_account_role(
+				&DELEGATOR,
+				AccountRole::LiquidityProvider
+			));
+		});
+	}
+
+	#[test]
+	fn snapshot_splits_a_multi_operator_delegator_bid_across_both_operators() {
+		const BID: u128 = 1_000;
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const VALIDATOR_A: u64 = 210;
+		const VALIDATOR_B: u64 = 211;
+		const DELEGATOR: u64 = 5000;
+		const BID_TO_A: u128 = 400;
+		const BID_TO_B: u128 = 600;
+
+		new_test_ext().execute_with(|| {
+			for (operator, validator) in [(OPERATOR_A, VALIDATOR_A), (OPERATOR_B, VALIDATOR_B)] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+				MockFlip::credit_funds(&validator, BID);
+				assert_ok!(ValidatorPallet::register_as_validator(RuntimeOrigin::signed(
+					validator
+				)));
+				assert_ok!(ValidatorPallet::start_bidding(RuntimeOrigin::signed(validator)));
+				assert_ok!(ValidatorPallet::claim_validator(
+					OriginTrait::signed(operator),
+					validator
+				));
+				assert_ok!(ValidatorPallet::accept_operator(
+					OriginTrait::signed(validator),
+					operator
+				));
+			}
+
+			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+				}
+			));
+
+			let (snapshots, _independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
+				<Test as crate::Config>::KeygenQualification,
+			>(&Default::default());
+
+			assert_eq!(
+				snapshots.get(&OPERATOR_A).unwrap().delegators.get(&DELEGATOR),
+				Some(&BID_TO_A)
+			);
+			assert_eq!(
+				snapshots.get(&OPERATOR_B).unwrap().delegators.get(&DELEGATOR),
+				Some(&BID_TO_B)
+			);
+		});
+	}
+
+	#[test]
+	fn snapshot_prorates_a_multi_operator_delegator_after_balance_shrinks() {
+		const BID: u128 = 1_000;
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const VALIDATOR_A: u64 = 210;
+		const VALIDATOR_B: u64 = 211;
+		const DELEGATOR: u64 = 5000;
+		const BID_TO_A: u128 = 400;
+		const BID_TO_B: u128 = 600;
+
+		new_test_ext().execute_with(|| {
+			for (operator, validator) in [(OPERATOR_A, VALIDATOR_A), (OPERATOR_B, VALIDATOR_B)] {
+				assert_ok!(ValidatorPallet::register_as_operator(
+					OriginTrait::signed(operator),
+					OPERATOR_SETTINGS,
+					vanity()
+				));
+				MockFlip::credit_funds(&validator, BID);
+				assert_ok!(ValidatorPallet::register_as_validator(RuntimeOrigin::signed(
+					validator
+				)));
+				assert_ok!(ValidatorPallet::start_bidding(RuntimeOrigin::signed(validator)));
+				assert_ok!(ValidatorPallet::claim_validator(
+					OriginTrait::signed(operator),
+					validator
+				));
+				assert_ok!(ValidatorPallet::accept_operator(
+					OriginTrait::signed(validator),
+					operator
+				));
+			}
+
+			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
+			assert_ok!(ValidatorPallet::delegate_multi(
+				OriginTrait::signed(DELEGATOR),
+				DelegatorRelations {
+					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+				}
+			));
+
+			// Simulate a slash: the delegator's balance drops below the sum of its two max
+			// bids (both relations were valid when written, so this can only happen after the
+			// fact). Each relation should be prorated proportionally, not just capped
+			// independently -- otherwise the same shrunk balance would be double-counted.
+			const NEW_BALANCE: u128 = 500;
+			assert!(MockFlip::try_debit_funds(&DELEGATOR, (BID_TO_A + BID_TO_B) - NEW_BALANCE)
+				.is_some());
+
+			let (snapshots, _independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
+				<Test as crate::Config>::KeygenQualification,
+			>(&Default::default());
+
+			let bid_a = *snapshots.get(&OPERATOR_A).unwrap().delegators.get(&DELEGATOR).unwrap();
+			let bid_b = *snapshots.get(&OPERATOR_B).unwrap().delegators.get(&DELEGATOR).unwrap();
+
+			assert_eq!(bid_a + bid_b, NEW_BALANCE);
+			// Proportional to the original 400:600 split.
+			assert_eq!(bid_a, NEW_BALANCE * BID_TO_A / (BID_TO_A + BID_TO_B));
+		});
+	}
+
+	#[test]
+	fn delegate_multi_to_multiple_operators_sums_bond_after_rotation() {
+		const OPERATOR_A: u64 = 200;
+		const OPERATOR_B: u64 = 201;
+		const DELEGATOR: u64 = 5000;
+		const BID_TO_A: u128 = 1_000;
+		const BID_TO_B: u128 = 1_500;
+
+		new_test_ext()
+			.then_execute_with_checks(|| {
+				for operator in [OPERATOR_A, OPERATOR_B] {
+					assert_ok!(ValidatorPallet::register_as_operator(
+						OriginTrait::signed(operator),
+						OperatorSettings {
+							fee_bps: DEFAULT_MIN_OPERATOR_FEE,
+							delegation_acceptance: DelegationAcceptance::Allow,
+						},
+						vanity()
+					));
+				}
+
+				MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
+				assert_ok!(ValidatorPallet::delegate_multi(
+					OriginTrait::signed(DELEGATOR),
+					DelegatorRelations {
+						operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
+					}
+				));
+
+				// `WINNING_BIDS` accounts already hold the Validator role from genesis (see
+				// `all_validators()` in mock.rs), so `claim_validator` can run before
+				// `set_default_test_bids` actually starts their bidding.
+				assert_ok!(ValidatorPallet::claim_validator(
+					OriginTrait::signed(OPERATOR_A),
+					WINNING_BIDS[0].bidder_id
+				));
+				assert_ok!(ValidatorPallet::accept_operator(
+					OriginTrait::signed(WINNING_BIDS[0].bidder_id),
+					OPERATOR_A
+				));
+				assert_ok!(ValidatorPallet::claim_validator(
+					OriginTrait::signed(OPERATOR_B),
+					WINNING_BIDS[1].bidder_id
+				));
+				assert_ok!(ValidatorPallet::accept_operator(
+					OriginTrait::signed(WINNING_BIDS[1].bidder_id),
+					OPERATOR_B
+				));
+
+				set_default_test_bids();
+				ValidatorPallet::start_authority_rotation();
+				assert_rotation_phase_matches!(RotationPhase::KeygensInProgress(..));
+			})
+			.then_execute_at_next_block(|_| {
+				MockKeyRotatorA::keygen_success();
+			})
+			.then_execute_at_next_block(|_| {
+				assert_rotation_phase_matches!(RotationPhase::KeyHandoversInProgress(..));
+				MockKeyRotatorA::key_handover_success();
+			})
+			.then_execute_at_next_block(|_| {
+				assert_rotation_phase_matches!(RotationPhase::<Test>::ActivatingKeys(..));
+				MockKeyRotatorA::keys_activated();
+			})
+			.then_execute_at_next_block(|_| {
+				assert_rotation_phase_matches!(RotationPhase::SessionRotating(..));
+			})
+			.then_execute_at_next_block(|_| {
+				assert_rotation_phase_matches!(RotationPhase::Idle);
+				// a delegator appearing in two operators' snapshots must
+				// be bonded for the SUM of both relations
+				assert_eq!(MockBonderFor::<Test>::get_bond(&DELEGATOR), BID_TO_A + BID_TO_B);
+			});
 	}
 }
 

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1965,12 +1965,13 @@ fn should_expire_all_previous_epochs() {
 #[cfg(test)]
 fn single_relation(delegator: u64) -> Option<(u64, u128)> {
 	DelegationChoices::<Test>::get(delegator).map(|relations| {
+		let operators = ValidatorPallet::resolved_operators(relations);
 		assert_eq!(
-			relations.operators.len(),
+			operators.len(),
 			1,
 			"single_relation() test helper only supports a single-relation delegator"
 		);
-		relations.operators.into_iter().next().unwrap()
+		operators.into_iter().next().unwrap()
 	})
 }
 
@@ -2453,11 +2454,11 @@ mod delegation {
 
 			DelegationChoices::<Test>::insert(
 				ALICE,
-				DelegatorRelations { operators: BTreeMap::from([(BOB, BID)]) },
+				DelegationPlan::try_from_amounts(BTreeMap::from([(BOB, BID)])).unwrap(),
 			);
 			DelegationChoices::<Test>::insert(
 				INDEPENDENT_VALIDATOR,
-				DelegatorRelations { operators: BTreeMap::from([(BOB, BID)]) },
+				DelegationPlan::try_from_amounts(BTreeMap::from([(BOB, BID)])).unwrap(),
 			);
 
 			let (snapshots, independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
@@ -3369,13 +3370,17 @@ mod delegation {
 
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, BID_TO_A),
+					(OPERATOR_B, BID_TO_B)
+				]))
+				.unwrap()
 			));
 
 			assert_eq!(
-				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				ValidatorPallet::resolved_operators(
+					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
+				),
 				BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			);
 
@@ -3421,16 +3426,17 @@ mod delegation {
 			// stake.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([
-						(OPERATOR_A, REQUESTED_TO_A),
-						(OPERATOR_B, REQUESTED_TO_B)
-					])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, REQUESTED_TO_A),
+					(OPERATOR_B, REQUESTED_TO_B)
+				]))
+				.unwrap()
 			));
 
 			let requested_total = REQUESTED_TO_A + REQUESTED_TO_B;
-			let stored = DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators;
+			let stored = ValidatorPallet::resolved_operators(
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap(),
+			);
 			assert_eq!(stored.values().copied().sum::<u128>(), BALANCE);
 			// Proportional to the original 1400:600 (7:3) split.
 			assert_eq!(
@@ -3468,15 +3474,16 @@ mod delegation {
 			// must succeed, since only the aggregate is checked against the minimum.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([
-						(OPERATOR_A, half_of_min),
-						(OPERATOR_B, min_bid - half_of_min)
-					])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, half_of_min),
+					(OPERATOR_B, min_bid - half_of_min)
+				]))
+				.unwrap()
 			));
 			assert_eq!(
-				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				ValidatorPallet::resolved_operators(
+					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
+				),
 				BTreeMap::from([(OPERATOR_A, half_of_min), (OPERATOR_B, min_bid - half_of_min)])
 			);
 
@@ -3484,7 +3491,8 @@ mod delegation {
 			assert_noop!(
 				ValidatorPallet::delegate_multi(
 					OriginTrait::signed(DELEGATOR),
-					DelegatorRelations { operators: BTreeMap::from([(OPERATOR_A, half_of_min)]) }
+					DelegationPlan::try_from_amounts(BTreeMap::from([(OPERATOR_A, half_of_min)]))
+						.unwrap()
 				),
 				Error::<Test>::DelegationAmountBelowMinimum
 			);
@@ -3510,24 +3518,27 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, BID_TO_A),
+					(OPERATOR_B, BID_TO_B)
+				]))
+				.unwrap()
 			));
 
 			// Submitting a new plan that still includes OPERATOR_B unchanged, but reduces
 			// OPERATOR_A, leaves OPERATOR_B untouched.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([
-						(OPERATOR_A, BID_TO_A - 100),
-						(OPERATOR_B, BID_TO_B)
-					])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, BID_TO_A - 100),
+					(OPERATOR_B, BID_TO_B)
+				]))
+				.unwrap()
 			));
 			assert_eq!(
-				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				ValidatorPallet::resolved_operators(
+					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
+				),
 				BTreeMap::from([(OPERATOR_A, BID_TO_A - 100), (OPERATOR_B, BID_TO_B)])
 			);
 
@@ -3535,18 +3546,21 @@ mod delegation {
 			// still delegating (to OPERATOR_B) so the LP role must not be dropped.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations { operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]) }
+				DelegationPlan::try_from_amounts(BTreeMap::from([(OPERATOR_B, BID_TO_B)])).unwrap()
 			));
 			assert_eq!(
-				DelegationChoices::<Test>::get(DELEGATOR).unwrap().operators,
+				ValidatorPallet::resolved_operators(
+					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
+				),
 				BTreeMap::from([(OPERATOR_B, BID_TO_B)])
 			);
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(
 				Event::DelegationPlanUpdated {
 					delegator: DELEGATOR,
-					plan: DelegatorRelations {
-						operators: BTreeMap::from([(OPERATOR_B, BID_TO_B)]),
-					},
+					plan: DelegationPlan::try_from_amounts(BTreeMap::from([(
+						OPERATOR_B, BID_TO_B,
+					)]))
+					.unwrap(),
 				},
 			));
 			assert!(<Roles as AccountRoleRegistry<Test>>::has_account_role(
@@ -3558,7 +3572,7 @@ mod delegation {
 			// mirroring `undelegate`'s behaviour.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations { operators: Default::default() }
+				DelegationPlan::try_from_amounts(Default::default()).unwrap()
 			));
 			assert!(!DelegationChoices::<Test>::contains_key(DELEGATOR));
 			assert!(!<Roles as AccountRoleRegistry<Test>>::has_account_role(
@@ -3604,9 +3618,11 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, BID_TO_A),
+					(OPERATOR_B, BID_TO_B)
+				]))
+				.unwrap()
 			));
 
 			let (snapshots, _independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
@@ -3660,9 +3676,11 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegatorRelations {
-					operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
-				}
+				DelegationPlan::try_from_amounts(BTreeMap::from([
+					(OPERATOR_A, BID_TO_A),
+					(OPERATOR_B, BID_TO_B)
+				]))
+				.unwrap()
 			));
 
 			// Simulate a slash: the delegator's balance drops below the sum of its two max
@@ -3710,9 +3728,11 @@ mod delegation {
 				MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 				assert_ok!(ValidatorPallet::delegate_multi(
 					OriginTrait::signed(DELEGATOR),
-					DelegatorRelations {
-						operators: BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
-					}
+					DelegationPlan::try_from_amounts(BTreeMap::from([
+						(OPERATOR_A, BID_TO_A),
+						(OPERATOR_B, BID_TO_B)
+					]))
+					.unwrap()
 				));
 
 				// `WINNING_BIDS` accounts already hold the Validator role from genesis (see

--- a/state-chain/pallets/cf-validator/src/tests.rs
+++ b/state-chain/pallets/cf-validator/src/tests.rs
@@ -1965,7 +1965,7 @@ fn should_expire_all_previous_epochs() {
 #[cfg(test)]
 fn single_relation(delegator: u64) -> Option<(u64, u128)> {
 	DelegationChoices::<Test>::get(delegator).map(|relations| {
-		let operators = ValidatorPallet::resolved_operators(relations);
+		let operators = relations.into_map();
 		assert_eq!(
 			operators.len(),
 			1,
@@ -1973,6 +1973,18 @@ fn single_relation(delegator: u64) -> Option<(u64, u128)> {
 		);
 		operators.into_iter().next().unwrap()
 	})
+}
+
+/// Builds a `delegate_multi` input plan from concrete (non-`Max`) per-operator amounts.
+#[cfg(test)]
+fn fixed_plan(entries: impl IntoIterator<Item = (u64, u128)>) -> RequestedDelegationPlanOf<Test> {
+	DelegationPlan::try_from_map(
+		entries
+			.into_iter()
+			.map(|(operator, amount)| (operator, DelegationAmount::Some(amount)))
+			.collect(),
+	)
+	.unwrap()
 }
 
 #[cfg(test)]
@@ -2454,11 +2466,11 @@ mod delegation {
 
 			DelegationChoices::<Test>::insert(
 				ALICE,
-				DelegationPlan::try_from_amounts(BTreeMap::from([(BOB, BID)])).unwrap(),
+				DelegationPlan::try_from_map(BTreeMap::from([(BOB, BID)])).unwrap(),
 			);
 			DelegationChoices::<Test>::insert(
 				INDEPENDENT_VALIDATOR,
-				DelegationPlan::try_from_amounts(BTreeMap::from([(BOB, BID)])).unwrap(),
+				DelegationPlan::try_from_map(BTreeMap::from([(BOB, BID)])).unwrap(),
 			);
 
 			let (snapshots, independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
@@ -3370,17 +3382,11 @@ mod delegation {
 
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, BID_TO_A),
-					(OPERATOR_B, BID_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			));
 
 			assert_eq!(
-				ValidatorPallet::resolved_operators(
-					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
-				),
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().into_map(),
 				BTreeMap::from([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			);
 
@@ -3426,17 +3432,11 @@ mod delegation {
 			// stake.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, REQUESTED_TO_A),
-					(OPERATOR_B, REQUESTED_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, REQUESTED_TO_A), (OPERATOR_B, REQUESTED_TO_B)])
 			));
 
 			let requested_total = REQUESTED_TO_A + REQUESTED_TO_B;
-			let stored = ValidatorPallet::resolved_operators(
-				DelegationChoices::<Test>::get(DELEGATOR).unwrap(),
-			);
+			let stored = DelegationChoices::<Test>::get(DELEGATOR).unwrap().into_map();
 			assert_eq!(stored.values().copied().sum::<u128>(), BALANCE);
 			// Proportional to the original 1400:600 (7:3) split.
 			assert_eq!(
@@ -3474,16 +3474,10 @@ mod delegation {
 			// must succeed, since only the aggregate is checked against the minimum.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, half_of_min),
-					(OPERATOR_B, min_bid - half_of_min)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, half_of_min), (OPERATOR_B, min_bid - half_of_min)])
 			));
 			assert_eq!(
-				ValidatorPallet::resolved_operators(
-					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
-				),
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().into_map(),
 				BTreeMap::from([(OPERATOR_A, half_of_min), (OPERATOR_B, min_bid - half_of_min)])
 			);
 
@@ -3491,8 +3485,7 @@ mod delegation {
 			assert_noop!(
 				ValidatorPallet::delegate_multi(
 					OriginTrait::signed(DELEGATOR),
-					DelegationPlan::try_from_amounts(BTreeMap::from([(OPERATOR_A, half_of_min)]))
-						.unwrap()
+					fixed_plan([(OPERATOR_A, half_of_min)])
 				),
 				Error::<Test>::DelegationAmountBelowMinimum
 			);
@@ -3518,27 +3511,17 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, BID_TO_A),
-					(OPERATOR_B, BID_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			));
 
 			// Submitting a new plan that still includes OPERATOR_B unchanged, but reduces
 			// OPERATOR_A, leaves OPERATOR_B untouched.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, BID_TO_A - 100),
-					(OPERATOR_B, BID_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, BID_TO_A - 100), (OPERATOR_B, BID_TO_B)])
 			));
 			assert_eq!(
-				ValidatorPallet::resolved_operators(
-					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
-				),
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().into_map(),
 				BTreeMap::from([(OPERATOR_A, BID_TO_A - 100), (OPERATOR_B, BID_TO_B)])
 			);
 
@@ -3546,21 +3529,17 @@ mod delegation {
 			// still delegating (to OPERATOR_B) so the LP role must not be dropped.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([(OPERATOR_B, BID_TO_B)])).unwrap()
+				fixed_plan([(OPERATOR_B, BID_TO_B)])
 			));
 			assert_eq!(
-				ValidatorPallet::resolved_operators(
-					DelegationChoices::<Test>::get(DELEGATOR).unwrap()
-				),
+				DelegationChoices::<Test>::get(DELEGATOR).unwrap().into_map(),
 				BTreeMap::from([(OPERATOR_B, BID_TO_B)])
 			);
 			System::assert_last_event(RuntimeEvent::ValidatorPallet(
 				Event::DelegationPlanUpdated {
 					delegator: DELEGATOR,
-					plan: DelegationPlan::try_from_amounts(BTreeMap::from([(
-						OPERATOR_B, BID_TO_B,
-					)]))
-					.unwrap(),
+					plan: DelegationPlan::try_from_map(BTreeMap::from([(OPERATOR_B, BID_TO_B)]))
+						.unwrap(),
 				},
 			));
 			assert!(<Roles as AccountRoleRegistry<Test>>::has_account_role(
@@ -3572,7 +3551,7 @@ mod delegation {
 			// mirroring `undelegate`'s behaviour.
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(Default::default()).unwrap()
+				fixed_plan([])
 			));
 			assert!(!DelegationChoices::<Test>::contains_key(DELEGATOR));
 			assert!(!<Roles as AccountRoleRegistry<Test>>::has_account_role(
@@ -3618,11 +3597,7 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, BID_TO_A),
-					(OPERATOR_B, BID_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			));
 
 			let (snapshots, _independent_bidders) = ValidatorPallet::build_delegation_snapshots::<
@@ -3676,11 +3651,7 @@ mod delegation {
 			MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 			assert_ok!(ValidatorPallet::delegate_multi(
 				OriginTrait::signed(DELEGATOR),
-				DelegationPlan::try_from_amounts(BTreeMap::from([
-					(OPERATOR_A, BID_TO_A),
-					(OPERATOR_B, BID_TO_B)
-				]))
-				.unwrap()
+				fixed_plan([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 			));
 
 			// Simulate a slash: the delegator's balance drops below the sum of its two max
@@ -3728,11 +3699,7 @@ mod delegation {
 				MockFlip::credit_funds(&DELEGATOR, BID_TO_A + BID_TO_B);
 				assert_ok!(ValidatorPallet::delegate_multi(
 					OriginTrait::signed(DELEGATOR),
-					DelegationPlan::try_from_amounts(BTreeMap::from([
-						(OPERATOR_A, BID_TO_A),
-						(OPERATOR_B, BID_TO_B)
-					]))
-					.unwrap()
+					fixed_plan([(OPERATOR_A, BID_TO_A), (OPERATOR_B, BID_TO_B)])
 				));
 
 				// `WINNING_BIDS` accounts already hold the Validator role from genesis (see

--- a/state-chain/pallets/cf-validator/src/weights.rs
+++ b/state-chain/pallets/cf-validator/src/weights.rs
@@ -73,6 +73,7 @@ pub trait WeightInfo {
 	fn deregister_as_operator() -> Weight;
 	fn delegate() -> Weight;
 	fn undelegate() -> Weight;
+	fn delegate_multi() -> Weight;
 	fn report_witnessing_task_restart() -> Weight;
 	fn delegate_grandpa_vote() -> Weight;
 	fn revoke_grandpa_delegation() -> Weight;
@@ -224,8 +225,8 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `Validator::MinimumValidatorStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::OperatorChoice` (r:400 w:0)
 	/// Proof: `Validator::OperatorChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::MinimumAuctionBid` (r:1 w:0)
 	/// Proof: `Validator::MinimumAuctionBid` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::CurrentAuthorities` (r:1 w:0)
@@ -531,8 +532,8 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	}
 	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
 	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::OperatorSettingsLookup` (r:1 w:0)
 	/// Proof: `Validator::OperatorSettingsLookup` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::Exceptions` (r:1 w:1)
@@ -582,8 +583,8 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::ManagedValidators` (r:1 w:1)
 	/// Proof: `Validator::ManagedValidators` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::LastExpiredEpoch` (r:1 w:0)
 	/// Proof: `Validator::LastExpiredEpoch` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::CurrentEpoch` (r:1 w:0)
@@ -613,8 +614,8 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 	/// Proof: `Validator::Exceptions` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Flip::Account` (r:1 w:0)
 	/// Proof: `Flip::Account` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:1)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:1)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Funding::MinimumFunding` (r:1 w:0)
 	/// Proof: `Funding::MinimumFunding` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn delegate() -> Weight {
@@ -626,8 +627,8 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Validator::DelegationChoice` (r:1 w:1)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:1)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn undelegate() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `546`
@@ -635,6 +636,12 @@ impl<T: frame_system::Config> WeightInfo for PalletWeight<T> {
 		// Minimum execution time: 21_254_000 picoseconds.
 		Weight::from_parts(21_632_000, 4011)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	// TODO: placeholder pending real benchmarks 
+	fn delegate_multi() -> Weight {
+		Weight::from_parts(57_965_000, 8029)
+			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
@@ -834,8 +841,8 @@ impl WeightInfo for () {
 	/// Proof: `Validator::MinimumValidatorStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::OperatorChoice` (r:400 w:0)
 	/// Proof: `Validator::OperatorChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::MinimumAuctionBid` (r:1 w:0)
 	/// Proof: `Validator::MinimumAuctionBid` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::CurrentAuthorities` (r:1 w:0)
@@ -1141,8 +1148,8 @@ impl WeightInfo for () {
 	}
 	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)
 	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::OperatorSettingsLookup` (r:1 w:0)
 	/// Proof: `Validator::OperatorSettingsLookup` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::Exceptions` (r:1 w:1)
@@ -1192,8 +1199,8 @@ impl WeightInfo for () {
 	/// Proof: `AccountRoles::AccountRoles` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::ManagedValidators` (r:1 w:1)
 	/// Proof: `Validator::ManagedValidators` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:0)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:0)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::LastExpiredEpoch` (r:1 w:0)
 	/// Proof: `Validator::LastExpiredEpoch` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `Validator::CurrentEpoch` (r:1 w:0)
@@ -1223,8 +1230,8 @@ impl WeightInfo for () {
 	/// Proof: `Validator::Exceptions` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Flip::Account` (r:1 w:0)
 	/// Proof: `Flip::Account` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
-	/// Storage: `Validator::DelegationChoice` (r:1 w:1)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:1)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `Funding::MinimumFunding` (r:1 w:0)
 	/// Proof: `Funding::MinimumFunding` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn delegate() -> Weight {
@@ -1236,8 +1243,8 @@ impl WeightInfo for () {
 			.saturating_add(ParityDbWeight::get().reads(7_u64))
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Validator::DelegationChoice` (r:1 w:1)
-	/// Proof: `Validator::DelegationChoice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Validator::DelegationChoices` (r:1 w:1)
+	/// Proof: `Validator::DelegationChoices` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn undelegate() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `546`
@@ -1245,6 +1252,12 @@ impl WeightInfo for () {
 		// Minimum execution time: 21_254_000 picoseconds.
 		Weight::from_parts(21_632_000, 4011)
 			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
+	}
+	// TODO: placeholder pending real benchmarks
+	fn delegate_multi() -> Weight {
+		Weight::from_parts(57_965_000, 8029)
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
 			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `AccountRoles::AccountRoles` (r:1 w:0)

--- a/state-chain/runtime/src/configs.rs
+++ b/state-chain/runtime/src/configs.rs
@@ -147,6 +147,7 @@ impl pallet_cf_validator::Config for Runtime {
 	type MinimumFunding = Funding;
 	type CfePeerRegistration = CfeInterface;
 	type GrandpaDelegation = Grandpa;
+	type MaxOperatorsPerDelegator = ConstU32<20>;
 }
 
 parameter_types! {

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -421,12 +421,12 @@ decl_runtime_apis!(
 		fn cf_common_account_info(
 			account_id: &AccountId32,
 			should_sweep: ShouldSweep,
-		) -> before_version_19::RpcAccountInfoCommonItems<FlipBalance>;
+		) -> before_version_19::RpcAccountInfoCommonItems;
 		#[changed_in(21)]
 		fn cf_common_account_info(
 			account_id: &AccountId32,
 			should_sweep: ShouldSweep,
-		) -> before_version_21::RpcAccountInfoCommonItems<FlipBalance>;
+		) -> before_version_21::RpcAccountInfoCommonItems;
 		fn cf_common_account_info(
 			account_id: &AccountId32,
 			should_sweep: ShouldSweep,

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -422,6 +422,11 @@ decl_runtime_apis!(
 			account_id: &AccountId32,
 			should_sweep: ShouldSweep,
 		) -> before_version_19::RpcAccountInfoCommonItems<FlipBalance>;
+		#[changed_in(21)]
+		fn cf_common_account_info(
+			account_id: &AccountId32,
+			should_sweep: ShouldSweep,
+		) -> before_version_21::RpcAccountInfoCommonItems<FlipBalance>;
 		fn cf_common_account_info(
 			account_id: &AccountId32,
 			should_sweep: ShouldSweep,

--- a/state-chain/runtime/src/runtime_apis/custom_api.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api.rs
@@ -412,11 +412,11 @@ decl_runtime_apis!(
 		#[changed_in(16)]
 		fn cf_common_account_info(
 			account_id: &AccountId32,
-		) -> before_version_16::RpcAccountInfoCommonItems<FlipBalance>;
+		) -> before_version_16::RpcAccountInfoCommonItems;
 		#[changed_in(17)]
 		fn cf_common_account_info(
 			account_id: &AccountId32,
-		) -> before_version_17::RpcAccountInfoCommonItems<FlipBalance>;
+		) -> before_version_17::RpcAccountInfoCommonItems;
 		#[changed_in(19)]
 		fn cf_common_account_info(
 			account_id: &AccountId32,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -892,10 +892,12 @@ pub struct RpcAccountInfoCommonItems<Balance> {
 	pub bound_redeem_address: Option<EvmAddress>,
 	#[serde(skip_serializing_if = "BTreeMap::is_empty")]
 	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub current_delegation_status: Option<DelegationInfo<Balance>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
+	/// Operator -> bid, for each operator this account currently delegates to.
+	#[serde(skip_serializing_if = "BTreeMap::is_empty")]
+	pub current_delegation_status: BTreeMap<AccountId32, Balance>,
+	/// Operator -> bid, for each operator this account will delegate to next epoch.
+	#[serde(skip_serializing_if = "BTreeMap::is_empty")]
+	pub upcoming_delegation_status: BTreeMap<AccountId32, Balance>,
 }
 
 impl<Balance: HasChangelog> HasChangelog for RpcAccountInfoCommonItems<Balance>
@@ -931,12 +933,14 @@ impl<A> RpcAccountInfoCommonItems<A> {
 				.collect::<Result<_, E>>()?,
 			upcoming_delegation_status: self
 				.upcoming_delegation_status
-				.map(|d| d.try_map_bid(&f))
-				.transpose()?,
+				.into_iter()
+				.map(|(operator, bid)| Ok((operator, f(bid)?)))
+				.collect::<Result<_, E>>()?,
 			current_delegation_status: self
 				.current_delegation_status
-				.map(|d| d.try_map_bid(&f))
-				.transpose()?,
+				.into_iter()
+				.map(|(operator, bid)| Ok((operator, f(bid)?)))
+				.collect::<Result<_, E>>()?,
 		})
 	}
 }

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -43,7 +43,7 @@ use cf_utilities::migrations::{
 		IsHistoricalType, Migration, NewFieldWithDefault, OverrideMigrationWith, Version,
 	},
 	primitives::{NewTypeWithDefault, WrappedAccountId32},
-	v20300, HasChangelog,
+	v20400, HasChangelog,
 };
 use codec::{Decode, Encode};
 use ethereum_eip712::eip712::TypedData;
@@ -913,14 +913,14 @@ impl HasChangelog for RpcAccountInfoCommonItems<FlipBalance> {
 	type in_20200 = _RpcAccountInfoCommonItems::see_field_changelogs_and_also<
 		_RpcAccountInfoCommonItems::field::account_id::Added,
 	>;
-	// Before the v20300 cycle, a delegator could only delegate to a single operator at a time,
+	// Before the v20400 cycle, a delegator could only delegate to a single operator at a time,
 	// so these fields were `Option<DelegationInfo<Balance>>` rather than a map of every operator
 	// it delegates to.
-	type in_20300 =
+	type in_20400 =
 		_RpcAccountInfoCommonItems::see_field_changelogs_and_also<DelegationStatusFieldsBecameMaps>;
 }
 
-/// Historically (before v20300) `current_delegation_status`/`upcoming_delegation_status` were a
+/// Historically (before v20400) `current_delegation_status`/`upcoming_delegation_status` were a
 /// single optional `DelegationInfo { operator, bid }`, since a delegator could only delegate to
 /// one operator at a time. `try_backwards` is lossy if there's more than one relation -- there's
 /// no way to represent that in the old shape, so it errors instead of silently dropping data.
@@ -935,7 +935,7 @@ pub struct DelegationStatusMigration;
 #[derive(Debug)]
 pub struct TooManyDelegationsForHistoricalStatus;
 
-impl Migration<BTreeMap<WrappedAccountId32, FlipBalance>, v20300> for DelegationStatusMigration {
+impl Migration<BTreeMap<WrappedAccountId32, FlipBalance>, v20400> for DelegationStatusMigration {
 	type From = Option<(WrappedAccountId32, FlipBalance)>;
 	type BackwardsError = TooManyDelegationsForHistoricalStatus;
 
@@ -962,10 +962,10 @@ impl Migration<BTreeMap<WrappedAccountId32, FlipBalance>, v20300> for Delegation
 
 pub struct DelegationStatusFieldsBecameMaps;
 
-impl<To> _RpcAccountInfoCommonItems::FieldCustomMigration<To, v20300>
+impl<To> _RpcAccountInfoCommonItems::FieldCustomMigration<To, v20400>
 	for DelegationStatusFieldsBecameMaps
 where
-	To: _RpcAccountInfoCommonItems::HistoricalTypesAt<v20300>
+	To: _RpcAccountInfoCommonItems::HistoricalTypesAt<v20400>
 		+ _RpcAccountInfoCommonItems::Types<
 			current_delegation_status = BTreeMap<WrappedAccountId32, FlipBalance>,
 			upcoming_delegation_status = BTreeMap<WrappedAccountId32, FlipBalance>,

--- a/state-chain/runtime/src/runtime_apis/custom_api/types.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types.rs
@@ -40,10 +40,10 @@ pub use cf_primitives::{AssetAmount, BasisPoints};
 use cf_utilities::migrations::{
 	basics::{
 		vCurrent, GlobalMigrationFromGeneric, HasGenericVariant, HasVersion, IdentityMigration,
-		IsHistoricalType, Migration, NewFieldWithDefault,
+		IsHistoricalType, Migration, NewFieldWithDefault, OverrideMigrationWith, Version,
 	},
-	primitives::NewTypeWithDefault,
-	v20100, v20200, v20300, HasChangelog,
+	primitives::{NewTypeWithDefault, WrappedAccountId32},
+	v20300, HasChangelog,
 };
 use codec::{Decode, Encode};
 use ethereum_eip712::eip712::TypedData;
@@ -900,17 +900,79 @@ pub struct RpcAccountInfoCommonItems<Balance> {
 	pub upcoming_delegation_status: BTreeMap<AccountId32, Balance>,
 }
 
-impl<Balance: HasChangelog> HasChangelog for RpcAccountInfoCommonItems<Balance>
-where
-	Balance: Default,
-	<Balance as HasVersion<v20100>>::HistoricalType: Default,
-	<Balance as HasVersion<v20200>>::HistoricalType: Default,
-	<Balance as HasVersion<v20300>>::HistoricalType: Default,
-{
+// `HasChangelog` is only ever needed for `RpcAccountInfoCommonItems<FlipBalance>` -- that's the
+// only instantiation that appears on the wire (`cf_common_account_info`'s return type, and the
+// `before_version_*` snapshots derived from it). Pinning `Balance` to `FlipBalance` concretely
+// (rather than a generic `Balance: HasChangelog` impl) avoids having to reason generically about
+// an arbitrary `Balance`'s own historical/generic-variant representation below -- for the one
+// concrete type that's actually used, `FlipBalance = u128` is identity-migrated (its historical
+// and generic-variant types are just `u128` itself), which keeps the delegation-field migration
+// below straightforward.
+impl HasChangelog for RpcAccountInfoCommonItems<FlipBalance> {
 	type if_unspecified = _RpcAccountInfoCommonItems::see_field_changelogs;
 	type in_20200 = _RpcAccountInfoCommonItems::see_field_changelogs_and_also<
 		_RpcAccountInfoCommonItems::field::account_id::Added,
 	>;
+	// Before the v20300 cycle, a delegator could only delegate to a single operator at a time,
+	// so these fields were `Option<DelegationInfo<Balance>>` rather than a map of every operator
+	// it delegates to.
+	type in_20300 =
+		_RpcAccountInfoCommonItems::see_field_changelogs_and_also<DelegationStatusFieldsBecameMaps>;
+}
+
+/// Historically (before v20300) `current_delegation_status`/`upcoming_delegation_status` were a
+/// single optional `DelegationInfo { operator, bid }`, since a delegator could only delegate to
+/// one operator at a time. `try_backwards` is lossy if there's more than one relation -- there's
+/// no way to represent that in the old shape, so it errors instead of silently dropping data.
+///
+/// The historical shape is expressed as `Option<(WrappedAccountId32, FlipBalance)>` rather than
+/// `Option<DelegationInfo<FlipBalance>>` directly: `DelegationInfo` has no blanket
+/// `IsHistoricalType` impl, but a plain tuple does (via the framework's `TupleWith2Entries`
+/// blanket impl), and a struct's SCALE encoding is identical to a tuple of the same fields in the
+/// same order, so this round-trips against real historical data byte-for-byte.
+pub struct DelegationStatusMigration;
+
+#[derive(Debug)]
+pub struct TooManyDelegationsForHistoricalStatus;
+
+impl Migration<BTreeMap<WrappedAccountId32, FlipBalance>, v20300> for DelegationStatusMigration {
+	type From = Option<(WrappedAccountId32, FlipBalance)>;
+	type BackwardsError = TooManyDelegationsForHistoricalStatus;
+
+	fn try_forwards(
+		x: Self::From,
+	) -> Result<BTreeMap<WrappedAccountId32, FlipBalance>, Self::ForwardsError> {
+		Ok(match x {
+			None => BTreeMap::new(),
+			Some((operator, bid)) => BTreeMap::from([(operator, bid)]),
+		})
+	}
+
+	fn try_backwards(
+		x: BTreeMap<WrappedAccountId32, FlipBalance>,
+	) -> Result<Self::From, Self::BackwardsError> {
+		let mut entries = x.into_iter();
+		match (entries.next(), entries.next()) {
+			(None, _) => Ok(None),
+			(Some(entry), None) => Ok(Some(entry)),
+			(Some(_), Some(_)) => Err(TooManyDelegationsForHistoricalStatus),
+		}
+	}
+}
+
+pub struct DelegationStatusFieldsBecameMaps;
+
+impl<To> _RpcAccountInfoCommonItems::FieldCustomMigration<To, v20300>
+	for DelegationStatusFieldsBecameMaps
+where
+	To: _RpcAccountInfoCommonItems::HistoricalTypesAt<v20300>
+		+ _RpcAccountInfoCommonItems::Types<
+			current_delegation_status = BTreeMap<WrappedAccountId32, FlipBalance>,
+			upcoming_delegation_status = BTreeMap<WrappedAccountId32, FlipBalance>,
+		>,
+{
+	type current_delegation_status = OverrideMigrationWith<DelegationStatusMigration>;
+	type upcoming_delegation_status = OverrideMigrationWith<DelegationStatusMigration>;
 }
 
 impl<A> RpcAccountInfoCommonItems<A> {

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_16.rs
@@ -59,12 +59,8 @@ impl From<VaultAddresses> for super::VaultAddresses {
 	}
 }
 
-pub type RpcAccountInfoCommonItems<Balance: HasChangelog + Default>
-	= <super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20000>>::HistoricalType
-where
-	<Balance as HasVersion<v20300>>::HistoricalType: Default,
-	<Balance as HasVersion<v20200>>::HistoricalType: Default,
-	<Balance as HasVersion<v20100>>::HistoricalType: Default;
+pub type RpcAccountInfoCommonItems =
+	<super::RpcAccountInfoCommonItems<FlipBalance> as HasVersion<v20000>>::HistoricalType;
 
 pub type AssetMap<T: HasChangelog + Default>
 	= <super::AssetMap<T> as HasVersion<v20000>>::HistoricalType

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_17.rs
@@ -19,7 +19,7 @@ use cf_chains::instances::{
 	EvmInstance, PolkadotCryptoInstance, PolkadotInstance, SolanaCryptoInstance, SolanaInstance,
 };
 use cf_traits::{lending::LoanId, SafeModeSet};
-use cf_utilities::migrations::{basics::HasVersion, v20100, v20200, v20300};
+use cf_utilities::migrations::{basics::HasVersion, v20100};
 use codec::{DecodeWithMemTracking, MaxEncodedLen};
 use frame_support::sp_runtime::Percent;
 use pallet_cf_lending_pools::{LendingPoolConfiguration, NetworkFeeContributions};
@@ -293,12 +293,8 @@ impl From<LiquidityProviderInfo> for super::LiquidityProviderInfo {
 	}
 }
 
-pub type RpcAccountInfoCommonItems<Balance: HasChangelog + Default>
-	= <super::RpcAccountInfoCommonItems<Balance> as HasVersion<v20100>>::HistoricalType
-where
-	<Balance as HasVersion<v20300>>::HistoricalType: Default,
-	<Balance as HasVersion<v20200>>::HistoricalType: Default,
-	<Balance as HasVersion<v20100>>::HistoricalType: Default;
+pub type RpcAccountInfoCommonItems =
+	<super::RpcAccountInfoCommonItems<FlipBalance> as HasVersion<v20100>>::HistoricalType;
 
 // VaultAddresses as returned by api_version 16 runtimes: has usdt fields added in v16
 // but lacks the tron field added in v17.

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
@@ -19,6 +19,10 @@ use cf_chains::instances::{
 	ArbitrumInstance, AssethubInstance, BitcoinCryptoInstance, BitcoinInstance, EthereumInstance,
 	EvmInstance, PolkadotCryptoInstance, PolkadotInstance, SolanaCryptoInstance, SolanaInstance,
 };
+use cf_utilities::migrations::{
+	basics::{try_migrate_from_historical_type, HasVersion},
+	v20200,
+};
 use codec::{DecodeWithMemTracking, MaxEncodedLen};
 use pallet_cf_lending_pools::LendingPoolConfiguration;
 
@@ -192,45 +196,13 @@ impl From<LiquidityProviderInfo> for super::LiquidityProviderInfo {
 	}
 }
 
-// Decode-only intermediate (converted to the current type via `From`); no serde needed.
-#[derive(Encode, Decode, TypeInfo, Clone, Default, Debug)]
-pub struct RpcAccountInfoCommonItems<Balance> {
-	pub account_id: Option<AccountId32>,
-	pub vanity_name: VanityName,
-	pub flip_balance: Balance,
-	pub asset_balances: AssetMap<Balance>,
-	pub bond: Balance,
-	pub estimated_redeemable_balance: Balance,
-	pub bound_redeem_address: Option<EvmAddress>,
-	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
-	pub current_delegation_status: Option<DelegationInfo<Balance>>,
-	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
-}
-
-impl<B: Default> From<RpcAccountInfoCommonItems<B>> for super::RpcAccountInfoCommonItems<B> {
-	fn from(value: RpcAccountInfoCommonItems<B>) -> Self {
-		Self {
-			account_id: value.account_id,
-			vanity_name: value.vanity_name,
-			flip_balance: value.flip_balance,
-			asset_balances: value.asset_balances.into(),
-			bond: value.bond,
-			estimated_redeemable_balance: value.estimated_redeemable_balance,
-			bound_redeem_address: value.bound_redeem_address,
-			restricted_balances: value.restricted_balances,
-			current_delegation_status: value
-				.current_delegation_status
-				.into_iter()
-				.map(|d| (d.operator, d.bid))
-				.collect(),
-			upcoming_delegation_status: value
-				.upcoming_delegation_status
-				.into_iter()
-				.map(|d| (d.operator, d.bid))
-				.collect(),
-		}
-	}
-}
+// Before v19, `cf_common_account_info` didn't take a `should_sweep` parameter, but the
+// `RpcAccountInfoCommonItems` shape itself is unchanged from the v20200 historical shape (the
+// `should_sweep` parameter and the delegation-status shape are unrelated axes) -- so this is the
+// same `HasChangelog`-derived historical type as `before_version_21`, not a hand-written struct.
+// Convert a value of this type via `try_migrate_from_historical_type`, not a manual `From` impl.
+pub type RpcAccountInfoCommonItems =
+	<super::RpcAccountInfoCommonItems<FlipBalance> as HasVersion<v20200>>::HistoricalType;
 
 #[derive(Encode, Decode, Eq, PartialEq, TypeInfo, Serialize, Deserialize)]
 pub struct ValidatorInfo {
@@ -611,13 +583,19 @@ impl From<RuntimeApiAccountInfo> for super::RuntimeApiAccountInfo {
 
 #[derive(Encode, Decode, TypeInfo)]
 pub struct RuntimeApiAccountInfoWrapper {
-	pub common_items: RpcAccountInfoCommonItems<FlipBalance>,
+	pub common_items: RpcAccountInfoCommonItems,
 	pub role: RuntimeApiAccountInfo,
 }
 
-impl From<RuntimeApiAccountInfoWrapper> for super::RuntimeApiAccountInfoWrapper {
-	fn from(value: RuntimeApiAccountInfoWrapper) -> Self {
-		Self { common_items: value.common_items.into(), role: value.role.into() }
+impl TryFrom<RuntimeApiAccountInfoWrapper> for super::RuntimeApiAccountInfoWrapper {
+	type Error = ();
+
+	fn try_from(value: RuntimeApiAccountInfoWrapper) -> Result<Self, Self::Error> {
+		Ok(Self {
+			common_items: try_migrate_from_historical_type(v20200, value.common_items)
+				.map_err(|_| ())?,
+			role: value.role.into(),
+		})
 	}
 }
 

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_19.rs
@@ -218,8 +218,16 @@ impl<B: Default> From<RpcAccountInfoCommonItems<B>> for super::RpcAccountInfoCom
 			estimated_redeemable_balance: value.estimated_redeemable_balance,
 			bound_redeem_address: value.bound_redeem_address,
 			restricted_balances: value.restricted_balances,
-			current_delegation_status: value.current_delegation_status,
-			upcoming_delegation_status: value.upcoming_delegation_status,
+			current_delegation_status: value
+				.current_delegation_status
+				.into_iter()
+				.map(|d| (d.operator, d.bid))
+				.collect(),
+			upcoming_delegation_status: value
+				.upcoming_delegation_status
+				.into_iter()
+				.map(|d| (d.operator, d.bid))
+				.collect(),
 		}
 	}
 }

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use cf_utilities::migrations::{basics::HasVersion, v20300};
 
 /// The runtime offence shape before failed broadcasts became chain-specific.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Serialize, Deserialize)]
@@ -72,49 +73,11 @@ pub fn into_current_offences<T>(entries: Vec<(Offence, T)>) -> Vec<(super::Offen
 		.collect()
 }
 
-// Decode-only intermediate (converted to the current type via `From`); no serde needed.
-//
-// A delegator used to be able to delegate to at most one operator at a time, so
+// Before v20400, a delegator could only delegate to a single operator at a time, so
 // `current_delegation_status`/`upcoming_delegation_status` were a single optional
 // `DelegationInfo { operator, bid }` rather than a map of every operator it delegates to.
-#[derive(Encode, Decode, TypeInfo, Clone, Default, Debug)]
-pub struct RpcAccountInfoCommonItems<Balance> {
-	pub account_id: Option<AccountId32>,
-	pub vanity_name: VanityName,
-	pub flip_balance: Balance,
-	pub asset_balances: cf_chains::assets::any::AssetMap<Balance>,
-	pub bond: Balance,
-	pub estimated_redeemable_balance: Balance,
-	pub bound_redeem_address: Option<EvmAddress>,
-	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
-	pub current_delegation_status: Option<DelegationInfo<Balance>>,
-	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
-}
-
-impl<B: Default> From<RpcAccountInfoCommonItems<B>> for super::RpcAccountInfoCommonItems<B> {
-	fn from(value: RpcAccountInfoCommonItems<B>) -> Self {
-		Self {
-			account_id: value.account_id,
-			vanity_name: value.vanity_name,
-			flip_balance: value.flip_balance,
-			asset_balances: value.asset_balances,
-			bond: value.bond,
-			estimated_redeemable_balance: value.estimated_redeemable_balance,
-			bound_redeem_address: value.bound_redeem_address,
-			restricted_balances: value.restricted_balances,
-			current_delegation_status: value
-				.current_delegation_status
-				.into_iter()
-				.map(|d| (d.operator, d.bid))
-				.collect(),
-			upcoming_delegation_status: value
-				.upcoming_delegation_status
-				.into_iter()
-				.map(|d| (d.operator, d.bid))
-				.collect(),
-		}
-	}
-}
+pub type RpcAccountInfoCommonItems =
+	<super::RpcAccountInfoCommonItems<FlipBalance> as HasVersion<v20300>>::HistoricalType;
 
 #[cfg(test)]
 mod tests {

--- a/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
+++ b/state-chain/runtime/src/runtime_apis/custom_api/types/before_version_21.rs
@@ -72,6 +72,50 @@ pub fn into_current_offences<T>(entries: Vec<(Offence, T)>) -> Vec<(super::Offen
 		.collect()
 }
 
+// Decode-only intermediate (converted to the current type via `From`); no serde needed.
+//
+// A delegator used to be able to delegate to at most one operator at a time, so
+// `current_delegation_status`/`upcoming_delegation_status` were a single optional
+// `DelegationInfo { operator, bid }` rather than a map of every operator it delegates to.
+#[derive(Encode, Decode, TypeInfo, Clone, Default, Debug)]
+pub struct RpcAccountInfoCommonItems<Balance> {
+	pub account_id: Option<AccountId32>,
+	pub vanity_name: VanityName,
+	pub flip_balance: Balance,
+	pub asset_balances: cf_chains::assets::any::AssetMap<Balance>,
+	pub bond: Balance,
+	pub estimated_redeemable_balance: Balance,
+	pub bound_redeem_address: Option<EvmAddress>,
+	pub restricted_balances: BTreeMap<EvmAddress, Balance>,
+	pub current_delegation_status: Option<DelegationInfo<Balance>>,
+	pub upcoming_delegation_status: Option<DelegationInfo<Balance>>,
+}
+
+impl<B: Default> From<RpcAccountInfoCommonItems<B>> for super::RpcAccountInfoCommonItems<B> {
+	fn from(value: RpcAccountInfoCommonItems<B>) -> Self {
+		Self {
+			account_id: value.account_id,
+			vanity_name: value.vanity_name,
+			flip_balance: value.flip_balance,
+			asset_balances: value.asset_balances,
+			bond: value.bond,
+			estimated_redeemable_balance: value.estimated_redeemable_balance,
+			bound_redeem_address: value.bound_redeem_address,
+			restricted_balances: value.restricted_balances,
+			current_delegation_status: value
+				.current_delegation_status
+				.into_iter()
+				.map(|d| (d.operator, d.bid))
+				.collect(),
+			upcoming_delegation_status: value
+				.upcoming_delegation_status
+				.into_iter()
+				.map(|d| (d.operator, d.bid))
+				.collect(),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -813,12 +813,24 @@ impl_runtime_apis! {
 			should_sweep: ShouldSweep,
 		) -> RpcAccountInfoCommonItems<FlipBalance> {
 			let flip_account = pallet_cf_flip::Account::<Runtime>::get(account_id);
-			let upcoming_delegation_status = pallet_cf_validator::DelegationChoice::<Runtime>::get(account_id)
-				.map(|(operator, max_bid)| DelegationInfo { operator, bid: core::cmp::min(flip_account.total(), max_bid) });
-			let current_delegation_status = pallet_cf_validator::DelegationSnapshots::<Runtime>::iter_prefix(Validator::current_epoch())
-				.find_map(|(operator, snapshot)| snapshot.delegators.get(account_id).map(|&bid|
-					DelegationInfo { operator, bid }
-				));
+			// Operator -> bid, for every operator this account currently delegates to (a
+			// delegator may hold relations to multiple operators simultaneously).
+			let upcoming_delegation_status: BTreeMap<AccountId, FlipBalance> =
+				pallet_cf_validator::DelegationChoices::<Runtime>::get(account_id)
+					.map(|relations| {
+						relations
+							.operators
+							.into_iter()
+							.map(|(operator, max_bid)| (operator, core::cmp::min(flip_account.total(), max_bid)))
+							.collect()
+					})
+					.unwrap_or_default();
+			// Operator -> bid, for every operator whose current-epoch snapshot counts this
+			// account as one of its delegators.
+			let current_delegation_status: BTreeMap<AccountId, FlipBalance> =
+				pallet_cf_validator::DelegationSnapshots::<Runtime>::iter_prefix(Validator::current_epoch())
+					.filter_map(|(operator, snapshot)| snapshot.delegators.get(account_id).map(|&bid| (operator, bid)))
+					.collect();
 
 			// Call optimized version if we know that we don't have to sweep
 			let asset_balances = match should_sweep {
@@ -997,9 +1009,10 @@ impl_runtime_apis! {
 								bond: Flip::bond(account),
 								reward: reward_of(account),
 								role,
-								// `Validator`-role accounts can't hold a `DelegationChoice`
-								// (`delegate` rejects Validator/Operator callers), so a Validator
-								// here can only be demoted from this same operator's own set.
+								// `Validator`-role accounts can't hold a `DelegationChoices` entry
+								// (`delegate`/`delegate_multi` reject Validator/Operator callers),
+								// so a Validator here can only be demoted from this same
+								// operator's own set.
 								managed_by: (role == AccountRole::Validator).then(|| operator.clone()),
 								delegated_to: Some(operator.clone()),
 							});
@@ -2200,7 +2213,9 @@ impl_runtime_apis! {
 			let caller_id = EthereumAccount(caller).into_account_id();
 			let required_deposit = match call {
 				EthereumSCApi::Delegation { call: DelegationApi::Delegate { increase: DelegationAmount::Some(ref increase), .. } } => {
-					pallet_cf_validator::DelegationChoice::<Runtime>::get(&caller_id).map(|(_, bid)| bid).unwrap_or_default()
+					pallet_cf_validator::DelegationChoices::<Runtime>::get(&caller_id)
+						.map(|relations| relations.operators.values().copied().sum::<FlipBalance>())
+						.unwrap_or_default()
 						.saturating_add(*increase)
 						.saturating_sub(pallet_cf_flip::Pallet::<Runtime>::balance(&caller_id))
 				},

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -819,8 +819,21 @@ impl_runtime_apis! {
 				pallet_cf_validator::DelegationChoices::<Runtime>::get(account_id)
 					.map(|relations| {
 						relations
-							.operators
+							.into_map()
 							.into_iter()
+							.map(|(operator, max_bid)| {
+								let max_bid = match max_bid {
+									pallet_cf_validator::DelegationAmount::Some(max_bid) => max_bid,
+									pallet_cf_validator::DelegationAmount::Max => {
+										cf_runtime_utilities::log_or_panic!(
+											"DelegationChoices entry for {:?} contains an unresolved Max amount",
+											operator,
+										);
+										0
+									},
+								};
+								(operator, max_bid)
+							})
 							.map(|(operator, max_bid)| (operator, core::cmp::min(flip_account.total(), max_bid)))
 							.collect()
 					})
@@ -2214,7 +2227,21 @@ impl_runtime_apis! {
 			let required_deposit = match call {
 				EthereumSCApi::Delegation { call: DelegationApi::Delegate { increase: DelegationAmount::Some(ref increase), .. } } => {
 					pallet_cf_validator::DelegationChoices::<Runtime>::get(&caller_id)
-						.map(|relations| relations.operators.values().copied().sum::<FlipBalance>())
+						.map(|relations| {
+							relations
+								.into_map()
+								.into_values()
+								.map(|max_bid| match max_bid {
+									pallet_cf_validator::DelegationAmount::Some(max_bid) => max_bid,
+									pallet_cf_validator::DelegationAmount::Max => {
+										cf_runtime_utilities::log_or_panic!(
+											"DelegationChoices entry contains an unresolved Max amount",
+										);
+										0
+									},
+								})
+								.sum::<FlipBalance>()
+						})
 						.unwrap_or_default()
 						.saturating_add(*increase)
 						.saturating_sub(pallet_cf_flip::Pallet::<Runtime>::balance(&caller_id))

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -821,19 +821,6 @@ impl_runtime_apis! {
 						relations
 							.into_map()
 							.into_iter()
-							.map(|(operator, max_bid)| {
-								let max_bid = match max_bid {
-									pallet_cf_validator::DelegationAmount::Some(max_bid) => max_bid,
-									pallet_cf_validator::DelegationAmount::Max => {
-										cf_runtime_utilities::log_or_panic!(
-											"DelegationChoices entry for {:?} contains an unresolved Max amount",
-											operator,
-										);
-										0
-									},
-								};
-								(operator, max_bid)
-							})
 							.map(|(operator, max_bid)| (operator, core::cmp::min(flip_account.total(), max_bid)))
 							.collect()
 					})
@@ -2227,21 +2214,7 @@ impl_runtime_apis! {
 			let required_deposit = match call {
 				EthereumSCApi::Delegation { call: DelegationApi::Delegate { increase: DelegationAmount::Some(ref increase), .. } } => {
 					pallet_cf_validator::DelegationChoices::<Runtime>::get(&caller_id)
-						.map(|relations| {
-							relations
-								.into_map()
-								.into_values()
-								.map(|max_bid| match max_bid {
-									pallet_cf_validator::DelegationAmount::Some(max_bid) => max_bid,
-									pallet_cf_validator::DelegationAmount::Max => {
-										cf_runtime_utilities::log_or_panic!(
-											"DelegationChoices entry contains an unresolved Max amount",
-										);
-										0
-									},
-								})
-								.sum::<FlipBalance>()
-						})
+						.map(|relations| relations.into_map().into_values().sum::<FlipBalance>())
 						.unwrap_or_default()
 						.saturating_add(*increase)
 						.saturating_sub(pallet_cf_flip::Pallet::<Runtime>::balance(&caller_id))

--- a/utilities/src/without_std/migrations.rs
+++ b/utilities/src/without_std/migrations.rs
@@ -233,4 +233,9 @@ define_all_runtime_versions! {
 		canonical_patch: Unreleased,
 		changelog_entry: in_20300,
 	},
+	{
+		release: v20400,
+		canonical_patch: Unreleased,
+		changelog_entry: in_20400,
+	},
 }

--- a/utilities/src/without_std/migrations/primitives.rs
+++ b/utilities/src/without_std/migrations/primitives.rs
@@ -148,6 +148,7 @@ macro_rules! impl_identity_migrations_with_wrapper {
 }
 
 impl_identity_migrations_with_wrapper! {
+	#[derive(PartialOrd, PartialEq, Eq, Ord)]
 	struct WrappedAccountId32(sp_core::crypto::AccountId32) where |x: [u8; 32]| sp_core::crypto::AccountId32::new(x);
 }
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-3089

## Summary

This PR adds multi operator delegation support. The previous delegate/undelegate interface is kept as is and will be usable for cases where the delegator has delegated only to a single operator. A new `delegate_multi` extrinsic is added to support declarative multi delegation plan which overwrites any existing plan.

- The `DelegationChoice` storage entry is changed to allow storing multi-operator delegation. Migration was added to migrate the storage.

### RPCS

`cf_common_account_info` rpc is changed and the shape of returned `RpcAccountInfoCommonItems` changed to include a map of operator->amount for current and upcoming delegations.

### Extrinsics & Events

new extrinsic called `delegate_multi` was added that emits a new `DelegationPlanUpdated` event.

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [x] Integration tests for runtime-wide behaviours.
    * [x] Bouncer tests for E2E features involving external chains.
  * [x] Benchmarks: did you leave any dangling placeholders?
  * [x] Migrations: if you wrote one, did you test it using try-runtime?
  * [x] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
