### PR TITLE
fix: count pending interest as debt in lending risk checks

### DIFF
--- a/state-chain/pallets/cf-lending-pools/src/general_lending.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending.rs
@@ -531,7 +531,7 @@ impl<T: Config> LoanAccount<T> {
 		let total_owed = self
 			.loans
 			.values()
-			.map(|loan| loan.owed_principal_usd_value(price_cache))
+			.map(|loan| loan.total_owed_usd_value(price_cache))
 			.try_fold(0u128, |acc, x| x.map(|v| acc.saturating_add(v)))?;
 
 		let swapped_from_collateral = match &self.liquidation_status {
@@ -563,17 +563,17 @@ impl<T: Config> LoanAccount<T> {
 	/// Returns error if oracle prices are not available, or if collateral is zero.
 	pub fn derive_ltv(&self, price_cache: &OraclePriceCache<T>) -> Result<FixedU64, Error<T>> {
 		let collateral = self.total_collateral_usd_value(price_cache)?;
-		let principal = self.total_owed_usd_value(price_cache)?;
+		let owed = self.total_owed_usd_value(price_cache)?;
 
 		if collateral == 0 {
-			if principal == 0 {
+			if owed == 0 {
 				return Ok(FixedU64::zero());
 			} else {
 				return Ok(FixedU64::max_value());
 			}
 		}
 
-		Ok(FixedU64::from_rational(principal, collateral))
+		Ok(FixedU64::from_rational(owed, collateral))
 	}
 
 	pub fn check_low_ltv_penalty_and_collect_interest(
@@ -641,11 +641,11 @@ impl<T: Config> LoanAccount<T> {
 		}
 	}
 
-	/// Collect just enough collateral from supply pools to cover the outstanding loan
-	/// principal plus a buffer for the maximum oracle price slippage allowed for the
-	/// upcoming liquidation swaps, then split the collected collateral proportionally to
-	/// the usd value of each loan (to give each loan a fair chance of being liquidated
-	/// without a loss). When multiple collateral assets are involved, each is drawn
+	/// Collect just enough collateral from supply pools to cover the outstanding debt
+	/// (principal plus pending interest) plus a buffer for the maximum oracle price slippage
+	/// allowed for the upcoming liquidation swaps, then split the collected collateral
+	/// proportionally to the usd value of each loan (to give each loan a fair chance of being
+	/// liquidated without a loss). When multiple collateral assets are involved, each is drawn
 	/// proportionally to its available USD value. Returns error if oracle prices aren't
 	/// available.
 	pub(super) fn prepare_collateral_for_liquidation(
@@ -739,11 +739,11 @@ impl<T: Config> LoanAccount<T> {
 			return Ok(Default::default());
 		}
 
-		let principal_amounts_usd = self
+		let owed_amounts_usd = self
 			.loans
 			.iter()
 			.map(|(loan_id, loan)| {
-				loan.owed_principal_usd_value(price_cache)
+				loan.total_owed_usd_value(price_cache)
 					.map(|usd_value| ((*loan_id, loan.asset), usd_value))
 			})
 			.collect::<Result<Vec<_>, Error<T>>>()?;
@@ -753,7 +753,7 @@ impl<T: Config> LoanAccount<T> {
 		for (collateral_asset, collateral_amount) in collateral_to_liquidate {
 			let distribution = utils::distribute_proportionally(
 				collateral_amount,
-				principal_amounts_usd.iter().map(|(k, v)| (k, *v)),
+				owed_amounts_usd.iter().map(|(k, v)| (k, *v)),
 			);
 
 			for ((loan_id, loan_asset), collateral_amount) in distribution {
@@ -978,18 +978,21 @@ pub struct PriceCacheAndThreshold<'a, T: Config> {
 }
 
 impl<T: Config> GeneralLoan<T> {
-	fn owed_principal_usd_value(
-		&self,
-		price_cache: &OraclePriceCache<T>,
-	) -> Result<AssetAmount, Error<T>> {
-		price_cache.usd_value_of(self.asset, self.owed_principal)
-	}
-
 	/// The total amount owed on the loan, in the loan's asset: the principal plus all pending
 	/// interest (whole units only — sub-unit interest remainders are excluded).
 	fn total_owed(&self) -> AssetAmount {
 		self.owed_principal
 			.saturating_add(self.pending_interest.total().into_asset_amount())
+	}
+
+	/// USD value of [Self::total_owed]. Pending interest is included so that every risk
+	/// check (LTV, withdrawal headroom, liquidation sizing) sees the same debt that
+	/// repayment collects.
+	fn total_owed_usd_value(
+		&self,
+		price_cache: &OraclePriceCache<T>,
+	) -> Result<AssetAmount, Error<T>> {
+		price_cache.usd_value_of(self.asset, self.total_owed())
 	}
 
 	fn collect_pending_interest(&mut self) {
@@ -1855,7 +1858,7 @@ fn required_liquidation_amount<T: Config>(
 		let total_loans_usd =
 			loan_account.loans.values().try_fold(0 as AssetAmount, |sum, loan| {
 				price_cache
-					.usd_value_of_allow_stale(loan.asset, loan.owed_principal)
+					.usd_value_of_allow_stale(loan.asset, loan.total_owed())
 					.map(|usd| sum.saturating_add(usd))
 			})?;
 

--- a/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
+++ b/state-chain/pallets/cf-lending-pools/src/general_lending/general_lending_tests.rs
@@ -6944,3 +6944,158 @@ mod utilisation_cap {
 		});
 	}
 }
+
+/// Pending (not yet collected) interest is real debt and must be counted by every risk check,
+/// not only by repayment.
+mod pending_interest_is_debt {
+	use super::*;
+	use cf_primitives::Beneficiary;
+
+	const BROKER: u64 = 999;
+	const BROKER_BPS: u16 = 100;
+
+	/// Pool exactly covers the principal and the network's share of the origination fee, so
+	/// utilisation hits 100% and network/broker interest can't be collected and stays pending.
+	fn init_pool_amount() -> AssetAmount {
+		let (origination_fee_network, _) = take_network_fee(ORIGINATION_FEE);
+		PRINCIPAL + origination_fee_network
+	}
+
+	fn create_brokered_loan_on_fully_utilised_pool() {
+		MockBalance::credit_account(&BORROWER, COLLATERAL_ASSET, INIT_COLLATERAL);
+		MockRefundAddressRegistry::register_refund_address(BORROWER, LOAN_CHAIN);
+		register_as_broker(&BROKER);
+		assert_ok!(LendingPools::new_lending_pool(COLLATERAL_ASSET));
+		assert_ok!(supply_funds::<Test>(
+			BORROWER,
+			COLLATERAL_ASSET,
+			INIT_COLLATERAL,
+			SupplyAddedActionType::Manual,
+		));
+		assert_ok!(LendingPools::new_loan(
+			BORROWER,
+			LOAN_ASSET,
+			PRINCIPAL,
+			Some(Beneficiary { account: BROKER, bps: BROKER_BPS }),
+		));
+		assert_eq!(GeneralLendingPools::<Test>::get(LOAN_ASSET).unwrap().available_amount, 0);
+	}
+
+	fn account() -> LoanAccount<Test> {
+		LoanAccounts::<Test>::get(BORROWER).unwrap()
+	}
+
+	fn loan() -> GeneralLoan<Test> {
+		account().loans.get(&LOAN_ID).unwrap().clone()
+	}
+
+	#[test]
+	fn withdrawal_headroom_includes_pending_interest() {
+		new_test_ext()
+			.with_funded_pool(init_pool_amount())
+			.then_execute_with(|_| create_brokered_loan_on_fully_utilised_pool())
+			.then_process_blocks_until_block(
+				INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
+			)
+			.then_execute_with(|_| {
+				let loan = loan();
+				assert!(loan.total_owed() > loan.owed_principal, "expected pending interest");
+
+				let balance_before = MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET);
+
+				// Withdraw as much collateral as the LTV target allows:
+				assert_ok!(general_lending::remove_lender_funds::<Test>(
+					BORROWER,
+					COLLATERAL_ASSET,
+					None
+				));
+
+				assert_eq!(
+					account().derive_ltv(&OraclePriceCache::default()).unwrap(),
+					CONFIG.ltv_thresholds.target.into()
+				);
+
+				// The collateral left behind secures principal *and* pending interest
+				// (collateral is priced at 1 USD, loan asset at SWAP_RATE, target LTV is 80%):
+				let required_collateral = loan.total_owed() * SWAP_RATE * 5 / 4;
+				assert_eq!(
+					GeneralLendingPools::<Test>::get(COLLATERAL_ASSET)
+						.unwrap()
+						.get_supply_position_for_account(&BORROWER),
+					Ok(required_collateral)
+				);
+				assert_eq!(
+					MockBalance::get_balance(&BORROWER, COLLATERAL_ASSET),
+					balance_before + (INIT_COLLATERAL - required_collateral)
+				);
+			});
+	}
+
+	#[test]
+	fn liquidation_collateral_covers_pending_interest() {
+		// Pushes LTV just above the soft liquidation threshold.
+		const NEW_SWAP_RATE: u128 = 24;
+
+		new_test_ext()
+			.with_funded_pool(init_pool_amount())
+			.then_execute_with(|_| create_brokered_loan_on_fully_utilised_pool())
+			.then_process_blocks_until_block(
+				INIT_BLOCK + CONFIG.interest_payment_interval_blocks as u64,
+			)
+			.then_execute_with(|_| {
+				let loan = loan();
+				assert!(loan.total_owed() > loan.owed_principal, "expected pending interest");
+				MockPriceFeedApi::set_price_usd_fine(LOAN_ASSET, NEW_SWAP_RATE);
+				loan
+			})
+			.then_execute_at_next_block(|loan| {
+				let swap_id = match &account().liquidation_status {
+					LiquidationStatus::Liquidating { liquidation_swaps, liquidation_type } => {
+						assert_eq!(*liquidation_type, LiquidationType::Soft);
+						*liquidation_swaps.keys().next().unwrap()
+					},
+					other => panic!("expected liquidation, got {other:?}"),
+				};
+
+				let buffer = bps_to_permill(CONFIG.soft_liquidation_max_oracle_slippage)
+					.saturating_add(CONFIG.liquidation_fee(LOAN_ASSET));
+
+				// Collateral is sized off the full debt, so the liquidation can repay pending
+				// interest as well as the principal:
+				assert_eq!(
+					MockSwapRequestHandler::<Test>::get_swap_requests()
+						.get(&swap_id)
+						.unwrap()
+						.input_amount,
+					required_collateral_with_buffer(loan.total_owed() * NEW_SWAP_RATE, buffer)
+				);
+
+				// Executing the swap at oracle price repays everything, including the interest
+				// that was pending, and pays the broker:
+				let input = MockSwapRequestHandler::<Test>::get_swap_requests()
+					.get(&swap_id)
+					.unwrap()
+					.input_amount;
+				let output = input / NEW_SWAP_RATE;
+				MockSwapRequestHandler::<Test>::set_swap_request_progress(
+					swap_id,
+					SwapExecutionProgress {
+						remaining_input_amount: 0,
+						accumulated_output_amount: output,
+					},
+				);
+				LendingPools::process_loan_swap_outcome(
+					swap_id,
+					LendingSwapType::Liquidation { borrower_id: BORROWER, loan_id: LOAN_ID },
+					output,
+				);
+
+				assert_has_event::<Test>(RuntimeEvent::LendingPools(Event::<Test>::LoanSettled {
+					loan_id: LOAN_ID,
+					outstanding_principal: 0,
+					via_liquidation: true,
+				}));
+				assert!(MockBalance::get_balance(&BROKER, LOAN_ASSET) > 0);
+			});
+	}
+}


### PR DESCRIPTION
# Pull Request

Closes: PRO-3128

## Summary

Risk-sensitive paths in the lending pallet (LTV, withdrawal headroom, liquidation collateral sizing and split, utilisation-cap sum) valued `owed_principal` only, while repayment charges `total_owed()` = principal + pending interest.
A borrower could therefore withdraw collateral against the pending portion of their debt, and liquidation collateral was not sized to cover it.

Impact in practice is negligible: pool interest is folded into principal whenever it exceeds the $0.10 threshold, and network/broker/low-LTV interest only stays pending while the pool has zero available liquidity at the loan's interest tick. Mainnet currently has network extra interest at zero and no brokered loans. This is a correctness fix.

Change: add `GeneralLoan::total_owed_usd_value` (replacing `owed_principal_usd_value`) and use it in `LoanAccount::total_owed_usd_value`, the per-loan split in `prepare_collateral_for_liquidation`, and `required_liquidation_amount`. Interest accrual still compounds on `owed_principal` only.

Regression tests in `pending_interest_is_debt`: withdrawal headroom is computed from total debt, and the liquidation swap is sized from total debt and settles the loan in full.

## API Changes

None.

### RPCS

No wire changes. `ltv_ratio` reported by the RPC now includes pending interest (it uses `derive_ltv`). `principal_amount` fields are unchanged.

### Extrinsics & Events

None.

---

## Checklist

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants. (n/a)
    * [ ] Integration tests for runtime-wide behaviours. (n/a)
    * [ ] Bouncer tests for E2E features involving external chains. (n/a)
  * [x] Benchmarks: no changes to storage access; weights unaffected.
  * [x] Migrations: none.
  * [x] Bouncer typegen: no runtime type changes.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
