### PR TITLE
chore: consolidate dependabot github actions bumps

### DIFF
--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Import SSH key 🔑
-      uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+      uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
           ssh-private-key: ${{ inputs.ssh-private-key }}
     - name: Config Git 🛠

--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -147,6 +147,6 @@ jobs:
           password: ${{ secrets.CF_DOCKERHUB_TOKEN }}
 
       - name: Lint 🐳🔬
-        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        uses: hadolint/hadolint-action@06be81baf89a55ffd0e24b8f04a4185738dd3387 # v3.5.0
         with:
           dockerfile: ci/docker/${{ matrix.environment }}/${{ matrix.dockerfile }}.Dockerfile

--- a/.github/workflows/_05_force_version_bump.yml
+++ b/.github/workflows/_05_force_version_bump.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: "bouncer/pnpm-lock.yaml"
 
       - name: Download latest release binaries
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
         with:
           workflow: release-${{ inputs.network-to-check-against }}.yml
           name: chainflip-backend-bin

--- a/.github/workflows/_100_run_benchmarks.yml
+++ b/.github/workflows/_100_run_benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
           esac
 
       - name: Fetch chainflip-node with benchmarks from ${{ inputs.commit_sha }}
-        uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
         with:
           workflow: ci-benchmarks-${{ steps.artefact-source.outputs.source }}.yml
           workflow_conclusion: completed

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.0"
 

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.0"
 
@@ -80,7 +80,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.4.0"
 

--- a/.github/workflows/_120_benchmark_block_execution.yml
+++ b/.github/workflows/_120_benchmark_block_execution.yml
@@ -102,7 +102,7 @@ jobs:
           echo "Using commit $FULL_SHA"
 
       - name: Fetch chainflip-node from ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
-        uses: dawidd6/action-download-artifact@fe9d59ce33ce92db8a6ac90b2c8be6b6d90417c8
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
         with:
           workflow: ci-benchmarks-${{ inputs.binary_artefact_source }}.yml
           workflow_conclusion: completed

--- a/.github/workflows/_22_check_blocktime.yml
+++ b/.github/workflows/_22_check_blocktime.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download Binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
 

--- a/.github/workflows/_23_check_generated_bouncer_dependencies.yml
+++ b/.github/workflows/_23_check_generated_bouncer_dependencies.yml
@@ -20,7 +20,7 @@ jobs:
           git status --porcelain
 
       - name: Download Binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
 

--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Docker meta 📄
         id: meta
-        uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ${{ matrix.docker-repo }}/${{ matrix.target }}
           flavor: |
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
 
@@ -180,7 +180,7 @@ jobs:
 
       - name: Docker meta 📄
         id: meta
-        uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ${{ matrix.docker-repo }}/${{ matrix.target }}
           flavor: |

--- a/.github/workflows/_25_package.yml
+++ b/.github/workflows/_25_package.yml
@@ -38,7 +38,7 @@ jobs:
           cache: rust
 
       - name: Download binaries from same run 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
           path: ./target/release

--- a/.github/workflows/_26_docker_external_networks.yml
+++ b/.github/workflows/_26_docker_external_networks.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Docker meta 📄
         id: meta
-        uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ghcr.io/${{ github.repository }}/${{ inputs.network }}-${{ inputs.localnet-speed-setting }}
           flavor: |

--- a/.github/workflows/_27_benchmarks.yml
+++ b/.github/workflows/_27_benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download previously built binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-node-ubuntu-benchmarks-${{ matrix.profile }}
 

--- a/.github/workflows/_30_publish.yml
+++ b/.github/workflows/_30_publish.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download packages 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-packages
           path: packages
@@ -62,14 +62,14 @@ jobs:
       - name: Import prod GPG package signing key 🗝️
         id: import_gpg_prod
         if: inputs.environment == 'production'
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
         with:
           gpg_private_key: ${{ secrets.CF_PROD_PGP_KEY }}
 
       - name: Import dev GPG package signing key 🗝️
         id: import_gpg_dev
         if: inputs.environment == 'development'
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
         with:
           gpg_private_key: ${{ secrets.CF_DEV_PGP_KEY }}
 

--- a/.github/workflows/_40_post_check.yml
+++ b/.github/workflows/_40_post_check.yml
@@ -127,7 +127,7 @@ jobs:
           npm install -g wscat
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin${{ inputs.chainflip-backend-bin-suffix }}
 
@@ -372,7 +372,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download Binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin${{ inputs.chainflip-backend-bin-suffix }}
 

--- a/.github/workflows/_41_test_benchmarks.yml
+++ b/.github/workflows/_41_test_benchmarks.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin-benchmarks
       - name: Update permissions on chainflip-node 🚓

--- a/.github/workflows/_50_release.yml
+++ b/.github/workflows/_50_release.yml
@@ -20,7 +20,7 @@ jobs:
           echo "RELEASE_DIR=chainflip_${{ github.ref_name }}_ubuntu_22.04_amd64" >> $GITHUB_ENV
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
           path: ${{ env.RELEASE_DIR }}
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin-compressed
 

--- a/.github/workflows/_60_upload.yml
+++ b/.github/workflows/_60_upload.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin
           path: assets/bin
 
       - name: Download Mac M2 binaries 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin-mac-m2
           path: /tmp/assets/m2
@@ -43,25 +43,25 @@ jobs:
           mv /tmp/assets/m2/libchainflip_engine_v*.dylib assets/m2/
 
       - name: Download packages 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-packages
           path: assets/debian
 
       - name: Download runtime 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-node-runtime-production-${{ inputs.version }}
           path: assets/runtime
 
       - name: Download public images 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-public-images
           path: assets/docker/public
 
       - name: Download private images 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-private-images
           path: assets/docker/private

--- a/.github/workflows/_61_upload_versioned_build_artifacts.yml
+++ b/.github/workflows/_61_upload_versioned_build_artifacts.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download Artifacts 📥
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: artifacts
           pattern: chainflip-backend-bin*
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download runtime 📥
         if: inputs.is_release == true
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-node-runtime-production-${{ steps.version.outputs.version }}
           path: artifacts

--- a/.github/workflows/docker-build-rust-base.yml
+++ b/.github/workflows/docker-build-rust-base.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Docker meta 🔖
         id: meta
-        uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: ${{ steps.image_tags.outputs.image_tag }}

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Download upgrade-to binaries 📥
         if: inputs.run-job && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-backend-bin-try-runtime
           path: upgrade-to-bins
@@ -182,7 +182,7 @@ jobs:
 
       - name: Download upgrade-to runtime 📥
         if: inputs.run-job && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: chainflip-node-runtime-try-runtime-${{ steps.main-version.outputs.version }}
           path: upgrade-to-runtime


### PR DESCRIPTION
Consolidates the five open dependabot PRs into a single signed commit so CI can run on all the GitHub Actions bumps together.

Supersedes #6849, #6850, #6851, #6852, #6853.

## Updates

| Action | From | To |
|---|---|---|
| actions/download-artifact | 4.1.8 | 8.0.1 |
| docker/metadata-action | 5.3.0 | 6.2.0 |
| oven-sh/setup-bun | 1.2.2 | 2.2.0 |
| crazy-max/ghaction-import-gpg | 6.0.0 | 7.0.0 |
| hadolint/hadolint-action | 3.1.0 | 3.5.0 |
| dawidd6/action-download-artifact | 3.0.0 | 3.1.4 |
| webfactory/ssh-agent | 0.9.0 | 0.10.0 |

All five branches cherry-picked cleanly onto main with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9e6TErB3L3W327VPERYix