### PR TITLE
fix(ci): pick the PR's own merge commit, not main's tip

### DIFF
--- a/.github/workflows/ci-cherry-pick.yml
+++ b/.github/workflows/ci-cherry-pick.yml
@@ -14,6 +14,10 @@ jobs:
   cherry-pick:
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'pick-to-release')) }}
     runs-on: namespace-profile-default-light
+    env:
+      # Taken from the event rather than the checkout: main's tip at runner start is the wrong
+      # commit as soon as another PR merges in between.
+      COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -30,8 +34,6 @@ jobs:
         run: |
           set -x
           git fetch --all
-          COMMIT_SHA=$(git rev-parse HEAD)
-          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
 
           RELEASE_BRANCH="release/$(git branch -r | grep 'origin/release/[0-9]\+\.[0-9]' | sed 's/.*release\///' | sort -V | tail -n1)"
           echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> $GITHUB_ENV


### PR DESCRIPTION
# Pull Request

## Summary

`ci-cherry-pick.yml` can pick the wrong commit, silently.

The job checks out `ref: main` and then resolves what to pick with:

```bash
COMMIT_SHA=$(git rev-parse HEAD)
```

That is main's tip **at the moment the runner checks out**, not the commit the triggering PR produced. When two labelled PRs merge close together, the second one's commit is already on `main` by the time the first run reaches its checkout, so both runs pick the later commit.

Everything else in the job comes from the event payload and is therefore correct per-run — only the sha is inferred from the checkout, so the result looks plausible while carrying the wrong commit.

### Observed

#6862 and #6863 merged seconds apart and produced pick PRs #6864 and #6865. Their bodies show the two runs had the right events:

| | `Original PR` | commit picked |
|---|---|---|
| #6864 | #6862 | `48881dc7c5` — **#6863's commit** |
| #6865 | #6863 | `48881dc7c5` — correct |

So the run for #6862 correctly identified its own triggering PR, and opened a PR with #6862's title, but picked the other PR's commit. That is what makes this easy to miss: everything a reviewer skims — title, `Original PR` link — is right, and only the contents are wrong. (#6864 was manually retitled after the fact, so its title no longer reads as it did at creation.)

#6862 — `feat: harden key handover`, a multisig hardening change — was never picked, and `release/2.3` has been missing it since. It is being picked manually in #6868.

### Fix

Take the sha from the event payload, where the title already comes from, as a job-level env var so the pick step and the PR step read the same value:

```yaml
env:
  COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
```

`main` is linear squash-merges, so `merge_commit_sha` is an ordinary single-parent commit and `git cherry-pick -x` needs no `-m`.

### Note on the sibling workflow

`ci-forward-port.yml` is **not** affected. It triggers on `push` and enumerates the pushed commits with `git cherry`, so it never has to infer which commit the event refers to.

## API Changes

None. CI only.

### RPCS

No changes.

### Extrinsics & Events

No changes.

---

## Verification

* YAML parses.
* Logic reviewed against the #6862/#6863 timeline: with this change each run picks its own PR's commit regardless of what else merges in between.

Not covered by an automated test — this path only executes on a merged, labelled PR. Worth watching the next `pick-to-release` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
