### PR TITLE
fix: Do not remove active zmq connection prematurely

### DIFF
--- a/engine/p2p/src/core.rs
+++ b/engine/p2p/src/core.rs
@@ -312,29 +312,8 @@ pub async fn start(
 ) -> anyhow::Result<()> {
 	debug!("Our derived x25519 pubkey: {}", pk_to_string(&p2p_key.encryption_key.public_key));
 
-	let zmq_context = zmq::Context::new();
-
-	zmq_context.set_max_sockets(65536).expect("should update socket limit");
-
-	let authenticator = auth::start_authentication_thread(zmq_context.clone());
-
-	let (reconnect_sender, reconnect_receiver) = tokio::sync::mpsc::unbounded_channel();
-
-	let (monitor_handle, monitor_event_receiver) =
-		monitor::start_monitoring_thread(zmq_context.clone());
-
-	let mut context = P2PContext {
-		zmq_context,
-		key: p2p_key.encryption_key,
-		monitor_handle,
-		authenticator,
-		active_connections: ActiveConnectionWrapper::new(),
-		x25519_to_account_id: Default::default(),
-		reconnect_context: ReconnectContext::new(reconnect_sender),
-		incoming_message_sender,
-		our_account_id,
-		stop_thread: Arc::new(AtomicBool::new(false)),
-	};
+	let (mut context, monitor_event_receiver, reconnect_receiver) =
+		P2PContext::spawn(p2p_key.encryption_key, our_account_id, incoming_message_sender);
 
 	debug!("Registering peer info for {} peers", current_peers.len());
 	for peer_info in current_peers {
@@ -362,6 +341,40 @@ fn disconnect_socket(_socket: ConnectedOutgoingSocket) {
 }
 
 impl P2PContext {
+	/// Returns the context together with the receivers for monitor events and
+	/// reconnection requests, which are fed by the threads spawned here.
+	fn spawn(
+		key: X25519KeyPair,
+		our_account_id: AccountId,
+		incoming_message_sender: FairSender<AccountId, Vec<u8>>,
+	) -> (Self, UnboundedReceiver<MonitorEvent>, UnboundedReceiver<AccountId>) {
+		let zmq_context = zmq::Context::new();
+
+		zmq_context.set_max_sockets(65536).expect("should update socket limit");
+
+		let authenticator = auth::start_authentication_thread(zmq_context.clone());
+
+		let (reconnect_sender, reconnect_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+		let (monitor_handle, monitor_event_receiver) =
+			monitor::start_monitoring_thread(zmq_context.clone());
+
+		let context = P2PContext {
+			zmq_context,
+			key,
+			monitor_handle,
+			authenticator,
+			active_connections: ActiveConnectionWrapper::new(),
+			x25519_to_account_id: Default::default(),
+			reconnect_context: ReconnectContext::new(reconnect_sender),
+			incoming_message_sender,
+			our_account_id,
+			stop_thread: Arc::new(AtomicBool::new(false)),
+		};
+
+		(context, monitor_event_receiver, reconnect_receiver)
+	}
+
 	async fn control_loop(
 		mut self,
 		mut outgoing_message_receiver: UnboundedReceiver<OutgoingMultisigStageMessages>,
@@ -532,34 +545,35 @@ impl P2PContext {
 	}
 
 	fn reconnect_to_peer(&mut self, account_id: &AccountId) {
-		if let Some(peer) = self.active_connections.remove(account_id) {
-			match peer.state {
-				ConnectionState::ReconnectionScheduled => {
-					info!("Reconnecting to peer: {account_id}");
-					self.connect_to_peer(peer.info.clone(), peer.last_activity.get());
-				},
-				ConnectionState::Connected(_) => {
-					// It is possible that while we were waiting to reconnect,
-					// we received a peer info update and created a new "connection".
-					// It is safe to drop the reconnection attempt even if this
-					// ZMQ connection is not "healthy" since reconnecting
-					// is now in ZMQ's hands, and it shouldn't be possible that we
-					// have missed any new `ConnectionFailure` event since we wouldn't
-					// be in `Connected` state now.
-					debug!(
-						"Reconnection attempt to {} cancelled: ZMQ socket already exists.",
-						account_id
-					);
-				},
-				ConnectionState::Stale => {
-					debug!(
-						"Reconnection attempt to {} cancelled: connection is stale.",
-						account_id
-					);
-				},
-			}
-		} else {
-			debug!("Will not reconnect to now deregistered peer: {}", account_id);
+		// By the time the reconnect timer fires, the peer might have moved to another state.
+		// The peer's entry in `active_connections` must only be replaced if the peer is still in
+		// the `ReconnectionScheduled` state (PRO-3119).
+		match self.active_connections.get(account_id).map(|peer| &peer.state) {
+			Some(ConnectionState::ReconnectionScheduled) => {
+				info!("Reconnecting to peer: {account_id}");
+				if let Some(peer) = self.active_connections.remove(account_id) {
+					self.connect_to_peer(peer.info, peer.last_activity.get());
+				}
+			},
+			Some(ConnectionState::Connected(_)) => {
+				// It is possible that while we were waiting to reconnect,
+				// we received a peer info update and created a new "connection".
+				// It is safe to drop the reconnection attempt even if this
+				// ZMQ connection is not "healthy" since reconnecting
+				// is now in ZMQ's hands, and it shouldn't be possible that we
+				// have missed any new `ConnectionFailure` event since we wouldn't
+				// be in `Connected` state now.
+				debug!(
+					"Reconnection attempt to {} cancelled: ZMQ socket already exists.",
+					account_id
+				);
+			},
+			Some(ConnectionState::Stale) => {
+				debug!("Reconnection attempt to {} cancelled: connection is stale.", account_id);
+			},
+			None => {
+				debug!("Will not reconnect to now deregistered peer: {}", account_id);
+			},
 		}
 	}
 

--- a/engine/p2p/src/core/tests.rs
+++ b/engine/p2p/src/core/tests.rs
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{PeerInfo, PeerUpdate};
+use super::{monitor::MonitorEvent, ConnectionState, P2PContext, PeerInfo, PeerUpdate};
 use crate::{
 	core::{ACTIVITY_CHECK_INTERVAL, MAX_INACTIVITY_THRESHOLD},
 	fair_channel::{fair_channel, FairReceiver},
@@ -23,7 +23,7 @@ use crate::{
 use cf_primitives::AccountId;
 use cf_utilities::Port;
 use sp_core::ed25519::Public;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{info_span, Instrument};
 
 fn create_node_info(id: AccountId, node_key: &ed25519_dalek::SigningKey, port: Port) -> PeerInfo {
@@ -235,4 +235,72 @@ async fn stale_connections() {
 	// Ensure that we can re-activate stale connections when needed
 	send_and_receive_message(&node1, &mut node2).await.unwrap();
 	send_and_receive_message(&node2, &mut node1).await.unwrap();
+}
+
+/// Build a context without running the control loop, so that the control-loop
+/// event handlers can be driven deterministically. The receivers are returned
+/// only so that the caller can keep them alive for the duration of the test.
+fn create_context(
+	our_account_id: AccountId,
+) -> (P2PContext, UnboundedReceiver<MonitorEvent>, UnboundedReceiver<AccountId>) {
+	let (incoming_message_sender, _incoming_message_receiver) =
+		fair_channel(super::INCOMING_MESSAGE_PER_PEER_LIMIT);
+
+	P2PContext::spawn(
+		P2PKey::new(create_keypair().as_bytes()).encryption_key,
+		our_account_id,
+		incoming_message_sender,
+	)
+}
+
+fn connection_state<'a>(
+	context: &'a P2PContext,
+	account_id: &AccountId,
+) -> Option<&'a ConnectionState> {
+	context.active_connections.get(account_id).map(|peer| &peer.state)
+}
+
+/// A reconnect timer that fires after the peer has been re-registered (and thus
+/// freshly connected) must not remove the peer from `active_connections`.
+#[tokio::test]
+async fn reconnect_timer_keeps_reconnected_peer() {
+	let (mut context, _monitor_events, _reconnects) = create_context(AccountId::new([1; 32]));
+	let peer = create_node_info(AccountId::new([2; 32]), &create_keypair(), 8096);
+	let peer_id = peer.account_id.clone();
+
+	context.add_or_update_peer(peer.clone());
+	context.handle_monitor_event(MonitorEvent::ConnectionFailure(peer_id.clone()));
+	assert!(matches!(
+		connection_state(&context, &peer_id),
+		Some(ConnectionState::ReconnectionScheduled)
+	));
+
+	// Peer info update arrives while the reconnect timer is pending:
+	context.add_or_update_peer(peer);
+	assert!(matches!(connection_state(&context, &peer_id), Some(ConnectionState::Connected(_))));
+
+	// The (now redundant) timer fires:
+	context.reconnect_to_peer(&peer_id);
+	assert!(matches!(connection_state(&context, &peer_id), Some(ConnectionState::Connected(_))));
+}
+
+/// A reconnect timer that fires after the peer has been deemed stale must not
+/// remove the peer from `active_connections`.
+#[tokio::test(start_paused = true)]
+async fn reconnect_timer_keeps_stale_peer() {
+	let (mut context, _monitor_events, _reconnects) = create_context(AccountId::new([1; 32]));
+	let peer = create_node_info(AccountId::new([2; 32]), &create_keypair(), 8097);
+	let peer_id = peer.account_id.clone();
+
+	context.add_or_update_peer(peer);
+	context.handle_monitor_event(MonitorEvent::ConnectionFailure(peer_id.clone()));
+
+	// Connection becomes stale while the reconnect timer is pending:
+	tokio::time::advance(MAX_INACTIVITY_THRESHOLD + Duration::from_secs(1)).await;
+	context.check_activity();
+	assert!(matches!(connection_state(&context, &peer_id), Some(ConnectionState::Stale)));
+
+	// The (now redundant) timer fires:
+	context.reconnect_to_peer(&peer_id);
+	assert!(matches!(connection_state(&context, &peer_id), Some(ConnectionState::Stale)));
 }


### PR DESCRIPTION
# Pull Request

Closes: PRO-3119

## Summary

- Updated `reconnect_to_peer` to only remove a peer's entry from active_connection in the branch where it is going to be immediately replaced.
- Created `P2PContext::spawn` so that the code for initialising `P2PContext` can also be used in the new tests. I decided against calling it `P2PContext::new` as it has significant side effects (e.g. spawning threads).

---

## *Checklist*

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [x] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [ ] Benchmarks: did you leave any dangling placeholders?
  * [ ] Migrations: if you wrote one, did you test it using try-runtime?
  * [ ] Bouncer typegen: if you changed any runtime types you might need to update this.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [ ] Unrelated changes are isolated in dedicated commits.
  * [ ] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
* [x] Consider asking an AI for a local review to catch any embarrassing mistakes early.
* [x] Vice-versa: read your code carefully to ensure no AIs added anything embarrassing.
