### PR TITLE
fix: cap managed validator bids by max_bid in cf_operator_info

### DIFF
--- a/state-chain/cf-integration-tests/src/funding.rs
+++ b/state-chain/cf-integration-tests/src/funding.rs
@@ -17,7 +17,7 @@
 use crate::genesis::GENESIS_BALANCE;
 
 use super::{genesis, network, *};
-use cf_primitives::{FLIPPERINOS_PER_FLIP, GENESIS_EPOCH};
+use cf_primitives::{AccountRole, FLIPPERINOS_PER_FLIP, GENESIS_EPOCH};
 use cf_test_utilities::TestExternalities;
 use cf_traits::{offence_reporting::OffenceReporter, AccountInfo, EpochInfo};
 use mock_runtime::MIN_FUNDING;
@@ -199,6 +199,39 @@ fn validator_info_includes_bid_and_max_bid() {
 		let validator_info = Runtime::cf_validator_info(validator);
 		assert_eq!(validator_info.max_bid, Some(MAX_BID));
 		assert_eq!(validator_info.bid, MAX_BID);
+	});
+}
+
+#[test]
+fn operator_info_managed_validator_bid_respects_max_bid() {
+	use state_chain_runtime::runtime_apis::custom_api::runtime_decl_for_custom_runtime_api::CustomRuntimeApi;
+
+	const MAX_BID: FlipBalance = GENESIS_BALANCE / 2;
+
+	super::genesis::with_test_defaults().build().execute_with(|| {
+		let (_, _, new_validators) = crate::authorities::fund_authorities_and_join_auction(1);
+		let validator = new_validators.first().expect("a validator was created");
+		let operator = AccountId::from([0xee; 32]);
+		network::new_account(&operator, AccountRole::Operator);
+		assert_ok!(Validator::claim_validator(
+			RuntimeOrigin::signed(operator.clone()),
+			validator.clone()
+		));
+		assert_ok!(Validator::accept_operator(
+			RuntimeOrigin::signed(validator.clone()),
+			operator.clone(),
+		));
+
+		assert_ok!(Validator::set_validator_max_bid(
+			RuntimeOrigin::signed(validator.clone()),
+			Some(MAX_BID),
+		));
+		assert!(Flip::balance(validator) > MAX_BID);
+
+		assert_eq!(
+			Runtime::cf_operator_info(&operator).managed_validators.get(validator),
+			Some(&MAX_BID)
+		);
 	});
 }
 

--- a/state-chain/runtime/src/runtime_apis/impl_api.rs
+++ b/state-chain/runtime/src/runtime_apis/impl_api.rs
@@ -896,7 +896,7 @@ impl_runtime_apis! {
 				managed_validators: pallet_cf_validator::Pallet::<Runtime>::get_all_associations_by_operator(
 					account_id,
 					AssociationToOperator::Validator,
-					|account_id, _| pallet_cf_flip::Pallet::<Runtime>::balance(account_id)
+					|account_id, _| pallet_cf_validator::Pallet::<Runtime>::validator_bid(account_id)
 				),
 				settings,
 				allowed,


### PR DESCRIPTION
## Summary

`cf_operator_info` reported managed validators' raw FLIP balance, ignoring any `max_bid` the validator had set. The auction and delegation snapshot both use `validator_bid`, so the operator's `upcoming_delegation.validators` amounts disagreed with `current_delegation.validators` whenever `max_bid < balance`. The delegators map in the same struct was already capped correctly.

This switches the managed validators closure to `validator_bid`, the same function used by the auction and by `cf_validator_info`. Return value only, no wire-shape change, so no runtime API versioning.

Reported by the frontend team while handling the max_bid change across backends.

## Test

New integration test `operator_info_managed_validator_bid_respects_max_bid` in `cf-integration-tests` fails on main with the raw balance and passes with this change.

To be cherry-picked to `release/2.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9e6TErB3L3W327VPERYix