### PR TITLE
chore: forward-port Tron support in the elections tracker from 2.2

### DIFF
--- a/api/bin/chainflip-elections-tracker/src/bin/log_votes_summary.rs
+++ b/api/bin/chainflip-elections-tracker/src/bin/log_votes_summary.rs
@@ -28,12 +28,12 @@ use pallet_cf_elections::{
 };
 use serde::Serialize;
 use state_chain_runtime::{
-	ArbitrumInstance, BitcoinInstance, EthereumInstance, Runtime, SolanaInstance,
+	ArbitrumInstance, BitcoinInstance, EthereumInstance, Runtime, SolanaInstance, TronInstance,
 	chainflip::witnessing::{
 		arbitrum_elections::ArbitrumElectoralSystemRunner,
 		bitcoin_elections::BitcoinElectoralSystemRunner,
 		ethereum_elections::EthereumElectoralSystemRunner,
-		solana_elections::SolanaElectoralSystemRunner,
+		solana_elections::SolanaElectoralSystemRunner, tron_elections::TronElectoralSystemRunner,
 	},
 };
 use std::{
@@ -78,11 +78,20 @@ type ArbitrumElectionProperties =
 type ArbitrumBitmapComponent = <ArbitrumVoteStorageTuple as VoteStorage>::BitmapComponent;
 type ArbitrumIndividualComponent = <ArbitrumVoteStorageTuple as VoteStorage>::IndividualComponent;
 
+type TronVoteStorageTuple = <TronElectoralSystemRunner as ElectoralSystemTypes>::VoteStorage;
+type TronElectionIdentifierExtra =
+	<TronElectoralSystemRunner as ElectoralSystemTypes>::ElectionIdentifierExtra;
+type TronElectionProperties =
+	<TronElectoralSystemRunner as ElectoralSystemTypes>::ElectionProperties;
+type TronBitmapComponent = <TronVoteStorageTuple as VoteStorage>::BitmapComponent;
+type TronIndividualComponent = <TronVoteStorageTuple as VoteStorage>::IndividualComponent;
+
 // Type aliases for the ElectionBitmapComponents types
 type BitcoinElectionBitmapComponents = ElectionBitmapComponents<Runtime, BitcoinInstance>;
 type SolanaElectionBitmapComponents = ElectionBitmapComponents<Runtime, SolanaInstance>;
 type EthereumElectionBitmapComponents = ElectionBitmapComponents<Runtime, EthereumInstance>;
 type ArbitrumElectionBitmapComponents = ElectionBitmapComponents<Runtime, ArbitrumInstance>;
+type TronElectionBitmapComponents = ElectionBitmapComponents<Runtime, TronInstance>;
 
 // ===== Dashboard types (JSON-serializable for the web UI) =====
 
@@ -93,6 +102,7 @@ struct BlockUpdate {
 	solana: ChainElections,
 	ethereum: ChainElections,
 	arbitrum: ChainElections,
+	tron: ChainElections,
 }
 
 #[derive(Serialize, Clone)]
@@ -235,6 +245,7 @@ async fn handle_ws_client(ws: warp::ws::WebSocket, mut rx: broadcast::Receiver<S
 
 // Helper functions for human-readable election and vote type names
 use pallet_cf_elections::electoral_systems::composite::{
+	tuple_5_impls::CompositeElectionIdentifierExtra as Composite5Extra,
 	tuple_6_impls::CompositeElectionIdentifierExtra as Composite6Extra,
 	tuple_7_impls::CompositeElectionIdentifierExtra as Composite7Extra,
 	tuple_8_impls::CompositeElectionIdentifierExtra as Composite8Extra,
@@ -292,6 +303,18 @@ fn arbitrum_election_type_name(
 		Composite6Extra::D(_) => "KeyManager",
 		Composite6Extra::EE(_) => "FeeTracking",
 		Composite6Extra::FF(_) => "Liveness",
+	}
+}
+
+fn tron_election_type_name(
+	election_id: &ElectionIdentifier<TronElectionIdentifierExtra>,
+) -> &'static str {
+	match election_id.extra() {
+		Composite5Extra::A(_) => "BlockHeight",
+		Composite5Extra::B(_) => "DepositChannel",
+		Composite5Extra::C(_) => "VaultDeposit",
+		Composite5Extra::D(_) => "KeyManager",
+		Composite5Extra::EE(_) => "Liveness",
 	}
 }
 
@@ -394,6 +417,27 @@ async fn build_block_update(
 				)
 			})?,
 	);
