### PR TITLE
perf: aggregate commitments before deriving party pubkeys in keygen

### DIFF
--- a/engine/multisig/src/client/keygen/keygen_detail.rs
+++ b/engine/multisig/src/client/keygen/keygen_detail.rs
@@ -516,10 +516,19 @@ pub fn derive_local_pubkeys_for_parties<P: ECPoint>(
 	// commitments.
 	// I.e. y_i = G * f_1(i) + G * f_2(i) + ... G * f_n(i), where
 	// G * f_j(i) = G * s_j + G * c_j_1(i) + G * c_j_2(i) + ... + c_j_{t-1}(i)
+	//
+	// The sum over parties can be pulled inside the polynomial: y_i = A(i), where A's
+	// k-th coefficient commitment is the sum of every party's k-th coefficient
+	// commitment. Aggregating first costs n * t point additions and then only one
+	// degree-t evaluation per receiving party, rather than one per (party, receiver)
+	// pair: n * t point multiplications instead of n^2 * t.
 
 	use rayon::prelude::*;
 
 	// TODO: As a sanity check, assert that commitments are only from sharing parties
+
+	let aggregate_commitments =
+		aggregate_coefficient_commitments(sharing_params.key_params.threshold, commitments);
 
 	sharing_params
 		.indexes_to_share_at
@@ -527,18 +536,20 @@ pub fn derive_local_pubkeys_for_parties<P: ECPoint>(
 		.map(|IndexPair { current_index, future_index }| {
 			(
 				*current_index,
-				commitments
-					.values()
-					.map(|party_commitments| {
-						evaluate_polynomial::<_, _, P::Scalar>(
-							(0..=sharing_params.key_params.threshold)
-								.map(|k| &party_commitments.commitments.0[k as usize]),
-							*future_index,
-						)
-					})
-					.sum(),
+				evaluate_polynomial::<_, _, P::Scalar>(aggregate_commitments.iter(), *future_index),
 			)
 		})
+		.collect()
+}
+
+/// Coefficient-wise sum of all parties' commitment vectors, i.e. the commitments to the
+/// coefficients of the aggregate sharing polynomial `f_1 + f_2 + ... + f_n`.
+fn aggregate_coefficient_commitments<P: ECPoint>(
+	threshold: AuthorityCount,
+	commitments: &BTreeMap<AuthorityCount, DKGCommitment<P>>,
+) -> Vec<P> {
+	(0..=threshold as usize)
+		.map(|k| commitments.values().map(|c| c.commitments.0[k]).sum())
 		.collect()
 }
 
@@ -629,6 +640,95 @@ mod tests {
 		);
 
 		assert_eq!(secret, reconstruct_secret(&shares));
+	}
+
+	/// Reference implementation of [derive_local_pubkeys_for_parties]: evaluate every
+	/// party's commitment polynomial at each receiver's index and sum the results.
+	/// Deliberately mirrors the pre-aggregation implementation, including reading exactly
+	/// `threshold + 1` coefficients by index rather than iterating the whole vector.
+	fn derive_local_pubkeys_naive<P: ECPoint>(
+		sharing_params: &SharingParameters,
+		commitments: &BTreeMap<AuthorityCount, DKGCommitment<P>>,
+	) -> BTreeMap<AuthorityCount, P> {
+		sharing_params
+			.indexes_to_share_at
+			.iter()
+			.map(|IndexPair { current_index, future_index }| {
+				(
+					*current_index,
+					commitments
+						.values()
+						.map(|c| {
+							evaluate_polynomial::<_, _, P::Scalar>(
+								(0..=sharing_params.key_params.threshold)
+									.map(|k| &c.commitments.0[k as usize]),
+								*future_index,
+							)
+						})
+						.sum(),
+				)
+			})
+			.collect()
+	}
+
+	/// Check `derive_local_pubkeys_for_parties` against the naive reference and against
+	/// the secret shares themselves (each derived pubkey must be `G * sum of shares`).
+	fn check_derived_pubkeys<C: CryptoScheme>(
+		rng: &mut Rng,
+		sharing_params: &SharingParameters,
+		dealer_idxs: &[AuthorityCount],
+	) {
+		let (commitments, outgoing_shares): (BTreeMap<_, _>, BTreeMap<_, _>) = dealer_idxs
+			.iter()
+			.map(|idx| {
+				let (_secret, commitments, shares) =
+					generate_secret_and_shares::<C::Point>(rng, sharing_params, None);
+				((*idx, DKGCommitment { commitments }), (*idx, shares))
+			})
+			.unzip();
+
+		let derived = derive_local_pubkeys_for_parties(sharing_params, &commitments);
+
+		assert_eq!(derived, derive_local_pubkeys_naive(sharing_params, &commitments));
+
+		assert_eq!(derived.len(), sharing_params.indexes_to_share_at.len());
+		for (receiver_idx, pubkey) in &derived {
+			let secret_share: <C::Point as ECPoint>::Scalar =
+				outgoing_shares.values().map(|shares| shares[receiver_idx].value.clone()).sum();
+			assert_eq!(*pubkey, C::Point::from_scalar(&secret_share));
+		}
+	}
+
+	fn derived_pubkeys_match_naive_for_scheme<C: CryptoScheme>() {
+		use rand::SeedableRng;
+		let mut rng = Rng::from_seed([1; 32]);
+
+		// Regular keygen: every party deals and receives, current and future indexes coincide.
+		let params = ThresholdParameters::from_share_count(7);
+		check_derived_pubkeys::<C>(
+			&mut rng,
+			&SharingParameters::for_keygen(params),
+			&[1, 2, 3, 4, 5, 6, 7],
+		);
+
+		// Key handover: only some parties deal, only some receive, and receivers are
+		// evaluated at their (non-consecutive w.r.t. the current ceremony) future indexes.
+		let handover_params = SharingParameters {
+			indexes_to_share_at: BTreeSet::from_iter([
+				IndexPair { current_index: 2, future_index: 1 },
+				IndexPair { current_index: 3, future_index: 2 },
+				IndexPair { current_index: 6, future_index: 3 },
+				IndexPair { current_index: 8, future_index: 4 },
+			]),
+			key_params: ThresholdParameters::from_share_count(4),
+		};
+		check_derived_pubkeys::<C>(&mut rng, &handover_params, &[1, 4, 5, 6, 7]);
+	}
+
+	#[test]
+	fn derived_pubkeys_match_naive() {
+		use crate::client::helpers::test_all_crypto_schemes;
+		test_all_crypto_schemes!(derived_pubkeys_match_naive_for_scheme());
 	}
 
 	#[test]


