### PR TITLE
chore: pick outstanding main commits to release/2.3 (incl. key handover hardening)

### DIFF
--- a/.github/actions/get-workflow-commit/action.yml
+++ b/.github/actions/get-workflow-commit/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Get workflow commit SHA
       id: get-workflow-commit
-      uses: actions/github-script@v5
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/setup-git/action.yml
+++ b/.github/actions/setup-git/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Import SSH key 🔑
-      uses: webfactory/ssh-agent@v0.9.0
+      uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
       with:
           ssh-private-key: ${{ inputs.ssh-private-key }}
     - name: Config Git 🛠

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    # "/" only covers .github/workflows plus a root-level action.yml, so the
+    # glob is needed to reach our composite actions under .github/actions.
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Europe/Berlin"
+    # Minimum age before an update is eligible, so a compromised release has
+    # time to be spotted and yanked before it reaches us. Only default-days is
+    # supported for github-actions; the semver-* variants are not.
+    cooldown:
+      default-days: 14
+    # ci-pr.yml enforces conventional-commit PR titles; the default
+    # "Bump <action> from x to y" would fail that check.
+    commit-message:
+      prefix: "chore"
+    # Minor/patch bumps land as a single PR. Majors stay ungrouped so a
+    # breaking runtime bump can be reviewed and reverted on its own.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5

--- a/.github/workflows/_01_pre_check.yml
+++ b/.github/workflows/_01_pre_check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install pnpm 💿
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 
@@ -147,6 +147,6 @@ jobs:
           password: ${{ secrets.CF_DOCKERHUB_TOKEN }}
 
       - name: Lint 🐳🔬
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: ci/docker/${{ matrix.environment }}/${{ matrix.dockerfile }}.Dockerfile

--- a/.github/workflows/_05_force_version_bump.yml
+++ b/.github/workflows/_05_force_version_bump.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install pnpm 💿
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10
 

--- a/.github/workflows/_100_run_benchmarks.yml
+++ b/.github/workflows/_100_run_benchmarks.yml
@@ -123,7 +123,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Make a pull request with the changed weight files 🕯️
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ github.ref_name }}
           title: "[AUTOMATED] Benchmark results"

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer

--- a/.github/workflows/_10_test.yml
+++ b/.github/workflows/_10_test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           bun install
 
-      - uses: taiki-e/install-action@a209ff0ce0349f9e7cadc4ba8f6a415c8d3b0813
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc
         with:
           tool: nextest@0.9.92
 

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -91,12 +91,12 @@ jobs:
           bun run build
 
       - name: Install cargo-llvm-cov 💿
-        uses: taiki-e/install-action@c2648687d6fe1a5a70a4b65c84715cafab1f3451
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov@0.9.0
 
       - name: Generate code coverage ✨
-        run: cargo llvm-cov --lib --features ${{ inputs.test_features}} --workspace --codecov --output-path lcov.info
+        run: cargo llvm-cov --coverage-host-only --lib --features ${{ inputs.test_features}} --workspace --codecov --output-path lcov.info
 
       - name: Upload coverage to Codecov 📊
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer
@@ -82,7 +82,7 @@ jobs:
       - name: Install Bun Runtime
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: "latest"
+          bun-version: "1.4.0"
 
       - name: Build TypeScript Signer for Ethereum EIP712 tests
         working-directory: state-chain/ethereum-eip712/ts-signer

--- a/.github/workflows/_11_coverage.yml
+++ b/.github/workflows/_11_coverage.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 
@@ -42,7 +42,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 
@@ -80,7 +80,7 @@ jobs:
         run: apt-get update && apt-get install -y unzip
 
       - name: Install Bun Runtime
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: "latest"
 

--- a/.github/workflows/_20_build.yml
+++ b/.github/workflows/_20_build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_21_build_m2.yml
+++ b/.github/workflows/_21_build_m2.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_23_check_generated_bouncer_dependencies.yml
+++ b/.github/workflows/_23_check_generated_bouncer_dependencies.yml
@@ -34,7 +34,7 @@ jobs:
           node-version-file: ./bouncer/.nvmrc
           cache-dependency-path: "bouncer/pnpm-lock.yaml"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 

--- a/.github/workflows/_24_docker.yml
+++ b/.github/workflows/_24_docker.yml
@@ -93,10 +93,10 @@ jobs:
           name: chainflip-backend-bin
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta
@@ -173,10 +173,10 @@ jobs:
           name: chainflip-backend-bin
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta

--- a/.github/workflows/_25_package.yml
+++ b/.github/workflows/_25_package.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
 

--- a/.github/workflows/_26_docker_external_networks.yml
+++ b/.github/workflows/_26_docker_external_networks.yml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 📄
         id: meta

--- a/.github/workflows/_27_benchmarks.yml
+++ b/.github/workflows/_27_benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set up Rust cache 🦀💰
         if: contains(inputs.ci-runner, 'no-cache') == false
-        uses: namespacelabs/nscloud-cache-action@v1
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
         with:
           cache: rust
       - name: Build with benchmarks

--- a/.github/workflows/_50_release.yml
+++ b/.github/workflows/_50_release.yml
@@ -55,7 +55,7 @@ jobs:
         run: envsubst < RELEASE_TEMPLATE.md > RELEASE.md
 
       - name: Release 🚀
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           name: Chainflip ${{ inputs.network }}:${{ github.ref_name }}
           generate_release_notes: false

--- a/.github/workflows/ci-cherry-pick.yml
+++ b/.github/workflows/ci-cherry-pick.yml
@@ -41,7 +41,7 @@ jobs:
           git cherry-pick -x $COMMIT_SHA
 
       - name: Create Pull Request 🐂
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           commit-message: "pick: ${{ env.COMMIT_SHA }} to ${{ env.RELEASE_BRANCH }}"

--- a/.github/workflows/ci-forward-port.yml
+++ b/.github/workflows/ci-forward-port.yml
@@ -114,7 +114,7 @@ jobs:
           git cherry-pick -x "${{ matrix.commit.sha }}"
 
       - name: Create Pull Request 🐂
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CF_BACKEND_GITHUB_TOKEN }}
           commit-message: "forward-port: ${{ matrix.commit.sha }} to main"

--- a/.github/workflows/debug-ci-failure.yml
+++ b/.github/workflows/debug-ci-failure.yml
@@ -69,7 +69,7 @@ jobs:
             -c "SELECT name, COUNT(*) FROM event GROUP BY name ORDER BY count DESC LIMIT 5"
 
       - name: Run Claude Code debugger
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.CF_PROTOCOL_ANTHROPIC_API_KEY }}
           claude_args: >-

--- a/.github/workflows/docker-build-rust-base.yml
+++ b/.github/workflows/docker-build-rust-base.yml
@@ -42,10 +42,10 @@ jobs:
         run: echo "Docker Image Tag output ${{ steps.image_tags.outputs.image_tag }}"
 
       - name: Install and configure Namespace CLI 📟
-        uses: namespacelabs/nscloud-setup@v0
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0.0.12
 
       - name: Set up Namespace Buildx 👷
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
 
       - name: Docker meta 🔖
         id: meta

--- a/bouncer/shared/new_sol_address.ts
+++ b/bouncer/shared/new_sol_address.ts
@@ -4,3 +4,13 @@ import { sha256 } from 'shared/utils';
 export function newSolAddress(seed: string): string {
   return Keypair.fromSeed(sha256(seed)).publicKey.toBase58();
 }
