### PR TITLE
fix: (cherry-pick) reject multiple deposits sharing the same tx_id

### DIFF
--- a/state-chain/pallets/cf-ingress-egress/src/lib.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/lib.rs
@@ -170,6 +170,7 @@ pub struct PendingPrewitnessedDeposit<T: Config<I>, I: 'static> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo)]
 pub struct TransactionRejectionStatus<BlockNumber> {
+	/// expire_at == 0 means "rejected, awaiting cleanup"
 	expires_at: BlockNumber,
 	/// We can't expire if the rejected tx has been prewitnessed. We need to wait until the
 	/// rejection is processed.
@@ -1368,6 +1369,9 @@ pub mod pallet {
 						&account_id,
 						&tx_id,
 						|status| match status.take() {
+							Some(TransactionRejectionStatus { expires_at, .. })
+								if expires_at.is_zero() =>
+								Ok(()),
 							Some(TransactionRejectionStatus { prewitnessed, expires_at })
 								if !prewitnessed && expires_at <= now =>
 							{
@@ -1832,6 +1836,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			&lookup_id,
 			&tx_id,
 			|opt| match opt {
+				Some(status) if status.expires_at.is_zero() => Ok(false),
 				Some(status) => {
 					ensure!(!status.prewitnessed, Error::<T, I>::TransactionAlreadyPrewitnessed);
 					status.expires_at = expires_at;
@@ -3035,16 +3040,37 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 								// (screening_id) or, by the channel owner if the owner is not
 								// whitelisted.
 								let screening_id = T::ScreeningBrokerId::get();
-								match (
-									TransactionsMarkedForRejection::<T, I>::take(
-										&screening_id,
+								let check_rejection = |id: &AccountIdFor<T>| -> bool {
+									TransactionsMarkedForRejection::<T, I>::mutate(
+										id,
 										tx_id,
-									),
-									TransactionsMarkedForRejection::<T, I>::take(broker_id, tx_id),
-								) {
-									(None, None) => None,
-									_ => Some(()),
+										|status| match status {
+											Some(status) => {
+												// If expires_at == 0 we know we've already rejected
+												// a deposit for the same tx_id
+												// avoid creating a duplicate expiry entry for it
+												if !status.expires_at.is_zero() {
+													ReportExpiresAt::<T, I>::append(
+														<frame_system::Pallet<T>>::block_number()
+															.saturating_add(One::one()),
+														(id.clone(), tx_id),
+													);
+													status.expires_at = Zero::zero();
+												}
+												true
+											},
+											None => false,
+										},
+									)
+								};
+
+								let screening_broker_found = check_rejection(&screening_id);
+								let broker_found = check_rejection(broker_id);
+
+								if screening_broker_found || broker_found {
+									return Some(())
 								}
+								None
 							})
 							// Collect to ensure that the iterator is fully consumed.
 							.collect::<Vec<_>>()

--- a/state-chain/pallets/cf-ingress-egress/src/tests.rs
+++ b/state-chain/pallets/cf-ingress-egress/src/tests.rs
@@ -3317,8 +3317,8 @@ fn additional_action_prefunds_from_a_flip_deposit_without_swapping() {
 mod evm_transaction_rejection {
 	use super::*;
 	use crate::{
-		RefundFailureReason, ScheduledTransactionsForRejection, TransactionRejectionDetails,
-		TransactionRejectionStatus, TransactionsMarkedForRejection,
+		RefundFailureReason, ReportExpiresAt, ScheduledTransactionsForRejection,
+		TransactionRejectionDetails, TransactionRejectionStatus, TransactionsMarkedForRejection,
 	};
 	use cf_chains::{
 		assets::eth::Asset as EthAsset, evm::Hash as EvmHash, ChannelLifecycleHooks,
@@ -3328,6 +3328,7 @@ mod evm_transaction_rejection {
 		mocks::account_role_registry::MockAccountRoleRegistry, AccountRoleRegistry, DepositApi,
 	};
 	use mocks::lending_pools::MockBoostApi;
+	use sp_runtime::traits::Zero;
 	use std::str::FromStr;
 
 	const ETH: EthAsset = EthAsset::Eth;
@@ -3681,6 +3682,60 @@ mod evm_transaction_rejection {
 	}
 
 	#[test]
+	fn rejects_multiple_deposits_sharing_the_same_transaction() {
+		new_test_ext().execute_with(|| {
+			let tx_id = EvmHash::repeat_byte(0xaa);
+			let request_deposit_address = || {
+				let (_, deposit_address, block, _) =
+					EthereumIngressEgress::request_liquidity_deposit_address(
+						BROKER,
+						BROKER,
+						ETH,
+						0,
+						ForeignChainAddress::Eth(Default::default()),
+						None,
+					)
+					.unwrap();
+
+				let deposit_address: <Ethereum as Chain>::ChainAccount =
+					deposit_address.try_into().unwrap();
+				(deposit_address, block)
+			};
+
+			let (first_deposit_address, first_block) = request_deposit_address();
+			let (second_deposit_address, second_block) = request_deposit_address();
+			assert_ne!(first_deposit_address, second_deposit_address);
+
+			assert_ok!(EthereumIngressEgress::mark_transaction_for_rejection(
+				OriginTrait::signed(BROKER),
+				tx_id,
+			));
+			for (deposit_address, block) in
+				[(first_deposit_address, first_block), (second_deposit_address, second_block)]
+			{
+				EthereumIngressEgress::process_channel_deposit_full_witness(
+					DepositWitness {
+						deposit_address,
+						asset: ETH,
+						amount: DEFAULT_DEPOSIT_AMOUNT,
+						deposit_details: DepositDetails { tx_hashes: Some(vec![tx_id]) },
+					},
+					block,
+				);
+			}
+
+			assert_eq!(ScheduledTransactionsForRejection::<Test, Instance1>::decode_len(), Some(2));
+			assert!(MockSwapRequestHandler::<Test>::get_swap_requests().is_empty());
+			assert!(TransactionsMarkedForRejection::<Test, Instance1>::get(BROKER, tx_id)
+				.is_some_and(|status| status.expires_at.is_zero()));
+			assert_eq!(
+				ReportExpiresAt::<Test, Instance1>::get(System::block_number() + 1),
+				vec![(BROKER, tx_id)],
+			);
+		});
+	}
+
+	#[test]
 	fn whitelisted_broker_can_mark_tx_for_rejection_for_lp() {
 		new_test_ext().execute_with(|| {
 			let tx_id = EvmHash::from_str(
@@ -3738,9 +3793,17 @@ mod evm_transaction_rejection {
 				}) if deposit_details.deposit_ids().unwrap().contains(&tx_id)
 			);
 
-			assert!(TransactionsMarkedForRejection::<Test, Instance1>::get(SCREENING_ID, tx_id).is_none());
-
+			assert!(TransactionsMarkedForRejection::<Test, Instance1>::get(SCREENING_ID, tx_id).is_some_and(|status| status.expires_at.is_zero()));
 			assert!(MockSwapRequestHandler::<Test>::get_swap_requests().is_empty());
+
+			tx_id
+		})
+		.then_process_blocks(1)
+		.then_execute_with(|tx_id| {
+			assert!(!TransactionsMarkedForRejection::<Test, Instance1>::contains_key(
+				SCREENING_ID,
+				tx_id,
+			));
 		});
 	}
 


### PR DESCRIPTION
# Pull Request

Closes: PRO-3111

## Summary

Cherry-pick of https://github.com/chainflip-io/chainflip-backend/commit/5b673bcb6576e407d0f8e03a222b2ffebbe12d08 .

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