### PR DESCRIPTION
# Pull Request

## Summary

I asked AI to check if there are any low hanging fruit in the multisig module wrt performance and it found this simple optimisation that's low/zero risk and with a potentially huge payoff.

**Change**:

In `derive_local_pubkeys_for_parties` (run in `finalize_keygen` for every keygen and key handover) instead of evaluating 150 polynomials and summing the results, we add polynomials first and evaluate once. Point addition is associative and commutative, so summing first and evaluating once is the same group element by definition. Evaluating is the expensive part. This effectively reduces complexity from `n * n * t` to `n * t`. 

**Safety**:

This is safe because the data is public and we just need to compute the result, the how is not important (there is no secrets involved so no side channel attack possible; overflowing is not a concern because of modulo arithmetic). Tests confirm that the slow method (current code) produces the same result as the new code. Even if this code was somehow wrong, this would be caught during keygen verification.

**Impact**:

Results of keygen will now be reported ~90s sooner (see empirical findings below). Also, while this function was on a separate blocking thread, so didn't mess with the tokio runtime directly, it likely saturated most/all validator CPU cores for 1-2 mins possibly leading to degraded performance during rotations.

**AI summary** (I verified and edited):

Since the group is commutative, the sum over dealers can be pulled inside the polynomial:

```
y_i = Σ_j f_j(i)·G = Σ_k (Σ_j C_{j,k}) · i^k
```

So this PR first sums the commitment vectors coefficient-wise (`n * (t+1)` point additions) and then evaluates the single aggregate polynomial once per receiver (`n * t` steps). The result is the same group element; nothing on the wire or in the hash commitments changes, and the function signature and callers are untouched.

### Measured

Benchmark at `n = 150`, `t = 99`, same commitments, outputs asserted equal (M1 Max, crypto crates at opt-level 3):

| scheme | rayon threads | before | after |
|---|---|---|---|
| secp256k1 (EVM/BTC) | 4 | 29.8 s | 0.37 s |
| secp256k1 (EVM/BTC) | 10 | 17.7 s | 0.28 s |
| ed25519 (Solana) | 4 | 24.1 s | 0.17 s |
| ed25519 (Solana) | 10 | 12.6 s | 0.09 s |

On mainnet (4 vCPU, engine 2.2.11, rotation to epoch 477 on 2026-09-10) the four concurrent keygens (138 parties) all spent ~93 s between the last stage-9 message and `Ceremony took`, i.e. about 28% of the 337 s keygen wall time, and all four completed at the same instant, which is the signature of this function contending for the four cores.

### Tests

`derived_pubkeys_match_naive` runs for all four crypto schemes and covers a plain keygen and a handover-shaped case (subset of dealers, subset of receivers, non-consecutive future indexes). It checks the new implementation against a naive reference that mirrors the replaced code exactly, and independently against the secrets: each derived key must equal `G * (sum of the shares that receiver was dealt)`.

## API Changes

None.

### RPCS

None.

### Extrinsics & Events

None.

---

## Checklist

* The PR is complete:
  * [x] Scope is clear and fully implemented.
  * [ ] Reviewers are assigned.
  * Tests:
    * [x] Unit tests for isolated local conditions.
    * [ ] Proptests for important invariants.
    * [ ] Integration tests for runtime-wide behaviours.
    * [ ] Bouncer tests for E2E features involving external chains.
  * [x] Benchmarks: no placeholders.
  * [x] Migrations: none.
  * [x] Bouncer typegen: no runtime type changes.
* Make life easy for the reviewer:
  * [x] Intended behaviours are clear and, where possible, covered by tests.
  * [x] Unrelated changes are isolated in dedicated commits.
  * [x] Interfaces are clearly documented.
  * [x] Anything non-obvious is documented in the `Summary` section above.