+
+// A Solana keypair derived deterministically from `rng`, so generated account addresses are
+// reproducible from the seed rather than cryptographically random.
+export function seededSolanaKeypair(rng: () => number): Keypair {
+  const seed = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    seed[i] = Math.floor(rng() * 256);
+  }
+  return Keypair.fromSeed(seed);
+}

--- a/bouncer/shared/swapping.ts
+++ b/bouncer/shared/swapping.ts
@@ -1,7 +1,8 @@
-import { Keypair, PublicKey } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { u8aToHex } from '@polkadot/util';
-import { randomAsHex } from 'polkadot/util-crypto';
 import { performSwap, performVaultSwap } from 'shared/perform_swap';
+import { seededHexBytes } from 'shared/utils/seeded_rng';
+import { seededSolanaKeypair } from 'shared/new_sol_address';
 import {
   chainFromAsset,
   getContractAddress,
@@ -42,15 +43,23 @@ const MAX_CCM_BYTES_USDT = 632;
 const SOLANA_BYTES_PER_ACCOUNT = 33;
 const BYTES_PER_ALT = 34; // 32 + 1 + 1 (for vector lengths)
 
-function newSolanaCcmAdditionalData(maxBytes: number) {
+// Options for the public CCM metadata builders. `rng` (defaulting to `Math.random`) seeds the
+// otherwise-random message/metadata generation so a run can be reproduced from a fixed seed.
+export type CcmMetadataOptions = {
+  message?: string;
+  additionalData?: string;
+  rng?: () => number;
+};
+
+function newSolanaCcmAdditionalData(maxBytes: number, rng: () => number) {
   // Test all combinations
-  const useLegacy = maxBytes < BYTES_PER_ALT || Math.random() < 0.5;
-  const useAlt = !useLegacy && Math.random() < 0.5;
+  const useLegacy = maxBytes < BYTES_PER_ALT || rng() < 0.5;
+  const useAlt = !useLegacy && rng() < 0.5;
   let bytesAvailable = maxBytes;
 
   const additionalAccounts = [];
   const cfReceiverAddress = getContractAddress('Solana', 'CFTESTER');
-  const fallbackAddress = Keypair.generate().publicKey.toBytes();
+  const fallbackAddress = seededSolanaKeypair(rng).publicKey.toBytes();
 
   if (useAlt) {
     // We will only use one ALT
@@ -61,12 +70,12 @@ function newSolanaCcmAdditionalData(maxBytes: number) {
   }
 
   const maxAccounts = Math.floor(bytesAvailable / SOLANA_BYTES_PER_ACCOUNT);
-  const numAdditionalAccounts = Math.floor(Math.random() * maxAccounts);
+  const numAdditionalAccounts = Math.floor(rng() * maxAccounts);
 
   for (let i = 0; i < numAdditionalAccounts; i++) {
     additionalAccounts.push({
-      pubkey: Keypair.generate().publicKey.toBytes(),
-      is_writable: Math.random() < 0.5,
+      pubkey: seededSolanaKeypair(rng).publicKey.toBytes(),
+      is_writable: rng() < 0.5,
     });
   }
 
@@ -107,13 +116,19 @@ function newSolanaCcmAdditionalData(maxBytes: number) {
 
 // Generate random bytes. Setting a minimum length of 10 because very short messages can end up
 // with the SC returning an ASCII character in SwapDepositAddressReady.
-function newCcmArbitraryBytes(maxLength: number): string {
-  return randomAsHex(Math.floor(Math.random() * Math.max(0, maxLength - 10)) + 10);
+function newCcmArbitraryBytes(maxLength: number, rng: () => number): string {
+  const numBytes = Math.floor(rng() * Math.max(0, maxLength - 10)) + 10;
+  return seededHexBytes(numBytes, rng);
 }
 
 // For Solana the maximum number of extra accounts that can be passed is limited by the tx size
 // and therefore also depends on the message length.
-function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: number): string {
+function newCcmAdditionalData(
+  destAsset: Asset,
+  message: string,
+  rng: () => number,
+  maxLength?: number,
+): string {
   const destChain = chainFromAsset(destAsset);
 
   switch (destChain) {
@@ -138,7 +153,7 @@ function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: num
       if (maxLength !== undefined) {
         bytesAvailable = Math.min(bytesAvailable, maxLength);
       }
-      const ccmAdditionalData = newSolanaCcmAdditionalData(bytesAvailable);
+      const ccmAdditionalData = newSolanaCcmAdditionalData(bytesAvailable, rng);
       if (ccmAdditionalData.slice(2).length / 2 > MAX_CCM_ADDITIONAL_DATA_LENGTH) {
         throw new Error(`CCM additional data length exceeds limit: ${ccmAdditionalData.length}`);
       }
@@ -149,7 +164,7 @@ function newCcmAdditionalData(destAsset: Asset, message: string, maxLength?: num
   }
 }
 
-function newCcmMessage(destAsset: Asset, maxLength?: number): string {
+function newCcmMessage(destAsset: Asset, rng: () => number, maxLength?: number): string {
   const destChain = chainFromAsset(destAsset);
   let length: number;
 
@@ -181,7 +196,7 @@ function newCcmMessage(destAsset: Asset, maxLength?: number): string {
     length = Math.min(length, maxLength);
   }
 
-  return newCcmArbitraryBytes(length);
+  return newCcmArbitraryBytes(length, rng);
 }
 // Minimum overhead to ensure simple CCM transactions succeed
 const OVERHEAD_COMPUTE_UNITS = 30000;
@@ -189,11 +204,11 @@ const OVERHEAD_ENERGY = 20000;
 
 export async function newCcmMetadata(
   destAsset: Asset,
-  ccmMessage?: string,
-  ccmAdditionalDataArray?: string,
+  options: CcmMetadataOptions = {},
 ): Promise<CcmDepositMetadata> {
-  const message = ccmMessage ?? newCcmMessage(destAsset);
-  const ccmAdditionalData = ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message);
+  const rng = options.rng ?? Math.random;
+  const message = options.message ?? newCcmMessage(destAsset, rng);
+  const ccmAdditionalData = options.additionalData ?? newCcmAdditionalData(destAsset, message, rng);
   const destChain = chainFromAsset(destAsset);
 
   let userLogicGasBudget;
@@ -224,9 +239,10 @@ export async function newCcmMetadata(
 export async function newVaultSwapCcmMetadata(
   sourceAsset: Asset,
   destAsset: Asset,
-  ccmMessage?: string,
-  ccmAdditionalDataArray?: string,
+  options: CcmMetadataOptions = {},
 ): Promise<CcmDepositMetadata> {
+  const rng = options.rng ?? Math.random;
+  const { message: ccmMessage, additionalData: ccmAdditionalDataArray } = options;
   const sourceChain = chainFromAsset(sourceAsset);
   let messageMaxLength;
   let metadataMaxLength;
@@ -254,11 +270,11 @@ export async function newVaultSwapCcmMetadata(
     }
   }
 
-  const message = ccmMessage ?? newCcmMessage(destAsset, messageMaxLength);
+  const message = ccmMessage ?? newCcmMessage(destAsset, rng, messageMaxLength);
   // For now we only enforce empty ccmAdditionalData for Vault swaps, not deposit channels.
   const ccmAdditionalData =
-    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, metadataMaxLength);
-  return newCcmMetadata(destAsset, message, ccmAdditionalData);
+    ccmAdditionalDataArray ?? newCcmAdditionalData(destAsset, message, rng, metadataMaxLength);
+  return newCcmMetadata(destAsset, { message, additionalData: ccmAdditionalData });
 }
 
 export async function prepareSwap(

--- a/bouncer/shared/utils.ts
+++ b/bouncer/shared/utils.ts
@@ -349,7 +349,7 @@ export function defaultAssetAmounts(asset: Asset): string {
     case 'Bnb':
       return '5';
     case 'HubDot':
-      return '50';
+      return '200';
     case 'Usdc':
     case 'Usdt':
     case 'ArbUsdc':

--- a/bouncer/shared/utils/seeded_rng.ts
+++ b/bouncer/shared/utils/seeded_rng.ts
@@ -16,3 +16,15 @@ export function seededRng(seed: number): () => number {
   };
 }
 /* eslint-enable no-bitwise, operator-assignment */
+
+/** Deterministic `0x`-prefixed random bytes of the given length, driven by `rng` so the content — */
+/** not just the length — is reproducible from the seed. */
+export function seededHexBytes(numBytes: number, rng: () => number): `0x${string}` {
+  let hex = '0x';
+  for (let i = 0; i < numBytes; i++) {
+    hex += Math.floor(rng() * 256)
+      .toString(16)
+      .padStart(2, '0');
+  }
+  return hex as `0x${string}`;
+}

--- a/bouncer/tests/all_swaps.ts
+++ b/bouncer/tests/all_swaps.ts
@@ -42,13 +42,14 @@ export async function initiateSwap(
   destAsset: Asset,
   functionCall: typeof testSwap | typeof testVaultSwap,
   ccmSwap: boolean = false,
+  rng: () => number = Math.random,
 ): Promise<SwapParams | VaultSwapParams> {
   let ccmSwapMetadata;
   if (ccmSwap) {
     ccmSwapMetadata =
       functionCall === testSwap
-        ? await newCcmMetadata(destAsset)
-        : await newVaultSwapCcmMetadata(sourceAsset, destAsset);
+        ? await newCcmMetadata(destAsset, { rng })
+        : await newVaultSwapCcmMetadata(sourceAsset, destAsset, { rng });
   }
 
   if (destAsset === 'Btc') {
@@ -57,7 +58,7 @@ export async function initiateSwap(
       cf,
       sourceAsset,
       destAsset,
-      btcAddressTypesArray[Math.floor(Math.random() * btcAddressTypesArray.length)],
+      btcAddressTypesArray[Math.floor(rng() * btcAddressTypesArray.length)],
       ccmSwapMetadata,
       testContext.swapContext,
     );
@@ -249,12 +250,22 @@ export function testAllSwaps(timeoutPerSwap: number, thoroughlyTestedAssets: Ass
     ccmSwap: boolean = false,
   ) {
     allSwapsCount++;
+    const swapNumber = allSwapsCount;
     const swapType = functionCall === testSwap ? 'Swap' : 'VaultSwap';
     allSwaps.push({
-      name: `Swap ${allSwapsCount}: ${sourceAsset} to ${destAsset} (${ccmSwap ? 'CCM ' : ''}${swapType})`,
+      name: `Swap ${swapNumber}: ${sourceAsset} to ${destAsset} (${ccmSwap ? 'CCM ' : ''}${swapType})`,
       test: async (context) => {
         const cf = await newChainflipIO(context.logger, [] as []);
-        await initiateSwap(cf, context, sourceAsset, destAsset, functionCall, ccmSwap);
+        // Deterministic per-swap seed derived from the AllSwaps seed, so CCM generation is reproducible
+        await initiateSwap(
+          cf,
+          context,
+          sourceAsset,
+          destAsset,
+          functionCall,
+          ccmSwap,
+          seededRng(GENERATE_SWAPS_SEED + swapNumber),
+        );
       },
     });
   }

--- a/bouncer/tests/delegate_flip.ts
+++ b/bouncer/tests/delegate_flip.ts
@@ -200,7 +200,7 @@ export async function testCcmSwapFundAccount(testContext: TestContext) {
   }
 
   const ccmMessage = web3.eth.abi.encodeParameters(['address', 'bytes'], [scUtilsAddress, pubkey]);
-  const ccmMetadata = await newCcmMetadata('Flip', ccmMessage);
+  const ccmMetadata = await newCcmMetadata('Flip', { message: ccmMessage });
   // Override gas budget for this particular use case
   ccmMetadata.gasBudget = '1000000';
 

--- a/bouncer/tests/gaslimit_ccm.test.ts
+++ b/bouncer/tests/gaslimit_ccm.test.ts
@@ -236,10 +236,9 @@ async function testGasLimitSwapToEvm<A = []>(
 
   const gasConsumption = getRandomGasConsumption(chainFromAsset(destAsset));
 
-  const ccmMetadata = await newCcmMetadata(
-    destAsset,
-    web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
-  );
+  const ccmMetadata = await newCcmMetadata(destAsset, {
+    message: web3.eth.abi.encodeParameters(['string', 'uint256'], ['GasTest', gasConsumption]),
+  });
 
   // Estimating gas separately. We can't rely on the default gas estimation in `newCcmMetadata()`
   // because the CF tester gas consumption depends on the gas limit, making this a circular calculation.
@@ -378,10 +377,9 @@ async function testTronInsufficientGas<A = []>(
 
   // No need to override the gasBudget since the numberOfStores will make sure the energy
   // consumption is higher than the budget.
-  const ccmMetadata = await newCcmMetadata(
-    destAsset,
-    tronWeb.utils.abi.encodeParams(['string', 'uint256'], ['GasTest', numberOfStores]),
-  );
+  const ccmMetadata = await newCcmMetadata(destAsset, {
+    message: tronWeb.utils.abi.encodeParams(['string', 'uint256'], ['GasTest', numberOfStores]),
+  });
 
   const { tag, destAddress, broadcastId, gasLimitBudget } = await executeAndTrackCcmSwap(
     cf,

--- a/engine/multisig/src/client/keygen/keygen_data.rs
+++ b/engine/multisig/src/client/keygen/keygen_data.rs
@@ -17,7 +17,10 @@
 #[cfg(test)]
 mod tests;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+	collections::{BTreeMap, BTreeSet},
+	marker::PhantomData,
+};
 
 use cf_primitives::AuthorityCount;
 use serde::{Deserialize, Serialize};
@@ -171,8 +174,59 @@ impl<P: ECPoint> PreProcessStageDataCheck<KeygenStageName> for KeygenData<P> {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
 pub struct HashComm1(pub sp_core::H256);
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialOrd, Ord, PartialEq, Eq)]
 pub struct PubkeyShares0<P: ECPoint>(#[serde(bound = "")] pub BTreeMap<AuthorityCount, P>);
+
+// Manual, size-bounded `Deserialize`. `PubkeyShares0` is the only keygen message that
+// eagerly deserializes - and cryptographically validates - one EC point per map entry, and it is
+// accepted from *unauthorised* ceremonies, before we know the participant set. A peer could
+// otherwise declare an enormous map and make us validate an unbounded number of attacker-chosen
+// points inside the single-threaded, per-chain ceremony manager - starving honest ceremony
+// traffic (e.g. secret-share delivery) on that chain. Bound the entry count to `MAX_AUTHORITIES`
+// before any point is decoded, so the per-message cost cannot exceed that of a legitimate
+// ceremony. (`is_initial_stage_data_size_valid` also checks this, but only *after* the whole map
+// has been deserialized - too late to bound the work.)
+impl<'de, P: ECPoint> Deserialize<'de> for PubkeyShares0<P> {
+	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		struct MapVisitor<P>(PhantomData<P>);
+
+		impl<'de, P: ECPoint> serde::de::Visitor<'de> for MapVisitor<P> {
+			type Value = BTreeMap<AuthorityCount, P>;
+
+			fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+				write!(f, "a map of at most {MAX_AUTHORITIES} pubkey shares")
+			}
+
+			fn visit_map<A: serde::de::MapAccess<'de>>(
+				self,
+				mut access: A,
+			) -> Result<Self::Value, A::Error> {
+				let max = MAX_AUTHORITIES as usize;
+
+				// Reject from the declared length first, before decoding a single point...
+				if access.size_hint().is_some_and(|len| len > max) {
+					return Err(serde::de::Error::custom(
+						"PubkeyShares0 map exceeds MAX_AUTHORITIES",
+					))
+				}
+
+				let mut map = BTreeMap::new();
+				while let Some((k, v)) = access.next_entry::<AuthorityCount, P>()? {
+					// ...and again as we decode, in case the deserializer under-reports the hint.
+					if map.len() >= max {
+						return Err(serde::de::Error::custom(
+							"PubkeyShares0 map exceeds MAX_AUTHORITIES",
+						))
+					}
+					map.insert(k, v);
+				}
+				Ok(map)
+			}
+		}
+
+		deserializer.deserialize_map(MapVisitor::<P>(PhantomData)).map(PubkeyShares0)
+	}
+}
 
 pub type VerifyHashComm2 = BroadcastVerificationMessage<HashComm1>;
 

--- a/engine/multisig/src/client/keygen/keygen_data/tests.rs
+++ b/engine/multisig/src/client/keygen/keygen_data/tests.rs
@@ -334,3 +334,26 @@ fn should_delay_correct_data_for_stage() {
 		}
 	}
 }
+
+#[test]
+fn pubkey_shares0_deserialization_is_bounded_by_max_authorities() {
+	let mut rng = Rng::from_seed([0; 32]);
+
+	let pubkey_shares = |count: AuthorityCount, rng: &mut Rng| {
+		PubkeyShares0::<Point>((1..=count).map(|i| (i, Point::random(rng))).collect())
+	};
+
+	// A map of exactly MAX_AUTHORITIES entries is within bounds and round-trips unchanged.
+	let within_limit = pubkey_shares(MAX_AUTHORITIES, &mut rng);
+	let bytes = bincode::serialize(&within_limit).expect("serialization can't fail");
+	assert_eq!(
+		bincode::deserialize::<PubkeyShares0<Point>>(&bytes).expect("within-limit map decodes"),
+		within_limit,
+	);
+
+	// One entry beyond the limit is rejected by the size-bounded deserializer, even though the
+	// (unbounded) derived serializer will happily produce it.
+	let over_limit = pubkey_shares(MAX_AUTHORITIES + 1, &mut rng);
+	let bytes = bincode::serialize(&over_limit).expect("serialization can't fail");
+	assert!(bincode::deserialize::<PubkeyShares0<Point>>(&bytes).is_err());
+}

--- a/engine/multisig/src/client/keygen/keygen_stages.rs
+++ b/engine/multisig/src/client/keygen/keygen_stages.rs
@@ -835,14 +835,11 @@ impl<Crypto: CryptoScheme> BroadcastStageProcessor<KeygenCeremony<Crypto>>
 			return StageResult::Error(idxs_to_report, KeygenFailureReason::InvalidComplaint)
 		}
 
-		// No honest party reaches this: it takes `threshold + 1` complaints against
-		// one party, which is also the number needed to sign, so this cannot be
-		// used to evict a dealer more cheaply than owning the key outright. It
-		// caps the disclosure rather than preventing it - what keeps an honest
-		// dealer safe is that only corrupt parties ever complain about it.
+		// This ensures that disclosure is capped: oversharing may result in full key
+		// reconstruction, so it is safer to abort (even if this party ends up getting evicted).
 		let over_blamed = parties_blamed_beyond_disclosure_limit(
 			&verified_complaints,
-			self.keygen_common.sharing_params.key_params.threshold as usize,
+			disclosure_limit(self.keygen_common.sharing_params.key_params.threshold as usize),
 			&common.validator_mapping,
 		);
 
@@ -866,16 +863,28 @@ impl<Crypto: CryptoScheme> BroadcastStageProcessor<KeygenCeremony<Crypto>>
 	}
 }
 
-/// Parties blamed by enough others that answering every complaint would expose
-/// their sharing polynomial.
+/// How many shares a party may be made to reveal in one blame round.
 ///
-/// A blame response carries one evaluation of the sender's polynomial per
-/// complainer, and `threshold + 1` evaluations determine a polynomial of degree
-/// `threshold`. Exposing it exposes the secret behind it, which during a key
-/// handover is that party's share of the live aggregate key.
+/// A blame response publishes one evaluation of the sender's polynomial per
+/// complainer, and `threshold + 1` of them determine a polynomial of degree
+/// `threshold`. Capping at `threshold` looks one short, but only to an observer
+/// with no share of its own: every participant already holds one evaluation, and
+/// one that declines to complain keeps it off the wire. Published plus held is
+/// then exactly enough, so a single node defeats that bound.
+///
+/// At `threshold / 2` an attacker needs `threshold + 1 - c` non-complainers, which
+/// is more than `n / 3` - no cheaper than breaking the Byzantine assumption
+/// outright. `disclosure_cost_exceeds_byzantine_bound` pins this across set sizes.
+pub(super) fn disclosure_limit(threshold: usize) -> usize {
+	threshold / 2
+}
+
+/// Parties blamed past [`disclosure_limit`], for whom answering every complaint
+/// would expose too much of their sharing polynomial - and with it the secret
+/// behind it, which during a key handover is their share of the live aggregate key.
 fn parties_blamed_beyond_disclosure_limit(
 	complaints: &BTreeMap<AuthorityCount, Complaints6>,
-	threshold: usize,
+	limit: usize,
 	validator_mapping: &PartyIdxMapping,
 ) -> BTreeSet<AuthorityCount> {
 	let mut blame_counts: BTreeMap<AuthorityCount, usize> = BTreeMap::new();
@@ -888,7 +897,7 @@ fn parties_blamed_beyond_disclosure_limit(
 
 	let over_blamed: BTreeSet<_> = blame_counts
 		.into_iter()
-		.filter_map(|(idx_blamed, count)| (count > threshold).then_some(idx_blamed))
+		.filter_map(|(idx_blamed, count)| (count > limit).then_some(idx_blamed))
 		.collect();
 
 	if !over_blamed.is_empty() {
@@ -1002,7 +1011,9 @@ impl<Crypto: CryptoScheme> BroadcastStageProcessor<KeygenCeremony<Crypto>>
 		if !idxs_to_reveal.is_empty() {
 			warn!(
 				revealed = idxs_to_reveal.len(),
-				limit = self.keygen_common.sharing_params.key_params.threshold,
+				limit = disclosure_limit(
+					self.keygen_common.sharing_params.key_params.threshold as usize
+				),
 				"Revealing secret shares in response to complaints",
 			);
 		}
@@ -1216,17 +1227,46 @@ mod tests {
 	}
 
 	#[test]
-	fn disclosure_limit_is_exceeded_one_complaint_past_the_threshold() {
-		const THRESHOLD: usize = 3;
+	fn disclosure_limit_is_exceeded_one_complaint_past_the_limit() {
+		const LIMIT: usize = 3;
 
 		let at_limit = complaints(&[(1, &[9]), (2, &[9]), (3, &[9])]);
-		assert!(parties_blamed_beyond_disclosure_limit(&at_limit, THRESHOLD, &mapping()).is_empty());
+		assert!(parties_blamed_beyond_disclosure_limit(&at_limit, LIMIT, &mapping()).is_empty());
 
 		let over_limit = complaints(&[(1, &[9]), (2, &[9]), (3, &[9]), (4, &[9])]);
 		assert_eq!(
-			parties_blamed_beyond_disclosure_limit(&over_limit, THRESHOLD, &mapping()),
+			parties_blamed_beyond_disclosure_limit(&over_limit, LIMIT, &mapping()),
 			BTreeSet::from([9]),
 		);
+	}
+
+	/// The property the limit exists for. `c` evaluations are published and each
+	/// colluding non-complainer adds the one it was dealt, so extracting a
+	/// polynomial needs `threshold + 1 - c` of them - which must exceed `n / 3`.
+	#[test]
+	fn disclosure_cost_exceeds_byzantine_bound() {
+		for share_count in 1..=500u32 {
+			let threshold = cf_utilities::threshold_from_share_count(share_count) as usize;
+			let limit = disclosure_limit(threshold);
+
+			// Evaluations still needed once `limit` are public, i.e. colluding
+			// non-complainers required.
+			let coalition = threshold + 1 - limit;
+
+			assert!(
+				coalition * 3 > share_count as usize,
+				"n={share_count}: threshold={threshold} limit={limit} lets a coalition of \
+				 {coalition} extract a polynomial, which is not more than n/3",
+			);
+		}
+	}
+
+	/// At the mainnet authority count the limit is 49, down from 99.
+	#[test]
+	fn disclosure_limit_at_mainnet_set_size() {
+		let threshold = cf_utilities::threshold_from_share_count(150) as usize;
+		assert_eq!(threshold, 99);
+		assert_eq!(disclosure_limit(threshold), 49);
 	}
 
 	#[test]

--- a/engine/multisig/src/client/keygen/tests.rs
+++ b/engine/multisig/src/client/keygen/tests.rs
@@ -151,15 +151,16 @@ async fn should_enter_blaming_stage_on_timeout_secret_shares() {
 	ceremony.complete();
 }
 
-/// A party blamed by `threshold + 1` others would reveal enough evaluations to
-/// have its sharing polynomial reconstructed, so the ceremony must abort before
-/// the blame round rather than let it answer.
+/// Past the limit, the revealed evaluations plus the one every participant already
+/// holds would reconstruct the polynomial, so the ceremony aborts before the blame
+/// round rather than let the party answer.
 #[tokio::test]
 async fn should_abort_rather_than_reveal_enough_shares_to_reconstruct_polynomial() {
 	let mut ceremony = KeygenCeremonyRunnerEth::new_with_default();
 
 	let party_count = ceremony.nodes.len() as u32;
 	let threshold = cf_utilities::threshold_from_share_count(party_count) as usize;
+	let limit = super::keygen_stages::disclosure_limit(threshold);
 
 	let bad_dealer = ceremony.nodes.keys().next().unwrap().clone();
 
@@ -167,10 +168,10 @@ async fn should_abort_rather_than_reveal_enough_shares_to_reconstruct_polynomial
 		.nodes
 		.keys()
 		.filter(|id| **id != bad_dealer)
-		.take(threshold + 1)
+		.take(limit + 1)
 		.cloned()
 		.collect();
-	assert_eq!(targets.len(), threshold + 1);
+	assert_eq!(targets.len(), limit + 1);
 
 	let messages = ceremony.request().await;
 
@@ -198,22 +199,22 @@ async fn should_abort_rather_than_reveal_enough_shares_to_reconstruct_polynomial
 	);
 }
 
-/// The bound must not fire at exactly `threshold` complaints, where the
-/// polynomial still has a degree of freedom: the blame round runs as usual and
-/// the ceremony recovers.
+/// The bound must not fire *at* the disclosure limit, where enough degrees of
+/// freedom remain: the blame round runs as usual and the ceremony recovers.
 #[tokio::test]
 async fn should_still_enter_blame_round_at_the_disclosure_limit() {
 	let mut ceremony = KeygenCeremonyRunnerEth::new_with_default();
 
 	let party_count = ceremony.nodes.len() as u32;
 	let threshold = cf_utilities::threshold_from_share_count(party_count) as usize;
+	let limit = super::keygen_stages::disclosure_limit(threshold);
 
 	let bad_dealer = ceremony.nodes.keys().next().unwrap().clone();
 	let targets: Vec<_> = ceremony
 		.nodes
 		.keys()
 		.filter(|id| **id != bad_dealer)
-		.take(threshold)
+		.take(limit)
 		.cloned()
 		.collect();
 

--- a/engine/src/btc/rpc.rs
+++ b/engine/src/btc/rpc.rs
@@ -18,7 +18,7 @@ use cf_chains::btc::BitcoinNetwork;
 use futures_core::Future;
 use thiserror::Error;
 
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use serde;
@@ -37,6 +37,11 @@ use anyhow::{anyhow, Result};
 // https://github.com/bitcoin/bitcoin/blob/fb7b5293844ea6adc5dcf5ad0a0c5890b4495939/src/rpc/protocol.h#L58
 const RPC_VERIFY_ALREADY_IN_CHAIN: i32 = -27;
 
+/// How much of a response body to quote when reporting it as [`Error::BadResponse`]. Applies only
+/// to a body that failed to parse, never to one we return: enough to identify the source of a proxy
+/// error page without flooding the logs.
+const MAX_REPORTED_BODY_LEN: usize = 512;
+
 // From jsonrpc crate
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RpcError {
@@ -53,6 +58,12 @@ pub enum Error {
 	Transport(reqwest::Error),
 	Json(serde_json::Error),
 	Rpc(RpcError),
+	/// The endpoint replied with something that isn't a JSON-RPC response at all, for example a
+	/// `502 Bad Gateway` page from a proxy in front of the node.
+	BadResponse {
+		status: StatusCode,
+		body: String,
+	},
 }
 
 impl std::fmt::Display for Error {
@@ -61,6 +72,8 @@ impl std::fmt::Display for Error {
 			Error::Transport(ref e) => write!(f, "Transport error: {}", e),
 			Error::Json(ref e) => write!(f, "JSON decode error: {}", e),
 			Error::Rpc(ref e) => write!(f, "RPC error response: {:?}", e),
+			Error::BadResponse { status, ref body } =>
+				write!(f, "Unexpected response with status `{status}`: {body:?}"),
 		}
 	}
 }
@@ -172,45 +185,81 @@ async fn call_rpc_raw(
 		.await
 		.map_err(Error::Transport)?;
 
-	let response = response
-		.json::<Vec<serde_json::Value>>()
-		.await
-		.map_err(Error::Transport)
-		.and_then(|result| match params.clone() {
-			ReqParams::Batch(params) =>
-				if params.len() == result.len() {
-					// a bunch of json result values containing an error and a result field.
-					Ok(result)
-				} else {
-					Err(Error::Rpc(RpcError {
+	let status = response.status();
+	let body = response.bytes().await.map_err(Error::Transport)?;
+
+	parse_response(status, &body, method, &params)
+}
+
+/// Extracts the results from the response to a JSON-RPC (batch) request.
+///
+/// The status is only used for reporting: the node itself replies with an error status *and* a
+/// well-formed JSON-RPC body (a `400 Bad Request` carrying a parse error, for example), whereas
+/// anything sitting in front of it replies with a body we can't decode at all. Reporting the
+/// latter as [`Error::BadResponse`] keeps the status and the body of, say, a `502 Bad Gateway`
+/// page visible instead of reducing it to a decoding error.
+fn parse_response(
+	status: StatusCode,
+	body: &[u8],
+	method: &str,
+	params: &ReqParams,
+) -> Result<Vec<serde_json::Value>, Error> {
+	let bad_response = || Error::BadResponse {
+		status,
+		body: String::from_utf8_lossy(&body[..body.len().min(MAX_REPORTED_BODY_LEN)]).into_owned(),
+	};
+
+	match serde_json::from_slice::<serde_json::Value>(body) {
+		Ok(serde_json::Value::Array(replies)) => {
+			if let ReqParams::Batch(params) = params {
+				if params.len() != replies.len() {
+					return Err(Error::Rpc(RpcError {
 						code: -1,
 						message: "Incorrect response number for batch request".to_string(),
 						data: None,
 					}))
-				},
-			ReqParams::Empty => Ok(result),
-		})?;
-
-	response
-		.into_iter()
-		.map(|r| {
-			if r.is_object() {
-				let error = &r["error"];
-				if !error.is_null() {
-					Err(Error::Rpc(serde_json::from_value(error.clone()).map_err(Error::Json)?))
-				} else {
-					Ok(r["result"].to_owned())
 				}
-			} else {
-				tracing::warn!(
-					"The rpc response returned for {method:?} with params: {params:?}
-					was not a valid json object: {:?}",
-					r.clone()
-				);
-				Err(Error::Rpc(serde_json::from_value(r).map_err(Error::Json)?))
 			}
-		})
-		.collect::<Result<_, Error>>()
+			replies
+				.iter()
+				.map(|reply| match reply.as_object().and_then(result_from_reply) {
+					Some(result) => result,
+					None => {
+						tracing::warn!(
+							"The rpc response returned for {method:?} with params: {params:?} \
+							was not a valid json-rpc reply: {reply:?}"
+						);
+						Err(bad_response())
+					},
+				})
+				.collect()
+		},
+		// A single reply instead of a batch: the node rejected the request as a whole.
+		Ok(serde_json::Value::Object(reply)) => match result_from_reply(&reply) {
+			Some(result) => result.map(|result| vec![result]),
+			None => Err(bad_response()),
+		},
+		_ => Err(bad_response()),
+	}
+}
+
+/// The result of a single JSON-RPC reply, or the error it reported.
+///
+/// `None` for a reply carrying neither, which is not a JSON-RPC reply at all — the caller decides
+/// how to report that. Note that a `result` that is present but `null` is a valid result, which
+/// some methods do return.
+///
+/// A reply carrying *both* is malformed too, but is reported as the error it names: the node's own
+/// message says more about what went wrong than the raw body does.
+fn result_from_reply(
+	reply: &Map<String, serde_json::Value>,
+) -> Option<Result<serde_json::Value, Error>> {
+	match (reply.get("error"), reply.get("result")) {
+		(Some(error), _) if !error.is_null() =>
+			Some(Err(serde_json::from_value(error.clone()).map_or_else(Error::Json, Error::Rpc))),
+		(_, Some(result)) => Some(Ok(result.clone())),
+		_ => None,
+	}
 }
 
 /// Get the BitcoinNetwork by calling the `getblockchaininfo` RPC.
@@ -555,9 +604,111 @@ impl BtcRpcApi for BtcRpcClient {
 
 #[cfg(test)]
 mod tests {
-	use cf_utilities::assert_panics;
+	use cf_utilities::{assert_matches, assert_panics};
 
 	use super::*;
+
+	#[test]
+	fn proxy_error_page_reports_status_and_body() {
+		// A gateway in front of the node replies with html, which is not a JSON-RPC response.
+		let body = b"<html><head><title>502 Bad Gateway</title></head></html>";
+		assert_matches!(
+			parse_response(
+				StatusCode::BAD_GATEWAY,
+				body,
+				"getblockhash",
+				&ReqParams::Batch(vec![json!([json!(0)])]),
+			),
+			Err(Error::BadResponse { status, body })
+				if status == StatusCode::BAD_GATEWAY && body.contains("502 Bad Gateway")
+		);
+	}
+
+	#[test]
+	fn empty_response_reports_status() {
+		// For example the empty body of a `401 Unauthorized` from the node itself.
+		assert_matches!(
+			parse_response(StatusCode::UNAUTHORIZED, b"", "getblockhash", &ReqParams::Empty),
+			Err(Error::BadResponse { status, body }) if status == StatusCode::UNAUTHORIZED && body.is_empty()
+		);
+	}
+
+	#[test]
+	fn reported_body_is_truncated() {
+		let body = vec![b'x'; MAX_REPORTED_BODY_LEN * 2];
+		assert_matches!(
+			parse_response(StatusCode::BAD_GATEWAY, &body, "getblockhash", &ReqParams::Empty),
+			Err(Error::BadResponse { body, .. }) if body.len() == MAX_REPORTED_BODY_LEN
+		);
+	}
+
+	#[test]
+	fn rejected_request_reports_rpc_error() {
+		// The node rejects a malformed request as a whole, replying with a single JSON-RPC error
+		// object rather than a batch.
+		let body = br#"{"result":null,"error":{"code":-32700,"message":"Parse error"},"id":null}"#;
+		assert_matches!(
+			parse_response(
+				StatusCode::BAD_REQUEST,
+				body,
+				"getblockhash",
+				&ReqParams::Batch(vec![json!([json!(0)])]),
+			),
+			Err(Error::Rpc(RpcError { code: -32700, .. }))
+		);
+	}
+
+	#[test]
+	fn batch_replies_are_unwrapped() {
+		let body = br#"[{"result":1,"error":null,"id":0},{"result":2,"error":null,"id":1}]"#;
+		let params = ReqParams::Batch(vec![json!([json!(0)]), json!([json!(1)])]);
+		assert_eq!(
+			parse_response(StatusCode::OK, body, "getblockhash", &params).unwrap(),
+			vec![json!(1), json!(2)]
+		);
+	}
+
+	#[test]
+	fn batch_reply_error_is_reported() {
+		let body = br#"[{"result":null,"error":{"code":-8,"message":"Block height out of range"},"id":0}]"#;
+		let params = ReqParams::Batch(vec![json!([json!(0)])]);
+		assert_matches!(
+			parse_response(StatusCode::INTERNAL_SERVER_ERROR, body, "getblockhash", &params),
+			Err(Error::Rpc(RpcError { code: -8, .. }))
+		);
+	}
+
+	#[test]
+	fn reply_with_neither_result_nor_error_is_rejected() {
+		// A reply object carrying neither `result` nor `error` is not a JSON-RPC reply.
+		let body = br#"[{"id":0}]"#;
+		let params = ReqParams::Batch(vec![json!([json!(0)])]);
+		assert_matches!(
+			parse_response(StatusCode::OK, body, "getblockhash", &params),
+			Err(Error::BadResponse { .. })
+		);
+	}
+
+	#[test]
+	fn null_result_is_preserved() {
+		// A present-but-null `result` is a valid result that some methods return.
+		let body = br#"[{"result":null,"error":null,"id":0}]"#;
+		let params = ReqParams::Batch(vec![json!([json!(0)])]);
+		assert_eq!(
+			parse_response(StatusCode::OK, body, "getblockhash", &params).unwrap(),
+			vec![serde_json::Value::Null]
+		);
+	}
+
+	#[test]
+	fn incomplete_batch_reply_is_rejected() {
+		let body = br#"[{"result":1,"error":null,"id":0}]"#;
+		let params = ReqParams::Batch(vec![json!([json!(0)]), json!([json!(1)])]);
+		assert_matches!(
+			parse_response(StatusCode::OK, body, "getblockhash", &params),
+			Err(Error::Rpc(RpcError { code: -1, .. }))
+		);
+	}
 
 	#[test]
 	fn test_nonstandard_version_tx() {

--- a/engine/src/retrier.rs
+++ b/engine/src/retrier.rs
@@ -128,16 +128,28 @@ type SubmissionFutureOutput =
 type SubmissionFuture = Pin<Box<dyn Future<Output = SubmissionFutureOutput> + Send + 'static>>;
 type SubmissionFutures = FuturesUnordered<SubmissionFuture>;
 
+// The error of the attempt that caused the delay is carried along so that it can be reported to
+// the caller if we end up giving up on the request.
 type RetryDelays = FuturesUnordered<
-	Pin<Box<dyn Future<Output = (RequestId, RequestLog, Attempt, RetryLimit)> + Send + 'static>>,
+	Pin<
+		Box<
+			dyn Future<Output = (RequestId, RequestLog, Attempt, RetryLimit, anyhow::Error)>
+				+ Send
+				+ 'static,
+		>,
+	>,
 >;
 
 type BoxAny = Box<dyn Any + Send>;
 
-type RequestPackage<Client> = (oneshot::Sender<BoxAny>, FutureAnyGenerator<Client>);
+/// What is sent back to the caller: either the response, or the reason we stopped trying to get
+/// one.
+type RequestResponse = Result<BoxAny>;
+
+type RequestPackage<Client> = (oneshot::Sender<RequestResponse>, FutureAnyGenerator<Client>);
 
 type RequestSent<Client> =
-	(oneshot::Sender<BoxAny>, RequestLog, FutureAnyGenerator<Client>, RetryLimit);
+	(oneshot::Sender<RequestResponse>, RequestLog, FutureAnyGenerator<Client>, RetryLimit);
 
 /// Tracks all the retries
 #[derive(Clone)]
@@ -367,7 +379,7 @@ pub trait RetryLimitReturn: Send + 'static {
 	fn into_retry_limit(param_type: Self) -> RetryLimit;
 
 	fn inner_to_return_type<T: Send + 'static>(
-		inner: Result<BoxAny, tokio::sync::oneshot::error::RecvError>,
+		inner: Result<RequestResponse, tokio::sync::oneshot::error::RecvError>,
 		log_message: String,
 	) -> Self::ReturnType<T>;
 }
@@ -382,12 +394,14 @@ impl RetryLimitReturn for NoRetryLimit {
 	}
 
 	fn inner_to_return_type<T: Send + 'static>(
-		inner: Result<BoxAny, tokio::sync::oneshot::error::RecvError>,
+		inner: Result<RequestResponse, tokio::sync::oneshot::error::RecvError>,
 		_log_message: String,
 	) -> Self::ReturnType<T> {
-		let result: BoxAny = inner.expect(
-			"Since there is no limit on the number of retries, we should eventually get a value",
-		);
+		let result: BoxAny = inner
+			.expect(
+				"Since there is no limit on the number of retries, we should eventually get a value",
+			)
+			.expect("We only report an error once a retry limit is reached, and there is none here");
 		*result.downcast::<T>().expect("We know we cast the T into an any, and it is a T that we are receiving. Hitting this is a programmer error.")
 	}
 }
@@ -400,10 +414,12 @@ impl RetryLimitReturn for u32 {
 	}
 
 	fn inner_to_return_type<T: Send + 'static>(
-		inner: Result<BoxAny, tokio::sync::oneshot::error::RecvError>,
+		inner: Result<RequestResponse, tokio::sync::oneshot::error::RecvError>,
 		log_message: String,
 	) -> Self::ReturnType<T> {
-		let result: BoxAny = inner.map_err(|_| anyhow::anyhow!("{log_message}"))?;
+		// The outer error only tells us the retrier dropped the channel without responding, which
+		// it shouldn't do. The error of the request itself comes through the inner result.
+		let result: BoxAny = inner.map_err(|e| anyhow::anyhow!("{log_message}: {e}"))??;
 		Ok(*result.downcast::<T>().expect("We know we cast the T into an any, and it is a T that we are receiving. Hitting this is a programmer error."))
 	}
 }
@@ -449,6 +465,7 @@ where
 						request_holder.insert(request_id, (response_sender, closure));
 					} else {
 						tracing::warn!("Retrier {name}: No clients available for request when received `{request_log}` with id `{request_id}`. Dropping request.");
+						let _result = response_sender.send(Err(anyhow::anyhow!("Retrier {name}: No clients available for request `{request_log}` with id `{request_id}`.")));
 					}
 				},
 				let (request_id, request_log, retry_limit, primary_or_backup, result) = submission_holder.next_or_pending() => {
@@ -456,7 +473,7 @@ where
 					match result {
 						Ok(value) => {
 							if let Some((response_sender, _)) = request_holder.remove(&request_id) {
-								let _result = response_sender.send(value);
+								let _result = response_sender.send(Ok(value));
 							}
 						},
 						Err((e, attempt)) => {
@@ -479,13 +496,13 @@ where
 								async move {
 									tokio::time::sleep(sleep_duration).await;
 									// pass in primary or backup so we know which client to use.
-									(request_id, request_log, attempt, retry_limit)
+									(request_id, request_log, attempt, retry_limit, e)
 								}
 							));
 						},
 					}
 				},
-				let (request_id, request_log, attempt, retry_limit) = retry_delays.next_or_pending() => {
+				let (request_id, request_log, attempt, retry_limit, last_error) = retry_delays.next_or_pending() => {
 					let next_attempt = attempt.saturating_add(1);
 
 					let (response_sender, closure) = request_holder.get(&request_id).expect("We only remove these on success, and if it's in `retry_delays` then it must still be in `request_holder`");
@@ -497,7 +514,9 @@ where
 						match retry_limit {
 							RetryLimit::Limit(max_attempts) if next_attempt >= max_attempts => {
 								tracing::trace!("Retrier {name}: Has reached maximum attempts of `{max_attempts}` for `{request_log}` with id `{request_id}`. Not retrying.");
-								request_holder.remove(&request_id);
+								if let Some((response_sender, _)) = request_holder.remove(&request_id) {
+									let _result = response_sender.send(Err(anyhow::anyhow!("Retrier {name}: Reached maximum attempts of `{max_attempts}` for request `{request_log}` with id `{request_id}`. Last error: {last_error}")));
+								}
 							}
 							_ => {
 								// This await should always return immediately since we must already have a client if we've already made a request.
@@ -506,7 +525,9 @@ where
 									submission_holder.push(submission_future(next_client, request_log, retry_limit, closure, request_id, initial_request_timeout, next_attempt, max_retry_delay, next_primary_or_backup));
 								} else {
 									tracing::warn!("Retrier {name}: No clients available for request `{request_log}` with id `{request_id}`. Dropping request.");
-									request_holder.remove(&request_id);
+									if let Some((response_sender, _)) = request_holder.remove(&request_id) {
+										let _result = response_sender.send(Err(anyhow::anyhow!("Retrier {name}: No clients available for request `{request_log}` with id `{request_id}`. Last error: {last_error}")));
+									}
 								}
 							}
 						}
@@ -525,7 +546,7 @@ where
 		specific_closure: TypedFutureGenerator<T, Client>,
 		request_log: RequestLog,
 		retry_limit: RetryLimit,
-	) -> oneshot::Receiver<BoxAny> {
+	) -> oneshot::Receiver<RequestResponse> {
 		let future_any_fn: FutureAnyGenerator<Client> = Box::pin(move |client| {
 			let future = specific_closure(client);
 			Box::pin(async move {
@@ -534,7 +555,7 @@ where
 				Ok(result)
 			})
 		});
-		let (tx, rx) = oneshot::channel::<BoxAny>();
+		let (tx, rx) = oneshot::channel::<RequestResponse>();
 		let _result = self.request_sender.send((tx, request_log, future_any_fn, retry_limit)).await;
 		rx
 	}
@@ -562,7 +583,7 @@ where
 		let rx = self.send_request(specific_closure, request_log.clone(), retry_limit).await;
 		R::inner_to_return_type(
 			rx.await,
-			format!("Maximum attempt of `{retry_limit:?}` reached for request `{request_log}`."),
+			format!("Retrier dropped request `{request_log}` (limit `{retry_limit:?}`) without returning a result."),
 		)
 	}
 }
@@ -603,10 +624,10 @@ mod tests {
 	}
 
 	async fn check_result<T: PartialEq + std::fmt::Debug + Send + Clone + 'static>(
-		result_rx: oneshot::Receiver<BoxAny>,
+		result_rx: oneshot::Receiver<RequestResponse>,
 		expected: T,
 	) {
-		let result: Box<dyn Any> = result_rx.await.unwrap();
+		let result: Box<dyn Any> = result_rx.await.unwrap().unwrap();
 		let downcasted = result.downcast_ref::<T>().unwrap();
 		assert_eq!(downcasted, &expected);
 	}
@@ -894,13 +915,15 @@ mod tests {
 		.unwrap();
 	}
 
+	const REQUEST_ERROR: &str = "Sorry, this just doesn't work.";
+
 	fn specific_fut_err<T: Send + Clone + 'static, Client: Debug>(
 		timeout: Duration,
 	) -> TypedFutureGenerator<T, Client> {
 		Box::pin(move |_client| {
 			Box::pin(async move {
 				tokio::time::sleep(timeout).await;
-				Err(anyhow::anyhow!("Sorry, this just doesn't work."))
+				Err(anyhow::anyhow!("{REQUEST_ERROR}"))
 			})
 		})
 	}
@@ -921,7 +944,7 @@ mod tests {
 					100,
 				);
 
-				retrier_client
+				let error = retrier_client
 					.request_with_limit(
 						RequestLog::new("request".to_string(), None),
 						specific_fut_err::<(), _>(INITIAL_TIMEOUT),
@@ -929,6 +952,13 @@ mod tests {
 					)
 					.await
 					.unwrap_err();
+
+				// The error of the last attempt should be reported to the caller, rather than
+				// only ending up in the logs.
+				assert!(
+					error.to_string().contains(REQUEST_ERROR),
+					"Expected the request error to be reported, got: {error}"
+				);
 
 				Ok(())
 			}

--- a/state-chain/chains/src/btc/vault_swap_encoding.rs
+++ b/state-chain/chains/src/btc/vault_swap_encoding.rs
@@ -22,7 +22,10 @@ use sp_core::ConstU32;
 use sp_runtime::BoundedVec;
 use sp_std::vec::Vec;
 
-// The maximum length of data that can be encoded in a nulldata utxo
+// Historically Bitcoin Core's default OP_RETURN relay limit (`-datacarriersize`
+// defaulted to 83 bytes, ~80 usable). Since v30.0 (Oct 2025) the default is
+// 100,000 bytes, so this is no longer network-enforced — just a conservative
+// capacity hint that comfortably fits the payload below.
 const MAX_NULLDATA_LENGTH: usize = 80;
 
 #[repr(u8)]


### PR DESCRIPTION
# Pull Request

## Summary

Picks everything currently on `main` that `release/2.3` is missing — 10 commits, all applied cleanly with `-x`.

Most notably this includes **`feat: harden key handover` (#6862)**, which never reached the release branch. Its automated pick PR was opened with the right title but carried the wrong commit (see below), so 2.3 has been missing the multisig hardening.

### Contents

| Commit | |
|---|---|
| `feat: harden key handover (#6862)` | multisig hardening — the important one |
| `fix: report bad bitcoin RPC responses instead of decode errors (PRO-1083) (#6802)` | engine |
| `fix: PRO-3076 report the underlying error when the retrier gives up (#6838)` | engine |
| `feat: bouncer seedable ccm (#6822)` | test |
| `chore: correct outdated comment on MAX_NULLDATA_LENGTH (#6823)` | docs |
| `chore: pin gh actions to a commit sha (#6832)` | CI |
| `chore: update end-of-life gh action tags (#6833)` | CI |
| `chore: add dependabot config for github actions (#6834)` | CI |
| `chore: pin bun to 1.4.0 in CI (#6831)` | CI |
| `chore: update taiki-e install action (#6828)` | CI |

### Deliberately excluded

* `chore: version bump 2.4 (#6829)` — belongs on `main` only.
* Six commits already on 2.3 via the `pick-to-release` workflow, including `chore: run liveness clean up migration for all chains (#6863)`.

### Why #6862 was missed

`ci-cherry-pick.yml` resolved the commit to pick with `git rev-parse HEAD` after checking out `main`, i.e. main's tip *at runner start* rather than the commit the triggering PR produced. #6862 and #6863 merged close together, so both workflow runs picked #6863's commit — with correct titles, since those come from the event payload. #6862's change was therefore never picked.

Fix for the workflow itself is in a separate PR.

## API Changes

None beyond what already landed on `main` in the listed PRs. No new API surface is introduced by the backport itself.

### RPCS

No changes.

### Extrinsics & Events

No changes.

---

## Verification

* `cargo check -p chainflip-engine -p multisig --all-targets` — clean (only the two pre-existing `custom-rpc` deprecation warnings already present on the branch).
* All 10 picks applied without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
