### PR TITLE
chore: pin bun to 1.4.0 in CI

### DIFF
--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer
@@ -82,7 +82,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer


### PR DESCRIPTION
# Pull Request

## Summary

bun-version was set to `latest`, so every run re-downloaded whatever bun had most recently released. 

1.4.0 is the version latest currently resolves to, so this is a no-op until we deliberately move it.
