### PR TITLE
chore: update taiki-e install action

### DIFF
--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           bun install
 
-      - uses: taiki-e/install-action@a209ff0ce0349f9e7cadc4ba8f6a415c8d3b0813
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc
         with:
           tool: nextest@0.9.92
 

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -93,10 +93,10 @@ jobs:
       - name: Install cargo-llvm-cov 💿
         uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov@0.9.0
 
       - name: Generate code coverage ✨
-        run: cargo llvm-cov --lib --features ${{ inputs.test_features}} --workspace --codecov --output-path lcov.info
+        run: cargo llvm-cov --coverage-host-only --lib --features ${{ inputs.test_features}} --workspace --codecov --output-path lcov.info
 
       - name: Upload coverage to Codecov 📊
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -91,7 +91,7 @@ jobs:
           bun run build
 
       - name: Install cargo-llvm-cov 💿
-        uses: taiki-e/install-action@c2648687d6fe1a5a70a4b65c84715cafab1f3451
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
# Pull Request

Pins the action to a new hash. 

I also had to add a new argument to the llvm-cov invocation to ensure compatibility with the new version (AI-verbose explanation is in the commit).