### PR TITLE
fix: use finalised source for assethub chaintracking

### DIFF
--- a/engine/src/witness/dot/dot_source.rs
+++ b/engine/src/witness/dot/dot_source.rs
@@ -55,6 +55,13 @@ macro_rules! polkadot_source {
 						tokio::time::timeout(TIMEOUT, state.stream.next()).await
 					{
 						if let Ok((hash, header)) = result {
+							// Genesis has no parent block whose runtime metadata can be used to
+							// decode its events. There are no genesis events relevant to
+							// witnessing, so wait for the first non-genesis header instead.
+							if header.number == 0 {
+								continue
+							}
+
 							let Some(events) = unwrap_events(
 								state.client.events(hash, header.parent_hash, $retry_limit).await,
 							) else {

--- a/engine/src/witness/hub.rs
+++ b/engine/src/witness/hub.rs
@@ -291,15 +291,17 @@ pub fn start<StateChainClient, ProcessCall, ProcessingFut>(
 								.participating(state_chain_client.account_id())
 								.await;
 
-						let unfinalised_source = HubUnfinalisedSource::new(hub_client.clone())
+						// Deposit witnessing uses finalised blocks, so chain tracking must use
+						// finalised blocks too. Otherwise a newly opened channel can have an
+						// `opened_at` height ahead of a deposit's finalised block.
+						let finalised_source = HubFinalisedSource::new(hub_client.clone())
 							.strictly_monotonic()
 							.then(|header| async move {
 								header.data.iter().filter_map(filter_map_events).collect()
 							})
 							.shared(scope);
 
-						unfinalised_source
-							.clone()
+						finalised_source
 							.chunk_by_time(epoch_source.clone(), scope)
 							.chain_tracking(state_chain_client.clone(), hub_client.clone())
 							.logging("chain tracking")


### PR DESCRIPTION
# Pull Request

Related: PRO-3117

## Summary

We're having problems with assethub witnessing, caused by the fact that deposits land in deposit channels in a block prior to their stored `opened_at`. This can only be the case because chain tracking uses unfinalised blocks.

This PR makes assethub chaintracking use finalised block data.

But: the runtime version submitted as part of the chaintracking data is still fetched from the latest unfinalised head.

## API Changes

None

---

## *Checklist [feel free to add/remove/edit as appropriate but please don't ignore]*

Before marking this as ready for review, consider the following:

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
* Make life easy for the reviewer:
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