+	let mut tron_shared_data_map = client
+		.storage_map::<pallet_cf_elections::SharedData<Runtime, TronInstance>, BTreeMap<_, _>>(
+			block_hash,
+		)
+		.await
+		.map_err(|e| {
+			format!("Failed to fetch Tron shared data at block {}: {:?}", block_number, e)
+		})?;
+	tron_shared_data_map.extend(
+		client
+			.storage_map::<pallet_cf_elections::SharedData<Runtime, TronInstance>, BTreeMap<_, _>>(
+				last_block_hash,
+			)
+			.await
+			.map_err(|e| {
+				format!(
+					"Failed to fetch Tron shared data at block {}: {:?}",
+					previous_block_number, e
+				)
+			})?,
+	);
 
 	// ===== Query ElectionProperties at X-1 (to get all active elections before this block) =====
 	let bitcoin_elections_prev: BTreeMap<
@@ -452,6 +496,20 @@ async fn build_block_update(
 				previous_block_number, e
 			)
 		})?;
+	let tron_elections_prev: BTreeMap<
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+		TronElectionProperties,
+	> = client
+		.storage_map::<pallet_cf_elections::ElectionProperties<Runtime, TronInstance>, _>(
+			last_block_hash,
+		)
+		.await
+		.map_err(|e| {
+			format!(
+				"Failed to fetch Tron election properties at block {}: {:?}",
+				previous_block_number, e
+			)
+		})?;
 
 	// ===== Query ElectionProperties at X (to detect completed elections) =====
 	let bitcoin_elections_curr: BTreeMap<
@@ -506,6 +564,17 @@ async fn build_block_update(
 				"Failed to fetch Arbitrum election properties at block {}: {:?}",
 				block_number, e
 			)
+		})?;
+	let tron_elections_curr: BTreeMap<
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+		TronElectionProperties,
+	> = client
+		.storage_map::<pallet_cf_elections::ElectionProperties<Runtime, TronInstance>, _>(
+			block_hash,
+		)
+		.await
+		.map_err(|e| {
+			format!("Failed to fetch Tron election properties at block {}: {:?}", block_number, e)
 		})?;
 
 	// ===== Query BitmapComponents at X-1 (existing shared votes) =====
@@ -565,6 +634,18 @@ async fn build_block_update(
 				previous_block_number, e
 			)
 		})?;
+	let tron_bitmap_components: BTreeMap<UniqueMonotonicIdentifier, TronElectionBitmapComponents> =
+		client
+			.storage_map::<pallet_cf_elections::BitmapComponents<Runtime, TronInstance>, _>(
+				last_block_hash,
+			)
+			.await
+			.map_err(|e| {
+				format!(
+					"Failed to fetch Tron bitmap components at block {}: {:?}",
+					previous_block_number, e
+				)
+			})?;
 
 	// ===== Build mapping from UniqueMonotonicIdentifier to full ElectionIdentifier =====
 	let btc_unique_to_election: BTreeMap<
