### PR TITLE
chore: pin gh actions to a commit sha to avoid silent updates

### DIFF
--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Import SSH key 🔑
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
       with:
           ssh-private-key: ${{ inputs.ssh-private-key }}
     - name: Config Git 🛠

--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install pnpm 💿
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 
@@ -147,6 +147,6 @@ jobs:
           password: ${{ secrets.CF_DOCKERHUB_TOKEN }}
 
       - name: Lint 🐳🔬
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: ci/docker/${{ matrix.environment }}/${{ matrix.dockerfile }}.Dockerfile

--- a/.github/workflows/_05_force_version_bump.yml
+++ b/.github/workflows/_05_force_version_bump.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install pnpm 💿
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 
@@ -80,7 +80,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 

--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_23_check_generated_bouncer_dependencies.yml
+++ b/.github/workflows/_23_check_generated_bouncer_dependencies.yml
@@ -34,7 +34,7 @@ jobs:
           node-version-file: ./bouncer/.nvmrc
           cache-dependency-path: "bouncer/pnpm-lock.yaml"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 

--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -93,10 +93,10 @@ jobs:
           name: chainflip-backend-bin
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta
@@ -173,10 +173,10 @@ jobs:
           name: chainflip-backend-bin
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta

--- a/.github/workflows/_25_package.yml
+++ b/.github/workflows/_25_package.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_26_docker_external_networks.yml
+++ b/.github/workflows/_26_docker_external_networks.yml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta

--- a/.github/workflows/_27_benchmarks.yml
+++ b/.github/workflows/_27_benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
       - name: Build with benchmarks

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -69,7 +69,7 @@ jobs:
             -c "SELECT name, COUNT(*) FROM event GROUP BY name ORDER BY count DESC LIMIT 5"
 
       - name: Run Claude Code debugger
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.CF_PROTOCOL_ANTHROPIC_API_KEY }}
           claude_args: >-

--- a/.github/workflows/docker-build-rust-base.yml
+++ b/.github/workflows/docker-build-rust-base.yml
@@ -42,10 +42,10 @@ jobs:
         run: echo "Docker Image Tag output ${{ steps.image_tags.outputs.image_tag }}"
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 🔖
         id: meta


### PR DESCRIPTION
## Summary

Pins a bunch of github actions to the currently resolved sha.

Details in the individual commit comments. 