@@ -595,6 +676,10 @@ async fn build_block_update(
 		.keys()
 		.map(|eid| (*eid.unique_monotonic(), *eid))
 		.collect();
+	let tron_unique_to_election: BTreeMap<
+		UniqueMonotonicIdentifier,
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+	> = tron_elections_prev.keys().map(|eid| (*eid.unique_monotonic(), *eid)).collect();
 
 	// ===== Build vote summary from storage =====
 	let mut bitcoin_storage_votes: BTreeMap<
@@ -612,6 +697,10 @@ async fn build_block_update(
 	let mut arbitrum_storage_votes: BTreeMap<
 		ElectionIdentifier<ArbitrumElectionIdentifierExtra>,
 		Vec<(ArbitrumBitmapComponent, u32)>,
+	> = BTreeMap::new();
+	let mut tron_storage_votes: BTreeMap<
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+		Vec<(TronBitmapComponent, u32)>,
 	> = BTreeMap::new();
 
 	for (unique_id, bitmap_data) in &bitcoin_bitmap_components {
@@ -644,6 +733,15 @@ async fn build_block_update(
 	for (unique_id, bitmap_data) in &arbitrum_bitmap_components {
 		if let Some(election_id) = arb_unique_to_election.get(unique_id) {
 			let vote_list = arbitrum_storage_votes.entry(*election_id).or_default();
+			for (bitmap_component, bitvec) in &bitmap_data.bitmaps {
+				let count = bitvec.count_ones() as u32;
+				vote_list.push((bitmap_component.clone(), count));
+			}
+		}
+	}
+	for (unique_id, bitmap_data) in &tron_bitmap_components {
+		if let Some(election_id) = tron_unique_to_election.get(unique_id) {
+			let vote_list = tron_storage_votes.entry(*election_id).or_default();
 			for (bitmap_component, bitvec) in &bitmap_data.bitmaps {
 				let count = bitvec.count_ones() as u32;
 				vote_list.push((bitmap_component.clone(), count));
@@ -689,6 +787,17 @@ async fn build_block_update(
 				previous_block_number, e
 			)
 		})?;
+	let tron_individual_components: Vec<_> = client
+		.storage_double_map::<pallet_cf_elections::IndividualComponents<Runtime, TronInstance>, Vec<_>>(
+			last_block_hash,
+		)
+		.await
+		.map_err(|e| {
+			format!(
+				"Failed to fetch Tron individual components at block {}: {:?}",
+				previous_block_number, e
+			)
+		})?;
 
 	let mut bitcoin_individual_votes: BTreeMap<
 		ElectionIdentifier<BitcoinElectionIdentifierExtra>,
@@ -705,6 +814,10 @@ async fn build_block_update(
 	let mut arbitrum_individual_votes: BTreeMap<
 		ElectionIdentifier<ArbitrumElectionIdentifierExtra>,
 		Vec<(ArbitrumIndividualComponent, u32)>,
+	> = BTreeMap::new();
+	let mut tron_individual_votes: BTreeMap<
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+		Vec<(TronIndividualComponent, u32)>,
 	> = BTreeMap::new();
 
 	for ((unique_id, _validator), (_props, component)) in &bitcoin_individual_components {
@@ -747,6 +860,16 @@ async fn build_block_update(
 			}
 		}
 	}
+	for ((unique_id, _validator), (_props, component)) in &tron_individual_components {
+		if let Some(election_id) = tron_unique_to_election.get(unique_id) {
+			let vote_list = tron_individual_votes.entry(*election_id).or_default();
+			if let Some((_, count)) = vote_list.iter_mut().find(|(c, _)| c == component) {
+				*count += 1;
+			} else {
+				vote_list.push((component.clone(), 1));
+			}
+		}
+	}
 
 	// ===== Track new votes from extrinsics =====
 	let mut bitcoin_extrinsic_votes: BTreeMap<
@@ -764,6 +887,10 @@ async fn build_block_update(
 	let mut arbitrum_extrinsic_votes: BTreeMap<
 		ElectionIdentifier<ArbitrumElectionIdentifierExtra>,
 		BTreeMap<<ArbitrumVoteStorageTuple as VoteStorage>::PartialVote, u32>,
+	> = BTreeMap::new();
+	let mut tron_extrinsic_votes: BTreeMap<
+		ElectionIdentifier<TronElectionIdentifierExtra>,
+		BTreeMap<<TronVoteStorageTuple as VoteStorage>::PartialVote, u32>,
 	> = BTreeMap::new();
 	let signed_block = client
 		.base_rpc_client
@@ -921,6 +1048,45 @@ async fn build_block_update(
 				},
 				_ => {},
 			},
+			state_chain_runtime::RuntimeCall::TronElections(call) =>
+				match call {
+					pallet_cf_elections::Call::vote { authority_votes } => {
+						for (election_id, vote) in *authority_votes {
+							match vote {
+								pallet_cf_elections::vote_storage::AuthorityVote::PartialVote(
+									partial,
+								) => {
+									tron_extrinsic_votes
+										.entry(election_id)
+										.or_default()
+										.entry(partial.clone())
+										.and_modify(|entry| *entry += 1)
+										.or_insert(1);
+								},
+								pallet_cf_elections::vote_storage::AuthorityVote::Vote(
+									full_vote,
+								) => {
+									let partial = <TronVoteStorageTuple as VoteStorage>::vote_into_partial_vote(&full_vote, |shared_data| {
+										let hash = SharedDataHash::of(&shared_data);
+										tron_shared_data_map.insert(hash, shared_data);
+										hash
+									});
+									tron_extrinsic_votes
+										.entry(election_id)
+										.or_default()
+										.entry(partial.clone())
+										.and_modify(|entry| *entry += 1)
+										.or_insert(1);
+								},
+							}
+						}
+					},
+					pallet_cf_elections::Call::provide_shared_data { shared_data } => {
+						let shared_data_hash = SharedDataHash::of(&shared_data);
+						tron_shared_data_map.insert(shared_data_hash, *shared_data);
+					},
+					_ => {},
+				},
 			_ => {},
 		}
 	}
@@ -946,6 +1112,11 @@ async fn build_block_update(
 		.filter(|eid| !arbitrum_elections_curr.contains_key(eid))
 		.cloned()
 		.collect();
+	let tron_completed: Vec<_> = tron_elections_prev
+		.keys()
+		.filter(|eid| !tron_elections_curr.contains_key(eid))
+		.cloned()
+		.collect();
 
 	let btc_active = bitcoin_elections_prev.len();
 	let btc_completed_count = bitcoin_completed.len();
@@ -955,6 +1126,8 @@ async fn build_block_update(
 	let eth_completed_count = ethereum_completed.len();
 	let arb_active = arbitrum_elections_prev.len();
 	let arb_completed_count = arbitrum_completed.len();
+	let tron_active = tron_elections_prev.len();
+	let tron_completed_count = tron_completed.len();
 
 	// ===== Build dashboard update =====
 	let btc_election_summaries: Vec<ElectionSummary> = bitcoin_elections_prev
@@ -1181,6 +1354,58 @@ async fn build_block_update(
 		})
 		.collect();
 
+	let tron_election_summaries: Vec<ElectionSummary> = tron_elections_prev
+		.iter()
+		.map(|(election_id, props)| {
+			let is_completed = tron_completed.contains(election_id);
+			let bitmap_votes = tron_storage_votes
+				.get(election_id)
+				.map(|votes| {
+					votes
+						.iter()
+						.map(|(comp, count)| VoteGroup {
+							component: format_tron_bitmap_component(comp, &tron_shared_data_map),
+							count: *count,
+						})
+						.collect()
+				})
+				.unwrap_or_default();
+			let individual_votes = tron_individual_votes
+				.get(election_id)
+				.map(|votes| {
+					votes
+						.iter()
+						.map(|(comp, count)| VoteGroup {
+							component: format_for_display(&format!("{:?}", comp)),
+							count: *count,
+						})
+						.collect()
+				})
+				.unwrap_or_default();
+			let extrinsic_votes = tron_extrinsic_votes
+				.get(election_id)
+				.map(|votes| {
+					votes
+						.iter()
+						.map(|(partial, count)| {
+							let detail = format_tron_vote_detail(partial, &tron_shared_data_map);
+							ExtrinsicVoteGroup { detail, count: *count }
+						})
+						.collect()
+				})
+				.unwrap_or_default();
+			ElectionSummary {
+				election_type: tron_election_type_name(election_id).to_string(),
+				composite_id: format!("{:?}", election_id.extra()),
+				election_properties: format_for_display(&format!("{:?}", props)),
+				completed: is_completed,
+				bitmap_votes,
+				individual_votes,
+				extrinsic_votes,
+			}
+		})
+		.collect();
+
 	Ok(BlockUpdate {
 		block_number,
 		bitcoin: ChainElections {
@@ -1202,6 +1427,11 @@ async fn build_block_update(
 			active_count: arb_active,
 			completed_count: arb_completed_count,
 			elections: arb_election_summaries,
+		},
+		tron: ChainElections {
+			active_count: tron_active,
+			completed_count: tron_completed_count,
+			elections: tron_election_summaries,
 		},
 	})
 }
@@ -1304,6 +1534,36 @@ fn print_block_summary(update: &BlockUpdate) {
 		update.arbitrum.active_count, update.arbitrum.completed_count
 	);
 	for el in &update.arbitrum.elections {
+		let status = if el.completed { " [COMPLETED]" } else { "" };
+		println!(
+			"  [{}] {} {}{}",
+			el.election_type, el.composite_id, el.election_properties, status
+		);
+		if !el.bitmap_votes.is_empty() {
+			println!("    Bitmap votes (from storage at block {}):", prev);
+			for v in &el.bitmap_votes {
+				println!("      {}: {} votes", v.component, v.count);
+			}
+		}
+		if !el.individual_votes.is_empty() {
+			println!("    Individual votes (from storage at block {}):", prev);
+			for v in &el.individual_votes {
+				println!("      {}: {} votes", v.component, v.count);
+			}
+		}
+		if !el.extrinsic_votes.is_empty() {
+			println!("    New votes this block:");
+			for v in &el.extrinsic_votes {
+				println!("      {}: {} votes", v.detail, v.count);
+			}
+		}
+	}
+
+	println!(
+		"\nTRON ELECTIONS ({} active, {} completed this block):",
+		update.tron.active_count, update.tron.completed_count
+	);
+	for el in &update.tron.elections {
 		let status = if el.completed { " [COMPLETED]" } else { "" };
 		println!(
 			"  [{}] {} {}{}",
@@ -1619,6 +1879,20 @@ fn format_arbitrum_bitmap_component(
 	}
 }
 
+fn format_tron_bitmap_component(
+	component: &TronBitmapComponent,
+	shared_data_map: &BTreeMap<SharedDataHash, impl std::fmt::Debug>,
+) -> String {
+	use pallet_cf_elections::vote_storage::composite::tuple_5_impls::CompositeBitmapComponent;
+	match component {
+		CompositeBitmapComponent::A(hash) => resolve_shared_data_value(hash, shared_data_map),
+		CompositeBitmapComponent::B(hash) => resolve_shared_data_value(hash, shared_data_map),
+		CompositeBitmapComponent::C(hash) => resolve_shared_data_value(hash, shared_data_map),
+		CompositeBitmapComponent::D(hash) => resolve_shared_data_value(hash, shared_data_map),
+		CompositeBitmapComponent::EE(value) => bytes_to_hex(&format!("{:?}", value)),
+	}
+}
+
 fn format_ethereum_vote_detail(
 	partial: &<EthereumVoteStorageTuple as VoteStorage>::PartialVote,
 	shared_data_map: &BTreeMap<SharedDataHash, impl std::fmt::Debug>,
@@ -1648,6 +1922,20 @@ fn format_arbitrum_vote_detail(
 		CompositePartialVote::D(inner) => resolve_shared_data_value(inner, shared_data_map),
 		CompositePartialVote::EE(inner) => bytes_to_hex(&format!("{:?}", inner)),
 		CompositePartialVote::FF(inner) => bytes_to_hex(&format!("{:?}", inner)),
+	}
+}
+
+fn format_tron_vote_detail(
+	partial: &<TronVoteStorageTuple as VoteStorage>::PartialVote,
+	shared_data_map: &BTreeMap<SharedDataHash, impl std::fmt::Debug>,
+) -> String {
+	use pallet_cf_elections::vote_storage::composite::tuple_5_impls::CompositePartialVote;
+	match partial {
+		CompositePartialVote::A(inner) => resolve_shared_data_value(inner, shared_data_map),
+		CompositePartialVote::B(inner) => resolve_shared_data_value(inner, shared_data_map),
+		CompositePartialVote::C(inner) => resolve_shared_data_value(inner, shared_data_map),
+		CompositePartialVote::D(inner) => resolve_shared_data_value(inner, shared_data_map),
+		CompositePartialVote::EE(inner) => bytes_to_hex(&format!("{:?}", inner)),
 	}
 }
 

--- a/api/bin/chainflip-elections-tracker/src/dashboard.html
+++ b/api/bin/chainflip-elections-tracker/src/dashboard.html
@@ -190,6 +190,7 @@
         .chain-header.solana { color: #9945ff; }
         .chain-header.ethereum { color: #627eea; }
         .chain-header.arbitrum { color: #28a0f0; }
+        .chain-header.tron { color: #eb0029; }
         .chain-stats {
             color: #8b949e;
             font-weight: 400;
@@ -490,6 +491,7 @@
                     ${renderChain('solana', 'Solana', data.solana, blockIndex)}
                     ${renderChain('ethereum', 'Ethereum', data.ethereum, blockIndex)}
                     ${renderChain('arbitrum', 'Arbitrum', data.arbitrum, blockIndex)}
+                    ${renderChain('tron', 'Tron', data.tron, blockIndex)}
                 </div>
             `;
         }


### PR DESCRIPTION
# Pull Request

## Summary

Forward-ports the Tron elections-tracker support from `release/2.2` to `main`.

`main`'s elections tracker had **no Tron references at all** — it covered Ethereum, Bitcoin, Arbitrum and Solana only, while 2.2 has had Tron since June. This adds Tron as a parallel fifth block, matching the existing per-chain structure.

Cherry-picked from `42b6a8be64` on `release/2.2` (applied cleanly).

Found while auditing which `release/2.2` commits never made it back to `main`. Of 45 candidates, only three were genuine, still-applicable gaps; this is one of them.

## API Changes

None. The elections tracker is an operational/monitoring binary.

### RPCS

No changes.

### Extrinsics & Events

No changes.

---

## Verification

* `cargo check -p chainflip-elections-tracker --all-targets` — clean (only the two pre-existing `custom-rpc` deprecation warnings already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
